### PR TITLE
bun create: print the git timing line after postinstall, not from the worker thread

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -91,11 +91,11 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
     // `bun `-prefixed tasks run with bun itself; posix spawn does no PATH
     // lookup, so exec the absolute self path (the printed argv keeps `bun`).
     let mut exec_argv0: Option<&[u8]> = None;
-    if let Some(ref client) = npm_client {
-        if strings::starts_with(task, b"bun ") {
+    if strings::starts_with(task, b"bun ") {
+        if npm_client.is_some() {
             argv = &argv[2..];
-            exec_argv0 = Some(client.bin);
         }
+        exec_argv0 = bun_core::self_exe_path().ok().map(bun_core::ZStr::as_bytes);
     }
 
     pretty!("\n<r><d>$<b>");

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1,5 +1,5 @@
 use bun_collections::VecExt;
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::cell::Cell;
 use std::io::Write as _;
 
@@ -88,8 +88,15 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
     debug_assert_eq!(argv.len(), total);
 
     let mut argv: &[&[u8]] = &argv;
-    if npm_client.is_some() && strings::starts_with(task, b"bun ") {
-        argv = &argv[2..];
+    // A task starting with `bun ` runs with bun itself instead of `<exe> run`.
+    // The literal `bun` from the task string is display-only: posix spawn does
+    // no PATH lookup, so exec the absolute self path instead.
+    let mut exec_argv0: Option<&[u8]> = None;
+    if let Some(ref client) = npm_client {
+        if strings::starts_with(task, b"bun ") {
+            argv = &argv[2..];
+            exec_argv0 = Some(client.bin);
+        }
     }
 
     pretty!("\n<r><d>$<b>");
@@ -106,8 +113,20 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
 
     let _unbuffered = Output::disable_buffering_scope();
 
-    let _ = spawn_sync::spawn(&spawn_sync::Options {
-        argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
+    let spawn_argv: Vec<Box<[u8]>> = argv
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            Box::<[u8]>::from(if i == 0 {
+                exec_argv0.unwrap_or(s)
+            } else {
+                *s
+            })
+        })
+        .collect();
+
+    let result = spawn_sync::spawn(&spawn_sync::Options {
+        argv: spawn_argv,
         envp: None,
         cwd: Box::from(cwd),
         stderr: spawn_sync::SyncStdio::Inherit,
@@ -126,6 +145,16 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
         windows: (),
         ..Default::default()
     });
+
+    match result {
+        Ok(Ok(_)) => {}
+        Ok(Err(err)) => {
+            bun_core::pretty_errorln!("<r><red>error<r><d>:<r> failed to run task: {}", err);
+        }
+        Err(err) => {
+            bun_core::pretty_errorln!("<r><red>error<r><d>:<r> failed to run task: {}", err);
+        }
+    }
 }
 
 // We don't want to allocate memory each time
@@ -1085,13 +1114,15 @@ impl CreateCommand {
             if !create_options.skip_install {
                 GitHandler::spawn(destination, path_env, create_options.verbose);
             } else {
-                if create_options.verbose {
-                    create_options.skip_git =
-                        GitHandler::run::<true>(destination, path_env).unwrap_or(false);
+                let created = if create_options.verbose {
+                    GitHandler::run::<true>(destination, path_env).unwrap_or(false)
                 } else {
-                    create_options.skip_git =
-                        GitHandler::run::<false>(destination, path_env).unwrap_or(false);
+                    GitHandler::run::<false>(destination, path_env).unwrap_or(false)
+                };
+                if created {
+                    GitHandler::print_timing();
                 }
+                create_options.skip_git = created;
             }
         }
 
@@ -2375,6 +2406,7 @@ impl CreateListExamplesCommand {
 struct GitHandler;
 
 static SUCCESS: AtomicU32 = AtomicU32::new(0);
+static GIT_ELAPSED_NS: AtomicU64 = AtomicU64::new(0);
 // bun_threading has no top-level Thread wrapper yet,
 // so use std::thread::JoinHandle directly (CLI-only, no JSC interaction).
 // PORTING.md §Global mutable state: written in `spawn`, taken in `wait`, both
@@ -2424,7 +2456,20 @@ impl GitHandler {
         let outcome = SUCCESS.load(Ordering::Acquire) == 1;
         // SAFETY: THREAD set in spawn() on this same thread before wait() called
         let _ = unsafe { (*THREAD.get()).take() }.unwrap().join();
+        if outcome {
+            Self::print_timing();
+        }
         outcome
+    }
+
+    // Printed from the main thread (inline for the synchronous path, after
+    // `wait()` for the concurrent path) so the timing line cannot interleave
+    // with a postinstall task's output.
+    fn print_timing() {
+        bun_core::pretty_error!("\n");
+        Output::print_start_end(0, GIT_ELAPSED_NS.load(Ordering::Acquire) as i128);
+        bun_core::pretty_error!(" <d>git<r>\n");
+        Output::flush();
     }
 
     fn run<const VERBOSE: bool>(destination: &[u8], path: &[u8]) -> crate::Result<bool> {
@@ -2497,9 +2542,10 @@ impl GitHandler {
                 })?;
             }
 
-            bun_core::pretty_error!("\n");
-            Output::print_start_end(git_start, bun_core::time::nano_timestamp());
-            bun_core::pretty_error!(" <d>git<r>\n");
+            GIT_ELAPSED_NS.store(
+                (bun_core::time::nano_timestamp() - git_start) as u64,
+                Ordering::Release,
+            );
             return Ok(true);
         }
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -116,13 +116,7 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
     let spawn_argv: Vec<Box<[u8]>> = argv
         .iter()
         .enumerate()
-        .map(|(i, s)| {
-            Box::<[u8]>::from(if i == 0 {
-                exec_argv0.unwrap_or(s)
-            } else {
-                *s
-            })
-        })
+        .map(|(i, s)| Box::<[u8]>::from(if i == 0 { exec_argv0.unwrap_or(s) } else { *s }))
         .collect();
 
     let result = spawn_sync::spawn(&spawn_sync::Options {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -88,9 +88,8 @@ fn exec_task(task_: &[u8], cwd: &[u8], _path: &[u8], npm_client: Option<NPMClien
     debug_assert_eq!(argv.len(), total);
 
     let mut argv: &[&[u8]] = &argv;
-    // A task starting with `bun ` runs with bun itself instead of `<exe> run`.
-    // The literal `bun` from the task string is display-only: posix spawn does
-    // no PATH lookup, so exec the absolute self path instead.
+    // `bun `-prefixed tasks run with bun itself; posix spawn does no PATH
+    // lookup, so exec the absolute self path (the printed argv keeps `bun`).
     let mut exec_argv0: Option<&[u8]> = None;
     if let Some(ref client) = npm_client {
         if strings::starts_with(task, b"bun ") {
@@ -1116,7 +1115,7 @@ impl CreateCommand {
                 if created {
                     GitHandler::print_timing();
                 }
-                create_options.skip_git = created;
+                create_options.skip_git = !created;
             }
         }
 
@@ -2456,9 +2455,8 @@ impl GitHandler {
         outcome
     }
 
-    // Printed from the main thread (inline for the synchronous path, after
-    // `wait()` for the concurrent path) so the timing line cannot interleave
-    // with a postinstall task's output.
+    // Always called from the main thread so the timing line cannot
+    // interleave with postinstall output.
     fn print_timing() {
         bun_core::pretty_error!("\n");
         Output::print_start_end(0, GIT_ELAPSED_NS.load(Ordering::Acquire) as i128);

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -490,3 +490,93 @@ it("should not crash with --no-install and bun-create.postinstall starting with 
   expect(err).not.toContain("error:");
   expect(exitCode).toBe(0);
 });
+
+// The `[Xs] git` timing line used to be printed directly from the git worker
+// thread, racing with postinstall output on the main thread (issue #36953).
+// The stub git blocks its `commit` until postinstall starts, then postinstall
+// waits for the stub to finish before printing its last line, so without the
+// fix the timing line reliably lands between PI_START and PI_END.
+// POSIX-only: the stub `git` is a shell script.
+it.skipIf(!isPosix)("should not interleave the git timing line with postinstall output", async () => {
+  using dir = tempDir("create-git-timing", {
+    "bin/git": `#!/bin/sh
+case "$*" in
+  *commit*)
+    i=0
+    while [ ! -f postinstall_started ] && [ $i -lt 600 ]; do sleep 0.05; i=$((i+1)); done
+    touch git_finished
+    ;;
+esac
+exit 0
+`,
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({
+      name: "tmpl",
+      version: "1.0.0",
+      "bun-create": { postinstall: "postinstall-step" },
+      scripts: { "postinstall-step": "sh scripts/postinstall.sh" },
+      dependencies: { localdep: "file:./localdep" },
+    }),
+    "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+    "bun-create/tmpl/scripts/postinstall.sh": `#!/bin/sh
+echo PI_START >&2
+touch postinstall_started
+i=0
+while [ ! -f git_finished ] && [ $i -lt 600 ]; do sleep 0.05; i=$((i+1)); done
+sleep 0.5
+echo PI_END >&2
+`,
+  });
+  chmodSync(join(String(dir), "bin", "git"), 0o755);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest")],
+    cwd: String(dir),
+    env: {
+      ...env,
+      PATH: join(String(dir), "bin") + ":" + process.env.PATH,
+      BUN_CREATE_DIR: join(String(dir), "bun-create"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [err, _out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+  expect(err).toContain("PI_START");
+  const endIdx = err.indexOf("PI_END");
+  expect(endIdx).toBeGreaterThan(-1);
+  const gitIdx = err.indexOf("] git");
+  expect(gitIdx).toBeGreaterThan(endIdx);
+  expect(exitCode).toBe(0);
+}, 45_000);
+
+// On POSIX, a `bun `-prefixed bun-create postinstall task used to silently not
+// run: the `<exe> run` prefix was stripped, leaving the bare string `bun` as
+// argv[0], and posix spawn does no PATH lookup (issue #36953).
+it("should run a bun-create postinstall task that starts with 'bun '", async () => {
+  using dir = tempDir("create-bun-postinstall", {
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({
+      name: "tmpl",
+      version: "1.0.0",
+      "bun-create": { postinstall: "bun scripts/marker.ts" },
+      dependencies: { localdep: "file:./localdep" },
+    }),
+    "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+    "bun-create/tmpl/scripts/marker.ts": `await Bun.write("marker.txt", "ran");`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest"), "--no-git"],
+    cwd: String(dir),
+    env: { ...env, BUN_CREATE_DIR: join(String(dir), "bun-create") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(out).toContain("$ bun scripts/marker.ts");
+  expect(err).not.toContain("error:");
+  expect(await Bun.file(join(String(dir), "dest", "marker.txt")).text()).toBe("ran");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -525,6 +525,8 @@ echo PI_START >&2
 touch postinstall_started
 i=0
 while [ ! -f git_finished ] && [ $i -lt 600 ]; do sleep 0.05; i=$((i+1)); done
+# the worker's stderr write happens after the stub exits and is not observable
+# from here; give the unfixed binary time to print before the last line
 sleep 0.5
 echo PI_END >&2
 `,
@@ -567,6 +569,34 @@ it("should run a bun-create postinstall task that starts with 'bun '", async () 
       dependencies: { localdep: "file:./localdep" },
     }),
     "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+    "bun-create/tmpl/scripts/marker.ts": `await Bun.write("marker.txt", "ran");`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest"), "--no-git"],
+    cwd: String(dir),
+    env: { ...env, BUN_CREATE_DIR: join(String(dir), "bun-create") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(out).toContain("$ bun scripts/marker.ts");
+  expect(err).not.toContain("error:");
+  expect(await Bun.file(join(String(dir), "dest", "marker.txt")).text()).toBe("ran");
+  expect(exitCode).toBe(0);
+});
+
+// Same as above, but the template has no dependencies: postinstall then runs
+// without the npm client, and the bare `bun` argv[0] hit the same ENOENT.
+it("should run a bun-prefixed postinstall task for a template without dependencies", async () => {
+  using dir = tempDir("create-bun-postinstall-nodeps", {
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({
+      name: "tmpl",
+      version: "1.0.0",
+      "bun-create": { postinstall: "bun scripts/marker.ts" },
+    }),
     "bun-create/tmpl/scripts/marker.ts": `await Bun.write("marker.txt", "ran");`,
   });
 

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -497,9 +497,11 @@ it("should not crash with --no-install and bun-create.postinstall starting with 
 // waits for the stub to finish before printing its last line, so without the
 // fix the timing line reliably lands between PI_START and PI_END.
 // POSIX-only: the stub `git` is a shell script.
-it.skipIf(!isPosix)("should not interleave the git timing line with postinstall output", async () => {
-  using dir = tempDir("create-git-timing", {
-    "bin/git": `#!/bin/sh
+it.skipIf(!isPosix)(
+  "should not interleave the git timing line with postinstall output",
+  async () => {
+    using dir = tempDir("create-git-timing", {
+      "bin/git": `#!/bin/sh
 case "$*" in
   *commit*)
     i=0
@@ -509,16 +511,16 @@ case "$*" in
 esac
 exit 0
 `,
-    "bun-create/tmpl/index.js": "// hi\n",
-    "bun-create/tmpl/package.json": JSON.stringify({
-      name: "tmpl",
-      version: "1.0.0",
-      "bun-create": { postinstall: "postinstall-step" },
-      scripts: { "postinstall-step": "sh scripts/postinstall.sh" },
-      dependencies: { localdep: "file:./localdep" },
-    }),
-    "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
-    "bun-create/tmpl/scripts/postinstall.sh": `#!/bin/sh
+      "bun-create/tmpl/index.js": "// hi\n",
+      "bun-create/tmpl/package.json": JSON.stringify({
+        name: "tmpl",
+        version: "1.0.0",
+        "bun-create": { postinstall: "postinstall-step" },
+        scripts: { "postinstall-step": "sh scripts/postinstall.sh" },
+        dependencies: { localdep: "file:./localdep" },
+      }),
+      "bun-create/tmpl/localdep/package.json": JSON.stringify({ name: "localdep", version: "1.0.0" }),
+      "bun-create/tmpl/scripts/postinstall.sh": `#!/bin/sh
 echo PI_START >&2
 touch postinstall_started
 i=0
@@ -526,29 +528,31 @@ while [ ! -f git_finished ] && [ $i -lt 600 ]; do sleep 0.05; i=$((i+1)); done
 sleep 0.5
 echo PI_END >&2
 `,
-  });
-  chmodSync(join(String(dir), "bin", "git"), 0o755);
+    });
+    chmodSync(join(String(dir), "bin", "git"), 0o755);
 
-  await using proc = spawn({
-    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest")],
-    cwd: String(dir),
-    env: {
-      ...env,
-      PATH: join(String(dir), "bin") + ":" + process.env.PATH,
-      BUN_CREATE_DIR: join(String(dir), "bun-create"),
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = spawn({
+      cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest")],
+      cwd: String(dir),
+      env: {
+        ...env,
+        PATH: join(String(dir), "bin") + ":" + process.env.PATH,
+        BUN_CREATE_DIR: join(String(dir), "bun-create"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [err, _out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
-  expect(err).toContain("PI_START");
-  const endIdx = err.indexOf("PI_END");
-  expect(endIdx).toBeGreaterThan(-1);
-  const gitIdx = err.indexOf("] git");
-  expect(gitIdx).toBeGreaterThan(endIdx);
-  expect(exitCode).toBe(0);
-}, 45_000);
+    const [err, _out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(err).toContain("PI_START");
+    const endIdx = err.indexOf("PI_END");
+    expect(endIdx).toBeGreaterThan(-1);
+    const gitIdx = err.indexOf("] git");
+    expect(gitIdx).toBeGreaterThan(endIdx);
+    expect(exitCode).toBe(0);
+  },
+  45_000,
+);
 
 // On POSIX, a `bun `-prefixed bun-create postinstall task used to silently not
 // run: the `<exe> run` prefix was stripped, leaving the bare string `bun` as

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -584,3 +584,26 @@ it("should run a bun-create postinstall task that starts with 'bun '", async () 
   expect(await Bun.file(join(String(dir), "dest", "marker.txt")).text()).toBe("ran");
   expect(exitCode).toBe(0);
 });
+
+// The synchronous git path (no dependencies) set skip_git to the git
+// *success* instead of its negation, so the final message was suppressed on
+// success and printed when git was missing.
+it("should print the git message for a template without dependencies", async () => {
+  using dir = tempDir("create-no-deps-git", {
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({ name: "tmpl", version: "1.0.0" }),
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest")],
+    cwd: String(dir),
+    env: { ...env, BUN_CREATE_DIR: join(String(dir), "bun-create") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(err).not.toContain("error:");
+  expect(out).toContain("A local git repository was created for you.");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #36953

### Repro

A template with dependencies and a `bun-create.postinstall` task that streams output. `bun create` runs `git init/add/commit` on a worker thread concurrently with install + postinstall, and the worker printed its timing line the moment git finished:

```
$ bun scripts/install.ts
postinstall: step 1
postinstall: step 2

[2.15s] git          <- interleaved mid-postinstall
postinstall: step 3
```

### Cause

`GitHandler::run` printed `[Xs] git` directly from the git worker thread, racing with the postinstall child process writing to the same inherited stderr on the main thread.

### Fix

`GitHandler::run` now records the elapsed time in an atomic, and the line is printed from the main thread after `GitHandler::wait()` returns, i.e. after postinstall has completed. The synchronous path (`--no-install` or a dependency-less template) still prints inline as before.

While reproducing, a second bug in the same code path surfaced: on POSIX, a `bun-create.postinstall` task starting with `bun ` (exactly the reporter's template, `"postinstall": "bun scripts/install.ts"`) silently never ran. `exec_task` strips the `<exe> run` prefix, leaving the bare string `bun` as argv[0], and posix spawn does no PATH lookup, so the spawn failed with ENOENT and the error was discarded. The task now spawns with the absolute self path (display still shows `bun`), and spawn failures are reported instead of swallowed. This was present before the Rust port (verified on bun 1.3.14); Windows was unaffected because uv_spawn resolves argv[0] against PATH.

### Verification

Two tests in `test/cli/install/bun-create.test.ts`:
- a stub `git` whose `commit` is sequenced against the postinstall task so the unfixed binary reliably prints `[Xs] git` between postinstall lines; asserts the timing line comes after the last postinstall line
- a template with `"postinstall": "bun scripts/marker.ts"`; asserts the task actually ran

Both fail on the unfixed binary and pass with the fix; the full file (23 tests) passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.0 (3215e1a4b)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [116.93ms]
(pass) should not crash > ["create",""] [107.76ms]
(pass) should not crash > ["create","--"] [103.88ms]
(pass) should not crash > ["create","--",""] [109.71ms]
(pass) should not crash > ["create","--help"] [101.85ms]
(pass) should create selected template with @ prefix [490.35ms]
(pass) should create selected template with @ prefix implicit `/create` [484.07ms]
(pass) should create selected template with @ prefix implicit `/create` with version [370.66ms]
(pass) handles a close-delimited GitHub tarball body split across packets [808.93ms]
(pass) keeps tarball entry paths within the destination when checking for conflicting files [286.59ms]
(pass) reports an error and exits when the template's package.json entry body is truncated [262.46ms]
(pass) does not busy-wait on the futex while git runs [1669.93ms]
Copying files... 

[15.00ms] git

[103.00ms] bun create /tmp/cr8-12GwCjp5/bun-create/
... (truncated)

release without fix: 9 FAILED
bun test v1.3.14 (0d9b296a)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [2.56ms]
(pass) should not crash > ["create",""] [1.88ms]
(pass) should not crash > ["create","--"] [1.41ms]
(pass) should not crash > ["create","--",""] [1.46ms]
(pass) should not crash > ["create","--help"] [1.82ms]
(pass) should create selected template with @ prefix [59.86ms]
(pass) should create selected template with @ prefix implicit `/create` [45.60ms]
(pass) should create selected template with @ prefix implicit `/create` with version [41.00ms]
(pass) handles a close-delimited GitHub tarball body split across packets [27.30ms]
230 |     },
231 |   });
232 | 
233 |   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
234 | 
235 |   expect(err).not.toContain("could conflict");
                        ^
error: expect(received).not.toContain(expected)

Expected to not contain: "could conflict"
Received: "[github] GET owner/conflict-check-template... \nDecompressing owner/conflict-check-template... \nExtracting owner/conflict-check-template... \n\nerror: The directory dest/ contains files that could conflict:\
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.0 (3215e1a4b)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [133.62ms]
(pass) should not crash > ["create",""] [113.43ms]
(pass) should not crash > ["create","--"] [111.50ms]
(pass) should not crash > ["create","--",""] [104.17ms]
(pass) should not crash > ["create","--help"] [107.76ms]
(pass) should create selected template with @ prefix [395.21ms]
(pass) should create selected template with @ prefix implicit `/create` [380.18ms]
(pass) should create selected template with @ prefix implicit `/create` with version [393.65ms]
(pass) handles a close-delimited GitHub tarball body split across packets [827.30ms]
(pass) keeps tarball entry paths within the destination when checking for conflicting files [281.76ms]
(pass) reports an error and exits when the template's package.json entry body is truncated [261.33ms]
(pass) does not busy-wait on the futex while git runs [1678.07ms]
Copying files... 

[17.00ms] git

[106.00ms] bun create /tmp/cr8-1235Qa3X/bun-create/
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3215e1a4bd
  features     baseline

22 deps, 106 codegen, 1175 objects in 609ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1237] install /workspace/bun
bun install v1.3.14 (0d9b296a)

Checked 124 installs across 170 packages (no changes) [8.00ms]
[2/1237] install /workspace/bun/packages/bun-error
bun install v1.3.14 (0d9b296a)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1237] install /workspace/bun/src/node-fallbacks
bun install v1.3.14 (0d9b296a)

Checked 129 installs across 147 packages (no changes) [8.00ms]
[4/1237] gen ErrorCode+*.h
[5/1237] fetch picohttpparser
[picohttpparser] up to date
[6/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1237] fetch tinycc
[tinycc] up to date
[8/1236] gen .bind.ts → GeneratedBindings.cpp
[9/1236] gen bindgenv2
[10/1236] fetch zlib
[zlib] up to date
[11/1236] subst deps/libjpeg-turbo/jconfig.h
[12/1236] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/create_command.rs   |  64 ++++++++++++----
 test/cli/install/bun-create.test.ts | 147 ++++++++++++++++++++++++++++++++++++
 2 files changed, 198 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/cli/create_command.rs        6     13      0
test/cli/install/bun-create.test.ts      2      2      0
```

</details>

**root cause** · written by the author bot

The git initialization runs on a background thread concurrently with dependency installation, and that thread printed its timing line directly to the terminal as soon as it finished, so the log raced with a postinstall task writing output on the main thread and landed mid-stream. The fix stops the worker thread from printing, instead recording the elapsed git time and emitting the timing line from the main thread only after the git work has completed and the postinstall output is done. As a related hardening, bun-prefixed postinstall commands now spawn with the resolved absolute Bun executa…

<!-- robobun:evidence:end -->