### PR TITLE
Bun.serve: don't serve sourcemaps for HTML routes in production

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -508,6 +508,20 @@ If an environment variable is not set, you may see runtime errors like `Referenc
 
 See [HTML & static sites](/bundler/html-static#inline-environment-variables) for build-time configuration and examples.
 
+## Sourcemaps
+
+In development, Bun generates linked sourcemaps for bundled routes and serves them alongside the JavaScript and CSS chunks. In production (`development: false`), sourcemaps are disabled by default so your original source code is not exposed by the server.
+
+To override the default, set the `sourcemap` option in your `bunfig.toml`:
+
+```toml title="bunfig.toml" icon="settings"
+[serve.static]
+sourcemap = "linked" # serve sourcemaps in production too
+# sourcemap = "inline"   # embed sourcemaps in the chunks
+# sourcemap = "external" # emit .map files without a sourceMappingURL comment
+# sourcemap = false      # never generate sourcemaps
+```
+
 ## How It Works
 
 Bun uses `HTMLRewriter` to scan for `<script>` and `<link>` tags in HTML files, uses them as entrypoints for Bun's bundler, generates an optimized bundle for the JavaScript/TypeScript/TSX/JSX and CSS files, and serves the result.
@@ -518,7 +532,7 @@ Bun uses `HTMLRewriter` to scan for `<script>` and `<link>` tags in HTML files, 
 <Step title="1. <script> Processing">
 - Transpiles TypeScript, JSX, and TSX in `<script>` tags
 - Bundles imported dependencies
-- Generates sourcemaps for debugging
+- Generates sourcemaps for debugging in development
 - Minifies when `development` is not `true` in `Bun.serve()`
 
 ```html title="index.html" icon="file-code"

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1611,6 +1611,33 @@ impl<'a> Parser<'a> {
             }
         }
 
+        if let Some(sourcemap) = serve_obj.get(b"sourcemap") {
+            if let Some(v) = sourcemap.as_bool() {
+                self.ctx.args.serve_sourcemap = Some(if v {
+                    api::SourceMapMode::Linked
+                } else {
+                    api::SourceMapMode::None
+                });
+            } else if let Some(s) = sourcemap.as_string(self.bump) {
+                match s {
+                    b"none" => self.ctx.args.serve_sourcemap = Some(api::SourceMapMode::None),
+                    b"linked" => self.ctx.args.serve_sourcemap = Some(api::SourceMapMode::Linked),
+                    b"inline" => self.ctx.args.serve_sourcemap = Some(api::SourceMapMode::Inline),
+                    b"external" => {
+                        self.ctx.args.serve_sourcemap = Some(api::SourceMapMode::External)
+                    }
+                    _ => {
+                        self.add_error(
+                            sourcemap.loc,
+                            b"Expected sourcemap to be one of 'none', 'linked', 'inline', or 'external'",
+                        )?;
+                    }
+                }
+            } else {
+                self.add_error(sourcemap.loc, b"Expected sourcemap to be boolean or string")?;
+            }
+        }
+
         if let Some(expr) = serve_obj.get(b"define") {
             self.ctx.args.serve_define = Some(self.parse_define_map(&expr)?);
         }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -205,6 +205,7 @@ pub mod api {
         pub serve_public_path: Option<Box<[u8]>>,
         pub serve_hmr: Option<bool>,
         pub serve_define: Option<StringMap>,
+        pub serve_sourcemap: Option<SourceMapMode>,
 
         /// from `--no-addons`. `None` == `true`.
         pub allow_addons: Option<bool>,

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -496,9 +496,7 @@ impl Route {
             config.force_node_env = bundler_options::ForceNodeEnv::Development;
             config.jsx.development = true;
         }
-        // Development defaults to linked sourcemaps; production defaults to
-        // none so original sources are not served publicly. `[serve.static]
-        // sourcemap` in bunfig overrides either default.
+        // Production defaults to no sourcemaps so original sources are not served publicly.
         config.source_map = if let Some(mode) = cli.args.serve_sourcemap {
             bundler_options::SourceMapOption::from_api(Some(mode))
         } else if is_development {

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -496,7 +496,16 @@ impl Route {
             config.force_node_env = bundler_options::ForceNodeEnv::Development;
             config.jsx.development = true;
         }
-        config.source_map = bundler_options::SourceMapOption::Linked;
+        // Development defaults to linked sourcemaps; production defaults to
+        // none so original sources are not served publicly. `[serve.static]
+        // sourcemap` in bunfig overrides either default.
+        config.source_map = if let Some(mode) = cli.args.serve_sourcemap {
+            bundler_options::SourceMapOption::from_api(Some(mode))
+        } else if is_development {
+            bundler_options::SourceMapOption::Linked
+        } else {
+            bundler_options::SourceMapOption::None
+        };
 
         let completion_task =
             create_and_schedule_completion_task(config, plugins, global, vm.event_loop())?;

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -952,6 +952,8 @@ describe("production headers and import.meta.env", () => {
         catch (e) { evalError = String(e); }
         console.log(JSON.stringify({
           jsContainsImportMetaEnv: js.includes("import.meta.env"),
+          jsHasSourceMapURL: js.includes("sourceMappingURL"),
+          jsHasDebugId: js.includes("debugId"),
           evalError,
           result: globalThis.result ?? null,
           htmlETag,
@@ -985,6 +987,8 @@ describe("production headers and import.meta.env", () => {
     }
     return JSON.parse(stdout) as {
       jsContainsImportMetaEnv: boolean;
+      jsHasSourceMapURL: boolean;
+      jsHasDebugId: boolean;
       evalError: string | null;
       result: Record<string, unknown> | null;
       htmlETag: string | null;
@@ -1020,10 +1024,12 @@ describe("production headers and import.meta.env", () => {
     expect(out.jsETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.cssETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.svgETag).toMatch(/^"[0-9a-f]{16}"$/);
-    expect(out.mapStatus).toBe(200);
-    expect(out.mapETag).toMatch(/^"[0-9a-f]{16}"$/);
-    expect(out.mapETag).not.toBe('"0000000000000000"');
-    expect(out.mapETag).not.toBe(out.jsETag);
+
+    // Production must not emit sourcemap comments or serve .map files;
+    // they contain the original source code.
+    expect(out.jsHasSourceMapURL).toBe(false);
+    expect(out.jsHasDebugId).toBe(false);
+    expect(out.mapStatus).toBe(404);
 
     // Production: HTML revalidates via ETag; content-hashed assets cache forever.
     expect({
@@ -1031,13 +1037,11 @@ describe("production headers and import.meta.env", () => {
       js: out.jsCacheControl,
       css: out.cssCacheControl,
       svg: out.svgCacheControl,
-      map: out.mapCacheControl,
     }).toEqual({
       html: "no-cache",
       js: "public, max-age=31536000, immutable",
       css: "public, max-age=31536000, immutable",
       svg: "public, max-age=31536000, immutable",
-      map: "public, max-age=31536000, immutable",
     });
 
     // A conditional request with the HTML ETag returns 304.
@@ -1053,8 +1057,11 @@ describe("production headers and import.meta.env", () => {
 
     expect(out.htmlETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.jsETag).toMatch(/^"[0-9a-f]{16}"$/);
+    expect(out.jsHasSourceMapURL).toBe(true);
+    expect(out.mapStatus).toBe(200);
     expect(out.mapETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.mapETag).not.toBe('"0000000000000000"');
+    expect(out.mapETag).not.toBe(out.jsETag);
 
     // Dev mode should not set aggressive Cache-Control.
     expect(out.htmlCacheControl).toBeNull();
@@ -1077,6 +1084,8 @@ describe("production headers and import.meta.env", () => {
         "index.html": `<!DOCTYPE html><html><body><script type="module" src="./app.ts"></script></body></html>`,
         "app.ts": appBody,
         "serve.ts": serveTs,
+        // Production serves no sourcemaps by default; opt in to exercise map ETags.
+        "bunfig.toml": `[serve.static]\nsourcemap = "linked"`,
       });
       await using proc = Bun.spawn({
         cmd: [bunExe(), "serve.ts"],
@@ -1095,5 +1104,50 @@ describe("production headers and import.meta.env", () => {
     expect(a).toMatch(/^"[0-9a-f]{16}"$/);
     expect(b).toMatch(/^"[0-9a-f]{16}"$/);
     expect(a).not.toBe(b);
+  });
+
+  test("bunfig [serve.static] sourcemap overrides the per-mode default", async () => {
+    const run = async (development: string, bunfig: string) => {
+      const dir = tempDirWithFiles("html-sourcemap-override", {
+        "index.html": `<!DOCTYPE html><html><body><script type="module" src="./app.ts"></script></body></html>`,
+        "app.ts": `console.log("hello" as string);`,
+        "bunfig.toml": bunfig,
+        "serve.ts": /*js*/ `
+          import index from "./index.html";
+          const server = Bun.serve({ port: 0, development: ${development}, routes: { "/": index } });
+          const base = server.url.href;
+          const html = await (await fetch(base)).text();
+          const jsPath = html.match(/src="([^"]+\\.js)"/)[1];
+          const js = await (await fetch(new URL(jsPath, base))).text();
+          const mapRes = await fetch(new URL(jsPath + ".map", base));
+          console.log(JSON.stringify({
+            hasMapComment: js.includes("sourceMappingURL"),
+            mapStatus: mapRes.status,
+          }));
+          await server.stop(true);
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "serve.ts"],
+        env: { ...bunEnv, NODE_ENV: undefined },
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
+      return JSON.parse(stdout) as { hasMapComment: boolean; mapStatus: number };
+    };
+
+    // Opt back into linked sourcemaps in production.
+    expect(await run("false", `[serve.static]\nsourcemap = "linked"`)).toEqual({
+      hasMapComment: true,
+      mapStatus: 200,
+    });
+    // Opt out of sourcemaps in development.
+    expect(await run("{ hmr: false }", `[serve.static]\nsourcemap = false`)).toEqual({
+      hasMapComment: false,
+      mapStatus: 404,
+    });
   });
 });

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1058,6 +1058,7 @@ describe("production headers and import.meta.env", () => {
     expect(out.htmlETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.jsETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.jsHasSourceMapURL).toBe(true);
+    expect(out.jsHasDebugId).toBe(true);
     expect(out.mapStatus).toBe(200);
     expect(out.mapETag).toMatch(/^"[0-9a-f]{16}"$/);
     expect(out.mapETag).not.toBe('"0000000000000000"');
@@ -1121,7 +1122,8 @@ describe("production headers and import.meta.env", () => {
           const js = await (await fetch(new URL(jsPath, base))).text();
           const mapRes = await fetch(new URL(jsPath + ".map", base));
           console.log(JSON.stringify({
-            hasMapComment: js.includes("sourceMappingURL"),
+            hasLinkedMapComment: /sourceMappingURL=\\/chunk-[a-z0-9]+\\.js\\.map/.test(js),
+            hasInlineMapComment: js.includes("sourceMappingURL=data:application/json"),
             mapStatus: mapRes.status,
           }));
           await server.stop(true);
@@ -1136,18 +1138,28 @@ describe("production headers and import.meta.env", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
-      return JSON.parse(stdout) as { hasMapComment: boolean; mapStatus: number };
+      return JSON.parse(stdout) as {
+        hasLinkedMapComment: boolean;
+        hasInlineMapComment: boolean;
+        mapStatus: number;
+      };
     };
 
-    // Opt back into linked sourcemaps in production.
-    expect(await run("false", `[serve.static]\nsourcemap = "linked"`)).toEqual({
-      hasMapComment: true,
-      mapStatus: 200,
-    });
-    // Opt out of sourcemaps in development.
-    expect(await run("{ hmr: false }", `[serve.static]\nsourcemap = false`)).toEqual({
-      hasMapComment: false,
-      mapStatus: 404,
-    });
+    const cases: [development: string, bunfigValue: string, expected: Awaited<ReturnType<typeof run>>][] = [
+      // Opt back into sourcemaps in production.
+      ["false", `"linked"`, { hasLinkedMapComment: true, hasInlineMapComment: false, mapStatus: 200 }],
+      ["false", `true`, { hasLinkedMapComment: true, hasInlineMapComment: false, mapStatus: 200 }],
+      ["false", `"inline"`, { hasLinkedMapComment: false, hasInlineMapComment: true, mapStatus: 404 }],
+      // External emits .map files without a sourceMappingURL comment.
+      ["false", `"external"`, { hasLinkedMapComment: false, hasInlineMapComment: false, mapStatus: 200 }],
+      // "none" matches the production default.
+      ["false", `"none"`, { hasLinkedMapComment: false, hasInlineMapComment: false, mapStatus: 404 }],
+      // Opt out of sourcemaps in development.
+      ["{ hmr: false }", `false`, { hasLinkedMapComment: false, hasInlineMapComment: false, mapStatus: 404 }],
+    ];
+    const results = await Promise.all(
+      cases.map(([development, value]) => run(development, `[serve.static]\nsourcemap = ${value}`)),
+    );
+    expect(results).toEqual(cases.map(([, , expected]) => expected));
   });
 });


### PR DESCRIPTION
### Problem

Fixes #36980

With `development: false`, `Bun.serve` HTML-import bundles still ended with:

```
//# debugId=176A91D20735B3A564756E2164756E21
//# sourceMappingURL=/chunk-yhrkxxeb.js.map
```

and the server registered every `.map` output as a public static route. The maps contain full `sourcesContent`, so production servers exposed their original TS/JS source to anyone who fetched the URL from the comment.

### Cause

`HTMLBundle.rs` hardcoded `SourceMapOption::Linked` for route bundles regardless of mode, right after the `is_development` branches that configure minification and NODE_ENV, and `on_complete` registers all output files (including `.map`) as routes.

### Fix

- Production (`development: false`) now defaults to no sourcemaps: no `sourceMappingURL`/`debugId` comments, no `.map` routes. Development keeps linked sourcemaps.
- New `sourcemap` option in bunfig's `[serve.static]` section (mirroring the existing `minify` override) to change the default in either mode:

  ```toml
  [serve.static]
  sourcemap = "linked" # or "inline", "external", "none", true, false
  ```

Documented in `docs/bundler/fullstack.mdx`.

### Verification

Updated the production header tests in `test/js/bun/http/bun-serve-html.test.ts` to assert production chunks have no sourcemap comments and `.map` URLs 404, and added coverage for the bunfig override in both directions (production opt-in serves maps with ETags, development opt-out stops serving them). The existing map-ETag test now opts in via bunfig.

`bun bd test test/js/bun/http/bun-serve-html.test.ts`: 18 pass, 2 skip. The updated tests fail against bun without this change (maps served with 200 in production).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (c1a03cd83)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_D4Npwt {
  "/": "/tmp/html-css-js_D4Npwt/index.html",
  "/dashboard": "/tmp/html-css-js_D4Npwt/dashboard.html",
}
[0.11ms] bundle index.html 1.09 KB
[0.08ms] bundle dashboard.html 1.27 KB
(pass) serve html [694.19ms]
waitForServer /tmp/bun-serve-html-txt_kql07D {
  "/": "/tmp/bun-serve-html-txt_kql07D/index.html",
}
[0.19ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [589.77ms]
waitForServer /tmp/html-css-js-failing-plugin_h78pDG {
  "/": "/tmp/html-css-js-failing-plugin_h78pDG/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_h78pDG/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_h78pDG/styles.css:0
(pass) serve plugins > serve html with failing plugin [516.29ms]
waitForServer /tmp/html-css-js-empty-plugins_qN2kSm {
  "/": "/tmp/html-css-js-empty-plugins_qN2kSm/index.html",
}
[0.12ms] bu
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (b66764ff3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_Zq5FY5 {
  "/": "/tmp/html-css-js_Zq5FY5/index.html",
  "/dashboard": "/tmp/html-css-js_Zq5FY5/dashboard.html",
}
[0.00ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [18.63ms]
waitForServer /tmp/bun-serve-html-txt_DJjjOu {
  "/": "/tmp/bun-serve-html-txt_DJjjOu/index.html",
}
[0.00ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [17.56ms]
waitForServer /tmp/html-css-js-failing-plugin_UBw5WD {
  "/": "/tmp/html-css-js-failing-plugin_UBw5WD/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_UBw5WD/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_UBw5WD/styles.css:0
(pass) serve plugins > serve html with failing plugin [16.70ms]
waitForServer /tmp/html-css-js-empty-plugins_MAbkTi {
  "/": "/tmp/html-css-js-empty-plugins_MAbkTi/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [14.02ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_PgxAe4 {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (c1a03cd83)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_B57YMX {
  "/": "/tmp/html-css-js_B57YMX/index.html",
  "/dashboard": "/tmp/html-css-js_B57YMX/dashboard.html",
}
[0.11ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [633.60ms]
waitForServer /tmp/bun-serve-html-txt_9F10KG {
  "/": "/tmp/bun-serve-html-txt_9F10KG/index.html",
}
[0.15ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [573.08ms]
waitForServer /tmp/html-css-js-failing-plugin_o11F24 {
  "/": "/tmp/html-css-js-failing-plugin_o11F24/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_o11F24/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_o11F24/styles.css:0
(pass) serve plugins > serve html with failing plugin [512.73ms]
waitForServer /tmp/html-css-js-empty-plugins_apHXel {
  "/": "/tmp/html-css-js-empty-plugins_apHXel/index.html",
}
[0.11ms] bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 696ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/121] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[1/121] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brot
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/fullstack.mdx              | 16 ++++++-
 src/bunfig/bunfig.rs                    | 27 ++++++++++++
 src/options_types/schema.rs             |  1 +
 src/runtime/server/HTMLBundle.rs        |  9 +++-
 test/js/bun/http/bun-serve-html.test.ts | 78 ++++++++++++++++++++++++++++++---
 5 files changed, 123 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
docs/bundler/fullstack.mdx                   1      1      0
src/bunfig/bunfig.rs                         2      2      0
src/options_types/schema.rs                  1      1      0
src/runtime/server/HTMLBundle.rs             2      3      0
test/js/bun/http/bun-serve-html.test.ts      2      6      0
```

</details>

**root cause** · written by the author bot

The bug occurred because HTMLBundle applied the linked sourcemap setting unconditionally, so production servers with development set to false still emitted debugId and sourceMappingURL annotations and served the corresponding .map routes. The fix adds a serve.sourcemap option accepting boolean and string values, plumbed through the config parsing into the transform options, so users can explicitly control sourcemap generation. When no explicit value is given, the bundle now defaults to linked sourcemaps in development and disables them entirely in production, ensuring sourcemaps are no long…

<!-- robobun:evidence:end -->