### PR TITLE
jsc: back JsRef::Weak with a real JSC::Weak handle

### DIFF
--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -1,5 +1,5 @@
-// The methods used below (`get() -> Option`, `has()`, `try_swap()`) live on
-// the Optional wrapper, so import it under the local name `Strong`.
+// The methods used below (`get() -> Option`, `has()`, `set()`) live on the
+// Optional wrapper, so import it under the local name `Strong`.
 use crate::strong::Optional as Strong;
 use crate::weak::Weak;
 use crate::{JSGlobalObject, JSValue};

--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -250,6 +250,63 @@ impl Default for JsRef {
     }
 }
 
+/// Non-registering sibling of [`JsRef`] for wrapper back-pointers that are
+/// only read synchronously while the wrapper is rooted by the caller (the
+/// receiver of a host fn, or a value just created / passed in on the JS
+/// stack).
+///
+/// Holds the bare `JSValue` with no GC registration, so it costs nothing per
+/// object — a [`JsRef::Weak`] allocates a `JSC::Weak` handle, and for
+/// precise-allocated wrapper cells that means a `WeakBlock` in the cell's own
+/// `WeakSet` (1 KB each), which is too heavy to pay on every `Request` /
+/// `Response` construction. In exchange `try_get()` says nothing about
+/// liveness: a read after the wrapper dies hands back a dangling value.
+/// Deferred readers (event-loop callbacks, queued tasks, socket/timer
+/// dispatch) must use [`JsRef`], whose weak read goes dead the moment GC
+/// reaps the referent.
+pub enum RawJsRef {
+    Value(JSValue),
+    Finalized,
+}
+
+impl RawJsRef {
+    pub fn init(value: JSValue) -> Self {
+        debug_assert!(!value.is_empty_or_undefined_or_null());
+        RawJsRef::Value(value)
+    }
+
+    pub fn empty() -> Self {
+        RawJsRef::Value(JSValue::UNDEFINED)
+    }
+
+    pub fn try_get(&self) -> Option<JSValue> {
+        match self {
+            RawJsRef::Value(value) => {
+                if value.is_empty_or_undefined_or_null() {
+                    None
+                } else {
+                    Some(*value)
+                }
+            }
+            RawJsRef::Finalized => None,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.try_get().is_none()
+    }
+
+    pub fn finalize(&mut self) {
+        *self = RawJsRef::Finalized;
+    }
+}
+
+impl Default for RawJsRef {
+    fn default() -> Self {
+        RawJsRef::empty()
+    }
+}
+
 /// Forwarding accessors for the common `JsCell<JsRef>` field shape, so call
 /// sites read `field.try_get()` / `field.get_or_undefined()` instead of the
 /// double-step `field.get().try_get()` / `field.get().get()`.

--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 // The methods used below (`get() -> Option`, `has()`, `try_swap()`) live on
 // the Optional wrapper, so import it under the local name `Strong`.
 use crate::strong::Optional as Strong;
+use crate::weak::Weak;
 use crate::{JSGlobalObject, JSValue};
 
 /// Holds a reference to a JSValue with lifecycle management.
@@ -61,9 +62,11 @@ use crate::{JSGlobalObject, JSValue};
 ///
 /// # States
 ///
-/// - **Weak**: Holds a JSValue directly. Does NOT prevent garbage collection.
-///   The JSValue may become invalid if the object is collected.
-///   Use `try_get()` to safely check if the value is still alive.
+/// - **Weak**: Holds a passive `JSC::Weak` handle registered against the
+///   value's cell. Does NOT prevent garbage collection. `try_get()` returns
+///   `None` from the moment GC reaps the referent — before the lazy sweep
+///   runs the wrapper's destructor (which is what flips the ref to
+///   `Finalized`) — so a deferred reader can never observe a dead cell.
 ///
 /// - **Strong**: Holds a Strong reference that prevents garbage collection.
 ///   The JavaScript object will stay alive as long as this reference exists.
@@ -95,16 +98,17 @@ use crate::{JSGlobalObject, JSValue};
 /// Common pattern: Start strong, downgrade to weak when idle, upgrade to strong when active.
 /// See ServerWebSocket, UDPSocket, MySQLConnection, and ValkeyClient for examples.
 ///
-/// `JsRef` is `!Send + !Sync` (transitively via `JSValue` and `Strong`): the
-/// `StrongRootBlock` slot backing `Strong` hangs off the per-VM JSVMClientData
-/// and must be dropped on the JS thread.
+/// `JsRef` is `!Send + !Sync` (transitively via `Weak` and `Strong`): the
+/// `StrongRootBlock` slot backing `Strong` hangs off the per-VM JSVMClientData,
+/// and the `JSC::Weak` handle backing `Weak` lives in the cell's `WeakSet`;
+/// both must be created and dropped on the JS thread.
 pub enum JsRef {
-    Weak(JSValue),
+    Weak(Weak<()>),
     Strong(Strong),
     Finalized,
 }
 
-// Belt-and-suspenders: JSValue and Strong are already !Send/!Sync, but make it
+// Belt-and-suspenders: Weak and Strong are already !Send/!Sync, but make it
 // explicit so a future refactor of those types cannot accidentally make JsRef
 // sendable.
 const _: PhantomData<*const ()> = PhantomData;
@@ -112,7 +116,7 @@ const _: PhantomData<*const ()> = PhantomData;
 impl JsRef {
     pub fn init_weak(value: JSValue) -> Self {
         debug_assert!(!value.is_empty_or_undefined_or_null());
-        JsRef::Weak(value)
+        JsRef::Weak(Weak::create_passive(value))
     }
 
     pub fn init_strong(value: JSValue, global: &JSGlobalObject) -> Self {
@@ -121,18 +125,12 @@ impl JsRef {
     }
 
     pub fn empty() -> Self {
-        JsRef::Weak(JSValue::UNDEFINED)
+        JsRef::Weak(Weak::default())
     }
 
     pub fn try_get(&self) -> Option<JSValue> {
         match self {
-            JsRef::Weak(weak) => {
-                if weak.is_empty_or_undefined_or_null() {
-                    None
-                } else {
-                    Some(*weak)
-                }
-            }
+            JsRef::Weak(weak) => weak.get(),
             JsRef::Strong(strong) => strong.get(),
             JsRef::Finalized => None,
         }
@@ -148,17 +146,12 @@ impl JsRef {
 
     pub fn set_weak(&mut self, value: JSValue) {
         debug_assert!(!value.is_empty_or_undefined_or_null());
-        match self {
-            JsRef::Weak(_) => {}
-            JsRef::Strong(_) => {
-                // `Strong`'s `Drop` releases the block slot when `*self` is
-                // overwritten below, so no explicit deinit is needed.
-            }
-            JsRef::Finalized => {
-                return;
-            }
+        if matches!(self, JsRef::Finalized) {
+            return;
         }
-        *self = JsRef::Weak(value);
+        // Overwriting `*self` drops the prior variant (a `Strong`'s `Drop`
+        // releases its block slot; a `Weak`'s `Drop` frees its handle).
+        *self = JsRef::Weak(Weak::create_passive(value));
     }
 
     pub fn set_strong(&mut self, value: JSValue, global: &JSGlobalObject) {
@@ -173,9 +166,13 @@ impl JsRef {
     pub fn upgrade(&mut self, global: &JSGlobalObject) {
         match self {
             JsRef::Weak(weak) => {
-                debug_assert!(!weak.is_empty_or_undefined_or_null());
-                let weak = *weak;
-                *self = JsRef::Strong(Strong::create(weak, global));
+                // A reaped referent cannot be resurrected: stay `Weak` (dead)
+                // so readers keep seeing `None`. This also makes an upgrade
+                // that races wrapper collection a skip instead of a re-root
+                // of a dead cell.
+                if let Some(value) = weak.get() {
+                    *self = JsRef::Strong(Strong::create(value, global));
+                }
             }
             JsRef::Strong(_) => {}
             JsRef::Finalized => {
@@ -188,12 +185,14 @@ impl JsRef {
         match self {
             JsRef::Weak(_) => {}
             JsRef::Strong(strong) => {
-                let value = strong.try_swap().unwrap_or(JSValue::UNDEFINED);
-                value.ensure_still_alive();
-                // The old `Strong` is dropped by the assignment below; the
-                // `strong` borrow ends at its last use above, permitting
-                // reassignment of `*self`.
-                *self = JsRef::Weak(value);
+                // Register the weak handle while the `Strong` still roots the
+                // referent, so there is no window in which the value is
+                // unrooted; the old `Strong` is dropped by the assignment.
+                let weak = match strong.get() {
+                    Some(value) => Weak::create_passive(value),
+                    None => Weak::default(),
+                };
+                *self = JsRef::Weak(weak);
             }
             JsRef::Finalized => {}
         }
@@ -201,7 +200,7 @@ impl JsRef {
 
     pub fn is_empty(&self) -> bool {
         match self {
-            JsRef::Weak(weak) => weak.is_empty_or_undefined_or_null(),
+            JsRef::Weak(weak) => weak.get().is_none(),
             JsRef::Strong(strong) => !strong.has(),
             JsRef::Finalized => true,
         }
@@ -209,7 +208,7 @@ impl JsRef {
 
     pub fn is_not_empty(&self) -> bool {
         match self {
-            JsRef::Weak(weak) => !weak.is_empty_or_undefined_or_null(),
+            JsRef::Weak(weak) => weak.get().is_some(),
             JsRef::Strong(strong) => strong.has(),
             JsRef::Finalized => false,
         }
@@ -229,9 +228,9 @@ impl JsRef {
 
     pub fn update(&mut self, global: &JSGlobalObject, value: JSValue) {
         match self {
-            JsRef::Weak(weak) => {
+            JsRef::Weak(_) => {
                 debug_assert!(!value.is_empty_or_undefined_or_null());
-                *weak = value;
+                *self = JsRef::Weak(Weak::create_passive(value));
             }
             JsRef::Strong(strong) => {
                 if strong.get() != Some(value) {

--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -62,11 +62,9 @@ use crate::{JSGlobalObject, JSValue};
 ///
 /// # States
 ///
-/// - **Weak**: Holds a passive `JSC::Weak` handle registered against the
-///   value's cell. Does NOT prevent garbage collection. `try_get()` returns
-///   `None` from the moment GC reaps the referent — before the lazy sweep
-///   runs the wrapper's destructor (which is what flips the ref to
-///   `Finalized`) — so a deferred reader can never observe a dead cell.
+/// - **Weak**: A passive `JSC::Weak` handle on the value's cell. Does NOT
+///   prevent garbage collection. `try_get()` reads `None` from the moment GC
+///   reaps the referent, before any sweep runs the wrapper's destructor.
 ///
 /// - **Strong**: Holds a Strong reference that prevents garbage collection.
 ///   The JavaScript object will stay alive as long as this reference exists.
@@ -98,10 +96,9 @@ use crate::{JSGlobalObject, JSValue};
 /// Common pattern: Start strong, downgrade to weak when idle, upgrade to strong when active.
 /// See ServerWebSocket, UDPSocket, MySQLConnection, and ValkeyClient for examples.
 ///
-/// `JsRef` is `!Send + !Sync` (transitively via `Weak` and `Strong`): the
-/// `StrongRootBlock` slot backing `Strong` hangs off the per-VM JSVMClientData,
-/// and the `JSC::Weak` handle backing `Weak` lives in the cell's `WeakSet`;
-/// both must be created and dropped on the JS thread.
+/// `JsRef` is `!Send + !Sync` (transitively via `Weak` and `Strong`): both
+/// handles live in per-VM GC structures and must be created and dropped on
+/// the JS thread.
 pub enum JsRef {
     Weak(Weak<()>),
     Strong(Strong),
@@ -149,8 +146,7 @@ impl JsRef {
         if matches!(self, JsRef::Finalized) {
             return;
         }
-        // Overwriting `*self` drops the prior variant (a `Strong`'s `Drop`
-        // releases its block slot; a `Weak`'s `Drop` frees its handle).
+        // The assignment drops the prior variant's handle.
         *self = JsRef::Weak(Weak::create_passive(value));
     }
 
@@ -166,10 +162,8 @@ impl JsRef {
     pub fn upgrade(&mut self, global: &JSGlobalObject) {
         match self {
             JsRef::Weak(weak) => {
-                // A reaped referent cannot be resurrected: stay `Weak` (dead)
-                // so readers keep seeing `None`. This also makes an upgrade
-                // that races wrapper collection a skip instead of a re-root
-                // of a dead cell.
+                // A reaped referent cannot be resurrected: stay dead-`Weak`
+                // so readers keep seeing `None`.
                 if let Some(value) = weak.get() {
                     *self = JsRef::Strong(Strong::create(value, global));
                 }
@@ -186,8 +180,7 @@ impl JsRef {
             JsRef::Weak(_) => {}
             JsRef::Strong(strong) => {
                 // Register the weak handle while the `Strong` still roots the
-                // referent, so there is no window in which the value is
-                // unrooted; the old `Strong` is dropped by the assignment.
+                // referent, so the value is never unrooted.
                 let weak = match strong.get() {
                     Some(value) => Weak::create_passive(value),
                     None => Weak::default(),
@@ -251,19 +244,15 @@ impl Default for JsRef {
 }
 
 /// Non-registering sibling of [`JsRef`] for wrapper back-pointers that are
-/// only read synchronously while the wrapper is rooted by the caller (the
-/// receiver of a host fn, or a value just created / passed in on the JS
-/// stack).
+/// only read synchronously while the wrapper is rooted by the caller
+/// (host-fn receiver, or a value just created on the JS stack).
 ///
-/// Holds the bare `JSValue` with no GC registration, so it costs nothing per
-/// object — a [`JsRef::Weak`] allocates a `JSC::Weak` handle, and for
-/// precise-allocated wrapper cells that means a `WeakBlock` in the cell's own
-/// `WeakSet` (1 KB each), which is too heavy to pay on every `Request` /
-/// `Response` construction. In exchange `try_get()` says nothing about
-/// liveness: a read after the wrapper dies hands back a dangling value.
-/// Deferred readers (event-loop callbacks, queued tasks, socket/timer
-/// dispatch) must use [`JsRef`], whose weak read goes dead the moment GC
-/// reaps the referent.
+/// The bare `JSValue` costs nothing per object, where a registered
+/// [`JsRef::Weak`] on a precise-allocated wrapper cell costs a 1 KB
+/// `WeakBlock` in the cell's own `WeakSet` — too heavy for every
+/// `Request`/`Response` construction. In exchange `try_get()` says nothing
+/// about liveness, so deferred readers (event-loop callbacks, queued tasks)
+/// must use [`JsRef`].
 pub enum RawJsRef {
     Value(JSValue),
     Finalized,

--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -112,7 +112,7 @@ const _: PhantomData<*const ()> = PhantomData;
 
 impl JsRef {
     pub fn init_weak(value: JSValue) -> Self {
-        debug_assert!(!value.is_empty_or_undefined_or_null());
+        debug_assert!(value.is_object());
         JsRef::Weak(Weak::create_passive(value))
     }
 
@@ -142,7 +142,7 @@ impl JsRef {
     }
 
     pub fn set_weak(&mut self, value: JSValue) {
-        debug_assert!(!value.is_empty_or_undefined_or_null());
+        debug_assert!(value.is_object());
         if matches!(self, JsRef::Finalized) {
             return;
         }
@@ -212,6 +212,19 @@ impl JsRef {
         matches!(self, JsRef::Strong(_))
     }
 
+    /// True when a wrapper was held here and can no longer be used: either GC
+    /// reaped it (the weak handle is registered but reads dead, before the
+    /// sweep has run `finalize()`) or `finalize()` already ran. Create-if-
+    /// missing callers must check this before minting a fresh wrapper over
+    /// the same native object, which would double-run its finalizer.
+    pub fn is_dead(&self) -> bool {
+        match self {
+            JsRef::Weak(weak) => weak.is_registered() && weak.get().is_none(),
+            JsRef::Strong(_) => false,
+            JsRef::Finalized => true,
+        }
+    }
+
     pub fn finalize(&mut self) {
         // Overwriting `*self` drops the prior variant (releasing the `Strong`
         // block slot via its `Drop`), so no explicit deinit step is needed.
@@ -222,7 +235,7 @@ impl JsRef {
     pub fn update(&mut self, global: &JSGlobalObject, value: JSValue) {
         match self {
             JsRef::Weak(_) => {
-                debug_assert!(!value.is_empty_or_undefined_or_null());
+                debug_assert!(value.is_object());
                 *self = JsRef::Weak(Weak::create_passive(value));
             }
             JsRef::Strong(strong) => {

--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 // The methods used below (`get() -> Option`, `has()`, `try_swap()`) live on
 // the Optional wrapper, so import it under the local name `Strong`.
 use crate::strong::Optional as Strong;
@@ -105,10 +103,18 @@ pub enum JsRef {
     Finalized,
 }
 
-// Belt-and-suspenders: Weak and Strong are already !Send/!Sync, but make it
-// explicit so a future refactor of those types cannot accidentally make JsRef
-// sendable.
-const _: PhantomData<*const ()> = PhantomData;
+// Compile-time proof that `JsRef` stays `!Send`/`!Sync`: only the blanket
+// impl applies today, and a refactor of `Weak`/`Strong` that made `JsRef`
+// `Send` or `Sync` would make the selection ambiguous and fail the build.
+const _: () = {
+    trait AmbiguousIfImpl<A> {
+        fn some_item() {}
+    }
+    impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+    impl<T: ?Sized + Send> AmbiguousIfImpl<u8> for T {}
+    impl<T: ?Sized + Sync> AmbiguousIfImpl<u16> for T {}
+    let _ = <JsRef as AmbiguousIfImpl<_>>::some_item;
+};
 
 impl JsRef {
     pub fn init_weak(value: JSValue) -> Self {

--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -58,12 +58,11 @@ impl WeakImpl {
 
 // `WeakImpl` is an opaque `UnsafeCell`-backed ZST handle (`&WeakImpl` is
 // ABI-identical to non-null `*const WeakImpl`; C++ slot mutation is interior).
-// `new` is `safe fn`: the weak handle registers against `value`'s own cell
-// (callers pass a live object value — enforced by the `is_object()` guard in
-// the constructors below, which implies a readable cell header), and `ctx` is
-// an opaque round-trip pointer C++ only stores and forwards to the finalizer
-// (never dereferenced as Rust data) — same contract as `JSC__VM__holdAPILock`.
-// `delete` consumes the allocation and so stays `unsafe fn`.
+// `new` is `safe fn`: it registers against `value`'s own cell (the
+// `is_object()` guard in the constructors below admits only live object
+// values), and `ctx` is an opaque round-trip pointer C++ only stores and
+// forwards to the finalizer. `delete` consumes the allocation and so stays
+// `unsafe fn`.
 unsafe extern "C" {
     fn Bun__WeakRef__delete(this: *mut WeakImpl);
     safe fn Bun__WeakRef__new(
@@ -91,10 +90,9 @@ impl<T> Default for Weak<T> {
 
 impl<T> Weak<T> {
     /// A weak handle with no finalize callback, registered against `value`'s
-    /// own cell (no global needed). `get()` reads `None` from the moment GC
-    /// reaps the referent, before any sweep runs cell destructors.
-    ///
-    /// Non-object values produce an empty handle (`get()` is `None`).
+    /// own cell. `get()` reads `None` from the moment GC reaps the referent,
+    /// before any sweep runs cell destructors; non-object values produce an
+    /// empty handle.
     pub fn create_passive(value: JSValue) -> Self {
         if !value.is_object() {
             return Self::default();

--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -131,6 +131,13 @@ impl<T> Weak<T> {
         Some(result)
     }
 
+    /// True when a handle was registered, whether or not the referent is
+    /// still alive. Distinguishes a reaped handle (`is_registered()` with
+    /// `get() == None`) from a default/empty one.
+    pub fn is_registered(&self) -> bool {
+        self.r#ref.is_some()
+    }
+
     pub fn clear(&mut self) {
         let Some(r#ref) = self.r#ref else {
             return;

--- a/src/jsc/Weak.rs
+++ b/src/jsc/Weak.rs
@@ -2,7 +2,7 @@ use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 
-use crate::{JSGlobalObject, JSValue};
+use crate::JSValue;
 
 #[repr(u32)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -19,13 +19,11 @@ bun_opaque::opaque_ffi! {
 
 impl WeakImpl {
     fn init(
-        global_this: &JSGlobalObject,
         value: JSValue,
         ref_type: WeakRefType,
         ctx: Option<NonNull<c_void>>,
     ) -> NonNull<WeakImpl> {
         NonNull::new(Bun__WeakRef__new(
-            global_this,
             value,
             ref_type,
             ctx.map_or(core::ptr::null_mut(), |p| p.as_ptr()),
@@ -60,14 +58,15 @@ impl WeakImpl {
 
 // `WeakImpl` is an opaque `UnsafeCell`-backed ZST handle (`&WeakImpl` is
 // ABI-identical to non-null `*const WeakImpl`; C++ slot mutation is interior).
-// `new` is `safe fn`: `&JSGlobalObject` is the non-null handle proof, and `ctx`
-// is an opaque round-trip pointer C++ only stores and forwards to the finalizer
+// `new` is `safe fn`: the weak handle registers against `value`'s own cell
+// (callers pass a live object value — enforced by the `is_object()` guard in
+// the constructors below, which implies a readable cell header), and `ctx` is
+// an opaque round-trip pointer C++ only stores and forwards to the finalizer
 // (never dereferenced as Rust data) — same contract as `JSC__VM__holdAPILock`.
 // `delete` consumes the allocation and so stays `unsafe fn`.
 unsafe extern "C" {
     fn Bun__WeakRef__delete(this: *mut WeakImpl);
     safe fn Bun__WeakRef__new(
-        global: &JSGlobalObject,
         value: JSValue,
         ref_type: WeakRefType,
         ctx: *mut c_void,
@@ -91,28 +90,25 @@ impl<T> Default for Weak<T> {
 }
 
 impl<T> Weak<T> {
-    /// A weak handle with no finalize callback. `get()` reads `None` from the
-    /// moment GC reaps the referent, before any sweep runs cell destructors.
-    pub fn create_passive(value: JSValue, global_this: &JSGlobalObject) -> Self {
-        if value.is_empty() {
+    /// A weak handle with no finalize callback, registered against `value`'s
+    /// own cell (no global needed). `get()` reads `None` from the moment GC
+    /// reaps the referent, before any sweep runs cell destructors.
+    ///
+    /// Non-object values produce an empty handle (`get()` is `None`).
+    pub fn create_passive(value: JSValue) -> Self {
+        if !value.is_object() {
             return Self::default();
         }
         Self {
-            r#ref: Some(WeakImpl::init(global_this, value, WeakRefType::None, None)),
+            r#ref: Some(WeakImpl::init(value, WeakRefType::None, None)),
             _ctx: PhantomData,
         }
     }
 
-    pub fn create(
-        value: JSValue,
-        global_this: &JSGlobalObject,
-        ref_type: WeakRefType,
-        ctx: &mut T,
-    ) -> Self {
-        if !value.is_empty() {
+    pub fn create(value: JSValue, ref_type: WeakRefType, ctx: &mut T) -> Self {
+        if value.is_object() {
             return Self {
                 r#ref: Some(WeakImpl::init(
-                    global_this,
                     value,
                     ref_type,
                     Some(NonNull::from(ctx).cast::<c_void>()),

--- a/src/jsc/bindings/Weak.cpp
+++ b/src/jsc/bindings/Weak.cpp
@@ -77,10 +77,13 @@ class WeakRef {
     WTF_MAKE_TZONE_ALLOCATED(WeakRef);
 
 public:
-    WeakRef(JSC::VM& vm, JSC::JSValue value, WeakRefType kind, void* ctx = nullptr)
+    // The weak handle is registered against the cell's own WeakSet, so no
+    // VM/globalObject is needed. Non-object values produce an empty handle.
+    WeakRef(JSC::JSValue value, WeakRefType kind, void* ctx = nullptr)
     {
-
         JSC::JSObject* object = value.getObject();
+        if (!object) [[unlikely]]
+            return;
         if (object->type() == JSC::JSType::GlobalProxyType)
             object = uncheckedDowncast<JSC::JSGlobalProxy>(object)->target();
 
@@ -107,9 +110,9 @@ extern "C" void Bun__WeakRef__delete(Bun::WeakRef* weakRef)
     delete weakRef;
 }
 
-extern "C" Bun::WeakRef* Bun__WeakRef__new(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, Bun::WeakRefType kind, void* ctx)
+extern "C" Bun::WeakRef* Bun__WeakRef__new(JSC::EncodedJSValue encodedValue, Bun::WeakRefType kind, void* ctx)
 {
-    return new Bun::WeakRef(globalObject->vm(), JSC::JSValue::decode(encodedValue), kind, ctx);
+    return new Bun::WeakRef(JSC::JSValue::decode(encodedValue), kind, ctx);
 }
 
 extern "C" JSC::EncodedJSValue Bun__WeakRef__get(Bun::WeakRef* weakRef)

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -382,7 +382,7 @@ pub use self::counters::Counters;
 pub use self::decoded_js_value::DecodedJSValue;
 pub use self::deprecated_strong::DeprecatedStrong;
 pub use self::js_array::JSArray;
-pub use self::js_ref::JsRef;
+pub use self::js_ref::{JsRef, RawJsRef};
 pub use self::string_builder::StringBuilder;
 pub use self::uuid::{UUID, UUID5, UUID7};
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -549,13 +549,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.js_value.try_get().expect("js_value alive")
     }
 
-    /// Returns the wrapper while it is alive (`Strong`, or `Weak` with the
-    /// cell still reachable), or `None` once GC has reaped the cell or
-    /// `finalize()` has set `Finalized`. While the wrapper is alive its
-    /// WriteBarrier slots still root the handlers; once it is reaped the
-    /// `config` shadows may point at dead cells, and the `Weak` read goes
-    /// `None` before the sweep runs `finalize()`, so no dispatch can observe
-    /// that window. Dispatch trampolines answer 503+close on `None`.
+    /// Returns the wrapper while it is alive, or `None` once GC has reaped
+    /// the cell (the `Weak` read goes dead before the sweep runs `finalize()`)
+    /// or `finalize()` has set `Finalized`. A live wrapper's WriteBarrier
+    /// slots root the handlers the `config` shadows point at. Dispatch
+    /// trampolines answer 503+close on `None`.
     pub(crate) fn js_value_for_dispatch(&self) -> Option<JSValue> {
         self.js_value.try_get()
     }
@@ -1753,9 +1751,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             && !self.has_active_web_sockets()
         {
             // Make the wrapper collectible. Dispatch still works while the
-            // wrapper is alive (its WriteBarrier slots still root the
-            // handlers); the `js_value_for_dispatch` gate trips as soon as GC
-            // reaps the wrapper, before its finalizer runs.
+            // wrapper is alive; the `js_value_for_dispatch` gate trips as
+            // soon as GC reaps it.
             self.js_value.downgrade();
             if let Some(ws) = self.config.websocket.as_mut() {
                 ws.handler.app = None;

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -549,11 +549,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.js_value.try_get().expect("js_value alive")
     }
 
-    /// Returns the wrapper while it is alive (`Strong` or `Weak`), or `None`
-    /// once `finalize()` has set `Finalized`. `Weak` means the wrapper cell is
-    /// still live (its WriteBarrier slots still root the handlers); only
-    /// `Finalized` means the slots are gone and the `config` shadows may point
-    /// at freed cells. Dispatch trampolines answer 503+close on `None`.
+    /// Returns the wrapper while it is alive (`Strong`, or `Weak` with the
+    /// cell still reachable), or `None` once GC has reaped the cell or
+    /// `finalize()` has set `Finalized`. While the wrapper is alive its
+    /// WriteBarrier slots still root the handlers; once it is reaped the
+    /// `config` shadows may point at dead cells, and the `Weak` read goes
+    /// `None` before the sweep runs `finalize()`, so no dispatch can observe
+    /// that window. Dispatch trampolines answer 503+close on `None`.
     pub(crate) fn js_value_for_dispatch(&self) -> Option<JSValue> {
         self.js_value.try_get()
     }
@@ -1750,10 +1752,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             && !self.has_listener()
             && !self.has_active_web_sockets()
         {
-            // Make the wrapper collectible. Dispatch still works while it is
-            // `Weak` (its WriteBarrier slots still root the handlers); the
-            // `js_value_for_dispatch` gate only trips once the wrapper is
-            // actually finalized.
+            // Make the wrapper collectible. Dispatch still works while the
+            // wrapper is alive (its WriteBarrier slots still root the
+            // handlers); the `js_value_for_dispatch` gate trips as soon as GC
+            // reaps the wrapper, before its finalizer runs.
             self.js_value.downgrade();
             if let Some(ws) = self.config.websocket.as_mut() {
                 ws.handler.app = None;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1560,9 +1560,10 @@ impl<const SSL: bool> NewSocket<SSL> {
         if let Some(value) = self.this_value.get().try_get() {
             return value;
         }
-        if matches!(self.this_value.get(), JsRef::Finalized) {
-            // The JS wrapper was already garbage-collected. Creating a new one
-            // here would result in a second `finalize` (and double-deref) later.
+        if self.this_value.get().is_dead() {
+            // The JS wrapper was garbage-collected (possibly reaped but not
+            // yet swept). Creating a new one here would result in a second
+            // `finalize` (and double-deref) later.
             return JSValue::UNDEFINED;
         }
         let value = self.to_js(global);

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1717,7 +1717,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 if let Some(stream) = locked.readable.get(global_object) {
                     stream.value.ensure_still_alive();
                     Self::stream_set_cached(js_value, global_object, stream.value);
-                    locked.readable.downgrade(global_object);
+                    locked.readable.downgrade();
                 }
             }
         }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -77,9 +77,9 @@ impl Strong {
     /// Release the GC root while keeping the stream readable via `Weak`. The
     /// owning wrapper's `m_stream` `WriteBarrier` keeps the stream alive from
     /// here.
-    pub(crate) fn downgrade(&mut self, global: &JSGlobalObject) {
+    pub(crate) fn downgrade(&mut self) {
         if let Self::Held(s) = self {
-            *self = Self::Weak(bun_jsc::Weak::create_passive(s.get(), global));
+            *self = Self::Weak(bun_jsc::Weak::create_passive(s.get()));
         }
     }
 
@@ -103,7 +103,7 @@ impl Strong {
             match self {
                 Self::Held(s) => s.set(global, first.value),
                 Self::Weak(_) | Self::Empty => {
-                    *self = Self::Weak(bun_jsc::Weak::create_passive(first.value, global))
+                    *self = Self::Weak(bun_jsc::Weak::create_passive(first.value))
                 }
             }
             return Ok(Some(second));

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -14,7 +14,7 @@ use crate::webcore::BlobExt as _;
 use crate::webcore::blob::ZigStringBlobExt as _;
 use crate::webcore::body::{self, BodyHiveHandle, BodyMixin, Value as BodyValue};
 use crate::webcore::jsc::{
-    self as jsc, CallFrame, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsRef, JsResult,
+    self as jsc, CallFrame, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsResult, RawJsRef,
 };
 use crate::webcore::{AbortSignal, Blob, CookieMap, FetchHeaders, ReadableStream, Response};
 use bun_alloc::AllocError;
@@ -59,7 +59,7 @@ const _: () = {
         fn to_js(self, global: &bun_jsc::JSGlobalObject) -> bun_jsc::JSValue {
             // Route through the inherent `Request::to_js` so generic
             // `<T: JsClass>::to_js` callers also run `calculate_estimated_byte_size`,
-            // `js_ref = .init_weak(...)`, and `check_body_stream_ref` —
+            // `js_ref = RawJsRef::init(...)`, and `check_body_stream_ref` —
             // otherwise the wrapper reports size 0 and any Locked-body
             // ReadableStream is never migrated into the GC slot.
             let ptr = bun_core::heap::into_raw(Box::new(self));
@@ -97,7 +97,7 @@ pub struct Request {
     /// `finalize()` decouples from `Box` and must release this handle exactly
     /// once before `Box::from_raw().drop()` (which would otherwise re-run it).
     body: ManuallyDrop<BodyHiveHandle>,
-    js_ref: JsCell<JsRef>,
+    js_ref: JsCell<RawJsRef>,
     pub method: Method,
     pub(crate) flags: Flags,
     pub(crate) request_context: AnyRequestContext,
@@ -440,9 +440,9 @@ impl Request {
     ) {
         // `JSBunRequest::create` bypasses `to_js`, so seed the still-empty
         // `js_ref` for `check_body_stream_ref`; guarded so a pre-populated
-        // Strong is never downgraded.
+        // slot is never overwritten.
         if cloned.js_ref.get().is_empty() {
-            cloned.js_ref.set(JsRef::init_weak(js_wrapper));
+            cloned.js_ref.set(RawJsRef::init(js_wrapper));
         }
         cloned.check_body_stream_ref(global_this);
         self.sync_cloned_body_stream_caches(this_value, js_wrapper, global_this);
@@ -466,7 +466,7 @@ impl Request {
             headers: JsCell::new(headers),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
-            js_ref: JsCell::new(JsRef::empty()),
+            js_ref: JsCell::new(RawJsRef::empty()),
             method,
             flags: Flags::default(),
             request_context: AnyRequestContext::NULL,
@@ -523,7 +523,7 @@ impl Request {
             global_object,
             std::ptr::from_ref::<Request>(self).cast_mut().cast::<()>(),
         );
-        self.js_ref.set(JsRef::init_weak(js_value));
+        self.js_ref.set(RawJsRef::init(js_value));
 
         self.check_body_stream_ref(global_object);
         js_value
@@ -1032,7 +1032,7 @@ impl Request {
             headers: JsCell::new(None),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
-            js_ref: JsCell::new(JsRef::init_weak(this_value)),
+            js_ref: JsCell::new(RawJsRef::init(this_value)),
             method: Method::GET,
             flags: Flags::default(),
             request_context: AnyRequestContext::NULL,
@@ -1574,8 +1574,8 @@ impl Request {
         };
 
         // `ptr::write` is a raw bit-overwrite — no destructors run on the old
-        // `*req`, so Drop impls on `JsRef` / `strong::Optional` don't fire on
-        // the caller's sentinel.
+        // `*req`, so Drop impls on `strong::Optional` don't fire on the
+        // caller's sentinel (`RawJsRef` has no Drop).
         // The old `req.body` hive ref is intentionally NOT unref'd here:
         // `clone()` seeds it with a dangling sentinel, and `construct_into`
         // releases its seed via the ptr-equality arm of its `cleanup`.
@@ -1591,7 +1591,7 @@ impl Request {
                     headers: JsCell::new(headers),
                     signal: JsCell::new(None),
                     body: ManuallyDrop::new(body),
-                    js_ref: JsCell::new(JsRef::empty()),
+                    js_ref: JsCell::new(RawJsRef::empty()),
                     method: self.method,
                     flags: self.flags,
                     request_context: AnyRequestContext::NULL,
@@ -1624,7 +1624,7 @@ impl Request {
             body: ManuallyDrop::new(unsafe {
                 BodyHiveHandle::from_raw(NonNull::dangling().as_ptr())
             }),
-            js_ref: JsCell::new(JsRef::empty()),
+            js_ref: JsCell::new(RawJsRef::empty()),
             method: Method::GET,
             flags: Flags::default(),
             request_context: AnyRequestContext::NULL,
@@ -1693,7 +1693,7 @@ impl Request {
             headers: JsCell::new(None),
             signal: JsCell::new(signal),
             body: ManuallyDrop::new(body),
-            js_ref: JsCell::new(JsRef::empty()),
+            js_ref: JsCell::new(RawJsRef::empty()),
             method,
             flags: Flags {
                 https,

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -8,8 +8,8 @@ use bun_jsc::{AbortSignal, AbortSignalRef, GlobalRef};
 
 use crate::webcore::BlobExt as _;
 use crate::webcore::jsc::{
-    BuiltinName, CallFrame, HTTPHeaderName, JSGlobalObject, JSType, JSValue, JsError, JsRef,
-    JsResult, StringJsc as _,
+    BuiltinName, CallFrame, HTTPHeaderName, JSGlobalObject, JSType, JSValue, JsError, JsResult,
+    RawJsRef, StringJsc as _,
 };
 use bun_core::Output;
 use bun_core::{OwnedString, String as BunString, WTFStringImplExt as _, ZigStringSlice};
@@ -222,7 +222,7 @@ pub struct Response {
     /// Response was GC'd (null) instead of dereferencing a freed pointer when
     /// backpressure lets GC run between `render()` and the async callback.
     pub(crate) weak_ptr_data: WeakPtrData,
-    js_ref: JsCell<JsRef>,
+    js_ref: JsCell<RawJsRef>,
 
     // We must report a consistent value for this
     reported_estimated_size: Cell<usize>,
@@ -240,7 +240,7 @@ impl Default for Response {
             redirected: Cell::new(false),
             ref_count: Cell::new(1),
             weak_ptr_data: WeakPtrData::EMPTY,
-            js_ref: JsCell::new(JsRef::empty()),
+            js_ref: JsCell::new(RawJsRef::empty()),
             reported_estimated_size: Cell::new(0),
             abort_listener: JsCell::new(None),
         }
@@ -492,7 +492,7 @@ impl Response {
             core::ptr::from_ref::<Self>(self).cast_mut().cast::<()>(),
             global_object,
         );
-        self.js_ref.set(JsRef::init_weak(js_value));
+        self.js_ref.set(RawJsRef::init(js_value));
 
         self.check_body_stream_ref(global_object);
         js_value
@@ -931,11 +931,12 @@ impl Response {
             //   (Body.rs renames `deinit` → `reset`). `drop_in_place` here
             //   would leak refcounted payloads (WTFStringImpl, Blob store).
             // - `url: OwnedString` — assignment drops the old value (WTF deref).
-            // - `JsRef` — assignment drops the `Strong` arm (block slot released).
+            // - `RawJsRef` — plain value, no Drop; overwritten for the
+            //   Finalized/empty signal only.
             (*this).init.set(Init::default());
             (*this).body.get_mut().reset();
             (*this).url.set(OwnedString::new(BunString::empty()));
-            (*this).js_ref.set(JsRef::empty());
+            (*this).js_ref.set(RawJsRef::empty());
             (*this).abort_listener.set(None);
 
             // Contents are gone; the allocation itself stays until any outstanding
@@ -984,7 +985,7 @@ impl Response {
         // call if other refs remain, so hand ownership back to the raw refcount
         // FIRST so a panic in the work below leaks instead of UAF-ing siblings.
         let this = bun_core::heap::release(self);
-        this.js_ref.with_mut(JsRef::finalize);
+        this.js_ref.with_mut(RawJsRef::finalize);
         // SAFETY: `heap::release` returned the live raw pointer for the +1 we
         // just reclaimed from the JS wrapper.
         Self::unref(this);
@@ -1218,7 +1219,7 @@ impl Response {
         // SAFETY: `response` is freshly boxed and uniquely owned here.
         let js_value = unsafe { (*response).to_js(global_this) };
         // SAFETY: `to_js` does not free the payload; still uniquely owned.
-        unsafe { (*response).js_ref.set(JsRef::init_weak(js_value)) };
+        unsafe { (*response).js_ref.set(RawJsRef::init(js_value)) };
         Ok(js_value)
     }
 
@@ -1248,7 +1249,7 @@ impl Response {
                             ..Default::default()
                         }),
                         body: JsCell::new(Body::new(BodyValue::Empty)),
-                        js_ref: JsCell::new(JsRef::init_weak(js_this)),
+                        js_ref: JsCell::new(RawJsRef::init(js_this)),
                         ..Default::default()
                     };
 
@@ -1355,7 +1356,7 @@ impl Response {
         let response = bun_core::heap::into_raw(Box::new(Response {
             body: JsCell::new(body),
             init: JsCell::new(init),
-            js_ref: JsCell::new(JsRef::init_weak(js_this)),
+            js_ref: JsCell::new(RawJsRef::init(js_this)),
             ..Default::default()
         }));
         // SAFETY: `response` is freshly boxed and uniquely owned by this fn

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1217,9 +1217,8 @@ impl Response {
         }));
 
         // SAFETY: `response` is freshly boxed and uniquely owned here.
+        // `to_js` seeds `js_ref` itself.
         let js_value = unsafe { (*response).to_js(global_this) };
-        // SAFETY: `to_js` does not free the payload; still uniquely owned.
-        unsafe { (*response).js_ref.set(RawJsRef::init(js_value)) };
         Ok(js_value)
     }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -861,7 +861,17 @@ impl FetchTasklet {
                         self.drop_backpressure_if_unobserved(&readable, &bytes);
                     } else {
                         readable.value.ensure_still_alive();
-                        response.detach_readable_stream(&global_this);
+                        if self.response.get().is_some() {
+                            // Wrapper verified alive by the weak read: safe to
+                            // clear its cached-stream slot too.
+                            response.detach_readable_stream(&global_this);
+                        } else if let BodyValue::Locked(locked) = response.get_body_value() {
+                            // Dead wrapper: writing ZERO into its slot would
+                            // run a write barrier on an unmarked cell. Its
+                            // finalizer clears the slot; only release the
+                            // native ref here.
+                            let _ = core::mem::take(&mut locked.readable);
+                        }
                         bytes.on_data(Self::temporary_chunk(chunk, true))?;
                     }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1890,12 +1890,8 @@ impl FetchTasklet {
         // SAFETY: `response` is freshly allocated above; ownership transfers to JSC.
         let response_js = Response::make_maybe_pooled(&global_this, response);
         response_js.ensure_still_alive();
-        self.response = jsc::Weak::<FetchTasklet>::create(
-            response_js,
-            &global_this,
-            jsc::WeakRefType::FetchResponse,
-            self,
-        );
+        self.response =
+            jsc::Weak::<FetchTasklet>::create(response_js, jsc::WeakRefType::FetchResponse, self);
         // Response is intrusively refcounted; bump for native_response.
         // SAFETY: `response` is the live heap allocation owned by JSC after
         // `make_maybe_pooled`; `ref_` bumps the intrusive refcount.

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -838,7 +838,17 @@ impl FetchTasklet {
             bun_output::scoped_log!(FetchTasklet, "onBodyReceived Current Response");
             let size_hint = self.get_size_hint();
             response.set_size_hint(size_hint);
-            if let Some(readable) = response.get_body_readable_stream(&global_this) {
+            // Not `get_body_readable_stream`: this deferred callback reaches
+            // the Response through `native_response` (no JS root), so the
+            // wrapper may be unmarked but not yet swept and the `js_ref()` raw
+            // read is not liveness-checked. `Locked.readable` is a real
+            // `JSC::Weak` on the stream and reads `None` exactly when the
+            // stream is gone. Same guard as `BodyAbortListener::on_abort`.
+            let readable = match response.get_body_value() {
+                BodyValue::Locked(locked) => locked.readable.get(&global_this),
+                _ => None,
+            };
+            if let Some(readable) = readable {
                 bun_output::scoped_log!(
                     FetchTasklet,
                     "onBodyReceived CurrentResponse BodyReadableStream"

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -690,7 +690,7 @@ test("requests after GC collects the stopped server's wrapper are refused, never
       });
 
       let retained = [];
-      for (let round = 0; round < 150 && !closed; round++) {
+      for (let round = 0; round < 300 && !closed; round++) {
         // Park a request in flight before provoking a collection, so its
         // dispatch races the reap the way a loop-delivered straggler would.
         c.write("GET /r" + round + " HTTP/1.1\r\nHost: x\r\n\r\n");

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -596,6 +596,148 @@ test("should be able to await server.stop()", async () => {
   expect(async () => await fetch(server.url)).toThrow();
 });
 
+// Lifecycle canary for the JsRef weak-reference primitive, exercised through
+// Bun.serve's dispatch trampolines: after a graceful stop() downgrades the
+// server wrapper to a weak ref, an idle keep-alive socket keeps answering
+// requests while the wrapper is alive, and once GC collects the wrapper every
+// subsequent request must be refused (503 or close). A request must never be
+// dispatched through the dead wrapper: on a build where the weak read does
+// not go dead at reap time this surfaces as a 200 arriving after the first
+// refusal, or as heap-verification crashes (Heap::addToRememberedSet
+// "isMarked(cell)" asserts, Integrity::auditCell segfaults) taking the child
+// down. Each round parks a request in flight while an async full collection
+// runs, so a dispatch races every reap the way a real straggler would.
+//
+// No Bun.gc(true): a synchronous full GC sweeps synchronously, which
+// finalizes the wrapper in the same call and leaves nothing racing. The
+// retain-then-release churn grows old space so the non-synchronous
+// collections escalate to full (eden cannot collect the promoted wrapper).
+test("requests after GC collects the stopped server's wrapper are refused, never dispatched", async () => {
+  const childSrc = String.raw`
+      const net = require("net");
+      const tick = () => new Promise(r => setImmediate(r));
+      const fail = msg => {
+        console.log(JSON.stringify({ error: msg }));
+        process.exit(0);
+      };
+
+      // Keep the server binding confined to this scope so stale stack slots
+      // don't pin the wrapper once GC is asked to collect it.
+      const c = await (async () => {
+        let srv = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          idleTimeout: 0,
+          fetch() {
+            return new Response("ok");
+          },
+        });
+        const sock = net.connect(srv.port, "127.0.0.1");
+        sock.setNoDelay(true);
+        sock.on("error", () => {});
+        await new Promise((res, rej) => {
+          sock.on("connect", res);
+          sock.on("error", rej);
+        });
+        let first = "";
+        const onData = d => (first += d);
+        sock.on("data", onData);
+        sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+        const dl = Date.now() + 15000;
+        while (!first.includes("\r\n\r\nok") && Date.now() < dl) await tick();
+        if (!first.includes("\r\n\r\nok")) fail("no-first-response");
+        sock.off("data", onData);
+        // Closes the listener; with no in-flight requests or websockets the
+        // wrapper is downgraded to a weak ref while the idle keep-alive
+        // socket stays open. The drain promise is not awaited; its own
+        // semantics are not under test here.
+        srv.stop(false);
+        await tick();
+        srv = null;
+        return sock;
+      })();
+
+      // Wire-order response parser: n200/n503 count responses, and a 200
+      // parsed after the first 503 is the late-dispatch signal.
+      let buf = "";
+      let n200 = 0;
+      let n503 = 0;
+      let late200 = false;
+      let closed = false;
+      c.on("close", () => (closed = true));
+      c.on("data", d => {
+        buf += d;
+        while (true) {
+          const i200 = buf.indexOf(" 200 OK\r\n");
+          const i503 = buf.indexOf(" 503 Service Unavailable\r\n");
+          if (i200 !== -1 && (i503 === -1 || i200 < i503)) {
+            const end = buf.indexOf("\r\n\r\nok", i200);
+            if (end === -1) return; // wait for the body
+            n200++;
+            if (n503 > 0) late200 = true;
+            buf = buf.slice(end + 6);
+            continue;
+          }
+          if (i503 !== -1) {
+            const end = buf.indexOf("\r\n\r\n", i503);
+            if (end === -1) return; // wait for the header end
+            n503++;
+            buf = buf.slice(end + 4);
+            continue;
+          }
+          return;
+        }
+      });
+
+      let retained = [];
+      for (let round = 0; round < 150 && !closed; round++) {
+        // Park a request in flight before provoking a collection, so its
+        // dispatch races the reap the way a loop-delivered straggler would.
+        c.write("GET /r" + round + " HTTP/1.1\r\nHost: x\r\n\r\n");
+        for (let i = 0; i < 2000; i++) retained.push({ i, f: () => i, pad: new Array(4).fill(i) });
+        if (retained.length > 20000) retained = [];
+        Bun.gc(false);
+        await tick();
+      }
+      // Drain any trailing response/close.
+      const dl = Date.now() + 3000;
+      while (!closed && Date.now() < dl) await tick();
+      console.log(JSON.stringify({ n200over0: n200 > 0, n503, closed, late200 }));
+      process.exit(0);
+    `;
+
+  const results = [];
+  for (let i = 0; i < 3; i++) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", childSrc],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    let parsed = null;
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {}
+    results.push({
+      late200: parsed ? parsed.late200 : "unparsed: " + stdout.trim(),
+      served: parsed ? parsed.n200over0 : false,
+      died: parsed ? parsed.closed || parsed.n503 > 0 : false,
+      stderr: exitCode === 0 ? "" : stderr.slice(-500),
+      exitCode,
+    });
+    const last = results[results.length - 1];
+    if (last.exitCode !== 0 || last.late200 !== false) break;
+  }
+
+  expect(results.map(r => ({ late200: r.late200, served: r.served, stderr: r.stderr, exitCode: r.exitCode }))).toEqual(
+    Array.from({ length: results.length }, () => ({ late200: false, served: true, stderr: "", exitCode: 0 })),
+  );
+  // GC reaching the wrapper is scheduling-dependent per child; at least one
+  // child must drive the server to death for the run to prove anything.
+  expect(results.some(r => r.died)).toBe(true);
+}, 120_000);
+
 test("should be able to await server.stop(true) with keep alive", async () => {
   const { promise, resolve } = Promise.withResolvers();
   const ready = Promise.withResolvers();


### PR DESCRIPTION
### What

`JsRef::Weak` was a bare `JSValue` copy with no GC registration. `try_get()` could only check for empty/undefined/null, so between the collection that determines a wrapper dead and the sweep that runs its destructor (which is what flips the ref to `Finalized`), every deferred reader got a dangling value back and called callbacks out of a dead cell's slots.

Four recent use-after-free fixes hit exactly this shape through different holders: fs.watchFile (#36926), UDP socket unref (#36930), Bun.serve graceful stop (#35130, open), and Bun.Terminal PTY EOF (#36962, open). Those are the per-site functional fixes; this PR fixes the primitive so the failure mode cannot be memory-unsafe anywhere, including the holders nobody has fuzzed yet.

Crash signatures of this class on debug/ASAN builds:

```
ASSERTION FAILED: isMarked(cell)  (JSC::Heap::addToRememberedSet)
segfaults in JSC::Integrity::auditCellFully under Bun__JSValue__call
```

and on release builds, type confusion where an unrelated closure runs as the callback once the cell is reused.

### Fix

`JsRef::Weak` now holds a passive `bun_jsc::Weak` (a real `JSC::Weak` handle) registered against the value's own cell:

- `try_get()` reads `None` from the moment GC reaps the referent, before any sweep. A deferred reader skips its event instead of dispatching through a dead wrapper.
- `downgrade()` registers the weak handle while the `Strong` still roots the value, so there is no unrooted window. It keeps its no-argument signature: the handle registers against the cell's own `WeakSet`, no global needed.
- `upgrade()` of a reaped referent is a no-op instead of resurrecting a dangling `JSValue` into a `Strong`.
- `is_empty()` / `is_not_empty()` now report liveness, not just "a value was stored".

The C++ `Bun::WeakRef` constructor never used its `VM&` argument, so the `globalObject` parameter is dropped from `Bun__WeakRef__new` and from `Weak::create` / `Weak::create_passive` (three call sites), and the constructor now tolerates non-object values instead of null-dereferencing `value.getObject()`.

The `JsRef` enum shape and method signatures are unchanged, so the holders (server, sockets, timers, SQL, Terminal, watchers) pick the semantics up without edits. `ReadableStream`'s `StreamSlot` already used this exact Held-Strong/real-Weak pattern; this generalizes it.

One deliberate carve-out: the `js_ref` slot on `Request`/`Response` is only ever read synchronously while the wrapper is rooted by the caller, and wrapper cells are precise-allocated, so registering a weak handle there costs a 1 KB `WeakBlock` in the cell's own `WeakSet` on every construction. The request-clone-leak RSS test caught that regression on every release lane in the first CI run. Those two slots now use `RawJsRef`, a non-registering sibling type whose synchronous-reader contract is documented on the type; every deferred holder keeps the registered `JsRef`.

### Verification

- `bun bd test` over the heavy `JsRef` holders: `bun-server.test.ts`, `terminal.test.ts`, `fs.watchFile.test.ts`, `dgram.test.ts`, `fetch.stream.test.ts`, `setTimeout.test.js`, `request.test.ts`, `body.test.ts`. Failures match the clean-main baseline exactly (3 bun-server tests and 3 setTimeout RSS-leak tests fail identically on unmodified main in this environment).
- `request-clone-leak.test.ts` RSS deltas match the clean-main baseline within noise after the `RawJsRef` carve-out (measured side by side locally; the first push regressed the release lanes by 3-6x).
- New lifecycle test in `bun-server.test.ts`: a keep-alive connection keeps a request in flight against a gracefully stopped server while full collections run. It asserts the server answers while the downgraded wrapper is alive, refuses (503/close) once GC collects it, never serves a 200 after the first refusal, and never crashes.

### On fail-before provability

The dead-but-unswept wrapper state is not reachable from JS sequencing on a debug build: generated wrapper cells are PreciseAllocations, and `Heap::finalize()` sweeps those at the end of the same collection cycle that reaps them (`sweepInFinalize()` -> `sweepPreciseAllocations()`), before the event loop can dispatch anything. The remaining window is the gap between collector cycle-end and the mutator's finalize handshake, which is where the observed crashes live; it cannot be hit deterministically without instrumentation in `src/`.

Probe evidence: 20/20 runs of the straggler repro against the unfixed debug build complete as 200s, then one 503, then close, exit 0, no sanitizer output. The new test is therefore a canary for the crash signatures above rather than a deterministic reproduction; the fix removes the window by construction (the weak handle is cleared by the same reap that makes the cell dead, with no code path in between that can observe the difference).

### Perf

A weak read is one FFI call into `JSC::Weak::get()` instead of an inline tag check, and each downgraded holder owns one heap-allocated `Bun::WeakRef` node, freed on upgrade/finalize/overwrite. fetch() already uses the same mechanism per response (`WeakRefType::FetchResponse`). Hot per-object paths (`Request`/`Response` construction) pay nothing: their slots use the non-registering `RawJsRef`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->