### PR TITLE
crash handler: explain thread-limit exhaustion instead of claiming a bug in Bun

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1748,11 +1748,9 @@ mod draft {
         std::panic::set_hook(Box::new(rust_panic_hook));
     }
 
-    /// Printed instead of "This indicates a bug in Bun" when a crash happened
-    /// while the system could not create more threads. WTF's `Thread::create`
-    /// release-asserts when `pthread_create` fails (e.g. JSC GC helper threads
-    /// under a low `RLIMIT_NPROC` or container pids limit), and bun's own
-    /// required thread spawns panic, so this is the message for both.
+    /// Printed instead of "This indicates a bug in Bun" when the crash
+    /// happened while the system could not create more threads (low
+    /// `RLIMIT_NPROC` or container pids limit).
     const THREAD_LIMIT_MESSAGE: &[u8] =
         b"Bun was unable to create a new thread: the system's thread limit was reached.\n\
         \n\
@@ -1760,9 +1758,9 @@ mod draft {
         (for example `ulimit -u`) or reduce concurrency. In containers, the pids\n\
         limit (for example `docker run --pids-limit`) may also need to be raised.\n\n";
 
-    /// Best-effort probe for thread exhaustion. By the time the crash handler
-    /// runs, the failed `pthread_create` is long gone; the only evidence left
-    /// is that spawning a thread still fails with `EAGAIN`.
+    /// Best-effort probe for thread exhaustion: the `pthread_create` failure
+    /// that caused the crash is gone, but a fresh spawn still failing with
+    /// `EAGAIN` means the limit is still hit.
     #[cfg(unix)]
     fn is_thread_limit_reached() -> bool {
         extern "C" fn probe_main(_: *mut core::ffi::c_void) -> *mut core::ffi::c_void {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -802,6 +802,11 @@ mod draft {
                 PANIC_STAGE.with(|s| s.set(1));
                 let _ = PANICKING.fetch_add(1, Ordering::SeqCst);
 
+                let thread_limit_reached = matches!(
+                    reason,
+                    CrashReason::Abort | CrashReason::Trap(_) | CrashReason::Panic(_)
+                ) && is_thread_limit_reached();
+
                 {
                     let _panic_guard = PANIC_MUTEX.lock();
 
@@ -1057,6 +1062,12 @@ mod draft {
                         // SAFETY: single-threaded mutation under panic_mutex
                         HAS_PRINTED_MESSAGE.store(true, Ordering::Relaxed);
 
+                        if thread_limit_reached {
+                            if writer.write_all(THREAD_LIMIT_MESSAGE).is_err() {
+                                abort();
+                            }
+                        }
+
                         dump_stack_trace(trace, WriteStackTraceLimits::default());
 
                         if write!(
@@ -1124,6 +1135,10 @@ mod draft {
                                 if writer.write_all(
                                 b"Bun has run out of memory.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
                             ).is_err() { abort(); }
+                            } else if thread_limit_reached {
+                                if writer.write_all(THREAD_LIMIT_MESSAGE).is_err() {
+                                    abort();
+                                }
                             } else {
                                 if writer.write_all(
                                 b"Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
@@ -1733,6 +1748,57 @@ mod draft {
         std::panic::set_hook(Box::new(rust_panic_hook));
     }
 
+    /// Printed instead of "This indicates a bug in Bun" when a crash happened
+    /// while the system could not create more threads. WTF's `Thread::create`
+    /// release-asserts when `pthread_create` fails (e.g. JSC GC helper threads
+    /// under a low `RLIMIT_NPROC` or container pids limit), and bun's own
+    /// required thread spawns panic, so this is the message for both.
+    const THREAD_LIMIT_MESSAGE: &[u8] =
+        b"Bun was unable to create a new thread: the system's thread limit was reached.\n\
+        \n\
+        This is a resource limit, not a bug in Bun. To fix it, raise the limit\n\
+        (for example `ulimit -u`) or reduce concurrency. In containers, the pids\n\
+        limit (for example `docker run --pids-limit`) may also need to be raised.\n\n";
+
+    /// Best-effort probe for thread exhaustion. By the time the crash handler
+    /// runs, the failed `pthread_create` is long gone; the only evidence left
+    /// is that spawning a thread still fails with `EAGAIN`.
+    #[cfg(unix)]
+    fn is_thread_limit_reached() -> bool {
+        extern "C" fn probe_main(_: *mut core::ffi::c_void) -> *mut core::ffi::c_void {
+            core::ptr::null_mut()
+        }
+        let mut attr = core::mem::MaybeUninit::<libc::pthread_attr_t>::uninit();
+        // SAFETY: valid out-pointer; pthread_attr_init fully initializes it.
+        if unsafe { libc::pthread_attr_init(attr.as_mut_ptr()) } != 0 {
+            return false;
+        }
+        // SAFETY: attr was initialized above.
+        unsafe {
+            libc::pthread_attr_setdetachstate(attr.as_mut_ptr(), libc::PTHREAD_CREATE_DETACHED);
+            libc::pthread_attr_setstacksize(attr.as_mut_ptr(), 128 * 1024);
+        }
+        let mut thread = core::mem::MaybeUninit::<libc::pthread_t>::uninit();
+        // SAFETY: attr is initialized, probe_main matches the required
+        // signature, and a detached no-op thread needs no join.
+        let rc = unsafe {
+            libc::pthread_create(
+                thread.as_mut_ptr(),
+                attr.as_ptr(),
+                probe_main,
+                core::ptr::null_mut(),
+            )
+        };
+        // SAFETY: attr was initialized above.
+        unsafe { libc::pthread_attr_destroy(attr.as_mut_ptr()) };
+        rc == libc::EAGAIN
+    }
+
+    #[cfg(not(unix))]
+    fn is_thread_limit_reached() -> bool {
+        false
+    }
+
     /// `std::panic` hook: emit the same trace-string + auto-report as the fatal
     /// `crash_handler()` path, then **abort**.
     /// With `panic = "abort"` no unwind starts after this hook returns, so there
@@ -1813,6 +1879,12 @@ mod draft {
                 let _ = writeln!(writer, "Crashed while {}", action);
             }
 
+            let thread_limit_reached = is_thread_limit_reached();
+            if thread_limit_reached {
+                let _ = writer.write_all(b"\n");
+                let _ = writer.write_all(THREAD_LIMIT_MESSAGE);
+            }
+
             let mut addr_buf: [usize; 20] = [0; 20];
             let idx = debug::capture_stack_trace(debug::return_address(), &mut addr_buf);
             let trace = StackTrace {
@@ -1832,17 +1904,24 @@ mod draft {
                     }
                 );
             } else {
-                let _ = writer.write_all(b"oh no");
-                if enable_ansi_colors_stderr() {
-                    let _ = writer.write_all(&Output::pretty_fmt::<true>("<r><d>:<r> "));
+                if thread_limit_reached {
+                    let _ = writer.write_all(
+                        b"To send a redacted crash report to Bun's team,\n\
+                      please file a GitHub issue using the link below:\n\n ",
+                    );
                 } else {
-                    let _ = writer.write_all(b": ");
-                }
-                let _ = writer.write_all(
-                    b"Bun has crashed. This indicates a bug in Bun, not your code.\n\n\
+                    let _ = writer.write_all(b"oh no");
+                    if enable_ansi_colors_stderr() {
+                        let _ = writer.write_all(&Output::pretty_fmt::<true>("<r><d>:<r> "));
+                    } else {
+                        let _ = writer.write_all(b": ");
+                    }
+                    let _ = writer.write_all(
+                        b"Bun has crashed. This indicates a bug in Bun, not your code.\n\n\
                   To send a redacted crash report to Bun's team,\n\
                   please file a GitHub issue using the link below:\n\n ",
-                );
+                    );
+                }
                 if enable_ansi_colors_stderr() {
                     let _ = writer.write_all(&Output::pretty_fmt::<true>("<cyan>"));
                 }

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1139,6 +1139,9 @@ mod draft {
                                 if writer.write_all(THREAD_LIMIT_MESSAGE).is_err() {
                                     abort();
                                 }
+                                if writer.write_all(
+                                b"To send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
+                            ).is_err() { abort(); }
                             } else {
                                 if writer.write_all(
                                 b"Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -625,7 +625,7 @@ describe.if(isLinux)("crash while the thread limit is exhausted", () => {
       cwd: String(dir),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("SETUP_FAILED");
     return { stderr, exitCode };
   }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,17 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isASAN,
+  isDebug,
+  isLinux,
+  isPosix,
+  isWindows,
+  libcPathForDlopen,
+  mergeWindowEnvs,
+  tempDir,
+} from "harness";
 import { rmSync } from "node:fs";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
@@ -560,3 +571,86 @@ test.if(isWindows)(
     }
   },
 );
+
+// A crash while the OS refuses to create new threads (RLIMIT_NPROC / cgroup
+// pids limit) is a resource limit problem, not a bug in Bun.
+// WTF::Thread::create release-asserts when pthread_create fails (e.g. JSC GC
+// helper threads in a pids-limited container), and bun's own required thread
+// spawns (HTTP client thread, IO watcher) panic; both used to print "This
+// indicates a bug in Bun, not your code." and link a crash report. See
+// https://github.com/oven-sh/bun/issues/36979.
+//
+// The fixture exhausts the limit for real: it lowers RLIMIT_NPROC to 1 (and
+// drops root first if needed, since the limit is not enforced for root), so
+// the crash handler's pthread_create probe gets a genuine EAGAIN.
+describe.if(isLinux)("crash while the thread limit is exhausted", () => {
+  const exhaustThreadLimit = `
+    import { dlopen } from "bun:ffi";
+    const libc = dlopen(process.env.TEST_LIBC_PATH, {
+      setrlimit: { args: ["i32", "ptr"], returns: "i32" },
+      setuid: { args: ["u32"], returns: "i32" },
+    });
+    // Pre-load the module and pre-spawn lazy threads (GC helpers, the
+    // concurrent collector) so nothing between lowering the limit and the
+    // deliberate crash needs a new thread.
+    const crashHandlerTestHooks = require("bun:internal-for-testing").crash_handler;
+    Bun.gc(false);
+    Bun.gc(true);
+    const RLIMIT_NPROC = 6;
+    const limit = new BigUint64Array([1n, 1n]);
+    if (libc.symbols.setrlimit(RLIMIT_NPROC, limit) !== 0) {
+      console.error("SETUP_FAILED: setrlimit");
+      process.exit(42);
+    }
+    // RLIMIT_NPROC is only enforced for non-root users.
+    if (process.getuid() === 0 && libc.symbols.setuid(65534) !== 0) {
+      console.error("SETUP_FAILED: setuid");
+      process.exit(42);
+    }
+  `;
+
+  async function runThreadLimitFixture(body: string): Promise<{ stderr: string; exitCode: number | null }> {
+    using dir = tempDir("thread-limit-crash", { "fixture.ts": exhaustThreadLimit + body });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts", "--debug-crash-handler-use-trace-string"],
+      env: { ...noReportEnv, TEST_LIBC_PATH: libcPathForDlopen() },
+      cwd: String(dir),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("SETUP_FAILED");
+    return { stderr, exitCode };
+  }
+
+  function expectThreadLimitMessage(stderr: string, exitCode: number | null) {
+    expect(stderr).toContain("Bun was unable to create a new thread: the system's thread limit was reached");
+    expect(stderr).toContain("ulimit -u");
+    expect(stderr).not.toContain("This indicates a bug in Bun");
+    expect(exitCode).not.toBe(0);
+  }
+
+  test.concurrent("a panic explains the limit instead of claiming a bug in Bun", async () => {
+    const { stderr, exitCode } = await runThreadLimitFixture(`
+      crashHandlerTestHooks.panic();
+    `);
+    expectThreadLimitMessage(stderr, exitCode);
+  });
+
+  test.concurrent("a failed HTTP client thread spawn explains the limit", async () => {
+    const { stderr, exitCode } = await runThreadLimitFixture(`
+      // fetch lazily spawns the HTTP client thread; with the limit exhausted
+      // the spawn currently fails with EAGAIN and the spawn site panics.
+      await fetch("http://127.0.0.1:1/").catch(() => {});
+      console.error("FETCH_HANDLED_GRACEFULLY");
+      process.exit(0);
+    `);
+    // If fetch ever learns to surface the spawn failure as a catchable error
+    // instead of crashing (see #32245), that is also a correct outcome.
+    if (stderr.includes("FETCH_HANDLED_GRACEFULLY")) {
+      expect(exitCode).toBe(0);
+      return;
+    }
+    expect(stderr).toContain("Failed to start HTTP Client thread");
+    expectThreadLimitMessage(stderr, exitCode);
+  });
+});

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -596,10 +596,18 @@ describe.if(isLinux)("crash while the thread limit is exhausted", () => {
     const crashHandlerTestHooks = require("bun:internal-for-testing").crash_handler;
     Bun.gc(false);
     Bun.gc(true);
+    // The crash below is deliberate; don't leave a core dump behind for CI's
+    // core collector to flag (the internal-for-testing crash hooks do the
+    // same via suppress_core_dumps_if_necessary).
+    const RLIMIT_CORE = 4;
+    if (libc.symbols.setrlimit(RLIMIT_CORE, new BigUint64Array([0n, 0n])) !== 0) {
+      console.error("SETUP_FAILED: setrlimit core");
+      process.exit(42);
+    }
     const RLIMIT_NPROC = 6;
     const limit = new BigUint64Array([1n, 1n]);
     if (libc.symbols.setrlimit(RLIMIT_NPROC, limit) !== 0) {
-      console.error("SETUP_FAILED: setrlimit");
+      console.error("SETUP_FAILED: setrlimit nproc");
       process.exit(42);
     }
     // RLIMIT_NPROC is only enforced for non-root users.


### PR DESCRIPTION
### What does this PR do?

Fixes #36979.

When the OS cannot create more threads (low `ulimit -u` / `RLIMIT_NPROC`, or a container pids limit), Bun dies with:

```
panic(main thread): abort() called
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

In the issue, 8 parallel Chromium workers exhausted the container's task limit; the freshly spawned Bun child then failed a thread spawn ~12ms into startup and told the user to file a crash report.

### Repro

```sh
su nobody -s /bin/bash -c 'ulimit -u 8; bun app.mjs'
```

Any script that triggers a GC or `fetch()` aborts: `WTF::Thread::create` release-asserts when `pthread_create` fails (here, JSC GC helper threads via `ParallelHelperPool` -> `AutomaticThread::start`), and Bun's own required spawns (HTTP client thread, IO watcher) panic.

### The fix

The crash itself is unavoidable without the thread (and WTF's assert is in the prebuilt JSC), but the presentation is wrong: this is a resource limit, not a Bun bug. The failed `pthread_create` is long gone when the crash handler runs, so it now probes for the condition: it attempts to spawn a minimal detached no-op thread, and `EAGAIN` means the limit is (still) exhausted. When the probe fires for an abort, trap, or panic, the handler prints:

```
Bun was unable to create a new thread: the system's thread limit was reached.

This is a resource limit, not a bug in Bun. To fix it, raise the limit
(for example `ulimit -u`) or reduce concurrency. In containers, the pids
limit (for example `docker run --pids-limit`) may also need to be raised.
```

instead of "This indicates a bug in Bun, not your code", on both the signal path (release `abort()`/trap) and the Rust panic hook. This follows the existing precedent for OOM and `SystemFdQuotaExceeded` messaging.

### Tests

Two tests in `test/cli/run/run-crash-handler.test.ts` (Linux). The fixture exhausts the limit for real: it lowers `RLIMIT_NPROC` to 1 via `setrlimit` (dropping root first when needed, since the limit is not enforced for root) after pre-spawning lazy threads, then:

- triggers a deliberate panic (exercises the signal-path printer release aborts go through), and
- calls `fetch()`, whose HTTP client thread spawn fails with EAGAIN (exercises the panic hook). This test also accepts a future where fetch surfaces the failure as a catchable error instead (#32245).

Both fail on the unfixed build and pass with the fix. Also verified the original repro end to end with a non-ASAN debug build (ASAN builds intentionally don't install the SIGABRT handler): the `ulimit -u 10` abort now prints the message above through the real `WTF::Thread::create` assert path.

Related (complementary, per-site graceful handling): #32245, #33845, #34705.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->