### PR TITLE
bundler: make --metafile output deterministic across build directories

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1534,7 +1534,7 @@ The guarantee rests on a few properties of the output:
 - **Content-derived hashes.** `[hash]` placeholders in output filenames, artifact `hash` values, and the sourcemap `debugId` are computed from output content, not from the build environment.
 - **Deterministic ordering.** Chunks, sourcemap entries, and the metafile's `inputs` (sorted by path) are emitted in a stable order that does not depend on filesystem layout or parallel scheduling.
 
-Anything the build embeds from the environment is part of the input: `define` values, environment variables inlined via the `env` option, and `banner`/`footer` text all change the output when they change. Two outputs fall outside the guarantee: `--format=cjs` inlines the absolute path of any source file that uses `import.meta.url` (ESM output keeps it symbolic), and executables produced by `--compile` embed the Bun runtime itself. Bytecode artifacts from `--bytecode` are not covered either.
+Anything the build embeds from the environment is part of the input: `define` values, environment variables inlined via the `env` option, and `banner`/`footer` text all change the output when they change. Two outputs fall outside the guarantee: `--format=cjs` inlines the absolute path of any source file that uses `import.meta.url`, `.path`, `.dir`, or `.dirname` (ESM output keeps them symbolic), and executables produced by `--compile` embed the Bun runtime itself. Bytecode artifacts from `--bytecode` are not covered either.
 
 ## Bytecode
 

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1523,6 +1523,19 @@ BuildArtifact (entry-point) {
 
 </CodeGroup>
 
+## Reproducible builds
+
+For a given version of Bun, `bun build` output is deterministic: building the same sources with the same configuration produces byte-identical bundles, sourcemaps, and assets on every run, no matter which directory the project is built from. This is what makes build outputs safe to cache and compare across machines, for example in remote caching systems or reproducible-build checks.
+
+The guarantee rests on a few properties of the output:
+
+- **No timestamps.** Build output never embeds wall-clock time, so there is no `SOURCE_DATE_EPOCH` equivalent to configure.
+- **No absolute paths.** Sourcemap `sources` are relative paths, and the metafile's `inputs` and `outputs` keys are relative to the build's working directory.
+- **Content-derived hashes.** `[hash]` placeholders in output filenames, artifact `hash` values, and the sourcemap `debugId` are computed from output content, not from the build environment.
+- **Deterministic ordering.** Chunks, sourcemap entries, and the metafile's `inputs` (sorted by path) are emitted in a stable order that does not depend on filesystem layout or parallel scheduling.
+
+Anything the build embeds from the environment is part of the input: `define` values, environment variables inlined via the `env` option, and `banner`/`footer` text all change the output when they change. Executables produced by `--compile` embed the Bun runtime itself and are outside this guarantee.
+
 ## Bytecode
 
 The `bytecode: boolean` option generates bytecode for any JavaScript/TypeScript entrypoints, which can greatly improve startup times for large applications. Requires `"target": "bun"` and a matching version of Bun.

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1534,7 +1534,7 @@ The guarantee rests on a few properties of the output:
 - **Content-derived hashes.** `[hash]` placeholders in output filenames, artifact `hash` values, and the sourcemap `debugId` are computed from output content, not from the build environment.
 - **Deterministic ordering.** Chunks, sourcemap entries, and the metafile's `inputs` (sorted by path) are emitted in a stable order that does not depend on filesystem layout or parallel scheduling.
 
-Anything the build embeds from the environment is part of the input: `define` values, environment variables inlined via the `env` option, and `banner`/`footer` text all change the output when they change. Executables produced by `--compile` embed the Bun runtime itself and are outside this guarantee.
+Anything the build embeds from the environment is part of the input: `define` values, environment variables inlined via the `env` option, and `banner`/`footer` text all change the output when they change. Two outputs fall outside the guarantee: `--format=cjs` inlines the absolute path of any source file that uses `import.meta.url` (ESM output keeps it symbolic), and executables produced by `--compile` embed the Bun runtime itself. Bytecode artifacts from `--bytecode` are not covered either.
 
 ## Bytecode
 

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1407,7 +1407,11 @@ impl Layers {
 }
 
 impl CssImportOrder {
-    pub(crate) fn hash<H: bun_core::Hasher + ?Sized>(&self, hasher: &mut H) {
+    pub(crate) fn hash<H: bun_core::Hasher + ?Sized>(
+        &self,
+        hasher: &mut H,
+        sources: &[bun_ast::Source],
+    ) {
         // TODO: conditions, condition_import_records
 
         // core::mem::Discriminant is opaque/pointer-sized; hash an explicit u8 tag instead.
@@ -1433,10 +1437,12 @@ impl CssImportOrder {
                 hasher.update(b"\x00");
             }
             CssImportOrderKind::ExternalPath(path) => hasher.update(path.text),
-            // Note: `Index` is a `#[repr(transparent)]` u32 newtype but
-            // doesn't impl `AsBytes`; hash the inner u32.
+            // Hash the file's pretty path, not its source index: these hashes
+            // decide CSS chunk identity and output order, and source indices
+            // are assigned in a scheduling-dependent order.
             CssImportOrderKind::SourceIndex(idx) => {
-                bun_core::write_any_to_hasher(hasher, idx.get())
+                hasher.update(sources[idx.get() as usize].path.pretty);
+                hasher.update(b"\x00");
             }
         }
     }

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1423,18 +1423,17 @@ impl CssImportOrder {
         bun_core::write_any_to_hasher(hasher, tag);
         match &self.kind {
             CssImportOrderKind::Layers(layers) => {
+                // Join each layer's parts with "." and NUL-terminate each
+                // layer, so distinct layer lists can't hash identically.
                 for layer in layers.inner().slice() {
                     for (i, layer_name) in layer.v.slice().iter().enumerate() {
-                        let is_last = i == layers.inner().len() as usize - 1;
-                        if is_last {
-                            hasher.update(layer_name);
-                        } else {
-                            hasher.update(layer_name);
+                        if i > 0 {
                             hasher.update(b".");
                         }
+                        hasher.update(layer_name);
                     }
+                    hasher.update(b"\x00");
                 }
-                hasher.update(b"\x00");
             }
             CssImportOrderKind::ExternalPath(path) => hasher.update(path.text),
             // Hash the file's pretty path, not its source index: these hashes

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1421,27 +1421,32 @@ impl CssImportOrder {
             CssImportOrderKind::SourceIndex(_) => 2,
         };
         bun_core::write_any_to_hasher(hasher, tag);
+        // Length-prefix every count and byte string below: unescaped CSS
+        // identifiers can contain any byte, so separators can't delimit.
         match &self.kind {
             CssImportOrderKind::Layers(layers) => {
-                // Join each layer's parts with "." and NUL-terminate each
-                // layer, so distinct layer lists can't hash identically.
-                for layer in layers.inner().slice() {
-                    for (i, layer_name) in layer.v.slice().iter().enumerate() {
-                        if i > 0 {
-                            hasher.update(b".");
-                        }
+                let layer_list = layers.inner().slice();
+                bun_core::write_any_to_hasher(hasher, layer_list.len());
+                for layer in layer_list {
+                    let parts = layer.v.slice();
+                    bun_core::write_any_to_hasher(hasher, parts.len());
+                    for layer_name in parts.iter() {
+                        bun_core::write_any_to_hasher(hasher, layer_name.len());
                         hasher.update(layer_name);
                     }
-                    hasher.update(b"\x00");
                 }
             }
-            CssImportOrderKind::ExternalPath(path) => hasher.update(path.text),
+            CssImportOrderKind::ExternalPath(path) => {
+                bun_core::write_any_to_hasher(hasher, path.text.len());
+                hasher.update(path.text);
+            }
             // Hash the file's pretty path, not its source index: these hashes
             // decide CSS chunk identity and output order, and source indices
             // are assigned in a scheduling-dependent order.
             CssImportOrderKind::SourceIndex(idx) => {
-                hasher.update(sources[idx.get() as usize].path.pretty);
-                hasher.update(b"\x00");
+                let pretty = sources[idx.get() as usize].path.pretty;
+                bun_core::write_any_to_hasher(hasher, pretty.len());
+                hasher.update(pretty);
             }
         }
     }

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -229,10 +229,9 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
         }
     }
 
-    // Write inputs sorted by pretty path. Source indices are assigned while
-    // draining a hash map keyed by absolute paths, so index order varies with
-    // the directory the project lives in; emitting in index order would make
-    // metafile bytes differ between checkouts of the same project.
+    // Emit inputs sorted by pretty path: source indices are assigned in
+    // absolute-path hash order, so emitting in index order would make the
+    // metafile bytes depend on where the project directory lives.
     let mut ordered_inputs: Vec<u32> = Vec::with_capacity(sources.len());
     for source_index in 0..sources.len() as u32 {
         if !seen_sources.is_set(source_index as usize) {

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -229,14 +229,12 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
         }
     }
 
-    // Write inputs
-    let mut source_index: u32 = 0;
-    while (source_index as usize) < sources.len() {
-        // (defer-style increment moved to end of loop body)
-        let si = source_index;
-        source_index += 1;
-        let source_index = si;
-
+    // Write inputs sorted by pretty path. Source indices are assigned while
+    // draining a hash map keyed by absolute paths, so index order varies with
+    // the directory the project lives in; emitting in index order would make
+    // metafile bytes differ between checkouts of the same project.
+    let mut ordered_inputs: Vec<u32> = Vec::with_capacity(sources.len());
+    for source_index in 0..sources.len() as u32 {
         if !seen_sources.is_set(source_index as usize) {
             continue;
         }
@@ -247,14 +245,23 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
         }
 
         let source = &sources[source_index as usize];
-        if source.path.text.is_empty() {
+        if source.path.text.is_empty() || source.path.pretty.is_empty() {
             continue;
         }
 
+        ordered_inputs.push(source_index);
+    }
+    ordered_inputs.sort_unstable_by(|&a, &b| {
+        sources[a as usize]
+            .path
+            .pretty
+            .cmp(sources[b as usize].path.pretty)
+            .then(a.cmp(&b))
+    });
+
+    for &source_index in &ordered_inputs {
+        let source = &sources[source_index as usize];
         let path = source.path.pretty;
-        if path.is_empty() {
-            continue;
-        }
 
         if !first_input {
             j.push_static(b",");

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -77,6 +77,7 @@ pub(crate) fn compute_chunks(
     let css_asts = this.graph.ast.items_css();
     let mut html_chunks: ArrayHashMap<&[u8], Chunk> = ArrayHashMap::new();
     let loaders = parse_graph.input_files.items_loader();
+    let sources = parse_graph.input_files.items_source();
     let ast_targets = this.graph.ast.items_target();
 
     let code_splitting = this.graph.code_splitting;
@@ -159,7 +160,7 @@ pub(crate) fn compute_chunks(
                 let mut hasher = Wyhash::init(5);
                 bun_core::write_any_to_hasher(&mut hasher, order.len());
                 for x in order.slice() {
-                    x.hash(&mut hasher);
+                    x.hash(&mut hasher, sources);
                 }
                 hasher.final_()
             };
@@ -233,7 +234,7 @@ pub(crate) fn compute_chunks(
                     let mut hasher = Wyhash::init(5);
                     bun_core::write_any_to_hasher(&mut hasher, order.len());
                     for x in order.slice() {
-                        x.hash(&mut hasher);
+                        x.hash(&mut hasher, sources);
                     }
                     hasher.final_()
                 };

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1302,4 +1302,71 @@ describe("metafile determinism", () => {
     const keys = Object.keys((result.metafile as Metafile).inputs);
     expect(keys).toEqual([...keys].sort());
   });
+
+  async function buildEntries(dir: string, entries: string[], metaName: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...entries, "--outdir=dist", `--metafile=${metaName}`],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    return await Bun.file(`${dir}/${metaName}`).text();
+  }
+
+  // CSS chunks attached to JS or HTML entries are keyed and ordered by hash;
+  // that hash must be derived from file paths, not source indices, or the
+  // outputs section reshuffles between runs and directories.
+  test.concurrent("multi-entry CSS chunk order is deterministic across runs and directories", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 1; i <= 4; i++) {
+      files[`c${i}.css`] = `.c${i} { color: red; }`;
+      files[`e${i}.js`] = `import "./c${i}.css"; console.log(${i});`;
+    }
+    using dirA = tempDir("metafile-css-order-a", files);
+    using dirB = tempDir("metafile-css-order-b-much-longer", files);
+    const entries = ["e1.js", "e2.js", "e3.js", "e4.js"];
+
+    // Same directory, repeated builds: byte-identical.
+    const a1 = await buildEntries(String(dirA), entries, "m1.json");
+    const a2 = await buildEntries(String(dirA), entries, "m2.json");
+    const a3 = await buildEntries(String(dirA), entries, "m3.json");
+    expect(a2).toBe(a1);
+    expect(a3).toBe(a1);
+
+    // Different directory: same key order, identical after prefix strip.
+    const b1 = await buildEntries(String(dirB), entries, "m1.json");
+    const metaA = JSON.parse(a1) as Metafile;
+    const metaB = JSON.parse(b1) as Metafile;
+    expect(Object.keys(metaB.outputs)).toEqual(Object.keys(metaA.outputs));
+    expect(stripDirPrefix(b1, String(dirB))).toBe(stripDirPrefix(a1, String(dirA)));
+  });
+
+  test.concurrent("multi-page HTML build metafile is deterministic across runs and directories", async () => {
+    const files: Record<string, string> = {};
+    for (const page of ["alpha", "beta", "gamma"]) {
+      files[`${page}.css`] = `.${page} { color: blue; }`;
+      files[`${page}.js`] = `console.log("${page}");`;
+      files[`${page}.html`] =
+        `<!DOCTYPE html><html><head><link rel="stylesheet" href="./${page}.css"></head>` +
+        `<body><script src="./${page}.js"></script></body></html>`;
+    }
+    using dirA = tempDir("metafile-html-det-a", files);
+    using dirB = tempDir("metafile-html-det-b-much-longer", files);
+    const entries = ["alpha.html", "beta.html", "gamma.html"];
+
+    const a1 = await buildEntries(String(dirA), entries, "m1.json");
+    const a2 = await buildEntries(String(dirA), entries, "m2.json");
+    expect(a2).toBe(a1);
+
+    const b1 = await buildEntries(String(dirB), entries, "m1.json");
+    const metaA = JSON.parse(a1) as Metafile;
+    const metaB = JSON.parse(b1) as Metafile;
+    expect(Object.keys(metaB.inputs)).toEqual(Object.keys(metaA.inputs));
+    expect(Object.keys(metaB.outputs)).toEqual(Object.keys(metaA.outputs));
+    expect(stripDirPrefix(b1, String(dirB))).toBe(stripDirPrefix(a1, String(dirA)));
+  });
 });

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1201,3 +1201,105 @@ describe("bun build --metafile-md", () => {
     expect(content).toContain("node_modules/lodash");
   });
 });
+
+describe("metafile determinism", () => {
+  // Module names are chosen so sorted order differs from discovery order:
+  // the entry is discovered first but "src/aaa.js" sorts before it.
+  const determinismProject = {
+    "src/entry.js": `
+      import { a } from "./aaa.js";
+      import { shared } from "./nested/shared.js";
+      import { z } from "./zebra.js";
+      import { m } from "./mango.js";
+      import { k } from "./kiwi.js";
+      import { p } from "./peach.js";
+      import { g } from "./grape.js";
+      import text from "./data.txt";
+      import img from "./img.png";
+      import "./styles.css";
+      console.log(a, shared, z, m, k, p, g, text, img);
+    `,
+    "src/aaa.js": `export const a = "a";`,
+    "src/zebra.js": `import { shared } from "./nested/shared.js"; export const z = "z" + shared;`,
+    "src/mango.js": `export const m = "m";`,
+    "src/kiwi.js": `export const k = "k";`,
+    "src/peach.js": `export const p = "p";`,
+    "src/grape.js": `export const g = "g";`,
+    "src/nested/shared.js": `export const shared = "s";`,
+    "src/data.txt": `hello`,
+    "src/img.png": `not-really-a-png`,
+    "src/styles.css": `.a { color: red; }`,
+  };
+
+  async function buildIn(dir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./src/entry.js", "--outdir=dist", "--metafile=meta.json", "--sourcemap=linked"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const outputNames = (
+      await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: `${dir}/dist`, onlyFiles: true }))
+    ).sort();
+    const outputs = new Map<string, string>();
+    for (const name of outputNames) {
+      outputs.set(name, await Bun.file(`${dir}/dist/${name}`).text());
+    }
+    return { meta: await Bun.file(`${dir}/meta.json`).text(), outputs };
+  }
+
+  // imports[].path may still hold the importing directory's resolved absolute
+  // path for some records; strip each directory's own prefix (in its
+  // JSON-escaped form) so every remaining byte must match.
+  function stripDirPrefix(meta: string, dir: string): string {
+    const escaped = (s: string) => JSON.stringify(s).slice(1, -1);
+    const slashed = dir.replaceAll("\\", "/");
+    return meta
+      .replaceAll(escaped(`${dir}/`), "")
+      .replaceAll(escaped(`${dir}\\`), "")
+      .replaceAll(escaped(dir), "")
+      .replaceAll(`${slashed}/`, "")
+      .replaceAll(slashed, "");
+  }
+
+  test.concurrent("build output is byte-identical across different project directories", async () => {
+    using dirA = tempDir("metafile-det-a", determinismProject);
+    using dirB = tempDir("metafile-det-b-much-longer-path", determinismProject);
+
+    const a = await buildIn(String(dirA));
+    const b = await buildIn(String(dirB));
+
+    // Bundles, sourcemaps, and assets must not depend on where the project lives.
+    expect([...b.outputs.keys()]).toEqual([...a.outputs.keys()]);
+    for (const [name, contents] of a.outputs) {
+      expect(b.outputs.get(name)).toBe(contents);
+    }
+
+    // The metafile must list inputs in the same order in both builds.
+    const metaA = JSON.parse(a.meta) as Metafile;
+    const metaB = JSON.parse(b.meta) as Metafile;
+    expect(Object.keys(metaB.inputs)).toEqual(Object.keys(metaA.inputs));
+    expect(Object.keys(metaB.outputs)).toEqual(Object.keys(metaA.outputs));
+
+    // Byte-identical once each directory's own absolute prefix is stripped.
+    expect(stripDirPrefix(b.meta, String(dirB))).toBe(stripDirPrefix(a.meta, String(dirA)));
+  });
+
+  test.concurrent("metafile inputs are sorted by path", async () => {
+    using dir = tempDir("metafile-sorted", determinismProject);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/src/entry.js`],
+      metafile: true,
+    });
+    expect(result.success).toBe(true);
+
+    const keys = Object.keys((result.metafile as Metafile).inputs);
+    expect(keys).toEqual([...keys].sort());
+  });
+});

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1239,7 +1239,7 @@ describe("metafile determinism", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
 


### PR DESCRIPTION
## Repro

```sh
# same project copied to two directories
cd /tmp/a/proj        && bun build src/entry.js --outdir=out --metafile=meta.json
cd /tmp/b-longer/proj && bun build src/entry.js --outdir=out --metafile=meta.json
```

The two `meta.json` files list the same `inputs` in different orders:

```
/tmp/a/proj:        ["entry.js", "data.txt", "dynamic.js", "shared.js", "data.json", ...]
/tmp/b-longer/proj: ["entry.js", "shared.js", "data.txt", "styles.css", "img.png", ...]
```

Bundles, sourcemaps, and assets are already byte-identical across the two directories; the metafile is the one artifact that differs, which breaks byte-level output comparison in remote caching and reproducible-build setups.

## Cause

`MetafileBuilder::generate` emits `inputs` in source-index order. Source indices are assigned in `process_resolve_queue`, which drains `ResolveQueue`, a `StringHashMap` keyed by resolved absolute paths, in hash-map iteration order. That order is a function of the absolute path bytes: stable for a given checkout location (8/8 repeated builds produce identical metafiles), different between checkout locations.

## Fix

Collect the reachable input indices and sort them by pretty path (index as tie-break) before emitting. Key order in the `inputs` object carries no meaning for JSON consumers, and sorting makes the bytes independent of both the path-hash iteration order and parse scheduling.

esbuild for comparison: its metafile paths are working-directory-relative by default, with the source comment noting that this "leads to reproducible builds across machines" (absolute paths are opt-in via `--abs-paths=metafile`). Its inputs are emitted in its own single-threaded discovery order; Bun's discovery is parallel and not reproducible, so sorted order is the stable equivalent. Key order is the only divergence; paths and structure remain esbuild-compatible.

## Remaining gap

`imports[].path` inside each input can still carry the resolved absolute path of the first importer; #34534 (open) fixes that by emitting the same pretty path used as the `inputs` key. The new cross-directory test strips each build's own directory prefix before comparing, so the two fixes land independently; together they make the metafile fully byte-identical across build directories.

## Verification

Two new tests in `test/bundler/metafile.test.ts`:

- `build output is byte-identical across different project directories`: builds the same project (JS, CSS, text, a file-loader asset, a shared module) from two temp directories and asserts every emitted file is byte-identical, metafile `inputs`/`outputs` key order matches, and metafile bytes match after stripping each directory's own absolute prefix.
- `metafile inputs are sorted by path`: the `Bun.build` metafile surface.

Both fail on main (inputs order differs across directories / is unsorted) and pass with this change. The 41 existing metafile tests and the 12 esbuild metafile compat tests pass.

Docs: new "Reproducible builds" section in `docs/bundler/index.mdx` stating the contract: no timestamps (nothing for a `SOURCE_DATE_EPOCH` knob to do), no absolute paths in sourcemap `sources` or metafile keys, content-derived hashes (including the sourcemap `debugId`), deterministic ordering. The metafile path claim is deliberately scoped to the `inputs`/`outputs` keys until #34534 lands.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/metafile.test.ts
bun test v1.4.0 (10b0f393a)

test/bundler/metafile.test.ts:
(pass) bundler metafile > metafile option returns metafile object [118.39ms]
(pass) bundler metafile > metafile inputs contain file metadata [118.66ms]
(pass) bundler metafile > metafile outputs contain chunk metadata [92.18ms]
(pass) bundler metafile > metafile tracks import relationships [64.69ms]
(pass) bundler metafile > metafile imports have resolved path and original specifier [67.82ms]
(pass) bundler metafile > metafile without option returns undefined [68.55ms]
(pass) bundler metafile > metafile tracks exports [76.15ms]
(pass) bundler metafile > metafile includes entryPoint for entry chunks [74.08ms]
(pass) bundler metafile > metafile includes format for JS inputs [80.13ms]
(pass) bundler metafile > metafile detects cjs format for CommonJS files [85.96ms]
(pass) bundler metafile > metafile marks external imports [67.37ms]
(pass) bundler metafile > metafile with code splitting [80.43ms]
(pass) bundler metafile > metafile includes with claus
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (fca392a42)

test/bundler/metafile.test.ts:
(pass) bundler metafile > metafile option returns metafile object [4.41ms]
(pass) bundler metafile > metafile inputs contain file metadata [2.24ms]
(pass) bundler metafile > metafile outputs contain chunk metadata [1.76ms]
(pass) bundler metafile > metafile tracks import relationships [2.09ms]
(pass) bundler metafile > metafile imports have resolved path and original specifier [1.77ms]
(pass) bundler metafile > metafile without option returns undefined [1.61ms]
(pass) bundler metafile > metafile tracks exports [1.79ms]
(pass) bundler metafile > metafile includes entryPoint for entry chunks [1.76ms]
(pass) bundler metafile > metafile includes format for JS inputs [1.78ms]
(pass) bundler metafile > metafile detects cjs format for CommonJS files [1.70ms]
(pass) bundler metafile > metafile marks external imports [1.72ms]
(pass) bundler metafile > metafile with code splitting [1.98ms]
(pass) bundler metafile > metafile includes with clause for JSON imports [1.71ms]
(pass) bundler metafile > metafile tracks require-call imports [1.67ms]
(pass) bundler metafile > metafile tracks dynamic-import imports [1.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/metafile.test.ts
bun test v1.4.0 (10b0f393a)

test/bundler/metafile.test.ts:
(pass) bundler metafile > metafile option returns metafile object [137.95ms]
(pass) bundler metafile > metafile inputs contain file metadata [114.86ms]
(pass) bundler metafile > metafile outputs contain chunk metadata [66.27ms]
(pass) bundler metafile > metafile tracks import relationships [63.14ms]
(pass) bundler metafile > metafile imports have resolved path and original specifier [71.44ms]
(pass) bundler metafile > metafile without option returns undefined [61.58ms]
(pass) bundler metafile > metafile tracks exports [48.84ms]
(pass) bundler metafile > metafile includes entryPoint for entry chunks [68.75ms]
(pass) bundler metafile > metafile includes format for JS inputs [77.74ms]
(pass) bundler metafile > metafile detects cjs format for CommonJS files [83.44ms]
(pass) bundler metafile > metafile marks external imports [65.88ms]
(pass) bundler metafile > metafile with code splitting [72.10ms]
(pass) bundler metafile > metafile includes with claus
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 832ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/index.mdx                        |  13 ++
 src/bundler/Chunk.rs                          |  40 +++---
 src/bundler/linker_context/MetafileBuilder.rs |  30 +++--
 src/bundler/linker_context/computeChunks.rs   |   5 +-
 test/bundler/metafile.test.ts                 | 169 ++++++++++++++++++++++++++
 5 files changed, 228 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
docs/bundler/index.mdx                             2      4      0
src/bundler/Chunk.rs                               3      6      0
src/bundler/linker_context/MetafileBuilder.rs      3      2      0
src/bundler/linker_context/computeChunks.rs        1      3      0
test/bundler/metafile.test.ts                      1      4      0
```

</details>

<!-- robobun:evidence:end -->