### PR TITLE
test: pin eager compression coder release when the piped source errors

### DIFF
--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import zlib from "node:zlib";
 
 // CompressionStream et al are C++ subclasses of JSTransformStream so that
@@ -713,3 +714,59 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
     expect(decoded).toBe("hello world");
   });
 });
+
+// The native coder (a gzip deflate context is ~280 KiB of zlib state) must be
+// released eagerly at the transform's terminal (ClearAlgorithms: post-flush,
+// error, cancel), not left to the cell's finalizer. Finalizers run late, so a
+// busy loop of pipelines whose SOURCE errors otherwise retains every context:
+// Bun.gc(true) cannot reclaim them and RSS grows by ~280 KiB per iteration.
+test(
+  "errored pipeline releases the compression coder eagerly",
+  async () => {
+    const src = `
+      const N = 512, WARM = 64;
+      const rss = () => { Bun.gc(true); return process.memoryUsage().rss; };
+      async function run() {
+        let n = 0;
+        const source = new ReadableStream({
+          pull(c) {
+            n++;
+            if (n > 5) throw new Error("source failed");
+            c.enqueue(new Uint8Array(8192).fill(n));
+          },
+        });
+        try { await new Response(source.pipeThrough(new CompressionStream("gzip"))).arrayBuffer(); } catch {}
+      }
+      for (let i = 0; i < WARM; i++) await run();
+      const before = rss();
+      for (let i = WARM; i < N; i++) await run();
+      console.log(JSON.stringify({ deltaMiB: (rss() - before) / 1048576 }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: {
+        ...bunEnv,
+        // Under ASAN the freed contexts land in the allocator quarantine
+        // (default quarantine_size_mb=256) instead of being returned, so the
+        // RSS delta over-reports by far more than the retention this guards
+        // against even when nothing leaks.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const { deltaMiB } = JSON.parse(stdout.trim());
+    // 448 retained gzip contexts measure ~130 MiB (bun 1.3.14, whose
+    // node:zlib-backed implementation freed them only via finalizer); eager
+    // release measures 7 MiB release / 8 MiB debug+ASAN.
+    expect(deltaMiB).toBeLessThan(64);
+    expect(exitCode).toBe(0);
+  },
+  // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
+  // outlives the default per-test timeout.
+  60_000,
+);

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -720,6 +720,8 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
 // error, cancel), not left to the cell's finalizer. Finalizers run late, so a
 // busy loop of pipelines whose SOURCE errors otherwise retains every context:
 // Bun.gc(true) cannot reclaim them and RSS grows by ~280 KiB per iteration.
+// The 60s timeout covers the debug/ASAN child: 512 pipelines plus a full GC
+// per RSS sample outlive the default per-test timeout there.
 test("errored pipeline releases the compression coder eagerly", async () => {
   const src = `
       const N = 512, WARM = 64;
@@ -733,7 +735,13 @@ test("errored pipeline releases the compression coder eagerly", async () => {
             c.enqueue(new Uint8Array(8192).fill(n));
           },
         });
-        try { await new Response(source.pipeThrough(new CompressionStream("gzip"))).arrayBuffer(); } catch {}
+        try {
+          await new Response(source.pipeThrough(new CompressionStream("gzip"))).arrayBuffer();
+        } catch (error) {
+          if (error instanceof Error && error.message === "source failed") return;
+          throw error;
+        }
+        throw new Error("expected the pipeline to reject with the source error");
       }
       for (let i = 0; i < WARM; i++) await run();
       const before = rss();
@@ -763,4 +771,4 @@ test("errored pipeline releases the compression coder eagerly", async () => {
   // release measures 7 MiB release / 8 MiB debug+ASAN.
   expect(deltaMiB).toBeLessThan(64);
   expect(exitCode).toBe(0);
-}, 60_000); // outlives the default per-test timeout. // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
+}, 60_000);

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -763,5 +763,4 @@ test("errored pipeline releases the compression coder eagerly", async () => {
   // release measures 7 MiB release / 8 MiB debug+ASAN.
   expect(deltaMiB).toBeLessThan(64);
   expect(exitCode).toBe(0);
-}, // outlives the default per-test timeout. // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
-60_000);
+}, 60_000); // outlives the default per-test timeout. // A debug/ASAN child running 512 pipelines plus per-iteration full GCs

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -763,6 +763,5 @@ test("errored pipeline releases the compression coder eagerly", async () => {
   // release measures 7 MiB release / 8 MiB debug+ASAN.
   expect(deltaMiB).toBeLessThan(64);
   expect(exitCode).toBe(0);
-}, // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
-// outlives the default per-test timeout.
+}, // outlives the default per-test timeout. // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
 60_000);

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -720,10 +720,8 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
 // error, cancel), not left to the cell's finalizer. Finalizers run late, so a
 // busy loop of pipelines whose SOURCE errors otherwise retains every context:
 // Bun.gc(true) cannot reclaim them and RSS grows by ~280 KiB per iteration.
-test(
-  "errored pipeline releases the compression coder eagerly",
-  async () => {
-    const src = `
+test("errored pipeline releases the compression coder eagerly", async () => {
+  const src = `
       const N = 512, WARM = 64;
       const rss = () => { Bun.gc(true); return process.memoryUsage().rss; };
       async function run() {
@@ -743,30 +741,28 @@ test(
       console.log(JSON.stringify({ deltaMiB: (rss() - before) / 1048576 }));
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", src],
-      env: {
-        ...bunEnv,
-        // Under ASAN the freed contexts land in the allocator quarantine
-        // (default quarantine_size_mb=256) instead of being returned, so the
-        // RSS delta over-reports by far more than the retention this guards
-        // against even when nothing leaks.
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: {
+      ...bunEnv,
+      // Under ASAN the freed contexts land in the allocator quarantine
+      // (default quarantine_size_mb=256) instead of being returned, so the
+      // RSS delta over-reports by far more than the retention this guards
+      // against even when nothing leaks.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    const { deltaMiB } = JSON.parse(stdout.trim());
-    // 448 retained gzip contexts measure ~130 MiB (bun 1.3.14, whose
-    // node:zlib-backed implementation freed them only via finalizer); eager
-    // release measures 7 MiB release / 8 MiB debug+ASAN.
-    expect(deltaMiB).toBeLessThan(64);
-    expect(exitCode).toBe(0);
-  },
-  // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
-  // outlives the default per-test timeout.
-  60_000,
-);
+  expect(stderr).toBe("");
+  const { deltaMiB } = JSON.parse(stdout.trim());
+  // 448 retained gzip contexts measure ~130 MiB (bun 1.3.14, whose
+  // node:zlib-backed implementation freed them only via finalizer); eager
+  // release measures 7 MiB release / 8 MiB debug+ASAN.
+  expect(deltaMiB).toBeLessThan(64);
+  expect(exitCode).toBe(0);
+}, // A debug/ASAN child running 512 pipelines plus per-iteration full GCs
+// outlives the default per-test timeout.
+60_000);


### PR DESCRIPTION
## What

Adds a regression test pinning that CompressionStream releases its native coder eagerly when the piped source errors, rather than leaving it to the cell's finalizer.

## Why

Before the native rewrite in #36695, CompressionStream was a JS builtin wrapping node:zlib, and a pipeline whose source throws released its deflate context (~280 KiB of zlib state) only at finalization. A busy loop of failing pipelines retained every context: Bun.gc(true) could not reclaim them and RSS grew ~280 KiB per iteration until the process went idle. A server gzipping response bodies whose upstreams abort holds hundreds of MB of dead deflate contexts under sustained load, with nothing visible in heapUsed.

Repro loop (what the test runs in a child process):

```js
let n = 0;
const src = new ReadableStream({
  pull(c) {
    if (++n > 5) throw new Error("source failed");
    c.enqueue(new Uint8Array(8192).fill(n));
  },
});
try { await new Response(src.pipeThrough(new CompressionStream("gzip"))).arrayBuffer(); } catch {}
```

Measured RSS growth over 448 errored pipelines (after full GC):

- bun 1.3.14 (node:zlib-backed implementation): 132 MiB; at 3000 iterations RSS reaches ~874 MB and survives Bun.gc(true)
- after #36695: 7 MiB release, 8 MiB debug+ASAN

#36695 frees the coder at ClearAlgorithms, the shared terminal for post-flush, error, and cancel, leaving the finalizer as a fallback for abandoned streams. Nothing pinned that behavior; this test does, with a 64 MiB bound.

## Verification

- Fails on bun 1.3.14: expect(deltaMiB).toBeLessThan(64) receives 132
- Passes on current main: bun bd test test/js/web/streams/compression.test.ts, 36 pass
- The child disables the ASAN allocator quarantine (quarantine_size_mb=0, same approach as the shell and archive leak tests) so the delta measures retention rather than quarantined frees

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/streams/compression.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/streams/compression.test.ts
bun test v1.4.0 (459064d56)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [16.06ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [3.59ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [3.08ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.96ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [16.13ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [22.86ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [62.84ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [14.54ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [21.09ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [38.53ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [12.86ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = zstd frame) [18.29ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = skippable frame) [7.84ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses many concatenated zstd frames larger than one output chunk [15.38ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a zstd stream with a leading skippable frame [9.97ms]
(pass) CompressionStream and DecompressionStream > zstd > rejects trailing garbage after a zstd frame [10.32ms]
(pass) CompressionStream and DecompressionStream > all formats > works with 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/streams/compression.test.ts | 59 +++++++++++++++++++++++++++++++++
 1 file changed, 59 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
test/js/web/streams/compression.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->