### PR TITLE
resolver: reuse interned package.json/tsconfig parses across dir-cache busts

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -84,6 +84,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "parse_args.rs": "runtime/node/util/parse_args.rs",
   "patch.rs": "patch/patch.rs",
   "postgres.rs": "sql_jsc/postgres.rs",
+  "resolver/resolver.rs": "resolver/resolver.rs",
   "runtime/dns_jsc/dns.rs": "runtime/dns_jsc/dns.rs",
   "runtime/node/types.rs": "runtime/node/types.rs",
   "runtime/socket/socket.rs": "runtime/socket/socket.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -496,4 +496,8 @@ export const resolverInternals = {
   packageJsonArenaLen: $newRustFunction("resolver/resolver.rs", "jsPackageJsonArenaLen", 0) as () => number,
   /** Entries retained by the process-lifetime merged-tsconfig arena. */
   tsconfigArenaLen: $newRustFunction("resolver/resolver.rs", "jsTsconfigArenaLen", 0) as () => number,
+  /** Total package.json parses performed (reuse skips these). */
+  packageJsonParseCount: $newRustFunction("resolver/resolver.rs", "jsPackageJsonParseCount", 0) as () => number,
+  /** Total tsconfig parses performed (reuse skips these). */
+  tsconfigParseCount: $newRustFunction("resolver/resolver.rs", "jsTsconfigParseCount", 0) as () => number,
 };

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -490,3 +490,10 @@ export const fetchH3Internals = {
 export const fileSinkInternals = {
   liveCount: $newRustFunction("runtime/webcore/FileSink.rs", "TestingAPIs.fileSinkLiveCount", 0) as () => number,
 };
+
+export const resolverInternals = {
+  /** Entries retained by the process-lifetime parsed-package.json arena. */
+  packageJsonArenaLen: $newRustFunction("resolver/resolver.rs", "jsPackageJsonArenaLen", 0) as () => number,
+  /** Entries retained by the process-lifetime merged-tsconfig arena. */
+  tsconfigArenaLen: $newRustFunction("resolver/resolver.rs", "jsTsconfigArenaLen", 0) as () => number,
+};

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -404,6 +404,7 @@ impl PackageJSON {
             package_id,
             include_scripts_,
         )
+        .ok()
     }
 
     /// Joins `input_path` + "package.json", interns the joined path, and reads
@@ -486,13 +487,16 @@ impl PackageJSON {
         Some((package_json_path, entry_contents))
     }
 
+    /// `Err` returns the unparseable file's bytes (invalid JSON or non-object
+    /// root) so `Resolver::parse_package_json` can record the failure and skip
+    /// re-parsing the unchanged file on the next dir-cache bust.
     pub(crate) fn parse_with_contents<const INCLUDE_DEPENDENCIES: IncludeDependencies>(
         r: &mut resolver::Resolver<'_>,
         package_json_path: &'static [u8],
         entry_contents: Box<[u8]>,
         package_id: Option<PackageID>,
         include_scripts_: IncludeScripts,
-    ) -> Option<PackageJSON> {
+    ) -> Result<PackageJSON, Box<[u8]>> {
         let include_scripts = include_scripts_ == IncludeScripts::IncludeScripts;
 
         // SAFETY: see `read_for_parse` — same disjoint-singleton contract.
@@ -511,7 +515,7 @@ impl PackageJSON {
         // On the success path it is *moved* (not leaked) into
         // `package_json.source_contents` at the bottom of this fn, so the heap
         // allocation lives for the life of the returned `PackageJSON`. On every
-        // early `return None` below `entry_contents` drops and frees normally, after
+        // early `return Err` below `entry_contents` moves out whole, after
         // `json_source` is already dead. `Box<[u8]>` heap address is stable
         // across the move.
         let contents_static: &'static [u8] = unsafe { bun_ptr::detach_lifetime(&entry_contents) };
@@ -519,7 +523,7 @@ impl PackageJSON {
 
         let parsed_json = match r.caches.json.parse_package_json(r_log, &json_source) {
             Ok(Some(v)) => v,
-            Ok(None) => return None,
+            Ok(None) => return Err(entry_contents),
             Err(err) => {
                 if cfg!(debug_assertions) {
                     Output::print_error(format_args!(
@@ -528,7 +532,7 @@ impl PackageJSON {
                         bstr::BStr::new(err.name())
                     ));
                 }
-                return None;
+                return Err(entry_contents);
             }
         };
         let json: js_ast::Expr = parsed_json.root;
@@ -536,8 +540,7 @@ impl PackageJSON {
         if !json.is_object() {
             // Invalid package.json in node_modules is noisy.
             // Let's just ignore it.
-            // (allocator.free dropped — entry.contents owned by `entry`)
-            return None;
+            return Err(entry_contents);
         }
 
         let mut package_json = PackageJSON {
@@ -1057,7 +1060,7 @@ impl PackageJSON {
         // `mem::forget`, forbidden per docs/PORTING.md §Forbidden patterns).
         package_json.source_contents = entry_contents;
         package_json.json_tape = parsed_json.tape;
-        Some(package_json)
+        Ok(package_json)
     }
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -396,8 +396,28 @@ impl PackageJSON {
         package_id: Option<PackageID>,
         include_scripts_: IncludeScripts,
     ) -> Option<PackageJSON> {
-        let include_scripts = include_scripts_ == IncludeScripts::IncludeScripts;
+        let (package_json_path, entry_contents) = Self::read_for_parse(r, input_path, dirname_fd)?;
+        Self::parse_with_contents::<INCLUDE_DEPENDENCIES>(
+            r,
+            package_json_path,
+            entry_contents,
+            package_id,
+            include_scripts_,
+        )
+    }
 
+    /// Joins `input_path` + "package.json", interns the joined path, and reads
+    /// the file (with the same error logging `parse` always had). Split from
+    /// [`parse_with_contents`] so `Resolver::parse_package_json` can compare
+    /// the raw bytes against the already-interned copy and skip the parse
+    /// entirely when they match — a re-parse is not free even when its result
+    /// is discarded (nested JSON object/array handles land in the thread-local
+    /// AST store, which individual frees never shrink).
+    pub(crate) fn read_for_parse(
+        r: &mut resolver::Resolver<'_>,
+        input_path: &[u8],
+        dirname_fd: Fd,
+    ) -> Option<(&'static [u8], Box<[u8]>)> {
         // SAFETY: PORT (Stacked Borrows) — `r.fs()`/`r.log()` return RAW `*mut`
         // (see `Resolver::fs()` note in lib.rs). `fs` and `log` are DISTINCT
         // singletons so the two `&mut` projections below do not alias each other,
@@ -465,6 +485,23 @@ impl PackageJSON {
                 bstr::BStr::new(package_json_path)
             ));
         }
+
+        Some((package_json_path, entry_contents))
+    }
+
+    pub(crate) fn parse_with_contents<const INCLUDE_DEPENDENCIES: IncludeDependencies>(
+        r: &mut resolver::Resolver<'_>,
+        package_json_path: &'static [u8],
+        entry_contents: Box<[u8]>,
+        package_id: Option<PackageID>,
+        include_scripts_: IncludeScripts,
+    ) -> Option<PackageJSON> {
+        let include_scripts = include_scripts_ == IncludeScripts::IncludeScripts;
+
+        // SAFETY: see `read_for_parse` — same disjoint-singleton contract.
+        let r_fs: &mut fs::FileSystem = unsafe { &mut *r.fs() };
+        // SAFETY: see `read_for_parse`.
+        let r_log: &mut bun_ast::Log = unsafe { &mut *r.log() };
 
         // `bun_ast::Source.path` is the lightweight `bun_paths::fs::Path<'static>` (no
         // `pretty`/`is_node_module`); `key_path` is only used for `text`, so init the

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -407,12 +407,9 @@ impl PackageJSON {
     }
 
     /// Joins `input_path` + "package.json", interns the joined path, and reads
-    /// the file (with the same error logging `parse` always had). Split from
-    /// [`parse_with_contents`] so `Resolver::parse_package_json` can compare
-    /// the raw bytes against the already-interned copy and skip the parse
-    /// entirely when they match — a re-parse is not free even when its result
-    /// is discarded (nested JSON object/array handles land in the thread-local
-    /// AST store, which individual frees never shrink).
+    /// the file. Split from [`parse_with_contents`] so the caller can skip the
+    /// parse when the bytes match the interned copy — even a discarded
+    /// re-parse permanently grows the thread-local AST store.
     pub(crate) fn read_for_parse(
         r: &mut resolver::Resolver<'_>,
         input_path: &[u8],

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -426,13 +426,15 @@ fn intern_package_json(
     ptr
 }
 
-/// One file the tsconfig merge read: absolute path + raw bytes. The reuse
-/// check re-reads exactly these files and compares bytes, so an unchanged
-/// extends chain skips the whole parse+merge.
+/// One file the tsconfig merge visited: absolute path + raw bytes (`None`
+/// when the file was unreadable, e.g. a missing `extends` parent). The reuse
+/// check re-reads exactly these files and compares, so an unchanged extends
+/// chain skips the whole parse+merge while a parent that appears, vanishes,
+/// or changes forces a re-merge.
 #[derive(Clone, PartialEq, Eq)]
 struct TsconfigChainLink {
     path: Box<[u8]>,
-    contents: Box<[u8]>,
+    contents: Option<Box<[u8]>>,
 }
 
 struct InternedTsconfig {
@@ -4126,9 +4128,14 @@ impl<'a> Resolver<'a> {
             guard.by_path.get(root_path)?.chain.clone()
         };
         for link in &chain {
-            let bytes = self.read_file_for_tsconfig_reuse(&link.path)?;
-            if !strings::eql(&bytes, &link.contents) {
-                return None;
+            match (
+                self.read_file_for_tsconfig_reuse(&link.path),
+                &link.contents,
+            ) {
+                // Still unreadable (e.g. the extends parent is still missing).
+                (None, None) => {}
+                (Some(bytes), Some(recorded)) if strings::eql(&bytes, recorded) => {}
+                _ => return None,
             }
         }
         // Re-check under the lock: another thread may have re-interned this
@@ -4165,13 +4172,14 @@ impl<'a> Resolver<'a> {
         })
     }
 
-    /// On success, also returns the raw file bytes so `dir_info_uncached` can
-    /// record the extends-chain contents that `intern_tsconfig` dedupes on.
+    /// On a successful read, also returns the raw file bytes (even when the
+    /// JSONC fails to parse) so `dir_info_uncached` can record the
+    /// extends-chain contents that `intern_tsconfig` dedupes on.
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
         dirname_fd: FD,
-    ) -> crate::CrateResult<Option<(Box<TSConfigJSON>, Box<[u8]>)>> {
+    ) -> crate::CrateResult<(Option<Box<TSConfigJSON>>, Box<[u8]>)> {
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
         let mut entry = self.caches.fs.read_file_with_allocator(
@@ -4219,7 +4227,7 @@ impl<'a> Resolver<'a> {
             match TSConfigJSON::parse(unsafe { &mut *self.log() }, &source, &mut self.caches.json)?
             {
                 Some(r) => r,
-                None => return Ok(None),
+                None => return Ok((None, Box::from(&source.contents[..]))),
             };
 
         if result.has_base_url() {
@@ -4251,7 +4259,7 @@ impl<'a> Resolver<'a> {
         // `heap::take`, the final one is interned into the DirInfo cache.
         // The copied-out bytes feed the caller's `TsconfigChainLink` record
         // (only real parses reach here, so the copy is off the reuse path).
-        Ok(Some((result, Box::from(&source.contents[..]))))
+        Ok((Some(result), Box::from(&source.contents[..])))
     }
 
     pub fn bin_dirs(&self) -> &[&'static [u8]] {
@@ -6661,13 +6669,13 @@ impl<'a> Resolver<'a> {
                             FD::ZERO
                         },
                     ) {
-                        Ok(v) => v.map(|(config, contents)| {
+                        Ok((config, contents)) => {
                             chain.push(TsconfigChainLink {
                                 path: Box::from(tsconfigpath),
-                                contents,
+                                contents: Some(contents),
                             });
-                            bun_core::heap::into_raw(config)
-                        }),
+                            config.map(bun_core::heap::into_raw)
+                        }
                         Err(err) => {
                             let pretty = tsconfigpath;
                             if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
@@ -6724,14 +6732,22 @@ impl<'a> Resolver<'a> {
                             );
                             let parent_config_maybe: Option<*mut TSConfigJSON> =
                                 match self.parse_tsconfig(abs_path, FD::INVALID) {
-                                    Ok(v) => v.map(|(config, contents)| {
+                                    Ok((config, contents)) => {
                                         chain.push(TsconfigChainLink {
                                             path: Box::from(abs_path),
-                                            contents,
+                                            contents: Some(contents),
                                         });
-                                        bun_core::heap::into_raw(config)
-                                    }),
+                                        config.map(bun_core::heap::into_raw)
+                                    }
                                     Err(err) => {
+                                        // Recorded with `contents: None` so the
+                                        // reuse check re-merges once this parent
+                                        // becomes readable (e.g. it gets
+                                        // created after an unresolved extends).
+                                        chain.push(TsconfigChainLink {
+                                            path: Box::from(abs_path),
+                                            contents: None,
+                                        });
                                         let _ = self.log_mut().add_debug_fmt(
                                             None,
                                             bun_ast::Loc::EMPTY,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -318,15 +318,25 @@ fn main_fields_hash(fields: &[Box<[u8]>]) -> u64 {
     hasher.digest()
 }
 
-struct InternedPackageJson {
-    shape: PackageJsonParseShape,
+/// The outcome of the last parse for a (path, shape) pair: either the
+/// interned struct, or the bytes of a file that read fine but produced no
+/// `PackageJSON` (invalid JSON, non-object root). Recording failures too is
+/// what lets a bust over an unchanged-but-broken file skip the re-parse.
+enum InternedPackageJsonState {
     /// Arena slot; `NonNull` (not `&'static`) so mut-provenance from intern
     /// time survives to the `package_manager_package_id` write sites.
-    ptr: core::ptr::NonNull<PackageJSON>,
+    Parsed(core::ptr::NonNull<PackageJSON>),
+    Unparseable(Box<[u8]>),
 }
 
-// SAFETY: `ptr` targets an append-only arena slot; it crosses threads exactly
-// like the `&'static PackageJSON` refs the DirInfo cache already hands out.
+struct InternedPackageJson {
+    shape: PackageJsonParseShape,
+    state: InternedPackageJsonState,
+}
+
+// SAFETY: the `Parsed` pointer targets an append-only arena slot; it crosses
+// threads exactly like the `&'static PackageJSON` refs the DirInfo cache
+// already hands out.
 unsafe impl Send for InternedPackageJson {}
 
 #[derive(Default)]
@@ -342,9 +352,38 @@ struct PackageJsonInterner {
 static PACKAGE_JSON_INTERNER: std::sync::LazyLock<bun_threading::Guarded<PackageJsonInterner>> =
     std::sync::LazyLock::new(Default::default);
 
+/// Number of `PackageJSON::parse_with_contents` runs. Read via
+/// `bun:internal-for-testing` by leak regression tests (together with
+/// [`package_json_arena_len`]) to assert busts skip re-parses.
+static PACKAGE_JSON_PARSE_COUNT: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 /// Arena length; read via `bun:internal-for-testing` by leak regression tests.
 pub fn package_json_arena_len() -> usize {
     PACKAGE_JSON_INTERNER.lock().arena.len()
+}
+
+pub fn package_json_parse_count() -> usize {
+    PACKAGE_JSON_PARSE_COUNT.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Point the (path, shape) slot at `state`, replacing any previous record.
+fn set_package_json_slot(
+    interner: &mut PackageJsonInterner,
+    path: &'static [u8],
+    shape: PackageJsonParseShape,
+    state: InternedPackageJsonState,
+) {
+    match interner.by_path.get_mut(path) {
+        Some(slots) => match slots.iter_mut().find(|slot| slot.shape == shape) {
+            Some(slot) => slot.state = state,
+            None => slots.push(InternedPackageJson { shape, state }),
+        },
+        None => interner
+            .by_path
+            .put_static_key(path, vec![InternedPackageJson { shape, state }])
+            .expect("unreachable"),
+    }
 }
 
 /// Intern `pkg`, reusing the existing allocation when path, bytes, and shape
@@ -359,13 +398,17 @@ fn intern_package_json(
     let mut guard = PACKAGE_JSON_INTERNER.lock();
     let interner = &mut *guard;
 
-    if let Some(slot) = interner
+    if let Some(InternedPackageJson {
+        state: InternedPackageJsonState::Parsed(ptr),
+        ..
+    }) = interner
         .by_path
         .get_mut(path)
         .and_then(|slots| slots.iter_mut().find(|slot| slot.shape == shape))
     {
+        let mut cached_ptr = *ptr;
         // SAFETY: ARENA — arena slots are never freed or moved.
-        let cached: &PackageJSON = unsafe { slot.ptr.as_ref() };
+        let cached: &PackageJSON = unsafe { cached_ptr.as_ref() };
         if strings::eql(&cached.source_contents, &pkg.source_contents) {
             // Reuse; the fresh parse drops. Carry over a resolved package id,
             // but never clear one written by `enqueue_dependency_to_resolve`.
@@ -373,36 +416,41 @@ fn intern_package_json(
             if fresh_id != Install::INVALID_PACKAGE_ID
                 && cached.package_manager_package_id != fresh_id
             {
-                // SAFETY: `ptr` carries mut-provenance from intern time; same
-                // single-writer contract as the `package_manager_package_id`
-                // write in `enqueue_dependency_to_resolve`.
-                unsafe { slot.ptr.as_mut() }.package_manager_package_id = fresh_id;
+                // SAFETY: the pointer carries mut-provenance from intern time;
+                // same single-writer contract as the write in
+                // `enqueue_dependency_to_resolve`.
+                unsafe { cached_ptr.as_mut() }.package_manager_package_id = fresh_id;
             }
-            return slot.ptr;
+            return cached_ptr;
         }
-        // Bytes changed: intern the new parse and repoint the slot. The stale
-        // copy stays in the arena — un-busted DirInfos may still reference it.
-        interner.arena.push(Box::new(pkg));
-        // SAFETY: entries are never removed; the box interior is stable across
-        // `Vec` realloc. Derive from `&mut **last` so the returned pointer
-        // carries mut-provenance.
-        let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
-        slot.ptr = ptr;
-        return ptr;
     }
 
+    // New path, new bytes, or a previously unparseable file: intern the fresh
+    // parse and repoint the slot. A replaced copy stays in the arena —
+    // un-busted DirInfos may still reference it.
     interner.arena.push(Box::new(pkg));
-    // SAFETY: as above — stable box interior, mut-provenance via `&mut **last`.
+    // SAFETY: entries are never removed; the box interior is stable across
+    // `Vec` realloc. Derive from `&mut **last` so the returned pointer
+    // carries mut-provenance.
     let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
-    let entry = InternedPackageJson { shape, ptr };
-    match interner.by_path.get_mut(path) {
-        Some(slots) => slots.push(entry),
-        None => interner
-            .by_path
-            .put_static_key(path, vec![entry])
-            .expect("unreachable"),
-    }
+    set_package_json_slot(interner, path, shape, InternedPackageJsonState::Parsed(ptr));
     ptr
+}
+
+/// Record that `path` read fine but produced no `PackageJSON`, so the next
+/// bust over identical bytes can skip the re-parse.
+fn intern_unparseable_package_json(
+    path: &'static [u8],
+    shape: PackageJsonParseShape,
+    contents: Box<[u8]>,
+) {
+    let mut guard = PACKAGE_JSON_INTERNER.lock();
+    set_package_json_slot(
+        &mut guard,
+        path,
+        shape,
+        InternedPackageJsonState::Unparseable(contents),
+    );
 }
 
 /// One file the tsconfig merge visited; `contents: None` = unreadable (e.g. a
@@ -417,8 +465,10 @@ struct TsconfigChainLink {
 struct InternedTsconfig {
     /// Every file that fed the merge, root first, in walk order.
     chain: Vec<TsconfigChainLink>,
-    /// Points at a `TsconfigInterner::arena` slot.
-    ptr: core::ptr::NonNull<TSConfigJSON>,
+    /// `TsconfigInterner::arena` slot, or `None` when the chain produced no
+    /// config (the root read fine but its JSONC failed to parse); recording
+    /// that outcome lets a bust over unchanged bytes skip the re-parse.
+    ptr: Option<core::ptr::NonNull<TSConfigJSON>>,
 }
 
 // SAFETY: same contract as `InternedPackageJson` — append-only arena slot
@@ -438,81 +488,115 @@ struct TsconfigInterner {
 static TSCONFIG_INTERNER: std::sync::LazyLock<bun_threading::Guarded<TsconfigInterner>> =
     std::sync::LazyLock::new(Default::default);
 
+/// Number of `parse_tsconfig` runs; see [`package_json_parse_count`].
+static TSCONFIG_PARSE_COUNT: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 /// Arena length; read via `bun:internal-for-testing` by leak regression tests.
 pub fn tsconfig_arena_len() -> usize {
     TSCONFIG_INTERNER.lock().arena.len()
 }
 
-/// Intern the merge for `root_path`, reusing the existing allocation when the
-/// chain matches. `merged` came from `heap::into_raw`; on reuse it is
-/// destroyed here.
+pub fn tsconfig_parse_count() -> usize {
+    TSCONFIG_PARSE_COUNT.load(core::sync::atomic::Ordering::Relaxed)
+}
+
+/// Intern the merge for `root_path` (`None` = the chain produced no config),
+/// reusing the existing allocation when the chain matches. A `Some` pointer
+/// came from `heap::into_raw`; on reuse it is destroyed here.
 fn intern_tsconfig(
     root_path: &[u8],
     chain: Vec<TsconfigChainLink>,
-    merged: *mut TSConfigJSON,
-) -> core::ptr::NonNull<TSConfigJSON> {
+    merged: Option<*mut TSConfigJSON>,
+) -> Option<core::ptr::NonNull<TSConfigJSON>> {
     let mut guard = TSCONFIG_INTERNER.lock();
     let interner = &mut *guard;
 
     if let Some(slot) = interner.by_path.get_mut(root_path) {
-        if slot.chain == chain {
-            // SAFETY: `merged` came from `heap::into_raw` in the caller's
-            // merge walk and is uniquely owned here.
-            TSConfigJSON::destroy(unsafe { bun_core::heap::take(merged) });
+        if slot.chain == chain && slot.ptr.is_some() == merged.is_some() {
+            if let Some(merged) = merged {
+                // SAFETY: `merged` came from `heap::into_raw` in the caller's
+                // merge walk and is uniquely owned here.
+                TSConfigJSON::destroy(unsafe { bun_core::heap::take(merged) });
+            }
             return slot.ptr;
         }
-        // Chain changed: intern the new merge and repoint the slot; the stale
-        // copy stays in the arena (un-busted DirInfos may still reference it).
+    }
+
+    // New path or changed chain: intern the new outcome and repoint the slot;
+    // a replaced merge stays in the arena (un-busted DirInfos may still
+    // reference it).
+    let ptr = merged.map(|merged| {
         // SAFETY: as above — reclaim the caller's allocation.
         interner.arena.push(unsafe { bun_core::heap::take(merged) });
         // SAFETY: see `intern_package_json` — stable box interior,
         // mut-provenance via `&mut **last`.
-        let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
-        *slot = InternedTsconfig { chain, ptr };
-        return ptr;
+        core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap())
+    });
+    match interner.by_path.get_mut(root_path) {
+        Some(slot) => *slot = InternedTsconfig { chain, ptr },
+        None => interner
+            .by_path
+            .put(root_path, InternedTsconfig { chain, ptr })
+            .expect("unreachable"),
     }
-
-    // SAFETY: as above — reclaim the caller's allocation.
-    interner.arena.push(unsafe { bun_core::heap::take(merged) });
-    // SAFETY: as above.
-    let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
-    interner
-        .by_path
-        .put(root_path, InternedTsconfig { chain, ptr })
-        .expect("unreachable");
     ptr
 }
 
-/// Return the interned copy for (`package_json_path`, `shape`) when its bytes
-/// equal `contents`, skipping the parse (see `PackageJSON::read_for_parse`).
+/// Reuse outcome for `parse_package_json`'s fast path.
+enum PackageJsonReuse {
+    /// No usable record; parse.
+    Miss,
+    /// Unchanged bytes: the previous outcome stands (`None` = known
+    /// unparseable).
+    Hit(Option<core::ptr::NonNull<PackageJSON>>),
+}
+
+/// Fast path for `parse_package_json`: when the (path, shape) slot's recorded
+/// bytes equal `contents`, the previous outcome stands and the parse is
+/// skipped (see `PackageJSON::read_for_parse`).
 fn reuse_interned_package_json(
     package_json_path: &[u8],
     shape: PackageJsonParseShape,
     contents: &[u8],
     package_id: Option<Install::PackageID>,
-) -> Option<core::ptr::NonNull<PackageJSON>> {
+) -> PackageJsonReuse {
     let mut guard = PACKAGE_JSON_INTERNER.lock();
-    let slot = guard
+    let Some(slot) = guard
         .by_path
-        .get_mut(package_json_path)?
-        .iter_mut()
-        .find(|slot| slot.shape == shape)?;
-    // SAFETY: ARENA — arena slots are never freed or moved.
-    let cached: &PackageJSON = unsafe { slot.ptr.as_ref() };
-    if !strings::eql(&cached.source_contents, contents) {
-        return None;
-    }
-    // Apply the caller-provided lockfile id as the parse would have, but never
-    // clear an id written by `enqueue_dependency_to_resolve`.
-    if let Some(id) = package_id {
-        if id != Install::INVALID_PACKAGE_ID && cached.package_manager_package_id != id {
-            // SAFETY: `ptr` carries mut-provenance from intern time; same
-            // single-writer contract as the `package_manager_package_id`
-            // write in `enqueue_dependency_to_resolve`.
-            unsafe { slot.ptr.as_mut() }.package_manager_package_id = id;
+        .get_mut(package_json_path)
+        .and_then(|slots| slots.iter_mut().find(|slot| slot.shape == shape))
+    else {
+        return PackageJsonReuse::Miss;
+    };
+    match &slot.state {
+        InternedPackageJsonState::Parsed(ptr) => {
+            let mut cached_ptr = *ptr;
+            // SAFETY: ARENA — arena slots are never freed or moved.
+            let cached: &PackageJSON = unsafe { cached_ptr.as_ref() };
+            if !strings::eql(&cached.source_contents, contents) {
+                return PackageJsonReuse::Miss;
+            }
+            // Apply the caller-provided lockfile id as the parse would have,
+            // but never clear an id written by `enqueue_dependency_to_resolve`.
+            if let Some(id) = package_id {
+                if id != Install::INVALID_PACKAGE_ID && cached.package_manager_package_id != id {
+                    // SAFETY: the pointer carries mut-provenance from intern
+                    // time; same single-writer contract as the write in
+                    // `enqueue_dependency_to_resolve`.
+                    unsafe { cached_ptr.as_mut() }.package_manager_package_id = id;
+                }
+            }
+            PackageJsonReuse::Hit(Some(cached_ptr))
+        }
+        InternedPackageJsonState::Unparseable(recorded) => {
+            if strings::eql(recorded, contents) {
+                PackageJsonReuse::Hit(None)
+            } else {
+                PackageJsonReuse::Miss
+            }
         }
     }
-    Some(slot.ptr)
 }
 
 // `bun_core::declare_scope!` emits the per-scope `static ScopedLogger`; the
@@ -4085,12 +4169,14 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Reuse the interned merge for `root_path` when its recorded extends
-    /// chain is unchanged on disk; `None` means the caller must re-parse.
+    /// Reuse the interned outcome for `root_path` when its recorded extends
+    /// chain is unchanged on disk. Outer `None` means the caller must
+    /// re-parse; the inner value is the recorded merge (`None` = the chain
+    /// produced no config last time).
     fn reuse_interned_tsconfig(
         &mut self,
         root_path: &[u8],
-    ) -> Option<core::ptr::NonNull<TSConfigJSON>> {
+    ) -> Option<Option<core::ptr::NonNull<TSConfigJSON>>> {
         let chain: Vec<TsconfigChainLink> = {
             let guard = TSCONFIG_INTERNER.lock();
             // Clone the (small) record so files aren't read under the lock.
@@ -4148,6 +4234,7 @@ impl<'a> Resolver<'a> {
         file: &[u8],
         dirname_fd: FD,
     ) -> crate::CrateResult<(Option<Box<TSConfigJSON>>, Box<[u8]>)> {
+        TSCONFIG_PARSE_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
         let mut entry = self.caches.fs.read_file_with_allocator(
@@ -4255,12 +4342,12 @@ impl<'a> Resolver<'a> {
         else {
             return Ok(None);
         };
-        if let Some(interned) =
-            reuse_interned_package_json(package_json_path, shape, &contents, package_id)
-        {
-            return Ok(Some(interned));
+        match reuse_interned_package_json(package_json_path, shape, &contents, package_id) {
+            PackageJsonReuse::Hit(outcome) => return Ok(outcome),
+            PackageJsonReuse::Miss => {}
         }
 
+        PACKAGE_JSON_PARSE_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         // NOTE: `IncludeDependencies` is a
         // const generic on `PackageJSON::parse_with_contents`, `IncludeScripts`
         // is runtime (it only gates one branch).
@@ -4286,7 +4373,16 @@ impl<'a> Resolver<'a> {
                 include_scripts,
             )
         };
-        let Some(pkg) = pkg else { return Ok(None) };
+        let pkg = match pkg {
+            Ok(pkg) => pkg,
+            Err(contents) => {
+                // The file read fine but produced no `PackageJSON`; record the
+                // bytes so the next bust over an unchanged file skips the
+                // re-parse too.
+                intern_unparseable_package_json(package_json_path, shape, contents);
+                return Ok(None);
+            }
+        };
 
         // NOTE: the DirInfo cache holds `&'static` refs. PORTING.md
         // §Forbidden bars `Box::leak`; intern into the process-lifetime arena
@@ -6615,11 +6711,12 @@ impl<'a> Resolver<'a> {
             }
 
             if let Some(tsconfigpath) = tsconfig_path {
-                // Reuse the interned merge when the recorded extends chain is
-                // byte-identical on disk; see `PackageJSON::read_for_parse`
+                // Reuse the interned outcome when the recorded extends chain
+                // is byte-identical on disk; see `PackageJSON::read_for_parse`
                 // for why skipping the parse matters.
-                info.tsconfig_json = self.reuse_interned_tsconfig(tsconfigpath);
-                if info.tsconfig_json.is_none() {
+                if let Some(cached) = self.reuse_interned_tsconfig(tsconfigpath) {
+                    info.tsconfig_json = cached;
+                } else {
                     // Every file the merge below reads, in walk order.
                     let mut chain: Vec<TsconfigChainLink> = Vec::new();
                     let parsed_tsconfig: Option<*mut TSConfigJSON> = match self.parse_tsconfig(
@@ -6786,7 +6883,14 @@ impl<'a> Resolver<'a> {
                         // Interned into the process-lifetime arena (deduped against
                         // the previous merge for this path); outlives the resolver.
                         info.tsconfig_json =
-                            Some(intern_tsconfig(tsconfigpath, chain, merged_config));
+                            intern_tsconfig(tsconfigpath, chain, Some(merged_config));
+                    } else if !chain.is_empty() {
+                        // The root read fine but produced no config; record
+                        // that outcome so the next bust over unchanged bytes
+                        // skips the re-parse. (An unreadable root leaves the
+                        // chain empty and keeps its per-recompute error
+                        // reporting.)
+                        info.tsconfig_json = intern_tsconfig(tsconfigpath, chain, None);
                     }
                 }
                 info.enclosing_tsconfig_json = info.tsconfig_json();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -288,34 +288,27 @@ use bun_ast::SideEffects;
 // `LazyLock`. These append-only arenas are that storage; the `Box<T>` heap
 // address is stable across `Vec` growth, so handing out `&'static T` is sound.
 //
-// Entries are never removed, but `bust_dir_cache` + recompute re-parses the
-// directory's package.json / tsconfig.json each time (a failed bare-specifier
-// resolve busts the importer dir and retries; watchers bust on every change
-// event), so unconditional appends grow the arenas per bust, unbounded. The
-// interners below dedupe: re-interning a file whose bytes (and parse-shaping
-// options) are unchanged returns the existing allocation, and the arenas only
-// grow when contents actually change — which is the point of the bust.
+// Every `bust_dir_cache` + recompute re-parses the directory's package.json /
+// tsconfig.json (failed bare-specifier resolves retry through a bust; watchers
+// bust per change event), so the interners below reuse the existing entry for
+// unchanged inputs and the arenas only grow when file contents change.
 
-/// Resolver state (beyond the file bytes) that shapes what
-/// `PackageJSON::parse` produces; an interned copy is only reused for a parse
-/// with an identical shape.
+/// Resolver state beyond the file bytes that shapes what `PackageJSON::parse`
+/// produces; an interned copy is only reused for an identical shape.
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct PackageJsonParseShape {
     /// `ALLOW_DEPENDENCIES` in `parse_package_json` (populates `dependencies`).
     allow_dependencies: bool,
     /// `Resolver.care_about_scripts` (populates `scripts` / `config`).
     include_scripts: bool,
-    /// `parse` routes dependency-version parsing and lockfile id inference
-    /// through the auto-installer when one is wired.
+    /// The auto-installer changes dependency-version parsing and id inference.
     has_auto_installer: bool,
-    /// Content hash of `opts.main_fields` — only listed fields land in
-    /// `PackageJSON::main_fields`. Hashed rather than borrowed: opts are
-    /// per-resolver and may be freed while the interned copy lives on.
+    /// Only fields listed in `opts.main_fields` are captured. Hashed, not
+    /// borrowed: opts are per-resolver and may be freed first.
     main_fields_hash: u64,
 }
 
-/// Order-sensitive content hash of `opts.main_fields` for
-/// [`PackageJsonParseShape`] (length-prefixed so `["ab"]` ≠ `["a", "b"]`).
+/// Order-sensitive, length-prefixed content hash of `opts.main_fields`.
 fn main_fields_hash(fields: &[Box<[u8]>]) -> u64 {
     let mut hasher = XxHash64Streaming::new(0);
     for field in fields {
@@ -327,53 +320,41 @@ fn main_fields_hash(fields: &[Box<[u8]>]) -> u64 {
 
 struct InternedPackageJson {
     shape: PackageJsonParseShape,
-    /// Points at a `PackageJsonInterner::arena` slot. `NonNull` (not
-    /// `&'static`) so mut-provenance from intern time survives to write sites
-    /// (`package_manager_package_id`).
+    /// Arena slot; `NonNull` (not `&'static`) so mut-provenance from intern
+    /// time survives to the `package_manager_package_id` write sites.
     ptr: core::ptr::NonNull<PackageJSON>,
 }
 
-// SAFETY: `ptr` targets an append-only arena slot owned by the same `Guarded`
-// static; it crosses threads exactly like the `&'static PackageJSON` refs the
-// DirInfo cache already hands out.
+// SAFETY: `ptr` targets an append-only arena slot; it crosses threads exactly
+// like the `&'static PackageJSON` refs the DirInfo cache already hands out.
 unsafe impl Send for InternedPackageJson {}
 
 #[derive(Default)]
 struct PackageJsonInterner {
-    /// Process-lifetime storage; never shrinks (un-busted DirInfos may hold
-    /// `&'static` refs to old entries even after a newer parse replaces them
-    /// in `by_path`).
-    // `Box` is load-bearing: handed-out pointers target the box interior,
-    // which is stable across `Vec` realloc; unboxing would dangle.
+    /// Never shrinks: replaced entries may still be referenced by un-busted
+    /// DirInfos. `Box` keeps handed-out pointers stable across `Vec` realloc.
     #[expect(clippy::vec_box)]
     arena: Vec<Box<PackageJSON>>,
-    /// Interned copies per package.json path (keys are `dirname_store`
-    /// slices, so `'static`), at most one per parse shape.
+    /// Keys are `dirname_store` slices (`'static`); one slot per parse shape.
     by_path: bun_collections::StringHashMap<Vec<InternedPackageJson>>,
 }
 
 static PACKAGE_JSON_INTERNER: std::sync::LazyLock<bun_threading::Guarded<PackageJsonInterner>> =
     std::sync::LazyLock::new(Default::default);
 
-/// Number of `PackageJSON` parses retained by the process-lifetime arena.
-/// Read via `bun:internal-for-testing` so tests can assert dir-cache busts
-/// reuse the interned copy instead of appending one per bust.
+/// Arena length; read via `bun:internal-for-testing` by leak regression tests.
 pub fn package_json_arena_len() -> usize {
     PACKAGE_JSON_INTERNER.lock().arena.len()
 }
 
-/// Intern a parsed `PackageJSON` into the process-lifetime DirInfo arena,
-/// reusing the existing allocation when the path, the source bytes, and the
-/// parse shape match an already-interned copy.
-/// Returns `NonNull` (not `&'static`) so mut-provenance survives to write
-/// sites — handing out `&T` here and casting back to `*mut T` would be UB
-/// under Stacked Borrows.
+/// Intern `pkg`, reusing the existing allocation when path, bytes, and shape
+/// match. Returns `NonNull` (not `&'static`) so mut-provenance survives to
+/// write sites — a `&T`-to-`*mut T` cast would be UB under Stacked Borrows.
 fn intern_package_json(
     pkg: PackageJSON,
     shape: PackageJsonParseShape,
 ) -> core::ptr::NonNull<PackageJSON> {
-    // `PackageJSON::parse` interned the path into `dirname_store`
-    // (process-lifetime), so the key is genuinely `'static`.
+    // The path was interned into `dirname_store`, so it is genuinely `'static`.
     let path: &'static [u8] = pkg.source.path.text;
     let mut guard = PACKAGE_JSON_INTERNER.lock();
     let interner = &mut *guard;
@@ -386,10 +367,8 @@ fn intern_package_json(
         // SAFETY: ARENA — arena slots are never freed or moved.
         let cached: &PackageJSON = unsafe { slot.ptr.as_ref() };
         if strings::eql(&cached.source_contents, &pkg.source_contents) {
-            // Same bytes, same shape: hand out the interned copy; the fresh
-            // parse drops. Carry over a package id the fresh parse resolved
-            // (from the caller or the lockfile), but never clear one written
-            // earlier by `enqueue_dependency_to_resolve`.
+            // Reuse; the fresh parse drops. Carry over a resolved package id,
+            // but never clear one written by `enqueue_dependency_to_resolve`.
             let fresh_id = pkg.package_manager_package_id;
             if fresh_id != Install::INVALID_PACKAGE_ID
                 && cached.package_manager_package_id != fresh_id
@@ -426,11 +405,9 @@ fn intern_package_json(
     ptr
 }
 
-/// One file the tsconfig merge visited: absolute path + raw bytes (`None`
-/// when the file was unreadable, e.g. a missing `extends` parent). The reuse
-/// check re-reads exactly these files and compares, so an unchanged extends
-/// chain skips the whole parse+merge while a parent that appears, vanishes,
-/// or changes forces a re-merge.
+/// One file the tsconfig merge visited; `contents: None` = unreadable (e.g. a
+/// missing `extends` parent). The reuse check re-reads these, so any change,
+/// appearance, or disappearance in the chain forces a re-merge.
 #[derive(Clone, PartialEq, Eq)]
 struct TsconfigChainLink {
     path: Box<[u8]>,
@@ -450,28 +427,25 @@ unsafe impl Send for InternedTsconfig {}
 
 #[derive(Default)]
 struct TsconfigInterner {
-    /// Process-lifetime storage; never shrinks (see `PackageJsonInterner`).
+    /// Never shrinks; see `PackageJsonInterner::arena`.
     #[expect(clippy::vec_box)]
     arena: Vec<Box<TSConfigJSON>>,
-    /// Latest interned merge per root tsconfig/jsconfig path. Keys are owned
-    /// copies — the lookup path lives in a threadlocal buffer.
+    /// Keyed by root tsconfig/jsconfig path (owned copies — the lookup path
+    /// lives in a threadlocal buffer).
     by_path: bun_collections::StringHashMap<InternedTsconfig>,
 }
 
 static TSCONFIG_INTERNER: std::sync::LazyLock<bun_threading::Guarded<TsconfigInterner>> =
     std::sync::LazyLock::new(Default::default);
 
-/// Number of merged `TSConfigJSON`s retained by the process-lifetime arena.
-/// Read via `bun:internal-for-testing`; see [`package_json_arena_len`].
+/// Arena length; read via `bun:internal-for-testing` by leak regression tests.
 pub fn tsconfig_arena_len() -> usize {
     TSCONFIG_INTERNER.lock().arena.len()
 }
 
-/// Intern the merged tsconfig for `root_path` (the directory's
-/// tsconfig/jsconfig path), reusing the existing allocation when the
-/// extends chain read byte-identical files. `merged` is the caller's
-/// heap-allocated merge result (`heap::into_raw`); on reuse it is destroyed
-/// here.
+/// Intern the merge for `root_path`, reusing the existing allocation when the
+/// chain matches. `merged` came from `heap::into_raw`; on reuse it is
+/// destroyed here.
 fn intern_tsconfig(
     root_path: &[u8],
     chain: Vec<TsconfigChainLink>,
@@ -509,10 +483,8 @@ fn intern_tsconfig(
     ptr
 }
 
-/// Reuse check for `parse_package_json`: when an interned copy exists for
-/// (`package_json_path`, `shape`) and its source bytes equal `contents`,
-/// return it without parsing — a discarded re-parse still grows the
-/// thread-local AST store (see `PackageJSON::read_for_parse`).
+/// Return the interned copy for (`package_json_path`, `shape`) when its bytes
+/// equal `contents`, skipping the parse (see `PackageJSON::read_for_parse`).
 fn reuse_interned_package_json(
     package_json_path: &[u8],
     shape: PackageJsonParseShape,
@@ -530,9 +502,8 @@ fn reuse_interned_package_json(
     if !strings::eql(&cached.source_contents, contents) {
         return None;
     }
-    // A parse would have applied the caller-provided lockfile id
-    // (`PackageJSON::parse` does so before any inference); mirror that, but
-    // never clear an id written earlier by `enqueue_dependency_to_resolve`.
+    // Apply the caller-provided lockfile id as the parse would have, but never
+    // clear an id written by `enqueue_dependency_to_resolve`.
     if let Some(id) = package_id {
         if id != Install::INVALID_PACKAGE_ID && cached.package_manager_package_id != id {
             // SAFETY: `ptr` carries mut-provenance from intern time; same
@@ -4114,10 +4085,8 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Fast path for `dir_info_uncached`: reuse the interned merged tsconfig
-    /// for `root_path` when every file in its recorded extends chain is
-    /// byte-identical on disk. Any read error or mismatch returns `None` and
-    /// the caller re-parses (the parse path owns error reporting).
+    /// Reuse the interned merge for `root_path` when its recorded extends
+    /// chain is unchanged on disk; `None` means the caller must re-parse.
     fn reuse_interned_tsconfig(
         &mut self,
         root_path: &[u8],
@@ -4139,8 +4108,7 @@ impl<'a> Resolver<'a> {
             }
         }
         // Re-check under the lock: another thread may have re-interned this
-        // path while files were being read; only reuse when the recorded
-        // chain still matches what was just validated.
+        // path while the files were being read.
         let guard = TSCONFIG_INTERNER.lock();
         let slot = guard.by_path.get(root_path)?;
         (slot.chain == chain).then_some(slot.ptr)
@@ -4257,8 +4225,6 @@ impl<'a> Resolver<'a> {
         // NOTE: return the `Box` so the caller (`dir_info_uncached`) takes
         // ownership — intermediate configs in an extends-chain are dropped via
         // `heap::take`, the final one is interned into the DirInfo cache.
-        // The copied-out bytes feed the caller's `TsconfigChainLink` record
-        // (only real parses reach here, so the copy is off the reuse path).
         Ok((Some(result), Box::from(&source.contents[..])))
     }
 
@@ -6649,17 +6615,12 @@ impl<'a> Resolver<'a> {
             }
 
             if let Some(tsconfigpath) = tsconfig_path {
-                // Fast path: when this path was merged before and every file
-                // in its recorded extends chain is byte-identical on disk,
-                // reuse the interned merge without parsing. A dir-cache bust
-                // re-runs this on every failed bare-specifier resolve, and a
-                // re-parse retains memory even when its result is discarded
-                // (see `PackageJSON::read_for_parse`).
+                // Reuse the interned merge when the recorded extends chain is
+                // byte-identical on disk; see `PackageJSON::read_for_parse`
+                // for why skipping the parse matters.
                 info.tsconfig_json = self.reuse_interned_tsconfig(tsconfigpath);
                 if info.tsconfig_json.is_none() {
-                    // Every file feeding the merge below (root + extends parents,
-                    // in walk order), recorded so the next recompute can prove
-                    // the chain unchanged.
+                    // Every file the merge below reads, in walk order.
                     let mut chain: Vec<TsconfigChainLink> = Vec::new();
                     let parsed_tsconfig: Option<*mut TSConfigJSON> = match self.parse_tsconfig(
                         tsconfigpath,
@@ -6740,10 +6701,8 @@ impl<'a> Resolver<'a> {
                                         config.map(bun_core::heap::into_raw)
                                     }
                                     Err(err) => {
-                                        // Recorded with `contents: None` so the
-                                        // reuse check re-merges once this parent
-                                        // becomes readable (e.g. it gets
-                                        // created after an unresolved extends).
+                                        // `contents: None` so the reuse check
+                                        // re-merges once this parent appears.
                                         chain.push(TsconfigChainLink {
                                             path: Box::from(abs_path),
                                             contents: None,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -248,6 +248,7 @@ use ::bun_core::{FeatureFlags, Generation};
 use bun_ast::Msg;
 use bun_collections::BoundedArray;
 use bun_dotenv::env_loader as DotEnv;
+use bun_hash::XxHash64Streaming;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR};
 use bun_perf::system_timer::Timer;
 use bun_ptr::Interned;
@@ -286,23 +287,259 @@ use bun_ast::SideEffects;
 // `mem::forget` for this — process-lifetime storage must go through
 // `LazyLock`. These append-only arenas are that storage; the `Box<T>` heap
 // address is stable across `Vec` growth, so handing out `&'static T` is sound.
+//
+// Entries are never removed, but `bust_dir_cache` + recompute re-parses the
+// directory's package.json / tsconfig.json each time (a failed bare-specifier
+// resolve busts the importer dir and retries; watchers bust on every change
+// event), so unconditional appends grow the arenas per bust, unbounded. The
+// interners below dedupe: re-interning a file whose bytes (and parse-shaping
+// options) are unchanged returns the existing allocation, and the arenas only
+// grow when contents actually change — which is the point of the bust.
 
-/// Intern a parsed `PackageJSON` into the process-lifetime DirInfo arena.
+/// Resolver state (beyond the file bytes) that shapes what
+/// `PackageJSON::parse` produces; an interned copy is only reused for a parse
+/// with an identical shape.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct PackageJsonParseShape {
+    /// `ALLOW_DEPENDENCIES` in `parse_package_json` (populates `dependencies`).
+    allow_dependencies: bool,
+    /// `Resolver.care_about_scripts` (populates `scripts` / `config`).
+    include_scripts: bool,
+    /// `parse` routes dependency-version parsing and lockfile id inference
+    /// through the auto-installer when one is wired.
+    has_auto_installer: bool,
+    /// Content hash of `opts.main_fields` — only listed fields land in
+    /// `PackageJSON::main_fields`. Hashed rather than borrowed: opts are
+    /// per-resolver and may be freed while the interned copy lives on.
+    main_fields_hash: u64,
+}
+
+/// Order-sensitive content hash of `opts.main_fields` for
+/// [`PackageJsonParseShape`] (length-prefixed so `["ab"]` ≠ `["a", "b"]`).
+fn main_fields_hash(fields: &[Box<[u8]>]) -> u64 {
+    let mut hasher = XxHash64Streaming::new(0);
+    for field in fields {
+        hasher.update(&(field.len() as u64).to_le_bytes());
+        hasher.update(field);
+    }
+    hasher.digest()
+}
+
+struct InternedPackageJson {
+    shape: PackageJsonParseShape,
+    /// Points at a `PackageJsonInterner::arena` slot. `NonNull` (not
+    /// `&'static`) so mut-provenance from intern time survives to write sites
+    /// (`package_manager_package_id`).
+    ptr: core::ptr::NonNull<PackageJSON>,
+}
+
+// SAFETY: `ptr` targets an append-only arena slot owned by the same `Guarded`
+// static; it crosses threads exactly like the `&'static PackageJSON` refs the
+// DirInfo cache already hands out.
+unsafe impl Send for InternedPackageJson {}
+
+#[derive(Default)]
+struct PackageJsonInterner {
+    /// Process-lifetime storage; never shrinks (un-busted DirInfos may hold
+    /// `&'static` refs to old entries even after a newer parse replaces them
+    /// in `by_path`).
+    // `Box` is load-bearing: handed-out pointers target the box interior,
+    // which is stable across `Vec` realloc; unboxing would dangle.
+    #[expect(clippy::vec_box)]
+    arena: Vec<Box<PackageJSON>>,
+    /// Interned copies per package.json path (keys are `dirname_store`
+    /// slices, so `'static`), at most one per parse shape.
+    by_path: bun_collections::StringHashMap<Vec<InternedPackageJson>>,
+}
+
+static PACKAGE_JSON_INTERNER: std::sync::LazyLock<bun_threading::Guarded<PackageJsonInterner>> =
+    std::sync::LazyLock::new(Default::default);
+
+/// Number of `PackageJSON` parses retained by the process-lifetime arena.
+/// Read via `bun:internal-for-testing` so tests can assert dir-cache busts
+/// reuse the interned copy instead of appending one per bust.
+pub fn package_json_arena_len() -> usize {
+    PACKAGE_JSON_INTERNER.lock().arena.len()
+}
+
+/// Intern a parsed `PackageJSON` into the process-lifetime DirInfo arena,
+/// reusing the existing allocation when the path, the source bytes, and the
+/// parse shape match an already-interned copy.
 /// Returns `NonNull` (not `&'static`) so mut-provenance survives to write
 /// sites — handing out `&T` here and casting back to `*mut T` would be UB
 /// under Stacked Borrows.
-fn intern_package_json(pkg: PackageJSON) -> core::ptr::NonNull<PackageJSON> {
-    // `Box` is load-bearing: returns `NonNull<PackageJSON>` derived from the
-    // box interior, treated as `'static`; unboxing would dangle on `Vec` realloc.
+fn intern_package_json(
+    pkg: PackageJSON,
+    shape: PackageJsonParseShape,
+) -> core::ptr::NonNull<PackageJSON> {
+    // `PackageJSON::parse` interned the path into `dirname_store`
+    // (process-lifetime), so the key is genuinely `'static`.
+    let path: &'static [u8] = pkg.source.path.text;
+    let mut guard = PACKAGE_JSON_INTERNER.lock();
+    let interner = &mut *guard;
+
+    if let Some(slot) = interner
+        .by_path
+        .get_mut(path)
+        .and_then(|slots| slots.iter_mut().find(|slot| slot.shape == shape))
+    {
+        // SAFETY: ARENA — arena slots are never freed or moved.
+        let cached: &PackageJSON = unsafe { slot.ptr.as_ref() };
+        if strings::eql(&cached.source_contents, &pkg.source_contents) {
+            // Same bytes, same shape: hand out the interned copy; the fresh
+            // parse drops. Carry over a package id the fresh parse resolved
+            // (from the caller or the lockfile), but never clear one written
+            // earlier by `enqueue_dependency_to_resolve`.
+            let fresh_id = pkg.package_manager_package_id;
+            if fresh_id != Install::INVALID_PACKAGE_ID
+                && cached.package_manager_package_id != fresh_id
+            {
+                // SAFETY: `ptr` carries mut-provenance from intern time; same
+                // single-writer contract as the `package_manager_package_id`
+                // write in `enqueue_dependency_to_resolve`.
+                unsafe { slot.ptr.as_mut() }.package_manager_package_id = fresh_id;
+            }
+            return slot.ptr;
+        }
+        // Bytes changed: intern the new parse and repoint the slot. The stale
+        // copy stays in the arena — un-busted DirInfos may still reference it.
+        interner.arena.push(Box::new(pkg));
+        // SAFETY: entries are never removed; the box interior is stable across
+        // `Vec` realloc. Derive from `&mut **last` so the returned pointer
+        // carries mut-provenance.
+        let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
+        slot.ptr = ptr;
+        return ptr;
+    }
+
+    interner.arena.push(Box::new(pkg));
+    // SAFETY: as above — stable box interior, mut-provenance via `&mut **last`.
+    let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
+    let entry = InternedPackageJson { shape, ptr };
+    match interner.by_path.get_mut(path) {
+        Some(slots) => slots.push(entry),
+        None => interner
+            .by_path
+            .put_static_key(path, vec![entry])
+            .expect("unreachable"),
+    }
+    ptr
+}
+
+/// One file the tsconfig merge read: absolute path + raw bytes. The reuse
+/// check re-reads exactly these files and compares bytes, so an unchanged
+/// extends chain skips the whole parse+merge.
+#[derive(Clone, PartialEq, Eq)]
+struct TsconfigChainLink {
+    path: Box<[u8]>,
+    contents: Box<[u8]>,
+}
+
+struct InternedTsconfig {
+    /// Every file that fed the merge, root first, in walk order.
+    chain: Vec<TsconfigChainLink>,
+    /// Points at a `TsconfigInterner::arena` slot.
+    ptr: core::ptr::NonNull<TSConfigJSON>,
+}
+
+// SAFETY: same contract as `InternedPackageJson` — append-only arena slot
+// under the same `Guarded` static.
+unsafe impl Send for InternedTsconfig {}
+
+#[derive(Default)]
+struct TsconfigInterner {
+    /// Process-lifetime storage; never shrinks (see `PackageJsonInterner`).
     #[expect(clippy::vec_box)]
-    static ARENA: std::sync::LazyLock<bun_threading::Guarded<Vec<Box<PackageJSON>>>> =
-        std::sync::LazyLock::new(Default::default);
-    let mut guard = ARENA.lock();
-    guard.push(Box::new(pkg));
-    // SAFETY: ARENA is `'static` (LazyLock); entries are never removed; the
-    // `Box<PackageJSON>` heap address is stable across `Vec` reallocation.
-    // Derive from `&mut **last` so the returned pointer carries mut-provenance.
-    core::ptr::NonNull::from(&mut **guard.last_mut().unwrap())
+    arena: Vec<Box<TSConfigJSON>>,
+    /// Latest interned merge per root tsconfig/jsconfig path. Keys are owned
+    /// copies — the lookup path lives in a threadlocal buffer.
+    by_path: bun_collections::StringHashMap<InternedTsconfig>,
+}
+
+static TSCONFIG_INTERNER: std::sync::LazyLock<bun_threading::Guarded<TsconfigInterner>> =
+    std::sync::LazyLock::new(Default::default);
+
+/// Number of merged `TSConfigJSON`s retained by the process-lifetime arena.
+/// Read via `bun:internal-for-testing`; see [`package_json_arena_len`].
+pub fn tsconfig_arena_len() -> usize {
+    TSCONFIG_INTERNER.lock().arena.len()
+}
+
+/// Intern the merged tsconfig for `root_path` (the directory's
+/// tsconfig/jsconfig path), reusing the existing allocation when the
+/// extends chain read byte-identical files. `merged` is the caller's
+/// heap-allocated merge result (`heap::into_raw`); on reuse it is destroyed
+/// here.
+fn intern_tsconfig(
+    root_path: &[u8],
+    chain: Vec<TsconfigChainLink>,
+    merged: *mut TSConfigJSON,
+) -> core::ptr::NonNull<TSConfigJSON> {
+    let mut guard = TSCONFIG_INTERNER.lock();
+    let interner = &mut *guard;
+
+    if let Some(slot) = interner.by_path.get_mut(root_path) {
+        if slot.chain == chain {
+            // SAFETY: `merged` came from `heap::into_raw` in the caller's
+            // merge walk and is uniquely owned here.
+            TSConfigJSON::destroy(unsafe { bun_core::heap::take(merged) });
+            return slot.ptr;
+        }
+        // Chain changed: intern the new merge and repoint the slot; the stale
+        // copy stays in the arena (un-busted DirInfos may still reference it).
+        // SAFETY: as above — reclaim the caller's allocation.
+        interner.arena.push(unsafe { bun_core::heap::take(merged) });
+        // SAFETY: see `intern_package_json` — stable box interior,
+        // mut-provenance via `&mut **last`.
+        let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
+        *slot = InternedTsconfig { chain, ptr };
+        return ptr;
+    }
+
+    // SAFETY: as above — reclaim the caller's allocation.
+    interner.arena.push(unsafe { bun_core::heap::take(merged) });
+    // SAFETY: as above.
+    let ptr = core::ptr::NonNull::from(&mut **interner.arena.last_mut().unwrap());
+    interner
+        .by_path
+        .put(root_path, InternedTsconfig { chain, ptr })
+        .expect("unreachable");
+    ptr
+}
+
+/// Reuse check for `parse_package_json`: when an interned copy exists for
+/// (`package_json_path`, `shape`) and its source bytes equal `contents`,
+/// return it without parsing — a discarded re-parse still grows the
+/// thread-local AST store (see `PackageJSON::read_for_parse`).
+fn reuse_interned_package_json(
+    package_json_path: &[u8],
+    shape: PackageJsonParseShape,
+    contents: &[u8],
+    package_id: Option<Install::PackageID>,
+) -> Option<core::ptr::NonNull<PackageJSON>> {
+    let mut guard = PACKAGE_JSON_INTERNER.lock();
+    let slot = guard
+        .by_path
+        .get_mut(package_json_path)?
+        .iter_mut()
+        .find(|slot| slot.shape == shape)?;
+    // SAFETY: ARENA — arena slots are never freed or moved.
+    let cached: &PackageJSON = unsafe { slot.ptr.as_ref() };
+    if !strings::eql(&cached.source_contents, contents) {
+        return None;
+    }
+    // A parse would have applied the caller-provided lockfile id
+    // (`PackageJSON::parse` does so before any inference); mirror that, but
+    // never clear an id written earlier by `enqueue_dependency_to_resolve`.
+    if let Some(id) = package_id {
+        if id != Install::INVALID_PACKAGE_ID && cached.package_manager_package_id != id {
+            // SAFETY: `ptr` carries mut-provenance from intern time; same
+            // single-writer contract as the `package_manager_package_id`
+            // write in `enqueue_dependency_to_resolve`.
+            unsafe { slot.ptr.as_mut() }.package_manager_package_id = id;
+        }
+    }
+    Some(slot.ptr)
 }
 
 // `bun_core::declare_scope!` emits the per-scope `static ScopedLogger`; the
@@ -3875,11 +4112,66 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// Fast path for `dir_info_uncached`: reuse the interned merged tsconfig
+    /// for `root_path` when every file in its recorded extends chain is
+    /// byte-identical on disk. Any read error or mismatch returns `None` and
+    /// the caller re-parses (the parse path owns error reporting).
+    fn reuse_interned_tsconfig(
+        &mut self,
+        root_path: &[u8],
+    ) -> Option<core::ptr::NonNull<TSConfigJSON>> {
+        let chain: Vec<TsconfigChainLink> = {
+            let guard = TSCONFIG_INTERNER.lock();
+            // Clone the (small) record so files aren't read under the lock.
+            guard.by_path.get(root_path)?.chain.clone()
+        };
+        for link in &chain {
+            let bytes = self.read_file_for_tsconfig_reuse(&link.path)?;
+            if !strings::eql(&bytes, &link.contents) {
+                return None;
+            }
+        }
+        // Re-check under the lock: another thread may have re-interned this
+        // path while files were being read; only reuse when the recorded
+        // chain still matches what was just validated.
+        let guard = TSCONFIG_INTERNER.lock();
+        let slot = guard.by_path.get(root_path)?;
+        (slot.chain == chain).then_some(slot.ptr)
+    }
+
+    /// Read `path` for the tsconfig reuse check. `None` on any error — the
+    /// caller falls through to the parse path, which owns error reporting.
+    fn read_file_for_tsconfig_reuse(&mut self, path: &[u8]) -> Option<Vec<u8>> {
+        let mut entry = self
+            .caches
+            .fs
+            .read_file_with_allocator(
+                // SAFETY: process-global `FileSystem` singleton (see `fs()` NOTE); narrow `&mut`
+                // for this call only — `self.caches` is a field of `self` (disjoint allocation).
+                unsafe { &mut *self.fs() },
+                path,
+                FD::INVALID,
+                false,
+                None,
+                None,
+            )
+            .ok()?;
+        let contents = core::mem::take(&mut entry.contents);
+        let _ = entry.close_fd();
+        Some(match contents {
+            crate::cache::Contents::Owned(v) => v,
+            crate::cache::Contents::Empty => Vec::new(),
+            other => other.as_slice().to_vec(),
+        })
+    }
+
+    /// On success, also returns the raw file bytes so `dir_info_uncached` can
+    /// record the extends-chain contents that `intern_tsconfig` dedupes on.
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
         dirname_fd: FD,
-    ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
+    ) -> crate::CrateResult<Option<(Box<TSConfigJSON>, Box<[u8]>)>> {
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
         let mut entry = self.caches.fs.read_file_with_allocator(
@@ -3957,7 +4249,9 @@ impl<'a> Resolver<'a> {
         // NOTE: return the `Box` so the caller (`dir_info_uncached`) takes
         // ownership — intermediate configs in an extends-chain are dropped via
         // `heap::take`, the final one is interned into the DirInfo cache.
-        Ok(Some(result))
+        // The copied-out bytes feed the caller's `TsconfigChainLink` record
+        // (only real parses reach here, so the copy is off the reuse path).
+        Ok(Some((result, Box::from(&source.contents[..]))))
     }
 
     pub fn bin_dirs(&self) -> &[&'static [u8]] {
@@ -3976,27 +4270,44 @@ impl<'a> Resolver<'a> {
         package_id: Option<Install::PackageID>,
     ) -> crate::CrateResult<Option<core::ptr::NonNull<PackageJSON>>> {
         use crate::package_json::{IncludeDependencies, IncludeScripts};
+        let shape = PackageJsonParseShape {
+            allow_dependencies: ALLOW_DEPENDENCIES,
+            include_scripts: self.care_about_scripts,
+            has_auto_installer: self.package_manager.is_some(),
+            main_fields_hash: main_fields_hash(&self.opts.main_fields),
+        };
+        let Some((package_json_path, contents)) =
+            PackageJSON::read_for_parse(self, file, dirname_fd)
+        else {
+            return Ok(None);
+        };
+        if let Some(interned) =
+            reuse_interned_package_json(package_json_path, shape, &contents, package_id)
+        {
+            return Ok(Some(interned));
+        }
+
         // NOTE: `IncludeDependencies` is a
-        // const generic on `PackageJSON::parse`, `IncludeScripts` is runtime (it only
-        // gates one branch).
+        // const generic on `PackageJSON::parse_with_contents`, `IncludeScripts`
+        // is runtime (it only gates one branch).
         let include_scripts = if self.care_about_scripts {
             IncludeScripts::IncludeScripts
         } else {
             IncludeScripts::IgnoreScripts
         };
         let pkg = if ALLOW_DEPENDENCIES {
-            PackageJSON::parse::<{ IncludeDependencies::Local }>(
+            PackageJSON::parse_with_contents::<{ IncludeDependencies::Local }>(
                 self,
-                file,
-                dirname_fd,
+                package_json_path,
+                contents,
                 package_id,
                 include_scripts,
             )
         } else {
-            PackageJSON::parse::<{ IncludeDependencies::None }>(
+            PackageJSON::parse_with_contents::<{ IncludeDependencies::None }>(
                 self,
-                file,
-                dirname_fd,
+                package_json_path,
+                contents,
                 package_id,
                 include_scripts,
             )
@@ -4006,7 +4317,7 @@ impl<'a> Resolver<'a> {
         // NOTE: the DirInfo cache holds `&'static` refs. PORTING.md
         // §Forbidden bars `Box::leak`; intern into the process-lifetime arena
         // owned alongside the DirInfo singleton instead.
-        Ok(Some(intern_package_json(pkg)))
+        Ok(Some(intern_package_json(pkg, shape)))
     }
 
     fn dir_info_cached(&mut self, path: &[u8]) -> crate::CrateResult<Option<DirInfoRef>> {
@@ -6330,151 +6641,178 @@ impl<'a> Resolver<'a> {
             }
 
             if let Some(tsconfigpath) = tsconfig_path {
-                let parsed_tsconfig: Option<*mut TSConfigJSON> = match self.parse_tsconfig(
-                    tsconfigpath,
-                    if FeatureFlags::STORE_FILE_DESCRIPTORS {
-                        fd
-                    } else {
-                        FD::ZERO
-                    },
-                ) {
-                    Ok(v) => v.map(bun_core::heap::into_raw),
-                    Err(err) => {
-                        let pretty = tsconfigpath;
-                        if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
-                            let _ = self.log_mut().add_error_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "Cannot find tsconfig file {}",
-                                    bun_core::fmt::quote(pretty)
-                                ),
-                            );
-                        } else if err != crate::Error::ParseErrorAlreadyLogged
-                            && err != crate::Error::Sys(bun_errno::SystemErrno::EISDIR)
-                        {
-                            let _ = self.log_mut().add_error_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "Cannot read file {}: {}",
-                                    bun_core::fmt::quote(pretty),
-                                    bstr::BStr::new(err.name())
-                                ),
-                            );
+                // Fast path: when this path was merged before and every file
+                // in its recorded extends chain is byte-identical on disk,
+                // reuse the interned merge without parsing. A dir-cache bust
+                // re-runs this on every failed bare-specifier resolve, and a
+                // re-parse retains memory even when its result is discarded
+                // (see `PackageJSON::read_for_parse`).
+                info.tsconfig_json = self.reuse_interned_tsconfig(tsconfigpath);
+                if info.tsconfig_json.is_none() {
+                    // Every file feeding the merge below (root + extends parents,
+                    // in walk order), recorded so the next recompute can prove
+                    // the chain unchanged.
+                    let mut chain: Vec<TsconfigChainLink> = Vec::new();
+                    let parsed_tsconfig: Option<*mut TSConfigJSON> = match self.parse_tsconfig(
+                        tsconfigpath,
+                        if FeatureFlags::STORE_FILE_DESCRIPTORS {
+                            fd
+                        } else {
+                            FD::ZERO
+                        },
+                    ) {
+                        Ok(v) => v.map(|(config, contents)| {
+                            chain.push(TsconfigChainLink {
+                                path: Box::from(tsconfigpath),
+                                contents,
+                            });
+                            bun_core::heap::into_raw(config)
+                        }),
+                        Err(err) => {
+                            let pretty = tsconfigpath;
+                            if err == crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
+                                let _ = self.log_mut().add_error_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "Cannot find tsconfig file {}",
+                                        bun_core::fmt::quote(pretty)
+                                    ),
+                                );
+                            } else if err != crate::Error::ParseErrorAlreadyLogged
+                                && err != crate::Error::Sys(bun_errno::SystemErrno::EISDIR)
+                            {
+                                let _ = self.log_mut().add_error_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "Cannot read file {}: {}",
+                                        bun_core::fmt::quote(pretty),
+                                        bstr::BStr::new(err.name())
+                                    ),
+                                );
+                            }
+                            None
                         }
-                        None
-                    }
-                };
-                // NOTE: assigning info.tsconfig_json here and then freeing that
-                // allocation in the merge loop below before reassigning would
-                // leave a briefly-dangling reference
-                // (Option<&'static TSConfigJSON>, dir_info.rs) — UB.
-                // Defer the assignment to after the merge —
-                // it is always overwritten when parsed_tsconfig.is_some(), and DirInfo defaults
-                // tsconfig_json to None otherwise.
-                if let Some(tsconfig_json) = parsed_tsconfig {
-                    let mut parent_configs: BoundedArray<*mut TSConfigJSON, 64> =
-                        BoundedArray::default();
-                    parent_configs.append(tsconfig_json)?;
-                    // `current`/`parent_config_ptr`/`merged_config` are heap TSConfigJSON
-                    // allocations from `parse_tsconfig` (heap::alloc); uniquely owned by
-                    // this extends-chain walk and freed via heap::take below. Hold as
-                    // `BackRef` (pointee outlives holder) so the loop body reads via safe
-                    // `Deref` instead of three open-coded raw-ptr derefs.
-                    let mut current = bun_ptr::BackRef::from(
-                        core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"),
-                    );
-                    while !current.extends.is_empty() {
-                        let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        let abs_path = ResolvePath::join_abs_string_buf(
-                            ts_dir_name,
-                            bufs!(tsconfig_path_abs),
-                            &[ts_dir_name, &current.extends],
-                            bun_paths::Platform::AUTO,
+                    };
+                    // NOTE: assigning info.tsconfig_json here and then freeing that
+                    // allocation in the merge loop below before reassigning would
+                    // leave a briefly-dangling reference
+                    // (Option<&'static TSConfigJSON>, dir_info.rs) — UB.
+                    // Defer the assignment to after the merge —
+                    // it is always overwritten when parsed_tsconfig.is_some(), and DirInfo defaults
+                    // tsconfig_json to None otherwise.
+                    if let Some(tsconfig_json) = parsed_tsconfig {
+                        let mut parent_configs: BoundedArray<*mut TSConfigJSON, 64> =
+                            BoundedArray::default();
+                        parent_configs.append(tsconfig_json)?;
+                        // `current`/`parent_config_ptr`/`merged_config` are heap TSConfigJSON
+                        // allocations from `parse_tsconfig` (heap::alloc); uniquely owned by
+                        // this extends-chain walk and freed via heap::take below. Hold as
+                        // `BackRef` (pointee outlives holder) so the loop body reads via safe
+                        // `Deref` instead of three open-coded raw-ptr derefs.
+                        let mut current = bun_ptr::BackRef::from(
+                            core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"),
                         );
-                        let parent_config_maybe: Option<*mut TSConfigJSON> =
-                            match self.parse_tsconfig(abs_path, FD::INVALID) {
-                                Ok(v) => v.map(bun_core::heap::into_raw),
-                                Err(err) => {
-                                    let _ = self.log_mut().add_debug_fmt(
-                                        None,
-                                        bun_ast::Loc::EMPTY,
-                                        format_args!(
-                                            "{} loading tsconfig.json extends {}",
-                                            bstr::BStr::new(err.name()),
-                                            bun_core::fmt::quote(abs_path)
-                                        ),
-                                    );
-                                    break;
-                                }
-                            };
-                        if let Some(parent_config) = parent_config_maybe {
-                            parent_configs.append(parent_config)?;
-                            current = bun_ptr::BackRef::from(
-                                core::ptr::NonNull::new(parent_config).expect("heap alloc"),
+                        while !current.extends.is_empty() {
+                            let ts_dir_name = Dirname::dirname(&current.abs_path);
+                            let abs_path = ResolvePath::join_abs_string_buf(
+                                ts_dir_name,
+                                bufs!(tsconfig_path_abs),
+                                &[ts_dir_name, &current.extends],
+                                bun_paths::Platform::AUTO,
                             );
-                        } else {
-                            break;
+                            let parent_config_maybe: Option<*mut TSConfigJSON> =
+                                match self.parse_tsconfig(abs_path, FD::INVALID) {
+                                    Ok(v) => v.map(|(config, contents)| {
+                                        chain.push(TsconfigChainLink {
+                                            path: Box::from(abs_path),
+                                            contents,
+                                        });
+                                        bun_core::heap::into_raw(config)
+                                    }),
+                                    Err(err) => {
+                                        let _ = self.log_mut().add_debug_fmt(
+                                            None,
+                                            bun_ast::Loc::EMPTY,
+                                            format_args!(
+                                                "{} loading tsconfig.json extends {}",
+                                                bstr::BStr::new(err.name()),
+                                                bun_core::fmt::quote(abs_path)
+                                            ),
+                                        );
+                                        break;
+                                    }
+                                };
+                            if let Some(parent_config) = parent_config_maybe {
+                                parent_configs.append(parent_config)?;
+                                current = bun_ptr::BackRef::from(
+                                    core::ptr::NonNull::new(parent_config).expect("heap alloc"),
+                                );
+                            } else {
+                                break;
+                            }
                         }
+
+                        let merged_config = parent_configs.pop().unwrap();
+                        // starting from the base config (end of the list)
+                        // successively apply the inheritable attributes to the next config
+                        while let Some(parent_config_ptr) = parent_configs.pop() {
+                            // SAFETY: see loop-wide note above.
+                            let parent_config = unsafe { &mut *parent_config_ptr };
+                            // SAFETY: see loop-wide note above.
+                            let mc = unsafe { &mut *merged_config };
+                            mc.emit_decorator_metadata =
+                                mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
+                            if let Some(v) = parent_config.use_define_for_class_fields {
+                                mc.use_define_for_class_fields = Some(v);
+                            }
+                            if !parent_config.base_url.is_empty() {
+                                mc.base_url = core::mem::take(&mut parent_config.base_url);
+                            }
+                            mc.jsx = parent_config.merge_jsx(mc.jsx.clone());
+                            mc.jsx_flags.insert_all(parent_config.jsx_flags);
+
+                            if let Some(value) = parent_config.preserve_imports_not_used_as_values {
+                                mc.preserve_imports_not_used_as_values = Some(value);
+                            }
+
+                            // TypeScript replaces paths across extends (child overrides parent
+                            // entirely), so when a more-specific config defines paths, replace
+                            // rather than merge. base_url_for_paths is set whenever the paths
+                            // key is present in the JSON (even if empty), so it discriminates
+                            // "not defined" from "defined as {}" — the latter clears inherited
+                            // paths per TypeScript semantics.
+                            if !parent_config.base_url_for_paths.is_empty() {
+                                // The previous merged_config.paths is being replaced;
+                                // dropping the map frees the values automatically, so the
+                                // PathsMap from the deeper config doesn't leak.
+                                mc.paths = core::mem::take(&mut parent_config.paths);
+                                mc.base_url_for_paths =
+                                    core::mem::take(&mut parent_config.base_url_for_paths);
+                            } else {
+                                // paths were not moved to merged_config, so they're still owned
+                                // by parent_config. base_url_for_paths.len == 0 implies the map
+                                // is empty (it's only set when the `paths` key is present in the
+                                // JSON), so this is a no-op but documents the ownership.
+                                // (Drop handles parent_config.paths.)
+                            }
+                            // Every scalar/reference we need has been copied into merged_config
+                            // (strings live in dirname_store or default_allocator and outlive the
+                            // struct). The heap-allocated TSConfigJSON itself is no longer needed;
+                            // without this, every intermediate config in an extends chain leaks on
+                            // each dirInfoUncached() call, which is especially bad under HMR where
+                            // bustDirCache triggers a re-parse of the whole chain on every reload.
+                            // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
+                            TSConfigJSON::destroy(unsafe {
+                                bun_core::heap::take(parent_config_ptr)
+                            });
+                        }
+                        // Interned into the process-lifetime arena (deduped against
+                        // the previous merge for this path); outlives the resolver.
+                        info.tsconfig_json =
+                            Some(intern_tsconfig(tsconfigpath, chain, merged_config));
                     }
-
-                    let merged_config = parent_configs.pop().unwrap();
-                    // starting from the base config (end of the list)
-                    // successively apply the inheritable attributes to the next config
-                    while let Some(parent_config_ptr) = parent_configs.pop() {
-                        // SAFETY: see loop-wide note above.
-                        let parent_config = unsafe { &mut *parent_config_ptr };
-                        // SAFETY: see loop-wide note above.
-                        let mc = unsafe { &mut *merged_config };
-                        mc.emit_decorator_metadata =
-                            mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
-                        if let Some(v) = parent_config.use_define_for_class_fields {
-                            mc.use_define_for_class_fields = Some(v);
-                        }
-                        if !parent_config.base_url.is_empty() {
-                            mc.base_url = core::mem::take(&mut parent_config.base_url);
-                        }
-                        mc.jsx = parent_config.merge_jsx(mc.jsx.clone());
-                        mc.jsx_flags.insert_all(parent_config.jsx_flags);
-
-                        if let Some(value) = parent_config.preserve_imports_not_used_as_values {
-                            mc.preserve_imports_not_used_as_values = Some(value);
-                        }
-
-                        // TypeScript replaces paths across extends (child overrides parent
-                        // entirely), so when a more-specific config defines paths, replace
-                        // rather than merge. base_url_for_paths is set whenever the paths
-                        // key is present in the JSON (even if empty), so it discriminates
-                        // "not defined" from "defined as {}" — the latter clears inherited
-                        // paths per TypeScript semantics.
-                        if !parent_config.base_url_for_paths.is_empty() {
-                            // The previous merged_config.paths is being replaced;
-                            // dropping the map frees the values automatically, so the
-                            // PathsMap from the deeper config doesn't leak.
-                            mc.paths = core::mem::take(&mut parent_config.paths);
-                            mc.base_url_for_paths =
-                                core::mem::take(&mut parent_config.base_url_for_paths);
-                        } else {
-                            // paths were not moved to merged_config, so they're still owned
-                            // by parent_config. base_url_for_paths.len == 0 implies the map
-                            // is empty (it's only set when the `paths` key is present in the
-                            // JSON), so this is a no-op but documents the ownership.
-                            // (Drop handles parent_config.paths.)
-                        }
-                        // Every scalar/reference we need has been copied into merged_config
-                        // (strings live in dirname_store or default_allocator and outlive the
-                        // struct). The heap-allocated TSConfigJSON itself is no longer needed;
-                        // without this, every intermediate config in an extends chain leaks on
-                        // each dirInfoUncached() call, which is especially bad under HMR where
-                        // bustDirCache triggers a re-parse of the whole chain on every reload.
-                        // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
-                        TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config_ptr) });
-                    }
-                    // `merged_config` is a leaked Box (heap::alloc) interned into DirInfo; outlives the resolver.
-                    info.tsconfig_json = Some(
-                        core::ptr::NonNull::new(merged_config).expect("heap::alloc is non-null"),
-                    );
                 }
                 info.enclosing_tsconfig_json = info.tsconfig_json();
             }

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -94,4 +94,24 @@ pub use css::test_with_options as css_jsc_css_internals_test_with_options;
 // `bun_jsc`) rather than inventing a JSC edge into the collections crate.
 pub(crate) use crate::linear_fifo_testing::ordered_remove_probe as collections_linear_fifo_testing_ap_is_ordered_remove_probe;
 
+// `bun_resolver` has no JSC edge; these `bun:internal-for-testing` probes
+// read the resolver's process-lifetime parse arenas (leak regression tests).
+pub(crate) fn resolver_resolver_js_package_json_arena_len(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number(
+        bun_resolver::resolver::package_json_arena_len() as f64,
+    ))
+}
+
+pub(crate) fn resolver_resolver_js_tsconfig_arena_len(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number(
+        bun_resolver::resolver::tsconfig_arena_len() as f64,
+    ))
+}
+
 // ported from: generated_js2native.rs

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -114,4 +114,22 @@ pub(crate) fn resolver_resolver_js_tsconfig_arena_len(
     ))
 }
 
+pub(crate) fn resolver_resolver_js_package_json_parse_count(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number(
+        bun_resolver::resolver::package_json_parse_count() as f64,
+    ))
+}
+
+pub(crate) fn resolver_resolver_js_tsconfig_parse_count(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number(
+        bun_resolver::resolver::tsconfig_parse_count() as f64,
+    ))
+}
+
 // ported from: generated_js2native.rs

--- a/test/js/bun/resolve/dir-cache-bust-leak.test.ts
+++ b/test/js/bun/resolve/dir-cache-bust-leak.test.ts
@@ -30,6 +30,7 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
     "a/x.js": `module.exports = "a";`,
     "b/y.js": `module.exports = "b";`,
     "c/z.js": `module.exports = "c";`,
+    "c/z2.js": `module.exports = "c2";`,
     // The presence of node_modules keeps the runtime's auto-install out of
     // the failed resolves below (no registry traffic).
     "node_modules/.gitkeep": "",
@@ -73,7 +74,20 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
       const viaBase = require2("@base/z");
       for (let i = 0; i < 10; i++) miss();
       const p5 = pkgLen(), t5 = tsLen();
-      console.log(JSON.stringify({ before, after, viaBase, p0, p1, p2, p3, p4, p5, t0, t1, t2, t3, t4, t5 }));
+
+      // A parent that turns malformed re-merges once (without it), stays flat
+      // while malformed, and re-merges once more when fixed.
+      writeFileSync(join(here, "tsconfig.base.json"), "{ this is not json !!");
+      miss();
+      const t6 = tsLen();
+      for (let i = 0; i < 10; i++) miss();
+      const t7 = tsLen();
+      writeFileSync(join(here, "tsconfig.base.json"), ${JSON.stringify(JSON.stringify(tsconfigBase))});
+      miss();
+      const t8 = tsLen();
+      const viaBaseFixed = require2("@base/z2");
+      const p6 = pkgLen();
+      console.log(JSON.stringify({ before, after, viaBase, viaBaseFixed, p0, p1, p2, p3, p4, p5, p6, t0, t1, t2, t3, t4, t5, t6, t7, t8 }));
     `,
   });
 
@@ -110,6 +124,13 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
     tsBaseGrowth: out.t4 - out.t3,
     pkgFinalGrowth: out.p5 - out.p4,
     tsFinalGrowth: out.t5 - out.t4,
+    // A malformed parent re-merges once, stays flat while malformed, and
+    // re-merges once more when fixed.
+    tsMalformedGrowth: out.t6 - out.t5,
+    tsMalformedFlat: out.t7 - out.t6,
+    tsFixedGrowth: out.t8 - out.t7,
+    viaBaseFixed: out.viaBaseFixed,
+    pkgTailGrowth: out.p6 - out.p5,
   }).toEqual({
     before: "a",
     after: "b",
@@ -124,6 +145,11 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
     tsBaseGrowth: 1,
     pkgFinalGrowth: 0,
     tsFinalGrowth: 0,
+    tsMalformedGrowth: 1,
+    tsMalformedFlat: 0,
+    tsFixedGrowth: 1,
+    viaBaseFixed: "c2",
+    pkgTailGrowth: 0,
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/dir-cache-bust-leak.test.ts
+++ b/test/js/bun/resolve/dir-cache-bust-leak.test.ts
@@ -3,30 +3,31 @@
 // and tsconfig.json into process-lifetime arenas that never free. A
 // long-running process doing `try { require("optional-dep") } catch {}` from a
 // directory with a package.json leaked one full parsed copy per miss (~178 KB
-// per miss for a 26 KB package.json). The interner now reuses the existing
-// allocation when the file bytes (and, for tsconfig, the whole extends chain)
-// are unchanged, so the arenas only grow when contents actually change.
+// per miss for a 26 KB package.json). The interner now reuses the previous
+// outcome (including parse failures) when the file bytes are unchanged, so
+// the arenas only grow and files only re-parse when contents change.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", async () => {
-  const pkg = { name: "dir-cache-bust-fixture", version: "1.0.0" };
+  const pkgA = JSON.stringify({ name: "dir-cache-bust-fixture", version: "1.0.0", main: "./a/x.js" });
+  const pkgB = JSON.stringify({ name: "dir-cache-bust-fixture", version: "1.0.0", main: "./b/y.js" });
   // The extends target does not exist at first; the recompute must notice
   // when it appears.
-  const tsconfigWithPaths = {
+  const tsWithPaths = JSON.stringify({
     extends: "./tsconfig.base.json",
     compilerOptions: { baseUrl: ".", paths: { "@app/*": ["./a/*"] } },
-  };
-  const tsconfigNoPaths = {
+  });
+  const tsNoPaths = JSON.stringify({
     extends: "./tsconfig.base.json",
     compilerOptions: { baseUrl: "." },
-  };
-  const tsconfigBase = {
+  });
+  const tsBase = JSON.stringify({
     compilerOptions: { paths: { "@app/*": ["./b/*"], "@base/*": ["./c/*"] } },
-  };
+  });
   using dir = tempDir("dir-cache-bust-leak", {
-    "package.json": JSON.stringify(pkg),
-    "tsconfig.json": JSON.stringify(tsconfigWithPaths),
+    "package.json": pkgA,
+    "tsconfig.json": tsWithPaths,
     "a/x.js": `module.exports = "a";`,
     "b/y.js": `module.exports = "b";`,
     "c/z.js": `module.exports = "c";`,
@@ -46,48 +47,103 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
           require2("pkg-that-does-not-exist-xyz");
         } catch {}
       };
-      const pkgLen = resolverInternals.packageJsonArenaLen;
-      const tsLen = resolverInternals.tsconfigArenaLen;
+      const misses = n => { for (let i = 0; i < n; i++) miss(); };
+      const counts = () => [
+        resolverInternals.packageJsonArenaLen(),
+        resolverInternals.tsconfigArenaLen(),
+        resolverInternals.packageJsonParseCount(),
+        resolverInternals.tsconfigParseCount(),
+      ];
+      const out = {};
 
       // Settle initial parses (the first miss busts + recomputes the dir).
       miss();
-      const before = require2("@app/x");
-      const p0 = pkgLen(), t0 = tsLen();
-      for (let i = 0; i < 25; i++) miss();
-      const p1 = pkgLen(), t1 = tsLen();
+      out.before = require2("@app/x");
+      out.mainBefore = require2(here);
+      const s0 = counts();
+      misses(25);
+      const s1 = counts();
+      // 25 misses over unchanged files retain nothing and re-parse nothing.
+      out.missGrowth = [s1[0] - s0[0], s1[1] - s0[1], s1[2] - s0[2], s1[3] - s0[3]];
 
-      // Real edits must still be picked up by the bust: one new interned copy
-      // each, then flat again.
-      writeFileSync(join(here, "package.json"), ${JSON.stringify(JSON.stringify({ ...pkg, description: "edited" }))});
-      writeFileSync(join(here, "tsconfig.json"), ${JSON.stringify(JSON.stringify(tsconfigNoPaths))});
+      // package.json-only edit: one new interned copy, tsconfig untouched,
+      // and the new parse is actually served ("main" changes the resolution).
+      writeFileSync(join(here, "package.json"), ${JSON.stringify(pkgB)});
       miss();
-      const p2 = pkgLen(), t2 = tsLen();
-      for (let i = 0; i < 25; i++) miss();
-      const p3 = pkgLen(), t3 = tsLen();
+      const s2 = counts();
+      out.pkgEditGrowth = [s2[0] - s1[0], s2[1] - s1[1]];
+      out.mainAfter = require2(here);
+
+      // tsconfig-only edit: one new merge, package.json untouched.
+      writeFileSync(join(here, "tsconfig.json"), ${JSON.stringify(tsNoPaths)});
+      miss();
+      const s3 = counts();
+      out.tsEditGrowth = [s3[0] - s2[0], s3[1] - s2[1]];
+
+      // Rewriting both files with identical bytes (fresh mtimes) stays flat:
+      // reuse is keyed on contents, not timestamps.
+      writeFileSync(join(here, "package.json"), ${JSON.stringify(pkgB)});
+      writeFileSync(join(here, "tsconfig.json"), ${JSON.stringify(tsNoPaths)});
+      misses(2);
+      const s4 = counts();
+      out.sameBytesGrowth = [s4[0] - s3[0], s4[1] - s3[1], s4[2] - s3[2], s4[3] - s3[3]];
 
       // A previously-missing extends parent appearing must re-merge even
       // though the root file itself is unchanged.
-      writeFileSync(join(here, "tsconfig.base.json"), ${JSON.stringify(JSON.stringify(tsconfigBase))});
+      writeFileSync(join(here, "tsconfig.base.json"), ${JSON.stringify(tsBase)});
       miss();
-      const p4 = pkgLen(), t4 = tsLen();
-      const after = require2("@app/y");
-      const viaBase = require2("@base/z");
-      for (let i = 0; i < 10; i++) miss();
-      const p5 = pkgLen(), t5 = tsLen();
+      const s5 = counts();
+      out.baseGrowth = [s5[0] - s4[0], s5[1] - s4[1]];
+      out.after = require2("@app/y");
+      out.viaBase = require2("@base/z");
+      misses(10);
+      const s6 = counts();
+      out.postBaseGrowth = [s6[0] - s5[0], s6[1] - s5[1]];
 
       // A parent that turns malformed re-merges once (without it), stays flat
       // while malformed, and re-merges once more when fixed.
       writeFileSync(join(here, "tsconfig.base.json"), "{ this is not json !!");
       miss();
-      const t6 = tsLen();
-      for (let i = 0; i < 10; i++) miss();
-      const t7 = tsLen();
-      writeFileSync(join(here, "tsconfig.base.json"), ${JSON.stringify(JSON.stringify(tsconfigBase))});
+      const s7 = counts();
+      out.tsMalformedGrowth = s7[1] - s6[1];
+      misses(10);
+      const s8 = counts();
+      out.tsMalformedFlat = [s8[1] - s7[1], s8[3] - s7[3]];
+      writeFileSync(join(here, "tsconfig.base.json"), ${JSON.stringify(tsBase)});
       miss();
-      const t8 = tsLen();
-      const viaBaseFixed = require2("@base/z2");
-      const p6 = pkgLen();
-      console.log(JSON.stringify({ before, after, viaBase, viaBaseFixed, p0, p1, p2, p3, p4, p5, p6, t0, t1, t2, t3, t4, t5, t6, t7, t8 }));
+      const s9 = counts();
+      out.tsFixedGrowth = s9[1] - s8[1];
+      out.viaBaseFixed = require2("@base/z2");
+
+      // A broken root package.json is negative-cached: the failed outcome is
+      // recorded (no arena growth) and unchanged bytes skip the re-parse.
+      writeFileSync(join(here, "package.json"), "{ this is not json !!");
+      miss();
+      const s10 = counts();
+      out.pkgBrokenGrowth = s10[0] - s9[0];
+      misses(10);
+      const s11 = counts();
+      out.pkgBrokenFlat = [s11[0] - s10[0], s11[2] - s10[2]];
+      writeFileSync(join(here, "package.json"), ${JSON.stringify(pkgB)});
+      miss();
+      const s12 = counts();
+      out.pkgRestoredGrowth = s12[0] - s11[0];
+
+      // Same for a broken root tsconfig: the no-config outcome is recorded.
+      writeFileSync(join(here, "tsconfig.json"), "{ this is not json !!");
+      miss();
+      const s13 = counts();
+      out.tsBrokenGrowth = s13[1] - s12[1];
+      misses(10);
+      const s14 = counts();
+      out.tsBrokenFlat = [s14[1] - s13[1], s14[3] - s13[3]];
+      writeFileSync(join(here, "tsconfig.json"), ${JSON.stringify(tsNoPaths)});
+      miss();
+      const s15 = counts();
+      out.tsRestoredGrowth = s15[1] - s14[1];
+
+      out.arenaLens = [s0[0], s0[1]];
+      console.log(JSON.stringify(out));
     `,
   });
 
@@ -102,54 +158,42 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
 
   expect(stderr).toBe("");
   const out = JSON.parse(stdout);
-  expect(out.p0).toBeGreaterThanOrEqual(1);
-  expect(out.t0).toBeGreaterThanOrEqual(1);
-  expect({
-    // tsconfig paths resolve through the (re)parsed configs end to end.
-    before: out.before,
-    after: out.after,
-    viaBase: out.viaBase,
-    // 25 misses over unchanged files retain nothing (including re-probing the
-    // still-missing extends parent).
-    pkgMissGrowth: out.p1 - out.p0,
-    tsMissGrowth: out.t1 - out.t0,
-    // An edit is picked up as exactly one new interned copy.
-    pkgEditGrowth: out.p2 - out.p1,
-    tsEditGrowth: out.t2 - out.t1,
-    // And misses after the edit are flat again.
-    pkgPostEditGrowth: out.p3 - out.p2,
-    tsPostEditGrowth: out.t3 - out.t2,
-    // The extends parent appearing re-merges the chain exactly once.
-    pkgBaseGrowth: out.p4 - out.p3,
-    tsBaseGrowth: out.t4 - out.t3,
-    pkgFinalGrowth: out.p5 - out.p4,
-    tsFinalGrowth: out.t5 - out.t4,
-    // A malformed parent re-merges once, stays flat while malformed, and
-    // re-merges once more when fixed.
-    tsMalformedGrowth: out.t6 - out.t5,
-    tsMalformedFlat: out.t7 - out.t6,
-    tsFixedGrowth: out.t8 - out.t7,
-    viaBaseFixed: out.viaBaseFixed,
-    pkgTailGrowth: out.p6 - out.p5,
-  }).toEqual({
+  expect(out.arenaLens[0]).toBeGreaterThanOrEqual(1);
+  expect(out.arenaLens[1]).toBeGreaterThanOrEqual(1);
+  expect(out).toEqual({
+    arenaLens: out.arenaLens,
+    // tsconfig paths and package.json "main" resolve through the (re)parsed
+    // structs end to end.
     before: "a",
+    mainBefore: "a",
+    mainAfter: "b",
     after: "b",
     viaBase: "c",
-    pkgMissGrowth: 0,
-    tsMissGrowth: 0,
-    pkgEditGrowth: 1,
-    tsEditGrowth: 1,
-    pkgPostEditGrowth: 0,
-    tsPostEditGrowth: 0,
-    pkgBaseGrowth: 0,
-    tsBaseGrowth: 1,
-    pkgFinalGrowth: 0,
-    tsFinalGrowth: 0,
-    tsMalformedGrowth: 1,
-    tsMalformedFlat: 0,
-    tsFixedGrowth: 1,
     viaBaseFixed: "c2",
-    pkgTailGrowth: 0,
+    // [pkgArena, tsArena, pkgParses, tsParses] over 25 unchanged misses.
+    missGrowth: [0, 0, 0, 0],
+    // Each single-file edit grows only its own arena by exactly one.
+    pkgEditGrowth: [1, 0],
+    tsEditGrowth: [0, 1],
+    // Same-bytes rewrites (fresh mtimes) retain and re-parse nothing.
+    sameBytesGrowth: [0, 0, 0, 0],
+    // The extends parent appearing re-merges the chain exactly once.
+    baseGrowth: [0, 1],
+    postBaseGrowth: [0, 0],
+    // Malformed parent: one re-merge without it, flat while unchanged
+    // ([arena, parses]), one re-merge when fixed.
+    tsMalformedGrowth: 1,
+    tsMalformedFlat: [0, 0],
+    tsFixedGrowth: 1,
+    // Broken root package.json: no arena growth, no re-parses while
+    // unchanged, one new copy once restored.
+    pkgBrokenGrowth: 0,
+    pkgBrokenFlat: [0, 0],
+    pkgRestoredGrowth: 1,
+    // Broken root tsconfig: same story.
+    tsBrokenGrowth: 0,
+    tsBrokenFlat: [0, 0],
+    tsRestoredGrowth: 1,
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/dir-cache-bust-leak.test.ts
+++ b/test/js/bun/resolve/dir-cache-bust-leak.test.ts
@@ -4,21 +4,32 @@
 // long-running process doing `try { require("optional-dep") } catch {}` from a
 // directory with a package.json leaked one full parsed copy per miss (~178 KB
 // per miss for a 26 KB package.json). The interner now reuses the existing
-// allocation when the file bytes are unchanged, so the arenas only grow when
-// contents actually change.
+// allocation when the file bytes (and, for tsconfig, the whole extends chain)
+// are unchanged, so the arenas only grow when contents actually change.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", async () => {
   const pkg = { name: "dir-cache-bust-fixture", version: "1.0.0" };
-  const tsconfig = (dir: string) => ({
-    compilerOptions: { baseUrl: ".", paths: { "@app/*": [`./${dir}/*`] } },
-  });
+  // The extends target does not exist at first; the recompute must notice
+  // when it appears.
+  const tsconfigWithPaths = {
+    extends: "./tsconfig.base.json",
+    compilerOptions: { baseUrl: ".", paths: { "@app/*": ["./a/*"] } },
+  };
+  const tsconfigNoPaths = {
+    extends: "./tsconfig.base.json",
+    compilerOptions: { baseUrl: "." },
+  };
+  const tsconfigBase = {
+    compilerOptions: { paths: { "@app/*": ["./b/*"], "@base/*": ["./c/*"] } },
+  };
   using dir = tempDir("dir-cache-bust-leak", {
     "package.json": JSON.stringify(pkg),
-    "tsconfig.json": JSON.stringify(tsconfig("a")),
+    "tsconfig.json": JSON.stringify(tsconfigWithPaths),
     "a/x.js": `module.exports = "a";`,
     "b/y.js": `module.exports = "b";`,
+    "c/z.js": `module.exports = "c";`,
     // The presence of node_modules keeps the runtime's auto-install out of
     // the failed resolves below (no registry traffic).
     "node_modules/.gitkeep": "",
@@ -45,13 +56,22 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
       // Real edits must still be picked up by the bust: one new interned copy
       // each, then flat again.
       writeFileSync("package.json", ${JSON.stringify(JSON.stringify({ ...pkg, description: "edited" }))});
-      writeFileSync("tsconfig.json", ${JSON.stringify(JSON.stringify(tsconfig("b")))});
+      writeFileSync("tsconfig.json", ${JSON.stringify(JSON.stringify(tsconfigNoPaths))});
       miss();
       const p2 = pkgLen(), t2 = tsLen();
       for (let i = 0; i < 25; i++) miss();
       const p3 = pkgLen(), t3 = tsLen();
+
+      // A previously-missing extends parent appearing must re-merge even
+      // though the root file itself is unchanged.
+      writeFileSync("tsconfig.base.json", ${JSON.stringify(JSON.stringify(tsconfigBase))});
+      miss();
+      const p4 = pkgLen(), t4 = tsLen();
       const after = require2("@app/y");
-      console.log(JSON.stringify({ before, after, p0, p1, p2, p3, t0, t1, t2, t3 }));
+      const viaBase = require2("@base/z");
+      for (let i = 0; i < 10; i++) miss();
+      const p5 = pkgLen(), t5 = tsLen();
+      console.log(JSON.stringify({ before, after, viaBase, p0, p1, p2, p3, p4, p5, t0, t1, t2, t3, t4, t5 }));
     `,
   });
 
@@ -72,7 +92,9 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
     // tsconfig paths resolve through the (re)parsed configs end to end.
     before: out.before,
     after: out.after,
-    // 25 misses over unchanged files retain nothing.
+    viaBase: out.viaBase,
+    // 25 misses over unchanged files retain nothing (including re-probing the
+    // still-missing extends parent).
     pkgMissGrowth: out.p1 - out.p0,
     tsMissGrowth: out.t1 - out.t0,
     // An edit is picked up as exactly one new interned copy.
@@ -81,15 +103,25 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
     // And misses after the edit are flat again.
     pkgPostEditGrowth: out.p3 - out.p2,
     tsPostEditGrowth: out.t3 - out.t2,
+    // The extends parent appearing re-merges the chain exactly once.
+    pkgBaseGrowth: out.p4 - out.p3,
+    tsBaseGrowth: out.t4 - out.t3,
+    pkgFinalGrowth: out.p5 - out.p4,
+    tsFinalGrowth: out.t5 - out.t4,
   }).toEqual({
     before: "a",
     after: "b",
+    viaBase: "c",
     pkgMissGrowth: 0,
     tsMissGrowth: 0,
     pkgEditGrowth: 1,
     tsEditGrowth: 1,
     pkgPostEditGrowth: 0,
     tsPostEditGrowth: 0,
+    pkgBaseGrowth: 0,
+    tsBaseGrowth: 1,
+    pkgFinalGrowth: 0,
+    tsFinalGrowth: 0,
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/dir-cache-bust-leak.test.ts
+++ b/test/js/bun/resolve/dir-cache-bust-leak.test.ts
@@ -37,6 +37,8 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
       import { resolverInternals } from "bun:internal-for-testing";
       import { createRequire } from "node:module";
       import { writeFileSync } from "node:fs";
+      import { join } from "node:path";
+      const here = import.meta.dir;
       const require2 = createRequire(import.meta.url);
       const miss = () => {
         try {
@@ -55,8 +57,8 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
 
       // Real edits must still be picked up by the bust: one new interned copy
       // each, then flat again.
-      writeFileSync("package.json", ${JSON.stringify(JSON.stringify({ ...pkg, description: "edited" }))});
-      writeFileSync("tsconfig.json", ${JSON.stringify(JSON.stringify(tsconfigNoPaths))});
+      writeFileSync(join(here, "package.json"), ${JSON.stringify(JSON.stringify({ ...pkg, description: "edited" }))});
+      writeFileSync(join(here, "tsconfig.json"), ${JSON.stringify(JSON.stringify(tsconfigNoPaths))});
       miss();
       const p2 = pkgLen(), t2 = tsLen();
       for (let i = 0; i < 25; i++) miss();
@@ -64,7 +66,7 @@ test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", asy
 
       // A previously-missing extends parent appearing must re-merge even
       // though the root file itself is unchanged.
-      writeFileSync("tsconfig.base.json", ${JSON.stringify(JSON.stringify(tsconfigBase))});
+      writeFileSync(join(here, "tsconfig.base.json"), ${JSON.stringify(JSON.stringify(tsconfigBase))});
       miss();
       const p4 = pkgLen(), t4 = tsLen();
       const after = require2("@app/y");

--- a/test/js/bun/resolve/dir-cache-bust-leak.test.ts
+++ b/test/js/bun/resolve/dir-cache-bust-leak.test.ts
@@ -1,0 +1,95 @@
+// A failed bare-specifier resolve busts the importer's directory cache and
+// retries, and every recompute used to re-parse the directory's package.json
+// and tsconfig.json into process-lifetime arenas that never free. A
+// long-running process doing `try { require("optional-dep") } catch {}` from a
+// directory with a package.json leaked one full parsed copy per miss (~178 KB
+// per miss for a 26 KB package.json). The interner now reuses the existing
+// allocation when the file bytes are unchanged, so the arenas only grow when
+// contents actually change.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("dir cache busts don't re-intern unchanged package.json/tsconfig.json", async () => {
+  const pkg = { name: "dir-cache-bust-fixture", version: "1.0.0" };
+  const tsconfig = (dir: string) => ({
+    compilerOptions: { baseUrl: ".", paths: { "@app/*": [`./${dir}/*`] } },
+  });
+  using dir = tempDir("dir-cache-bust-leak", {
+    "package.json": JSON.stringify(pkg),
+    "tsconfig.json": JSON.stringify(tsconfig("a")),
+    "a/x.js": `module.exports = "a";`,
+    "b/y.js": `module.exports = "b";`,
+    // The presence of node_modules keeps the runtime's auto-install out of
+    // the failed resolves below (no registry traffic).
+    "node_modules/.gitkeep": "",
+    "main.mjs": `
+      import { resolverInternals } from "bun:internal-for-testing";
+      import { createRequire } from "node:module";
+      import { writeFileSync } from "node:fs";
+      const require2 = createRequire(import.meta.url);
+      const miss = () => {
+        try {
+          require2("pkg-that-does-not-exist-xyz");
+        } catch {}
+      };
+      const pkgLen = resolverInternals.packageJsonArenaLen;
+      const tsLen = resolverInternals.tsconfigArenaLen;
+
+      // Settle initial parses (the first miss busts + recomputes the dir).
+      miss();
+      const before = require2("@app/x");
+      const p0 = pkgLen(), t0 = tsLen();
+      for (let i = 0; i < 25; i++) miss();
+      const p1 = pkgLen(), t1 = tsLen();
+
+      // Real edits must still be picked up by the bust: one new interned copy
+      // each, then flat again.
+      writeFileSync("package.json", ${JSON.stringify(JSON.stringify({ ...pkg, description: "edited" }))});
+      writeFileSync("tsconfig.json", ${JSON.stringify(JSON.stringify(tsconfig("b")))});
+      miss();
+      const p2 = pkgLen(), t2 = tsLen();
+      for (let i = 0; i < 25; i++) miss();
+      const p3 = pkgLen(), t3 = tsLen();
+      const after = require2("@app/y");
+      console.log(JSON.stringify({ before, after, p0, p1, p2, p3, t0, t1, t2, t3 }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout);
+  expect(out.p0).toBeGreaterThanOrEqual(1);
+  expect(out.t0).toBeGreaterThanOrEqual(1);
+  expect({
+    // tsconfig paths resolve through the (re)parsed configs end to end.
+    before: out.before,
+    after: out.after,
+    // 25 misses over unchanged files retain nothing.
+    pkgMissGrowth: out.p1 - out.p0,
+    tsMissGrowth: out.t1 - out.t0,
+    // An edit is picked up as exactly one new interned copy.
+    pkgEditGrowth: out.p2 - out.p1,
+    tsEditGrowth: out.t2 - out.t1,
+    // And misses after the edit are flat again.
+    pkgPostEditGrowth: out.p3 - out.p2,
+    tsPostEditGrowth: out.t3 - out.t2,
+  }).toEqual({
+    before: "a",
+    after: "b",
+    pkgMissGrowth: 0,
+    tsMissGrowth: 0,
+    pkgEditGrowth: 1,
+    tsEditGrowth: 1,
+    pkgPostEditGrowth: 0,
+    tsPostEditGrowth: 0,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Reproduction

```js
const { createRequire } = require("node:module");
const req = createRequire("/tmp/app/x.js"); // /tmp/app has a package.json
for (let i = 0; i < 2000; i++) {
  try { req("some-optional-dep"); } catch {}
}
```

Every failed bare-specifier resolve busts the importer's directory cache and retries (`VirtualMachine` resolve loop), and every recompute re-parses the directory's package.json and tsconfig.json into process-lifetime storage that never frees. With a 26 KB package.json (200 deps, 200 exports entries), a release build leaks **178 KB per miss, 356 MB over 2000 misses**; RSS grows without bound while `heapUsed` stays flat. `try { require(optionalDep) } catch {}` probing is common in long-running servers, so this bleeds steadily. Watcher and hot-reload busts hit the same path, bounded by change events. Relative-specifier misses do not retrigger the parse, only bare ones.

After this change the same loop retains 7.3 KB/miss, the same as a directory with no package.json at all (the remainder is the busted directory-listing slot, a separate issue tracked by #36675).

## Cause

Two layers stack:

1. `intern_package_json` appends every parse to a static `Vec<Box<PackageJSON>>` with no dedup in front of it, so bust + recompute of an unchanged file appends a full copy (struct + owned source bytes + exports/imports maps + JSON tape) each time. The merged `TSConfigJSON` was a raw leaked `Box` per recompute with the same lifecycle.
2. Re-parsing and discarding the duplicate is not enough to fix it: nested JSON object/array handles allocate out of the thread-local AST store (`StoreRef<ObjectJSON>` in `new_store.rs`), which individual frees never shrink. That costs ~25 bytes per JSON object value per parse, so an exports-heavy package.json still grew 26 KB/miss with the struct itself deduped.

So the fix has to skip the re-parse entirely when nothing changed, while a real edit must still be picked up (that is the point of the bust).

## Fix

- **package.json**: the file read is split out of `PackageJSON::parse` (`read_for_parse` / `parse_with_contents`). `parse_package_json` compares the raw bytes against the interned copy for the same path and parse shape (dependency flavor, `care_about_scripts`, auto-installer presence, `main_fields`, all of which change what `parse` produces) and returns the existing allocation on a match, applying a caller-provided lockfile package id exactly as the parse would have.
- **tsconfig.json**: the interner records every file the extends-chain merge visited (path + bytes, in walk order; an unreadable `extends` parent is recorded as unreadable). A recompute re-reads just those files and reuses the interned merge when all are unchanged. Any mismatch falls through to the existing parse+merge path, which keeps its error reporting, so a parent that appears after the fact (or a malformed one that gets fixed) re-merges exactly as before.
- **Unparseable files**: a root that reads fine but fails to parse is recorded too (package.json slots hold the parsed struct or the failing bytes; the tsconfig slot's merge pointer is optional), so a persistently-broken file stops re-parsing per bust as well (~14 KB/miss measured for a broken 80 KB package.json before this). A fixed file re-parses exactly once.
- `intern_package_json` / `intern_tsconfig` keep a content-compare backstop for concurrent parses of the same path, and the arenas now only grow when file contents actually change. Stale copies stay in the arena because un-busted `DirInfo`s may still hold `&'static` refs to them.

`bun:internal-for-testing` gains `resolverInternals.packageJsonArenaLen` / `tsconfigArenaLen` / `packageJsonParseCount` / `tsconfigParseCount` so the test can assert exact arena growth and that reuse really skips the parse.

## Verification

New test `test/js/bun/resolve/dir-cache-bust-leak.test.ts` drives one fixture through the full matrix, asserting exact arena and parse-count deltas at each step: 25 unchanged misses retain nothing and parse nothing; a package.json-only edit grows only the package.json arena (and the edited `main` field actually changes what `require(dir)` resolves, so the fresh parse is proven to be served, not just interned); a tsconfig-only edit grows only the tsconfig arena; rewriting both files with identical bytes stays flat (reuse is content-keyed, not mtime-keyed); a missing `extends` parent appearing re-merges exactly once with its `paths` taking effect; a malformed parent re-merges once without it, stays flat while unchanged, and re-merges once when fixed; a broken root package.json or tsconfig.json adds nothing to the arenas and stops re-parsing while unchanged, then re-parses exactly once when restored. Fails on an unfixed build.

Release-build RSS for the 2000-miss loop (equal file counts in both dirs):

| fixture | before | after |
| --- | --- | --- |
| 26 KB package.json + tsconfig | 178.3 KB/miss (356 MB) | 7.3 KB/miss (14.7 MB) |
| 69 KB package.json, 800 exports conditions | 26.4 KB/miss | 6.3 KB/miss |
| same dir, files renamed so nothing parses | 6.3 KB/miss | 6.3 KB/miss |

The residual 6.3 KB/miss is the orphaned `DirEntry` per bust, which #36675 addresses independently; this PR does not overlap with it or with the `DirnameStore` re-interning in #34284.

`test/js/bun/resolve/` (293 pass; the one failure is a pre-existing debug-timeout in `load-same-js-file-a-lot.test.ts`, reported separately), tsconfig suites (`test/cli/run/tsconfig-override.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts`), auto-install suites (`run-autoinstall*.test.ts`, `resolve-autoinstall-*.test.ts`), `filter-workspace` / `multi-run` (direct `PackageJSON::parse` callers), `test/cli/hot/hot.test.ts`, and `test/bundler/esbuild/packagejson.test.ts` all pass on a debug ASAN build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/dir-cache-bust-leak.test.ts
bun test v1.4.0 (ee2c3bc27)

test/js/bun/resolve/dir-cache-bust-leak.test.ts:
154 |     stdout: "pipe",
155 |     stderr: "pipe",
156 |   });
157 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
158 | 
159 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ "SyntaxError: Export named 'resolverInternals' not found in module 'bun:internal-for-testing'.
+ 
+ Bun v1.4.0-debug+ee2c3bc27 (Linux x64)
+ "

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/bun/resolve/dir-cache-bust-leak.test.ts:159:18)
(fail) dir cache busts don't re-intern unchanged package.json/tsconfig.json [1390.86ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [3.42s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (6b6fb1a33)

test/js/bun/resolve/dir-cache-bust-leak.test.ts:
154 |     stdout: "pipe",
155 |     stderr: "pipe",
156 |   });
157 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
158 | 
159 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ "12 |       };
+ 13 |       const misses = n => { for (let i = 0; i < n; i++) miss(); };
+ 14 |       const counts = () => [
+ 15 |         resolverInternals.packageJsonArenaLen(),
+ 16 |         resolverInternals.tsconfigArenaLen(),
+ 17 |         resolverInternals.packageJsonParseCount(),
+                                ^
+ TypeError: resolverInternals.packageJsonParseCount is not a function. (In 'resolverInternals.packageJsonParseCount()', 'resolverInternals.packageJsonParseCount' is undefined)
+       at counts (/tmp/dir-cache-bust-leak_pnI5H7/main.mjs:17:27)
+       at /tmp/dir-cache-bust-leak_pnI5H7/main.mjs:26:18
+ 
+ Bun v1.4.0-canary.1+6b6fb1a33 (Linux x64)
+ "

- Expected  - 1
+ Received  + 13

      at <anonymous> (/workspace/bun/test/js/bun/resolve/dir-cache-bust-leak.test.ts:159:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/dir-cache-bust-leak.test.ts
bun test v1.4.0 (ee2c3bc27)

test/js/bun/resolve/dir-cache-bust-leak.test.ts:
(pass) dir cache busts don't re-intern unchanged package.json/tsconfig.json [1513.68ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [3.52s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 644ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (9069ms)
Bundle modules (69ms)
Postprocesss modules (66ms)
Bundle Functions (608ms)
Generate Code (30ms)

[9.86s] Bundled "src/js" for production
  2573 kb
  194 internal modules
  13 native modules
  84 internal functions across 17 files
[3/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/generate-js2native.ts               |   1 +
 src/js/internal-for-testing.ts                  |  11 +
 src/resolver/package_json.rs                    |  51 +-
 src/resolver/resolver.rs                        | 745 ++++++++++++++++++------
 src/runtime/dispatch_js2native.rs               |  38 ++
 test/js/bun/resolve/dir-cache-bust-leak.test.ts | 199 +++++++
 6 files changed, 874 insertions(+), 171 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/codegen/generate-js2native.ts                    1      2      0
src/js/internal-for-testing.ts                       1      3      0
src/resolver/package_json.rs                         9      5      0
src/resolver/resolver.rs                            19     47      0
src/runtime/dispatch_js2native.rs                    2      2      0
test/js/bun/resolve/dir-cache-bust-leak.test.ts      1      9      0
```

</details>

<!-- robobun:evidence:end -->