### PR TITLE
install: keep non-default ssh port in the ssh fallback clone URL

### DIFF
--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -835,9 +835,17 @@ fn normalize_protocol(npa_str: &[u8]) -> UrlProtocolPair<'_> {
     }
 }
 
+/// Whether `url` already parses as a URL (the same check `parse_url` makes before it falls back
+/// to `correct_url`). Input that parses must not be "corrected": the last colon in
+/// `ssh://git@host:2222/user/repo` is a port, not an scp-style path separator.
+pub(crate) fn is_parseable_url(url: &[u8]) -> bool {
+    JscUrl::from_utf8(url).map(OwnedJscUrl).is_some()
+}
+
 /// Attempt to correct an scp-style URL into a proper URL, parsable with jsc.URL.
 ///
-/// This function assumes that the input is an scp-style URL.
+/// This function assumes that the input is an scp-style URL, i.e. that `is_parseable_url`
+/// returned false for it.
 pub(crate) fn correct_url<'a>(
     url_proto_pair: &UrlProtocolPair<'a>,
 ) -> Result<UrlProtocolPair<'a>, AllocError> {

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -629,9 +629,9 @@ impl RepositoryExt for Repository {
         }
 
         if url.starts_with(b"ssh://") {
-            // npm's hosted-git-info only rewrites scp-style colons when URL parsing
-            // fails, so a URL that already parses (e.g. a numeric port) passes through.
-            if bun_url::origin_from_slice(url).is_some() {
+            // Like hosted-git-info's parseUrl, only "correct" URLs that do not parse as-is;
+            // ssh://git@github.com:2222/user/repo is a port, not an scp-style colon.
+            if hosted_git_info::is_parseable_url(url) {
                 return Some(url);
             }
 

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -629,6 +629,12 @@ impl RepositoryExt for Repository {
         }
 
         if url.starts_with(b"ssh://") {
+            // npm's hosted-git-info only rewrites scp-style colons when URL parsing
+            // fails, so a URL that already parses (e.g. a numeric port) passes through.
+            if bun_url::origin_from_slice(url).is_some() {
+                return Some(url);
+            }
+
             // TODO(markovejnovic): This is a stop-gap. One of the problems with the implementation
             // here is that we should integrate hosted_git_info more thoroughly into the codebase
             // to avoid the allocation and copy here. For now, the thread-local buffer is a good

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,7 +1,7 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
 import { readFileSync, readlinkSync, realpathSync, statSync } from "fs";
-import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
+import { access, chmod, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
   bunExe,
@@ -896,6 +896,48 @@ describe.concurrent("bun-install", () => {
     expect(stderr).toContain("long-git-dep");
     expect(stdout).toContain("bun install v1.");
     expect(exitCode).toBe(1);
+  });
+
+  // Shadow `git` with a shim that records its argv and fails, so the https clone
+  // attempt falls through to the ssh fallback and the test can assert the exact
+  // ssh:// URL bun hands to git.
+  it.skipIf(isWindows).each([
+    // #36931: a port is not the scp-style host:path colon; it must not become a
+    // path segment (ssh://git@localhost/52626/user/repo.git).
+    ["git+ssh://git@localhost:52626/user/repo.git#v1.0.0", "ssh://git@localhost:52626/user/repo.git"],
+    // scp-style colons inside an ssh:// URL are still rewritten to a slash...
+    ["git+ssh://git@localhost:user/repo.git", "ssh://git@localhost/user/repo.git"],
+    // ...including when the path happens to start with a digit.
+    ["git+ssh://git@localhost:1user/repo.git", "ssh://git@localhost/1user/repo.git"],
+  ])("ssh fallback clone URL for %s", async (dependency, expectedCloneUrl) => {
+    using dir = tempDir("git-ssh-port", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { pkg: dependency },
+      }),
+      "bin/git": `#!/bin/sh\necho "$@" >> "$GIT_ARGS_LOG"\nexit 1\n`,
+    });
+    await chmod(join(String(dir), "bin", "git"), 0o755);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...env,
+        PATH: `${join(String(dir), "bin")}:${env.PATH}`,
+        GIT_ARGS_LOG: join(String(dir), "git-args.log"),
+        BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("cloning repository");
+    expect(exitCode).toBe(1);
+
+    const gitArgs = (await file(join(String(dir), "git-args.log")).text()).split(/\s+/);
+    expect(gitArgs.filter(arg => arg.startsWith("ssh://"))).toEqual([expectedCloneUrl]);
   });
 
   it("should handle empty string in dependencies", async () => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -900,15 +900,22 @@ describe.concurrent("bun-install", () => {
 
   // Shadow `git` with a shim that records its argv and fails, so the https clone
   // attempt falls through to the ssh fallback and the test can assert the exact
-  // ssh:// URL bun hands to git.
+  // ssh:// URL bun hands to git. A URL that parses as-is must be passed through
+  // untouched; only one that does not gets its scp-style `host:path` colon
+  // rewritten to a slash.
   it.skipIf(isWindows).each([
-    // #36931: a port is not the scp-style host:path colon; it must not become a
-    // path segment (ssh://git@localhost/52626/user/repo.git).
+    // #36931: the port used to become a path segment (ssh://git@localhost/52626/...).
     ["git+ssh://git@localhost:52626/user/repo.git#v1.0.0", "ssh://git@localhost:52626/user/repo.git"],
-    // scp-style colons inside an ssh:// URL are still rewritten to a slash...
+    ["git+ssh://git@[::1]:2222/user/repo.git", "ssh://git@[::1]:2222/user/repo.git"],
+    ["git+ssh://git@localhost:2222/\u00fcser/repo.git", "ssh://git@localhost:2222/\u00fcser/repo.git"],
+    // A colon in the path is not an scp-style separator either.
+    ["git+ssh://git@localhost/user/re:po.git", "ssh://git@localhost/user/re:po.git"],
+    // Without userinfo, the colon of the scheme itself used to be rewritten (ssh///localhost/...).
+    ["git+ssh://localhost/user/repo.git", "ssh://localhost/user/repo.git"],
+    // scp-style colons are still rewritten, whatever the path starts with.
     ["git+ssh://git@localhost:user/repo.git", "ssh://git@localhost/user/repo.git"],
-    // ...including when the path happens to start with a digit.
     ["git+ssh://git@localhost:1user/repo.git", "ssh://git@localhost/1user/repo.git"],
+    ["git+ssh://git@h\u00f6st:user/repo.git", "ssh://git@h\u00f6st/user/repo.git"],
   ])("ssh fallback clone URL for %s", async (dependency, expectedCloneUrl) => {
     using dir = tempDir("git-ssh-port", {
       "package.json": JSON.stringify({
@@ -937,7 +944,7 @@ describe.concurrent("bun-install", () => {
     expect(exitCode).toBe(1);
 
     const gitArgs = (await file(join(String(dir), "git-args.log")).text()).split(/\s+/);
-    expect(gitArgs.filter(arg => arg.startsWith("ssh://"))).toEqual([expectedCloneUrl]);
+    expect(gitArgs.filter(arg => arg.startsWith("ssh"))).toEqual([expectedCloneUrl]);
   });
 
   it("should handle empty string in dependencies", async () => {

--- a/test/cli/install/hosted-git-info/cases.ts
+++ b/test/cli/install/hosted-git-info/cases.ts
@@ -1503,6 +1503,11 @@ export const validGitUrls: { [K in Provider]: { [K in string]: object } } = {
       auth: null,
       ...committishDefaults,
     },
+    // scp-style colon followed by a digit is still a path separator, not a port
+    // (hosted-git-info only applies this rewrite to input `new URL()` rejects)
+    "git+ssh://git@github.com:1foo/bar": { ...defaults.github, user: "1foo", default: "sshurl", auth: null },
+    "ssh://git@github.com:1foo/bar": { ...defaults.github, user: "1foo", default: "sshurl", auth: null },
+    "git@github.com:1foo/bar": { ...defaults.github, user: "1foo", default: "sshurl", auth: null },
 
     "git+ssh://github.com:foo/bar.git": { ...defaults.github, default: "sshurl" },
     [`git+ssh://github.com:foo/bar.git#${committishDefaults.committish}`]: {

--- a/test/cli/install/hosted-git-info/parse-url.test.ts
+++ b/test/cli/install/hosted-git-info/parse-url.test.ts
@@ -14,8 +14,22 @@ const okCases = [
   "github:foo/bar#branch with space",
 ];
 
+// The scp-style `host:path` -> `host/path` rewrite only applies to input that does not
+// already parse as a URL, so a port survives while a path starting with a digit is still
+// rewritten (corrected URLs are re-emitted with the git+ssh: protocol).
+const hrefCases = [
+  ["git+ssh://git@example.com:52626/user/repo.git#v1.0.0", "git+ssh://git@example.com:52626/user/repo.git#v1.0.0"],
+  ["ssh://git@example.com:52626/user/repo.git", "ssh://git@example.com:52626/user/repo.git"],
+  ["ssh://git@example.com:1user/repo.git", "git+ssh://git@example.com/1user/repo.git"],
+  ["git@example.com:1user/repo.git", "git+ssh://git@example.com/1user/repo.git"],
+];
+
 describe("parseUrl", () => {
   it.each(okCases)("parses %s", url => {
     expect(hostedGitInfo.parseUrl(url)).not.toBeNull();
+  });
+
+  it.each(hrefCases)("parses %s as %s", (url, href) => {
+    expect(hostedGitInfo.parseUrl(url)).toBe(href);
   });
 });


### PR DESCRIPTION
Fixes #36931

### Problem
- A git dependency with an explicit ssh port, `git+ssh://git@host:52626/user/repo.git#v1.3.2`, fails to install: the ssh clone attempt runs `git clone ssh://git@host/52626/user/repo.git`, with the port turned into a path segment.
- `Repository::try_ssh` (`src/install/repository.rs`, the `ssh://` branch) passes every `ssh://` URL through `hosted_git_info::correct_url`, which replaces the last colon with a slash. That rewrite exists for scp-style input such as `ssh://git@github.com:user/repo`, but it runs unconditionally, so it also hits a port, a `[::1]:2222` host, a colon inside the path, and, for a URL with no userinfo (`ssh://host/user/repo.git`), the colon of the scheme itself (git is handed `ssh///host/user/repo.git`).

### Fix
- `try_ssh` now returns an `ssh://` URL unchanged when it parses as a URL, and only runs `correct_url` when it does not. The check is `hosted_git_info::is_parseable_url`, a whole-string `WTF::URL` parse, the same call `hosted_git_info::parse_url` already makes before it falls back to `correct_url`.
- This is the order npm's hosted-git-info uses: `parseUrl` tries `new URL(giturl)` first and only calls `correctUrl` when that throws. `ssh://host:52626/path` parses, so npm never rewrites it; `ssh://host:user/repo` does not parse (non-numeric port), so it is still rewritten. `try_ssh` was the one caller of `correct_url` that skipped the parse step.
- Checking "does it parse" rather than "is the colon followed by a digit" matters: scp-style paths that start with a digit (`git@github.com:1Password/op-js.git`) do not parse as URLs and must still be rewritten, which npm does. A digit heuristic inside `correct_url` (the approach in #38887) stops rewriting those and also breaks `HostedGitInfo::from_url` for them, verified on a build with that change: `hostedGitInfo.parseUrl("git@github.com:1Password/op-js.git")` throws `InvalidGitUrl`, and for `git+ssh://git@github.com:1Password/op-js.git` the ssh fallback runs `git clone ssh://git@github.com:1Password/op-js.git`, which git rejects. Both work on main.
- The check has to parse the whole string. The first revision used `bun_url::origin_from_slice`, which parses only the leading ASCII prefix, so `ssh://git@höst:user/repo.git` was judged valid on `ssh://g` and no longer corrected; the `höst` test row below fails on that revision and passes on this one.
- Verified:
  - `test/cli/install/bun-install.test.ts`, "ssh fallback clone URL for ...": shadows `git` with a PATH shim that records its argv and asserts the exact `ssh://` URL for eight dependency specs. On a build without the fix the five pass-through rows fail (port, IPv6 + port, port + non-ASCII path, colon in the path, no userinfo; e.g. `ssh://git@localhost/52626/user/repo.git`, `ssh///localhost/user/repo.git`) and the three rewrite rows pass; with the fix all eight pass.
  - `test/cli/install/hosted-git-info/cases.ts` and `parse-url.test.ts`: cases for the port URL surviving `parse_url` and for digit-leading scp paths still being corrected. They pass on main; with #38887's `correct_url` change applied, all five fail, as does the digit-leading `bun-install.test.ts` row.
  - `bun bd test test/cli/install/hosted-git-info/`: 662 pass. `cargo clippy -p bun_install` and `cargo fmt` are clean.

### Background
- scp-style git URL: `user@host:path`, what `git clone git@github.com:foo/bar` takes. The colon separates host and path, not host and port. hosted-git-info (the npm library `src/install/hosted_git_info.rs` ports) turns these into parseable URLs by replacing that colon with a slash; this is `correctUrl` / `correct_url`.
- `try_https` / `try_ssh`: when cloning a git dependency, `PackageManagerTask` first tries an https form of the URL and, if that clone fails, an ssh form. `try_ssh` builds the ssh form; for input that is already `ssh://` its only job is the scp-style correction. `git+ssh:` dependencies are tagged as plain git dependencies without going through `hosted_git_info::parse_url` (`dependency.rs`), so `try_ssh` is the only place the issue's URL is inspected.
- `JscUrl::from_utf8` (`bun_url::whatwg::URL`): the WHATWG URL parser from WebKit; it returns nothing for input it rejects. For a non-special scheme such as `ssh:`, a non-numeric port (`:user/repo`) is a rejection and a numeric one (`:52626`) is not. `OwnedJscUrl` is the RAII wrapper that frees the C++ object.
- `HostedGitInfo::from_url` returns `None` for known hosts with an explicit port (`git+ssh://user@bitbucket.org:2222/foo/bar`) because the host lookup compares `host:port` against the provider domain. This is unrelated to the bug (such a dependency is treated as a plain git URL and cloned with the port intact, which is what the issue asks for), so this PR leaves it alone; it is why #38887's `cases.ts` entries do not pass even with that PR's change applied.

<details>
<summary>First revision</summary>

The first revision gated the correction on `bun_url::origin_from_slice(url).is_some()`. `origin_from_slice` hands only the bytes before the first non-ASCII one to the parser (its existing caller passes an already-serialized href), so for `ssh://git@höst:user/repo.git` it parsed `ssh://g`, reported it valid, and the scp-style colon was no longer rewritten, a change from main for that input. The current revision parses the full string and adds that input as a test row.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->
