### PR TITLE
fetch: don't touch the freed request clone when preconnect reuses a pooled socket

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3926,6 +3926,11 @@ impl<'a> HTTPClient<'a> {
             self.flags.defer_fail_until_connecting_is_complete = false;
             if self.state.stage == Stage::Fail {
                 self.dispatch_result_and_reset(true);
+            } else if self.flags.is_preconnect_only && self.state.stage == Stage::Done {
+                // Deferred preconnect completion (see `on_preconnect`): the
+                // dispatch frees the AsyncHTTP clone embedding `self`, so it
+                // runs here, where every caller returns straight afterwards.
+                self.dispatch_preconnect_result();
             }
         }
     }
@@ -4409,6 +4414,23 @@ impl<'a> HTTPClient<'a> {
         self.state.request_stage = RequestStage::Done;
         self.state.stage = Stage::Done;
         self.flags.proxy_tunneling = false;
+        // A preconnect that reuses a pooled keep-alive socket gets here
+        // synchronously inside `start_` → `connect` → `first_call`, and the
+        // terminal dispatch frees the ThreadlocalAsyncHTTP clone that embeds
+        // this client while those frames still use it. Defer the dispatch to
+        // `complete_connecting_process` — the same mechanism `fail()` uses
+        // for synchronous connect failures.
+        if self.flags.defer_fail_until_connecting_is_complete {
+            return;
+        }
+        self.dispatch_preconnect_result();
+    }
+
+    /// Terminal result for a preconnect-only request: the socket is already
+    /// back in the keep-alive pool and there is no response. Frees the
+    /// HTTP-thread AsyncHTTP clone embedding `self`; nothing may touch `self`
+    /// after this call.
+    fn dispatch_preconnect_result(&mut self) {
         self.result_callback.run(
             self.parent_async_http(),
             HTTPClientResult {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -208,7 +208,7 @@ pub struct Flags {
     pub reject_unauthorized: bool,
     pub(crate) is_preconnect_only: bool,
     pub is_streaming_request_body: bool,
-    pub(crate) defer_fail_until_connecting_is_complete: bool,
+    pub(crate) defer_terminal_dispatch_until_connecting_is_complete: bool,
     pub(crate) upgrade_state: HTTPUpgradeState,
     pub(crate) protocol: Protocol,
     pub forced_protocol: Option<Protocol>,
@@ -229,7 +229,7 @@ impl Default for Flags {
             reject_unauthorized: true,
             is_preconnect_only: false,
             is_streaming_request_body: false,
-            defer_fail_until_connecting_is_complete: false,
+            defer_terminal_dispatch_until_connecting_is_complete: false,
             upgrade_state: HTTPUpgradeState::None,
             protocol: Protocol::Http1_1,
             forced_protocol: None,
@@ -2061,7 +2061,7 @@ impl<'a> HTTPClient<'a> {
             self.state.response_stage = ResponseStage::Fail;
             self.state.fail = Some(err);
             self.state.stage = Stage::Fail;
-            if self.flags.defer_fail_until_connecting_is_complete {
+            if self.flags.defer_terminal_dispatch_until_connecting_is_complete {
                 return;
             }
             self.dispatch_result_and_reset(false);
@@ -2719,12 +2719,15 @@ impl<'a> HTTPClient<'a> {
     fn start_<const IS_SSL: bool>(&mut self) {
         self.unregister_abort_tracker();
 
-        // mark that we are connecting
-        self.flags.defer_fail_until_connecting_is_complete = true;
-        // this will call .fail() if the connection fails in the middle of the function avoiding UAF with can happen when the connection is aborted
+        // Mark that we are connecting: a terminal result reached inside this
+        // function (synchronous failure, or preconnect completing on a pooled
+        // socket) is recorded and dispatched by `complete_connecting_process()`
+        // instead, since the dispatch frees the AsyncHTTP clone embedding
+        // `self` while these frames still use it.
         // `complete_connecting_process()` cannot be a Drop guard here
         // (it needs `&mut self`, which would alias every other `self.*` call in the body),
         // so it is called explicitly before each return.
+        self.flags.defer_terminal_dispatch_until_connecting_is_complete = true;
 
         // Aborted before connecting
         if self.signals.get(signals::Field::Aborted) {
@@ -3922,8 +3925,8 @@ impl<'a> HTTPClient<'a> {
     }
 
     fn complete_connecting_process(&mut self) {
-        if self.flags.defer_fail_until_connecting_is_complete {
-            self.flags.defer_fail_until_connecting_is_complete = false;
+        if self.flags.defer_terminal_dispatch_until_connecting_is_complete {
+            self.flags.defer_terminal_dispatch_until_connecting_is_complete = false;
             if self.state.stage == Stage::Fail {
                 self.dispatch_result_and_reset(true);
             } else if self.flags.is_preconnect_only && self.state.stage == Stage::Done {
@@ -3992,7 +3995,7 @@ impl<'a> HTTPClient<'a> {
             self.state.fail = Some(err);
             self.state.stage = Stage::Fail;
 
-            if !self.flags.defer_fail_until_connecting_is_complete {
+            if !self.flags.defer_terminal_dispatch_until_connecting_is_complete {
                 self.dispatch_result_and_reset(true);
             }
         }
@@ -4412,9 +4415,9 @@ impl<'a> HTTPClient<'a> {
         self.state.request_stage = RequestStage::Done;
         self.state.stage = Stage::Done;
         self.flags.proxy_tunneling = false;
-        // Synchronous pooled-reuse path: `start_`/`connect` still use `self`,
-        // so the clone-freeing dispatch is deferred, as in `fail()`.
-        if self.flags.defer_fail_until_connecting_is_complete {
+        // True when pooled-socket reuse reached here synchronously inside
+        // `start_`/`connect`; `complete_connecting_process` dispatches then.
+        if self.flags.defer_terminal_dispatch_until_connecting_is_complete {
             return;
         }
         self.dispatch_preconnect_result();

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2061,7 +2061,10 @@ impl<'a> HTTPClient<'a> {
             self.state.response_stage = ResponseStage::Fail;
             self.state.fail = Some(err);
             self.state.stage = Stage::Fail;
-            if self.flags.defer_terminal_dispatch_until_connecting_is_complete {
+            if self
+                .flags
+                .defer_terminal_dispatch_until_connecting_is_complete
+            {
                 return;
             }
             self.dispatch_result_and_reset(false);
@@ -2727,7 +2730,8 @@ impl<'a> HTTPClient<'a> {
         // `complete_connecting_process()` cannot be a Drop guard here
         // (it needs `&mut self`, which would alias every other `self.*` call in the body),
         // so it is called explicitly before each return.
-        self.flags.defer_terminal_dispatch_until_connecting_is_complete = true;
+        self.flags
+            .defer_terminal_dispatch_until_connecting_is_complete = true;
 
         // Aborted before connecting
         if self.signals.get(signals::Field::Aborted) {
@@ -3925,8 +3929,12 @@ impl<'a> HTTPClient<'a> {
     }
 
     fn complete_connecting_process(&mut self) {
-        if self.flags.defer_terminal_dispatch_until_connecting_is_complete {
-            self.flags.defer_terminal_dispatch_until_connecting_is_complete = false;
+        if self
+            .flags
+            .defer_terminal_dispatch_until_connecting_is_complete
+        {
+            self.flags
+                .defer_terminal_dispatch_until_connecting_is_complete = false;
             if self.state.stage == Stage::Fail {
                 self.dispatch_result_and_reset(true);
             } else if self.flags.is_preconnect_only && self.state.stage == Stage::Done {
@@ -3995,7 +4003,10 @@ impl<'a> HTTPClient<'a> {
             self.state.fail = Some(err);
             self.state.stage = Stage::Fail;
 
-            if !self.flags.defer_terminal_dispatch_until_connecting_is_complete {
+            if !self
+                .flags
+                .defer_terminal_dispatch_until_connecting_is_complete
+            {
                 self.dispatch_result_and_reset(true);
             }
         }
@@ -4417,7 +4428,10 @@ impl<'a> HTTPClient<'a> {
         self.flags.proxy_tunneling = false;
         // True when pooled-socket reuse reached here synchronously inside
         // `start_`/`connect`; `complete_connecting_process` dispatches then.
-        if self.flags.defer_terminal_dispatch_until_connecting_is_complete {
+        if self
+            .flags
+            .defer_terminal_dispatch_until_connecting_is_complete
+        {
             return;
         }
         self.dispatch_preconnect_result();

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4412,9 +4412,8 @@ impl<'a> HTTPClient<'a> {
         self.state.request_stage = RequestStage::Done;
         self.state.stage = Stage::Done;
         self.flags.proxy_tunneling = false;
-        // Pooled-socket reuse reaches here synchronously inside `start_` →
-        // `connect`, whose frames still use `self`; defer the clone-freeing
-        // dispatch to `complete_connecting_process`, as `fail()` does.
+        // Synchronous pooled-reuse path: `start_`/`connect` still use `self`,
+        // so the clone-freeing dispatch is deferred, as in `fail()`.
         if self.flags.defer_fail_until_connecting_is_complete {
             return;
         }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3927,9 +3927,7 @@ impl<'a> HTTPClient<'a> {
             if self.state.stage == Stage::Fail {
                 self.dispatch_result_and_reset(true);
             } else if self.flags.is_preconnect_only && self.state.stage == Stage::Done {
-                // Deferred preconnect completion (see `on_preconnect`): the
-                // dispatch frees the AsyncHTTP clone embedding `self`, so it
-                // runs here, where every caller returns straight afterwards.
+                // Deferred preconnect success (see `on_preconnect`).
                 self.dispatch_preconnect_result();
             }
         }
@@ -4414,22 +4412,17 @@ impl<'a> HTTPClient<'a> {
         self.state.request_stage = RequestStage::Done;
         self.state.stage = Stage::Done;
         self.flags.proxy_tunneling = false;
-        // A preconnect that reuses a pooled keep-alive socket gets here
-        // synchronously inside `start_` → `connect` → `first_call`, and the
-        // terminal dispatch frees the ThreadlocalAsyncHTTP clone that embeds
-        // this client while those frames still use it. Defer the dispatch to
-        // `complete_connecting_process` — the same mechanism `fail()` uses
-        // for synchronous connect failures.
+        // Pooled-socket reuse reaches here synchronously inside `start_` →
+        // `connect`, whose frames still use `self`; defer the clone-freeing
+        // dispatch to `complete_connecting_process`, as `fail()` does.
         if self.flags.defer_fail_until_connecting_is_complete {
             return;
         }
         self.dispatch_preconnect_result();
     }
 
-    /// Terminal result for a preconnect-only request: the socket is already
-    /// back in the keep-alive pool and there is no response. Frees the
-    /// HTTP-thread AsyncHTTP clone embedding `self`; nothing may touch `self`
-    /// after this call.
+    /// Terminal result for a preconnect-only request. Frees the HTTP-thread
+    /// AsyncHTTP clone embedding `self`; nothing may touch `self` afterwards.
     fn dispatch_preconnect_result(&mut self) {
         self.result_callback.run(
             self.parent_async_http(),

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -144,6 +144,7 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
           await Bun.sleep(25);
         }
         listener.stop(true);
+        console.log("connections:", sockets.length);
         console.log("OK");`,
       ],
       env: {
@@ -159,6 +160,12 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("AddressSanitizer");
     expect(stdout).toContain("OK");
+    // Prove the pooled-reuse precondition was exercised: most iterations must
+    // have reused the parked socket instead of opening a fresh connection,
+    // otherwise this test passes without ever reaching the path it guards.
+    const connections = Number(/connections: (\d+)/.exec(stdout)?.[1]);
+    expect(connections).toBeGreaterThanOrEqual(1);
+    expect(connections).toBeLessThan(10);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -136,9 +136,14 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
           },
         });
         const url = \`http://127.0.0.1:\${listener.port}\`;
-        // The first iteration parks a socket in the keep-alive pool; later
-        // iterations reuse it. The sleeps give the HTTP thread time to pool
-        // the socket between iterations (preconnect has no completion signal).
+        // The first preconnect parks a socket in the keep-alive pool; wait for
+        // the server to observe its connection before continuing (the park on
+        // the client side follows it by microseconds and has no JS signal).
+        fetch.preconnect(url);
+        const deadline = Date.now() + 5000;
+        while (sockets.length === 0 && Date.now() < deadline) await Bun.sleep(5);
+        // Later iterations reuse the parked socket; short sleeps keep each
+        // preconnect's HTTP-thread turn ahead of the next call.
         for (let i = 0; i < 20; i++) {
           fetch.preconnect(url);
           await Bun.sleep(25);
@@ -166,6 +171,51 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
     const connections = Number(/connections: (\d+)/.exec(stdout)?.[1]);
     expect(connections).toBeGreaterThanOrEqual(1);
     expect(connections).toBeLessThan(10);
+    expect(exitCode).toBe(0);
+  });
+
+  // Companion to the test above that runs on every build: each preconnect
+  // holds one of BUN_CONFIG_MAX_HTTP_REQUESTS slots until its completion is
+  // dispatched, so if the pooled-reuse path ever drops that dispatch, the
+  // preconnect loop pins all 4 slots and the final fetch can never start.
+  it("pooled preconnects release their request slots", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const sockets = [];
+        const listener = Bun.listen({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            open(socket) {
+              sockets.push(socket);
+            },
+            data(socket) {
+              socket.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok");
+            },
+            close() {},
+          },
+        });
+        const url = \`http://127.0.0.1:\${listener.port}\`;
+        fetch.preconnect(url);
+        const deadline = Date.now() + 5000;
+        while (sockets.length === 0 && Date.now() < deadline) await Bun.sleep(5);
+        for (let i = 0; i < 20; i++) {
+          fetch.preconnect(url);
+          await Bun.sleep(25);
+        }
+        const response = await fetch(url);
+        console.log("status:", response.status);
+        listener.stop(true);`,
+      ],
+      env: { ...bunEnv, BUN_CONFIG_MAX_HTTP_REQUESTS: "4" },
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stdout).toContain("status: 200");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import "harness";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 
 // TODO: on Windows, these tests fail.
 // This feature is mostly meant for serverless JS environments, so we can no-op it on Windows.
@@ -111,6 +111,55 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
     expect(await proc.exited).toBe(0);
 
     await promise;
+  });
+
+  // A preconnect that finds a pooled keep-alive socket for its origin used to
+  // complete (and free the HTTP-thread request clone) synchronously inside the
+  // connect call, whose caller then kept using the freed memory. Only the
+  // second and later preconnects to the same origin hit that path, and only
+  // ASAN can observe the use-after-free, so this runs in a child process.
+  it.skipIf(!isASAN)("repeated fetch.preconnect to the same origin doesn't use freed memory", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const sockets = [];
+        const listener = Bun.listen({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            open(socket) {
+              sockets.push(socket);
+            },
+            data() {},
+            close() {},
+          },
+        });
+        const url = \`http://127.0.0.1:\${listener.port}\`;
+        // The first iteration parks a socket in the keep-alive pool; later
+        // iterations reuse it. The sleeps give the HTTP thread time to pool
+        // the socket between iterations (preconnect has no completion signal).
+        for (let i = 0; i < 20; i++) {
+          fetch.preconnect(url);
+          await Bun.sleep(25);
+        }
+        listener.stop(true);
+        console.log("OK");`,
+      ],
+      env: {
+        ...bunEnv,
+        // symbolize=0 so a sanitizer report aborts the child immediately
+        // instead of stalling for minutes in llvm-symbolizer; leak checking
+        // is irrelevant here and needs symbolized suppressions, so keep it off.
+        ASAN_OPTIONS: "symbolize=0:detect_leaks=0:halt_on_error=1:allow_user_segv_handler=1:disable_coredump=0",
+      },
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stdout).toContain("OK");
+    expect(exitCode).toBe(0);
   });
 
   it("fetch.preconnect validates the URL", async () => {

--- a/test/js/web/fetch/fetch-preconnect.test.ts
+++ b/test/js/web/fetch/fetch-preconnect.test.ts
@@ -205,7 +205,9 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
           fetch.preconnect(url);
           await Bun.sleep(25);
         }
+        const preconnectConnections = sockets.length;
         const response = await fetch(url);
+        console.log("connections:", preconnectConnections);
         console.log("status:", response.status);
         listener.stop(true);`,
       ],
@@ -216,6 +218,11 @@ describe.concurrent.todoIf(isWindows)("fetch.preconnect", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("AddressSanitizer");
     expect(stdout).toContain("status: 200");
+    // Same precondition proof as the test above: the loop must have reused
+    // the parked socket, or the deferred-dispatch path was never exercised.
+    const connections = Number(/connections: (\d+)/.exec(stdout)?.[1]);
+    expect(connections).toBeGreaterThanOrEqual(1);
+    expect(connections).toBeLessThan(10);
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Crash

`fetch.preconnect()` to an origin that already has a socket parked in the keep-alive pool reads and writes freed memory on the HTTP thread. Found during an audit of the fetch HTTP client's terminal-dispatch ordering (the same family as the `Option::unwrap() on a None value` panic at `FetchTasklet::callback`'s `http` unwrap: a freed client's stage guards live in recycled memory and can re-dispatch a stale result into a freed tasklet).

ASAN, unfixed build (second `fetch.preconnect` to the same origin):

```
==ERROR: AddressSanitizer: heap-use-after-free ... READ of size 1 ... thread T3 (HTTP Client)
  READ:  HTTPClient::start_            lib.rs:2868  (request_stage check after connect() returned)
  freed: AsyncHTTP::on_async_http_callback_raw  AsyncHTTP.rs:788 (terminal dispatch deallocates the clone)
         <- HTTPClient::on_preconnect  lib.rs:4412
         <- HTTPClient::first_call     lib.rs:1983
         <- HTTPContext::connect       (pooled keep-alive reuse)
         <- HTTPClient::start_
```

### Cause

The first preconnect parks its socket in the keep-alive pool. A second preconnect to the same origin takes the pooled socket inside `HTTPContext::connect`, which calls `on_open`/`first_call` synchronously; for a preconnect-only client that runs `on_preconnect`, whose terminal `result_callback.run` frees the `ThreadlocalAsyncHTTP` clone that embeds the `HTTPClient`. Control then returns into `start_`, which still dereferences the freed client: the `request_stage == Pending` abort-tracker check, and `complete_connecting_process()`, which also writes a flag into the freed block and, if the block was recycled, can re-dispatch a terminal result into a freed consumer.

Synchronous connect *failures* already avoid exactly this: `start_` sets a defer flag, `fail()` only records the failure while the flag is set, and `complete_connecting_process()` performs the dispatch as the last action of `start_`. The preconnect success dispatch bypassed that mechanism.

### Fix

Route the preconnect completion through the same deferral: `on_preconnect` still unregisters the abort tracker and releases the socket to the pool, but when the defer flag is set it leaves the terminal stage recorded and returns; `complete_connecting_process()` then dispatches the preconnect result as its last action, after which every caller returns without touching the client. The fresh-connect path (empty pool, socket opens from the event loop) is unchanged: the flag is already clear, so `on_preconnect` dispatches directly as before.

Since the flag now defers a success dispatch as well, `defer_fail_until_connecting_is_complete` is renamed to `defer_terminal_dispatch_until_connecting_is_complete` (single file, no external surface).

### Verification

Two tests in `test/js/web/fetch/fetch-preconnect.test.ts`, both spawning a child that loops `fetch.preconnect` against a local listener and asserting the loop actually reused the parked socket (connection count stays low) rather than opening fresh connections:

- ASAN test (`skipIf(!isASAN)`; the release build corrupts silently): unfixed debug+ASAN build crashes with the `heap-use-after-free` above on the first pooled reuse, every run; fixed build passes with `connections: 1`.
- Slot-release test (all builds, `BUN_CONFIG_MAX_HTTP_REQUESTS=4`): each preconnect holds a request slot until its completion dispatch runs, so a dropped deferred dispatch pins all four slots and the final `fetch()` can never start. Verified it fails (the fetch starves and the child hangs) when the deferred dispatch arm is removed while the early return stays, a breakage the ASAN test alone cannot observe.
- `test/js/bun/http/proxy.test.ts` (68), `proxy-stress-lifecycle` + `proxy-stress-errors` (146), `proxy-stress-adversarial` + `proxy-stress-concurrent` (182), and `fetch-abort-queued.test.ts` all pass on the fixed ASAN build.
- `test/js/web/fetch/fetch.test.ts`: identical failure set to an unfixed baseline in the same container (pre-existing debug/ASAN timeouts and utf16+gc failures, verified by running them against the unfixed build).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-preconnect.test.ts

<!-- robobun:evidence:end -->