### PR TITLE
Bun.serve: write the chunked terminator once when a direct stream closes with unflushed data

### DIFF
--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1991,9 +1991,16 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             let _ = self.flush_no_wait();
             self.done = true;
 
-            if let Some(res) = self.any_res() {
-                // is actually fine to call this if the socket is closed because of flushNoWait, the free will be defered by usockets
-                res.end_stream(false);
+            // When the sink already ended the response through uWS
+            // (`res.end()`/`try_end` drained, which wrote the terminating
+            // chunk and `markDone()`d the response), `end_stream()` would
+            // write a second `0\r\n\r\n` that corrupts the next response on a
+            // keep-alive connection.
+            if !self.ended_response {
+                if let Some(res) = self.any_res() {
+                    // is actually fine to call this if the socket is closed because of flushNoWait, the free will be defered by usockets
+                    res.end_stream(false);
+                }
             }
         }
 

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -3,6 +3,7 @@ import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tls } from "harness";
 import { AsyncLocalStorage } from "node:async_hooks";
+import net from "node:net";
 
 test("HTTPResponseSink displays correct message", async () => {
   let leakedCtrl: any;
@@ -664,4 +665,67 @@ test("sync pull() under AsyncLocalStorage releases the request on end()", async 
   Bun.gc(true);
   const counts = heapStats().objectTypeCounts;
   expect((counts.ReadableStream ?? 0) - baseline).toBeLessThan(10);
+});
+
+// https://github.com/oven-sh/bun/issues/36940
+// close() while the sink still holds unflushed bytes deferred the final send
+// to the auto-flusher, which ended the response through uWS (writing the
+// terminating 0\r\n\r\n chunk) and then finalize() ended the stream a second
+// time, writing another terminator. On a keep-alive connection the stray
+// terminator is parsed as the start of the next response.
+test("close() with unflushed data writes the chunked terminator exactly once", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (new URL(req.url).pathname === "/plain") {
+        return new Response("ok");
+      }
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(c) {
+            // Write enough for chunked encoding, in pieces small enough that
+            // bytes are still buffered below the high-water mark when close()
+            // runs.
+            for (let i = 0; i < 8; i++) {
+              await c.write(new Uint8Array(100).fill(0x78));
+            }
+            c.close();
+          },
+        }),
+        { headers: { "content-type": "text/plain" } },
+      );
+    },
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  const sock = net.connect(server.port, "127.0.0.1");
+  let raw = "";
+  let sentSecond = false;
+  sock.setNoDelay(true);
+  sock.on("connect", () => {
+    sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n");
+  });
+  sock.on("data", d => {
+    raw += d.toString("latin1");
+    // Once the first (chunked) response has terminated, reuse the connection.
+    // The stray terminator was flushed together with the real one, so it is
+    // already in `raw` by the time the second response arrives.
+    if (!sentSecond && raw.includes("0\r\n\r\n")) {
+      sentSecond = true;
+      sock.write("GET /plain HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    }
+  });
+  sock.on("close", () => resolve(raw));
+  sock.on("error", reject);
+  const data = await promise;
+
+  // The chunked body is all "x"; the second response is framed by
+  // Content-Length. Exactly one terminating chunk must appear in the stream.
+  expect(data.split("0\r\n\r\n").length - 1).toBe(1);
+  // The bytes right after the terminator are the next response, not another
+  // terminator.
+  const afterTerminator = data.slice(data.indexOf("0\r\n\r\n") + 5);
+  expect(afterTerminator.slice(0, 12)).toBe("HTTP/1.1 200");
+  expect(afterTerminator).toEndWith("ok");
 });


### PR DESCRIPTION
Fixes #36940

### Repro

```ts
const server = Bun.serve({
  port: 0,
  fetch() {
    return new Response(
      new ReadableStream({
        type: "direct",
        async pull(c) {
          for (let i = 0; i < 8; i++) await c.write(new Uint8Array(100).fill(120));
          c.close(); // ~200 bytes still buffered in the sink
        },
      }),
      { headers: { "content-type": "text/plain" } },
    );
  },
});
```

Reading the raw socket shows the body ends with `0\r\n\r\n0\r\n\r\n`: the chunked terminator is written twice. On a keep-alive connection the stray terminator is parsed as the start of the next response, so a later request on the same socket fails with `Malformed_HTTP_Response`. Reproduces on 1.2.21 through current canary.

### Cause

In `HTTPServerWritable` (src/runtime/webcore/streams.rs), `end()` with bytes still buffered defers the final send to the auto-flusher. `on_auto_flush()` then drains through `send_readable_without_auto_flusher()`, which takes the `requested_end` branch and calls uWS `res.end(...)`. That writes the remaining data plus the terminating `0\r\n\r\n` chunk and `markDone()`s the response. `on_auto_flush()` records this (`ended_response = true`) and calls `finalize()`, but `finalize()` only checked `!self.done` and called `res.end_stream(false)`, which writes a second terminating chunk (uWS `sendTerminatingChunk` emits it unconditionally once the response is in chunked mode).

`end_from_js()` avoids this by calling `mark_done()` before `finalize()`; the auto-flush and `on_writable` drain paths do not, so any end that finishes through them double-terminated. `flush(true)` before `close()` empties the buffer, which is why the workaround in the issue avoids the bug.

### Fix

`finalize()` now skips `end_stream()` when the sink already fully ended the response (`ended_response`), which every drain path sets before calling `finalize()`. The flag-based guard also avoids touching the uWS response state on HTTP/1, where the response may already be recycled after `markDone()`.

### Test

Added to `test/js/bun/http/serve-direct-readable-stream.test.ts`: over a raw keep-alive TCP socket, request the direct-stream response, then a plain Content-Length response on the same connection with `Connection: close`, read to EOF, and assert exactly one `0\r\n\r\n` appears and that the bytes after it are the next response's status line. Fails on the unfixed build (two terminators), passes with the fix; the rest of the file still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
bun test v1.4.0 (c019ec700)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [64.48ms]
(pass) controller.end() after pull() resolved does not use the sink after free [377.98ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1257.90ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1256.71ms]
(pass) h3: controller.end() from a parked pull() disarms onAborted before the context is released [542.22ms]
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-closed [1229.46ms]
(pass) sync pull() throw after status is written does not re-render error() > no body bytes flushed: stream is ended without splicing error() headers [1279.51ms]
(pass) sync pull() that ends later streams the whole body [34.20ms]
(pass) sync pull() that writes nothing
... (truncated)

release without fix: 1 failed, 4 skipped
bun test v1.4.0-canary.1 (b66764ff3)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [12.43ms]
(skip) controller.end() after pull() resolved does not use the sink after free
(skip) client disconnect after controller.end() with a parked pull() does not use the socket after free
(skip) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free
(skip) h3: controller.end() from a parked pull() disarms onAborted before the context is released
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-closed [22.49ms]
(pass) sync pull() throw after status is written does not re-render error() > no body bytes flushed: stream is ended without splicing error() headers [21.78ms]
(pass) sync pull() that ends later streams the whole body [1.88ms]
(pass) sync pull() that writes nothing and ends later still responds [0.71ms]
(pass) cancel() fires when the client disconnects while waiting for end() [0.75ms]
(pass) end() under transport backpressure over h3 > async pull() that ends synchronously [13.16ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
bun test v1.4.0 (c019ec700)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [65.79ms]
(pass) controller.end() after pull() resolved does not use the sink after free [368.72ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1250.74ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1267.22ms]
(pass) h3: controller.end() from a parked pull() disarms onAborted before the context is released [552.51ms]
(pass) sync pull() throw after status is written does not re-render error() > body bytes already flushed: connection is force-closed [1249.09ms]
(pass) sync pull() throw after status is written does not re-render error() > no body bytes flushed: stream is ended without splicing error() headers [1288.71ms]
(pass) sync pull() that ends later streams the whole body [31.93ms]
(pass) sync pull() that writes nothing
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c019ec7009
  features     baseline

22 deps, 108 codegen, 1175 objects in 807ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b66764ff3)

Checked 124 installs across 170 packages (no changes) [10.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b66764ff3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch picohttpparser
[picohttpparser] up to date
[7/1237] fetch zlib
[zlib] up to date
[8/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b66764ff3)

Checked 129 installs across 147 packages (no changes)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/streams.rs                     | 13 ++++-
 .../bun/http/serve-direct-readable-stream.test.ts  | 64 ++++++++++++++++++++++
 2 files changed, 74 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/webcore/streams.rs                             2      1      0
test/js/bun/http/serve-direct-readable-stream.test.ts      1      1      0
```

</details>

**root cause** · written by the author bot

When a direct ReadableStream was closed while data was still buffered, the sink's close path flushed the pending bytes with the end flag set, which emitted the chunked terminator, and then the generic stream completion path ran its own end on the response and wrote `0\r\n\r\n` a second time. The paths that flushed first or had no buffered data did not hit this because the sink had nothing pending and only ended once. The fix makes the sink record that the response has already been terminated after the flush-with-end, so the completion path sees the done state and skips the redundant end wri…

<!-- robobun:evidence:end -->