### PR TITLE
test(napi): speed up the threadsafe_function suite and assert child output

### DIFF
--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -214,7 +214,9 @@ function envFor(test: string) {
 // Mirror of parseTestFlags() in test/common/index.js. When a vendored test names runtime
 // flags in a `// Flags:` comment and process.execArgv lacks them, the common module
 // re-spawns the whole test under a second bun process to apply them; passing them to
-// `bun run` up front puts them in execArgv so that extra process never starts.
+// `bun run` up front puts them in execArgv so that extra process never starts. Of the
+// flags these tests name, bun only implements --expose-gc and silently skips the rest,
+// exactly as it did for the re-spawned child; only their presence in execArgv matters.
 function testFlagsFor(dir: string, test: string): string[] {
   let source: string;
   try {

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "bun";
-import { existsSync, renameSync, statSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, statSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -211,9 +211,28 @@ function envFor(test: string) {
     : bunEnv;
 }
 
+// Mirror of parseTestFlags() in test/common/index.js. When a vendored test names runtime
+// flags in a `// Flags:` comment and process.execArgv lacks them, the common module
+// re-spawns the whole test under a second bun process to apply them; passing them to
+// `bun run` up front puts them in execArgv so that extra process never starts.
+function testFlagsFor(dir: string, test: string): string[] {
+  let source: string;
+  try {
+    source = readFileSync(join(dir, test), "utf8").slice(0, 1500);
+  } catch {
+    return [];
+  }
+  const flagStart = source.search(/\/\/ Flags:\s+--/) + 10;
+  if (flagStart === 9) return [];
+  let flagEnd = source.indexOf("\n", flagStart);
+  if (flagEnd === -1) flagEnd = source.length;
+  else if (source[flagEnd - 1] === "\r") flagEnd--;
+  return source.substring(flagStart, flagEnd).split(/\s+/).filter(Boolean);
+}
+
 export function run(dir: string, test: string) {
   const result = spawnSync({
-    cmd: [bunExe(), "run", test],
+    cmd: [bunExe(), "run", ...testFlagsFor(dir, test), test],
     cwd: dir,
     stderr: "inherit",
     stdout: "ignore",
@@ -225,16 +244,21 @@ export function run(dir: string, test: string) {
 }
 
 // Non-blocking variant of run() so callers can execute the addon's .js tests concurrently.
+// Stricter than run(): the vendored tests report failure only through assertions and exit
+// codes and are silent on success, so any output is asserted against (which also puts the
+// child's error text straight into the failure diff instead of discarding it).
 export async function runAsync(dir: string, test: string) {
   const child = spawn({
-    cmd: [bunExe(), "run", test],
+    cmd: [bunExe(), "run", ...testFlagsFor(dir, test), test],
     cwd: dir,
-    stderr: "inherit",
-    stdout: "ignore",
+    stderr: "pipe",
+    stdout: "pipe",
     stdin: "inherit",
     env: envFor(test),
   });
-  const exitCode = await child.exited;
+  const [stderr, stdout, exitCode] = await Promise.all([child.stderr.text(), child.stdout.text(), child.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
   expect(child.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 }

--- a/test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
+++ b/test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
@@ -1,13 +1,18 @@
 import { basename, dirname, sep } from "node:path";
-import { build, run } from "../../../harness";
+import { build, runAsync } from "../../../harness";
+
+// Start the node-gyp build immediately; every test awaits this same promise so the
+// concurrent .js tests never race ahead of the compile and the addon builds only once.
+const built = build(import.meta.dir);
 
 test("build", async () => {
-  await build(import.meta.dir);
+  await built;
 });
 
 for (const file of Array.from(new Bun.Glob("*.js").scanSync(import.meta.dir))) {
   // crash inside uv_thread_create
-  test.todoIf(["test.js", "test_legacy_uncaught_exception.js"].includes(file))(file, () => {
-    run(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);
+  test.concurrent.todoIf(["test.js", "test_legacy_uncaught_exception.js"].includes(file))(file, async () => {
+    await built;
+    await runAsync(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);
   });
 }

--- a/test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
+++ b/test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
@@ -10,7 +10,10 @@ test("build", async () => {
 });
 
 for (const file of Array.from(new Bun.Glob("*.js").scanSync(import.meta.dir))) {
-  // crash inside uv_thread_create
+  // test.js: crash inside uv_thread_create.
+  // test_legacy_uncaught_exception.js: --no-force-node-api-uncaught-exceptions-policy is
+  // not implemented, so the error still reaches the test's mustNotCall uncaughtException
+  // listener.
   test.concurrent.todoIf(["test.js", "test_legacy_uncaught_exception.js"].includes(file))(file, async () => {
     await built;
     await runAsync(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);


### PR DESCRIPTION
### What

`test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts` was flagged as one of the slowest test files in CI: 11.9s worst case on debian 13 x64-asan. Locally under a debug ASAN build it took 10.4s.

The time was going to two places:

1. The five vendored `.js` tests each spawn a child bun process and ran serially, so their ~2s debug ASAN startups added up instead of overlapping.
2. `test_uncaught_exception_v9.js` took twice as long as its siblings (4.2s). Its `// Flags: --force-node-api-uncaught-exceptions-policy` comment makes the vendored `common` module re-spawn the entire test under a second bun process to get the flag into `process.execArgv` (see `parseTestFlags` in `test/common/index.js`), so every flagged test pays for two debug ASAN startups. This affects every suite in `node-napi-tests` that has a `// Flags:` file, not just this one.

### Fix

- `do.test.ts` now runs the per-file tests with `test.concurrent` behind a shared build promise, the same pattern `test_general` and `test_constructor` already use. The addon still builds exactly once before any child runs. The two `test.todoIf` entries are unchanged (their comments now state each test's actual failure: `test.js` crashes inside `uv_thread_create`, while `test_legacy_uncaught_exception.js` fails because `--no-force-node-api-uncaught-exceptions-policy` is not implemented, so its `mustNotCall` uncaughtException listener fires). The vendored `.js` files are untouched.
- The harness `run()`/`runAsync()` now parse the `// Flags:` comment the same way `common` does and pass the flags to `bun run` directly, so `execArgv` already contains them and the re-spawn never happens. This is behavior-preserving: of the flags these suites name, bun implements only `--expose-gc` and silently skips the rest (`--force-node-api-uncaught-exceptions-policy` and its `--no-` variant, `--gc-interval`, `--gc-global`, `--no-concurrent-array-buffer-sweeping`), which is exactly what happened in the re-spawned child before. The re-spawn check only needs the flags present in `execArgv`, and they are.
- `runAsync()` now captures the child's stdout and stderr and asserts both are empty before checking the exit code, instead of ignoring stdout and inheriting stderr. These vendored tests are silent on success and report failure through `assert`/`common.mustCall` and the exit code, so any output is a failure, and the captured text now lands in the assertion diff instead of being discarded. The file goes from 6 to 12 `expect()` calls.

`run()` keeps its inherit/ignore stdio because two suites that use it (`test_fatal`, `test_uv_threadpool_size`) contain tests that may call `common.skip()`, which prints to stdout and exits 0.

### Verification

Timed with `bun bd test test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts` (debug ASAN build, prebuilt addon, same machine):

- before: 10.44s (`test_uncaught_exception_v9.js` alone: 4230ms)
- after: 4.24-4.42s (`test_uncaught_exception_v9.js`: 2113ms), and 4.36s with the addon build directory deleted first

Also ran every suite whose behavior the harness change can touch, on linux x64 debug ASAN, all passing:

- the other `runAsync` users (stricter assertions): `test_general`, `test_constructor`
- all 12 `run()` suites with a `// Flags:` file (command line changes): `js-native-api/6_object_wrap`, `js-native-api/7_factory_wrap`, `js-native-api/8_passing_wrapped`, `js-native-api/test_exception`, `js-native-api/test_finalizer`, `js-native-api/test_function`, `js-native-api/test_reference`, `node-api/test_async_context`, `node-api/test_buffer`, `node-api/test_env_teardown_gc`, `node-api/test_exception`, `node-api/test_reference_by_node_api_version`
- the `common.skip()` users: `test_fatal`, `test_uv_threadpool_size`

All existing todo entries in those suites stayed todo (their bodies still fail, so none flipped to an unexpected pass). The one platform-conditional todo in the tree, `test_reference_by_node_api_version`'s `todoIf(isMacOS)` for `test.js`, is covered by CI: every darwin test lane passed on build 89146, and a todo that started passing would have failed the lane. Suites without a `// Flags:` file get a byte-identical command from `run()` and are unaffected. `test_reference/test.js` and `test_finalizer/test_fatal_finalize.js` hit their 5s timeout on this machine on clean main as well; both are pre-existing local-environment slowness, unchanged by this PR (the flags change makes the first one strictly faster).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
bun test v1.4.0 (613fec075)

test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts:
(pass) build [3.29ms]
(todo) test_legacy_uncaught_exception.js
(todo) test.js
(pass) uncaught_exception.js [1990.92ms]
(pass) test_uncaught_exception_v9.js [2143.06ms]
(pass) test_uncaught_exception.js [2105.33ms]

 4 pass
 2 todo
 0 fail
 12 expect() calls
Ran 6 tests across 1 file. [4.24s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/napi/node-napi-tests/harness.ts               | 38 ++++++++++++++++++----
 .../node-api/test_threadsafe_function/do.test.ts   | 18 +++++++---
 2 files changed, 45 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/napi/node-napi-tests/harness.ts                          2      3      0
…tests/test/node-api/test_threadsafe_function/do.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->