### PR TITLE
node:fs: reject cp() with the real error when the dest parent stat fails

### DIFF
--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -30,7 +30,7 @@ const {
 const { dirname, isAbsolute, join, parse, resolve } = require("node:path");
 
 const PromisePrototypeThen = $Promise.prototype.$then;
-const PromiseReject = Promise.$reject;
+const PromiseReject = Promise.$reject.bind(Promise);
 
 async function checkPaths(src, dest, opts) {
   if (opts.filter && !(await opts.filter(src, dest))) {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -655,6 +655,60 @@ test.skipIf(!isPosix)(
   },
 );
 
+// internal/fs/cp is lazily loaded by the first cp() call and captures
+// fs.promises.stat at that moment, so the subprocess patches it up front to
+// make the options-less stat(destParent) call in pathExists() fail with EIO.
+// cp must reject with that error; an unbound Promise.$reject capture used to
+// turn it into "TypeError: |this| is not an object" with no code/syscall.
+// (The pre-existing dest directory keeps macOS off the clonefile fast path,
+// and checkParentPaths' stat(destParent, { bigint: true }) passes through.)
+test("cp surfaces non-ENOENT stat errors from the dest parent existence check", async () => {
+  using dir = tempDir("cp-parent-stat-error", {
+    "src/a.txt": "hi",
+    "p/out/.keep": "",
+  });
+  const script = `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const fsp = fs.promises;
+    const realStat = fsp.stat;
+    fsp.stat = function (p, opts) {
+      if (opts === undefined && path.basename(String(p)) === "p") {
+        const err = new Error("EIO: i/o error, stat '" + p + "'");
+        err.code = "EIO";
+        err.errno = -5;
+        err.syscall = "stat";
+        err.path = String(p);
+        return Promise.reject(err);
+      }
+      return realStat(p, opts);
+    };
+    const report = (face, e) => console.log(face + ": " + (e ? e.name + " " + e.code + " " + e.syscall : "no error"));
+    const src = path.resolve("src");
+    const dest = path.resolve("p", "out");
+    fsp
+      .cp(src, dest, { recursive: true })
+      .then(
+        () => report("promises", null),
+        e => report("promises", e),
+      )
+      .then(() => {
+        fs.cp(src, dest, { recursive: true }, e => report("callback", e));
+      });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("promises: Error EIO stat\ncallback: Error EIO stat\n");
+  expect(exitCode).toBe(0);
+});
+
 test.skipIf(!isLinux)("fs.cp and fs.copyFile create the destination with the source file's mode", async () => {
   using dir = tempDir("cp-dest-mode", {});
   const destNames = ["dest-copyFile.bin", "dest-cp.bin"];


### PR DESCRIPTION
### Problem

When `fs.promises.cp` / `fs.cp` with `{ recursive: true }` checks whether the destination's parent directory exists and that `stat` fails with anything other than `ENOENT`, the promise/callback receives

```
TypeError: |this| is not an object
```

with no `code`/`errno`/`syscall`/`path`, instead of the real filesystem error (`ELOOP`, `ENOTDIR`, `EIO`, ...). Node reports the underlying error (verified against v26.3.0). `cpSync` is unaffected.

The window is between `lstat(dest)` returning `ENOENT` (plus `checkParentPaths()` passing) and the `stat(dirname(dest))` in `pathExists()` failing with a non-`ENOENT` error, e.g. the parent flipping from absent to a symlink loop in between. It reproduces deterministically with syscall fault injection:

```sh
mkdir cpfx && strace -f -qq -o /dev/null -P "$PWD/cpfx" -e trace=statx -e inject=statx:error=EIO bun repro.mjs
```

### Cause

`src/js/internal/fs/cp.ts` captured the intrinsic unbound:

```ts
const PromiseReject = Promise.$reject;
```

`pathExistsRejected()` calls `PromiseReject(err)` with `this === undefined`, and `Promise.reject` throws when its receiver is not an object. The other builtins that capture this intrinsic (`node/vm`, `node/diagnostics_channel`, `internal/streams/operators`, `internal/primordials`) all bind it; this was the only unbound capture in `src/js`.

### Fix

```ts
const PromiseReject = Promise.$reject.bind(Promise);
```

### Test

`internal/fs/cp` is lazily loaded by the first `cp()` call and captures `fs.promises.stat` at that moment, so the test's subprocess patches `fs.promises.stat` up front to reject with `EIO` for exactly the options-less `stat(destParent)` call that `pathExists()` makes (the `{ bigint: true }` calls from `checkParentPaths()` pass through to the real `stat`). That exercises the same rejection path deterministically on every platform, without fault injection, and covers both the promise and callback faces.

Before the fix (also on bun 1.4.0): both faces reject with `TypeError: |this| is not an object`, `code=undefined`.
After: both faces reject with the injected `EIO` error carrying `code`/`syscall`, matching node.

```
bun bd test test/js/node/fs/cp.test.ts
 50 pass
 5 skip
 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->