### PR TITLE
Deflake load-same-js-file-a-lot.test.ts under debug/ASAN builds

### DIFF
--- a/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
+++ b/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
 import { isASAN, isDebug } from "harness";
 
-const asanIsSlowMultiplier = isASAN ? 0.2 : 1;
-const count = Math.floor(10000 * asanIsSlowMultiplier);
+// Debug and ASAN builds are much slower than release, so scale the workload
+// down on the same predicate the timeouts below use.
+const slowBuildMultiplier = isDebug || isASAN ? 0.2 : 1;
+const count = Math.floor(10000 * slowBuildMultiplier);
 
 test(
   `load the same file ${count} times`,

--- a/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
+++ b/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
@@ -31,16 +31,20 @@ test(
     Bun.gc(true);
     Bun.unsafe.gcAggressionLevel(prev);
   },
-  isDebug || isASAN ? 20_000 : 5000,
+  isDebug || isASAN ? 60_000 : 5000,
 );
 
-test(`load the same empty JS file ${count} times`, async () => {
-  const prev = Bun.unsafe.gcAggressionLevel();
-  Bun.unsafe.gcAggressionLevel(0);
-  for (let i = 0; i < count; i++) {
-    const { default: obj } = await import("./load-same-empty-js-file-a-lot.js?i=" + i);
-    expect(obj).toEqual({});
-  }
-  Bun.gc(true);
-  Bun.unsafe.gcAggressionLevel(prev);
-});
+test(
+  `load the same empty JS file ${count} times`,
+  async () => {
+    const prev = Bun.unsafe.gcAggressionLevel();
+    Bun.unsafe.gcAggressionLevel(0);
+    for (let i = 0; i < count; i++) {
+      const { default: obj } = await import("./load-same-empty-js-file-a-lot.js?i=" + i);
+      expect(obj).toEqual({});
+    }
+    Bun.gc(true);
+    Bun.unsafe.gcAggressionLevel(prev);
+  },
+  isDebug || isASAN ? 60_000 : 5000,
+);


### PR DESCRIPTION
### Problem

Commit 28fd495b39 ("Deflake test/js/bun/resolve/load-same-js-file-a-lot.test.ts") gave the first test in this file a `isDebug || isASAN ? 20_000 : 5000` timeout, but the second test ("load the same empty JS file N times") runs the same 2000-iteration dynamic import loop with the default 5s timeout. Under a debug+ASAN build it reliably times out:

```
(fail) load the same empty JS file 2000 times [5000.28ms]
  ^ this test timed out after 5000ms.
```

While measuring, two more problems in the same file turned up:

- The first test's 20s budget is marginal on a loaded machine: observed 14.5s and 15.4s passing, and two consecutive runs killed at 20s.
- The iteration-count multiplier gated on `isASAN` only, while the timeouts gate on `isDebug || isASAN`. A debug build without ASAN (the default `bun bd` on Windows and Intel macs, or `--asan=off`) ran the full 10000 iterations, measured at ~40s and ~24.5s, nearly exhausting any reasonable ceiling.

### Fix

- Give both tests a 60s ceiling under `isDebug || isASAN`. The timeout is a ceiling, not a target, so passing runs are unaffected.
- Scale the iteration count on the same predicate the timeouts use (`isDebug || isASAN ? 0.2 : 1`), matching the existing idiom in e.g. `test/js/bun/yaml/yaml.test.ts`. Release keeps the full 10000 iterations; the count=2000 debug cell is the same one the original deflake commit already chose for ASAN.

### Verification

Debug+ASAN (`bun bd test`), count=2000:

```
(pass) load the same file 2000 times [14447.07ms]
(pass) load the same empty JS file 2000 times [8411.74ms]
```

Debug without ASAN (`bun bd --asan=off test`), count=2000 (was 40s/24.5s at count=10000):

```
(pass) load the same file 2000 times [7925.81ms]
(pass) load the same empty JS file 2000 times [4802.77ms]
```

Release (`USE_SYSTEM_BUN=1 bun test`), count=10000:

```
(pass) load the same file 10000 times [1306.28ms]
(pass) load the same empty JS file 10000 times [941.47ms]
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/resolve/load-same-js-file-a-lot.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/resolve/load-same-js-file-a-lot.test.ts
bun test v1.4.0 (13cbf9e04)

test/js/bun/resolve/load-same-js-file-a-lot.test.ts:
(pass) load the same file 2000 times [14406.04ms]
(pass) load the same empty JS file 2000 times [8338.25ms]

 2 pass
 0 fail
 14000 expect() calls
Ran 2 tests across 1 file. [24.73s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../js/bun/resolve/load-same-js-file-a-lot.test.ts | 32 +++++++++++++---------
 1 file changed, 19 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
test/js/bun/resolve/load-same-js-file-a-lot.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->