### PR TITLE
Bun.markdown: add front matter support

### DIFF
--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -7,11 +7,13 @@ description: Parse and render Markdown with Bun's built-in Markdown API, support
   **Unstable API** — This API is under active development and may change in future versions of Bun.
 </Callout>
 
-Bun includes a fast, built-in Markdown parser written in Rust. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:
+Bun includes a fast, built-in Markdown parser written in Rust. It supports GitHub Flavored Markdown (GFM) extensions and provides these APIs:
 
 - `Bun.markdown.html()` — render Markdown to an HTML string
 - `Bun.markdown.render()` — render Markdown with custom callbacks for each element
 - `Bun.markdown.react()` — render Markdown to React JSX elements
+- `Bun.markdown.ansi()` — render Markdown to an ANSI-colored terminal string
+- `Bun.markdown.frontmatter()` — split a front-matter block from a document
 
 ---
 
@@ -69,6 +71,7 @@ All available options:
 | `noHtmlBlocks`         | `false` | Disable HTML blocks                                         |
 | `noHtmlSpans`          | `false` | Disable inline HTML                                         |
 | `tagFilter`            | `false` | GFM tag filter for disallowed HTML tags                     |
+| `frontmatter`          | `true`  | Skip a leading front-matter block — see [Front matter](#front-matter) |
 
 #### Autolinks
 
@@ -96,6 +99,54 @@ Bun.markdown.html("## Hello World", { headings: true });
 // Enable only heading IDs (no autolink)
 Bun.markdown.html("## Hello World", { headings: { ids: true } });
 // '<h2 id="hello-world">Hello World</h2>\n'
+```
+
+---
+
+## Front matter
+
+Documents from static-site generators often start with a metadata block: `---` fences around YAML (Jekyll, Astro, Eleventy, VitePress) or `+++` fences around TOML (Hugo, Zola). All of the renderers — `html()`, `render()`, `react()`, `ansi()`, and `bun file.md` in the terminal — recognize a front-matter block at the very start of the input and skip it instead of rendering it:
+
+```ts
+const html = Bun.markdown.html(`---
+title: Hello
+---
+# Heading
+`);
+// "<h1>Heading</h1>\n"
+```
+
+A block only counts as front matter when it would parse: the fences must be closed, and the metadata must be a mapping (or empty). Anything else renders as plain CommonMark, so `---\nFoo\n---` is still a thematic break followed by a setext heading. The one CommonMark reading this changes is an empty block: `---\n---` at the very start of a document is treated as empty front matter and renders to nothing, instead of two thematic breaks. Pass `frontmatter: false` to disable the skip entirely:
+
+```ts
+Bun.markdown.html("---\ntitle: Hello\n---\n", { frontmatter: false });
+// "<hr />\n<h2>title: Hello</h2>\n"
+```
+
+### `Bun.markdown.frontmatter()`
+
+Parse the metadata and get the remaining body — no extra dependency needed:
+
+```ts
+const { data, content } = Bun.markdown.frontmatter(await Bun.file("post.md").text());
+data; // { title: "Hello", tags: ["a", "b"] }
+content; // the document after the block
+```
+
+The fence picks the parser: `---` is YAML and `+++` is TOML. JSON front matter between `---` fences works too, since JSON is valid YAML. `data` distinguishes the three possible shapes:
+
+- an **object** when the block parses as a mapping
+- **`{}`** when the block is empty (`---\n---`)
+- **`null`** when the input has no front-matter block — including a `---` block whose content is a scalar or sequence, which stays part of `content`
+
+Invalid YAML or TOML inside the fences throws a `SyntaxError` (a typo in your metadata should be loud).
+
+```ts
+Bun.markdown.frontmatter("+++\ntitle = 'Hello'\n+++\nbody");
+// { data: { title: "Hello" }, content: "body" }
+
+Bun.markdown.frontmatter("# Just a doc");
+// { data: null, content: "# Just a doc" }
 ```
 
 ---

--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -116,7 +116,9 @@ title: Hello
 // "<h1>Heading</h1>\n"
 ```
 
-A block only counts as front matter when it would parse: the fences must be closed, and the metadata must be a mapping (or empty). Anything else renders as plain CommonMark, so `---\nFoo\n---` is still a thematic break followed by a setext heading. The one CommonMark reading this changes is an empty block: `---\n---` at the very start of a document is treated as empty front matter and renders to nothing, instead of two thematic breaks. Pass `frontmatter: false` to disable the skip entirely:
+Detection is purely structural, the same rule other Markdown engines use: the opening fence must sit at the very start of the input (a UTF-8 BOM is allowed), the first line inside the block must not be blank, and a matching closing fence — exactly three markers — must start a later line. The metadata is never parsed to decide, so a block with a YAML typo is still skipped. YAML's `...` document-end marker is not accepted as a closer, and `----` is a thematic break, not a fence.
+
+Because the rule is structural, two CommonMark readings change under the default: `---\n---` at the very start of a document is an empty front-matter block rendering to nothing (instead of two thematic breaks), and a document like `---\nFoo\n---` has its first block skipped (instead of a thematic break plus a setext heading). Pass `frontmatter: false` to restore the plain CommonMark reading:
 
 ```ts
 Bun.markdown.html("---\ntitle: Hello\n---\n", { frontmatter: false });
@@ -135,11 +137,11 @@ content; // the document after the block
 
 The fence picks the parser: `---` is YAML and `+++` is TOML. JSON front matter between `---` fences works too, since JSON is valid YAML. `data` distinguishes the three possible shapes:
 
-- an **object** when the block parses as a mapping
+- an **object** when the block has metadata
 - **`{}`** when the block is empty (`---\n---`)
-- **`null`** when the input has no front-matter block — including a `---` block whose content is a scalar or sequence, which stays part of `content`
+- **`null`** when the input has no front-matter block, in which case `content` is the input unchanged
 
-Invalid YAML or TOML inside the fences throws a `SyntaxError` (a typo in your metadata should be loud).
+Metadata that fails to parse throws a `SyntaxError`, and so does metadata that parses to something other than a mapping: `---\ntitle Hello\n---` (a missing colon) is a valid YAML scalar, and "YAML front matter must be a mapping" beats silently dropping the block. Error positions point into the document you passed, not the metadata slice.
 
 ```ts
 Bun.markdown.frontmatter("+++\ntitle = 'Hello'\n+++\nbody");

--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -54,23 +54,23 @@ const html = Bun.markdown.html("some markdown", {
 
 All available options:
 
-| Option                 | Default | Description                                                 |
-| ---------------------- | ------- | ----------------------------------------------------------- |
-| `tables`               | `true`  | GFM tables                                                  |
-| `strikethrough`        | `true`  | GFM strikethrough (`~~text~~`)                              |
-| `tasklists`            | `true`  | GFM task lists (`- [x] item`)                               |
-| `autolinks`            | `false` | Enable autolinks — see [Autolinks](#autolinks)              |
-| `headings`             | `false` | Heading IDs and autolinks — see [Heading IDs](#heading-ids) |
-| `hardSoftBreaks`       | `false` | Treat soft line breaks as hard breaks                       |
-| `wikiLinks`            | `false` | Enable `[[wiki links]]`                                     |
-| `underline`            | `false` | `__text__` renders as `<u>` instead of `<strong>`           |
-| `latexMath`            | `false` | Enable `$inline$` and `$$display$$` math                    |
-| `collapseWhitespace`   | `false` | Collapse whitespace in text                                 |
-| `permissiveAtxHeaders` | `false` | ATX headers without space after `#`                         |
-| `noIndentedCodeBlocks` | `false` | Disable indented code blocks                                |
-| `noHtmlBlocks`         | `false` | Disable HTML blocks                                         |
-| `noHtmlSpans`          | `false` | Disable inline HTML                                         |
-| `tagFilter`            | `false` | GFM tag filter for disallowed HTML tags                     |
+| Option                 | Default | Description                                                           |
+| ---------------------- | ------- | --------------------------------------------------------------------- |
+| `tables`               | `true`  | GFM tables                                                            |
+| `strikethrough`        | `true`  | GFM strikethrough (`~~text~~`)                                        |
+| `tasklists`            | `true`  | GFM task lists (`- [x] item`)                                         |
+| `autolinks`            | `false` | Enable autolinks — see [Autolinks](#autolinks)                        |
+| `headings`             | `false` | Heading IDs and autolinks — see [Heading IDs](#heading-ids)           |
+| `hardSoftBreaks`       | `false` | Treat soft line breaks as hard breaks                                 |
+| `wikiLinks`            | `false` | Enable `[[wiki links]]`                                               |
+| `underline`            | `false` | `__text__` renders as `<u>` instead of `<strong>`                     |
+| `latexMath`            | `false` | Enable `$inline$` and `$$display$$` math                              |
+| `collapseWhitespace`   | `false` | Collapse whitespace in text                                           |
+| `permissiveAtxHeaders` | `false` | ATX headers without space after `#`                                   |
+| `noIndentedCodeBlocks` | `false` | Disable indented code blocks                                          |
+| `noHtmlBlocks`         | `false` | Disable HTML blocks                                                   |
+| `noHtmlSpans`          | `false` | Disable inline HTML                                                   |
+| `tagFilter`            | `false` | GFM tag filter for disallowed HTML tags                               |
 | `frontmatter`          | `true`  | Skip a leading front-matter block — see [Front matter](#front-matter) |
 
 #### Autolinks

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1083,6 +1083,14 @@ declare module "bun" {
        */
       tagFilter?: boolean;
       /**
+       * Recognize a front-matter block at the very start of the input
+       * (`---` YAML fences or `+++` TOML fences) and skip it instead of
+       * rendering it. Set to `false` to treat the block as plain CommonMark
+       * (thematic break + setext heading).
+       * Default: `true`.
+       */
+      frontmatter?: boolean;
+      /**
        * Enable autolinks. Pass `true` to enable all autolink types (URL, WWW, email),
        * or an object to enable individually.
        *
@@ -1377,6 +1385,13 @@ declare module "bun" {
        * @default false
        */
       kittyGraphics?: boolean;
+      /**
+       * Recognize a front-matter block at the very start of the input
+       * (`---` YAML fences or `+++` TOML fences) and skip it instead of
+       * rendering it.
+       * @default true
+       */
+      frontmatter?: boolean;
     }
 
     /**
@@ -1508,6 +1523,44 @@ declare module "bun" {
       components?: ComponentOverrides,
       options?: ReactOptions,
     ): import("./jsx.d.ts").JSX.Element;
+
+    /** Result of {@link frontmatter}. */
+    interface FrontmatterResult {
+      /**
+       * The parsed front-matter data: an object for a block that parses as
+       * a mapping, `{}` for an empty block, `null` when the input has no
+       * front-matter block.
+       */
+      data: Record<string, unknown> | null;
+      /** The input with the front-matter block removed. */
+      content: string;
+    }
+
+    /**
+     * Split a leading front-matter block from a document.
+     *
+     * Supports `---` fences (YAML) and `+++` fences (TOML) at the very
+     * start of the input; JSON between `---` fences also works, since JSON
+     * is valid YAML. The block must parse as a mapping (or be empty) to
+     * count as front matter: `---\nFoo\n---` is a thematic break plus a
+     * setext heading, not front matter, and comes back with `data: null`
+     * and the input unchanged.
+     *
+     * Invalid YAML or TOML inside the fences throws a `SyntaxError`.
+     *
+     * @param input The text (or buffer) to split
+     * @returns `{ data, content }`
+     *
+     * @example
+     * ```ts
+     * const { data, content } = Bun.markdown.frontmatter("---\ntitle: Hello\n---\n# Heading");
+     * data; // { title: "Hello" }
+     * content; // "# Heading"
+     * ```
+     */
+    export function frontmatter(
+      input: string | NodeJS.TypedArray | DataView<ArrayBufferLike> | ArrayBufferLike,
+    ): FrontmatterResult;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1083,10 +1083,11 @@ declare module "bun" {
        */
       tagFilter?: boolean;
       /**
-       * Recognize a front-matter block at the very start of the input
-       * (`---` YAML fences or `+++` TOML fences) and skip it instead of
-       * rendering it. Set to `false` to treat the block as plain CommonMark
-       * (thematic break + setext heading).
+       * Skip a front-matter block (`---` YAML fences or `+++` TOML fences)
+       * at the very start of the input. Detection is structural — the
+       * fences must be closed and the first inner line non-blank — and the
+       * metadata is never parsed. Set to `false` to render the block as
+       * plain CommonMark.
        * Default: `true`.
        */
       frontmatter?: boolean;
@@ -1386,9 +1387,8 @@ declare module "bun" {
        */
       kittyGraphics?: boolean;
       /**
-       * Recognize a front-matter block at the very start of the input
-       * (`---` YAML fences or `+++` TOML fences) and skip it instead of
-       * rendering it.
+       * Skip a front-matter block (`---` YAML fences or `+++` TOML fences)
+       * at the very start of the input.
        * @default true
        */
       frontmatter?: boolean;
@@ -1527,9 +1527,9 @@ declare module "bun" {
     /** Result of {@link frontmatter}. */
     interface FrontmatterResult {
       /**
-       * The parsed front-matter data: an object for a block that parses as
-       * a mapping, `{}` for an empty block, `null` when the input has no
-       * front-matter block.
+       * The parsed front-matter data: an object for a block with metadata,
+       * `{}` for an empty block, `null` when the input has no front-matter
+       * block.
        */
       data: Record<string, unknown> | null;
       /** The input with the front-matter block removed. */
@@ -1541,12 +1541,13 @@ declare module "bun" {
      *
      * Supports `---` fences (YAML) and `+++` fences (TOML) at the very
      * start of the input; JSON between `---` fences also works, since JSON
-     * is valid YAML. The block must parse as a mapping (or be empty) to
-     * count as front matter: `---\nFoo\n---` is a thematic break plus a
-     * setext heading, not front matter, and comes back with `data: null`
-     * and the input unchanged.
+     * is valid YAML. Detection is structural (closed fences, non-blank
+     * first inner line); with no block present, `data` is `null` and the
+     * input comes back unchanged.
      *
-     * Invalid YAML or TOML inside the fences throws a `SyntaxError`.
+     * Metadata that fails to parse throws a `SyntaxError`, as does metadata
+     * that is not a mapping — `---\ntitle Hello\n---` (a missing colon) is
+     * a valid YAML scalar, and the error beats silently dropping the block.
      *
      * @param input The text (or buffer) to split
      * @returns `{ data, content }`

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2703,6 +2703,9 @@ pub fn render_to_ansi<'a>(
     theme: Theme<'a>,
 ) -> Result<Option<Box<[u8]>>, crate::parser::ParserError> {
     use crate::parser::ParserError;
+    // Strip before `AnsiRenderer::init` captures the text: block offsets the
+    // parser reports must index the renderer's copy.
+    let text = options.strip_frontmatter(text);
     // `AnsiRenderer::init` reserves output space proportional to the input, so
     // an input the parser cannot address has to be rejected before it is
     // allocated for, not only when `Parser::init` sees it.

--- a/src/md/frontmatter.rs
+++ b/src/md/frontmatter.rs
@@ -1,0 +1,110 @@
+//! Structural front-matter detection: `---` (YAML) and `+++` (TOML) fences.
+//!
+//! Detection never parses the metadata — the same purely structural rule
+//! pulldown-cmark, comrak, goldmark and markdown-it use — so renderers can
+//! skip a block without touching a YAML/TOML parser. `Bun.markdown.frontmatter`
+//! is the one consumer that parses what `detect` finds.
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Lang {
+    /// `---` fences. Fenced JSON parses through YAML (JSON is valid YAML).
+    Yaml,
+    /// `+++` fences (Hugo, Zola).
+    Toml,
+}
+
+pub struct Block {
+    pub lang: Lang,
+    /// Offset of the opening fence: 3 when a UTF-8 BOM precedes it, else 0.
+    pub start: usize,
+    /// The metadata text between the fences.
+    pub meta: core::ops::Range<usize>,
+    /// Offset of the first byte after the block (start of the body).
+    pub body_start: usize,
+}
+
+/// True when a fence (exactly three `marker` bytes) starts at `pos`.
+fn is_fence_at(input: &[u8], pos: usize, marker: u8) -> bool {
+    input.len() >= pos + 3
+        && input[pos] == marker
+        && input[pos + 1] == marker
+        && input[pos + 2] == marker
+}
+
+/// Consume spaces/tabs, an optional `\r`, then `\n` or EOF after a fence's
+/// three marker bytes; None when the line carries other content
+/// (`----`, `--- text`, and YAML's `...` document-end marker never close).
+fn fence_line_end(input: &[u8], mut i: usize) -> Option<usize> {
+    while i < input.len() && (input[i] == b' ' || input[i] == b'\t') {
+        i += 1;
+    }
+    if i < input.len() && input[i] == b'\r' {
+        i += 1;
+    }
+    match input.get(i) {
+        None => Some(i),
+        Some(b'\n') => Some(i + 1),
+        Some(_) => None,
+    }
+}
+
+/// True when the line starting at `i` has no content (spaces/tabs only).
+fn line_is_blank(input: &[u8], mut i: usize) -> bool {
+    while i < input.len() && (input[i] == b' ' || input[i] == b'\t' || input[i] == b'\r') {
+        i += 1;
+    }
+    i >= input.len() || input[i] == b'\n'
+}
+
+/// Find a front-matter block at the very start of `input`, allowing a
+/// UTF-8 BOM (`fs.readFileSync(path, "utf8")` keeps BOMs). Purely
+/// structural: a fence at offset 0, a non-blank first inner line (a blank
+/// one reads as "thematic break, then prose"), and a matching closing
+/// fence at column 0.
+pub fn detect(input: &[u8]) -> Option<Block> {
+    let start = if input.starts_with(b"\xEF\xBB\xBF") {
+        3
+    } else {
+        0
+    };
+    let marker = *input.get(start)?;
+
+    let lang = match marker {
+        b'-' => Lang::Yaml,
+        b'+' => Lang::Toml,
+        _ => return None,
+    };
+    if !is_fence_at(input, start, marker) {
+        return None;
+    }
+    let meta_start = fence_line_end(input, start + 3)?;
+    if line_is_blank(input, meta_start) {
+        return None;
+    }
+
+    // The closing fence must start a line; indented content (e.g. inside a
+    // YAML block scalar) can never sit at column 0.
+    let mut line_start = meta_start;
+    while line_start < input.len() {
+        if is_fence_at(input, line_start, marker) {
+            if let Some(body_start) = fence_line_end(input, line_start + 3) {
+                return Some(Block {
+                    lang,
+                    start,
+                    meta: meta_start..line_start,
+                    body_start,
+                });
+            }
+        }
+        line_start += bun_core::strings::index_of(&input[line_start..], b"\n")? + 1;
+    }
+    None
+}
+
+/// `input` without a leading front-matter block; unchanged when none.
+pub fn strip(input: &[u8]) -> &[u8] {
+    match detect(input) {
+        Some(block) => &input[block.body_start..],
+        None => input,
+    }
+}

--- a/src/md/lib.rs
+++ b/src/md/lib.rs
@@ -6,6 +6,7 @@ pub mod autolinks;
 pub(crate) mod blocks;
 pub(crate) mod containers;
 pub(crate) mod entity;
+pub mod frontmatter;
 pub mod helpers;
 pub mod html_renderer;
 pub mod inlines;

--- a/src/md/root.rs
+++ b/src/md/root.rs
@@ -39,6 +39,8 @@ pub struct Options {
     pub(crate) tag_filter: bool,
     pub heading_ids: bool,
     pub autolink_headings: bool,
+    /// Skip a leading front-matter block (see [`crate::frontmatter`]).
+    pub frontmatter: bool,
 }
 
 impl Default for Options {
@@ -63,6 +65,7 @@ impl Default for Options {
             tag_filter: false,
             heading_ids: false,
             autolink_headings: false,
+            frontmatter: true,
         }
     }
 }
@@ -89,6 +92,7 @@ impl Options {
         tag_filter: false,
         heading_ids: false,
         autolink_headings: false,
+        frontmatter: false,
     };
 
     pub const TERMINAL: Self = Self {
@@ -101,8 +105,21 @@ impl Options {
         wiki_links: true,
         underline: true,
         latex_math: true,
+        frontmatter: true,
         ..Self::NONE
     };
+
+    /// The input with a leading front-matter block removed when
+    /// `frontmatter` is enabled. [`render_with_renderer`] callers apply this
+    /// before building a renderer that captures the source text, so block
+    /// offsets handed to the renderer match its copy of the input.
+    pub fn strip_frontmatter<'a>(&self, text: &'a [u8]) -> &'a [u8] {
+        if self.frontmatter {
+            crate::frontmatter::strip(text)
+        } else {
+            text
+        }
+    }
 
     pub(crate) fn to_flags(self) -> Flags {
         Flags {
@@ -183,6 +200,7 @@ impl Options {
         ("autolink_headings", "autolinkHeadings", |o, v| {
             o.autolink_headings = v
         }),
+        ("frontmatter", "frontmatter", |o, v| o.frontmatter = v),
     ];
 }
 
@@ -194,10 +212,15 @@ pub fn render_to_html_with_options(
     text: &[u8],
     options: Options,
 ) -> Result<Box<[u8]>, parser::ParserError> {
+    let text = options.strip_frontmatter(text);
     parser::render_to_html(text, options.to_flags(), options.to_render_options())
 }
 
 /// Parse and render using a custom renderer implementation.
+///
+/// Does not apply `Options::frontmatter`: the renderer was built from the
+/// caller's copy of the text, so the caller strips via
+/// [`Options::strip_frontmatter`] before constructing it.
 pub fn render_with_renderer<'a>(
     text: &'a [u8],
     options: Options,
@@ -213,6 +236,7 @@ pub fn render_with_renderer<'a>(
 
 pub use crate::types;
 
+pub use crate::frontmatter;
 pub use crate::helpers;
 
 pub use crate::ansi_renderer as ansi;

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -2,7 +2,7 @@
 
 use bun_core::StackCheck;
 use bun_jsc::{
-    ArrayBuffer, CallFrame, JSGlobalObject, JSValue, JsResult, MarkedArgumentBuffer,
+    ArrayBuffer, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, MarkedArgumentBuffer,
     RangeErrorOptions,
 };
 // Note: the `bun_md` crate's lib.rs is a
@@ -11,6 +11,8 @@ use bun_jsc::{
 use crate::node::StringOrBuffer;
 use bun_md::parser::{MAX_INPUT_LEN, ParserError};
 use bun_md::root as md;
+use bun_parsers::toml::TOML;
+use bun_parsers::yaml::{YAML, YamlParseError};
 
 // `bun_core::String::create_utf8_for_js` lives in `bun_jsc::bun_string_jsc`
 // (tier-6), not on `bun_core::String` itself.
@@ -105,6 +107,7 @@ pub(crate) fn create(global_this: &JSGlobalObject) -> JSValue {
             ("ansi", __jsc_host_render_to_ansi, 2),
             ("render", __jsc_host_render, 3),
             ("react", __jsc_host_render_react, 3),
+            ("frontmatter", __jsc_host_frontmatter, 1),
         ],
     )
 }
@@ -165,7 +168,11 @@ pub(crate) fn render_to_ansi(
         remote_image_paths: None,
         image_base_dir: None,
     };
+    let mut skip_frontmatter = true;
     if theme_value.is_object() {
+        if let Some(v) = theme_value.get_boolean_loose(global_this, "frontmatter")? {
+            skip_frontmatter = v;
+        }
         if let Some(v) = theme_value.get_boolean_loose(global_this, "colors")? {
             theme.colors = v;
         }
@@ -189,6 +196,12 @@ pub(crate) fn render_to_ansi(
             }
         }
     }
+
+    let input = if skip_frontmatter {
+        strip_frontmatter(input)
+    } else {
+        input
+    };
 
     let result = match md::render_to_ansi(input, md::Options::TERMINAL, theme) {
         Ok(Some(r)) => r,
@@ -225,8 +238,13 @@ fn render_to_html(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     };
 
     let options = parse_options(global_this, opts_value)?;
+    let input = if options.frontmatter {
+        strip_frontmatter(input)
+    } else {
+        input
+    };
 
-    let result = match md::render_to_html_with_options(input, options) {
+    let result = match md::render_to_html_with_options(input, options.md) {
         Ok(r) => r,
         Err(err) => return Err(parser_err_to_js(global_this, err, input.len())),
     };
@@ -234,9 +252,21 @@ fn render_to_html(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     create_utf8_for_js(global_this, &result)
 }
 
-fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<md::Options> {
+/// `md::Options` plus the binding-level `frontmatter` flag: the `bun_md`
+/// parser has no notion of front matter, so the strip happens here before
+/// the input reaches it.
+struct ParsedOptions {
+    md: md::Options,
+    frontmatter: bool,
+}
+
+fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<ParsedOptions> {
     let mut options = md::Options::default();
+    let mut frontmatter = true;
     if opts_value.is_object() {
+        if let Some(v) = opts_value.get_boolean_loose(global_this, "frontmatter")? {
+            frontmatter = v;
+        }
         // Handle compound autolinks: true | { url, www, email }
         if let Some(autolinks_val) = opts_value.get(global_this, "autolinks")? {
             if autolinks_val.is_boolean() {
@@ -299,7 +329,294 @@ fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<
             }
         }
     }
-    Ok(options)
+    Ok(ParsedOptions {
+        md: options,
+        frontmatter,
+    })
+}
+
+// ========================================
+// Front matter
+// ========================================
+
+#[derive(Clone, Copy)]
+enum FrontmatterLang {
+    /// `---` fences (Jekyll, Hugo, Astro, Eleventy, VitePress, Obsidian, …).
+    /// Also covers fenced JSON, which is valid YAML.
+    Yaml,
+    /// `+++` fences (Hugo, Zola).
+    Toml,
+}
+
+struct FrontmatterBlock {
+    lang: FrontmatterLang,
+    /// The metadata text between the fences.
+    meta: core::ops::Range<usize>,
+    /// Offset of the first byte after the block (start of the body).
+    body_start: usize,
+}
+
+/// True when a fence (exactly three `marker` bytes) starts at `pos`.
+fn is_fence_at(input: &[u8], pos: usize, marker: u8) -> bool {
+    input.len() >= pos + 3
+        && input[pos] == marker
+        && input[pos + 1] == marker
+        && input[pos + 2] == marker
+}
+
+/// Consume the rest of a fence line starting just past the three marker
+/// bytes: optional spaces/tabs, an optional `\r`, then `\n` or EOF. Returns
+/// the offset past the terminator; None when the line carries other content
+/// (`----`, `--- text`).
+fn fence_line_end(input: &[u8], mut i: usize) -> Option<usize> {
+    while i < input.len() && (input[i] == b' ' || input[i] == b'\t') {
+        i += 1;
+    }
+    if i < input.len() && input[i] == b'\r' {
+        i += 1;
+    }
+    match input.get(i) {
+        None => Some(i),
+        Some(b'\n') => Some(i + 1),
+        Some(_) => None,
+    }
+}
+
+/// Find a front-matter block at the very start of `input` (after an
+/// optional UTF-8 BOM — `fs.readFileSync(path, "utf8")` keeps BOMs).
+/// Purely structural; the caller decides whether the metadata parses.
+fn detect_frontmatter(input: &[u8]) -> Option<FrontmatterBlock> {
+    let start = if input.starts_with(b"\xEF\xBB\xBF") {
+        3
+    } else {
+        0
+    };
+    let marker = *input.get(start)?;
+
+    let lang = match marker {
+        b'-' => FrontmatterLang::Yaml,
+        b'+' => FrontmatterLang::Toml,
+        _ => return None,
+    };
+    if !is_fence_at(input, start, marker) {
+        return None;
+    }
+    let meta_start = fence_line_end(input, start + 3)?;
+
+    // The closing fence must start a line; indented content (e.g. inside a
+    // YAML block scalar) can never sit at column 0.
+    let mut line_start = meta_start;
+    while line_start < input.len() {
+        if is_fence_at(input, line_start, marker) {
+            if let Some(body_start) = fence_line_end(input, line_start + 3) {
+                return Some(FrontmatterBlock {
+                    lang,
+                    meta: meta_start..line_start,
+                    body_start,
+                });
+            }
+        }
+        line_start += bun_core::strings::index_of(&input[line_start..], b"\n")? + 1;
+    }
+    None
+}
+
+enum MetaShape {
+    Mapping,
+    Empty,
+    Other,
+}
+
+fn classify_meta_root(root: bun_ast::Expr) -> MetaShape {
+    use bun_ast::expr::Data;
+    match root.data {
+        Data::EObject(_) => MetaShape::Mapping,
+        Data::ENull(_) | Data::EMissing(_) => MetaShape::Empty,
+        _ => MetaShape::Other,
+    }
+}
+
+enum MetaParseError {
+    Syntax,
+    StackOverflow,
+    OutOfMemory,
+}
+
+fn map_parsers_error(e: bun_parsers::Error) -> MetaParseError {
+    match e {
+        bun_parsers::Error::StackOverflow => MetaParseError::StackOverflow,
+        bun_parsers::Error::Alloc(_) => MetaParseError::OutOfMemory,
+        _ => MetaParseError::Syntax,
+    }
+}
+
+/// Parse a front-matter metadata slice with the parser `lang` selects.
+/// Allocates from `arena`; the caller holds the `ASTMemoryAllocator` scope.
+fn parse_meta(
+    arena: &bun_alloc::Arena,
+    log: &mut bun_ast::Log,
+    lang: FrontmatterLang,
+    meta: &[u8],
+) -> Result<bun_ast::Expr, MetaParseError> {
+    match lang {
+        FrontmatterLang::Yaml => {
+            let source = bun_ast::Source::init_path_string(b"input.yaml", meta);
+            YAML::parse(&source, log, arena).map_err(|e| match e {
+                YamlParseError::OutOfMemory => MetaParseError::OutOfMemory,
+                YamlParseError::StackOverflow => MetaParseError::StackOverflow,
+                YamlParseError::SyntaxError => MetaParseError::Syntax,
+            })
+        }
+        FrontmatterLang::Toml => {
+            let source = bun_ast::Source::init_path_string(b"input.toml", meta);
+            TOML::parse(&source, log, arena, false).map_err(map_parsers_error)
+        }
+    }
+}
+
+/// When `input` begins with a front-matter block whose metadata parses as a
+/// mapping (or is empty), the offset where the body starts. A missing
+/// closing fence, metadata that fails to parse, or a scalar/sequence
+/// document is not front matter — `---\nFoo\n---` stays a thematic break
+/// plus a setext heading, exactly as CommonMark reads it.
+pub(crate) fn frontmatter_body_offset(input: &[u8]) -> Option<usize> {
+    let block = detect_frontmatter(input)?;
+    // The parsers index with i32 offsets (see `with_text_format_source`).
+    if block.meta.len() > i32::MAX as usize {
+        return None;
+    }
+
+    let arena = bun_alloc::Arena::new();
+    let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+    let _ast_scope = ast_memory_allocator.enter();
+    let mut log = bun_ast::Log::init();
+
+    match parse_meta(&arena, &mut log, block.lang, &input[block.meta.clone()]) {
+        Ok(root) => match classify_meta_root(root) {
+            MetaShape::Mapping | MetaShape::Empty => Some(block.body_start),
+            MetaShape::Other => None,
+        },
+        Err(_) => None,
+    }
+}
+
+/// Strip a leading front-matter block for the renderers; the input comes
+/// back unchanged when no valid block is present.
+pub(crate) fn strip_frontmatter(input: &[u8]) -> &[u8] {
+    match frontmatter_body_offset(input) {
+        Some(body_start) => &input[body_start..],
+        None => input,
+    }
+}
+
+/// Build the `{ data, content }` result object for `frontmatter()`.
+fn frontmatter_result(
+    global_this: &JSGlobalObject,
+    data: JSValue,
+    input_value: JSValue,
+    input: &[u8],
+    body_start: usize,
+) -> JsResult<JSValue> {
+    // With nothing split off, hand back the original string instead of
+    // re-encoding the bytes.
+    let content = if body_start == 0 && input_value.is_string() {
+        input_value
+    } else {
+        create_utf8_for_js(global_this, &input[body_start..])?
+    };
+    let result = JSValue::create_empty_object(global_this, 2);
+    result.put(global_this, b"data", data);
+    result.put(global_this, b"content", content);
+    Ok(result)
+}
+
+/// `Bun.markdown.frontmatter(text)` — split a leading front-matter block
+/// from a document. Returns `{ data, content }`: `data` is the parsed
+/// metadata (`---` fences = YAML, `+++` fences = TOML; fenced JSON works
+/// through the YAML parser because JSON is valid YAML) and `content` is the
+/// text after the block. With no front-matter block, `data` is `null` and
+/// `content` is the input unchanged.
+#[bun_jsc::host_fn]
+fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    let [input_value] = callframe.arguments_as_array::<1>();
+
+    if input_value.is_empty_or_undefined_or_null() {
+        return Err(global_this
+            .throw_invalid_arguments(format_args!("Expected a string or buffer to parse")));
+    }
+    let Some(buffer) = StringOrBuffer::from_js(global_this, input_value)? else {
+        return Err(global_this
+            .throw_invalid_arguments(format_args!("Expected a string or buffer to parse")));
+    };
+    let pinned = PinnedView::pin(global_this, &buffer)?;
+    let input: &[u8] = match &pinned {
+        Some(p) => p.slice(),
+        None => buffer.slice(),
+    };
+
+    // The YAML/TOML parsers index with i32 offsets; bound the input the
+    // same way `Bun.YAML.parse` and friends do.
+    if input.len() > i32::MAX as usize {
+        return Err(global_this.throw_range_error(
+            input.len() as i64,
+            RangeErrorOptions {
+                max: i64::from(i32::MAX),
+                field_name: b"input.byteLength",
+                ..Default::default()
+            },
+        ));
+    }
+
+    let Some(block) = detect_frontmatter(input) else {
+        return frontmatter_result(global_this, JSValue::NULL, input_value, input, 0);
+    };
+
+    let arena = bun_alloc::Arena::new();
+    let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+    let _ast_scope = ast_memory_allocator.enter();
+    let mut log = bun_ast::Log::init();
+
+    let root = match parse_meta(&arena, &mut log, block.lang, &input[block.meta.clone()]) {
+        Ok(root) => root,
+        Err(MetaParseError::OutOfMemory) => return Err(JsError::OutOfMemory),
+        Err(MetaParseError::StackOverflow) => return Err(global_this.throw_stack_overflow()),
+        Err(MetaParseError::Syntax) => {
+            // The renderers treat an unparseable block as document content;
+            // here the caller explicitly asked for the metadata, so a parse
+            // failure inside the fences is a typo worth surfacing.
+            let (what, fallback) = match block.lang {
+                FrontmatterLang::Toml => ("TOML", "Unable to parse TOML"),
+                FrontmatterLang::Yaml => ("YAML", "Unable to parse YAML string"),
+            };
+            let err = if let Some(first_msg) = log.msgs.first() {
+                global_this.create_syntax_error_instance(format_args!(
+                    "{} Parse error: {}",
+                    what,
+                    bstr::BStr::new(&first_msg.data.text)
+                ))
+            } else {
+                global_this.create_syntax_error_instance(format_args!(
+                    "{} Parse error: {}",
+                    what, fallback
+                ))
+            };
+            return Err(global_this.throw_value(err));
+        }
+    };
+
+    let data = match classify_meta_root(root) {
+        MetaShape::Mapping => match block.lang {
+            FrontmatterLang::Yaml => super::yaml_object::yaml_expr_to_js(global_this, root)?,
+            FrontmatterLang::Toml => super::expr_to_js(root, global_this)?,
+        },
+        MetaShape::Empty => JSValue::create_empty_object(global_this, 0),
+        // Valid YAML that is a scalar or sequence is not front matter.
+        MetaShape::Other => {
+            return frontmatter_result(global_this, JSValue::NULL, input_value, input, 0);
+        }
+    };
+
+    frontmatter_result(global_this, data, input_value, input, block.body_start)
 }
 
 /// `Bun.markdown.render(text, callbacks, options?)` — render markdown with custom callbacks.
@@ -329,9 +646,15 @@ fn render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVal
 
     // Parse parser options from 3rd argument
     let options = parse_options(global_this, opts_value)?;
+    let input = if options.frontmatter {
+        strip_frontmatter(input)
+    } else {
+        input
+    };
 
     // Create JS callback renderer
-    let mut js_renderer = match JsCallbackRenderer::init(global_this, input, options.heading_ids) {
+    let mut js_renderer = match JsCallbackRenderer::init(global_this, input, options.md.heading_ids)
+    {
         Ok(r) => r,
         Err(_) => return Err(global_this.throw_out_of_memory()),
     };
@@ -344,7 +667,7 @@ fn render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVal
     })?;
 
     // Run parser with the JS callback renderer
-    if let Err(err) = md::render_with_renderer(input, options, js_renderer.renderer()) {
+    if let Err(err) = md::render_with_renderer(input, options.md, js_renderer.renderer()) {
         return Err(parser_err_to_js(global_this, err, input.len()));
     }
 
@@ -422,12 +745,17 @@ fn render_ast(
 
     // Parse parser options from 3rd argument
     let options = parse_options(global_this, opts_value)?;
+    let input = if options.frontmatter {
+        strip_frontmatter(input)
+    } else {
+        input
+    };
 
     let mut renderer = match ParseRenderer::init(
         global_this,
         input,
         marked_args,
-        options.heading_ids,
+        options.md.heading_ids,
         react_version,
     ) {
         Ok(r) => r,
@@ -441,7 +769,7 @@ fn render_ast(
         JSValue::UNDEFINED
     })?;
 
-    if let Err(err) = md::render_with_renderer(input, options, renderer.renderer()) {
+    if let Err(err) = md::render_with_renderer(input, options.md, renderer.renderer()) {
         return Err(parser_err_to_js(global_this, err, input.len()));
     }
 

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -252,9 +252,8 @@ fn render_to_html(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     create_utf8_for_js(global_this, &result)
 }
 
-/// `md::Options` plus the binding-level `frontmatter` flag: the `bun_md`
-/// parser has no notion of front matter, so the strip happens here before
-/// the input reaches it.
+/// `md::Options` plus the binding-level `frontmatter` flag; `bun_md`
+/// itself knows nothing about front matter.
 struct ParsedOptions {
     md: md::Options,
     frontmatter: bool,
@@ -341,8 +340,7 @@ fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<
 
 #[derive(Clone, Copy)]
 enum FrontmatterLang {
-    /// `---` fences (Jekyll, Hugo, Astro, Eleventy, VitePress, Obsidian, …).
-    /// Also covers fenced JSON, which is valid YAML.
+    /// `---` fences. Fenced JSON parses through this too (JSON is valid YAML).
     Yaml,
     /// `+++` fences (Hugo, Zola).
     Toml,
@@ -364,9 +362,8 @@ fn is_fence_at(input: &[u8], pos: usize, marker: u8) -> bool {
         && input[pos + 2] == marker
 }
 
-/// Consume the rest of a fence line starting just past the three marker
-/// bytes: optional spaces/tabs, an optional `\r`, then `\n` or EOF. Returns
-/// the offset past the terminator; None when the line carries other content
+/// Consume spaces/tabs, an optional `\r`, then `\n` or EOF after a fence's
+/// three marker bytes; None when the line carries other content
 /// (`----`, `--- text`).
 fn fence_line_end(input: &[u8], mut i: usize) -> Option<usize> {
     while i < input.len() && (input[i] == b' ' || input[i] == b'\t') {
@@ -382,9 +379,9 @@ fn fence_line_end(input: &[u8], mut i: usize) -> Option<usize> {
     }
 }
 
-/// Find a front-matter block at the very start of `input` (after an
-/// optional UTF-8 BOM — `fs.readFileSync(path, "utf8")` keeps BOMs).
-/// Purely structural; the caller decides whether the metadata parses.
+/// Find a front-matter block at the very start of `input`, allowing a
+/// UTF-8 BOM (`fs.readFileSync(path, "utf8")` keeps BOMs). Purely
+/// structural; the caller decides whether the metadata parses.
 fn detect_frontmatter(input: &[u8]) -> Option<FrontmatterBlock> {
     let start = if input.starts_with(b"\xEF\xBB\xBF") {
         3
@@ -474,11 +471,9 @@ fn parse_meta(
     }
 }
 
-/// When `input` begins with a front-matter block whose metadata parses as a
-/// mapping (or is empty), the offset where the body starts. A missing
-/// closing fence, metadata that fails to parse, or a scalar/sequence
-/// document is not front matter — `---\nFoo\n---` stays a thematic break
-/// plus a setext heading, exactly as CommonMark reads it.
+/// The body offset when `input` starts with a front-matter block whose
+/// metadata parses as a mapping or is empty; anything else (unclosed
+/// fences, parse failures, scalar/sequence documents) is not front matter.
 pub(crate) fn frontmatter_body_offset(input: &[u8]) -> Option<usize> {
     let block = detect_frontmatter(input)?;
     // The parsers index with i32 offsets (see `with_text_format_source`).
@@ -500,8 +495,7 @@ pub(crate) fn frontmatter_body_offset(input: &[u8]) -> Option<usize> {
     }
 }
 
-/// Strip a leading front-matter block for the renderers; the input comes
-/// back unchanged when no valid block is present.
+/// Strip a leading front-matter block; unchanged when none is present.
 pub(crate) fn strip_frontmatter(input: &[u8]) -> &[u8] {
     match frontmatter_body_offset(input) {
         Some(body_start) => &input[body_start..],
@@ -509,7 +503,6 @@ pub(crate) fn strip_frontmatter(input: &[u8]) -> &[u8] {
     }
 }
 
-/// Build the `{ data, content }` result object for `frontmatter()`.
 fn frontmatter_result(
     global_this: &JSGlobalObject,
     data: JSValue,
@@ -517,7 +510,7 @@ fn frontmatter_result(
     input: &[u8],
     body_start: usize,
 ) -> JsResult<JSValue> {
-    // With nothing split off, hand back the original string instead of
+    // Nothing split off: hand back the original string instead of
     // re-encoding the bytes.
     let content = if body_start == 0 && input_value.is_string() {
         input_value
@@ -531,11 +524,8 @@ fn frontmatter_result(
 }
 
 /// `Bun.markdown.frontmatter(text)` — split a leading front-matter block
-/// from a document. Returns `{ data, content }`: `data` is the parsed
-/// metadata (`---` fences = YAML, `+++` fences = TOML; fenced JSON works
-/// through the YAML parser because JSON is valid YAML) and `content` is the
-/// text after the block. With no front-matter block, `data` is `null` and
-/// `content` is the input unchanged.
+/// (`---` YAML, `+++` TOML) into `{ data, content }`. `data` is `null`
+/// when no block is present.
 #[bun_jsc::host_fn]
 fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     let [input_value] = callframe.arguments_as_array::<1>();
@@ -554,8 +544,8 @@ fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<
         None => buffer.slice(),
     };
 
-    // The YAML/TOML parsers index with i32 offsets; bound the input the
-    // same way `Bun.YAML.parse` and friends do.
+    // The YAML/TOML parsers index with i32 offsets; bound the input like
+    // `Bun.YAML.parse` does.
     if input.len() > i32::MAX as usize {
         return Err(global_this.throw_range_error(
             input.len() as i64,
@@ -581,9 +571,8 @@ fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<
         Err(MetaParseError::OutOfMemory) => return Err(JsError::OutOfMemory),
         Err(MetaParseError::StackOverflow) => return Err(global_this.throw_stack_overflow()),
         Err(MetaParseError::Syntax) => {
-            // The renderers treat an unparseable block as document content;
-            // here the caller explicitly asked for the metadata, so a parse
-            // failure inside the fences is a typo worth surfacing.
+            // The renderers treat an unparseable block as content; the
+            // extractor was asked for the metadata, so surface the typo.
             let (what, fallback) = match block.lang {
                 FrontmatterLang::Toml => ("TOML", "Unable to parse TOML"),
                 FrontmatterLang::Yaml => ("YAML", "Unable to parse YAML string"),

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -168,10 +168,10 @@ pub(crate) fn render_to_ansi(
         remote_image_paths: None,
         image_base_dir: None,
     };
-    let mut skip_frontmatter = true;
+    let mut options = md::Options::TERMINAL;
     if theme_value.is_object() {
         if let Some(v) = theme_value.get_boolean_loose(global_this, "frontmatter")? {
-            skip_frontmatter = v;
+            options.frontmatter = v;
         }
         if let Some(v) = theme_value.get_boolean_loose(global_this, "colors")? {
             theme.colors = v;
@@ -197,13 +197,7 @@ pub(crate) fn render_to_ansi(
         }
     }
 
-    let input = if skip_frontmatter {
-        strip_frontmatter(input)
-    } else {
-        input
-    };
-
-    let result = match md::render_to_ansi(input, md::Options::TERMINAL, theme) {
+    let result = match md::render_to_ansi(input, options, theme) {
         Ok(Some(r)) => r,
         Ok(None) => {
             // The parser can only return null via JSError / JSTerminated
@@ -238,13 +232,8 @@ fn render_to_html(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     };
 
     let options = parse_options(global_this, opts_value)?;
-    let input = if options.frontmatter {
-        strip_frontmatter(input)
-    } else {
-        input
-    };
 
-    let result = match md::render_to_html_with_options(input, options.md) {
+    let result = match md::render_to_html_with_options(input, options) {
         Ok(r) => r,
         Err(err) => return Err(parser_err_to_js(global_this, err, input.len())),
     };
@@ -252,20 +241,9 @@ fn render_to_html(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
     create_utf8_for_js(global_this, &result)
 }
 
-/// `md::Options` plus the binding-level `frontmatter` flag; `bun_md`
-/// itself knows nothing about front matter.
-struct ParsedOptions {
-    md: md::Options,
-    frontmatter: bool,
-}
-
-fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<ParsedOptions> {
+fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<md::Options> {
     let mut options = md::Options::default();
-    let mut frontmatter = true;
     if opts_value.is_object() {
-        if let Some(v) = opts_value.get_boolean_loose(global_this, "frontmatter")? {
-            frontmatter = v;
-        }
         // Handle compound autolinks: true | { url, www, email }
         if let Some(autolinks_val) = opts_value.get(global_this, "autolinks")? {
             if autolinks_val.is_boolean() {
@@ -328,95 +306,16 @@ fn parse_options(global_this: &JSGlobalObject, opts_value: JSValue) -> JsResult<
             }
         }
     }
-    Ok(ParsedOptions {
-        md: options,
-        frontmatter,
-    })
+    Ok(options)
 }
 
 // ========================================
 // Front matter
 // ========================================
-
-#[derive(Clone, Copy)]
-enum FrontmatterLang {
-    /// `---` fences. Fenced JSON parses through this too (JSON is valid YAML).
-    Yaml,
-    /// `+++` fences (Hugo, Zola).
-    Toml,
-}
-
-struct FrontmatterBlock {
-    lang: FrontmatterLang,
-    /// The metadata text between the fences.
-    meta: core::ops::Range<usize>,
-    /// Offset of the first byte after the block (start of the body).
-    body_start: usize,
-}
-
-/// True when a fence (exactly three `marker` bytes) starts at `pos`.
-fn is_fence_at(input: &[u8], pos: usize, marker: u8) -> bool {
-    input.len() >= pos + 3
-        && input[pos] == marker
-        && input[pos + 1] == marker
-        && input[pos + 2] == marker
-}
-
-/// Consume spaces/tabs, an optional `\r`, then `\n` or EOF after a fence's
-/// three marker bytes; None when the line carries other content
-/// (`----`, `--- text`).
-fn fence_line_end(input: &[u8], mut i: usize) -> Option<usize> {
-    while i < input.len() && (input[i] == b' ' || input[i] == b'\t') {
-        i += 1;
-    }
-    if i < input.len() && input[i] == b'\r' {
-        i += 1;
-    }
-    match input.get(i) {
-        None => Some(i),
-        Some(b'\n') => Some(i + 1),
-        Some(_) => None,
-    }
-}
-
-/// Find a front-matter block at the very start of `input`, allowing a
-/// UTF-8 BOM (`fs.readFileSync(path, "utf8")` keeps BOMs). Purely
-/// structural; the caller decides whether the metadata parses.
-fn detect_frontmatter(input: &[u8]) -> Option<FrontmatterBlock> {
-    let start = if input.starts_with(b"\xEF\xBB\xBF") {
-        3
-    } else {
-        0
-    };
-    let marker = *input.get(start)?;
-
-    let lang = match marker {
-        b'-' => FrontmatterLang::Yaml,
-        b'+' => FrontmatterLang::Toml,
-        _ => return None,
-    };
-    if !is_fence_at(input, start, marker) {
-        return None;
-    }
-    let meta_start = fence_line_end(input, start + 3)?;
-
-    // The closing fence must start a line; indented content (e.g. inside a
-    // YAML block scalar) can never sit at column 0.
-    let mut line_start = meta_start;
-    while line_start < input.len() {
-        if is_fence_at(input, line_start, marker) {
-            if let Some(body_start) = fence_line_end(input, line_start + 3) {
-                return Some(FrontmatterBlock {
-                    lang,
-                    meta: meta_start..line_start,
-                    body_start,
-                });
-            }
-        }
-        line_start += bun_core::strings::index_of(&input[line_start..], b"\n")? + 1;
-    }
-    None
-}
+//
+// Detection is structural and lives in `bun_md::frontmatter`; the renderers
+// never parse the metadata. This section is only `Bun.markdown.frontmatter`,
+// the one consumer that does.
 
 enum MetaShape {
     Mapping,
@@ -447,59 +346,27 @@ fn map_parsers_error(e: bun_parsers::Error) -> MetaParseError {
     }
 }
 
-/// Parse a front-matter metadata slice with the parser `lang` selects.
-/// Allocates from `arena`; the caller holds the `ASTMemoryAllocator` scope.
+/// Parse front-matter metadata with the parser `lang` selects. Allocates
+/// from `arena`; the caller holds the `ASTMemoryAllocator` scope.
 fn parse_meta(
     arena: &bun_alloc::Arena,
     log: &mut bun_ast::Log,
-    lang: FrontmatterLang,
-    meta: &[u8],
+    lang: md::frontmatter::Lang,
+    source_text: &[u8],
 ) -> Result<bun_ast::Expr, MetaParseError> {
     match lang {
-        FrontmatterLang::Yaml => {
-            let source = bun_ast::Source::init_path_string(b"input.yaml", meta);
+        md::frontmatter::Lang::Yaml => {
+            let source = bun_ast::Source::init_path_string(b"input.yaml", source_text);
             YAML::parse(&source, log, arena).map_err(|e| match e {
                 YamlParseError::OutOfMemory => MetaParseError::OutOfMemory,
                 YamlParseError::StackOverflow => MetaParseError::StackOverflow,
                 YamlParseError::SyntaxError => MetaParseError::Syntax,
             })
         }
-        FrontmatterLang::Toml => {
-            let source = bun_ast::Source::init_path_string(b"input.toml", meta);
+        md::frontmatter::Lang::Toml => {
+            let source = bun_ast::Source::init_path_string(b"input.toml", source_text);
             TOML::parse(&source, log, arena, false).map_err(map_parsers_error)
         }
-    }
-}
-
-/// The body offset when `input` starts with a front-matter block whose
-/// metadata parses as a mapping or is empty; anything else (unclosed
-/// fences, parse failures, scalar/sequence documents) is not front matter.
-pub(crate) fn frontmatter_body_offset(input: &[u8]) -> Option<usize> {
-    let block = detect_frontmatter(input)?;
-    // The parsers index with i32 offsets (see `with_text_format_source`).
-    if block.meta.len() > i32::MAX as usize {
-        return None;
-    }
-
-    let arena = bun_alloc::Arena::new();
-    let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
-    let _ast_scope = ast_memory_allocator.enter();
-    let mut log = bun_ast::Log::init();
-
-    match parse_meta(&arena, &mut log, block.lang, &input[block.meta.clone()]) {
-        Ok(root) => match classify_meta_root(root) {
-            MetaShape::Mapping | MetaShape::Empty => Some(block.body_start),
-            MetaShape::Other => None,
-        },
-        Err(_) => None,
-    }
-}
-
-/// Strip a leading front-matter block; unchanged when none is present.
-pub(crate) fn strip_frontmatter(input: &[u8]) -> &[u8] {
-    match frontmatter_body_offset(input) {
-        Some(body_start) => &input[body_start..],
-        None => input,
     }
 }
 
@@ -524,8 +391,9 @@ fn frontmatter_result(
 }
 
 /// `Bun.markdown.frontmatter(text)` — split a leading front-matter block
-/// (`---` YAML, `+++` TOML) into `{ data, content }`. `data` is `null`
-/// when no block is present.
+/// (`---` YAML, `+++` TOML) into `{ data, content }`. `data` is `null` when
+/// no structural block is present; metadata that fails to parse or is not a
+/// mapping throws.
 #[bun_jsc::host_fn]
 fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     let [input_value] = callframe.arguments_as_array::<1>();
@@ -557,7 +425,7 @@ fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<
         ));
     }
 
-    let Some(block) = detect_frontmatter(input) else {
+    let Some(block) = md::frontmatter::detect(input) else {
         return frontmatter_result(global_this, JSValue::NULL, input_value, input, 0);
     };
 
@@ -566,16 +434,32 @@ fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<
     let _ast_scope = ast_memory_allocator.enter();
     let mut log = bun_ast::Log::init();
 
-    let root = match parse_meta(&arena, &mut log, block.lang, &input[block.meta.clone()]) {
+    // Error positions should land in the document the user is reading, so
+    // the parsed source starts at the top of the input: the opening `---`
+    // line is a YAML document-start marker (parsed as-is, BOM included),
+    // and for TOML the BOM and fence become a comment in a private copy.
+    let mut toml_buf: Vec<u8> = Vec::new();
+    let source_text: &[u8] = match block.lang {
+        md::frontmatter::Lang::Yaml => &input[..block.meta.end],
+        md::frontmatter::Lang::Toml => {
+            toml_buf.extend_from_slice(&input[..block.meta.end]);
+            toml_buf[..block.start].fill(b' ');
+            toml_buf[block.start] = b'#';
+            toml_buf[block.start + 1..block.start + 3].fill(b' ');
+            &toml_buf
+        }
+    };
+
+    let root = match parse_meta(&arena, &mut log, block.lang, source_text) {
         Ok(root) => root,
         Err(MetaParseError::OutOfMemory) => return Err(JsError::OutOfMemory),
         Err(MetaParseError::StackOverflow) => return Err(global_this.throw_stack_overflow()),
         Err(MetaParseError::Syntax) => {
-            // The renderers treat an unparseable block as content; the
-            // extractor was asked for the metadata, so surface the typo.
+            // The renderers skip an unparseable block; the extractor was
+            // asked for the metadata, so surface the typo.
             let (what, fallback) = match block.lang {
-                FrontmatterLang::Toml => ("TOML", "Unable to parse TOML"),
-                FrontmatterLang::Yaml => ("YAML", "Unable to parse YAML string"),
+                md::frontmatter::Lang::Toml => ("TOML", "Unable to parse TOML"),
+                md::frontmatter::Lang::Yaml => ("YAML", "Unable to parse YAML string"),
             };
             let err = if let Some(first_msg) = log.msgs.first() {
                 global_this.create_syntax_error_instance(format_args!(
@@ -595,13 +479,20 @@ fn frontmatter(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<
 
     let data = match classify_meta_root(root) {
         MetaShape::Mapping => match block.lang {
-            FrontmatterLang::Yaml => super::yaml_object::yaml_expr_to_js(global_this, root)?,
-            FrontmatterLang::Toml => super::expr_to_js(root, global_this)?,
+            md::frontmatter::Lang::Yaml => super::yaml_object::yaml_expr_to_js(global_this, root)?,
+            md::frontmatter::Lang::Toml => super::expr_to_js(root, global_this)?,
         },
         MetaShape::Empty => JSValue::create_empty_object(global_this, 0),
-        // Valid YAML that is a scalar or sequence is not front matter.
+        // The fences make the author's intent unambiguous, so metadata that
+        // parses to a scalar or sequence is an error, not content — same as
+        // the missing-colon typo (`title Hello`), which is a valid scalar.
         MetaShape::Other => {
-            return frontmatter_result(global_this, JSValue::NULL, input_value, input, 0);
+            let msg = match block.lang {
+                md::frontmatter::Lang::Yaml => "YAML front matter must be a mapping",
+                md::frontmatter::Lang::Toml => "TOML front matter must be a table",
+            };
+            return Err(global_this
+                .throw_value(global_this.create_syntax_error_instance(format_args!("{msg}"))));
         }
     };
 
@@ -635,15 +526,12 @@ fn render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVal
 
     // Parse parser options from 3rd argument
     let options = parse_options(global_this, opts_value)?;
-    let input = if options.frontmatter {
-        strip_frontmatter(input)
-    } else {
-        input
-    };
+    // `render_with_renderer` leaves the strip to us: the renderer below
+    // captures `input` as its source text.
+    let input = options.strip_frontmatter(input);
 
     // Create JS callback renderer
-    let mut js_renderer = match JsCallbackRenderer::init(global_this, input, options.md.heading_ids)
-    {
+    let mut js_renderer = match JsCallbackRenderer::init(global_this, input, options.heading_ids) {
         Ok(r) => r,
         Err(_) => return Err(global_this.throw_out_of_memory()),
     };
@@ -656,7 +544,7 @@ fn render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVal
     })?;
 
     // Run parser with the JS callback renderer
-    if let Err(err) = md::render_with_renderer(input, options.md, js_renderer.renderer()) {
+    if let Err(err) = md::render_with_renderer(input, options, js_renderer.renderer()) {
         return Err(parser_err_to_js(global_this, err, input.len()));
     }
 
@@ -734,17 +622,15 @@ fn render_ast(
 
     // Parse parser options from 3rd argument
     let options = parse_options(global_this, opts_value)?;
-    let input = if options.frontmatter {
-        strip_frontmatter(input)
-    } else {
-        input
-    };
+    // `render_with_renderer` leaves the strip to us: the renderer below
+    // captures `input` as its source text.
+    let input = options.strip_frontmatter(input);
 
     let mut renderer = match ParseRenderer::init(
         global_this,
         input,
         marked_args,
-        options.md.heading_ids,
+        options.heading_ids,
         react_version,
     ) {
         Ok(r) => r,
@@ -758,7 +644,7 @@ fn render_ast(
         JSValue::UNDEFINED
     })?;
 
-    if let Err(err) = md::render_with_renderer(input, options.md, renderer.renderer()) {
+    if let Err(err) = md::render_with_renderer(input, options, renderer.renderer()) {
         return Err(parser_err_to_js(global_this, err, input.len()));
     }
 

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -1066,6 +1066,24 @@ pub(crate) fn parse(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult
     )
 }
 
+/// Convert an already-parsed YAML `Expr` to a JS value, resolving anchors
+/// and aliases the same way `parse` does. Used by `Bun.markdown.frontmatter`
+/// for `---` fenced metadata.
+pub(crate) fn yaml_expr_to_js(global: &JSGlobalObject, root: Expr) -> JsResult<JSValue> {
+    let mut ctx = ParserCtx {
+        seen_objects: HashMap::default(),
+        stack_check: StackCheck::init(),
+        global,
+        root,
+        result: JSValue::ZERO,
+    };
+    MarkedArgumentBuffer::run(&mut ctx, ParserCtx::run);
+    if ctx.result.is_empty() {
+        return Err(JsError::Thrown);
+    }
+    Ok(ctx.result)
+}
+
 struct ParserCtx<'a> {
     seen_objects: HashMap<*const c_void, JSValue>,
     stack_check: StackCheck,

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -1066,9 +1066,8 @@ pub(crate) fn parse(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult
     )
 }
 
-/// Convert an already-parsed YAML `Expr` to a JS value, resolving anchors
-/// and aliases the same way `parse` does. Used by `Bun.markdown.frontmatter`
-/// for `---` fenced metadata.
+/// Convert a parsed YAML `Expr` to a JS value, resolving anchors and
+/// aliases the same way `parse` does. Used by `Bun.markdown.frontmatter`.
 pub(crate) fn yaml_expr_to_js(global: &JSGlobalObject, root: Expr) -> JsResult<JSValue> {
     let mut ctx = ParserCtx {
         seen_objects: HashMap::default(),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3441,9 +3441,6 @@ impl RunCommand {
                 Global::exit(1);
             }
         };
-        // Skip a leading front-matter block, like the `Bun.markdown`
-        // renderers do by default.
-        let contents: &[u8] = crate::api::markdown_object::strip_frontmatter(&contents);
 
         // Theme selection: colors when stdout is a TTY (or forced on),
         // hyperlinks when colors are on. Light/dark detected from env.
@@ -3503,8 +3500,8 @@ impl RunCommand {
         // actually contains an image marker — otherwise the whole block
         // is a no-op.
         let mut remote_map: StringHashMap<Box<[u8]>> = StringHashMap::default();
-        if kitty_graphics && strings::contains(contents, b"![") {
-            Self::prefetch_remote_images(contents, md_opts, &mut remote_map);
+        if kitty_graphics && strings::contains(&contents, b"![") {
+            Self::prefetch_remote_images(&contents, md_opts, &mut remote_map);
         }
 
         // Relative image paths in the markdown should resolve against
@@ -3548,7 +3545,7 @@ impl RunCommand {
             image_base_dir: Some(image_base_dir),
         };
 
-        let rendered = match md::render_to_ansi(contents, md_opts, theme) {
+        let rendered = match md::render_to_ansi(&contents, md_opts, theme) {
             Err(bun_md::parser::ParserError::OutOfMemory) => bun_core::out_of_memory(),
             Err(bun_md::parser::ParserError::StackOverflow) => {
                 pretty_errorln!(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3493,15 +3493,21 @@ impl RunCommand {
         let is_tty = Output::is_stdout_tty();
         let kitty_graphics = colors && is_tty && md::detect_kitty_graphics();
 
-        let md_opts: md::Options = md::Options::TERMINAL;
+        let mut md_opts: md::Options = md::Options::TERMINAL;
+
+        // Strip the front matter once so the image prefetch pre-scan and
+        // the renderer see the same document; with the flag left on,
+        // render_to_ansi would strip a second block from the body.
+        let contents: &[u8] = md_opts.strip_frontmatter(&contents);
+        md_opts.frontmatter = false;
 
         // Pre-scan for http(s) image URLs so Kitty can display them
         // inline. Only runs when kitty_graphics is on and the document
         // actually contains an image marker — otherwise the whole block
         // is a no-op.
         let mut remote_map: StringHashMap<Box<[u8]>> = StringHashMap::default();
-        if kitty_graphics && strings::contains(&contents, b"![") {
-            Self::prefetch_remote_images(&contents, md_opts, &mut remote_map);
+        if kitty_graphics && strings::contains(contents, b"![") {
+            Self::prefetch_remote_images(contents, md_opts, &mut remote_map);
         }
 
         // Relative image paths in the markdown should resolve against
@@ -3545,7 +3551,7 @@ impl RunCommand {
             image_base_dir: Some(image_base_dir),
         };
 
-        let rendered = match md::render_to_ansi(&contents, md_opts, theme) {
+        let rendered = match md::render_to_ansi(contents, md_opts, theme) {
             Err(bun_md::parser::ParserError::OutOfMemory) => bun_core::out_of_memory(),
             Err(bun_md::parser::ParserError::StackOverflow) => {
                 pretty_errorln!(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3441,8 +3441,8 @@ impl RunCommand {
                 Global::exit(1);
             }
         };
-        // Front matter is metadata, not document content — skip it the
-        // same way the `Bun.markdown` renderers do by default.
+        // Skip a leading front-matter block, like the `Bun.markdown`
+        // renderers do by default.
         let contents: &[u8] = crate::api::markdown_object::strip_frontmatter(&contents);
 
         // Theme selection: colors when stdout is a TTY (or forced on),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3441,6 +3441,9 @@ impl RunCommand {
                 Global::exit(1);
             }
         };
+        // Front matter is metadata, not document content — skip it the
+        // same way the `Bun.markdown` renderers do by default.
+        let contents: &[u8] = crate::api::markdown_object::strip_frontmatter(&contents);
 
         // Theme selection: colors when stdout is a TTY (or forced on),
         // hyperlinks when colors are on. Light/dark detected from env.
@@ -3500,8 +3503,8 @@ impl RunCommand {
         // actually contains an image marker — otherwise the whole block
         // is a no-op.
         let mut remote_map: StringHashMap<Box<[u8]>> = StringHashMap::default();
-        if kitty_graphics && strings::contains(&contents, b"![") {
-            Self::prefetch_remote_images(&contents, md_opts, &mut remote_map);
+        if kitty_graphics && strings::contains(contents, b"![") {
+            Self::prefetch_remote_images(contents, md_opts, &mut remote_map);
         }
 
         // Relative image paths in the markdown should resolve against
@@ -3545,7 +3548,7 @@ impl RunCommand {
             image_base_dir: Some(image_base_dir),
         };
 
-        let rendered = match md::render_to_ansi(&contents, md_opts, theme) {
+        let rendered = match md::render_to_ansi(contents, md_opts, theme) {
             Err(bun_md::parser::ParserError::OutOfMemory) => bun_core::out_of_memory(),
             Err(bun_md::parser::ParserError::StackOverflow) => {
                 pretty_errorln!(

--- a/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
+++ b/test/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap
@@ -215,3 +215,11 @@ exports[`bun <file.md> shrinks table columns to fit COLUMNS and wraps cell conte
 \x1B[2m└───────────────────────┴────────────────────────┘\x1B[0m
 "
 `;
+
+exports[`bun <file.md> skips a leading front-matter block 1`] = `
+"\x1B[1m\x1B[35mHeading\x1B[0m
+\x1B[2m═══════\x1B[0m
+
+body\x1B[0m
+"
+`;

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -69,6 +69,13 @@ describe("bun <file.md>", () => {
     expect(await runMd(["above", "", "---", "", "below", ""].join("\n"))).toMatchSnapshot();
   });
 
+  test("skips a leading front-matter block", async () => {
+    const out = await runMd(["---", "title: Hello", "draft: true", "---", "", "# Heading", "", "body", ""].join("\n"));
+    expect(out).not.toContain("title");
+    expect(out).toContain("Heading");
+    expect(out).toContain("body");
+  });
+
   test("renders fenced code block with JS syntax highlighting", async () => {
     expect(
       await runMd(["```js", 'const name = "world";', "console.log(`hello ${name}`);", "```", ""].join("\n")),

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -72,8 +72,7 @@ describe("bun <file.md>", () => {
   test("skips a leading front-matter block", async () => {
     const out = await runMd(["---", "title: Hello", "draft: true", "---", "", "# Heading", "", "body", ""].join("\n"));
     expect(out).not.toContain("title");
-    expect(out).toContain("Heading");
-    expect(out).toContain("body");
+    expect(out).toMatchSnapshot();
   });
 
   test("renders fenced code block with JS syntax highlighting", async () => {

--- a/test/js/bun/md/md-frontmatter.test.ts
+++ b/test/js/bun/md/md-frontmatter.test.ts
@@ -127,8 +127,9 @@ describe("Bun.markdown.frontmatter", () => {
   });
 
   test("missing and nullish input throws", () => {
-    expect(() => (frontmatter as any)()).toThrow();
-    expect(() => (frontmatter as any)(null)).toThrow();
+    expect(() => (frontmatter as any)()).toThrow("Expected a string or buffer to parse");
+    expect(() => (frontmatter as any)(undefined)).toThrow("Expected a string or buffer to parse");
+    expect(() => (frontmatter as any)(null)).toThrow("Expected a string or buffer to parse");
   });
 });
 
@@ -171,11 +172,21 @@ describe("renderers skip front matter by default", () => {
   });
 
   test("ansi", () => {
-    const out = ansi(doc, { colors: false });
-    expect(out).not.toContain("title");
-    expect(out).toContain("Heading");
-    const off = ansi(doc, { colors: false, frontmatter: false });
-    expect(off).toContain("title");
+    expect(ansi(doc, { colors: false })).toMatchInlineSnapshot(`
+      "Heading
+      =======
+      "
+    `);
+    expect(ansi(doc, { colors: false, frontmatter: false })).toMatchInlineSnapshot(`
+      "------------------------------------------------------------
+
+      title: Hello
+      ------------
+
+      Heading
+      =======
+      "
+    `);
   });
 
   test("render", () => {
@@ -186,9 +197,8 @@ describe("renderers skip front matter by default", () => {
 
   test("react", () => {
     const el = react(doc) as any;
-    expect(el.props.children).toHaveLength(1);
-    expect(el.props.children[0].type).toBe("h1");
+    expect(el.props.children.map((c: any) => c.type)).toEqual(["h1"]);
     const off = react(doc, undefined, { frontmatter: false }) as any;
-    expect(off.props.children[0].type).toBe("hr");
+    expect(off.props.children.map((c: any) => c.type)).toEqual(["hr", "h2", "h1"]);
   });
 });

--- a/test/js/bun/md/md-frontmatter.test.ts
+++ b/test/js/bun/md/md-frontmatter.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+
+const { frontmatter, html, ansi, render, react } = Bun.markdown;
+
+describe("Bun.markdown.frontmatter", () => {
+  test("yaml fences", () => {
+    expect(frontmatter("---\ntitle: Hello\ntags:\n  - a\n  - b\n---\n# Heading\n")).toEqual({
+      data: { title: "Hello", tags: ["a", "b"] },
+      content: "# Heading\n",
+    });
+  });
+
+  test("toml fences", () => {
+    expect(frontmatter('+++\ntitle = "Hello"\nweight = 3\n+++\nbody\n')).toEqual({
+      data: { title: "Hello", weight: 3 },
+      content: "body\n",
+    });
+  });
+
+  test("fenced json parses through the yaml parser", () => {
+    expect(frontmatter('---\n{"title": "Hello"}\n---\nbody')).toEqual({
+      data: { title: "Hello" },
+      content: "body",
+    });
+  });
+
+  test("fenced json matches JSON.parse semantics", () => {
+    // JSON is valid YAML: no-space colons, duplicate keys (last wins),
+    // escapes, and nesting must come out exactly as JSON.parse reads them.
+    const json = '{"k":1,"a":{"b":[1,2,3],"c":"x y"},"s":"\\u00e9}","n":1e3,"t":true,"z":null,"k":2}';
+    expect(frontmatter(`---\n${json}\n---\nbody`).data).toEqual(JSON.parse(json));
+  });
+
+  test("empty block is {} (distinct from no block)", () => {
+    expect(frontmatter("---\n---\nbody")).toEqual({ data: {}, content: "body" });
+    expect(frontmatter("---\n# just a comment\n---\nbody")).toEqual({ data: {}, content: "body" });
+    expect(frontmatter("+++\n+++\nbody")).toEqual({ data: {}, content: "body" });
+  });
+
+  test("no block is null", () => {
+    expect(frontmatter("# Heading\n")).toEqual({ data: null, content: "# Heading\n" });
+    expect(frontmatter("")).toEqual({ data: null, content: "" });
+  });
+
+  test("block must start at offset 0", () => {
+    const blank = "\n---\ntitle: x\n---\n";
+    expect(frontmatter(blank)).toEqual({ data: null, content: blank });
+    const indented = " ---\ntitle: x\n---\n";
+    expect(frontmatter(indented)).toEqual({ data: null, content: indented });
+  });
+
+  test("unclosed fences are not front matter", () => {
+    const yaml = "---\ntitle: x\n";
+    expect(frontmatter(yaml)).toEqual({ data: null, content: yaml });
+    const mismatched = "+++\ntitle = 'x'\n---\nbody";
+    expect(frontmatter(mismatched)).toEqual({ data: null, content: mismatched });
+  });
+
+  test("scalar and sequence yaml are not front matter", () => {
+    const scalar = "---\nFoo\n---\nBar\n";
+    expect(frontmatter(scalar)).toEqual({ data: null, content: scalar });
+    const seq = "---\n- a\n- b\n---\nbody";
+    expect(frontmatter(seq)).toEqual({ data: null, content: seq });
+  });
+
+  test("four markers are a thematic break, not a fence", () => {
+    const doc = "----\ntitle: x\n----\n";
+    expect(frontmatter(doc)).toEqual({ data: null, content: doc });
+  });
+
+  test("closing fence may end at EOF and carry trailing whitespace", () => {
+    expect(frontmatter("---\ntitle: x\n---")).toEqual({ data: { title: "x" }, content: "" });
+    expect(frontmatter("---  \ntitle: x\n---\t\nbody")).toEqual({ data: { title: "x" }, content: "body" });
+  });
+
+  test("crlf line endings", () => {
+    expect(frontmatter("---\r\ntitle: x\r\n---\r\nbody\r\n")).toEqual({
+      data: { title: "x" },
+      content: "body\r\n",
+    });
+  });
+
+  test("utf-8 bom before the opening fence", () => {
+    expect(frontmatter("\uFEFF---\ntitle: x\n---\nbody")).toEqual({
+      data: { title: "x" },
+      content: "body",
+    });
+  });
+
+  test("a fence inside a block scalar does not close the block", () => {
+    const doc = "---\ndescription: |\n  text\n  ---\n  more\ntitle: x\n---\nbody";
+    expect(frontmatter(doc)).toEqual({
+      data: { description: "text\n---\nmore\n", title: "x" },
+      content: "body",
+    });
+  });
+
+  test("yaml anchors and aliases resolve", () => {
+    expect(frontmatter("---\nbase: &b\n  x: 1\nref: *b\n---\n").data).toEqual({
+      base: { x: 1 },
+      ref: { x: 1 },
+    });
+  });
+
+  test("invalid yaml in fences throws SyntaxError", () => {
+    expect(() => frontmatter("---\ntitle: [broken\n---\nbody")).toThrow(SyntaxError);
+  });
+
+  test("invalid toml in fences throws SyntaxError", () => {
+    expect(() => frontmatter("+++\n= broken\n+++\nbody")).toThrow(SyntaxError);
+  });
+
+  test("bare `{…}` objects are not front matter", () => {
+    // Only explicit `---`/`+++` fences mark front matter; a document that
+    // opens with a JSON snippet or template braces keeps its first block.
+    const json = '{"title": "Hello"}\nbody';
+    expect(frontmatter(json)).toEqual({ data: null, content: json });
+    const tpl = "{{ template }}\nbody";
+    expect(frontmatter(tpl)).toEqual({ data: null, content: tpl });
+  });
+
+  test("buffer input", () => {
+    expect(frontmatter(Buffer.from("---\ntitle: x\n---\nhi"))).toEqual({
+      data: { title: "x" },
+      content: "hi",
+    });
+  });
+
+  test("missing and nullish input throws", () => {
+    expect(() => (frontmatter as any)()).toThrow();
+    expect(() => (frontmatter as any)(null)).toThrow();
+  });
+});
+
+describe("renderers skip front matter by default", () => {
+  const doc = "---\ntitle: Hello\n---\n# Heading\n";
+
+  test("html", () => {
+    expect(html(doc)).toBe("<h1>Heading</h1>\n");
+  });
+
+  test("html with frontmatter: false", () => {
+    expect(html(doc, { frontmatter: false })).toBe("<hr />\n<h2>title: Hello</h2>\n<h1>Heading</h1>\n");
+  });
+
+  test("toml fences", () => {
+    expect(html('+++\ntitle = "Hello"\n+++\n# Heading\n')).toBe("<h1>Heading</h1>\n");
+  });
+
+  test("bare `{…}` objects render as content", () => {
+    expect(html('{"title": "Hello"}\n# Heading\n')).toBe(
+      "<p>{&quot;title&quot;: &quot;Hello&quot;}</p>\n<h1>Heading</h1>\n",
+    );
+  });
+
+  test("metadata that does not parse renders as markdown", () => {
+    expect(html("---\ntitle: [broken\n---\nbody\n")).toBe("<hr />\n<h2>title: [broken</h2>\n<p>body</p>\n");
+  });
+
+  test("scalar yaml keeps the CommonMark reading (hr + setext headings)", () => {
+    expect(html("---\nFoo\n---\nBar\n---\nBaz")).toBe("<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n");
+  });
+
+  test("empty block is skipped; frontmatter: false restores two thematic breaks", () => {
+    expect(html("---\n---\n")).toBe("");
+    expect(html("---\n---\n", { frontmatter: false })).toBe("<hr />\n<hr />\n");
+  });
+
+  test("document that is only front matter renders to nothing", () => {
+    expect(html("---\ntitle: Hello\n---")).toBe("");
+  });
+
+  test("ansi", () => {
+    const out = ansi(doc, { colors: false });
+    expect(out).not.toContain("title");
+    expect(out).toContain("Heading");
+    const off = ansi(doc, { colors: false, frontmatter: false });
+    expect(off).toContain("title");
+  });
+
+  test("render", () => {
+    const cb = { heading: (c: string, m: { level: number }) => `[h${m.level}:${c}]` };
+    expect(render(doc, cb)).toBe("[h1:Heading]");
+    expect(render(doc, cb, { frontmatter: false })).toBe("[h2:title: Hello][h1:Heading]");
+  });
+
+  test("react", () => {
+    const el = react(doc) as any;
+    expect(el.props.children).toHaveLength(1);
+    expect(el.props.children[0].type).toBe("h1");
+    const off = react(doc, undefined, { frontmatter: false }) as any;
+    expect(off.props.children[0].type).toBe("hr");
+  });
+});

--- a/test/js/bun/md/md-frontmatter.test.ts
+++ b/test/js/bun/md/md-frontmatter.test.ts
@@ -57,6 +57,7 @@ describe("Bun.markdown.frontmatter", () => {
   });
 
   test("scalar and sequence metadata throws (must be a mapping)", () => {
+    expect(() => frontmatter("---\nFoo\n---\nBar\n")).toThrow(SyntaxError);
     expect(() => frontmatter("---\nFoo\n---\nBar\n")).toThrow("YAML front matter must be a mapping");
     expect(() => frontmatter("---\n- a\n- b\n---\nbody")).toThrow("YAML front matter must be a mapping");
     // The likelier typo: a missing colon parses as a valid YAML scalar.

--- a/test/js/bun/md/md-frontmatter.test.ts
+++ b/test/js/bun/md/md-frontmatter.test.ts
@@ -56,11 +56,21 @@ describe("Bun.markdown.frontmatter", () => {
     expect(frontmatter(mismatched)).toEqual({ data: null, content: mismatched });
   });
 
-  test("scalar and sequence yaml are not front matter", () => {
-    const scalar = "---\nFoo\n---\nBar\n";
-    expect(frontmatter(scalar)).toEqual({ data: null, content: scalar });
-    const seq = "---\n- a\n- b\n---\nbody";
-    expect(frontmatter(seq)).toEqual({ data: null, content: seq });
+  test("scalar and sequence metadata throws (must be a mapping)", () => {
+    expect(() => frontmatter("---\nFoo\n---\nBar\n")).toThrow("YAML front matter must be a mapping");
+    expect(() => frontmatter("---\n- a\n- b\n---\nbody")).toThrow("YAML front matter must be a mapping");
+    // The likelier typo: a missing colon parses as a valid YAML scalar.
+    expect(() => frontmatter("---\ntitle Hello\n---\nbody")).toThrow("YAML front matter must be a mapping");
+  });
+
+  test("a blank first inner line is not front matter", () => {
+    const doc = "---\n\ntitle: x\n---\nbody";
+    expect(frontmatter(doc)).toEqual({ data: null, content: doc });
+  });
+
+  test("yaml's `...` document-end marker does not close the block", () => {
+    const doc = "---\ntitle: x\n...\nbody";
+    expect(frontmatter(doc)).toEqual({ data: null, content: doc });
   });
 
   test("four markers are a thematic break, not a fence", () => {
@@ -154,12 +164,22 @@ describe("renderers skip front matter by default", () => {
     );
   });
 
-  test("metadata that does not parse renders as markdown", () => {
-    expect(html("---\ntitle: [broken\n---\nbody\n")).toBe("<hr />\n<h2>title: [broken</h2>\n<p>body</p>\n");
+  test("unparseable metadata is still skipped (detection is structural)", () => {
+    expect(html("---\ntitle: [broken\n---\nbody\n")).toBe("<p>body</p>\n");
+    expect(html("---\ntitle: [broken\n---\nbody\n", { frontmatter: false })).toBe(
+      "<hr />\n<h2>title: [broken</h2>\n<p>body</p>\n",
+    );
   });
 
-  test("scalar yaml keeps the CommonMark reading (hr + setext headings)", () => {
-    expect(html("---\nFoo\n---\nBar\n---\nBaz")).toBe("<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n");
+  test("a scalar block is skipped; frontmatter: false restores the spec reading", () => {
+    expect(html("---\nFoo\n---\nBar\n---\nBaz")).toBe("<h2>Bar</h2>\n<p>Baz</p>\n");
+    expect(html("---\nFoo\n---\nBar\n---\nBaz", { frontmatter: false })).toBe(
+      "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    );
+  });
+
+  test("a blank first inner line renders as markdown", () => {
+    expect(html("---\n\nFoo\n---\n")).toBe("<hr />\n<h2>Foo</h2>\n");
   });
 
   test("empty block is skipped; frontmatter: false restores two thematic breaks", () => {

--- a/test/js/bun/md/md-frontmatter.test.ts
+++ b/test/js/bun/md/md-frontmatter.test.ts
@@ -237,7 +237,7 @@ describe("renderers skip front matter by default", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout).toBe('"<h1>Heading</h1>\\n"\n');
+    expect(JSON.parse(stdout)).toBe("<h1>Heading</h1>\n");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/md/md-frontmatter.test.ts
+++ b/test/js/bun/md/md-frontmatter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 const { frontmatter, html, ansi, render, react } = Bun.markdown;
 
@@ -221,5 +222,22 @@ describe("renderers skip front matter by default", () => {
     expect(el.props.children.map((c: any) => c.type)).toEqual(["h1"]);
     const off = react(doc, undefined, { frontmatter: false }) as any;
     expect(off.props.children.map((c: any) => c.type)).toEqual(["hr", "h2", "h1"]);
+  });
+
+  test("the .md import loader skips front matter", async () => {
+    using dir = tempDir("md-loader-fm-", {
+      "post.md": "---\ntitle: Hello\n---\n# Heading\n",
+      "main.ts": `import html from "./post.md";\nconsole.log(JSON.stringify(html));`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('"<h1>Heading</h1>\\n"\n');
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/md/md-spec.test.ts
+++ b/test/js/bun/md/md-spec.test.ts
@@ -258,9 +258,14 @@ for (const { name, file } of specFiles) {
   describe(name, () => {
     for (let i = 0; i < examples.length; i++) {
       const ex = examples[i];
+      // The one intentional deviation from the spec: with the default
+      // `frontmatter: true`, `---\n---` at the very start of a document is
+      // an empty front-matter block (rendering to nothing), not two
+      // thematic breaks. md-frontmatter.test.ts covers both readings.
+      const expected = ex.markdown === "---\n---" ? "" : ex.expected;
       test(`example ${i + 1} (line ${ex.line}): ${ex.section}`, () => {
         const actual = renderMarkdown(ex.markdown, ex.flags.length > 0 ? ex.flags : undefined);
-        expect(normalizeHtml(actual)).toBe(normalizeHtml(ex.expected));
+        expect(normalizeHtml(actual)).toBe(normalizeHtml(expected));
       });
     }
   });

--- a/test/js/bun/md/md-spec.test.ts
+++ b/test/js/bun/md/md-spec.test.ts
@@ -234,6 +234,13 @@ function normalizeHtml(html: string): string {
   return output.trim();
 }
 
+const FRONTMATTER_DEVIATIONS = new Map([
+  // An empty front-matter block, not two thematic breaks.
+  ["---\n---", ""],
+  // The first `---\nFoo\n---` is front matter, not hr + setext heading.
+  ["---\nFoo\n---\nBar\n---\nBaz", "<h2>Bar</h2>\n<p>Baz</p>\n"],
+]);
+
 const specFiles = [
   { name: "CommonMark", file: "spec.txt" },
   { name: "GFM Tables", file: "spec-tables.txt" },
@@ -258,11 +265,11 @@ for (const { name, file } of specFiles) {
   describe(name, () => {
     for (let i = 0; i < examples.length; i++) {
       const ex = examples[i];
-      // The one intentional deviation from the spec: with the default
-      // `frontmatter: true`, `---\n---` at the very start of a document is
-      // an empty front-matter block (rendering to nothing), not two
-      // thematic breaks. md-frontmatter.test.ts covers both readings.
-      const expected = ex.markdown === "---\n---" ? "" : ex.expected;
+      // The intentional deviations from the spec: with the default
+      // `frontmatter: true`, a structurally valid front-matter block at the
+      // very start of a document is skipped. Exactly two examples are
+      // affected; both readings are pinned in md-frontmatter.test.ts.
+      const expected = FRONTMATTER_DEVIATIONS.get(ex.markdown) ?? ex.expected;
       test(`example ${i + 1} (line ${ex.line}): ${ex.section}`, () => {
         const actual = renderMarkdown(ex.markdown, ex.flags.length > 0 ? ex.flags : undefined);
         expect(normalizeHtml(actual)).toBe(normalizeHtml(expected));


### PR DESCRIPTION
Closes #26605

`Bun.markdown.html()` on a document that starts with front matter rendered the metadata as CommonMark:

```ts
Bun.markdown.html('---\ntitle: "Hello World"\nauthor: "Bun"\n---\n\n# Heading\n');
// "<hr />\n<h2>title: &quot;Hello World&quot;\nauthor: &quot;Bun&quot;</h2>\n<h1>Heading</h1>\n"
```

That is the correct CommonMark reading (thematic break plus setext heading), but nobody writing front matter means that.

### What this adds

**All renderers skip front matter by default.** `html()`, `render()`, `react()`, `ansi()`, the `bun file.md` terminal renderer, and the bundler's Markdown loader recognize a front-matter block at the very start of the input and skip it. `frontmatter: false` (in the options object, or the theme object for `ansi()`) restores the plain CommonMark reading.

**Detection is purely structural**, the same rule pulldown-cmark, comrak, goldmark and markdown-it use, and it lives in the `bun_md` engine behind a single `Options.frontmatter` flag. A block counts as front matter when:

- a `---` (YAML) or `+++` (TOML) fence sits at offset 0 (an optional UTF-8 BOM is allowed, since `fs.readFileSync` keeps BOMs),
- the first inner line is non-blank (a blank one reads as "thematic break, then prose"), and
- a matching closing fence (exactly three markers, so `----` stays a thematic break) starts a later line. YAML's `...` document-end marker is not accepted as a closer; that choice is pinned in a test and documented.

The metadata is never parsed at render time: no YAML/TOML parser, no arena, no per-render cost beyond the fence scan. Renderers never throw because of a front-matter block.

Two CommonMark spec examples flip under the default: `---\n---` (empty block instead of two thematic breaks) and `---\nFoo\n---\nBar\n---\nBaz` (front matter instead of hr + setext heading). The spec runner asserts both new expectations explicitly, and the docs call them out. Every other spec example passes unchanged with the default on.

Bare `{...}` JSON front matter (old-style Hugo) is intentionally not recognized: it is the one form with real false-positive exposure under a default-on skip, gray-matter does not support it either, and fenced JSON already works because JSON is valid YAML. A test pins that fenced JSON (duplicate keys, no-space colons, escapes) matches `JSON.parse` exactly.

**`Bun.markdown.frontmatter(input)` returns `{ data, content }`** (gray-matter's field names, for easy migration from Astro/Eleventy/VitePress setups), and is the one place the metadata gets parsed:

- `data` is the parsed metadata object, `{}` for an empty block, and `null` only when the input has no structural block; `content` is the text after the block.
- Metadata that fails to parse throws a `SyntaxError`, and so does metadata that parses to a scalar or sequence ("YAML front matter must be a mapping"). That keeps the two shapes of the same typo consistent: `title: [x` (unclosed bracket) and `title Hello` (missing colon, a valid YAML scalar) both fail loudly instead of one throwing and the other silently returning `data: null`.
- Error positions land in document coordinates: the parsed YAML source includes the opening fence line, which is a YAML document-start marker, and the TOML path parses a private copy with the fence turned into a comment. Line numbers match the file the user is reading.
- Reuses the existing YAML/TOML parsers, including YAML anchor/alias resolution. No new dependencies.

### Implementation

Structural detection is `src/md/frontmatter.rs` (~100 lines, no new deps for `bun_md`). `render_to_html_with_options` and `render_to_ansi` strip internally; `render_with_renderer` documents that callers strip via `Options::strip_frontmatter` before building a renderer, because the renderer captures the source text that block offsets index into (the `render()`/`react()` bindings do exactly that). `YAMLObject.rs` gains a small helper to convert an already-parsed YAML `Expr` to a JS value with the same anchor/alias handling as `Bun.YAML.parse`.

### Verification

- `test/js/bun/md/md-frontmatter.test.ts`: 34 tests covering the extractor (fences, empty vs absent, offset-0 rule, blank first line, unclosed/mismatched fences, the `...` closer decision, mapping-required throws including the missing-colon case, CRLF, BOM, fences inside block scalars, anchors, buffer input) and all four renderers plus opt-out, with exact outputs for both flag states.
- The full `test/js/bun/md/` suite (CommonMark and GFM spec files, 1099 tests) passes, with the two deviations asserted explicitly.
- `test/cli/run/markdown-entrypoint.test.ts` covers `bun file.md` skipping front matter.
- `bun test test/integration/bun-types/bun-types.test.ts` passes for the type additions.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 13 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 35 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/markdown-entrypoint.test.ts test/js/bun/md/md-frontmatter.test.ts test/js/bun/md/md-spec.test.ts
bun test v1.4.0 (1ff6e21fc)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [159.92ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [119.46ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [118.96ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [118.03ms]
(pass) bun <file.md> > renders horizontal rules [117.77ms]
69 |     expect(await runMd(["above", "", "---", "", "below", ""].join("\n"))).toMatchSnapshot();
70 |   });
71 | 
72 |   test("skips a leading front-matter block", async () => {
73 |     const out = await runMd(["---", "title: Hello", "draft: true", "---", "", "# Heading", "", "body", ""].join("\n"));
74 |     expect(out).not.toContain("title");
                         ^
error: expect(received).not.toContain(expected)

Expected to not contain: "title"
Received: "\u001b[2m─────────
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (d270c9761)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [3.62ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [2.12ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [1.77ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [1.83ms]
(pass) bun <file.md> > renders horizontal rules [1.66ms]
(pass) bun <file.md> > skips a leading front-matter block [1.70ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [1.67ms]
(pass) bun <file.md> > renders fenced code block without language [2.04ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [1.70ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [17.65ms]
(pass) bun <file.md> > renders link with text + url pair fallback [1.75ms]
(pass) bun <file.md> > renders images as alt text with link [1.58ms]
(pass) bun <file.md> > renders wikilinks [2.52ms]
(pass) bun <file.md> > falls back to literal text when `[[` never closes [2.19ms]
(pass) bun <file.md> > renders simple table with alignment [1.70ms]
(pass) bu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/markdown-entrypoint.test.ts test/js/bun/md/md-frontmatter.test.ts test/js/bun/md/md-spec.test.ts
bun test v1.4.0 (1ff6e21fc)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [160.32ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [112.18ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [115.96ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [108.56ms]
(pass) bun <file.md> > renders horizontal rules [110.67ms]
(pass) bun <file.md> > skips a leading front-matter block [109.35ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [110.01ms]
(pass) bun <file.md> > renders fenced code block without language [117.82ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [125.28ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [1090.07ms]
(pass) bun <file.md> > renders link with text + url pair fallback [116.70ms]
(pass) bun <file.md> >
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 735ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/27] cc obj/packages/bun-usockets/src/bsd.c.o
[2/27] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[3/27] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[4/27] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[5/27] cc obj/packages/bun-usockets/src/fault_inject.c.o
[6/27] cc obj/packages/bun-usockets/src/context.c.o
[7/27] cc obj/packages/bun-usockets/src/loop.c.o
[8/27] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[9/27] cc obj/packages/bun-usockets/src/udp.c.o
[10/27] cc obj/packages/bun-usockets/src/quic.c.o
[11/27] cc obj/packages/bun-usockets/src/socket.c.o
[12/27] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[13/27] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[14/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[15/27] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[16/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[17/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[18/27] cxx obj/unified/UnifiedSource-src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/markdown.mdx                          |  89 ++++++--
 packages/bun-types/bun.d.ts                        |  54 +++++
 src/md/ansi_renderer.rs                            |   3 +
 src/md/frontmatter.rs                              | 110 ++++++++++
 src/md/lib.rs                                      |   1 +
 src/md/root.rs                                     |  24 ++
 src/runtime/api/MarkdownObject.rs                  | 207 +++++++++++++++++-
 src/runtime/api/YAMLObject.rs                      |  17 ++
 src/runtime/cli/run_command.rs                     |  14 +-
 .../__snapshots__/markdown-entrypoint.test.ts.snap |   8 +
 test/cli/run/markdown-entrypoint.test.ts           |   6 +
 test/js/bun/md/md-frontmatter.test.ts              | 243 +++++++++++++++++++++
 test/js/bun/md/md-spec.test.ts                     |  14 +-
 13 files changed, 765 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/runtime/markdown.mdx                                     2      4      0
packages/bun-types/bun.d.ts                                   3      7      0
src/md/ansi_renderer.rs                                       1      2      0
src/md/frontmatter.rs                                         0      1      0
src/md/lib.rs                                                 1      1      0
src/md/root.rs                                                1      1      0
src/runtime/api/MarkdownObject.rs                             5     18      0
src/runtime/api/YAMLObject.rs                                 4      3      0
src/runtime/cli/run_command.rs                                3      7      0
…/cli/run/__snapshots__/markdown-entrypoint.test.ts.snap      0      0      0
test/cli/run/markdown-entrypoint.test.ts                      1      2      0
test/js/bun/md/md-frontmatter.test.ts                         5     13      0
test/js/bun/md/md-spec.test.ts                                1      4      0
```

</details>

<!-- robobun:evidence:end -->