### PR TITLE
test: cover RST_STREAM and the Content-Length-mismatch arm of h2 header-time completion

### DIFF
--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -337,46 +337,58 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
     await withAdversarialServer(
       {
         onStream: (socket, id) => {
-          // END_HEADERS only (0x4) — no END_STREAM.
-          socket.write(
-            frame(
-              1,
-              0x4,
-              id,
-              Buffer.concat([
-                hpackStatus200,
-                hpackLit("content-length", "0"),
-                hpackLit("content-type", "text/event-stream"),
-              ]),
-            ),
-          );
+          if (id === 1) {
+            // END_HEADERS only (0x4) — no END_STREAM.
+            socket.write(
+              frame(
+                1,
+                0x4,
+                id,
+                Buffer.concat([
+                  hpackStatus200,
+                  hpackLit("content-length", "0"),
+                  hpackLit("content-type", "text/event-stream"),
+                ]),
+              ),
+            );
+          } else {
+            // Barrier request — clean END_STREAM close; see subprocess comment.
+            socket.write(frame(1, 0x5, id, hpackStatus200));
+          }
         },
       },
       async (url, state) => {
         await using proc = spawnFetch(`
-          const r = await fetch(${JSON.stringify(url)}, {
+          const opts = {
             protocol: "http2",
             signal: AbortSignal.timeout(8000),
             tls: { rejectUnauthorized: false },
-          });
+          };
+          const r = await fetch(${JSON.stringify(url)}, opts);
           const body = await r.text();
-          console.log(JSON.stringify({ status: r.status, body }));
+          // Second request on the same pooled session acts as a delivery
+          // barrier: RST_STREAM(1) was queued ahead of HEADERS(3) on the one
+          // socket, so this response arriving back proves the RST reached the
+          // server. Without it the subprocess can exit while the RST is still
+          // in the TLS/TCP send buffer, which Windows drops on process death
+          // (abortive close) — leaving state.rst empty.
+          const barrier = (await fetch(${JSON.stringify(url)}, opts)).status;
+          console.log(JSON.stringify({ status: r.status, body, barrier }));
         `);
         const { stdout, stderr, exitCode } = await collect(proc);
         // stderr first: on a crash it carries the panic/ASAN report.
         expect(stderr).toBe("");
-        expect(stdout.trim()).toBe('{"status":200,"body":""}');
+        expect(JSON.parse(stdout.trim())).toEqual({ status: 200, body: "", barrier: 200 });
         expect(exitCode).toBe(0);
-        // The stream was still open from the server's side, so completing the
-        // response must abandon it with RST_STREAM(CANCEL) or the server is
-        // left holding it half-open against MAX_CONCURRENT_STREAMS. The RST is
-        // flushed at delivery time, before the child exits; poll for the
-        // server to have parsed it.
-        const deadline = Date.now() + 5_000;
-        while (state.rst.length === 0 && Date.now() < deadline) {
-          await Bun.sleep(10);
-        }
-        expect(state.rst).toEqual([{ id: 1, code: 8 }]);
+        // The first stream was still open from the server's side, so
+        // completing the response must abandon it with RST_STREAM(CANCEL)
+        // (0x8) or the server is left holding it half-open against
+        // MAX_CONCURRENT_STREAMS. connections=1 proves the barrier rode the
+        // same socket, so ordering actually applies.
+        expect({ rst: state.rst, connections: state.connections }).toEqual({
+          rst: [{ id: 1, code: 8 }],
+          connections: 1,
+        });
       },
     );
   });

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -352,7 +352,7 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
           );
         },
       },
-      async url => {
+      async (url, state) => {
         await using proc = spawnFetch(`
           const r = await fetch(${JSON.stringify(url)}, {
             protocol: "http2",
@@ -366,6 +366,68 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
         // stderr first: on a crash it carries the panic/ASAN report.
         expect(stderr).toBe("");
         expect(stdout.trim()).toBe('{"status":200,"body":""}');
+        expect(exitCode).toBe(0);
+        // The stream was still open from the server's side, so completing the
+        // response must abandon it with RST_STREAM(CANCEL) or the server is
+        // left holding it half-open against MAX_CONCURRENT_STREAMS. The RST is
+        // flushed at delivery time, before the child exits; poll for the
+        // server to have parsed it.
+        const deadline = Date.now() + 5_000;
+        while (state.rst.length === 0 && Date.now() < deadline) {
+          await Bun.sleep(10);
+        }
+        expect(state.rst).toEqual([{ id: 1, code: 8 }]);
+      },
+    );
+  });
+
+  // 9b. Same zero-length-but-HasBody headers with DATA coalesced into the same
+  //     TLS record: the stray byte contradicts content-length: 0, so the body
+  //     must fail with a Content-Length mismatch (RFC 9113 §8.1.1) rather
+  //     than crash or surface the byte. The head was already valid when the
+  //     mismatch is detected, so fetch() resolves and the error lands on the
+  //     body, mirroring the mid-body mismatch paths.
+  test("content-length: 0 with coalesced DATA is a Content-Length mismatch", async () => {
+    await withAdversarialServer(
+      {
+        onStream: (socket, id) => {
+          // One write so HEADERS and DATA land in the same parseFrames pass.
+          socket.write(
+            Buffer.concat([
+              frame(
+                1,
+                0x4,
+                id,
+                Buffer.concat([
+                  hpackStatus200,
+                  hpackLit("content-length", "0"),
+                  hpackLit("content-type", "text/event-stream"),
+                ]),
+              ),
+              frame(0, 0, id, Buffer.from("x")),
+            ]),
+          );
+        },
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const out = await fetch(${JSON.stringify(url)}, {
+            protocol: "http2",
+            signal: AbortSignal.timeout(8000),
+            tls: { rejectUnauthorized: false },
+          }).then(
+            r =>
+              r.text().then(
+                body => ({ status: r.status, body }),
+                e => ({ status: r.status, bodyErr: e.code || e.name }),
+              ),
+            e => ({ err: e.code || e.name }),
+          );
+          console.log(JSON.stringify(out));
+        `);
+        const { stdout, stderr, exitCode } = await collect(proc);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({ status: 200, bodyErr: "HTTP2ContentLengthMismatch" });
         expect(exitCode).toBe(0);
       },
     );


### PR DESCRIPTION
### What does this PR do?

Test-only follow-up to #36941 (the header-time terminal detach fix in the HTTP/2/3 fetch client). Review of that change found two halves of its contract unasserted; this adds both to `test/js/web/fetch/fetch-http2-adversarial.test.ts`:

1. **RST_STREAM on completion.** When a `Content-Length: 0` response completes at header time the stream is still open from the server's side, so the deliver loop abandons it with `RST_STREAM(CANCEL)`; without that the server is left holding the stream half-open against `MAX_CONCURRENT_STREAMS`. The existing test now asserts the server received `RST_STREAM(CANCEL)` on stream 1, matching the `state.rst` assertions the suite already has for the other two detach-leaves-stream-open paths.

2. **Coalesced stray DATA.** New test: the same `content-length: 0` + SSE HEADERS with a 1-byte DATA frame in the same TLS record. The stray byte contradicts the declared length, so `finish_stream` rejects with `HTTP2ContentLengthMismatch` (RFC 9113 section 8.1.1). The head is already valid when the mismatch is detected, so `fetch()` resolves and the error lands on the body read, mirroring the existing mid-body mismatch behavior. This arm of the #36941 branch had no coverage.

### How did you verify your code works?

Both tests pass 3/3 consecutive runs against the debug+ASAN build on current main, and the whole `fetch-http2-adversarial.test.ts` file passes (17 tests).

Note for the fail-before check: the fix these tests cover is already merged (#36941), so there is no in-tree revision where they fail without a src change. On the pre-#36941 tree both scenarios crash the child with the `client.h2.is_none()` teardown assertion rather than producing the asserted outputs.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->