### PR TITLE
terminal: keep the wrapper alive while a drain dispatch is pending after PTY EOF

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -165,9 +165,8 @@ pub struct Terminal {
     /// The streaming writer has accepted bytes it hasn't flushed to the fd
     /// yet. Set by `write()` from `has_pending_data()`; cleared when
     /// `on_write` observes `Drained` so POSIX can fire the `drain` callback
-    /// (Windows fires it from `on_writable`). While true after PTY EOF, the
-    /// wrapper stays strongly held so the pending `drain` dispatch cannot
-    /// reach a collected object (`maybe_downgrade_after_eof`).
+    /// (Windows fires it from `on_writable`). Also gates the post-EOF
+    /// downgrade in `maybe_downgrade_after_eof`.
     writer_has_buffered: Cell<bool>,
 
     /// This PTY's own raw-mode state (mode + saved termios), so one terminal
@@ -1505,9 +1504,8 @@ impl Terminal {
         });
         self.writer_has_buffered.set(has_pending);
         if has_pending {
-            // A buffered write owes a `drain` dispatch; the wrapper is the
-            // callbacks' only GC root, and a write after PTY EOF (e.g. from
-            // the exit callback) finds it already downgraded.
+            // Keep the wrapper rooted for the pending drain dispatch; a write
+            // after PTY EOF finds it already downgraded.
             self.this_value.with_mut(|v| v.upgrade(global_object));
         }
         // A second write() can drain what an earlier one buffered; on_write saw
@@ -1741,8 +1739,7 @@ impl Terminal {
 
         // Close writer (closes write_fd). R-2: `with_mut` borrow is held across
         // the synchronous `on_writer_close` parent callback, but that callback
-        // touches only `flags`/`ref_count`/`writer_has_buffered`/`this_value`
-        // (separate `Cell`s/`JsCell`), never `writer`.
+        // touches only sibling `Cell`/`JsCell` fields, never `writer`.
         self.writer.with_mut(|w| w.close());
         self.write_fd.set(Fd::INVALID);
 
@@ -1788,7 +1785,6 @@ impl Terminal {
         bun_output::scoped_log!(Terminal, "onWriterClose");
         if !self.flags.get().contains(Flags::WRITER_DONE) {
             self.update_flags(|f| f.insert(Flags::WRITER_DONE));
-            // Buffered data that will never drain no longer pins the wrapper.
             // Must run before the deref below, which may free `self`.
             self.maybe_downgrade_after_eof();
             // Release writer's ref
@@ -1810,9 +1806,6 @@ impl Terminal {
                 );
             }
         }
-        // The drain that kept the wrapper rooted after EOF has now been
-        // dispatched (unless the callback buffered more data, which the
-        // `writer_has_buffered` check sees).
         self.maybe_downgrade_after_eof();
     }
 
@@ -1830,9 +1823,8 @@ impl Terminal {
         let _ = amount;
         // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect the
         // buffered→drained transition here instead. Windows fires the drain
-        // callback from `on_writable`, so only record the drained state — a
-        // stale `writer_has_buffered` would keep `maybe_downgrade_after_eof`
-        // from ever releasing the wrapper.
+        // callback from `on_writable`, so only record the drained state (a
+        // stale flag would block `maybe_downgrade_after_eof` forever).
         #[cfg(unix)]
         if status == WriteStatus::Drained && self.writer_has_buffered.replace(false) {
             self.on_writer_ready();
@@ -1867,8 +1859,7 @@ impl Terminal {
             f.insert(Flags::READER_DONE);
             f.remove(Flags::CONNECTED);
         });
-        // EOF from master - downgrade to weak ref to allow GC (deferred while
-        // the writer still owes a `drain` dispatch).
+        // EOF from master - downgrade to weak ref to allow GC.
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {
             self.maybe_downgrade_after_eof();
@@ -1880,13 +1871,11 @@ impl Terminal {
     /// Downgrade `this_value` once no further callback can fire: reader hit
     /// EOF *and* the writer has no buffered data awaiting a `drain` dispatch.
     /// The wrapper's cached callback slots are the only GC root of the
-    /// `data`/`exit`/`drain` functions, so downgrading while a drain is still
-    /// pending lets GC collect the wrapper before `on_writer_ready` runs and
-    /// the late dispatch reads a swept object.
+    /// callbacks, so downgrading with a drain still pending lets GC collect
+    /// the wrapper before `on_writer_ready` dispatches through it.
     ///
-    /// Reads only `Cell` fields (never `self.writer`): it is called from
-    /// writer-parent callbacks (`on_writer_ready`/`on_writer_close`) that can
-    /// run while a writer borrow is live up the stack.
+    /// Reads only `Cell` fields, never `self.writer`: callers include
+    /// writer-parent callbacks that run while a writer borrow is live.
     fn maybe_downgrade_after_eof(&self) {
         let flags = self.flags.get();
         if !flags.contains(Flags::READER_DONE) || flags.contains(Flags::FINALIZED) {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -165,7 +165,9 @@ pub struct Terminal {
     /// The streaming writer has accepted bytes it hasn't flushed to the fd
     /// yet. Set by `write()` from `has_pending_data()`; cleared when
     /// `on_write` observes `Drained` so POSIX can fire the `drain` callback
-    /// (Windows fires it from `on_writable`).
+    /// (Windows fires it from `on_writable`). While true after PTY EOF, the
+    /// wrapper stays strongly held so the pending `drain` dispatch cannot
+    /// reach a collected object (`maybe_downgrade_after_eof`).
     writer_has_buffered: Cell<bool>,
 
     /// This PTY's own raw-mode state (mode + saved termios), so one terminal
@@ -1502,6 +1504,12 @@ impl Terminal {
             (r, w.has_pending_data())
         });
         self.writer_has_buffered.set(has_pending);
+        if has_pending {
+            // A buffered write owes a `drain` dispatch; the wrapper is the
+            // callbacks' only GC root, and a write after PTY EOF (e.g. from
+            // the exit callback) finds it already downgraded.
+            self.this_value.with_mut(|v| v.upgrade(global_object));
+        }
         // A second write() can drain what an earlier one buffered; on_write saw
         // the cleared flag, so fire drain here (outside `with_mut`).
         #[cfg(unix)]
@@ -1733,7 +1741,8 @@ impl Terminal {
 
         // Close writer (closes write_fd). R-2: `with_mut` borrow is held across
         // the synchronous `on_writer_close` parent callback, but that callback
-        // touches only `flags`/`ref_count` (separate `Cell`s), never `writer`.
+        // touches only `flags`/`ref_count`/`writer_has_buffered`/`this_value`
+        // (separate `Cell`s/`JsCell`), never `writer`.
         self.writer.with_mut(|w| w.close());
         self.write_fd.set(Fd::INVALID);
 
@@ -1779,6 +1788,9 @@ impl Terminal {
         bun_output::scoped_log!(Terminal, "onWriterClose");
         if !self.flags.get().contains(Flags::WRITER_DONE) {
             self.update_flags(|f| f.insert(Flags::WRITER_DONE));
+            // Buffered data that will never drain no longer pins the wrapper.
+            // Must run before the deref below, which may free `self`.
+            self.maybe_downgrade_after_eof();
             // Release writer's ref
             self.deref_();
         }
@@ -1787,18 +1799,21 @@ impl Terminal {
     fn on_writer_ready(&self) {
         bun_output::scoped_log!(Terminal, "onWriterReady");
         // Call drain callback
-        let Some(this_jsvalue) = self.this_value.get().try_get() else {
-            return;
-        };
-        if let Some(callback) = js::gc::get(js::GcValue::Drain, this_jsvalue) {
-            let global_this = self.global();
-            global_this.bun_vm().event_loop_mut().run_callback(
-                callback,
-                global_this,
-                this_jsvalue,
-                &[this_jsvalue],
-            );
+        if let Some(this_jsvalue) = self.this_value.get().try_get() {
+            if let Some(callback) = js::gc::get(js::GcValue::Drain, this_jsvalue) {
+                let global_this = self.global();
+                global_this.bun_vm().event_loop_mut().run_callback(
+                    callback,
+                    global_this,
+                    this_jsvalue,
+                    &[this_jsvalue],
+                );
+            }
         }
+        // The drain that kept the wrapper rooted after EOF has now been
+        // dispatched (unless the callback buffered more data, which the
+        // `writer_has_buffered` check sees).
+        self.maybe_downgrade_after_eof();
     }
 
     fn on_writer_error(&self, err: &sys::Error) {
@@ -1815,13 +1830,17 @@ impl Terminal {
         let _ = amount;
         // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect the
         // buffered→drained transition here instead. Windows fires the drain
-        // callback from `on_writable`, so skip to avoid double-firing.
+        // callback from `on_writable`, so only record the drained state — a
+        // stale `writer_has_buffered` would keep `maybe_downgrade_after_eof`
+        // from ever releasing the wrapper.
         #[cfg(unix)]
         if status == WriteStatus::Drained && self.writer_has_buffered.replace(false) {
             self.on_writer_ready();
         }
         #[cfg(not(unix))]
-        let _ = status;
+        if matches!(status, WriteStatus::Drained | WriteStatus::EndOfFile) {
+            self.writer_has_buffered.set(false);
+        }
     }
 
     // IOReader callbacks
@@ -1848,13 +1867,35 @@ impl Terminal {
             f.insert(Flags::READER_DONE);
             f.remove(Flags::CONNECTED);
         });
-        // EOF from master - downgrade to weak ref to allow GC
+        // EOF from master - downgrade to weak ref to allow GC (deferred while
+        // the writer still owes a `drain` dispatch).
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {
-            self.this_value.with_mut(|v| v.downgrade());
+            self.maybe_downgrade_after_eof();
             self.call_exit_callback(exit_code, None);
         }
         self.deref_();
+    }
+
+    /// Downgrade `this_value` once no further callback can fire: reader hit
+    /// EOF *and* the writer has no buffered data awaiting a `drain` dispatch.
+    /// The wrapper's cached callback slots are the only GC root of the
+    /// `data`/`exit`/`drain` functions, so downgrading while a drain is still
+    /// pending lets GC collect the wrapper before `on_writer_ready` runs and
+    /// the late dispatch reads a swept object.
+    ///
+    /// Reads only `Cell` fields (never `self.writer`): it is called from
+    /// writer-parent callbacks (`on_writer_ready`/`on_writer_close`) that can
+    /// run while a writer borrow is live up the stack.
+    fn maybe_downgrade_after_eof(&self) {
+        let flags = self.flags.get();
+        if !flags.contains(Flags::READER_DONE) || flags.contains(Flags::FINALIZED) {
+            return;
+        }
+        if !flags.contains(Flags::WRITER_DONE) && self.writer_has_buffered.get() {
+            return;
+        }
+        self.this_value.with_mut(|v| v.downgrade());
     }
 
     /// Invoke the exit callback with PTY lifecycle status.

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -741,11 +741,7 @@ describe("Bun.Terminal", () => {
             env: bunEnv,
             stderr: "pipe",
           });
-          const [stdout, stderr, exitCode] = await Promise.all([
-            proc.stdout.text(),
-            proc.stderr.text(),
-            proc.exited,
-          ]);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           return { stdout: stdout.trim(), stderr, exitCode };
         };
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -698,6 +698,70 @@ describe("Bun.Terminal", () => {
 
       expect(drainCount).toBeGreaterThan(0);
     });
+
+    // After PTY EOF the wrapper used to be downgraded to a weak ref while
+    // buffered input the child never read was still flushing, so a GC in that
+    // window collected the wrapper together with the callbacks it roots: the
+    // pending drain dispatch was then lost (or, before a sweep, invoked a
+    // collected function). The wrapper must stay strongly held until the
+    // writer goes idle. Ten fresh processes, sequentially, because collection
+    // under conservative stack scanning is probabilistic per process (roughly
+    // half hit the window on an unfixed build; concurrent children skew the
+    // race uniformly, so sequential keeps the attempts independent). Each
+    // child bounds its wait at 20s and the loop stops at the first loss.
+    // Linux-only: the repro window depends on how the kernel drains PTY input
+    // after exit; the code under test is shared.
+    test.skipIf(!isLinux)(
+      "drain still fires when GC runs while unread input is buffered after the child exits",
+      async () => {
+        const childSrc = [
+          "const sleep = ms => new Promise(r => setTimeout(r, ms));",
+          "let sink;",
+          "function churn() { for (let i = 0; i < 500; i++) sink = { i, a: new Array(32).fill(i) }; }",
+          "let resolveDrain;",
+          "const drained = new Promise(r => (resolveDrain = r));",
+          "let proc = Bun.spawn(['sh', '-c', 'exit 0'], {",
+          "  terminal: { data() {}, exit() {}, drain() { resolveDrain('drain'); } },",
+          "});",
+          "const big = Buffer.alloc(65536, 97);",
+          "for (let i = 0; i < 16; i++) proc.terminal.write(big);",
+          "const exited = proc.exited;",
+          "proc = null;",
+          "await exited;",
+          "for (let i = 0; i < 4; i++) { churn(); await sleep(0); Bun.gc(true); }",
+          "const timer = setTimeout(() => resolveDrain('lost'), 20000);",
+          "const result = await drained;",
+          "clearTimeout(timer);",
+          "console.log(result);",
+        ].join("\n");
+
+        const run = async () => {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "-e", childSrc],
+            env: bunEnv,
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([
+            proc.stdout.text(),
+            proc.stderr.text(),
+            proc.exited,
+          ]);
+          return { stdout: stdout.trim(), stderr, exitCode };
+        };
+
+        const results = [];
+        for (let i = 0; i < 10; i++) {
+          const r = await run();
+          results.push(r);
+          if (r.stdout !== "drain") break;
+        }
+        expect(results.map(r => r.stdout)).toEqual(Array(results.length).fill("drain"));
+        expect(results.map(r => r.stderr)).toEqual(Array(results.length).fill(""));
+        expect(results.map(r => r.exitCode)).toEqual(Array(results.length).fill(0));
+        expect(results.length).toBe(10);
+      },
+      90_000,
+    );
   });
 
   describe.concurrent("subprocess interaction", () => {


### PR DESCRIPTION
### Problem

`Bun.spawn({ terminal })` can call a garbage-collected function as the `drain` callback, or silently drop the dispatch, when the PTY child exits while input the child never read is still buffered in the terminal's writer.

When the PTY master hits EOF, `Terminal::on_reader_finished` downgrades `this_value` to a weak ref and fires `exit`. The weak variant of `JsRef` is a raw `JSValue` with no liveness tracking, and the wrapper's cached callback slots are the only GC root of the `data`/`exit`/`drain` functions. Buffered input keeps flushing for another few hundred milliseconds after EOF (the kernel paces the discard), and when it finishes, `on_writer_ready` does `try_get()` on the weak ref and dispatches `drain` through whatever that address now holds:

- if the wrapper was collected and its finalizer ran, the dispatch is silently skipped (the drain callback is lost);
- if the cell was collected but not yet swept, the slot read returns a dead value and an unrelated, later-allocated function can be invoked as the drain callback (heap type confusion on release builds);
- under a debug build the same window trips `member call on null 'JSC::ClassInfo'` in `Bun__JSValue__call` via `Terminal::on_writer_ready` <- `PosixStreamingWriter::on_poll`.

Repro (roughly half of fresh processes lose the drain on an unfixed build):

```js
let proc = Bun.spawn(["sh", "-c", "exit 0"], {
  terminal: { data() {}, exit() {}, drain() { console.log("drain"); } },
});
const big = Buffer.alloc(65536, 97);
for (let i = 0; i < 16; i++) proc.terminal.write(big); // ~1MB the child never reads
const exited = proc.exited;
proc = null;
await exited;                            // EOF: ref downgraded, drain still pending
for (let i = 0; i < 4; i++) {            // GC in the window collects the wrapper
  await new Promise(r => setTimeout(r));
  Bun.gc(true);
}
```

### Fix

Keep `this_value` strong until the terminal is actually idle:

- `on_reader_finished` only downgrades when the writer has no buffered data (`maybe_downgrade_after_eof`).
- `on_writer_ready` downgrades after dispatching `drain` (unless the callback buffered more data), and `on_writer_close` downgrades when buffered data is dropped on close/error, so the wrapper never outlives its last possible callback.
- `write()` re-upgrades when it buffers data after EOF (e.g. a write from the `exit` callback), restoring the invariant that a pending drain implies a strong wrapper.
- The Windows writer now clears `writer_has_buffered` when it reports `Drained`; previously the flag was never cleared on Windows, which under the new rule would have kept a post-EOF wrapper strong forever.

The downgrade decision reads only `Cell` fields, so it is safe from the writer-parent callbacks that run while a writer borrow is live up the stack.

A strong wrapper does not pin the event loop (the polls are unreffed on child exit as before), so processes still exit normally with input left unflushed.

### Verification

New test in `test/js/bun/terminal/terminal.test.ts` runs ten fresh child processes sequentially, each buffering 1MB into a PTY child that exits immediately, forcing GC in the EOF-to-drain window, and requiring the drain callback to fire. Collection under conservative stack scanning is probabilistic per process (about half hit the window unfixed), so one process is not a reliable probe but ten sequential ones are; the loop stops at the first loss.

- unfixed debug build: test failed 4/4 runs (first or second child loses the drain)
- fixed debug build: passed 6/6 runs, ~5s
- `test/js/bun/terminal/` (132 tests), `spawn.test.ts`, `spawn-ipc-gc.test.ts`, `spawn-many-teardown.test.ts` all pass
- `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` clean

Not changed here: the generic `JsRef::Weak` liveness gap (a raw `JSValue`, no GC tracking) affects other consumers and deserves its own pass; the PTY fd retention after dropped sessions and the writer buffer retained by `close()` are separate issues.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->