### PR TITLE
ci: use a PAT to resolve stale comment-cop review threads

### DIFF
--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -115,7 +115,7 @@ jobs:
                     pullRequest(number: $pr) {
                       reviewThreads(first: 100, after: $after) {
                         pageInfo { hasNextPage endCursor }
-                        nodes { id isResolved comments(first: 1) { nodes { body } } }
+                        nodes { id isResolved comments(first: 1) { nodes { body author { login } } } }
                       }
                     }
                   }
@@ -133,8 +133,11 @@ jobs:
             const seenKeys = new Set();
             const toResolve = [];
             for (const t of threads) {
-              const body = t.comments.nodes[0]?.body || '';
-              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(body);
+              const root = t.comments.nodes[0];
+              // The marker alone is forgeable (anyone can paste it into their own
+              // review comment), so only trust threads this workflow opened.
+              if (root?.author?.login !== 'github-actions') continue;
+              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(root.body || '');
               if (!m) continue;
               const key = m[1];
               seenKeys.add(key);
@@ -206,3 +209,8 @@ jobs:
               }
             }
             core.info(`Resolved ${resolved} of ${ids.length} stale comment-cop thread(s).`);
+            if (ids.length > 0 && resolved === 0) {
+              // Fail the step (continue-on-error keeps the job green) so a dead
+              // token shows up as an error annotation instead of silent warnings.
+              core.setFailed(`All ${ids.length} resolveReviewThread mutations failed; check ROBOBUN_TOKEN.`);
+            }

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -25,6 +25,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Scan diff for added multi-line comments
+        id: scan
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -140,21 +141,12 @@ jobs:
               if (!t.isResolved && !presentKeys.has(key)) toResolve.push(t.id);
             }
 
-            // Auto-resolve threads whose flagged block is gone from the current diff.
-            if (toResolve.length > 0) {
-              const mut = `
-                mutation($id: ID!) {
-                  resolveReviewThread(input: { threadId: $id }) { thread { id } }
-                }`;
-              for (const id of toResolve) {
-                try {
-                  await github.graphql(mut, { id });
-                } catch (e) {
-                  core.warning(`resolveReviewThread failed for ${id}: ${e.message}`);
-                }
-              }
-              core.info(`Resolved ${toResolve.length} stale comment-cop thread(s).`);
-            }
+            // Threads whose flagged block is gone from the current diff are
+            // resolved by the next step, which authenticates with a PAT: the
+            // Actions GITHUB_TOKEN cannot call the resolveReviewThread mutation
+            // ("Resource not accessible by integration") even with
+            // pull-requests: write.
+            core.setOutput('stale-threads', toResolve.join(' '));
 
             // Post new line comments for groups not already flagged.
             const fresh = groups.filter(g => !seenKeys.has(keyFor(g)));
@@ -189,3 +181,28 @@ jobs:
               }
             }
             core.info(`Posted ${posted} review comment(s).`);
+
+      - name: Resolve stale threads
+        if: steps.scan.outputs.stale-threads
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          STALE_THREADS: ${{ steps.scan.outputs.stale-threads }}
+        with:
+          github-token: ${{ secrets.ROBOBUN_TOKEN }}
+          script: |
+            const ids = process.env.STALE_THREADS.split(' ').filter(Boolean);
+            const mut = `
+              mutation($id: ID!) {
+                resolveReviewThread(input: { threadId: $id }) { thread { id } }
+              }`;
+            let resolved = 0;
+            for (const id of ids) {
+              try {
+                await github.graphql(mut, { id });
+                resolved++;
+              } catch (e) {
+                core.warning(`resolveReviewThread failed for ${id}: ${e.message}`);
+              }
+            }
+            core.info(`Resolved ${resolved} of ${ids.length} stale comment-cop thread(s).`);


### PR DESCRIPTION
### Problem

Comment Cop is supposed to auto-resolve its own review threads once the flagged comment block disappears from the PR diff. That has never worked: every `resolveReviewThread` call fails with

```
Request failed due to following response errors:
 - Resource not accessible by integration
```

so stale bot threads accumulate on every claude-labeled PR and get cleaned up by hand. Example: [run 31002896415](https://github.com/oven-sh/bun/actions/runs/31002896415) on #36956 logged 64 consecutive `resolveReviewThread failed` warnings; earlier runs show the same, so it is not transient.

### Cause

GitHub rejects the `resolveReviewThread` GraphQL mutation specifically for the Actions `GITHUB_TOKEN`, even though the workflow grants `pull-requests: write` (posting review comments through REST works fine with the same token). The restriction does not apply to app tokens in general (CodeRabbit's installation token resolves threads on this repo) or to user tokens: I verified by running the exact mutation as robobun against one of the threads from that run (`PRRT_kwDOFVKCyc6Wol1B`), which succeeded, while the workflow's attempt on the same thread had failed.

### Fix

Split thread resolution out of the scan step:

- The scan step keeps using `GITHUB_TOKEN` to read the diff and post review comments, and now exports the stale thread ids as a step output instead of resolving them.
- A new step runs the `resolveReviewThread` mutations authenticated with the existing `ROBOBUN_TOKEN` repo secret, the same PAT release.yml already uses. The step is non-blocking (`continue-on-error`), but if every mutation fails it marks itself failed so a dead or under-scoped token surfaces as an error annotation in the run instead of repeating the silent-warning failure mode this PR fixes.

Since the resolve step now acts with real write authority, thread selection also got stricter: a thread only counts as comment-cop's if its root comment is authored by `github-actions` and carries the `<!-- comment-cop:... -->` marker. Previously the marker alone was trusted, and anyone can paste the marker into their own review comment.

The PAT's exposure stays narrow: the workflow checks out no PR code, the resolve step receives only GitHub-generated thread ids through `env` (never interpolated into the script), and the only operation it performs is resolving threads the bot itself opened. Fork PRs cannot trigger this workflow on their own: the `claude` label requires triage access to add, and the auto-labeler runs with a read-only token on fork PRs.

### Token choice

`ROBOBUN_TOKEN` is used because it already exists and demonstrably works. It is broader than this job needs (release.yml uses it to push to other oven-sh repos). If narrower credentials are preferred, either of these is a drop-in replacement for `github-token` in the resolve step, and both need someone with org access to provision:

- a fine-grained PAT on robobun scoped to oven-sh/bun with Pull requests read/write, or
- a dedicated GitHub App via `actions/create-github-app-token` (app installation tokens can run this mutation; only the Actions token is blocked).

### Verification

- Ran the mutation as a robobun user token against a real thread from the failing run: resolve and unresolve both succeed, confirming the restriction is specific to the Actions token.
- Confirmed `ROBOBUN_TOKEN` is a plain repo secret already consumed by non-environment jobs in release.yml, so it is available here.
- Dry-ran the new thread-selection logic against the live thread set of #36956: exactly the 64 genuine cop threads match (the same 64 the failing run tried to resolve), and the 5 human and other-bot threads are skipped.
- Validated the YAML and syntax-checked both embedded scripts.

Note: `pull_request_target` runs the workflow from the base branch, so CI on this PR cannot exercise the change; it takes effect once merged. The CI failures on this PR are pre-existing on main (asan lane) and unrelated to this workflow-only diff.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->