### PR TITLE
Spawn the detached child outside the temp dir in the socket-inherit test

### DIFF
--- a/test/js/node/child_process/child-process-socket-inherit.test.ts
+++ b/test/js/node/child_process/child-process-socket-inherit.test.ts
@@ -11,6 +11,7 @@ test.skipIf(!isWindows)("detached child does not inherit the parent's listening 
     "parent.mjs": `
       import { spawn } from "node:child_process";
       import { createServer } from "node:http";
+      import { tmpdir } from "node:os";
 
       const server = createServer((_request, response) => response.end("ok"));
       await new Promise((resolve, reject) => {
@@ -20,7 +21,11 @@ test.skipIf(!isWindows)("detached child does not inherit the parent's listening 
       const port = server.address().port;
 
       // Spawn a detached child while the listen socket is open, then exit.
+      // cwd: the child outlives the test and would otherwise inherit this temp
+      // dir as its working directory, making tempDir cleanup fail with EBUSY on
+      // Windows while the killed child is still tearing down.
       const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 100000)"], {
+        cwd: tmpdir(),
         detached: true,
         stdio: "ignore",
         windowsHide: true,


### PR DESCRIPTION
Fixes the Windows CI failure in `test/js/node/child_process/child-process-socket-inherit.test.ts`, which has been failing on the Windows 11 aarch64 lane since the test landed in #36938 (for example in build 89207):

```
EBUSY: resource busy or locked, rm 'C:\Windows\Temp\buntmp-Fbshlf\socket-inherit_Ev5bLB'
    at [Symbol.dispose] (C:\buildkite-agent\build\test\harness.ts:462:8)
```

### Cause

The fixture spawns a detached child (`setTimeout(() => {}, 100000)`) that inherits the parent's cwd, which is the test's temp dir. The test kills the child in its `finally`, but on Windows `process.kill` only initiates `TerminateProcess`: the process object, including its working directory handle, is released asynchronously. `using dir` disposal runs `fs.rmSync` immediately after, so cleanup races the child's teardown and fails with EBUSY whenever the child has not finished dying. The socket assertions themselves pass (all 3 expect calls run); only cleanup fails. On the slower aarch64 runners the rm loses the race most of the time.

It is worse on the failure paths: if the parent fixture exits non-zero, `childPid` is never parsed, the kill never runs, and the child holds the temp dir for the full 100 seconds.

### Fix

Spawn the detached child with an explicit `cwd` outside the temp dir (`os.tmpdir()`). The child then never holds the directory that disposal removes, in every path, with no timing dependence. `cwd` is independent of handle inheritance (`lpCurrentDirectory` vs `bInheritHandles` in `CreateProcess`), so the code path exercised by the test is unchanged: the child is still spawned with inheritable-handle semantics while the listen socket is open.

I considered retrying EBUSY in the harness `tempDir` disposal instead, but that would mask genuine process and handle leaks in every other Windows test.

### Verification (Windows 11 aarch64, the failing lane)

- Unmodified test, release build with the #36938 fix (same setup as CI): EBUSY in 3 of 5 runs.
- Fixed test, same build: 20 of 20 runs pass.
- Fixed test, debug build with `packages/bun-usockets/src/bsd.c` reverted to its pre-#36938 state: fails with `Expected: "ECONNREFUSED", Received: "connected"`, so the test still detects the original inherited-socket bug (#36936).
- Fixed test, debug build with current `bsd.c`: passes.

The test is `skipIf(!isWindows)`, so Linux lanes are unaffected.
