### PR TITLE
Implement Early Hints to Bun.serve

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -639,6 +639,12 @@ interface Server extends Disposable {
   subscriberCount(topic: string): number;
 
   /**
+   * Send an HTTP 103 Early Hints response before the final response.
+   * @returns false when the request is complete, transport is unsupported, or headers are empty
+   */
+  writeEarlyHints(request: Request, headers: HeadersInit): boolean;
+
+  /**
    * Get client IP address and port.
    * @returns null for closed requests or Unix sockets
    */

--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -354,6 +354,30 @@ Use this for development and hot reloading. Only `fetch`, `error`, `routes`, and
 
 ## Per-Request Controls
 
+### `server.writeEarlyHints(Request, HeadersInit)`
+
+Send an HTTP `103 Early Hints` response before the final response. This lets a
+browser begin fetching critical resources while your handler finishes rendering
+the document.
+
+```ts
+Bun.serve({
+  async fetch(req, server) {
+    server.writeEarlyHints(req, {
+      Link: "</app.css>; rel=preload; as=style, </app.js>; rel=modulepreload",
+    });
+
+    const html = await renderPage();
+    return new Response(html, {
+      headers: { "Content-Type": "text/html" },
+    });
+  },
+});
+```
+
+The method returns `false` when the request has already completed, the
+transport does not support informational responses, or `headers` is empty.
+
 ### `server.timeout(Request, seconds)`
 
 Override the idle timeout for an individual request. Pass `0` to disable the timeout entirely for that request.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1101,6 +1101,29 @@ declare module "bun" {
     subscriberCount(topic: string): number;
 
     /**
+     * Sends an HTTP 103 Early Hints response before the final response.
+     *
+     * Returns `false` when the request has already completed, the transport
+     * does not support informational responses, or `headers` is empty.
+     *
+     * @example
+     * ```js
+     * Bun.serve({
+     *   fetch(request, server) {
+     *     server.writeEarlyHints(request, {
+     *       Link: "</app.css>; rel=preload; as=style",
+     *     });
+     *
+     *     return new Response("<html>...</html>", {
+     *       headers: { "Content-Type": "text/html" },
+     *     });
+     *   },
+     * });
+     * ```
+     */
+    writeEarlyHints(request: Request, headers: HeadersInit): boolean;
+
+    /**
      * Returns the client IP address and port of the given Request. If the request was closed or is a unix socket, returns null.
      *
      * @example

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -184,6 +184,10 @@ impl AnyRequestContext {
         dispatch!(self, None, |_T, ctx| ctx.get_remote_socket_info())
     }
 
+    pub(crate) fn write_informational(self, data: &[u8]) -> bool {
+        dispatch!(self, false, |_T, ctx| ctx.write_informational(data))
+    }
+
     pub(crate) fn detach_request(self) {
         dispatch!(self, (), |_T, ctx| {
             ctx.req.set(None);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4414,6 +4414,25 @@ where
         })
     }
 
+    pub(crate) fn write_informational(&self, data: &[u8]) -> bool {
+        let Some(resp) = self.resp.get() else {
+            return false;
+        };
+
+        if resp.has_responded() {
+            return false;
+        }
+
+        // HTTP/3 has a distinct header-frame implementation. It does not yet
+        // support informational responses, so report that no hints were sent.
+        if matches!(resp, uws::AnyResponse::H3(_)) {
+            return false;
+        }
+
+        resp.write_informational(data);
+        true
+    }
+
     pub(crate) fn set_timeout(&self, seconds: c_uint) -> bool {
         if let Some(resp) = self.resp.get() {
             // SAFETY: FFI handle

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4419,7 +4419,7 @@ where
             return false;
         };
 
-        if resp.has_responded() {
+        if resp.has_responded() || self.flags.has_written_status() {
             return false;
         }
 

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -44,6 +44,10 @@ function generate(name) {
         fn: "doRequestIP",
         length: 1,
       },
+      writeEarlyHints: {
+        fn: "writeEarlyHints",
+        length: 2,
+      },
       timeout: {
         fn: "doTimeout",
         length: 2,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -19,7 +19,7 @@ use crate::webcore::{
 use ::bstr::BStr;
 use bun_collections::HashMap;
 use bun_core::{Output, fmt as bun_fmt};
-use bun_core::{String as BunString, ZigString, strings};
+use bun_core::{String as BunString, StringPointer, ZigString, strings};
 use bun_http::{self as http, Method, MimeType};
 use bun_jsc::Debugger::DebuggerId;
 use bun_jsc::ZigStringJsc as _;
@@ -1269,6 +1269,77 @@ fn fetch_headers_from_js(value: JSValue, global: &JSGlobalObject) -> Option<*mut
     FetchHeaders::cast_(value, global.vm()).map(|p| p.as_ptr())
 }
 
+fn render_early_hints(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Vec<u8>>> {
+    if let Some(headers) = FetchHeaders::cast_(value, global.vm()) {
+        return Ok(render_early_hints_from_headers(
+            bun_opaque::opaque_deref_mut(headers.as_ptr()),
+        ));
+    }
+
+    let Some(headers) = FetchHeaders::create_from_js(global, value)? else {
+        return Ok(None);
+    };
+
+    let result = render_early_hints_from_headers(bun_opaque::opaque_deref_mut(headers.as_ptr()));
+    bun_opaque::opaque_deref_mut(headers.as_ptr()).deref();
+    Ok(result)
+}
+
+fn render_early_hints_from_headers(headers: &mut FetchHeaders) -> Option<Vec<u8>> {
+    let mut header_count = 0;
+    let mut buffer_len = 0;
+    headers.count(&mut header_count, &mut buffer_len);
+    if header_count == 0 {
+        return None;
+    }
+
+    let header_count = usize::try_from(header_count).expect("header count fits usize");
+    let buffer_len = usize::try_from(buffer_len).expect("header length fits usize");
+    let mut names = Vec::with_capacity(header_count);
+    let mut values = Vec::with_capacity(header_count);
+    for _ in 0..header_count {
+        names.push(StringPointer {
+            offset: 0,
+            length: 0,
+        });
+        values.push(StringPointer {
+            offset: 0,
+            length: 0,
+        });
+    }
+    let mut buffer = vec![0; buffer_len];
+    headers.copy_to(names.as_mut_ptr(), values.as_mut_ptr(), buffer.as_mut_ptr());
+
+    let mut response = Vec::with_capacity(
+        b"HTTP/1.1 103 Early Hints\r\n".len()
+            + buffer_len
+            + header_count * b": \r\n".len()
+            + b"\r\n".len(),
+    );
+    response.extend_from_slice(b"HTTP/1.1 103 Early Hints\r\n");
+
+    for (name, value) in names.into_iter().zip(values) {
+        let name = name.slice(&buffer);
+        let value = value.slice(&buffer);
+        if name.is_empty()
+            || name
+                .iter()
+                .chain(value)
+                .any(|byte| matches!(byte, b'\r' | b'\n' | 0))
+        {
+            return None;
+        }
+
+        response.extend_from_slice(name);
+        response.extend_from_slice(b": ");
+        response.extend_from_slice(value);
+        response.extend_from_slice(b"\r\n");
+    }
+
+    response.extend_from_slice(b"\r\n");
+    Some(response)
+}
+
 /// Per-process latch for the dev-mode idle-timeout warning. The
 /// warning is gated on `DEBUG && !silent` and only fires once globally, so a
 /// single shared `AtomicBool` matches user-visible behavior.
@@ -1564,6 +1635,31 @@ where
             global.throw_invalid_arguments(format_args!("Expected Request object"))
         })?;
         self.request_ip(request)
+    }
+
+    /// Sends an HTTP 103 informational response for a live `Bun.serve()` request.
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn write_early_hints(
+        &mut self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let arguments = callframe.arguments();
+        if arguments.len() < 2 || arguments[0].is_empty_or_undefined_or_null() {
+            return Err(global.throw_not_enough_arguments("writeEarlyHints", 2, arguments.len()));
+        }
+
+        let request = arguments[0].as_class_ref::<Request>().ok_or_else(|| {
+            global.throw_invalid_arguments(format_args!("Expected Request object"))
+        })?;
+
+        let Some(data) = render_early_hints(global, arguments[1])? else {
+            return Ok(JSValue::FALSE);
+        };
+
+        Ok(JSValue::js_boolean(
+            request.request_context.write_informational(&data),
+        ))
     }
 
     /// `pub const doReload = onReload`

--- a/test/js/bun/http/fetch-h3.ts
+++ b/test/js/bun/http/fetch-h3.ts
@@ -30,6 +30,10 @@ function findCurlH3(): string | null {
   return (resolved = null);
 }
 
+export function hasCurlH3(): boolean {
+  return findCurlH3() !== null;
+}
+
 type Init = {
   method?: string;
   headers?: HeadersInit;
@@ -45,6 +49,16 @@ type Init = {
  * only relying on what's listed above.
  */
 export async function fetchH3(input: string | URL, init: Init = {}): Promise<Response> {
+  return (await fetchH3WithHeaderBlocks(input, init)).response;
+}
+
+/**
+ * fetchH3() plus every raw response header block captured by curl.
+ */
+export async function fetchH3WithHeaderBlocks(
+  input: string | URL,
+  init: Init = {},
+): Promise<{ response: Response; headerBlocks: string[] }> {
   const bin = findCurlH3();
   if (!bin) throw new Error("fetchH3: no HTTP/3-capable curl (set CURL_HTTP3=/path/to/curl)");
 
@@ -119,8 +133,11 @@ export async function fetchH3(input: string | URL, init: Init = {}): Promise<Res
   }
 
   // With -L curl emits one header block per hop; the final response is last.
-  const blocks = headerText.trimEnd().split(/\r?\n\r?\n/);
-  const lastBlock = blocks[blocks.length - 1] ?? "";
+  const headerBlocks = headerText
+    .trimEnd()
+    .split(/\r?\n\r?\n/)
+    .filter(Boolean);
+  const lastBlock = headerBlocks[headerBlocks.length - 1] ?? "";
   const lines = lastBlock.split(/\r?\n/);
   const statusLine = lines.shift() ?? "HTTP/3 502";
   const status = Number(statusLine.match(/HTTP\/3\s+(\d{3})/)?.[1] ?? "502");
@@ -133,7 +150,10 @@ export async function fetchH3(input: string | URL, init: Init = {}): Promise<Res
   }
 
   const noBody = status === 204 || status === 304 || method === "HEAD";
-  return new Response(noBody ? null : new Uint8Array(bodyBytes), { status, headers });
+  return {
+    response: new Response(noBody ? null : new Uint8Array(bodyBytes), { status, headers }),
+    headerBlocks,
+  };
 }
 
 /**

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createHash, randomBytes } from "crypto";
 import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
 import { join } from "path";
+import { fetchH3WithHeaderBlocks, hasCurlH3 } from "./fetch-h3";
 
 // Native HTTP/3 fetch wrapper. Every request in this file forces
 // `protocol: "http3"` so a regression that silently falls back to TCP
@@ -225,10 +226,21 @@ describe("Bun.serve HTTP/3", () => {
 
   test("writeEarlyHints returns false", async () => {
     await withServer(async port => {
-      const res = await fetchH3(port, "/early-hints");
-      expect(res.status).toBe(200);
-      expect(res.headers.get("link")).toBeNull();
-      expect(await res.text()).toBe("false");
+      const response = await fetchH3(port, "/early-hints");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("link")).toBeNull();
+      expect(await response.text()).toBe("false");
+    });
+  });
+
+  test.if(hasCurlH3())("writeEarlyHints emits no informational response", async () => {
+    await withServer(async port => {
+      const { response, headerBlocks } = await fetchH3WithHeaderBlocks(`https://127.0.0.1:${port}/early-hints`);
+      expect(headerBlocks.some(block => /^HTTP\/3 103(?:\s|$)/m.test(block))).toBe(false);
+      expect(headerBlocks.some(block => /^link:\s*<\/app\.css>/im.test(block))).toBe(false);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("link")).toBeNull();
+      expect(await response.text()).toBe("false");
     });
   });
 

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -50,8 +50,11 @@ const server = serve({
     }),
     "/file-route": Bun.file(process.env.BIG_FILE),
   },
-  async fetch(req) {
+  async fetch(req, server) {
     const url = new URL(req.url);
+    if (url.pathname === "/early-hints") {
+      return new Response(String(server.writeEarlyHints(req, { Link: "</app.css>; rel=preload; as=style" })));
+    }
     if (url.pathname === "/hello") {
       return new Response("hello over h3", {
         headers: { "x-proto": "h3", "content-type": "text/plain" },
@@ -217,6 +220,15 @@ describe("Bun.serve HTTP/3", () => {
       expect(res.status).toBe(200);
       expect(res.headers.get("x-proto")).toBe("h3");
       expect(await res.text()).toBe("hello over h3");
+    });
+  });
+
+  test("writeEarlyHints returns false", async () => {
+    await withServer(async port => {
+      const res = await fetchH3(port, "/early-hints");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("link")).toBeNull();
+      expect(await res.text()).toBe("false");
     });
   });
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2379,6 +2379,62 @@ describe("server.writeEarlyHints", () => {
     expect(response).toContain("final response");
   });
 
+  it("returns false after the final response begins streaming", async () => {
+    const statusFlushed = Promise.withResolvers<void>();
+    const hintsWritten = Promise.withResolvers<boolean>();
+    const completed = Promise.withResolvers<void>();
+    let started = false;
+    using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, server) {
+        return new Response(
+          new ReadableStream({
+            async pull(controller) {
+              if (started) return;
+              started = true;
+              controller.enqueue("first chunk");
+              await statusFlushed.promise;
+              hintsWritten.resolve(server.writeEarlyHints(req, { Link: "</late.css>; rel=preload; as=style" }));
+              controller.close();
+            },
+          }),
+        );
+      },
+    });
+
+    const chunks: Buffer[] = [];
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        data(_socket, data) {
+          chunks.push(Buffer.from(data));
+          if (Buffer.concat(chunks).includes("HTTP/1.1 200")) statusFlushed.resolve();
+        },
+        end() {
+          completed.resolve();
+        },
+        error(_socket, error) {
+          completed.reject(error);
+        },
+        close() {
+          completed.resolve();
+        },
+      },
+    });
+    connection.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    connection.flush();
+
+    await completed.promise;
+    const response = Buffer.concat(chunks).toString();
+    expect(await hintsWritten.promise).toBe(false);
+    expect(response).toStartWith("HTTP/1.1 200");
+    expect(response).not.toContain("HTTP/1.1 103 Early Hints");
+    expect(response).not.toContain("Link: </late.css>; rel=preload; as=style");
+    expect(response).toContain("first chunk");
+  });
+
   it("returns false after the request completes", async () => {
     let request: Request | undefined;
     using server = Bun.serve({

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2330,6 +2330,72 @@ it("#5859 arrayBuffer", async () => {
   expect(async () => await Bun.file(tmp).json()).toThrow();
 });
 
+describe("server.writeEarlyHints", () => {
+  it("sends a native 103 response before the final response", async () => {
+    const completed = Promise.withResolvers<void>();
+    using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req, server) {
+        expect(
+          server.writeEarlyHints(req, {
+            Link: "</app.css>; rel=preload; as=style",
+            "X-Trace-Id": "early-hints",
+          }),
+        ).toBe(true);
+        expect(server.writeEarlyHints(req, {})).toBe(false);
+        return new Response("final response");
+      },
+    });
+
+    const chunks: Buffer[] = [];
+    await using connection = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        data(_socket, data) {
+          chunks.push(Buffer.from(data));
+        },
+        end() {
+          completed.resolve();
+        },
+        error(_socket, error) {
+          completed.reject(error);
+        },
+        close() {
+          completed.resolve();
+        },
+      },
+    });
+    connection.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    connection.flush();
+
+    await completed.promise;
+    const response = Buffer.concat(chunks).toString();
+    expect(response).toStartWith(
+      "HTTP/1.1 103 Early Hints\r\nLink: </app.css>; rel=preload; as=style\r\nX-Trace-Id: early-hints\r\n\r\n",
+    );
+    expect(response).toContain("\r\n\r\nHTTP/1.1 200");
+    expect(response).toContain("final response");
+  });
+
+  it("returns false after the request completes", async () => {
+    let request: Request | undefined;
+    using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        request = req;
+        return new Response("final response");
+      },
+    });
+
+    await fetch(server.url).then(response => response.text());
+    expect(request).toBeDefined();
+    expect(server.writeEarlyHints(request!, { Link: "</app.css>; rel=preload; as=style" })).toBe(false);
+  });
+});
+
 describe("server.requestIP", () => {
   it.if(isIPv4())("v4", async () => {
     using server = Bun.serve({


### PR DESCRIPTION
### What does this PR do?

Implement to support [103 Early Hints](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/103) with native Bun.serve. Currently node.js compatible [`ServerResponse.writeEarlyHints`](https://bun.com/reference/node/http/ServerResponse/writeEarlyHints) is available to use with Bun but it has performance penalty.

Example of use cases:

```ts
Bun.serve({
  async fetch(req, server) {
    server.writeEarlyHints(req, {
      Link: "</app.css>; rel=preload; as=style, </app.js>; rel=modulepreload",
    });

    const html = await renderPage();
    return new Response(html, {
      headers: { "Content-Type": "text/html" },
    });
  },
});
```

### How did you verify your code works?

We do pre-built bun locally and test with our sample code to prove a feature works, together with adding test cases to cover this cases.

should also solves https://github.com/oven-sh/bun/issues/8690