### PR TITLE
Explain Windows EBUSY from temp dir cleanup in the test harness

### DIFF
--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -99,6 +99,8 @@ When a test file spawns a Bun process, we like for that file to end in `*-fixtur
 
 Generally, `await using` or `using` is a good idea to ensure proper resource cleanup. This works in most Bun APIs like Bun.listen, Bun.connect, Bun.spawn, Bun.serve, etc.
 
+On Windows, a spawned process that can outlive the test (`detached: true`, daemons, crash-reporter children) must not keep the temp dir as its working directory: give it `cwd: os.tmpdir()`, or kill it and await its exit before the test ends. A terminating process releases its cwd handle asynchronously, so `tempDir` disposal races it and fails with EBUSY.
+
 #### Async/await in tests
 
 Prefer async/await over callbacks.

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -99,7 +99,7 @@ When a test file spawns a Bun process, we like for that file to end in `*-fixtur
 
 Generally, `await using` or `using` is a good idea to ensure proper resource cleanup. This works in most Bun APIs like Bun.listen, Bun.connect, Bun.spawn, Bun.serve, etc.
 
-On Windows, a spawned process that can outlive the test (`detached: true`, daemons, crash-reporter children) must not keep the temp dir as its working directory: give it `cwd: os.tmpdir()`, or kill it and await its exit before the test ends. A terminating process releases its cwd handle asynchronously, so `tempDir` disposal races it and fails with EBUSY.
+On Windows, a spawned process that can outlive the test (`detached: true`, daemons, crash-reporter children) must not keep the temp dir as its working directory: give it `cwd: os.tmpdir()`, or kill it and await its exit before the test ends. A terminating process releases its cwd handle asynchronously, so `tempDir` disposal races it and fails with EBUSY. The same applies to the test process itself: after a `process.chdir()` into the temp dir, restore the cwd before the test ends (declare `using cwd = cwdScope(dir)` after `using dir = tempDir(...)` so it is undone first, or chdir back in a `finally`).
 
 #### Async/await in tests
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -13,7 +13,7 @@ import { ChildProcess, execSync, fork } from "child_process";
 import { readdir, rm, writeFile } from "fs/promises";
 import fs, { closeSync, openSync, rmSync } from "node:fs";
 import os from "node:os";
-import { dirname, isAbsolute, join } from "path";
+import { dirname, isAbsolute, join, sep } from "path";
 
 export const BREAKING_CHANGES_BUN_1_2 = false;
 
@@ -459,22 +459,31 @@ export function tempDirWithFiles(
 
 /**
  * On Windows, EBUSY/EPERM from removing a test directory almost always means a
- * process spawned by the test is still alive (or still terminating; handles are
- * released asynchronously after TerminateProcess) and holds the directory as
- * its cwd or has an open handle inside it. Several tests have independently
+ * process holds the directory as its cwd or has an open handle inside it:
+ * either the test process itself after a process.chdir(), or a process spawned
+ * by the test that is still alive (or still terminating; handles are released
+ * asynchronously after TerminateProcess). Several tests have independently
  * re-discovered this the hard way, so say it in the error instead of making the
  * next author bisect it again. The error is still thrown: a held directory is a
- * real leak that the test must fix, by awaiting the child's exit before
- * disposal or by spawning children that outlive the test with a cwd outside
- * the temp dir.
+ * real leak that the test must fix.
  */
 function rethrowWithRmDiagnostic(error: unknown, path: string): never {
   const code = (error as NodeJS.ErrnoException)?.code;
   if (process.platform === "win32" && (code === "EBUSY" || code === "EPERM") && error instanceof Error) {
-    error.message +=
-      `\nA process is likely still holding '${path}' as its working directory or has an open handle inside it. ` +
-      `Kill that process and await its exit before the directory is cleaned up, or spawn processes that can ` +
-      `outlive the test with a cwd outside the temp dir (e.g. cwd: os.tmpdir()).`;
+    let cwdInside = false;
+    try {
+      const cwd = process.cwd().toLowerCase();
+      const held = path.toLowerCase();
+      cwdInside = cwd === held || cwd.startsWith(held.endsWith(sep) ? held : held + sep);
+    } catch {}
+    error.message += cwdInside
+      ? `\nThis test process's own working directory is inside '${path}', which keeps the directory from being ` +
+        `removed. Restore the original cwd before cleanup runs: chdir back in a finally, or declare the cwd ` +
+        `change after the directory (e.g. \`using cwd = cwdScope(dir)\` after \`using dir = tempDir(...)\`) so ` +
+        `it is undone first.`
+      : `\nA process is likely still holding '${path}' as its working directory or has an open handle inside it. ` +
+        `Kill that process and await its exit before the directory is cleaned up, or spawn processes that can ` +
+        `outlive the test with a cwd outside the temp dir (e.g. cwd: os.tmpdir()).`;
   }
   throw error;
 }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -457,12 +457,40 @@ export function tempDirWithFiles(
   return base;
 }
 
+/**
+ * On Windows, EBUSY/EPERM from removing a test directory almost always means a
+ * process spawned by the test is still alive (or still terminating; handles are
+ * released asynchronously after TerminateProcess) and holds the directory as
+ * its cwd or has an open handle inside it. Several tests have independently
+ * re-discovered this the hard way, so say it in the error instead of making the
+ * next author bisect it again. The error is still thrown: a held directory is a
+ * real leak that the test must fix, by awaiting the child's exit before
+ * disposal or by spawning children that outlive the test with a cwd outside
+ * the temp dir.
+ */
+function rethrowWithRmDiagnostic(error: unknown, path: string): never {
+  const code = (error as NodeJS.ErrnoException)?.code;
+  if (process.platform === "win32" && (code === "EBUSY" || code === "EPERM") && error instanceof Error) {
+    error.message +=
+      `\nA process is likely still holding '${path}' as its working directory or has an open handle inside it. ` +
+      `Kill that process and await its exit before the directory is cleaned up, or spawn processes that can ` +
+      `outlive the test with a cwd outside the temp dir (e.g. cwd: os.tmpdir()).`;
+  }
+  throw error;
+}
+
 class DisposableString extends String {
   [Symbol.dispose]() {
-    fs.rmSync(this + "", { recursive: true, force: true });
+    try {
+      fs.rmSync(this + "", { recursive: true, force: true });
+    } catch (error) {
+      rethrowWithRmDiagnostic(error, this + "");
+    }
   }
   [Symbol.asyncDispose]() {
-    return fs.promises.rm(this + "", { recursive: true, force: true });
+    return fs.promises.rm(this + "", { recursive: true, force: true }).catch(error => {
+      rethrowWithRmDiagnostic(error, this + "");
+    });
   }
 }
 
@@ -1863,7 +1891,11 @@ export function cwdScope(cwd: string) {
 export function rmScope(path: string) {
   return {
     [Symbol.dispose]() {
-      fs.rmSync(path, { recursive: true, force: true });
+      try {
+        fs.rmSync(path, { recursive: true, force: true });
+      } catch (error) {
+        rethrowWithRmDiagnostic(error, path);
+      }
     },
   };
 }

--- a/test/internal/harness-rm-diagnostic.test.ts
+++ b/test/internal/harness-rm-diagnostic.test.ts
@@ -87,6 +87,30 @@ test.skipIf(!isWindows)("temp dir removal failures name the likely process hold 
   expect(fs.existsSync(held)).toBe(false);
 });
 
+test.skipIf(!isWindows)("temp dir removal failures name the test process's own cwd hold on Windows", () => {
+  const dir = tempDir("rm-diagnostic-cwd", { "a.txt": "x" });
+  const held = String(dir);
+  const original = process.cwd();
+  try {
+    process.chdir(held);
+    let error: NodeJS.ErrnoException | undefined;
+    try {
+      dir[Symbol.dispose]();
+    } catch (thrown) {
+      error = thrown as NodeJS.ErrnoException;
+    }
+    expect(error).toBeDefined();
+    expect(["EBUSY", "EPERM"]).toContain(error!.code);
+    expect(error!.message).toContain("This test process's own working directory");
+    expect(error!.message).not.toContain(DIAGNOSTIC);
+  } finally {
+    process.chdir(original);
+  }
+  // chdir is synchronous in this process, so disposal succeeds immediately.
+  dir[Symbol.dispose]();
+  expect(fs.existsSync(held)).toBe(false);
+});
+
 test("non-matching removal errors pass through unchanged", () => {
   // A path with a NUL byte fails validation before any syscall, on every
   // platform, with no `code` matching the diagnostic guard: the error must

--- a/test/internal/harness-rm-diagnostic.test.ts
+++ b/test/internal/harness-rm-diagnostic.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, rmScope, tempDir } from "harness";
+import * as fs from "node:fs";
+
+// The disposal paths in harness.ts (tempDir's DisposableString and rmScope)
+// append a diagnostic to EBUSY/EPERM on Windows so test authors don't have to
+// re-bisect "a process spawned by the test still holds the temp dir" (see
+// #31688, #36971). These tests pin that behavior: the diagnostic is appended,
+// the original error still propagates with its code intact, and everything
+// else passes through unchanged.
+
+const DIAGNOSTIC = "as its working directory or has an open handle inside it";
+
+test.skipIf(!isWindows)("temp dir removal failures name the likely process hold on Windows", async () => {
+  // Deliberately no `using`: the disposal calls are the subject under test.
+  const dir = tempDir("rm-diagnostic", { "a.txt": "x" });
+  const held = String(dir);
+
+  // A live child whose cwd is inside the dir holds it open for as long as the
+  // child exists, so every removal attempt below fails deterministically. The
+  // cwd handle is established by the child-side loader after CreateProcess
+  // returns, so wait for the child to print before touching the dir.
+  const child = Bun.spawn({
+    cmd: [bunExe(), "-e", "console.log('ready'); setInterval(() => {}, 1000)"],
+    env: bunEnv,
+    cwd: held,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  try {
+    const reader = child.stdout.getReader();
+    let started = "";
+    while (!started.includes("ready")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      started += new TextDecoder().decode(value);
+    }
+    expect(started).toContain("ready");
+
+    let syncError: NodeJS.ErrnoException | undefined;
+    try {
+      dir[Symbol.dispose]();
+    } catch (error) {
+      syncError = error as NodeJS.ErrnoException;
+    }
+    expect(syncError).toBeDefined();
+    expect(["EBUSY", "EPERM"]).toContain(syncError!.code);
+    expect(syncError!.message).toContain(DIAGNOSTIC);
+    expect(syncError!.message).toContain(held);
+
+    let asyncError: NodeJS.ErrnoException | undefined;
+    try {
+      await dir[Symbol.asyncDispose]();
+    } catch (error) {
+      asyncError = error as NodeJS.ErrnoException;
+    }
+    expect(asyncError).toBeDefined();
+    expect(["EBUSY", "EPERM"]).toContain(asyncError!.code);
+    expect(asyncError!.message).toContain(DIAGNOSTIC);
+
+    let scopeError: NodeJS.ErrnoException | undefined;
+    try {
+      rmScope(held)[Symbol.dispose]();
+    } catch (error) {
+      scopeError = error as NodeJS.ErrnoException;
+    }
+    expect(scopeError).toBeDefined();
+    expect(["EBUSY", "EPERM"]).toContain(scopeError!.code);
+    expect(scopeError!.message).toContain(DIAGNOSTIC);
+  } finally {
+    child.kill();
+    await child.exited;
+    // Clean the dir up for real. Handle release after exit is asynchronous,
+    // which is the whole point of the diagnostic, so poll with a deadline.
+    for (let attempt = 0; ; attempt++) {
+      try {
+        dir[Symbol.dispose]();
+        break;
+      } catch (error) {
+        if (attempt >= 100) throw error;
+        await Bun.sleep(50);
+      }
+    }
+  }
+  expect(fs.existsSync(held)).toBe(false);
+});
+
+test("non-matching removal errors pass through unchanged", () => {
+  // A path with a NUL byte fails validation before any syscall, on every
+  // platform, with no `code` matching the diagnostic guard: the error must
+  // come through the disposal catch untouched.
+  let error: Error | undefined;
+  try {
+    rmScope("\0")[Symbol.dispose]();
+  } catch (thrown) {
+    error = thrown as Error;
+  }
+  expect(error).toBeDefined();
+  expect(error!.message).not.toContain(DIAGNOSTIC);
+});
+
+test("tempDir sync dispose removes the dir when nothing holds it", () => {
+  let p: string = "";
+  {
+    using dir = tempDir("rm-diagnostic-sync", { "a.txt": "x" });
+    p = String(dir);
+    expect(fs.existsSync(p)).toBe(true);
+  }
+  expect(fs.existsSync(p)).toBe(false);
+});
+
+test("tempDir async dispose removes the dir when nothing holds it", async () => {
+  let p: string = "";
+  {
+    await using dir = tempDir("rm-diagnostic-async", { "a.txt": "x" });
+    p = String(dir);
+    expect(fs.existsSync(p)).toBe(true);
+  }
+  expect(fs.existsSync(p)).toBe(false);
+});


### PR DESCRIPTION
Follow-up to #36971. When `tempDir` disposal fails with EBUSY on Windows, the harness currently surfaces a bare filesystem error:

```
EBUSY: resource busy or locked, rm 'C:\Windows\Temp\buntmp-Fbshlf\socket-inherit_Ev5bLB'
    at [Symbol.dispose] (C:\buildkite-agent\build\test\harness.ts:462:8)
```

That error has now been independently bisected to the same root cause three times, each investigation ending in a per-test fix plus a locally worded comment:

- `test/cli/run/crash-report-command-char.test.ts` (#31688): crash-reporter child inherits the temp dir as cwd
- `test/js/node/inspector/inspector.test.ts` (ecaa553bf5): `--inspect-brk` child held the temp dir as cwd
- `test/js/node/child_process/child-process-socket-inherit.test.ts` (#36971): detached child inherits the temp dir as cwd

The cause is always a process holding the directory as its cwd (or an open handle inside it) when disposal runs: either a process spawned by the test, including one already killed (`TerminateProcess` releases handles asynchronously), or the test process itself after a `process.chdir()` into the dir that was not restored.

### Change

- `test/harness.ts`: when `rmSync`/`rm` in `DisposableString`'s dispose paths or `rmScope` fails with EBUSY or EPERM on Windows, append the diagnosis to the error message and rethrow. The two holder classes get different advice: if `process.cwd()` is inside the directory the message says to restore the cwd before cleanup (chdir back in a `finally`, or declare `cwdScope` after `tempDir` so it is undone first); otherwise it points at the spawned-process fixes (await the child's exit, or spawn it with a cwd outside the temp dir). The original error object is rethrown unchanged otherwise: `code`, `errno`, `syscall`, `path`, and the stack stay intact, and the test still fails. No retry and no swallow, so a held directory remains a hard failure (a retry would mask genuine process and handle leaks, which is why #36971 rejected it).
- `test/CLAUDE.md`: document both rules in the "Spawning processes" section, since the canonical multi-file example teaches `cwd: String(dir)` and any child that outlives the test reproduces this.
- `test/internal/harness-rm-diagnostic.test.ts`: regression tests. A live child with its cwd inside the dir makes sync disposal, async disposal, and `rmScope` all fail with the spawned-process diagnostic and an intact EBUSY/EPERM code; a `process.chdir()` into the dir produces the own-cwd diagnostic instead; non-matching errors (a pre-syscall validation error, portable to all platforms) pass through untouched; and the success paths still remove their directories on every platform.

### Verification (Windows 11 aarch64)

Restored the pre-#36971 fixture (detached child inheriting the temp dir cwd) to trigger the real failure through the new path; the test now fails with:

```
EBUSY: resource busy or locked, rm 'C:\Users\azureuser\AppData\Local\Temp\socket-inherit_lrjDJd'
A process is likely still holding 'C:\Users\azureuser\AppData\Local\Temp\socket-inherit_lrjDJd' as its working directory or has an open handle inside it. Kill that process and await its exit before the directory is cleaned up, or spawn processes that can outlive the test with a cwd outside the temp dir (e.g. cwd: os.tmpdir()).
    path: "C:\\Users\\azureuser\\AppData\\Local\\Temp\\socket-inherit_lrjDJd",
 syscall: "rm",
   errno: -4082,
    code: "EBUSY"
```

The regression tests pass 10/10 consecutive runs on Windows 11 aarch64 and on Linux (where the Windows-only cases skip). Success paths are unchanged: `tempDir` sync dispose, `tempDir` async dispose, and `rmScope` all still remove their directories, and the socket-inherit test passes 5/5 with the modified harness.

One detail the child-holder regression test encodes: a spawned child's cwd handle is established by the child-side loader after `CreateProcess` returns, so the test waits for the child to print before asserting removal fails. The same window is why the original flake in #36971 was intermittent rather than constant.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->