### PR TITLE
Reject hot-reloaded builtin JS from a different codegen generation in debug builds

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -718,6 +718,7 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
     resolve(cfg.codegenDir, "InternalModuleRegistry+createInternalModuleById.h"),
     resolve(cfg.codegenDir, "InternalModuleRegistry+enum.h"),
     resolve(cfg.codegenDir, "InternalModuleRegistry+numberOfModules.h"),
+    resolve(cfg.codegenDir, "InternalModuleRegistry+generation.h"),
     resolve(cfg.codegenDir, "NativeModuleImpl.h"),
     resolve(cfg.codegenDir, "SyntheticModuleType.h"),
     resolve(cfg.codegenDir, "GeneratedJS2Native.h"),

--- a/scripts/update-parallel-allowlist.mjs
+++ b/scripts/update-parallel-allowlist.mjs
@@ -141,7 +141,8 @@ const slowest = file => {
 };
 // bun install / link / global tests share the user-level bin and cache dirs;
 // run together they race on linking (EEXIST) even though each passes alone.
-const sharedStatePrefixes = ["cli/install/"];
+// internal-module-dev-reload rewrites the build dir's hot-reload JS under test.
+const sharedStatePrefixes = ["cli/install/", "js/bun/internal-module-dev-reload.test.ts"];
 const sharedStateExempt = ["cli/install/hosted-git-info/", "cli/install/migration/"];
 const isGood = file => {
   if (dockerPrefixes.some(prefix => file.startsWith(prefix)) || usesContainer(file)) return false;

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -243,17 +243,12 @@ if (out.exitCode !== 0) {
 
 mark("Bundle modules");
 
-// In debug builds the files written to JS_DIR are re-read from disk at runtime
-// (BUN_DYNAMIC_JS_LOAD_PATH) so src/js edits apply without relinking. Those
-// files bake in codegen-assigned numeric IDs — `$lazy` native-call IDs,
-// internal module registry indices, error-code IDs, js_classes IDs — that must
-// match the dispatch tables compiled into the binary. Stamp each file with a
-// hash of all of those ID spaces; InternalModuleRegistry.cpp refuses files
-// whose stamp doesn't match the one its build was generated with (a rebuild in
-// flight, or an aborted one, would otherwise dispatch to the wrong native
-// code). Module preprocessing has already registered every `$lazy` call a
-// module file can contain, so the signature is complete at this point, and the
-// hash doesn't cover file contents, so editing JS never invalidates it.
+// Hash of every codegen-assigned numeric ID space baked into module JS
+// ($lazy native-call IDs, module registry indices, error-code and js_classes
+// IDs). InternalModuleRegistry.cpp refuses hot-reloading JS_DIR files whose
+// stamp doesn't match the binary's, so a renumbering rebuild can't make
+// $lazy(N) dispatch to the wrong native code. Content isn't hashed: editing
+// JS never invalidates the stamp.
 const generation = new Bun.CryptoHasher("sha256")
   .update(JSON.stringify([moduleList, nativeStartIndex]))
   .update(getJS2NativeSignature())
@@ -300,9 +295,8 @@ for (const entrypoint of bundledEntryPoints) {
 
   const outputPath = path.join(JS_DIR, file_path);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  // The stamp is appended only to the on-disk copy (the embedded blob always
-  // matches the binary) and goes at the end so line numbers stay identical to
-  // the embedded sources. Its absence also marks a partially-written file.
+  // Stamp only the on-disk copy, at EOF so line numbers match the embedded
+  // sources (which always match the binary and don't need a stamp).
   fs.writeFileSync(outputPath, captured + generationStamp);
   outputs.set(file_path.replace(".js", ""), captured);
 }

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -395,8 +395,15 @@ writeIfNotChanged(
   path.join(CODEGEN_DIR, "InternalModuleRegistry+numberOfModules.h"),
   `#define BUN_INTERNAL_MODULE_COUNT ${moduleList.length}
 #define BUN_NATIVE_MODULE_START_INDEX ${nativeStartIndex}
-#define BUN_INTERNAL_MODULE_GENERATION "${generation}"
 `,
+);
+
+// Included only by InternalModuleRegistry.cpp (not from any header): the hash
+// changes on every ID renumbering, and keeping it off the PCH include chain
+// keeps that a one-TU recompile.
+writeIfNotChanged(
+  path.join(CODEGEN_DIR, "InternalModuleRegistry+generation.h"),
+  `#define BUN_INTERNAL_MODULE_GENERATION "${generation}"\n`,
 );
 
 // This code slice is used in InternalModuleRegistry.h for inlining the enum. I dont think we

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -15,10 +15,10 @@ import path from "path";
 import jsclasses from "./../jsc/bindings/js_classes";
 import { sliceSourceCode } from "./builtin-parser";
 import { createAssertClientJS, createLogClientJS } from "./client-js";
-import { getJS2NativeCPP, getJS2NativeRust } from "./generate-js2native";
+import { getJS2NativeCPP, getJS2NativeRust, getJS2NativeSignature } from "./generate-js2native";
 import { cap, checkAscii, writeIfNotChanged, writeIfNotChangedBinary } from "./helpers";
 import { createInternalModuleRegistry } from "./internal-module-registry-scanner";
-import { define } from "./replacements";
+import { define, getNumericReplacementsSignature } from "./replacements";
 
 const BASE = path.join(import.meta.dir, "../js");
 const debug = process.argv[2] === "--debug=ON";
@@ -243,6 +243,25 @@ if (out.exitCode !== 0) {
 
 mark("Bundle modules");
 
+// In debug builds the files written to JS_DIR are re-read from disk at runtime
+// (BUN_DYNAMIC_JS_LOAD_PATH) so src/js edits apply without relinking. Those
+// files bake in codegen-assigned numeric IDs — `$lazy` native-call IDs,
+// internal module registry indices, error-code IDs, js_classes IDs — that must
+// match the dispatch tables compiled into the binary. Stamp each file with a
+// hash of all of those ID spaces; InternalModuleRegistry.cpp refuses files
+// whose stamp doesn't match the one its build was generated with (a rebuild in
+// flight, or an aborted one, would otherwise dispatch to the wrong native
+// code). Module preprocessing has already registered every `$lazy` call a
+// module file can contain, so the signature is complete at this point, and the
+// hash doesn't cover file contents, so editing JS never invalidates it.
+const generation = new Bun.CryptoHasher("sha256")
+  .update(JSON.stringify([moduleList, nativeStartIndex]))
+  .update(getJS2NativeSignature())
+  .update(getNumericReplacementsSignature())
+  .digest("hex")
+  .slice(0, 16);
+const generationStamp = `// @bun-internal-module-generation=${generation}\n`;
+
 const outputs = new Map();
 
 for (const entrypoint of bundledEntryPoints) {
@@ -281,7 +300,10 @@ for (const entrypoint of bundledEntryPoints) {
 
   const outputPath = path.join(JS_DIR, file_path);
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, captured);
+  // The stamp is appended only to the on-disk copy (the embedded blob always
+  // matches the binary) and goes at the end so line numbers stay identical to
+  // the embedded sources. Its absence also marks a partially-written file.
+  fs.writeFileSync(outputPath, captured + generationStamp);
   outputs.set(file_path.replace(".js", ""), captured);
 }
 
@@ -379,6 +401,7 @@ writeIfNotChanged(
   path.join(CODEGEN_DIR, "InternalModuleRegistry+numberOfModules.h"),
   `#define BUN_INTERNAL_MODULE_COUNT ${moduleList.length}
 #define BUN_NATIVE_MODULE_START_INDEX ${nativeStartIndex}
+#define BUN_INTERNAL_MODULE_GENERATION "${generation}"
 `,
 );
 

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -249,13 +249,15 @@ mark("Bundle modules");
 // stamp doesn't match the binary's, so a renumbering rebuild can't make
 // $lazy(N) dispatch to the wrong native code. Content isn't hashed: editing
 // JS never invalidates the stamp.
+const js2nativeSignature = getJS2NativeSignature();
 const generation = new Bun.CryptoHasher("sha256")
   .update(JSON.stringify([moduleList, nativeStartIndex]))
-  .update(getJS2NativeSignature())
+  .update(js2nativeSignature)
   .update(getNumericReplacementsSignature())
   .digest("hex")
   .slice(0, 16);
 const generationStamp = `// @bun-internal-module-generation=${generation}\n`;
+const stampedNativeCallCount = (JSON.parse(js2nativeSignature) as unknown[]).length;
 
 const outputs = new Map();
 
@@ -291,6 +293,19 @@ for (const entrypoint of bundledEntryPoints) {
   const errors = [...captured.matchAll(/@bundleError\((.*)\)/g)];
   if (errors.length) {
     throw new Error(`Errors in ${entrypoint}:\n${errors.map(x => x[1]).join("\n")}`);
+  }
+
+  // Guard rail: the stamp is only sound if every $lazy ID this file bakes was
+  // registered before the stamp was computed. Registration happens during
+  // module preprocessing, so this can only fire if the stamp computation gets
+  // moved above it.
+  for (const match of captured.matchAll(/@lazy\((\d+)\)/g)) {
+    if (Number(match[1]) >= stampedNativeCallCount) {
+      throw new Error(
+        `${file_path} bakes $lazy ID ${match[1]}, but only ${stampedNativeCallCount} native calls were ` +
+          `registered when the generation stamp was computed.`,
+      );
+    }
   }
 
   const outputPath = path.join(JS_DIR, file_path);

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -174,13 +174,8 @@ export function registerNativeCall(
   return id;
 }
 
-/**
- * Stable description of the `$lazy` ID space as registered so far. Module
- * preprocessing registers every call site a module file can bake in, so when
- * called after that phase this pins the ID → native-function mapping those
- * files rely on. Part of the generation stamp bundle-modules.ts writes into
- * each hot-reloadable JS file.
- */
+/** The `$lazy` ID → native-function mapping registered so far, for the
+ * generation stamp bundle-modules.ts writes into hot-reloadable JS files. */
 export function getJS2NativeSignature(): string {
   return JSON.stringify(nativeCalls.map(call => [call.id, call.type, call.filename, call.symbol]));
 }

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -174,6 +174,17 @@ export function registerNativeCall(
   return id;
 }
 
+/**
+ * Stable description of the `$lazy` ID space as registered so far. Module
+ * preprocessing registers every call site a module file can bake in, so when
+ * called after that phase this pins the ID → native-function mapping those
+ * files rely on. Part of the generation stamp bundle-modules.ts writes into
+ * each hot-reloadable JS file.
+ */
+export function getJS2NativeSignature(): string {
+  return JSON.stringify(nativeCalls.map(call => [call.id, call.type, call.filename, call.symbol]));
+}
+
 function symbol(call: Pick<NativeCall, "type" | "symbol" | "filename">) {
   return call.type === "rust"
     ? `JS2Rust__${call.filename ? normalizeSymbolPathPrefix(call.filename) + "_" : ""}${call.symbol.replace(/[^A-Za-z]/g, "_")}`

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -175,9 +175,18 @@ export function registerNativeCall(
 }
 
 /** The `$lazy` ID → native-function mapping registered so far, for the
- * generation stamp bundle-modules.ts writes into hot-reloadable JS files. */
+ * generation stamp bundle-modules.ts writes into hot-reloadable JS files.
+ * Filenames are relativized so the hash doesn't change with the checkout
+ * location (rust entries store absolute paths). */
 export function getJS2NativeSignature(): string {
-  return JSON.stringify(nativeCalls.map(call => [call.id, call.type, call.filename, call.symbol]));
+  return JSON.stringify(
+    nativeCalls.map(call => [
+      call.id,
+      call.type,
+      (path.isAbsolute(call.filename) ? path.relative(srcDir, call.filename) : call.filename).replaceAll(sep, "/"),
+      call.symbol,
+    ]),
+  );
 }
 
 function symbol(call: Pick<NativeCall, "type" | "symbol" | "filename">) {

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -38,20 +38,17 @@ for (let id = 0; id < jsclasses.length; id++) {
   });
 }
 
-/** The `$makeErrorWithCode(<error_i>, ...)` and `$inherits(<id>, ...)` ID
- * orderings baked in by the rules above, for the generation stamp
- * bundle-modules.ts writes into hot-reloadable JS files. */
+/** The replacement rules that bake a numeric ID into builtin JS
+ * (`$makeErrorWithCode(<error_i>, ...` and `$inherits(<id>, ...`), for the
+ * generation stamp bundle-modules.ts writes into hot-reloadable JS files.
+ * Derived from the built rules themselves so the signature cannot drift from
+ * the numbering the rules actually emit. */
 export function getNumericReplacementsSignature(): string {
-  const errorCtors: string[] = [];
-  for (let i = 0; i < NodeErrors.length; i++) {
-    const [code, _constructor, _name, ...other_constructors] = NodeErrors[i];
-    errorCtors.push(code as string);
-    for (const con of other_constructors) {
-      if (con == null) continue;
-      errorCtors.push(`${code}_${con.name}`);
-    }
-  }
-  return JSON.stringify({ errorCtors, classes: jsclasses.map(c => c[0]) });
+  return JSON.stringify(
+    replacements
+      .filter(rule => rule.to !== undefined && /\(\d+, $/.test(rule.to))
+      .map(rule => [rule.from.source, rule.to]),
+  );
 }
 
 // These rules are run on the entire file, including within strings.

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -38,13 +38,9 @@ for (let id = 0; id < jsclasses.length; id++) {
   });
 }
 
-/**
- * Stable description of the numeric ID spaces the replacement rules above bake
- * into builtin JS: `$makeErrorWithCode(<error_i>, ...)` (ErrorCode.ts order,
- * including extra constructors) and `$inherits(<id>, ...)` (js_classes order).
- * Part of the generation stamp bundle-modules.ts writes into each
- * hot-reloadable JS file.
- */
+/** The `$makeErrorWithCode(<error_i>, ...)` and `$inherits(<id>, ...)` ID
+ * orderings baked in by the rules above, for the generation stamp
+ * bundle-modules.ts writes into hot-reloadable JS files. */
 export function getNumericReplacementsSignature(): string {
   const errorCtors: string[] = [];
   for (let i = 0; i < NodeErrors.length; i++) {

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -38,6 +38,26 @@ for (let id = 0; id < jsclasses.length; id++) {
   });
 }
 
+/**
+ * Stable description of the numeric ID spaces the replacement rules above bake
+ * into builtin JS: `$makeErrorWithCode(<error_i>, ...)` (ErrorCode.ts order,
+ * including extra constructors) and `$inherits(<id>, ...)` (js_classes order).
+ * Part of the generation stamp bundle-modules.ts writes into each
+ * hot-reloadable JS file.
+ */
+export function getNumericReplacementsSignature(): string {
+  const errorCtors: string[] = [];
+  for (let i = 0; i < NodeErrors.length; i++) {
+    const [code, _constructor, _name, ...other_constructors] = NodeErrors[i];
+    errorCtors.push(code as string);
+    for (const con of other_constructors) {
+      if (con == null) continue;
+      errorCtors.push(`${code}_${con.name}`);
+    }
+  }
+  return JSON.stringify({ errorCtors, classes: jsclasses.map(c => c[0]) });
+}
+
 // These rules are run on the entire file, including within strings.
 export const globalReplacements: ReplacementRule[] = [
   {

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -9,6 +9,12 @@
 #include <JavaScriptCore/Debugger.h>
 #include <utility>
 
+#if OS(WINDOWS)
+#include <stdlib.h> // _exit
+#else
+#include <unistd.h> // _exit
+#endif
+
 #include "InternalModuleRegistryConstants.h"
 #include "wtf/Forward.h"
 
@@ -101,10 +107,49 @@ ALWAYS_INLINE JSC::JSValue generateNativeModule(
 }
 
 #ifdef BUN_DYNAMIC_JS_LOAD_PATH
+// bundle-modules.ts ends every file in BUN_DYNAMIC_JS_LOAD_PATH with
+// `// @bun-internal-module-generation=<hash>`. The hash covers every
+// codegen-assigned numeric ID space those files bake in ($lazy native-call
+// IDs, internal module registry indices, error-code and js_classes IDs), and
+// BUN_INTERNAL_MODULE_GENERATION is the hash this binary's dispatch tables
+// were generated with. A file with a different stamp came from a different
+// codegen run (rebuild in flight, or an aborted one) and its IDs may dispatch
+// to the wrong native code; a file with no stamp is mid-write. Editing JS
+// doesn't change the stamp, so hot-reload keeps working.
+static bool hasMatchingGenerationStamp(const Vector<uint8_t>& contents)
+{
+    static constexpr char needle[] = "// @bun-internal-module-generation=";
+    static constexpr size_t needleLength = sizeof(needle) - 1;
+    static constexpr char expected[] = BUN_INTERNAL_MODULE_GENERATION;
+    static constexpr size_t expectedLength = sizeof(expected) - 1;
+
+    // The stamp is the last line; scan only the tail (slack for the trailing
+    // newline, or \r\n if the checkout rewrote it).
+    static constexpr size_t tailLength = needleLength + expectedLength + 8;
+    size_t begin = contents.size() > tailLength ? contents.size() - tailLength : 0;
+    for (size_t i = begin; i + needleLength + expectedLength <= contents.size(); i++) {
+        if (memcmp(contents.span().data() + i, needle, needleLength) == 0)
+            return memcmp(contents.span().data() + i + needleLength, expected, expectedLength) == 0;
+    }
+    return false;
+}
+
 JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, const WTF::String& moduleName, WTF::String fileBase, const WTF::String& urlString)
 {
     WTF::String file = makeString(ASCIILiteral::fromLiteralUnsafe(BUN_DYNAMIC_JS_LOAD_PATH), "/"_s, WTF::move(fileBase));
     if (auto contents = WTF::FileSystemImpl::readEntireFile(file)) {
+        if (!hasMatchingGenerationStamp(contents.value())) [[unlikely]] {
+            fprintf(stderr,
+                "\nFATAL: bun-debug hot-reloads builtin JS from disk, but \"%s\" was written by a different codegen generation than this binary (expected %s).\n"
+                "Codegen-assigned numeric IDs may have shifted, so loading it could dispatch to the wrong native bindings.\n"
+                "This usually means a build is in progress, a previous build stopped after codegen, or the file is mid-write.\n"
+                "Re-run `bun bd` (or let the in-flight build finish) and try again.\n\n",
+                file.utf8().span().data(), BUN_INTERNAL_MODULE_GENERATION);
+            fflush(nullptr);
+            // Deliberate clean exit instead of CRASH(): this is a build-state
+            // error, not a bug worth a panic report.
+            _exit(1);
+        }
         auto string = WTF::String::fromUTF8(contents.value());
         return generateModule(globalObject, vm, string, moduleName, urlString);
     } else {

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -107,31 +107,24 @@ ALWAYS_INLINE JSC::JSValue generateNativeModule(
 }
 
 #ifdef BUN_DYNAMIC_JS_LOAD_PATH
-// bundle-modules.ts ends every file in BUN_DYNAMIC_JS_LOAD_PATH with
-// `// @bun-internal-module-generation=<hash>`. The hash covers every
-// codegen-assigned numeric ID space those files bake in ($lazy native-call
-// IDs, internal module registry indices, error-code and js_classes IDs), and
-// BUN_INTERNAL_MODULE_GENERATION is the hash this binary's dispatch tables
-// were generated with. A file with a different stamp came from a different
-// codegen run (rebuild in flight, or an aborted one) and its IDs may dispatch
-// to the wrong native code; a file with no stamp is mid-write. Editing JS
-// doesn't change the stamp, so hot-reload keeps working.
+// bundle-modules.ts stamps every file it writes to BUN_DYNAMIC_JS_LOAD_PATH
+// with the generation hash of the codegen-assigned numeric IDs the file bakes
+// in; BUN_INTERNAL_MODULE_GENERATION is the hash this binary was generated
+// with. A different or missing stamp means the file's IDs may dispatch to the
+// wrong native code (rebuild in flight, aborted build, or a mid-write file).
 static bool hasMatchingGenerationStamp(const Vector<uint8_t>& contents)
 {
-    static constexpr char needle[] = "// @bun-internal-module-generation=";
-    static constexpr size_t needleLength = sizeof(needle) - 1;
-    static constexpr char expected[] = BUN_INTERNAL_MODULE_GENERATION;
+    static constexpr char expected[] = "// @bun-internal-module-generation=" BUN_INTERNAL_MODULE_GENERATION;
     static constexpr size_t expectedLength = sizeof(expected) - 1;
 
-    // The stamp is the last line; scan only the tail (slack for the trailing
-    // newline, or \r\n if the checkout rewrote it).
-    static constexpr size_t tailLength = needleLength + expectedLength + 8;
-    size_t begin = contents.size() > tailLength ? contents.size() - tailLength : 0;
-    for (size_t i = begin; i + needleLength + expectedLength <= contents.size(); i++) {
-        if (memcmp(contents.span().data() + i, needle, needleLength) == 0)
-            return memcmp(contents.span().data() + i + needleLength, expected, expectedLength) == 0;
-    }
-    return false;
+    // The stamp must be the last line: trim trailing whitespace, then require
+    // the exact suffix (a matching stamp earlier in the file doesn't count).
+    size_t end = contents.size();
+    while (end > 0 && (contents[end - 1] == '\n' || contents[end - 1] == '\r' || contents[end - 1] == ' '))
+        end--;
+    if (end < expectedLength)
+        return false;
+    return memcmp(contents.span().data() + end - expectedLength, expected, expectedLength) == 0;
 }
 
 JSValue initializeInternalModuleFromDisk(JSGlobalObject* globalObject, VM& vm, const WTF::String& moduleName, WTF::String fileBase, const WTF::String& urlString)

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -107,6 +107,8 @@ ALWAYS_INLINE JSC::JSValue generateNativeModule(
 }
 
 #ifdef BUN_DYNAMIC_JS_LOAD_PATH
+#include "InternalModuleRegistry+generation.h"
+
 // bundle-modules.ts stamps every file it writes to BUN_DYNAMIC_JS_LOAD_PATH
 // with the generation hash of the codegen-assigned numeric IDs the file bakes
 // in; BUN_INTERNAL_MODULE_GENERATION is the hash this binary was generated

--- a/test/js/bun/internal-module-dev-reload.test.ts
+++ b/test/js/bun/internal-module-dev-reload.test.ts
@@ -41,7 +41,10 @@ describe.skipIf(!hasDynamicJS)("builtin JS hot-reload generation guard", () => {
       // binding's $lazy ID by one (dispatches to a different native function)
       // and stamp the file as belonging to another generation.
       tampered = tampered.replace(/bound\(@lazy\((\d+)\)\)/, (_, id) => `bound(@lazy(${Number(id) + 1}))`);
-      tampered = tampered.replace(/(@bun-internal-module-generation=)[0-9a-f]+/, "$1" + "0".repeat(16));
+      tampered = tampered.replace(
+        /(@bun-internal-module-generation=)[0-9a-f]+/,
+        "$1" + Buffer.alloc(16, "0").toString(),
+      );
       expect(tampered).not.toBe(original.toString("latin1"));
       fs.writeFileSync(osJsPath, tampered, "latin1");
 
@@ -76,7 +79,7 @@ describe.skipIf(!hasDynamicJS)("builtin JS hot-reload generation guard", () => {
     try {
       // The valid stamp becomes a decoy: a foreign stamp follows it as the
       // real last line, as if a different codegen run appended to the file.
-      const foreignStamp = "// @bun-internal-module-generation=" + "0".repeat(16) + "\n";
+      const foreignStamp = "// @bun-internal-module-generation=" + Buffer.alloc(16, "0").toString() + "\n";
       fs.writeFileSync(osJsPath, Buffer.concat([original, Buffer.from(foreignStamp, "latin1")]));
 
       const { stdout, stderr, exitCode } = await requireOsInChild();

--- a/test/js/bun/internal-module-dev-reload.test.ts
+++ b/test/js/bun/internal-module-dev-reload.test.ts
@@ -57,9 +57,7 @@ describe.skipIf(!hasDynamicJS)("builtin JS hot-reload generation guard", () => {
     const original = fs.readFileSync(osJsPath);
     try {
       const marker = "BUN_DEV_RELOAD_MARKER_1b2d";
-      const edited = original
-        .toString("latin1")
-        .replace('"use strict";', `"use strict";console.error("${marker}");`);
+      const edited = original.toString("latin1").replace('"use strict";', `"use strict";console.error("${marker}");`);
       expect(edited).not.toBe(original.toString("latin1"));
       fs.writeFileSync(osJsPath, edited, "latin1");
 

--- a/test/js/bun/internal-module-dev-reload.test.ts
+++ b/test/js/bun/internal-module-dev-reload.test.ts
@@ -70,6 +70,23 @@ describe.skipIf(!hasDynamicJS)("builtin JS hot-reload generation guard", () => {
     }
   });
 
+  test("a valid stamp that is not the final line does not count", async () => {
+    const original = fs.readFileSync(osJsPath);
+    try {
+      // The valid stamp becomes a decoy: a foreign stamp follows it as the
+      // real last line, as if a different codegen run appended to the file.
+      const foreignStamp = "// @bun-internal-module-generation=" + "0".repeat(16) + "\n";
+      fs.writeFileSync(osJsPath, Buffer.concat([original, Buffer.from(foreignStamp, "latin1")]));
+
+      const { stdout, stderr, exitCode } = await requireOsInChild();
+      expect(stderr).toContain(SKEW_MESSAGE);
+      expect(stdout).not.toContain("function");
+      expect(exitCode).not.toBe(0);
+    } finally {
+      fs.writeFileSync(osJsPath, original);
+    }
+  });
+
   test("a truncated file (codegen mid-write) is rejected, not misparsed", async () => {
     const original = fs.readFileSync(osJsPath);
     try {

--- a/test/js/bun/internal-module-dev-reload.test.ts
+++ b/test/js/bun/internal-module-dev-reload.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import fs from "node:fs";
+import { dirname, join } from "node:path";
+
+// Non-CI debug builds hot-reload builtin JS from `<buildDir>/js`
+// (BUN_DYNAMIC_JS_LOAD_PATH) so `src/js` edits apply without relinking. Those
+// files bake in codegen-assigned numeric IDs ($lazy native-call IDs, internal
+// module registry indices, error-code IDs), so a file written by a different
+// codegen run than the one the binary was built from can dispatch to the wrong
+// native binding. Each file carries a trailing `@bun-internal-module-generation`
+// stamp that the loader checks; a mismatch must fail with an actionable error
+// instead of loading misnumbered code.
+//
+// Only dev debug builds have the hot-reload dir, so these tests skip elsewhere
+// (release, CI debug builds, USE_SYSTEM_BUN).
+const jsDir = join(dirname(bunExe()), "js");
+const osJsPath = join(jsDir, "node", "os.js");
+const hasDynamicJS = fs.existsSync(osJsPath);
+
+const SKEW_MESSAGE = "different codegen generation";
+
+async function requireOsInChild() {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "const os = require('node:os'); console.log(typeof os.freemem)"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.skipIf(!hasDynamicJS)("builtin JS hot-reload generation guard", () => {
+  test("a file from a different codegen generation is rejected with an actionable error", async () => {
+    const original = fs.readFileSync(osJsPath);
+    try {
+      let tampered = original.toString("latin1");
+      // Simulate a codegen run that renumbered native-call IDs: shift the os
+      // binding's $lazy ID by one (dispatches to a different native function)
+      // and stamp the file as belonging to another generation.
+      tampered = tampered.replace(/bound\(@lazy\((\d+)\)\)/, (_, id) => `bound(@lazy(${Number(id) + 1}))`);
+      tampered = tampered.replace(/(@bun-internal-module-generation=)[0-9a-f]+/, "$1" + "0".repeat(16));
+      expect(tampered).not.toBe(original.toString("latin1"));
+      fs.writeFileSync(osJsPath, tampered, "latin1");
+
+      const { stdout, stderr, exitCode } = await requireOsInChild();
+      expect(stderr).toContain(SKEW_MESSAGE);
+      expect(stdout).not.toContain("function");
+      expect(exitCode).not.toBe(0);
+    } finally {
+      fs.writeFileSync(osJsPath, original);
+    }
+  });
+
+  test("an edited file with an intact generation stamp still hot-reloads", async () => {
+    const original = fs.readFileSync(osJsPath);
+    try {
+      const marker = "BUN_DEV_RELOAD_MARKER_1b2d";
+      const edited = original
+        .toString("latin1")
+        .replace('"use strict";', `"use strict";console.error("${marker}");`);
+      expect(edited).not.toBe(original.toString("latin1"));
+      fs.writeFileSync(osJsPath, edited, "latin1");
+
+      const { stdout, stderr, exitCode } = await requireOsInChild();
+      expect(stderr).toContain(marker);
+      expect(stdout).toContain("function");
+      expect(exitCode).toBe(0);
+    } finally {
+      fs.writeFileSync(osJsPath, original);
+    }
+  });
+
+  test("a truncated file (codegen mid-write) is rejected, not misparsed", async () => {
+    const original = fs.readFileSync(osJsPath);
+    try {
+      // A partially-written file has no trailing generation stamp yet.
+      fs.writeFileSync(osJsPath, original.subarray(0, Math.floor(original.length / 2)));
+
+      const { stdout, stderr, exitCode } = await requireOsInChild();
+      expect(stderr).toContain(SKEW_MESSAGE);
+      expect(stdout).not.toContain("function");
+      expect(exitCode).not.toBe(0);
+    } finally {
+      fs.writeFileSync(osJsPath, original);
+    }
+  });
+});
+
+// Keep the file non-empty for runners without the hot-reload dir.
+test.skipIf(hasDynamicJS)("builtin JS hot-reload dir not present (release or CI build)", () => {
+  expect(hasDynamicJS).toBe(false);
+});

--- a/test/js/bun/internal-module-dev-reload.test.ts
+++ b/test/js/bun/internal-module-dev-reload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 import fs from "node:fs";
 import { dirname, join } from "node:path";
 
@@ -12,11 +12,12 @@ import { dirname, join } from "node:path";
 // stamp that the loader checks; a mismatch must fail with an actionable error
 // instead of loading misnumbered code.
 //
-// Only dev debug builds have the hot-reload dir, so these tests skip elsewhere
-// (release, CI debug builds, USE_SYSTEM_BUN).
+// Only dev debug builds read the hot-reload dir. Codegen writes `<buildDir>/js`
+// for release builds too, so gate on the build flavor as well as the dir; CI
+// debug builds and USE_SYSTEM_BUN have no dir next to the binary and skip.
 const jsDir = join(dirname(bunExe()), "js");
 const osJsPath = join(jsDir, "node", "os.js");
-const hasDynamicJS = fs.existsSync(osJsPath);
+const hasDynamicJS = isDebug && fs.existsSync(osJsPath);
 
 const SKEW_MESSAGE = "different codegen generation";
 
@@ -103,7 +104,7 @@ describe.skipIf(!hasDynamicJS)("builtin JS hot-reload generation guard", () => {
   });
 });
 
-// Keep the file non-empty for runners without the hot-reload dir.
-test.skipIf(hasDynamicJS)("builtin JS hot-reload dir not present (release or CI build)", () => {
+// Keep the file non-empty for runners without hot-reload support.
+test.skipIf(hasDynamicJS)("builtin JS hot-reload not supported by this build", () => {
   expect(hasDynamicJS).toBe(false);
 });

--- a/test/parallel-allowlist.json
+++ b/test/parallel-allowlist.json
@@ -9,7 +9,7 @@
     "stats": {
       "dirs": 285,
       "files": 1692,
-      "excluded": 217
+      "excluded": 218
     }
   },
   "dirs": [
@@ -353,6 +353,7 @@
     "internal/linear-fifo.test.ts",
     "js/bun/archive.test.ts",
     "js/bun/globals.test.js",
+    "js/bun/internal-module-dev-reload.test.ts",
     "js/bun/cron/cron-parse.test.ts",
     "js/bun/cron/in-process-cron.test.ts",
     "js/bun/crypto/wpt-webcrypto.generateKey.test.ts",


### PR DESCRIPTION
### Symptom

Debug builds intermittently died at `node:os` module load under concurrent process spawning:

```
[os] ASSERTION FAILED: obj[key] !== undefined
Missing freemem
  at symbolToStringify (node:os:150:10)
```

The failures looked like memory corruption (only under load, same fixture usually passed) and were first suspected to be the native `freemem` binding failing under memory pressure. The binding is fine.

### Cause

Non-CI debug builds hot-reload builtin JS from `<buildDir>/js` at runtime (`BUN_DYNAMIC_JS_LOAD_PATH`) so `src/js` edits apply without relinking. Those files bake in codegen-assigned numeric IDs:

- `$lazy(N)` native-call IDs (`$cpp` / `$rust` / `$bindgenFn`)
- internal module registry indices
- `$makeErrorWithCode(N, ...)` error-code IDs
- `$inherits(N, ...)` js_classes IDs

All of these are assigned by codegen order, and the matching dispatch tables are compiled into the binary. A rebuild rewrites the JS files early, while the old binary keeps running and spawning children until the link finishes minutes later. If the numbering shifted, `$lazy(N)` in the fresh JS dispatches to a different native function in the old binary. `node:os` calls `$lazy(96)` for its binding; off by one it receives the `node:path` binding, which has no `freemem`, and the debug assert fires. Renumbering os.js's `$lazy` ID by hand reproduces the reported output byte for byte, including the `node:os:150:10` frame (the line number matches the on-disk dev file). The "correlates with load" observation was the rebuild itself: it pegs the machine while it opens the skew window. A build that dies after codegen leaves the skew in place until the next successful build.

### Fix

`bundle-modules.ts` hashes all of the numeric ID spaces above and appends the hash as a trailing comment to every file it writes to the hot-reload dir:

```
// @bun-internal-module-generation=9894f3ec51adfb1a
```

The same hash is compiled into the binary via `InternalModuleRegistry+numberOfModules.h`, and the debug loader refuses a file whose stamp doesn't match:

```
FATAL: bun-debug hot-reloads builtin JS from disk, but ".../js/node/os.js" was written by a different codegen generation than this binary (expected 9894f3ec51adfb1a).
Codegen-assigned numeric IDs may have shifted, so loading it could dispatch to the wrong native bindings.
This usually means a build is in progress, a previous build stopped after codegen, or the file is mid-write.
Re-run `bun bd` (or let the in-flight build finish) and try again.
```

Design notes:

- The hash covers the ID mappings, not file contents, so editing builtin JS and reloading without a rebuild (the point of the feature) still works; only changes that renumber IDs invalidate it, and those require a relink for correctness anyway.
- The stamp is appended at EOF so stack-trace line numbers stay identical to the embedded sources, and its absence also catches a file caught mid-write by codegen (previously a confusing `Error parsing builtin: Unexpected end of script`).
- A clear fatal rather than a fallback: debug builds deliberately don't embed module sources (that's what keeps JS edits link-free), so there is nothing consistent to fall back to.
- Release and CI builds are unchanged: the embedded blob doesn't get the stamp, and the check compiles away with `BUN_DYNAMIC_JS_LOAD_PATH` undefined.

### Verification

`test/js/bun/internal-module-dev-reload.test.ts` (skips when the hot-reload dir doesn't exist, i.e. release, CI debug, `USE_SYSTEM_BUN`):

- a file with a shifted `$lazy` ID and foreign stamp is rejected with the actionable error (on an unfixed build this test fails by reproducing the `Missing freemem` assert verbatim)
- an edited file with an intact stamp still hot-reloads (feature regression guard)
- a truncated file is rejected with the same error instead of a parse error

Also verified by hand: normal `require('node:os')` works after rebuild, all 194 files in the dir are stamped, and smoke runs of `test/js/node/os`, `node:path`, `node:util`, and `test/js/web/fetch/fetch-http2-leak.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/internal-module-dev-reload.test.ts
bun test v1.4.0 (4b50fcad3)

test/js/bun/internal-module-dev-reload.test.ts:
47 |       );
48 |       expect(tampered).not.toBe(original.toString("latin1"));
49 |       fs.writeFileSync(osJsPath, tampered, "latin1");
50 | 
51 |       const { stdout, stderr, exitCode } = await requireOsInChild();
52 |       expect(stderr).toContain(SKEW_MESSAGE);
                          ^
error: expect(received).toContain(expected)

Expected to contain: "different codegen generation"
Received: "[os] ASSERTION FAILED: obj[key] !== undefined\nMissing freemem\n  at symbolToStringify (node:os:150:10)\n\nAssertionError: obj[key] !== undefined\n\nBun v1.4.0-debug+4b50fcad3 (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/js/bun/internal-module-dev-reload.test.ts:52:22)
(fail) builtin JS hot-reload generation guard > a file from a different codegen generation is rejected with an actionable error [334.62ms]
(pass) builtin JS hot-reload generation guard > an edited file with an intact generation stamp sti
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (b66764ff3)

test/js/bun/internal-module-dev-reload.test.ts:
(skip) builtin JS hot-reload generation guard > a file from a different codegen generation is rejected with an actionable error
(skip) builtin JS hot-reload generation guard > an edited file with an intact generation stamp still hot-reloads
(skip) builtin JS hot-reload generation guard > a valid stamp that is not the final line does not count
(skip) builtin JS hot-reload generation guard > a truncated file (codegen mid-write) is rejected, not misparsed
(pass) builtin JS hot-reload not supported by this build [0.02ms]

 1 pass
 4 skip
 0 fail
 1 expect() calls
Ran 5 tests across 1 file. [127.00ms]
__F:0:S:4
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/internal-module-dev-reload.test.ts
bun test v1.4.0 (4b50fcad3)

test/js/bun/internal-module-dev-reload.test.ts:
(pass) builtin JS hot-reload generation guard > a file from a different codegen generation is rejected with an actionable error [293.41ms]
(pass) builtin JS hot-reload generation guard > an edited file with an intact generation stamp still hot-reloads [306.14ms]
(pass) builtin JS hot-reload generation guard > a valid stamp that is not the final line does not count [259.07ms]
(pass) builtin JS hot-reload generation guard > a truncated file (codegen mid-write) is rejected, not misparsed [258.25ms]
(skip) builtin JS hot-reload not supported by this build

 4 pass
 1 skip
 0 fail
 14 expect() calls
Ran 5 tests across 1 file. [3.12s]
__F:0:S:1

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 679ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[2/24] gen cpp.rs (cppbind)
[3/24] gen JS modules (bundle-modules)
Preprocess modules (8843ms)
Bundle modules (74ms)
Postprocesss modules (49ms)
Bundle Functions (608ms)
Generate Code (17ms)

[9.60s] Bundled "src/js" for production
  2573 kb
  194 internal modules
  13 native modules
  84 internal functions across 17 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/codegen.ts                       |   1 +
 scripts/update-parallel-allowlist.mjs          |   4 +
 src/codegen/bundle-modules.ts                  |  45 +++++++++-
 src/codegen/generate-js2native.ts              |  15 ++++
 src/codegen/replacements.ts                    |  13 +++
 src/jsc/bindings/InternalModuleRegistry.cpp    |  40 +++++++++
 test/js/bun/internal-module-dev-reload.test.ts | 113 +++++++++++++++++++++++++
 test/parallel-allowlist.json                   |   3 +-
 8 files changed, 230 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
scripts/build/codegen.ts                            2      1      0
scripts/update-parallel-allowlist.mjs               1      2      0
src/codegen/bundle-modules.ts                       3      8      0
src/codegen/generate-js2native.ts                   2      4      0
src/codegen/replacements.ts                         2      3      0
src/jsc/bindings/InternalModuleRegistry.cpp         2      6      0
test/js/bun/internal-module-dev-reload.test.ts      1      5      0
test/parallel-allowlist.json                        0      0      0
```

</details>

<!-- robobun:evidence:end -->