### PR TITLE
install: document and pin the isolated linker's store layout

### DIFF
--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -90,7 +90,7 @@ node_modules/
 
 ### Resolution algorithm
 
-1. **Central store** — every package is installed once per *(package, resolved peer set)* in `node_modules/.bun/`
+1. **Central store** — every package is installed once per _(package, resolved peer set)_ in `node_modules/.bun/`
 2. **Symlinks** — the project's `node_modules`, each workspace's `node_modules`, and each store entry's `node_modules` contain relative symlinks to the store entries they depend on
 3. **Peer resolution** — each distinct resolved peer dependency set gets its own store entry, keyed by a hash suffix
 4. **Deduplication** — packages with identical resolutions and peer dependency sets are shared
@@ -111,7 +111,7 @@ The layout of `node_modules/.bun` is a stable, documented format. External tools
 
 ### Store entries
 
-Bun creates one directory in the store per *(package, resolved peer set)* pair:
+Bun creates one directory in the store per _(package, resolved peer set)_ pair:
 
 ```bash store entry path icon="folder"
 node_modules/.bun/<entry>/node_modules/<name>
@@ -121,14 +121,14 @@ node_modules/.bun/<entry>/node_modules/<name>
 
 `<entry>` is `<name>@<resolution>`, followed by a [peer-set suffix](#the-peer-set-suffix) when the package has resolved peer dependencies. In both the name and the resolution, the characters `/`, `\`, `:` and `#` are replaced with `+`:
 
-| Dependency source | Resolution text | Example entry name |
-| ----------------------- | ----------------------------------------- | ------------------------------------ |
-| npm registry | the resolved version | `is-number@7.0.0`, `@types+react@18.2.0` |
-| folder (`file:` directory) | `file+` + the path | `local-pkg@file+vendor+local-pkg` |
-| local tarball | the tarball path | `bar@.+bar-0.0.2.tgz` |
-| remote tarball | the tarball URL | `bar@https+++example.com+bar-0.0.2.tgz` |
-| Git | `git+` + the repository + `+` + the commit | `pkg@git+https+++github.com+user+repo.git+<commit>` |
-| GitHub | `github+` + owner + `+` + repo + `+` + the commit | `pkg@github+user+repo+<commit>` |
+| Dependency source          | Resolution text                                   | Example entry name                                  |
+| -------------------------- | ------------------------------------------------- | --------------------------------------------------- |
+| npm registry               | the resolved version                              | `is-number@7.0.0`, `@types+react@18.2.0`            |
+| folder (`file:` directory) | `file+` + the path                                | `local-pkg@file+vendor+local-pkg`                   |
+| local tarball              | the tarball path                                  | `bar@.+bar-0.0.2.tgz`                               |
+| remote tarball             | the tarball URL                                   | `bar@https+++example.com+bar-0.0.2.tgz`             |
+| Git                        | `git+` + the repository + `+` + the commit        | `pkg@git+https+++github.com+user+repo.git+<commit>` |
+| GitHub                     | `github+` + owner + `+` + repo + `+` + the commit | `pkg@github+user+repo+<commit>`                     |
 
 The root package and workspace packages never get store directories: dependents link directly to the project or workspace directory instead.
 
@@ -198,7 +198,7 @@ Workspace packages are not linked into the root `node_modules` unless the root p
 
 ### The fallback directory
 
-`node_modules/.bun/node_modules` contains one symlink per package *name*, pointing at the first store entry installed under that name. This directory sits on the resolution path of every package inside the store (between the entry's own `node_modules` and the project's), so it serves as a last-resort lookup for packages that require dependencies they did not declare. The [`install.hoistPattern`](/runtime/bunfig#install-hoistpattern) setting controls which names land here, and [`install.publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) additionally links matching names into the project's `node_modules`.
+`node_modules/.bun/node_modules` contains one symlink per package _name_, pointing at the first store entry installed under that name. This directory sits on the resolution path of every package inside the store (between the entry's own `node_modules` and the project's), so it serves as a last-resort lookup for packages that require dependencies they did not declare. The [`install.hoistPattern`](/runtime/bunfig#install-hoistpattern) setting controls which names land here, and [`install.publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) additionally links matching names into the project's `node_modules`.
 
 ### Scripts and the global store
 

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -146,7 +146,7 @@ The suffix is derived from the entry's resolved peers:
 
 1. Collect every peer dependency of the package that resolved to a package in the graph (required, optional, and auto-installed peers alike). Peers that did not resolve are excluded; a package whose peers resolved to nothing gets no suffix at all.
 2. Sort them by package name (byte order).
-3. Concatenate `<name><resolution>` for each, with no separator. The resolution text is the resolved version for registry packages; in general it is the same text that follows `<name>@` in `bun.lock`.
+3. Concatenate `<name><resolution>` for each, with no separator. The resolution text is the resolved version for registry packages; for peers from other sources it is the text that follows `<name>@` in `bun.lock`, with one exception: a folder-resolved peer hashes the bare path (for example `vendor/local-pkg`) without the `file:` prefix that `bun.lock` shows.
 4. Hash the bytes with 64-bit wyhash (the original "v1" variant with 32-byte rounds and five 64-bit primes), seed `0`, and format the result as 16 lowercase, zero-padded hex digits.
 
 Worked example: `peer-deps-fixed@1.0.0` declares a peer on `no-deps@^1.0.0`. Where that peer resolves to `1.0.0`, the hashed input is the bytes `no-deps1.0.0` and the entry is `peer-deps-fixed@1.0.0+7347ae2d86f1441a`; where it resolves to `1.1.0`, the input is `no-deps1.1.0` and the entry is `peer-deps-fixed@1.0.0+7ff199101204a65d`. Both entries coexist in the store, each linking its own `no-deps`.
@@ -164,7 +164,7 @@ node_modules/.bun/two-range-deps@1.0.0/node_modules/
 ```
 
 - The link is named after the **alias** the package depends on; the target uses the dependency's **real** package name.
-- Targets are relative: `../../<dep entry>/node_modules/<dep name>`, with one extra `../` when the alias is scoped (the link lives inside the alias's `@scope/` directory).
+- Targets are relative: `../../<dep entry>/node_modules/<dep name>`, with one extra `../` when the alias is scoped (the link lives inside the alias's `@scope/` directory). See [Windows fallback behavior](#windows-fallback-behavior) for the one case where targets are absolute.
 - A dependency on a workspace links to the workspace directory outside the store.
 - If a package depends on an alias equal to its own name, the link nests inside the package directory itself (`<entry>/node_modules/<name>/node_modules/<name>`) instead of colliding with it.
 
@@ -175,6 +175,10 @@ Node.js resolution walks real directories, so a package can only resolve the dep
 Each store entry's `node_modules/.bin` contains the executables of the package itself and of its resolved dependencies. The links are relative and resolve through the entry's own `node_modules`, e.g. `.bin/what-bin -> ../what-bin/what-bin.js`. On Windows, `.bin` entries are `.exe`/`.bunx` shims instead of symlinks.
 
 The project root and each workspace get the same treatment: bins of their direct dependencies land in `<project>/node_modules/.bin` and `<workspace>/node_modules/.bin`.
+
+### Windows fallback behavior
+
+Bun creates the links described here as symbolic links on every platform, including Windows when symbolic link creation is available (Developer Mode, or an elevated process). When it is not, Bun falls back to NTFS junctions for directory links. Junction targets are necessarily absolute paths, so in that mode link targets are not relative (reading one returns the absolute target, possibly with a trailing separator) and the installed tree is not relocatable. Re-running `bun install` accepts either form for an existing link. `.bin` entries on Windows are shims rather than links in both modes, as noted above.
 
 ### Project and workspace `node_modules`
 
@@ -204,7 +208,9 @@ Workspace packages are not linked into the root `node_modules` unless the root p
 
 Lifecycle scripts run with the store entry as their working directory (`<entry>/node_modules/<name>`), so a package that mutates its own files affects only that entry.
 
-When [`install.globalStore`](/runtime/bunfig#install-globalstore) is enabled, eligible entries are materialized in the shared [global virtual store](/pm/global-store) and `node_modules/.bun/<entry>` becomes a symlink to `<cache>/links/<entry>-<hash>`. The entry names and the layout inside each entry are unchanged; only the physical location moves.
+When [`install.globalStore`](/runtime/bunfig#install-globalstore) is enabled, eligible entries (npm, git, and tarball packages; folder, symlink, patched, root, and workspace packages always stay project-local) are materialized in the shared [global virtual store](/pm/global-store) and `node_modules/.bun/<entry>` becomes a symlink to `<cache>/links/<entry>-<hash>`. The entry names under `node_modules/.bun/` (including the peer-set suffix), the link names, the package directory, and the `.bin` shape are all the same as above, with two differences: the entry itself is a symlink rather than a directory, and dependency symlinks inside a global entry point at sibling global entries, so their relative targets carry the global `-<hash>` suffix (`../../<dep entry>-<hash>/node_modules/<dep name>`).
+
+The 16-hex `-<hash>` suffix is an internal cache key derived from the package's tarball integrity and its resolved dependency closure. It is **not part of this format** and is not reproducible externally; treat names under `<cache>/links/` as opaque and address entries through `node_modules/.bun/<entry>`.
 
 ## Comparison with hoisted installs
 

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -71,24 +71,31 @@ Instead of hoisting dependencies, isolated installs create a two-tier structure:
 
 ```bash tree layout of node_modules icon="list-tree"
 node_modules/
-├── .bun/                          # Central package store
-│   ├── package@1.0.0/             # Versioned package installations
+├── .bin/                               # Bins of the project's direct dependencies
+├── .bun/                               # Central package store
+│   ├── node_modules/                   # Fallback directory (one link per package name)
+│   ├── package@1.0.0/                  # One entry per package + resolved peer set
 │   │   └── node_modules/
-│   │       └── package/           # Actual package files
-│   ├── @scope+package@2.1.0/      # Scoped packages (+ replaces /)
+│   │       ├── .bin/                   # Bins of this package and its dependencies
+│   │       ├── package/                # Actual package files
+│   │       └── dep -> ../../dep@2.0.0/node_modules/dep   # One link per dependency
+│   ├── @scope+package@2.1.0/           # Scoped packages (+ replaces /)
 │   │   └── node_modules/
 │   │       └── @scope/
 │   │           └── package/
+│   ├── package@1.0.0+f8a822eca018d0a1/ # Entry with resolved peer dependencies
 │   └── ...
-└── package-name -> .bun/package@1.0.0/node_modules/package  # Symlinks
+└── package -> .bun/package@1.0.0/node_modules/package      # Direct dependencies
 ```
 
 ### Resolution algorithm
 
-1. **Central store** — All packages are installed in `node_modules/.bun/package@version/` directories
-2. **Symlinks** — Top-level `node_modules` contains symlinks pointing to the central store
-3. **Peer resolution** — Complex peer dependencies create specialized directory names
-4. **Deduplication** — Packages with identical package IDs and peer dependency sets are shared
+1. **Central store** — every package is installed once per *(package, resolved peer set)* in `node_modules/.bun/`
+2. **Symlinks** — the project's `node_modules`, each workspace's `node_modules`, and each store entry's `node_modules` contain relative symlinks to the store entries they depend on
+3. **Peer resolution** — each distinct resolved peer dependency set gets its own store entry, keyed by a hash suffix
+4. **Deduplication** — packages with identical resolutions and peer dependency sets are shared
+
+The exact naming and linking rules are specified in the [store layout reference](#store-layout-reference) below.
 
 ### Workspace handling
 
@@ -97,6 +104,107 @@ In monorepos, workspace dependencies are handled specially:
 - **Workspace packages** — Symlinked directly to their source directories, not the store
 - **Workspace dependencies** — Can access other workspace packages in the monorepo
 - **External dependencies** — Installed in the isolated store
+
+## Store layout reference
+
+The layout of `node_modules/.bun` is a stable, documented format. External tools can rely on it (for example, to cache each package as its own build action in a monorepo, or to assemble the same tree from already-extracted packages), and Bun's test suite pins this layout. Changes to it are treated as breaking changes to a documented format.
+
+### Store entries
+
+Bun creates one directory in the store per *(package, resolved peer set)* pair:
+
+```bash store entry path icon="folder"
+node_modules/.bun/<entry>/node_modules/<name>
+```
+
+`<name>` is the package's real name from its `package.json`, not the alias it was installed under. Scoped packages keep the scope as a real directory level: `@scope/pkg` lives at `<entry>/node_modules/@scope/pkg`.
+
+`<entry>` is `<name>@<resolution>`, followed by a [peer-set suffix](#the-peer-set-suffix) when the package has resolved peer dependencies. In both the name and the resolution, the characters `/`, `\`, `:` and `#` are replaced with `+`:
+
+| Dependency source | Resolution text | Example entry name |
+| ----------------------- | ----------------------------------------- | ------------------------------------ |
+| npm registry | the resolved version | `is-number@7.0.0`, `@types+react@18.2.0` |
+| folder (`file:` directory) | `file+` + the path | `local-pkg@file+vendor+local-pkg` |
+| local tarball | the tarball path | `bar@.+bar-0.0.2.tgz` |
+| remote tarball | the tarball URL | `bar@https+++example.com+bar-0.0.2.tgz` |
+| Git | `git+` + the repository + `+` + the commit | `pkg@git+https+++github.com+user+repo.git+<commit>` |
+| GitHub | `github+` + owner + `+` + repo + `+` + the commit | `pkg@github+user+repo+<commit>` |
+
+The root package and workspace packages never get store directories: dependents link directly to the project or workspace directory instead.
+
+Entry names are constructed, never parsed: versions, paths and URLs can themselves contain `@` and `+`, so the mapping is not reversible. Derive names forward from the package name, resolution, and peer set rather than splitting a directory name back into parts.
+
+### The peer-set suffix
+
+A package with peer dependencies can resolve to different dependency sets depending on where it appears in the graph, so each distinct resolved peer set gets its own store entry. These entries append `+` followed by 16 lowercase hex digits to the entry name:
+
+```bash store entry with peers icon="folder"
+node_modules/.bun/peer-deps-fixed@1.0.0+7347ae2d86f1441a/
+```
+
+The suffix is derived from the entry's resolved peers:
+
+1. Collect every peer dependency of the package that resolved to a package in the graph (required, optional, and auto-installed peers alike). Peers that did not resolve are excluded; a package whose peers resolved to nothing gets no suffix at all.
+2. Sort them by package name (byte order).
+3. Concatenate `<name><resolution>` for each, with no separator. The resolution text is the resolved version for registry packages; in general it is the same text that follows `<name>@` in `bun.lock`.
+4. Hash the bytes with 64-bit wyhash (the original "v1" variant with 32-byte rounds and five 64-bit primes), seed `0`, and format the result as 16 lowercase, zero-padded hex digits.
+
+Worked example: `peer-deps-fixed@1.0.0` declares a peer on `no-deps@^1.0.0`. Where that peer resolves to `1.0.0`, the hashed input is the bytes `no-deps1.0.0` and the entry is `peer-deps-fixed@1.0.0+7347ae2d86f1441a`; where it resolves to `1.1.0`, the input is `no-deps1.1.0` and the entry is `peer-deps-fixed@1.0.0+7ff199101204a65d`. Both entries coexist in the store, each linking its own `no-deps`.
+
+### Dependency symlinks inside an entry
+
+Alongside the package directory, an entry's `node_modules` contains one relative symlink per resolved dependency of the package (regular, optional, and resolved peer dependencies alike):
+
+```bash tree layout of a store entry icon="list-tree"
+node_modules/.bun/two-range-deps@1.0.0/node_modules/
+├── two-range-deps/                # the package's own files
+├── no-deps -> ../../no-deps@1.1.0/node_modules/no-deps
+└── @types/
+    └── is-number -> ../../../@types+is-number@2.0.0/node_modules/@types/is-number
+```
+
+- The link is named after the **alias** the package depends on; the target uses the dependency's **real** package name.
+- Targets are relative: `../../<dep entry>/node_modules/<dep name>`, with one extra `../` when the alias is scoped (the link lives inside the alias's `@scope/` directory).
+- A dependency on a workspace links to the workspace directory outside the store.
+- If a package depends on an alias equal to its own name, the link nests inside the package directory itself (`<entry>/node_modules/<name>/node_modules/<name>`) instead of colliding with it.
+
+Node.js resolution walks real directories, so a package can only resolve the dependencies linked next to it.
+
+### Bin placement
+
+Each store entry's `node_modules/.bin` contains the executables of the package itself and of its resolved dependencies. The links are relative and resolve through the entry's own `node_modules`, e.g. `.bin/what-bin -> ../what-bin/what-bin.js`. On Windows, `.bin` entries are `.exe`/`.bunx` shims instead of symlinks.
+
+The project root and each workspace get the same treatment: bins of their direct dependencies land in `<project>/node_modules/.bin` and `<workspace>/node_modules/.bin`.
+
+### Project and workspace `node_modules`
+
+The project's `node_modules` serves as the root's own entry: one relative symlink per direct dependency, named by the alias:
+
+```bash tree layout icon="list-tree"
+node_modules/
+├── is-number -> .bun/is-number@7.0.0/node_modules/is-number
+└── @types/
+    └── react -> ../.bun/@types+react@18.2.0/node_modules/@types/react
+```
+
+Workspace packages link their dependencies the same way from their own `node_modules`, pointing into the root store:
+
+```bash workspace links icon="folder"
+packages/app/node_modules/is-number -> ../../../node_modules/.bun/is-number@7.0.0/node_modules/is-number
+packages/app/node_modules/my-lib -> ../../my-lib
+```
+
+Workspace packages are not linked into the root `node_modules` unless the root package depends on them.
+
+### The fallback directory
+
+`node_modules/.bun/node_modules` contains one symlink per package *name*, pointing at the first store entry installed under that name. This directory sits on the resolution path of every package inside the store (between the entry's own `node_modules` and the project's), so it serves as a last-resort lookup for packages that require dependencies they did not declare. The [`install.hoistPattern`](/runtime/bunfig#install-hoistpattern) setting controls which names land here, and [`install.publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) additionally links matching names into the project's `node_modules`.
+
+### Scripts and the global store
+
+Lifecycle scripts run with the store entry as their working directory (`<entry>/node_modules/<name>`), so a package that mutates its own files affects only that entry.
+
+When [`install.globalStore`](/runtime/bunfig#install-globalstore) is enabled, eligible entries are materialized in the shared [global virtual store](/pm/global-store) and `node_modules/.bun/<entry>` becomes a symlink to `<cache>/links/<entry>-<hash>`. The entry names and the layout inside each entry are unchanged; only the physical location moves.
 
 ## Comparison with hoisted installs
 
@@ -113,14 +221,14 @@ In monorepos, workspace dependencies are handled specially:
 
 ### Peer dependency handling
 
-Isolated installs encode peer dependencies in the store path:
+Isolated installs encode resolved peer dependencies in the store path:
 
 ```bash tree layout of node_modules icon="list-tree"
-# Package with peer dependencies creates specialized paths
-node_modules/.bun/package@1.0.0_react@18.2.0/
+# Package with resolved peer dependencies creates specialized paths
+node_modules/.bun/package@1.0.0+f8a822eca018d0a1/
 ```
 
-The directory name includes both the package version and its peer dependency versions, so each unique combination gets its own installation.
+The directory name includes a hash of the package's resolved peer dependency set, so each unique combination gets its own installation. See [the peer-set suffix](#the-peer-set-suffix) for the exact derivation.
 
 ### Global virtual store
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -988,6 +988,11 @@ pub(crate) fn install_isolated_packages(
                 // nothing matched - create a new entry
             }
 
+            // This derivation (name-sorted `<peer name><peer resolution>`
+            // concatenation, Wyhash11 seed 0) names store entries on disk and
+            // is documented as a stable format in
+            // docs/pm/isolated-installs.mdx#the-peer-set-suffix. Changing any
+            // part of it is a breaking change to that format.
             let new_entry_peer_hash: store::entry::PeerHash = 'peer_hash: {
                 let peers = &node_peers[entry.node_id.get() as usize];
                 if peers.len() == 0 {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -988,11 +988,9 @@ pub(crate) fn install_isolated_packages(
                 // nothing matched - create a new entry
             }
 
-            // This derivation (name-sorted `<peer name><peer resolution>`
-            // concatenation, Wyhash11 seed 0) names store entries on disk and
-            // is documented as a stable format in
-            // docs/pm/isolated-installs.mdx#the-peer-set-suffix. Changing any
-            // part of it is a breaking change to that format.
+            // Names the on-disk store entry (`+<16 hex>` suffix); documented as a
+            // stable format in docs/pm/isolated-installs.mdx#the-peer-set-suffix.
+            // Changing the derivation is breaking.
             let new_entry_peer_hash: store::entry::PeerHash = 'peer_hash: {
                 let peers = &node_peers[entry.node_id.get() as usize];
                 if peers.len() == 0 {

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -250,10 +250,8 @@ impl<T: Copy> OrderedArraySet<T> {
 // or if peers are involved (see `PeerHash`):
 //   './node_modules/.bun/name@version+<16 hex digit peer set hash>/node_modules/name'
 //
-// This layout is documented as a stable format in
-// docs/pm/isolated-installs.mdx#store-layout-reference and pinned by the
-// "store layout contract" tests in test/cli/install/isolated-install.test.ts;
-// changing it is a breaking change to that format.
+// This layout is a documented stable format
+// (docs/pm/isolated-installs.mdx#store-layout-reference); changing it is breaking.
 //
 // Entries are created for workspaces (including the root), but only in memory. If
 // a module depends on a workspace, a symlink is created pointing outside the store

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -247,8 +247,13 @@ impl<T: Copy> OrderedArraySet<T> {
 //
 // A unique entry in the store. As a path looks like:
 //   './node_modules/.bun/name@version/node_modules/name'
-// or if peers are involved:
-//   './node_modules/.bun/name@version_peer1@version+peer2@version/node_modules/name'
+// or if peers are involved (see `PeerHash`):
+//   './node_modules/.bun/name@version+<16 hex digit peer set hash>/node_modules/name'
+//
+// This layout is documented as a stable format in
+// docs/pm/isolated-installs.mdx#store-layout-reference and pinned by the
+// "store layout contract" tests in test/cli/install/isolated-install.test.ts;
+// changing it is a breaking change to that format.
 //
 // Entries are created for workspaces (including the root), but only in memory. If
 // a module depends on a workspace, a symlink is created pointing outside the store

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2514,13 +2514,12 @@ describe("store layout contract", () => {
     // Inner layout: the package's own files live at
     // `<entry>/node_modules/<real name>` (scoped packages keep the `@scope/`
     // directory level).
+    expect(await file(join(bun, "bar@.+bar-0.0.2.tgz", "node_modules", "bar", "package.json")).json()).toMatchObject({
+      name: "bar",
+      version: "0.0.2",
+    });
     expect(
-      await file(join(bun, "bar@.+bar-0.0.2.tgz", "node_modules", "bar", "package.json")).json(),
-    ).toMatchObject({ name: "bar", version: "0.0.2" });
-    expect(
-      await file(
-        join(bun, "@types+is-number@1.0.0", "node_modules", "@types", "is-number", "package.json"),
-      ).json(),
+      await file(join(bun, "@types+is-number@1.0.0", "node_modules", "@types", "is-number", "package.json")).json(),
     ).toMatchObject({ name: "@types/is-number", version: "1.0.0" });
 
     // Each resolved dependency (peers included) is a relative symlink next to
@@ -2529,9 +2528,7 @@ describe("store layout contract", () => {
     const peerEntry = join(bun, "2-peer-deps-c@1.0.0+eadc6a10a694605e", "node_modules");
     expect(await readdirSorted(peerEntry)).toEqual(["2-peer-deps-c", "a-dep", "no-deps"]);
     expect(readlinkSync(join(peerEntry, "a-dep"))).toBe(join("..", "..", "a-dep@1.0.10", "node_modules", "a-dep"));
-    expect(readlinkSync(join(peerEntry, "no-deps"))).toBe(
-      join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"),
-    );
+    expect(readlinkSync(join(peerEntry, "no-deps"))).toBe(join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"));
     expect(readlinkSync(join(bun, "two-range-deps@1.0.0", "node_modules", "no-deps"))).toBe(
       join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"),
     );

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2451,6 +2451,8 @@ describe("store layout contract", () => {
   // entry naming (including the peer-set hash derivation), the inner
   // `node_modules` layout, symlink targets, and `.bin` placement. A failure here
   // is a breaking change to that format; update the docs together with the code.
+  // CI runners create real symlinks, so these tests pin the symlink mode; the
+  // Windows junction fallback (absolute targets) is documented but not pinned.
 
   test("entry naming, inner layout, and bin placement", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
@@ -2458,6 +2460,20 @@ describe("store layout contract", () => {
     await write(
       join(packageDir, "vendor", "local-pkg", "package.json"),
       JSON.stringify({ name: "local-pkg", version: "3.2.1" }),
+    );
+    // A folder-resolved package with a folder-resolved peer: the peer hash
+    // input uses the bare path (`vendor/local-pkg`), not the `file:` prefixed
+    // form that bun.lock displays. The peer is optional because resolving a
+    // required peer range consults the registry for the name, which does not
+    // exist there; the resolved peer still joins the peer set either way.
+    await write(
+      join(packageDir, "vendor", "dep-with-peer", "package.json"),
+      JSON.stringify({
+        name: "dep-with-peer",
+        version: "1.0.0",
+        peerDependencies: { "local-pkg": "*" },
+        peerDependenciesMeta: { "local-pkg": { optional: true } },
+      }),
     );
     // `bar-0.0.2.tgz` contains the package `bar@0.0.2`.
     await cp(join(import.meta.dir, "bar-0.0.2.tgz"), join(packageDir, "bar-0.0.2.tgz"));
@@ -2482,6 +2498,7 @@ describe("store layout contract", () => {
           "uses-what-bin": "1.0.0",
           "what-bin": "1.0.0",
           "local-pkg": "file:./vendor/local-pkg",
+          "dep-with-peer": "file:./vendor/dep-with-peer",
           "bar-tarball": "file:./bar-0.0.2.tgz",
         },
       }),
@@ -2497,12 +2514,15 @@ describe("store layout contract", () => {
     // the real package name from the tarball, not the alias. An entry with
     // resolved peers appends `+` and 16 lowercase hex digits of
     // wyhash(seed 0, concat of `<peer name><peer resolution>` sorted by name):
-    // here wyhash("a-dep1.0.10no-deps1.0.0") == 0xeadc6a10a694605e.
+    // here wyhash("a-dep1.0.10no-deps1.0.0") == 0xeadc6a10a694605e, and for
+    // the folder peer wyhash("local-pkgvendor/local-pkg") == 0x41721fadd4146e10
+    // (bare path, no `file:` prefix).
     expect(await readdirSorted(bun)).toEqual([
       "2-peer-deps-c@1.0.0+eadc6a10a694605e",
       "@types+is-number@1.0.0",
       "a-dep@1.0.10",
       "bar@.+bar-0.0.2.tgz",
+      "dep-with-peer@file+vendor+dep-with-peer+41721fadd4146e10",
       "local-pkg@file+vendor+local-pkg",
       "no-deps@1.0.0",
       "node_modules",
@@ -2535,6 +2555,11 @@ describe("store layout contract", () => {
     expect(readlinkSync(join(bun, "two-range-deps@1.0.0", "node_modules", "@types", "is-number"))).toBe(
       join("..", "..", "..", "@types+is-number@1.0.0", "node_modules", "@types", "is-number"),
     );
+    expect(
+      readlinkSync(
+        join(bun, "dep-with-peer@file+vendor+dep-with-peer+41721fadd4146e10", "node_modules", "local-pkg"),
+      ),
+    ).toBe(join("..", "..", "local-pkg@file+vendor+local-pkg", "node_modules", "local-pkg"));
 
     // The project's own node_modules is the root entry: a relative symlink per
     // direct dependency, named by the alias and pointing into the store.
@@ -2545,6 +2570,7 @@ describe("store layout contract", () => {
       "@types",
       "a-dep",
       "bar-tarball",
+      "dep-with-peer",
       "local-pkg",
       "no-deps",
       "two-range-deps",
@@ -2694,5 +2720,68 @@ describe("store layout contract", () => {
     } else {
       expect(readlinkSync(join(wsA, ".bin", "what-bin"))).toBe(join("..", "what-bin", "what-bin.js"));
     }
+  });
+
+  test("global store keeps entry names; only the physical location changes", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated", globalStore: true },
+    });
+
+    await write(
+      join(packageDir, "vendor", "local-pkg", "package.json"),
+      JSON.stringify({ name: "local-pkg", version: "3.2.1" }),
+    );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "store-layout-global-store",
+        dependencies: {
+          "peer-deps-fixed": "1.0.0",
+          "no-deps": "1.0.0",
+          "local-pkg": "file:./vendor/local-pkg",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const bun = join(packageDir, "node_modules", ".bun");
+
+    // Entry names under `node_modules/.bun/` (including the peer-set suffix)
+    // are identical to the project-local mode.
+    expect(await readdirSorted(bun)).toEqual([
+      "local-pkg@file+vendor+local-pkg",
+      "no-deps@1.0.0",
+      "node_modules",
+      "peer-deps-fixed@1.0.0+7347ae2d86f1441a",
+    ]);
+
+    // Eligible entries become symlinks into `<cache>/links/<entry>-<hash>`;
+    // the 16-hex global hash is an internal cache key, not part of the format.
+    expect(lstatSync(join(bun, "no-deps@1.0.0")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(bun, "no-deps@1.0.0"))).toMatch(/links[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}$/);
+    expect(lstatSync(join(bun, "peer-deps-fixed@1.0.0+7347ae2d86f1441a")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(bun, "peer-deps-fixed@1.0.0+7347ae2d86f1441a"))).toMatch(
+      /links[\/\\]peer-deps-fixed@1\.0\.0\+7347ae2d86f1441a-[0-9a-f]{16}$/,
+    );
+
+    // Folder-resolved packages always stay project-local.
+    expect(lstatSync(join(bun, "local-pkg@file+vendor+local-pkg")).isSymbolicLink()).toBe(false);
+    expect(lstatSync(join(bun, "local-pkg@file+vendor+local-pkg")).isDirectory()).toBe(true);
+
+    // Dep symlinks inside a global entry point at sibling global entries, so
+    // their relative targets carry the `-<hash>` suffix; the shape matches the
+    // project-local form once that suffix is stripped.
+    const globalPeerTarget = readlinkSync(
+      join(bun, "peer-deps-fixed@1.0.0+7347ae2d86f1441a", "node_modules", "no-deps"),
+    );
+    expect(globalPeerTarget).toMatch(/^\.\.[\/\\]\.\.[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}[\/\\]node_modules[\/\\]no-deps$/);
+    expect(withoutEntryHash(globalPeerTarget)).toBe(join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"));
+
+    // The project side is unchanged: root links still go through the
+    // project-local `.bun/<entry>` indirection.
+    expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+      join(".bun", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
   });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2556,9 +2556,7 @@ describe("store layout contract", () => {
       join("..", "..", "..", "@types+is-number@1.0.0", "node_modules", "@types", "is-number"),
     );
     expect(
-      readlinkSync(
-        join(bun, "dep-with-peer@file+vendor+dep-with-peer+41721fadd4146e10", "node_modules", "local-pkg"),
-      ),
+      readlinkSync(join(bun, "dep-with-peer@file+vendor+dep-with-peer+41721fadd4146e10", "node_modules", "local-pkg")),
     ).toBe(join("..", "..", "local-pkg@file+vendor+local-pkg", "node_modules", "local-pkg"));
 
     // The project's own node_modules is the root entry: a relative symlink per
@@ -2775,7 +2773,9 @@ describe("store layout contract", () => {
     const globalPeerTarget = readlinkSync(
       join(bun, "peer-deps-fixed@1.0.0+7347ae2d86f1441a", "node_modules", "no-deps"),
     );
-    expect(globalPeerTarget).toMatch(/^\.\.[\/\\]\.\.[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}[\/\\]node_modules[\/\\]no-deps$/);
+    expect(globalPeerTarget).toMatch(
+      /^\.\.[\/\\]\.\.[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}[\/\\]node_modules[\/\\]no-deps$/,
+    );
     expect(withoutEntryHash(globalPeerTarget)).toBe(join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"));
 
     // The project side is unchanged: root links still go through the

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
-import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { cp, mkdir, readlink, rm, symlink } from "fs/promises";
+import { VerdaccioRegistry, bunEnv, bunExe, isWindows, readdirSorted, runBunInstall, tempDir } from "harness";
 import { dirname, join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -2442,4 +2442,260 @@ test("invalid --linker value is echoed back in the error", async () => {
   expect(stderr).toContain('--linker: "isoalted"');
   expect(stderr).toContain("'isolated' or 'hoisted'");
   expect(exitCode).toBe(1);
+});
+
+describe("store layout contract", () => {
+  // The `node_modules/.bun` layout is documented as a stable format
+  // (docs/pm/isolated-installs.mdx#store-layout-reference) so external tools can
+  // cache and reassemble store entries. These tests pin the documented shape:
+  // entry naming (including the peer-set hash derivation), the inner
+  // `node_modules` layout, symlink targets, and `.bin` placement. A failure here
+  // is a breaking change to that format; update the docs together with the code.
+
+  test("entry naming, inner layout, and bin placement", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      join(packageDir, "vendor", "local-pkg", "package.json"),
+      JSON.stringify({ name: "local-pkg", version: "3.2.1" }),
+    );
+    // `bar-0.0.2.tgz` contains the package `bar@0.0.2`.
+    await cp(join(import.meta.dir, "bar-0.0.2.tgz"), join(packageDir, "bar-0.0.2.tgz"));
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "store-layout-contract",
+        dependencies: {
+          // `2-peer-deps-c` declares peers on `no-deps@1.0.0` and `a-dep@1.0.10`;
+          // both resolve here, so its entry carries a peer-set suffix.
+          "2-peer-deps-c": "1.0.0",
+          "no-deps": "1.0.0",
+          "a-dep": "1.0.10",
+          "@types/is-number": "1.0.0",
+          // `two-range-deps` depends on `no-deps@^1.0.0` and
+          // `@types/is-number@>=1.0.0`; both ranges are satisfied by the direct
+          // pins above, so its entry links against the same store entries
+          // instead of creating new ones.
+          "two-range-deps": "1.0.0",
+          // `uses-what-bin` depends on `what-bin`, which has a single bin entry.
+          "uses-what-bin": "1.0.0",
+          "what-bin": "1.0.0",
+          "local-pkg": "file:./vendor/local-pkg",
+          "bar-tarball": "file:./bar-0.0.2.tgz",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const bun = join(packageDir, "node_modules", ".bun");
+
+    // Entry naming: `<name>@<resolution>`, with `/`, `\`, `:` and `#` mapped to
+    // `+` in both halves. npm entries use the resolved version; folder entries
+    // use `file+<path>`; tarball entries use the escaped path and are named by
+    // the real package name from the tarball, not the alias. An entry with
+    // resolved peers appends `+` and 16 lowercase hex digits of
+    // wyhash(seed 0, concat of `<peer name><peer resolution>` sorted by name):
+    // here wyhash("a-dep1.0.10no-deps1.0.0") == 0xeadc6a10a694605e.
+    expect(await readdirSorted(bun)).toEqual([
+      "2-peer-deps-c@1.0.0+eadc6a10a694605e",
+      "@types+is-number@1.0.0",
+      "a-dep@1.0.10",
+      "bar@.+bar-0.0.2.tgz",
+      "local-pkg@file+vendor+local-pkg",
+      "no-deps@1.0.0",
+      "node_modules",
+      "two-range-deps@1.0.0",
+      "uses-what-bin@1.0.0",
+      "what-bin@1.0.0",
+    ]);
+
+    // Inner layout: the package's own files live at
+    // `<entry>/node_modules/<real name>` (scoped packages keep the `@scope/`
+    // directory level).
+    expect(
+      await file(join(bun, "bar@.+bar-0.0.2.tgz", "node_modules", "bar", "package.json")).json(),
+    ).toMatchObject({ name: "bar", version: "0.0.2" });
+    expect(
+      await file(
+        join(bun, "@types+is-number@1.0.0", "node_modules", "@types", "is-number", "package.json"),
+      ).json(),
+    ).toMatchObject({ name: "@types/is-number", version: "1.0.0" });
+
+    // Each resolved dependency (peers included) is a relative symlink next to
+    // the package: `../../<dep entry>/node_modules/<dep real name>`, one extra
+    // `..` for the scope directory of a scoped dependency name.
+    const peerEntry = join(bun, "2-peer-deps-c@1.0.0+eadc6a10a694605e", "node_modules");
+    expect(await readdirSorted(peerEntry)).toEqual(["2-peer-deps-c", "a-dep", "no-deps"]);
+    expect(readlinkSync(join(peerEntry, "a-dep"))).toBe(join("..", "..", "a-dep@1.0.10", "node_modules", "a-dep"));
+    expect(readlinkSync(join(peerEntry, "no-deps"))).toBe(
+      join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+    expect(readlinkSync(join(bun, "two-range-deps@1.0.0", "node_modules", "no-deps"))).toBe(
+      join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+    expect(readlinkSync(join(bun, "two-range-deps@1.0.0", "node_modules", "@types", "is-number"))).toBe(
+      join("..", "..", "..", "@types+is-number@1.0.0", "node_modules", "@types", "is-number"),
+    );
+
+    // The project's own node_modules is the root entry: a relative symlink per
+    // direct dependency, named by the alias and pointing into the store.
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([
+      ".bin",
+      ".bun",
+      "2-peer-deps-c",
+      "@types",
+      "a-dep",
+      "bar-tarball",
+      "local-pkg",
+      "no-deps",
+      "two-range-deps",
+      "uses-what-bin",
+      "what-bin",
+    ]);
+    expect(readlinkSync(join(packageDir, "node_modules", "2-peer-deps-c"))).toBe(
+      join(".bun", "2-peer-deps-c@1.0.0+eadc6a10a694605e", "node_modules", "2-peer-deps-c"),
+    );
+    expect(readlinkSync(join(packageDir, "node_modules", "@types", "is-number"))).toBe(
+      join("..", ".bun", "@types+is-number@1.0.0", "node_modules", "@types", "is-number"),
+    );
+    expect(readlinkSync(join(packageDir, "node_modules", "bar-tarball"))).toBe(
+      join(".bun", "bar@.+bar-0.0.2.tgz", "node_modules", "bar"),
+    );
+    expect(readlinkSync(join(packageDir, "node_modules", "local-pkg"))).toBe(
+      join(".bun", "local-pkg@file+vendor+local-pkg", "node_modules", "local-pkg"),
+    );
+
+    // Fallback directory: `node_modules/.bun/node_modules/<real name>` links the
+    // first-installed entry of every package name.
+    expect(readlinkSync(join(bun, "node_modules", "no-deps"))).toBe(
+      join("..", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+    expect(readlinkSync(join(bun, "node_modules", "@types", "is-number"))).toBe(
+      join("..", "..", "@types+is-number@1.0.0", "node_modules", "@types", "is-number"),
+    );
+
+    // Bin placement: every entry's `node_modules/.bin` holds the bins of the
+    // entry's own package and of its resolved dependencies, targeted through the
+    // entry's own `node_modules` (so they resolve through the sibling symlinks).
+    // The root entry's bins land in the project's `node_modules/.bin`.
+    if (isWindows) {
+      expect(existsSync(join(bun, "uses-what-bin@1.0.0", "node_modules", ".bin", "what-bin.bunx"))).toBe(true);
+      expect(existsSync(join(bun, "what-bin@1.0.0", "node_modules", ".bin", "what-bin.bunx"))).toBe(true);
+      expect(existsSync(join(packageDir, "node_modules", ".bin", "what-bin.bunx"))).toBe(true);
+    } else {
+      expect(readlinkSync(join(bun, "uses-what-bin@1.0.0", "node_modules", ".bin", "what-bin"))).toBe(
+        join("..", "what-bin", "what-bin.js"),
+      );
+      expect(readlinkSync(join(bun, "what-bin@1.0.0", "node_modules", ".bin", "what-bin"))).toBe(
+        join("..", "what-bin", "what-bin.js"),
+      );
+      expect(readlinkSync(join(packageDir, "node_modules", ".bin", "what-bin"))).toBe(
+        join("..", "what-bin", "what-bin.js"),
+      );
+    }
+  });
+
+  test("peer variants and workspace linking", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "store-layout-workspaces",
+        workspaces: ["packages/*"],
+      }),
+    );
+    // The workspaces resolve `peer-deps-fixed`'s `no-deps@^1.0.0` peer to
+    // different versions, so each peer set gets its own store entry.
+    await write(
+      join(packageDir, "packages", "ws-a", "package.json"),
+      JSON.stringify({
+        name: "ws-a",
+        version: "1.0.0",
+        dependencies: {
+          "peer-deps-fixed": "1.0.0",
+          "no-deps": "1.0.0",
+          "what-bin": "1.0.0",
+          "ws-b": "workspace:*",
+        },
+      }),
+    );
+    await write(
+      join(packageDir, "packages", "ws-b", "package.json"),
+      JSON.stringify({
+        name: "ws-b",
+        version: "1.0.0",
+        dependencies: {
+          "peer-deps-fixed": "1.0.0",
+          "no-deps": "1.1.0",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const bun = join(packageDir, "node_modules", ".bun");
+
+    // One entry per (package, resolved peer set):
+    // wyhash("no-deps1.0.0") == 0x7347ae2d86f1441a,
+    // wyhash("no-deps1.1.0") == 0x7ff199101204a65d.
+    // Workspace packages never get store entries; their dependencies link
+    // straight into the root store.
+    expect(await readdirSorted(bun)).toEqual([
+      "no-deps@1.0.0",
+      "no-deps@1.1.0",
+      "node_modules",
+      "peer-deps-fixed@1.0.0+7347ae2d86f1441a",
+      "peer-deps-fixed@1.0.0+7ff199101204a65d",
+      "what-bin@1.0.0",
+    ]);
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bun"]);
+
+    // Each variant's peer symlink points at its own resolved version.
+    expect(readlinkSync(join(bun, "peer-deps-fixed@1.0.0+7347ae2d86f1441a", "node_modules", "no-deps"))).toBe(
+      join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+    expect(readlinkSync(join(bun, "peer-deps-fixed@1.0.0+7ff199101204a65d", "node_modules", "no-deps"))).toBe(
+      join("..", "..", "no-deps@1.1.0", "node_modules", "no-deps"),
+    );
+
+    // Workspace dependencies are relative symlinks into the root store;
+    // workspace-to-workspace dependencies link to the workspace source
+    // directory. Bins of a workspace's dependencies land in the workspace's own
+    // `node_modules/.bin`.
+    const wsA = join(packageDir, "packages", "ws-a", "node_modules");
+    expect(readlinkSync(join(wsA, "peer-deps-fixed"))).toBe(
+      join(
+        "..",
+        "..",
+        "..",
+        "node_modules",
+        ".bun",
+        "peer-deps-fixed@1.0.0+7347ae2d86f1441a",
+        "node_modules",
+        "peer-deps-fixed",
+      ),
+    );
+    expect(readlinkSync(join(wsA, "ws-b"))).toBe(join("..", "..", "ws-b"));
+    const wsB = join(packageDir, "packages", "ws-b", "node_modules");
+    expect(readlinkSync(join(wsB, "peer-deps-fixed"))).toBe(
+      join(
+        "..",
+        "..",
+        "..",
+        "node_modules",
+        ".bun",
+        "peer-deps-fixed@1.0.0+7ff199101204a65d",
+        "node_modules",
+        "peer-deps-fixed",
+      ),
+    );
+    if (isWindows) {
+      expect(existsSync(join(wsA, ".bin", "what-bin.bunx"))).toBe(true);
+    } else {
+      expect(readlinkSync(join(wsA, ".bin", "what-bin"))).toBe(join("..", "what-bin", "what-bin.js"));
+    }
+  });
 });


### PR DESCRIPTION
### Context

Requested by @dylan-conway: under the isolated linker, each package lives at `node_modules/.bun/<name>@<version>[+<hash>]/node_modules/<name>` with relative sibling symlinks to its resolved dependencies. To cache each package as its own build action (deduplicated across a monorepo), or to assemble the same tree from already-extracted packages, tools need this directory shape to be a documented contract: entry naming (the scope `/` to `+` mapping, the peer-set suffix and what it is derived from), the inner layout, and `.bin` placement. Today it is observable but undocumented, so anything built against it can silently drift from what `bun install` produces.

### What this PR does

**Documents the store layout as a stable format** in a new "Store layout reference" section of `docs/pm/isolated-installs.mdx`:

- Entry naming per dependency source (npm, folder, local/remote tarball, git, GitHub), including the `/` `\` `:` `#` to `+` character mapping that turns `@scope/pkg` into `@scope+pkg`.
- The exact peer-set suffix derivation: collect the entry's resolved peers, sort by package name (byte order), concatenate `<name><resolution>` with no separator, hash with 64-bit wyhash (the original v1 variant, seed 0), format as 16 lowercase zero-padded hex digits. With a worked example: `peer-deps-fixed@1.0.0` whose `no-deps@^1.0.0` peer resolves to `1.0.0` hashes the bytes `no-deps1.0.0` into `peer-deps-fixed@1.0.0+7347ae2d86f1441a`.
- The inner entry layout (`<entry>/node_modules/<real name>` plus one relative sibling symlink per resolved dependency, alias-named, `../../<dep entry>/node_modules/<dep real name>` targets), `.bin` placement (each entry carries its own bins and its dependencies' bins; the project root and each workspace get their direct dependencies' bins), project/workspace linking, and the `node_modules/.bun/node_modules` fallback directory.

It also fixes the existing peer-dependency section of that page, which showed a `package@1.0.0_react@18.2.0` naming scheme that shipped code never produced.

**Pins the layout with regression tests** (`store layout contract` in `test/cli/install/isolated-install.test.ts`): exact store directory listings with hardcoded peer hashes (`2-peer-deps-c@1.0.0+eadc6a10a694605e` for the two-peer case, verifying the name-sorted concatenation), scoped/folder/tarball entry names, sibling symlink targets including the extra `..` for scoped aliases, bin placement at all three levels (entry, project root, workspace), range deduplication onto existing entries, per-peer-set entry splitting across workspaces, and workspace-to-workspace links. A failure in these tests now means a breaking change to the documented format.

**Points the code at the contract**: the stale layout comment in `Store.rs` (same never-shipped `_peer@version` scheme) now shows the real shape, and the peer-hash derivation site in `isolated_install.rs` warns that the derivation names on-disk entries and is documented as stable.

### Why document-and-lock rather than a producer command

Both options from the request were considered: (a) commit to the layout in docs plus tests, or (b) keep the format internal behind something like `bun pm store-entry --tarball=<file> --deps=<resolved list> --out=<dir>`.

The command does not remove the need for the contract. To produce one entry, a caller must supply the resolved peer set of the package and the full entry names of its dependencies (their peer hashes included), because the sibling symlinks and `.bin` links embed those names. Computing per-node resolved peer sets is the output of bun's whole-tree resolution, so the command's `--deps` input is exactly the information the layout contract describes, and the caller still has to obtain it from an install or a resolution pass. Documenting and pinning the layout is therefore the prerequisite for either path, and per the request the layout is not expected to change, so locking it is the smaller, complete deliverable. A producer command can still be layered on top later without changing the format, if a concrete consumer wants one.

The hash derivation was verified by reimplementing it independently and matching every hardcoded suffix against live installs (two single-peer cases, one two-peer case for the sort order, and the no-resolved-peers case which gets no suffix).

### Verification

```
bun bd test test/cli/install/isolated-install.test.ts
# 58 pass, 0 fail (includes the 2 new store layout contract tests)
```

The Rust changes are comments only; no behavior changes outside docs and tests.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->