### PR TITLE
Bun.listen: don't let GC collect an unref'd listener that is still listening

### DIFF
--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1012,9 +1012,11 @@ impl Listener {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         this.poll_ref.with_mut(|p| p.unref(bun_io::js_vm_ctx()));
-        if this.handlers.active_connections.get() == 0 {
-            this.this_value.with_mut(|r| r.downgrade());
-        }
+        // No `this_value` downgrade here: the socket is still listening, and a
+        // dispatched accept reads the handlers cell that only the wrapper's
+        // `handlers` slot roots — collecting the wrapper frees the callbacks
+        // out from under the open socket (and libuv/Node keep unref'd servers
+        // accepting). `do_stop` / `mark_inactive` downgrade once it's closed.
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1012,11 +1012,9 @@ impl Listener {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         this.poll_ref.with_mut(|p| p.unref(bun_io::js_vm_ctx()));
-        // No `this_value` downgrade here: the socket is still listening, and a
-        // dispatched accept reads the handlers cell that only the wrapper's
-        // `handlers` slot roots — collecting the wrapper frees the callbacks
-        // out from under the open socket (and libuv/Node keep unref'd servers
-        // accepting). `do_stop` / `mark_inactive` downgrade once it's closed.
+        // `this_value` stays strong: the wrapper roots the handlers a future
+        // accept dispatches into. `do_stop` / `mark_inactive` downgrade it
+        // once the listen socket is closed.
         Ok(JSValue::UNDEFINED)
     }
 

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3341,6 +3341,8 @@ it("an unref'd Bun.listen() with no other references keeps accepting across GC",
   // on_open into a swept cell (SIGABRT / type confusion) or, once the
   // finalizer had closed the socket, got ECONNREFUSED. unref() must only
   // release the event-loop hold; the wrapper stays reachable until stop().
+  // Raw TCP instead of fetch: the server replies and ends without reading the
+  // request, and on Windows closing with the request unread RSTs the exchange.
   const src = `
     const churnSink = [];
     function churn() {
@@ -3352,7 +3354,7 @@ it("an unref'd Bun.listen() with no other references keeps accepting across GC",
     function makeUnreffedListener() {
       const l = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {
         open(s) {
-          s.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\nConnection: close\\r\\n\\r\\nok");
+          s.write("ok");
           s.end();
         },
         data() {},
@@ -3361,6 +3363,16 @@ it("an unref'd Bun.listen() with no other references keeps accepting across GC",
       const port = l.port;
       l.unref();
       return port;
+    }
+    async function roundTrip(port) {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      let received = "";
+      await Bun.connect({ hostname: "127.0.0.1", port, socket: {
+        data(s, d) { received += d; },
+        close() { resolve(received); },
+        error(s, e) { reject(e); },
+      }});
+      return promise;
     }
     const ports = [];
     for (let round = 0; round < 4; round++) {
@@ -3371,8 +3383,8 @@ it("an unref'd Bun.listen() with no other references keeps accepting across GC",
       await Bun.sleep(1);
       Bun.gc(true);
       for (const port of ports) {
-        const text = await fetch("http://127.0.0.1:" + port + "/").then(r => r.text());
-        if (text !== "ok") throw new Error("listener " + port + " replied " + JSON.stringify(text));
+        const got = await roundTrip(port);
+        if (got !== "ok") throw new Error("listener " + port + " replied " + JSON.stringify(got));
       }
     }
     console.log("served " + ports.length + " listeners");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3333,3 +3333,62 @@ describe("TLS handshake callback throw", () => {
     }
   });
 });
+
+it("an unref'd Bun.listen() with no other references keeps accepting across GC", async () => {
+  // Listener.unref() used to downgrade the wrapper's GC ref to weak while the
+  // socket was still listening. GC then collected the wrapper (and the
+  // handlers cell it roots), so the next accepted connection either dispatched
+  // on_open into a swept cell (SIGABRT / type confusion) or, once the
+  // finalizer had closed the socket, got ECONNREFUSED. unref() must only
+  // release the event-loop hold; the wrapper stays reachable until stop().
+  const src = `
+    const churnSink = [];
+    function churn() {
+      let a = [];
+      for (let j = 0; j < 30000; j++) a.push(j & 1 ? { j } : "s" + j);
+      churnSink[0] = a;
+      for (let j = 0; j < 30000; j++) churnSink[1] = function () { return j; };
+    }
+    function makeUnreffedListener() {
+      const l = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {
+        open(s) {
+          s.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\nConnection: close\\r\\n\\r\\nok");
+          s.end();
+        },
+        data() {},
+        error() {},
+      }});
+      const port = l.port;
+      l.unref();
+      return port;
+    }
+    const ports = [];
+    for (let round = 0; round < 4; round++) {
+      ports.push(makeUnreffedListener());
+      churn();
+      Bun.gc(true);
+      churn();
+      await Bun.sleep(1);
+      Bun.gc(true);
+      for (const port of ports) {
+        const text = await fetch("http://127.0.0.1:" + port + "/").then(r => r.text());
+        if (text !== "ok") throw new Error("listener " + port + " replied " + JSON.stringify(text));
+      }
+    }
+    console.log("served " + ports.length + " listeners");
+  `;
+  // The subprocess must also exit on its own: unref() still has to release
+  // the listeners' event-loop refs even though their wrappers stay reachable.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "served 4 listeners",
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
## Reproduction

```js
function makeUnreffedListener() {
  const l = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {
    open(s) { s.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"); s.end(); },
    data() {},
  }});
  const port = l.port;
  l.unref();           // still listening; only the event-loop hold should drop
  return port;
}
const port = makeUnreffedListener();
Bun.gc(true); await Bun.sleep(1); Bun.gc(true);
console.log(await fetch("http://127.0.0.1:" + port + "/").then(r => r.text()));
```

Stock bun (release): `ConnectionRefused` once the collected wrapper's finalizer closes the still-listening socket. A fuzz variant that hammers the port while GC is in flight instead lands in the sweep window: 10/10 within 30s as a silent SIGABRT, `TypeError: r.text is not a function` on the fetch result, or another listener's `open` handler answering on the dropped listener's port. Under ASan the dispatch faults in `Bun__SocketHandlers__getField` (`JSSocketHandlers.cpp`) or as a UBSan member call on null ClassInfo in `Bun__JSValue__call`, reached from `NewSocket<false>::on_open` via `us_internal_dispatch_ready_poll`, i.e. a loop dispatch on the swept handlers cell before the finalizer ever runs.

## Cause

`Listener::unref` released the event-loop ref and then downgraded `this_value` to weak whenever `active_connections == 0`, while the listen socket was still open. That contradicts the field's own contract ("Strong while it is listening or has connections"): the wrapper's `handlers` slot is the only GC root of the `JSSocketHandlers` cell that every accept dispatches into. With the wrapper weak and the JS reference dropped, GC collects both while the socket keeps accepting, so `on_open` for the next connection reads a swept cell; after the finalizer runs, the port is closed outright, which is not Node semantics either (libuv keeps unref'd servers accepting).

## Fix

`unref()` now only does `poll_ref.unref()`. The idle downgrade already lives in the two places that are gated on the listen socket being closed: `do_stop` (close with no connections) and `Handlers::mark_inactive` (last connection drains after a close). A stopped or idle listener is still collected exactly as before; a listening one stays reachable until `stop()`, and the process can still exit because the event-loop ref is released.

This is a different site from #36181, which defers the finalizer's socket-group close out of the GC sweep when a collected listener still has live connections: that covers the teardown dispatch during finalization, while this bug fires on a fresh accept before any finalizer runs and needs no connections at drop time. Both changes stand on their own.

## Verification

New test in `test/js/bun/net/socket.test.ts` spawns a child that drops four unref'd listeners, drives GC with allocation churn, and fetches every port each round; the child must serve every request and then exit on its own (proving `unref()` still releases the loop).

`USE_SYSTEM_BUN=1`: child gets `ConnectionRefused` on the first collected listener, test fails (also fails on an unfixed debug build, 1.5s). `bun bd test`: passes (4.1s, ASan). The 30s fuzz hammer on the fixed debug build: 18 rounds, 80/80 requests served, no crash, no wrapper collected while listening.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->