### PR TITLE
Return an object when a jest mock function is invoked with new

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -968,10 +968,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Like [[Construct]] on an ordinary function: create `this` from
-    // newTarget.prototype (falling back to newTarget's realm's Object.prototype),
-    // run the implementation with it, and return the implementation's result
-    // only if it is an object.
+    // Ordinary-function [[Construct]]: create `this` from newTarget.prototype,
+    // return the implementation's result only when it is an object.
     JSObject* thisObject = nullptr;
     if (JSObject* newTarget = callframe->newTarget().getObject()) {
         JSGlobalObject* functionGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -968,8 +968,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Ordinary-function [[Construct]]: create `this` from newTarget.prototype,
-    // return the implementation's result only when it is an object.
     JSObject* thisObject = nullptr;
     if (JSObject* newTarget = callframe->newTarget().getObject()) {
         JSGlobalObject* functionGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -87,6 +87,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -463,7 +464,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -798,7 +799,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -810,7 +811,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -956,6 +956,36 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue().toThis(lexicalGlobalObject, ECMAMode::strict()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Like [[Construct]] on an ordinary function: create `this` from
+    // newTarget.prototype, run the implementation with it, and return the
+    // implementation's result only if it is an object.
+    JSObject* prototype = nullptr;
+    if (JSObject* newTarget = callframe->newTarget().getObject()) {
+        JSValue prototypeValue = newTarget->get(lexicalGlobalObject, vm.propertyNames->prototype);
+        RETURN_IF_EXCEPTION(scope, {});
+        prototype = prototypeValue.getObject();
+    }
+    JSObject* thisObject = prototype
+        ? JSC::constructEmptyObject(lexicalGlobalObject, prototype)
+        : JSC::constructEmptyObject(lexicalGlobalObject);
+
+    JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+    if (result && result.isObject())
+        return JSValue::encode(result);
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -969,17 +969,19 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Like [[Construct]] on an ordinary function: create `this` from
-    // newTarget.prototype, run the implementation with it, and return the
-    // implementation's result only if it is an object.
-    JSObject* prototype = nullptr;
+    // newTarget.prototype (falling back to newTarget's realm's Object.prototype),
+    // run the implementation with it, and return the implementation's result
+    // only if it is an object.
+    JSObject* thisObject = nullptr;
     if (JSObject* newTarget = callframe->newTarget().getObject()) {
-        JSValue prototypeValue = newTarget->get(lexicalGlobalObject, vm.propertyNames->prototype);
+        JSGlobalObject* functionGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
         RETURN_IF_EXCEPTION(scope, {});
-        prototype = prototypeValue.getObject();
+        Structure* structure = JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+        RETURN_IF_EXCEPTION(scope, {});
+        thisObject = JSC::constructEmptyObject(vm, structure);
+    } else {
+        thisObject = JSC::constructEmptyObject(lexicalGlobalObject);
     }
-    JSObject* thisObject = prototype
-        ? JSC::constructEmptyObject(lexicalGlobalObject, prototype)
-        : JSC::constructEmptyObject(lexicalGlobalObject);
 
     JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1170,3 +1170,67 @@ describe("spyOn", () => {
 
   // spyOn does not work with getters/setters yet.
 });
+
+describe("constructing a mock", () => {
+  // Previously, invoking a mock with `new` returned the implementation's
+  // result as-is, even when it was a primitive, which is invalid for a
+  // constructor and crashed the engine.
+  test("returns an object when there is no implementation", () => {
+    const fn = jest.fn();
+    const instance = new fn();
+    expect(typeof instance).toBe("object");
+    expect(instance).not.toBe(null);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("ignores a primitive return value", () => {
+    const fn = jest.fn(function () {
+      return 42;
+    });
+    const instance = Reflect.construct(fn, []);
+    expect(typeof instance).toBe("object");
+    expect(fn.mock.results[0]).toEqual({ type: "return", value: 42 });
+  });
+
+  test("returns the implementation's object return value", () => {
+    const result = { x: 1 };
+    const fn = jest.fn(function () {
+      return result;
+    });
+    expect(new fn()).toBe(result);
+  });
+
+  test("ignores a primitive from mockReturnValue", () => {
+    const fn = jest.fn().mockReturnValue(5);
+    const instance = new fn();
+    expect(typeof instance).toBe("object");
+    expect(fn()).toBe(5);
+  });
+
+  test("uses new.target's prototype for the instance", () => {
+    function Other() {}
+    const fn = jest.fn(function () {});
+    const instance = Reflect.construct(fn, [], Other);
+    expect(Object.getPrototypeOf(instance)).toBe(Other.prototype);
+  });
+
+  test("passes the instance to the implementation as this", () => {
+    let seenThis;
+    const fn = jest.fn(function () {
+      seenThis = this;
+      this.tagged = true;
+    });
+    const instance = new fn();
+    expect(seenThis).toBe(instance);
+    expect(instance.tagged).toBe(true);
+  });
+
+  if (isBun) {
+    test("constructing a spy on a non-function property does not crash", () => {
+      const obj = { foo: 123 };
+      const spy = spyOn(obj, "foo");
+      const instance = Reflect.construct(spy, []);
+      expect(typeof instance).toBe("object");
+    });
+  }
+});

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -4,6 +4,7 @@
  *  `bunx vitest test/js/bun/test/mock-fn.test.js`
  *  `NODE_OPTIONS=--experimental-vm-modules npx jest test/js/bun/test/mock-fn.test.js`
  */
+import vm from "node:vm";
 import test_interop from "./test-interop.js";
 var { isBun, describe, test, it, expect, jest, vi, mock, spyOn } = await test_interop();
 
@@ -1212,6 +1213,25 @@ describe("constructing a mock", () => {
     const fn = jest.fn(function () {});
     const instance = Reflect.construct(fn, [], Other);
     expect(Object.getPrototypeOf(instance)).toBe(Other.prototype);
+  });
+
+  test("falls back to Object.prototype when new.target has a primitive prototype", () => {
+    function Other() {}
+    Other.prototype = 1;
+    const fn = jest.fn(function () {});
+    const instance = Reflect.construct(fn, [], Other);
+    expect(Object.getPrototypeOf(instance)).toBe(Object.prototype);
+  });
+
+  test("uses new.target's realm for the fallback prototype", () => {
+    const context = vm.createContext({});
+    const OtherRealm = vm.runInContext("(function Other() {})", context);
+    OtherRealm.prototype = 1;
+    const otherObjectPrototype = vm.runInContext("Object.prototype", context);
+    expect(otherObjectPrototype).not.toBe(Object.prototype);
+    const fn = jest.fn(function () {});
+    const instance = Reflect.construct(fn, [], OtherRealm);
+    expect(Object.getPrototypeOf(instance)).toBe(otherObjectPrototype);
   });
 
   test("passes the instance to the implementation as this", () => {


### PR DESCRIPTION
Fixes a crash found by fuzzing (assertion `isCell()` in `Interpreter::executeConstruct`).

### Problem

`JSMockFunction` registered the same host function for both call and construct, so `new mockFn()` returned whatever the mock implementation returned, including primitives and `undefined`. JSC requires a native constructor to return an object: `Interpreter::executeConstruct` ends with `asObject(result)`. Debug builds hit the `isCell()` assertion, and release builds reinterpreted the primitive as an object pointer and handed a non-object back from `new`.

Repro (crashed debug builds, misbehaved in release):

```js
const jest = Bun.jest();
const spy = jest.spyOn({}, "foo"); // ReturnValue implementation: undefined
Reflect.construct(spy, []);
```

Also reachable in any test via `new (mock())()`, `new (mock(() => 42))()`, `mockReturnValue(5)` plus `new`, and so on.

### Fix

Give `JSMockFunction` a dedicated construct callback that follows ordinary `[[Construct]]` semantics, which is also what Jest's `mockConstructor` does in Node:

- create the instance from `new.target.prototype`, falling back to `Object.prototype`
- run the existing mock logic with that instance as `this`
- return the implementation's result only when it is an object, otherwise return the instance

The shared body of `jsMockFunctionCall` is factored into a helper taking an explicit `this` value; the call path is unchanged.

### Tests

Added a `constructing a mock` block to `test/js/bun/test/mock-fn.test.js` (the file is written to also run under Jest and Vitest, and the new unguarded tests match Jest's behavior in Node). 6 of the 7 new tests fail on bun before this change. Also verified the original fuzzer reproduction no longer crashes, and ran the mock, spyMatchers, jest-extended, and mock-module suites with `BUN_JSC_validateExceptionChecks=1` coverage for the new path.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (8326d1bd3)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.81ms]
(pass) mock() > mock [8.29ms]
(pass) mock() > checks the this value > mock [7.33ms]
(pass) mock() > checks the this value > _protoImpl [0.87ms]
(pass) mock() > checks the this value > getMockImplementation [1.54ms]
(pass) mock() > checks the this value > getMockName [0.78ms]
(pass) mock() > checks the this value > mockClear [0.65ms]
(pass) mock() > checks the this value > mockReset [0.61ms]
(pass) mock() > checks the this value > mockRestore [0.62ms]
(pass) mock() > checks the this value > mockImplementation [0.64ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.87ms]
(pass) mock() > checks the this value > withImplementation [0.65ms]
(pass) mock() > checks the this value > mockName [0.65ms]
(pass) mock() > checks the this value > mockReturnThis [0.56ms]
(pass) mock() > checks the this value > mockReturnValue [0.52ms]
(pass) mock() > checks the this value
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.03ms]
(pass) mock() > mock [0.10ms]
(pass) mock() > checks the this value > mock [0.13ms]
(pass) mock() > checks the this value > _protoImpl
(pass) mock() > checks the this value > getMockImplementation [0.03ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the this value > mockRejectedVal
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (8326d1bd3)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.08ms]
(pass) mock() > mock [7.63ms]
(pass) mock() > checks the this value > mock [7.45ms]
(pass) mock() > checks the this value > _protoImpl [0.81ms]
(pass) mock() > checks the this value > getMockImplementation [2.16ms]
(pass) mock() > checks the this value > getMockName [0.94ms]
(pass) mock() > checks the this value > mockClear [0.83ms]
(pass) mock() > checks the this value > mockReset [0.63ms]
(pass) mock() > checks the this value > mockRestore [0.73ms]
(pass) mock() > checks the this value > mockImplementation [0.70ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.93ms]
(pass) mock() > checks the this value > withImplementation [0.61ms]
(pass) mock() > checks the this value > mockName [0.60ms]
(pass) mock() > checks the this value > mockReturnThis [0.59ms]
(pass) mock() > checks the this value > mockReturnValue [0.53ms]
(pass) mock() > checks the this value
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     38eec5a653
  features     baseline

22 deps, 120 codegen, 1144 objects in 797ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [14.00ms]
[2/1206] gen ErrorCode+*.h
[3/1206] gen bindgenv2
[4/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [5.00ms]
[5/1206] fetch zlib
[zlib] up to date
[6/1206] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1206] fetch tinycc
[tinycc] up to date
[8/1205] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[9/1205] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1205] subst deps/zlib/zconf.h
[11/1205] gen .b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp | 34 +++++++++++++--
 test/js/bun/test/mock-fn.test.js    | 84 +++++++++++++++++++++++++++++++++++++
 2 files changed, 115 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp      9     10      0
test/js/bun/test/mock-fn.test.js         3      3      0
```

</details>

<!-- robobun:evidence:end -->