### PR TITLE
http(h2/h3): detach the stream before a terminal header-time progress update

### DIFF
--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -1038,8 +1038,14 @@ impl ClientSession {
             // Deep-copy before detaching: `response` borrows
             // `stream.decoded_headers`.
             client.h2_clone_metadata(&response);
+            // `is_done()`: a Content-Length: 0 response can reach here as
+            // `HasBody` (e.g. a text/event-stream content-type), which would
+            // make the headerProgress update below terminal. A terminal
+            // progressUpdate frees the AsyncHTTP embedding `client`, so it
+            // must never run while the stream is still attached.
             if result == HeaderResult::Finished
                 || (stream.remote_closed() && stream.body_buffer.is_empty())
+                || client.state.is_done()
             {
                 stream.client = None;
                 client.h2 = None;

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -1038,11 +1038,9 @@ impl ClientSession {
             // Deep-copy before detaching: `response` borrows
             // `stream.decoded_headers`.
             client.h2_clone_metadata(&response);
-            // `is_done()`: a Content-Length: 0 response can reach here as
-            // `HasBody` (e.g. a text/event-stream content-type), which would
-            // make the headerProgress update below terminal. A terminal
-            // progressUpdate frees the AsyncHTTP embedding `client`, so it
-            // must never run while the stream is still attached.
+            // `is_done()`: Content-Length: 0 can arrive as `HasBody` (e.g. an
+            // SSE content-type), which would make the headerProgress update
+            // below terminal and free `client` while the stream still holds it.
             if result == HeaderResult::Finished
                 || (stream.remote_closed() && stream.body_buffer.is_empty())
                 || client.state.is_done()

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -307,7 +307,15 @@ impl ClientSession {
                 Ok(r) => r,
                 Err(e) => return self.fail(stream, e),
             };
-            if result == HeaderResult::Finished || (done && st.body_buffer.is_empty()) {
+            // `is_done()`: a Content-Length: 0 response can reach here as
+            // `HasBody` (e.g. a text/event-stream content-type), which would
+            // make the headerProgress update below terminal. A terminal
+            // progressUpdate frees the AsyncHTTP embedding `client`, so it
+            // must never run while the stream is still attached.
+            if result == HeaderResult::Finished
+                || (done && st.body_buffer.is_empty())
+                || client.state.is_done()
+            {
                 if client.state.flags.is_redirect_pending {
                     self.detach(stream);
                     // SAFETY: re-derive — detach() invalidated the prior Unique tag.

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -307,11 +307,9 @@ impl ClientSession {
                 Ok(r) => r,
                 Err(e) => return self.fail(stream, e),
             };
-            // `is_done()`: a Content-Length: 0 response can reach here as
-            // `HasBody` (e.g. a text/event-stream content-type), which would
-            // make the headerProgress update below terminal. A terminal
-            // progressUpdate frees the AsyncHTTP embedding `client`, so it
-            // must never run while the stream is still attached.
+            // `is_done()`: Content-Length: 0 can arrive as `HasBody` (e.g. an
+            // SSE content-type), which would make the headerProgress update
+            // below terminal and free `client` while the stream still holds it.
             if result == HeaderResult::Finished
                 || (done && st.body_buffer.is_empty())
                 || client.state.is_done()

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -326,6 +326,49 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
     );
   });
 
+  // 9. Zero-length response that still announces a body: HEADERS carries
+  //    content-length: 0 plus an SSE content-type, without END_STREAM, so the
+  //    stream stays open from the server's side while the response is already
+  //    complete at header time. Delivering that completion must detach the
+  //    stream first; the unfixed path freed the in-flight request while the
+  //    session still referenced it. Runs in a subprocess because the failure
+  //    mode is a crash.
+  test("content-length: 0 response without END_STREAM completes without touching the freed request", async () => {
+    await withAdversarialServer(
+      {
+        onStream: (socket, id) => {
+          // END_HEADERS only (0x4) — no END_STREAM.
+          socket.write(
+            frame(
+              1,
+              0x4,
+              id,
+              Buffer.concat([
+                hpackStatus200,
+                hpackLit("content-length", "0"),
+                hpackLit("content-type", "text/event-stream"),
+              ]),
+            ),
+          );
+        },
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const r = await fetch(${JSON.stringify(url)}, {
+            protocol: "http2",
+            signal: AbortSignal.timeout(8000),
+            tls: { rejectUnauthorized: false },
+          });
+          const body = await r.text();
+          console.log(JSON.stringify({ status: r.status, body }));
+        `);
+        const { stdout, exitCode } = await collect(proc);
+        expect(stdout.trim()).toBe('{"status":200,"body":""}');
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
   // ───────────────────────────────────────────────────────────────────────────
   // Regressions for the H2Client.zig hardening pass.
   // ───────────────────────────────────────────────────────────────────────────

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -362,7 +362,9 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
           const body = await r.text();
           console.log(JSON.stringify({ status: r.status, body }));
         `);
-        const { stdout, exitCode } = await collect(proc);
+        const { stdout, stderr, exitCode } = await collect(proc);
+        // stderr first: on a crash it carries the panic/ASAN report.
+        expect(stderr).toBe("");
         expect(stdout.trim()).toBe('{"status":200,"body":""}');
         expect(exitCode).toBe(0);
       },


### PR DESCRIPTION
### What does this PR do?

Fixes a use-after-free in the HTTP/2 (and HTTP/3) fetch client when a server completes a response at header time without closing the stream.

**Problem**

`deliver_stream` follows a detach-before-terminal discipline: a terminal progress update (`has_more == false`) frees the `ThreadlocalAsyncHTTP` that embeds the `HTTPClient`, so every path that can dispatch one first clears `stream.client` / `client.h2` and removes the stream. The header-progress call missed one case: a response whose headers carry `Content-Length: 0` but still announce a body, e.g. a `text/event-stream` content-type (`handle_response_metadata` returns `ContinueStreaming` for SSE regardless of content length). `state.is_done()` is then already true at header time (`total_body_received >= content_length`, 0 >= 0), so the `headerProgress` update at `h2_client/ClientSession.rs:1061` dispatched a terminal result and freed the client while the stream was still attached to the session. The very next statement reads the freed `client.state`, and any later frame for that stream id (DATA, RST_STREAM, connection close) re-enters the freed client and can dispatch a second terminal result into the freed tasklet.

On a debug build the first terminal dispatch trips the teardown assertion deterministically:

```
panic: assertion failed: client.h2.is_none()
    <bun_http::async_http::AsyncHTTP>::on_async_http_callback_raw  src/http/AsyncHTTP.rs:754
    <bun_http::HTTPClient>::send_progress_update_multiplexed       src/http/lib.rs:4292
    <bun_http::h2_client::client_session::ClientSession>::deliver_stream  src/http/h2_client/ClientSession.rs:1061
```

The HTTP/3 client session has the same hole at the same point in its `deliver` (`h3_client/ClientSession.rs`).

Reachability: fetch only uses HTTP/2/3 when opted in (`protocol: "http2"`, the CLI flag, or the experimental env flags), so this does not affect default-configuration fetch.

**Fix**

Fold `client.state.is_done()` into the existing headers-complete-the-response branch in both sessions. The zero-length case now detaches the stream and finishes through `finish_stream` exactly like HEAD/204/304 and END_STREAM-at-headers already do: the response delivers complete with an empty body (same outcome as the HTTP/1.1 path for the identical response, where the terminal progress update also fires at header time), the Content-Length check in `finish_stream` still enforces RFC 9113 section 8.1.1 if stray DATA arrived in the same read, and the deliver loop RST_STREAMs the still-open stream so the server releases its slot. With the branch handling `is_done()`, the header-progress update below it can no longer be terminal (`state.fail` is only ever set by paths that dispatch and detach immediately).

(Correction from self-review: an earlier revision of this description claimed the HTTP/3 fold also changed redirect handling. It does not. `handle_response_metadata` returns `Finished` for every redirect-pending response (src/http/lib.rs:5260-5269), so the redirect sub-branch in the HTTP/3 session was already reachable before this change; the new `is_done()` condition only adds the non-redirect zero-length case.)

### How did you verify your code works?

New test in `test/js/web/fetch/fetch-http2-adversarial.test.ts`: a raw h2 server answers with HEADERS (`END_HEADERS` only, no `END_STREAM`) carrying `content-length: 0` and `content-type: text/event-stream`. Before the fix the child process aborts with the assertion above; after, fetch resolves with a complete empty 200 response and the child exits cleanly.

Also ran `fetch-http2-adversarial` (16 pass), `fetch-http2-client` (62 pass), `fetch-http2-leak` (7 pass), `fetch-http3-client` (53 pass), `fetch-http3-adversarial` (27 pass), and the undici-h2 / wpt-h2 suites against the debug+ASAN build.

