### PR TITLE
test(fetch-leak): pin mimalloc purge state in the HiveRef Request-body test

### DIFF
--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -707,7 +707,16 @@ describe("Request body HiveRef pool returns slot via Body.Value.deinit (does not
         console.log(JSON.stringify({ kind: "${kind}", baselineMB: (baseline / 1024 / 1024) | 0, finalMB: (final / 1024 / 1024) | 0, deltaMB: Math.round(deltaMB) }));
         // 32 cycles * 512 Requests * 128 KiB = 2 GiB through the pool. If deinit() is
         // skipped for any heap-backed variant, RSS climbs by ~2 GiB; with the
-        // Zig semantics it stays flat. 64 MiB is well above GC/allocator noise.
+        // Zig semantics it stays flat.
+        // Bun.gc() runs mimalloc's collect before the JSC sweep, so the bodies a
+        // measurement GC frees stay committed until a later purge (default delay
+        // 100ms) that this synchronous loop may never reach; whether each rss()
+        // read catches purged or unpurged state showed up on loaded CI runners as
+        // a flat 68-74 MB offset between the two reads. MIMALLOC_PURGE_DELAY=0 in
+        // the spawn env makes frees decommit eagerly so rss() measures live
+        // memory (delta settles at 0 instead of jumping by one cycle's working
+        // set). It cannot hide a real leak: purge only touches freed pages, and
+        // retained bodies measure at full size.
         // ASAN's quarantine retains freed allocations so widen the threshold there.
         if (deltaMB > ${isASAN ? 320 : 64}) {
           throw new Error("Request body (${kind}) leaked " + Math.round(deltaMB) + " MB over 32 cycles of 512 Requests");
@@ -716,7 +725,7 @@ describe("Request body HiveRef pool returns slot via Body.Value.deinit (does not
 
         await using proc = Bun.spawn({
           cmd: [bunExe(), "--smol", "-e", script],
-          env: bunEnv,
+          env: { ...bunEnv, MIMALLOC_PURGE_DELAY: "0" },
           stdout: "pipe",
           stderr: "pipe",
         });


### PR DESCRIPTION
### What does this PR do?

The "Request body HiveRef pool returns slot via Body.Value.deinit (does not leak)" String case in `test/js/web/fetch/fetch-leak.test.ts` gates on a 64 MB RSS delta and has been flaking on loaded CI lanes with marginal overages, always going green on retry:

```
error: Request body (String) leaked 74 MB over 32 cycles of 512 Requests
```

Observed in the last ~550 Buildkite builds: 88734 (macOS 13 x64, 74 MB), 88735 (Ubuntu 25.04 x64, 74 MB), 88783/88819/89090/89250 (Windows 11 aarch64, 68 MB), 89215 (Alpine 3.23 x64, 74 MB).

### Cause

The overage is not memory growth. `Bun.gc()` runs mimalloc's collect before the JSC sweep (`garbage_collect` in VirtualMachine.rs), so the 64 MiB of bodies each measurement GC frees stays committed until a later purge, and mimalloc's purge delay defaults to 100ms, which the test's synchronous cycle loop may never service. Whether the baseline and final `rss()` reads each land on purged or unpurged state is timing dependent, and the mismatch shows up as a flat offset of about one cycle's working set, not as a ramp:

- running the test's inner script on the release binary with per-cycle logging shows two discrete RSS levels and no growth
- inserting a single 300ms sleep before the baseline read (simulating a descheduled runner) reproduces the CI band deterministically: delta jumps to 61-85 MB at cycle 1 and stays flat through all 32 cycles
- with `MIMALLOC_PURGE_DELAY=0`, delta is -2 to 0 in every run, with or without the sleep

This also explains why the CI values cluster at exactly 68 and 74 MB per platform instead of varying with load.

### Fix

Set `MIMALLOC_PURGE_DELAY=0` in the spawned process env so frees decommit eagerly and `rss()` measures live memory. The 64 MB bound is unchanged. This mirrors the allocator-layer fix the same file already uses for ASAN retention (capping `quarantine_size_mb` in the readable-stream test) rather than widening thresholds over allocator behavior.

The env var cannot mask the regression the test guards: purge only decommits freed pages, and a skipped `Body.Value.deinit` keeps bodies resident. Retaining just 4 of the 32 cycles measures +260 MB against the 64 MB bound; the full leak is ~2 GiB.

An earlier revision of this PR raised the bound to 128 MB instead; review of the mechanism showed the noise band is purge timing, not an irreducible high-water, so this revision fixes the measurement and keeps the bound where it was.

### How did you verify your code works?

- `USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-leak.test.ts -t 'Request body'` passes 3/3 with deltaMB 0 (baseline RSS drops from ~100 MB to ~39 MB now that it reflects live memory)
- `bun bd test` (debug+ASAN) passes with deltaMB 7 against the unchanged 320 MB ASAN bound
- the release binary honors the env var (vendored mimalloc reads `MIMALLOC_*` via getenv on unix and windows; `MIMALLOC_VERBOSE=1` shows `option 'purge_delay': 0`)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->