### PR TITLE
Bump WebKit: assert the VM's API lock is held on HandleSet mutation

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "e6e37cda216c0292ae68c30c84a9dc8601d0fba5";
+export const WEBKIT_VERSION = "autobuild-preview-pr-387-f6049b84";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/JSCTestingHelpers.cpp
+++ b/src/jsc/bindings/JSCTestingHelpers.cpp
@@ -6,6 +6,13 @@
 #include <JavaScriptCore/JSString.h>
 #include "ZigGlobalObject.h"
 
+#if ASSERT_ENABLED
+#include "StrongRef.h"
+#include <JavaScriptCore/Strong.h>
+#include <JavaScriptCore/StrongInlines.h>
+#include <wtf/Threading.h>
+#endif
+
 #if OS(WINDOWS)
 #include <JavaScriptCore/ExecutableAllocator.h>
 #include <JavaScriptCore/JSBigInt.h>
@@ -64,6 +71,45 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStartOfFixedExecutableMemoryPool,
 }
 #endif
 
+#if ASSERT_ENABLED
+// Deliberately mutates a strong handle owned by this VM from a spawned thread
+// that does not hold the API lock. The debug-only thread-affinity assertions
+// (JSC::HandleSet::assertMayMutate for JSC::Strong, the Bun__StrongRef__*
+// asserts for StrongRootBlock slots) must abort the process before the
+// mutation lands; the test asserting on that crash is what keeps the
+// detectors from rotting silently. Only compiled when the assertions are.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionCrossThreadStrongHandleMutation,
+    (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    WTF::String kind = callframe->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (kind == "strong"_s) {
+        // The #30185 shape: a by-value Strong capture destroyed off-thread.
+        JSC::Strong<JSC::JSObject> strong(vm, JSC::constructEmptyObject(globalObject));
+        Ref<Thread> thread = Thread::create("StrongHandleGuardTest"_s, [strong]() mutable {
+            strong.clear();
+        });
+        thread->waitForCompletion();
+        return JSValue::encode(jsUndefined());
+    }
+
+    if (kind == "strongRef"_s) {
+        auto* ref = Bun__StrongRef__new(globalObject, JSValue::encode(JSC::constructEmptyObject(globalObject)));
+        Ref<Thread> thread = Thread::create("StrongHandleGuardTest"_s, [ref]() {
+            Bun__StrongRef__delete(ref);
+        });
+        thread->waitForCompletion();
+        return JSValue::encode(jsUndefined());
+    }
+
+    throwTypeError(globalObject, scope, "Expected \"strong\" or \"strongRef\""_s);
+    return {};
+}
+#endif
+
 JSC::JSValue createJSCTestingHelpers(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -84,6 +130,13 @@ JSC::JSValue createJSCTestingHelpers(Zig::GlobalObject* globalObject)
     object->putDirectNativeFunction(
         vm, globalObject, JSC::Identifier::fromString(vm, "startOfFixedExecutableMemoryPool"_s), 0,
         jsFunctionStartOfFixedExecutableMemoryPool, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+#endif
+
+#if ASSERT_ENABLED
+    object->putDirectNativeFunction(
+        vm, globalObject, JSC::Identifier::fromString(vm, "crossThreadStrongHandleMutation"_s), 1,
+        jsFunctionCrossThreadStrongHandleMutation, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
 #endif
 

--- a/src/jsc/bindings/JSCTestingHelpers.cpp
+++ b/src/jsc/bindings/JSCTestingHelpers.cpp
@@ -72,12 +72,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStartOfFixedExecutableMemoryPool,
 #endif
 
 #if ASSERT_ENABLED
-// Deliberately mutates a strong handle owned by this VM from a spawned thread
-// that does not hold the API lock. The debug-only thread-affinity assertions
-// (JSC::HandleSet::assertMayMutate for JSC::Strong, the Bun__StrongRef__*
-// asserts for StrongRootBlock slots) must abort the process before the
-// mutation lands; the test asserting on that crash is what keeps the
-// detectors from rotting silently. Only compiled when the assertions are.
+// Test hook: mutates a strong handle owned by this VM from a spawned thread
+// without the API lock. The debug assertions in JSC::HandleSet and
+// Bun__StrongRef__* must abort before the mutation lands;
+// strong-handle-thread-guard.test.ts asserts on that crash.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionCrossThreadStrongHandleMutation,
     (JSGlobalObject * globalObject, CallFrame* callframe))
 {

--- a/src/jsc/bindings/StrongRef.cpp
+++ b/src/jsc/bindings/StrongRef.cpp
@@ -48,12 +48,9 @@ static ALWAYS_INLINE StrongRootBlock* decodeStrongRefBlock(StrongRefImpl* ref)
     return reinterpret_cast<StrongRootBlock*>(slot - static_cast<uintptr_t>(decodeStrongRefIndex(ref)) * sizeof(StrongRootBlock::Slot) - StrongRootBlock::slotsOffset());
 }
 
-// The StrongRootBlock list hangs off JSVMClientData with no synchronization:
-// the "Srb" marking constraint (BunClientData.cpp) scans it assuming only the
-// mutator, holding the VM's API lock, ever writes it. These asserts are the
-// StrongRootBlock mirror of JSC::HandleSet::assertMayMutate, and check the
-// OWNER VM (the block's), so a thread that has some other VM's lock still
-// trips them.
+// The "Srb" marking constraint (BunClientData.cpp) scans the StrongRootBlock
+// list without synchronization; holding the owner VM's API lock is what
+// orders these mutations with that scan. Mirrors JSC::HandleSet's assertion.
 #define ASSERT_STRONG_REF_MUTATION_ALLOWED(vm) \
     ASSERT_WITH_MESSAGE((vm).currentThreadIsHoldingAPILock(), "Bun::StrongRef handles may only be created, written, or destroyed while holding their VM's API lock")
 

--- a/src/jsc/bindings/StrongRef.cpp
+++ b/src/jsc/bindings/StrongRef.cpp
@@ -48,9 +48,19 @@ static ALWAYS_INLINE StrongRootBlock* decodeStrongRefBlock(StrongRefImpl* ref)
     return reinterpret_cast<StrongRootBlock*>(slot - static_cast<uintptr_t>(decodeStrongRefIndex(ref)) * sizeof(StrongRootBlock::Slot) - StrongRootBlock::slotsOffset());
 }
 
+// The StrongRootBlock list hangs off JSVMClientData with no synchronization:
+// the "Srb" marking constraint (BunClientData.cpp) scans it assuming only the
+// mutator, holding the VM's API lock, ever writes it. These asserts are the
+// StrongRootBlock mirror of JSC::HandleSet::assertMayMutate, and check the
+// OWNER VM (the block's), so a thread that has some other VM's lock still
+// trips them.
+#define ASSERT_STRONG_REF_MUTATION_ALLOWED(vm) \
+    ASSERT_WITH_MESSAGE((vm).currentThreadIsHoldingAPILock(), "Bun::StrongRef handles may only be created, written, or destroyed while holding their VM's API lock")
+
 extern "C" StrongRefImpl* Bun__StrongRef__new(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
     auto& vm = JSC::getVM(globalObject);
+    ASSERT_STRONG_REF_MUTATION_ALLOWED(vm);
     unsigned index;
     auto* block = StrongRootBlock::acquire(clientDataFast(vm), vm, index);
     block->set(vm, index, JSC::JSValue::decode(encodedValue));
@@ -59,7 +69,9 @@ extern "C" StrongRefImpl* Bun__StrongRef__new(JSC::JSGlobalObject* globalObject,
 
 extern "C" void Bun__StrongRef__set(StrongRefImpl* _Nonnull ref, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue)
 {
-    decodeStrongRefBlock(ref)->write(JSC::getVM(globalObject), decodeStrongRefIndex(ref), JSC::JSValue::decode(encodedValue));
+    auto* block = decodeStrongRefBlock(ref);
+    ASSERT_STRONG_REF_MUTATION_ALLOWED(block->vm());
+    block->write(JSC::getVM(globalObject), decodeStrongRefIndex(ref), JSC::JSValue::decode(encodedValue));
 }
 
 // The Rust caller (Strong.rs Impl::destroy) skips this call once
@@ -71,6 +83,7 @@ extern "C" void Bun__StrongRef__delete(StrongRefImpl* _Nonnull ref)
 {
     auto* block = decodeStrongRefBlock(ref);
     auto& vm = block->vm();
+    ASSERT_STRONG_REF_MUTATION_ALLOWED(vm);
     auto* clientData = clientDataFast(vm);
     // This block just freed a slot, so the next acquire() should try it first
     // (covers the FIFO pattern where the oldest-armed block gets room while

--- a/test/js/bun/jsc/strong-handle-thread-guard-fixture.js
+++ b/test/js/bun/jsc/strong-handle-thread-guard-fixture.js
@@ -1,0 +1,7 @@
+import { jscInternals } from "bun:internal-for-testing";
+
+// Violates the strong-handle thread-affinity contract on purpose; in a debug
+// build the assertion must abort the process inside this call.
+jscInternals.crossThreadStrongHandleMutation(process.argv[2]);
+
+console.log("survived");

--- a/test/js/bun/jsc/strong-handle-thread-guard.test.ts
+++ b/test/js/bun/jsc/strong-handle-thread-guard.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import path from "path";
+
+// Each child deliberately mutates a strong handle owned by the main VM from a
+// spawned thread that does not hold the VM's API lock. Debug builds carry
+// assertions guarding exactly that (JSC::HandleSet::assertMayMutate for
+// JSC::Strong, the Bun__StrongRef__* asserts for StrongRootBlock slots), so
+// the child must die with the assertion's message before the mutation lands.
+//
+// This is the liveness check for those detectors: the previous guard for the
+// #30185 cross-thread HandleSet race was a probabilistic crash workload that
+// silently stopped detecting when GC scheduling changed (#35356, measured in
+// #36952). If a WebKit bump or binding refactor drops the assertions, the
+// child survives and this test fails instead of the coverage disappearing
+// unnoticed.
+//
+// These crashes are intentional; keep them out of crash reporting so CI does
+// not pin them on unrelated tests.
+const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" };
+
+for (const [kind, message] of [
+  ["strong", "Strong handles may only be created, written, or destroyed while holding their VM's API lock"],
+  ["strongRef", "Bun::StrongRef handles may only be created, written, or destroyed while holding their VM's API lock"],
+] as const) {
+  test.if(isDebug)(`unlocked off-thread ${kind} mutation aborts with the guard's message`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "strong-handle-thread-guard-fixture.js"), kind],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("ASSERTION FAILED");
+    expect(stderr).toContain(message);
+    expect(stdout).not.toContain("survived");
+    expect(exitCode).not.toBe(0);
+  });
+}


### PR DESCRIPTION
## What does this PR do?

Gives the #30185 bug class (a strong handle owned by one VM, mutated from a thread that does not hold that VM's API lock) a deterministic, self-verifying detector. Three pieces:

1. **WebKit bump** picking up oven-sh/WebKit#387: `HandleSet::allocate`, `deallocate`, and `writeBarrier` now assert (debug builds only) that the current thread holds the owning VM's API lock, matching the existing assertion in `Heap::protect`/`unprotect`. The pin currently points at that PR's preview build (`autobuild-preview-pr-387-f6049b84`) and flips to the merge commit once it lands.
2. **Mirror asserts for the Rust-side half**: since #35849, `bun_jsc::Strong` routes through `StrongRootBlock` slots instead of JSC's HandleSet, and the "Srb" marking constraint scans that list under the same mutator-only assumption, with no guard (`Strong.rs` checks only that the dropping thread has *a* VM, not the owner VM's lock, and the C++ `Bun::StrongRef` deleter bypasses even that). `Bun__StrongRef__new/set/delete` now carry the same debug-only assertion, checked against the owner VM (the block's), so holding some other VM's lock does not pass.
3. **A liveness test for both detectors**: `jscInternals.crossThreadStrongHandleMutation(kind)` (debug builds only) deliberately violates the contract from a spawned thread, and `test/js/bun/jsc/strong-handle-thread-guard.test.ts` asserts the child aborts with each guard's message. This is the piece that keeps the detectors from dying the way the old guard did: if a future WebKit bump or binding refactor drops an assertion, this test fails in the debug lanes instead of the coverage silently disappearing.

## Why

These mutation paths write lists that GC marking constraints scan ("Sh" for HandleSet, "Srb" for StrongRootBlock); the API lock is what orders mutations with the scans. A `JSC::Strong` captured by value in a cross-thread lambda and destroyed on the other thread was exactly #30185: `panic: Segmentation fault at address 0x10` in the Sh constraint, or a livelock on the torn `SentinelLinkedList`.

The class currently has no effective guard. The stress workload in `worker_heap_snapshot_gc.test.ts` was sized (#35200) to catch a reintroduced #30185 at roughly 60% per process, but after #35356 replaced per-tick GC collections with an idle timer, the same reintroduced bug produced 0 detections in 18,000 iterations (measured in #36952, which resizes the now-ineffective workload and defers a deterministic detector to this PR). Detection no longer depends on a GC scan landing in a few-instruction window: the unlocked mutation itself aborts, naming the invariant and the call site.

## Verification

- Reintroduced the canonical #30185 bug (by-value `Strong<JSPromise>` capture in `getHeapSnapshot`'s cross-thread lambda) on top of the bump: `bun bd` aborts on the first `worker.getHeapSnapshot()` round-trip, every run:

  ```
  ASSERTION FAILED: Strong handles may only be created, written, or destroyed while holding their VM's API lock
  vendor/WebKit/Source/JavaScriptCore/heap/HandleSet.cpp(106) : void JSC::HandleSet::assertMayMutate()
  ```

- The new liveness test passes with this diff (both children die with the right message) and fails without the src/ changes (the hook is gone, the child survives), on linux x64 debug+ASAN.
- No spurious assertion failures across the Strong-heavy suites locally (debug+ASAN): worker_threads, web workers, fetch (11,232 tests), streams, Bun.spawn, dns, timers, sqlite + Bun.password, node:vm, bun shell, plugin, bun:jsc, node:http2, mock functions. The only local failures are machine artifacts that reproduce identically without this change (stress-test timeouts on a throttled container, plus two already-tracked pre-existing bugs found along the way). First CI round on the bump alone: all 26 build/link lanes green, zero assertion failures anywhere.
- Release builds are unchanged: both assertions compile out (`ASSERT_ENABLED=0`), and the testing hook is not registered.

Upstream note: WebKit/WebKit@ff64aee116 replaces `HandleSet` with `StrongSet`/`StrongBlock`, so the fork's next upstream merge will hit a delete/modify conflict on these files and needs to port the assertion (tracked on oven-sh/WebKit#387). The liveness test is what enforces that port: if it gets dropped, the debug lanes fail.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/strong-handle-thread-guard.test.ts
bun test v1.4.0 (cce71d34a)

test/js/bun/jsc/strong-handle-thread-guard.test.ts:
29 |       env: noReportEnv,
30 |       stdio: ["ignore", "pipe", "pipe"],
31 |     });
32 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 | 
34 |     expect(stderr).toContain("ASSERTION FAILED");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "ASSERTION FAILED"
Received: "1 | import { jscInternals } from \"bun:internal-for-testing\";\n2 | \n3 | // Violates the strong-handle thread-affinity contract on purpose; in a debug\n4 | // build the assertion must abort the process inside this call.\n5 | jscInternals.crossThreadStrongHandleMutation(process.argv[2]);\n                 ^\nTypeError: jscInternals.crossThreadStrongHandleMutation is not a function. (In 'jscInternals.crossThreadStrongHandleMutation(process.argv[2])', 'jscInternals.crossThreadStrongHandleMutation' is undefined)\n      at /work
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (b66764ff3)

test/js/bun/jsc/strong-handle-thread-guard.test.ts:
(skip) unlocked off-thread strong mutation aborts with the guard's message
(skip) unlocked off-thread strongRef mutation aborts with the guard's message

 0 pass
 2 skip
 0 fail
Ran 2 tests across 1 file. [126.00ms]
__F:0:S:2
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/strong-handle-thread-guard.test.ts
bun test v1.4.0 (cce71d34a)

test/js/bun/jsc/strong-handle-thread-guard.test.ts:
(pass) unlocked off-thread strong mutation aborts with the guard's message [1063.33ms]
(pass) unlocked off-thread strongRef mutation aborts with the guard's message [1052.86ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [4.13s]
__F:0:S:0

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     cce71d34a1
  features     baseline

22 deps, 106 codegen, 1175 objects in 693ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b66764ff3)

Checked 124 installs across 170 packages (no changes) [16.00ms]
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b66764ff3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] fetch picohttpparser
[picohttpparser] up to date
[7/1238] fetch zlib
[zlib] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b66764ff3)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] subst deps/zlib/zlib.h
[12/1237] subst deps/zlib/zconf.h
[13/1188] fetch nodejs (prebuilt)
[nodejs] up to date
[14/118
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 src/jsc/bindings/JSCTestingHelpers.cpp             | 51 ++++++++++++++++++++++
 src/jsc/bindings/StrongRef.cpp                     | 12 ++++-
 .../bun/jsc/strong-handle-thread-guard-fixture.js  |  7 +++
 test/js/bun/jsc/strong-handle-thread-guard.test.ts | 39 +++++++++++++++++
 5 files changed, 109 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
scripts/build/deps/webkit.ts                               2      4      0
src/jsc/bindings/JSCTestingHelpers.cpp                     2      3      0
src/jsc/bindings/StrongRef.cpp                             2      4      0
test/js/bun/jsc/strong-handle-thread-guard-fixture.js      0      1      0
test/js/bun/jsc/strong-handle-thread-guard.test.ts         0      1      0
```

</details>

<!-- robobun:evidence:end -->