### PR TITLE
node:crypto: free the async job ctx before invoking the completion callback

### DIFF
--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -57,17 +57,12 @@ pub unsafe fn dispatch_erased(ptr: *mut ()) -> JsResult<()> {
     entry(ptr)
 }
 
-/// Free a queued job at VM shutdown without running its completion. The ctx
-/// `Drop` releases what it owns (native resources, JSC handles) — it must run
-/// while the VM is still live, which is why
-/// `release_queued_tasks_for_shutdown` claims this tag instead of leaving the
-/// job parked in the queue (where a C++-side ctx would strand its resources
-/// past the leak check).
+/// Free a queued job at VM shutdown without running its completion; the ctx
+/// `Drop` needs the still-live VM to release its JSC handles and resources.
 ///
 /// # Safety
-/// `ptr` must be a live `*mut AnyTaskJob<C>` produced by [`AnyTaskJob::create`]
-/// whose task was popped from the event-loop queue (the work-pool phase is
-/// done, so the queue held exclusive ownership); the job is freed.
+/// `ptr` must be a live `*mut AnyTaskJob<C>` from [`AnyTaskJob::create`],
+/// popped from the event-loop queue (so it held exclusive ownership); frees it.
 pub unsafe fn release_erased(ptr: *mut ()) {
     // SAFETY: `AnyTaskJob<C>` is `#[repr(C)]` with `release_erased` second;
     // caller contract that `ptr` is such an allocation.
@@ -183,8 +178,7 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         this.ctx.then(vm.global())
     }
 
-    /// [`release_erased`]'s monomorphic body: free the job (running `Drop for
-    /// C`) without calling [`AnyTaskJobCtx::then`].
+    /// [`release_erased`]'s monomorphic body.
     fn release(this: *mut Self) {
         // SAFETY: `this` was produced by `heap::into_raw` in `create`; the
         // caller (the popped queue entry) held exclusive ownership.

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -37,6 +37,7 @@ pub trait AnyTaskJobCtx: Sized {
 #[repr(C)]
 pub struct AnyTaskJob<C> {
     run_from_js_erased: fn(*mut ()) -> JsResult<()>,
+    release_erased: fn(*mut ()),
     vm: bun_ptr::BackRef<VirtualMachine>,
     task: WorkPoolTask,
     poll: KeepAlive,
@@ -56,7 +57,29 @@ pub unsafe fn dispatch_erased(ptr: *mut ()) -> JsResult<()> {
     entry(ptr)
 }
 
+/// Free a queued job at VM shutdown without running its completion. The ctx
+/// `Drop` releases what it owns (native resources, JSC handles) — it must run
+/// while the VM is still live, which is why
+/// `release_queued_tasks_for_shutdown` claims this tag instead of leaving the
+/// job parked in the queue (where a C++-side ctx would strand its resources
+/// past the leak check).
+///
+/// # Safety
+/// `ptr` must be a live `*mut AnyTaskJob<C>` produced by [`AnyTaskJob::create`]
+/// whose task was popped from the event-loop queue (the work-pool phase is
+/// done, so the queue held exclusive ownership); the job is freed.
+pub unsafe fn release_erased(ptr: *mut ()) {
+    // SAFETY: `AnyTaskJob<C>` is `#[repr(C)]` with `release_erased` second;
+    // caller contract that `ptr` is such an allocation.
+    let entry = unsafe { *ptr.cast::<fn(*mut ())>().add(1) };
+    entry(ptr)
+}
+
 const _: () = assert!(core::mem::offset_of!(AnyTaskJob<()>, run_from_js_erased) == 0);
+const _: () = assert!(
+    core::mem::offset_of!(AnyTaskJob<()>, release_erased)
+        == core::mem::size_of::<fn(*mut ()) -> JsResult<()>>()
+);
 
 impl<C> bun_event_loop::Taskable for AnyTaskJob<C> {
     const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::AnyTaskJob;
@@ -82,6 +105,7 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         let vm = bun_ptr::BackRef::new(global.bun_vm());
         let job = bun_core::heap::into_raw(Box::new(Self {
             run_from_js_erased: |p| Self::run_from_js(p.cast::<Self>()),
+            release_erased: |p| Self::release(p.cast::<Self>()),
             vm,
             task: WorkPoolTask {
                 node: Default::default(),
@@ -157,5 +181,13 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
             return Ok(());
         }
         this.ctx.then(vm.global())
+    }
+
+    /// [`release_erased`]'s monomorphic body: free the job (running `Drop for
+    /// C`) without calling [`AnyTaskJobCtx::then`].
+    fn release(this: *mut Self) {
+        // SAFETY: `this` was produced by `heap::into_raw` in `create`; the
+        // caller (the popped queue entry) held exclusive ownership.
+        drop(unsafe { bun_core::heap::take(this) });
     }
 }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -402,9 +402,7 @@ extern "C" size_t Bun__encoding__byteLengthUTF16AsUTF8(const char16_t* ptr, size
 extern "C" JSC::EncodedJSValue Bun__encoding__constructFromLatin1(void*, const unsigned char* ptr, size_t len, Encoding encoding);
 extern "C" JSC::EncodedJSValue Bun__encoding__constructFromUTF16(void*, const char16_t* ptr, size_t len, Encoding encoding);
 
-extern "C" void Bun__EventLoop__runCallback1(JSC::JSGlobalObject* global, JSC::EncodedJSValue callback, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue arg1);
 extern "C" void Bun__EventLoop__runCallback2(JSC::JSGlobalObject* global, JSC::EncodedJSValue callback, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue arg1, JSC::EncodedJSValue arg2);
-extern "C" void Bun__EventLoop__runCallback3(JSC::JSGlobalObject* global, JSC::EncodedJSValue callback, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue arg1, JSC::EncodedJSValue arg2, JSC::EncodedJSValue arg3);
 
 /// @note throws a JS exception and returns false if a stack overflow occurs
 template<bool isStrict, bool enableAsymmetricMatchers, bool skipPrototype = false>

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
@@ -40,30 +40,24 @@ void DhJobCtx::runTask(JSGlobalObject* globalObject)
     m_result = ByteSource::allocated(dp.release());
 }
 
-extern "C" void Bun__DhJobCtx__runFromJS(DhJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__DhJobCtx__takeCallbackArgs(DhJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
-void DhJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
+uint32_t DhJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
     if (!m_result) {
         // Same message as the synchronous path so callers observe identical errors either way.
-        JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "diffieHellman operation failed"_s);
-        Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-        return;
+        args[0] = JSValue::encode(createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "diffieHellman operation failed"_s));
+        return 1;
     }
 
-    JSValue result = WebCore::createBuffer(lexicalGlobalObject, m_result.span());
-
-    Bun__EventLoop__runCallback2(
-        lexicalGlobalObject,
-        JSValue::encode(callback),
-        JSValue::encode(jsUndefined()),
-        JSValue::encode(jsNull()),
-        JSValue::encode(result));
+    args[0] = JSValue::encode(jsNull());
+    args[1] = JSValue::encode(WebCore::createBuffer(lexicalGlobalObject, m_result.span()));
+    return 2;
 }
 
 extern "C" DhJob* Bun__DhJob__create(JSGlobalObject* globalObject, DhJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
@@ -51,12 +51,16 @@ uint32_t DhJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encoded
 
     if (!m_result) {
         // Same message as the synchronous path so callers observe identical errors either way.
-        args[0] = JSValue::encode(createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "diffieHellman operation failed"_s));
+        JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "diffieHellman operation failed"_s);
+        RETURN_IF_EXCEPTION(scope, 0);
+        args[0] = JSValue::encode(err);
         return 1;
     }
 
+    JSValue result = WebCore::createBuffer(lexicalGlobalObject, m_result.span());
+    RETURN_IF_EXCEPTION(scope, 0);
     args[0] = JSValue::encode(jsNull());
-    args[1] = JSValue::encode(WebCore::createBuffer(lexicalGlobalObject, m_result.span()));
+    args[1] = JSValue::encode(result);
     return 2;
 }
 

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.cpp
@@ -40,11 +40,11 @@ void DhJobCtx::runTask(JSGlobalObject* globalObject)
     m_result = ByteSource::allocated(dp.release());
 }
 
-extern "C" uint32_t Bun__DhJobCtx__takeCallbackArgs(DhJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__DhJobCtx__runFromJS(DhJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
-uint32_t DhJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+JSCallbackArgs DhJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject)
 {
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
@@ -52,16 +52,13 @@ uint32_t DhJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encoded
     if (!m_result) {
         // Same message as the synchronous path so callers observe identical errors either way.
         JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "diffieHellman operation failed"_s);
-        RETURN_IF_EXCEPTION(scope, 0);
-        args[0] = JSValue::encode(err);
-        return 1;
+        RETURN_IF_EXCEPTION(scope, {});
+        return { err };
     }
 
     JSValue result = WebCore::createBuffer(lexicalGlobalObject, m_result.span());
-    RETURN_IF_EXCEPTION(scope, 0);
-    args[0] = JSValue::encode(jsNull());
-    args[1] = JSValue::encode(result);
-    return 2;
+    RETURN_IF_EXCEPTION(scope, {});
+    return { jsNull(), result };
 }
 
 extern "C" DhJob* Bun__DhJob__create(JSGlobalObject* globalObject, DhJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.h
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.h
@@ -30,7 +30,7 @@ public:
     static std::optional<DhJobCtx> fromJS(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSObject* options);
 
     void runTask(JSC::JSGlobalObject*);
-    void runFromJS(JSC::JSGlobalObject*, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject*, JSC::EncodedJSValue* args);
     void deinit();
 
     RefPtr<KeyObjectData> m_privateKey;

--- a/src/jsc/bindings/node/crypto/CryptoDhJob.h
+++ b/src/jsc/bindings/node/crypto/CryptoDhJob.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "root.h"
+#include "JSCallbackArgs.h"
 #include "KeyObject.h"
 #include "CryptoUtil.h"
 
@@ -30,7 +31,7 @@ public:
     static std::optional<DhJobCtx> fromJS(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSObject* options);
 
     void runTask(JSC::JSGlobalObject*);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject*, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject*);
     void deinit();
 
     RefPtr<KeyObjectData> m_privateKey;

--- a/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
@@ -25,9 +25,9 @@ extern "C" void Bun__DhKeyPairJobCtx__runTask(DhKeyPairJobCtx* ctx, JSGlobalObje
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" void Bun__DhKeyPairJobCtx__runFromJS(DhKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__DhKeyPairJobCtx__takeCallbackArgs(DhKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
 
 extern "C" DhKeyPairJob* Bun__DhKeyPairJob__create(JSGlobalObject* globalObject, DhKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenDhKeyPair.cpp
@@ -25,9 +25,9 @@ extern "C" void Bun__DhKeyPairJobCtx__runTask(DhKeyPairJobCtx* ctx, JSGlobalObje
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" uint32_t Bun__DhKeyPairJobCtx__takeCallbackArgs(DhKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__DhKeyPairJobCtx__runFromJS(DhKeyPairJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
 
 extern "C" DhKeyPairJob* Bun__DhKeyPairJob__create(JSGlobalObject* globalObject, DhKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenDsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenDsaKeyPair.cpp
@@ -24,9 +24,9 @@ extern "C" void Bun__DsaKeyPairJobCtx__runTask(DsaKeyPairJobCtx* ctx, JSGlobalOb
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" void Bun__DsaKeyPairJobCtx__runFromJS(DsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__DsaKeyPairJobCtx__takeCallbackArgs(DsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
 
 extern "C" DsaKeyPairJob* Bun__DsaKeyPairJob__create(JSGlobalObject* globalObject, DsaKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenDsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenDsaKeyPair.cpp
@@ -24,9 +24,9 @@ extern "C" void Bun__DsaKeyPairJobCtx__runTask(DsaKeyPairJobCtx* ctx, JSGlobalOb
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" uint32_t Bun__DsaKeyPairJobCtx__takeCallbackArgs(DsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__DsaKeyPairJobCtx__runFromJS(DsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
 
 extern "C" DsaKeyPairJob* Bun__DsaKeyPairJob__create(JSGlobalObject* globalObject, DsaKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenEcKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenEcKeyPair.cpp
@@ -25,9 +25,9 @@ extern "C" void Bun__EcKeyPairJobCtx__runTask(EcKeyPairJobCtx* ctx, JSGlobalObje
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" void Bun__EcKeyPairJobCtx__runFromJS(EcKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__EcKeyPairJobCtx__takeCallbackArgs(EcKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
 
 extern "C" EcKeyPairJob* Bun__EcKeyPairJob__create(JSGlobalObject* globalObject, EcKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenEcKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenEcKeyPair.cpp
@@ -25,9 +25,9 @@ extern "C" void Bun__EcKeyPairJobCtx__runTask(EcKeyPairJobCtx* ctx, JSGlobalObje
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" uint32_t Bun__EcKeyPairJobCtx__takeCallbackArgs(EcKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__EcKeyPairJobCtx__runFromJS(EcKeyPairJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
 
 extern "C" EcKeyPairJob* Bun__EcKeyPairJob__create(JSGlobalObject* globalObject, EcKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
@@ -35,7 +35,9 @@ uint32_t KeyPairJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, En
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
     if (!m_keyObj.data()) {
-        args[0] = JSValue::encode(createCryptoError(lexicalGlobalObject, scope, m_opensslError, "key generation failed"_s));
+        JSValue err = createCryptoError(lexicalGlobalObject, scope, m_opensslError, "key generation failed"_s);
+        RETURN_IF_EXCEPTION(scope, 0);
+        args[0] = JSValue::encode(err);
         return 1;
     }
 

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
@@ -29,44 +29,36 @@ void KeyPairJobCtx::runTask(JSGlobalObject* globalObject, ncrypto::EVPKeyCtxPoin
     m_keyObj = KeyObject::create(CryptoKeyType::Private, WTF::move(key));
 }
 
-void KeyPairJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
+uint32_t KeyPairJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
-    auto exceptionCallback = [lexicalGlobalObject, callback](JSValue exceptionValue) {
-        Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(exceptionValue));
-    };
-
     if (!m_keyObj.data()) {
-        JSValue err = createCryptoError(lexicalGlobalObject, scope, m_opensslError, "key generation failed"_s);
-        Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-        return;
+        args[0] = JSValue::encode(createCryptoError(lexicalGlobalObject, scope, m_opensslError, "key generation failed"_s));
+        return 1;
     }
 
     JSValue publicKeyValue = m_keyObj.exportPublic(lexicalGlobalObject, scope, m_publicKeyEncoding);
     if (scope.exception()) [[unlikely]] {
         JSValue exceptionValue = scope.exception();
         (void)scope.tryClearException();
-        exceptionCallback(exceptionValue);
-        return;
+        args[0] = JSValue::encode(exceptionValue);
+        return 1;
     }
 
     JSValue privateKeyValue = m_keyObj.exportPrivate(lexicalGlobalObject, scope, m_privateKeyEncoding);
     if (scope.exception()) [[unlikely]] {
         JSValue exceptionValue = scope.exception();
         (void)scope.tryClearException();
-        exceptionCallback(exceptionValue);
-        return;
+        args[0] = JSValue::encode(exceptionValue);
+        return 1;
     }
 
-    Bun__EventLoop__runCallback3(
-        lexicalGlobalObject,
-        JSValue::encode(callback),
-        JSValue::encode(jsUndefined()),
-        JSValue::encode(jsNull()),
-        JSValue::encode(publicKeyValue),
-        JSValue::encode(privateKeyValue));
+    args[0] = JSValue::encode(jsNull());
+    args[1] = JSValue::encode(publicKeyValue);
+    args[2] = JSValue::encode(privateKeyValue);
+    return 3;
 }
 
 KeyEncodingConfig parseKeyEncodingConfig(JSGlobalObject* globalObject, ThrowScope& scope, JSValue keyTypeValue, JSValue optionsValue)

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
@@ -43,7 +43,9 @@ uint32_t KeyPairJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, En
 
     JSValue publicKeyValue = m_keyObj.exportPublic(lexicalGlobalObject, scope, m_publicKeyEncoding);
     if (scope.exception()) [[unlikely]] {
-        JSValue exceptionValue = scope.exception();
+        // The thrown value, not the Exception cell: the callback's err
+        // argument must be the Error object (node parity).
+        JSValue exceptionValue = scope.exception()->value();
         (void)scope.tryClearException();
         args[0] = JSValue::encode(exceptionValue);
         return 1;
@@ -51,7 +53,7 @@ uint32_t KeyPairJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, En
 
     JSValue privateKeyValue = m_keyObj.exportPrivate(lexicalGlobalObject, scope, m_privateKeyEncoding);
     if (scope.exception()) [[unlikely]] {
-        JSValue exceptionValue = scope.exception();
+        JSValue exceptionValue = scope.exception()->value();
         (void)scope.tryClearException();
         args[0] = JSValue::encode(exceptionValue);
         return 1;

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp
@@ -29,40 +29,33 @@ void KeyPairJobCtx::runTask(JSGlobalObject* globalObject, ncrypto::EVPKeyCtxPoin
     m_keyObj = KeyObject::create(CryptoKeyType::Private, WTF::move(key));
 }
 
-uint32_t KeyPairJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+JSCallbackArgs KeyPairJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject)
 {
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
 
     if (!m_keyObj.data()) {
         JSValue err = createCryptoError(lexicalGlobalObject, scope, m_opensslError, "key generation failed"_s);
-        RETURN_IF_EXCEPTION(scope, 0);
-        args[0] = JSValue::encode(err);
-        return 1;
+        RETURN_IF_EXCEPTION(scope, {});
+        return { err };
     }
 
     JSValue publicKeyValue = m_keyObj.exportPublic(lexicalGlobalObject, scope, m_publicKeyEncoding);
     if (scope.exception()) [[unlikely]] {
-        // The thrown value, not the Exception cell: the callback's err
-        // argument must be the Error object (node parity).
+        // The thrown Error, not the Exception cell (node parity).
         JSValue exceptionValue = scope.exception()->value();
         (void)scope.tryClearException();
-        args[0] = JSValue::encode(exceptionValue);
-        return 1;
+        return { exceptionValue };
     }
 
     JSValue privateKeyValue = m_keyObj.exportPrivate(lexicalGlobalObject, scope, m_privateKeyEncoding);
     if (scope.exception()) [[unlikely]] {
         JSValue exceptionValue = scope.exception()->value();
         (void)scope.tryClearException();
-        args[0] = JSValue::encode(exceptionValue);
-        return 1;
+        return { exceptionValue };
     }
 
-    args[0] = JSValue::encode(jsNull());
-    args[1] = JSValue::encode(publicKeyValue);
-    args[2] = JSValue::encode(privateKeyValue);
-    return 3;
+    return { jsNull(), publicKeyValue, privateKeyValue };
 }
 
 KeyEncodingConfig parseKeyEncodingConfig(JSGlobalObject* globalObject, ThrowScope& scope, JSValue keyTypeValue, JSValue optionsValue)

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.h
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.h
@@ -23,7 +23,7 @@ public:
     }
 
     void runTask(JSC::JSGlobalObject* globalObject, ncrypto::EVPKeyCtxPointer& ctx);
-    void runFromJS(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue* args);
     void deinit();
 
     int err() const { return m_opensslError; };

--- a/src/jsc/bindings/node/crypto/CryptoGenKeyPair.h
+++ b/src/jsc/bindings/node/crypto/CryptoGenKeyPair.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "root.h"
+#include "JSCallbackArgs.h"
 #include "ncrypto.h"
 #include "KeyObject.h"
 
@@ -23,7 +24,7 @@ public:
     }
 
     void runTask(JSC::JSGlobalObject* globalObject, ncrypto::EVPKeyCtxPointer& ctx);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject* globalObject);
     void deinit();
 
     int err() const { return m_opensslError; };

--- a/src/jsc/bindings/node/crypto/CryptoGenNidKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenNidKeyPair.cpp
@@ -25,9 +25,9 @@ extern "C" void Bun__NidKeyPairJobCtx__runTask(NidKeyPairJobCtx* ctx, JSGlobalOb
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" uint32_t Bun__NidKeyPairJobCtx__takeCallbackArgs(NidKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__NidKeyPairJobCtx__runFromJS(NidKeyPairJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
 
 extern "C" NidKeyPairJob* Bun__NidKeyPairJob__create(JSGlobalObject* globalObject, NidKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenNidKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenNidKeyPair.cpp
@@ -25,9 +25,9 @@ extern "C" void Bun__NidKeyPairJobCtx__runTask(NidKeyPairJobCtx* ctx, JSGlobalOb
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" void Bun__NidKeyPairJobCtx__runFromJS(NidKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__NidKeyPairJobCtx__takeCallbackArgs(NidKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
 
 extern "C" NidKeyPairJob* Bun__NidKeyPairJob__create(JSGlobalObject* globalObject, NidKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
@@ -26,9 +26,9 @@ extern "C" void Bun__RsaKeyPairJobCtx__runTask(RsaKeyPairJobCtx* ctx, JSGlobalOb
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" void Bun__RsaKeyPairJobCtx__runFromJS(RsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__RsaKeyPairJobCtx__takeCallbackArgs(RsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
 
 extern "C" RsaKeyPairJob* Bun__RsaKeyPairJob__create(JSGlobalObject* globalObject, RsaKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp
@@ -26,9 +26,9 @@ extern "C" void Bun__RsaKeyPairJobCtx__runTask(RsaKeyPairJobCtx* ctx, JSGlobalOb
     ctx->runTask(globalObject, keyCtx);
 }
 
-extern "C" uint32_t Bun__RsaKeyPairJobCtx__takeCallbackArgs(RsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__RsaKeyPairJobCtx__runFromJS(RsaKeyPairJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
 
 extern "C" RsaKeyPairJob* Bun__RsaKeyPairJob__create(JSGlobalObject* globalObject, RsaKeyPairJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -77,7 +77,9 @@ uint32_t HkdfJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!m_result) {
-        args[0] = JSValue::encode(createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "hkdf operation failed"_s));
+        JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "hkdf operation failed"_s);
+        RETURN_IF_EXCEPTION(scope, 0);
+        args[0] = JSValue::encode(err);
         return 1;
     }
 
@@ -86,14 +88,18 @@ uint32_t HkdfJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
 
     RefPtr<ArrayBuffer> buf = ArrayBuffer::tryCreateUninitialized(result.size(), 1);
     if (!buf) {
-        args[0] = JSValue::encode(createOutOfMemoryError(lexicalGlobalObject));
+        JSObject* err = createOutOfMemoryError(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, 0);
+        args[0] = JSValue::encode(err);
         return 1;
     }
 
     memcpy(buf->data(), result.data(), result.size());
 
+    JSValue resultBuffer = JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), buf.releaseNonNull());
+    RETURN_IF_EXCEPTION(scope, 0);
     args[0] = JSValue::encode(jsNull());
-    args[1] = JSValue::encode(JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), buf.releaseNonNull()));
+    args[1] = JSValue::encode(resultBuffer);
     return 2;
 }
 

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -67,20 +67,19 @@ void HkdfJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     m_result = ByteSource::allocated(dp.release());
 }
 
-extern "C" uint32_t Bun__HkdfJobCtx__takeCallbackArgs(HkdfJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+extern "C" void Bun__HkdfJobCtx__runFromJS(HkdfJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
+    *out = ctx->runFromJS(lexicalGlobalObject);
 }
-uint32_t HkdfJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+JSCallbackArgs HkdfJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject)
 {
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!m_result) {
         JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "hkdf operation failed"_s);
-        RETURN_IF_EXCEPTION(scope, 0);
-        args[0] = JSValue::encode(err);
-        return 1;
+        RETURN_IF_EXCEPTION(scope, {});
+        return { err };
     }
 
     auto& result = m_result.value();
@@ -89,18 +88,15 @@ uint32_t HkdfJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
     RefPtr<ArrayBuffer> buf = ArrayBuffer::tryCreateUninitialized(result.size(), 1);
     if (!buf) {
         JSObject* err = createOutOfMemoryError(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(scope, 0);
-        args[0] = JSValue::encode(err);
-        return 1;
+        RETURN_IF_EXCEPTION(scope, {});
+        return { err };
     }
 
     memcpy(buf->data(), result.data(), result.size());
 
     JSValue resultBuffer = JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), buf.releaseNonNull());
-    RETURN_IF_EXCEPTION(scope, 0);
-    args[0] = JSValue::encode(jsNull());
-    args[1] = JSValue::encode(resultBuffer);
-    return 2;
+    RETURN_IF_EXCEPTION(scope, {});
+    return { jsNull(), resultBuffer };
 }
 
 extern "C" void Bun__HkdfJobCtx__deinit(HkdfJobCtx* ctx)

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -67,19 +67,18 @@ void HkdfJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     m_result = ByteSource::allocated(dp.release());
 }
 
-extern "C" void Bun__HkdfJobCtx__runFromJS(HkdfJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__HkdfJobCtx__takeCallbackArgs(HkdfJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(lexicalGlobalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
 }
-void HkdfJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
+uint32_t HkdfJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!m_result) {
-        JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "hkdf operation failed"_s);
-        Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-        return;
+        args[0] = JSValue::encode(createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "hkdf operation failed"_s));
+        return 1;
     }
 
     auto& result = m_result.value();
@@ -87,18 +86,15 @@ void HkdfJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback
 
     RefPtr<ArrayBuffer> buf = ArrayBuffer::tryCreateUninitialized(result.size(), 1);
     if (!buf) {
-        JSObject* err = createOutOfMemoryError(lexicalGlobalObject);
-        Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-        return;
+        args[0] = JSValue::encode(createOutOfMemoryError(lexicalGlobalObject));
+        return 1;
     }
 
     memcpy(buf->data(), result.data(), result.size());
 
-    Bun__EventLoop__runCallback2(lexicalGlobalObject,
-        JSValue::encode(callback),
-        JSValue::encode(jsUndefined()),
-        JSValue::encode(jsNull()),
-        JSValue::encode(JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), buf.releaseNonNull())));
+    args[0] = JSValue::encode(jsNull());
+    args[1] = JSValue::encode(JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), buf.releaseNonNull()));
+    return 2;
 }
 
 extern "C" void Bun__HkdfJobCtx__deinit(HkdfJobCtx* ctx)

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.h
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.h
@@ -25,7 +25,7 @@ struct HkdfJobCtx {
     static std::optional<HkdfJobCtx> fromJS(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::ThrowScope&, Mode);
 
     void runTask(JSC::JSGlobalObject*);
-    void runFromJS(JSC::JSGlobalObject*, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject*, JSC::EncodedJSValue* args);
     void deinit();
 
     ncrypto::Digest m_digest;

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.h
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "root.h"
+#include "JSCallbackArgs.h"
 #include "helpers.h"
 #include "ncrypto.h"
 #include "CryptoUtil.h"
@@ -25,7 +26,7 @@ struct HkdfJobCtx {
     static std::optional<HkdfJobCtx> fromJS(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::ThrowScope&, Mode);
 
     void runTask(JSC::JSGlobalObject*);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject*, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject*);
     void deinit();
 
     ncrypto::Digest m_digest;

--- a/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
@@ -35,11 +35,11 @@ void SecretKeyJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     m_result = WTF::move(key);
 }
 
-extern "C" uint32_t Bun__SecretKeyJobCtx__takeCallbackArgs(SecretKeyJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+extern "C" void Bun__SecretKeyJobCtx__runFromJS(SecretKeyJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
+    *out = ctx->runFromJS(lexicalGlobalObject);
 }
-uint32_t SecretKeyJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+JSCallbackArgs SecretKeyJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject)
 {
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
@@ -47,21 +47,18 @@ uint32_t SecretKeyJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, 
 
     if (!m_result) {
         JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "key generation failed"_s);
-        RETURN_IF_EXCEPTION(scope, 0);
-        args[0] = JSValue::encode(err);
-        return 1;
+        RETURN_IF_EXCEPTION(scope, {});
+        return { err };
     }
 
     KeyObject keyObject = KeyObject::create(WTF::move(*m_result));
 
     Structure* structure = globalObject->m_JSSecretKeyObjectClassStructure.get(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, {});
     JSSecretKeyObject* secretKey = JSSecretKeyObject::create(vm, structure, lexicalGlobalObject, WTF::move(keyObject));
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, {});
 
-    args[0] = JSValue::encode(jsNull());
-    args[1] = JSValue::encode(secretKey);
-    return 2;
+    return { jsNull(), secretKey };
 }
 
 extern "C" void Bun__SecretKeyJobCtx__deinit(SecretKeyJobCtx* ctx)

--- a/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
@@ -46,14 +46,18 @@ uint32_t SecretKeyJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
     if (!m_result) {
-        args[0] = JSValue::encode(createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "key generation failed"_s));
+        JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "key generation failed"_s);
+        RETURN_IF_EXCEPTION(scope, 0);
+        args[0] = JSValue::encode(err);
         return 1;
     }
 
     KeyObject keyObject = KeyObject::create(WTF::move(*m_result));
 
     Structure* structure = globalObject->m_JSSecretKeyObjectClassStructure.get(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, 0);
     JSSecretKeyObject* secretKey = JSSecretKeyObject::create(vm, structure, lexicalGlobalObject, WTF::move(keyObject));
+    RETURN_IF_EXCEPTION(scope, 0);
 
     args[0] = JSValue::encode(jsNull());
     args[1] = JSValue::encode(secretKey);

--- a/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
@@ -35,20 +35,19 @@ void SecretKeyJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     m_result = WTF::move(key);
 }
 
-extern "C" void Bun__SecretKeyJobCtx__runFromJS(SecretKeyJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, JSC::JSValue callback)
+extern "C" uint32_t Bun__SecretKeyJobCtx__takeCallbackArgs(SecretKeyJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(lexicalGlobalObject, callback);
+    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
 }
-void SecretKeyJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSC::JSValue callback)
+uint32_t SecretKeyJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
     VM& vm = lexicalGlobalObject->vm();
     ThrowScope scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
     if (!m_result) {
-        JSObject* err = createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "key generation failed"_s);
-        Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-        return;
+        args[0] = JSValue::encode(createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "key generation failed"_s));
+        return 1;
     }
 
     KeyObject keyObject = KeyObject::create(WTF::move(*m_result));
@@ -56,11 +55,9 @@ void SecretKeyJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSC::JSValu
     Structure* structure = globalObject->m_JSSecretKeyObjectClassStructure.get(lexicalGlobalObject);
     JSSecretKeyObject* secretKey = JSSecretKeyObject::create(vm, structure, lexicalGlobalObject, WTF::move(keyObject));
 
-    Bun__EventLoop__runCallback2(lexicalGlobalObject,
-        JSValue::encode(callback),
-        JSValue::encode(jsUndefined()),
-        JSValue::encode(jsNull()),
-        JSValue::encode(secretKey));
+    args[0] = JSValue::encode(jsNull());
+    args[1] = JSValue::encode(secretKey);
+    return 2;
 }
 
 extern "C" void Bun__SecretKeyJobCtx__deinit(SecretKeyJobCtx* ctx)

--- a/src/jsc/bindings/node/crypto/CryptoKeygen.h
+++ b/src/jsc/bindings/node/crypto/CryptoKeygen.h
@@ -11,7 +11,7 @@ struct SecretKeyJobCtx {
     ~SecretKeyJobCtx() = default;
 
     void runTask(JSC::JSGlobalObject* lexicalGlobalObject);
-    void runFromJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue* args);
     void deinit();
 
     static std::optional<SecretKeyJobCtx> fromJS(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSValue typeValue, JSC::JSValue optionsValue);

--- a/src/jsc/bindings/node/crypto/CryptoKeygen.h
+++ b/src/jsc/bindings/node/crypto/CryptoKeygen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "root.h"
+#include "JSCallbackArgs.h"
 #include "ncrypto.h"
 
 namespace Bun {
@@ -11,7 +12,7 @@ struct SecretKeyJobCtx {
     ~SecretKeyJobCtx() = default;
 
     void runTask(JSC::JSGlobalObject* lexicalGlobalObject);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject* lexicalGlobalObject);
     void deinit();
 
     static std::optional<SecretKeyJobCtx> fromJS(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSValue typeValue, JSC::JSValue optionsValue);

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
@@ -33,15 +33,13 @@ void CheckPrimeJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     m_result = res != 0;
 }
 
-extern "C" uint32_t Bun__CheckPrimeJobCtx__takeCallbackArgs(CheckPrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+extern "C" void Bun__CheckPrimeJobCtx__runFromJS(CheckPrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
+    *out = ctx->runFromJS(lexicalGlobalObject);
 }
-uint32_t CheckPrimeJobCtx::takeCallbackArgs(JSGlobalObject*, EncodedJSValue* args)
+JSCallbackArgs CheckPrimeJobCtx::runFromJS(JSGlobalObject*)
 {
-    args[0] = JSValue::encode(jsUndefined());
-    args[1] = JSValue::encode(jsBoolean(m_result));
-    return 2;
+    return { jsUndefined(), jsBoolean(m_result) };
 }
 
 extern "C" void Bun__CheckPrimeJobCtx__deinit(CheckPrimeJobCtx* ctx)
@@ -198,11 +196,11 @@ void GeneratePrimeJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     });
 }
 
-extern "C" uint32_t Bun__GeneratePrimeJobCtx__takeCallbackArgs(GeneratePrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+extern "C" void Bun__GeneratePrimeJobCtx__runFromJS(GeneratePrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
+    *out = ctx->runFromJS(lexicalGlobalObject);
 }
-uint32_t GeneratePrimeJobCtx::takeCallbackArgs(JSGlobalObject* globalObject, EncodedJSValue* args)
+JSCallbackArgs GeneratePrimeJobCtx::runFromJS(JSGlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -210,16 +208,13 @@ uint32_t GeneratePrimeJobCtx::takeCallbackArgs(JSGlobalObject* globalObject, Enc
     JSValue result = GeneratePrimeJob::result(globalObject, scope, m_prime, m_bigint);
     EXCEPTION_ASSERT(result.isEmpty() == !!scope.exception());
     if (scope.exception()) [[unlikely]] {
-        // The thrown value, not the Exception cell (see KeyPairJobCtx).
+        // The thrown Error, not the Exception cell (node parity).
         JSValue err = scope.exception()->value();
         (void)scope.tryClearException();
-        args[0] = JSValue::encode(err);
-        return 1;
+        return { err };
     }
 
-    args[0] = JSValue::encode(jsUndefined());
-    args[1] = JSValue::encode(result);
-    return 2;
+    return { jsUndefined(), result };
 }
 
 extern "C" void Bun__GeneratePrimeJobCtx__deinit(GeneratePrimeJobCtx* ctx)

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
@@ -33,13 +33,15 @@ void CheckPrimeJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     m_result = res != 0;
 }
 
-extern "C" void Bun__CheckPrimeJobCtx__runFromJS(CheckPrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__CheckPrimeJobCtx__takeCallbackArgs(CheckPrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(lexicalGlobalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
 }
-void CheckPrimeJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
+uint32_t CheckPrimeJobCtx::takeCallbackArgs(JSGlobalObject*, EncodedJSValue* args)
 {
-    Bun__EventLoop__runCallback2(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(jsUndefined()), JSValue::encode(jsBoolean(m_result)));
+    args[0] = JSValue::encode(jsUndefined());
+    args[1] = JSValue::encode(jsBoolean(m_result));
+    return 2;
 }
 
 extern "C" void Bun__CheckPrimeJobCtx__deinit(CheckPrimeJobCtx* ctx)
@@ -196,11 +198,11 @@ void GeneratePrimeJobCtx::runTask(JSGlobalObject* lexicalGlobalObject)
     });
 }
 
-extern "C" void Bun__GeneratePrimeJobCtx__runFromJS(GeneratePrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__GeneratePrimeJobCtx__takeCallbackArgs(GeneratePrimeJobCtx* ctx, JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(lexicalGlobalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(lexicalGlobalObject, args);
 }
-void GeneratePrimeJobCtx::runFromJS(JSGlobalObject* globalObject, JSValue callback)
+uint32_t GeneratePrimeJobCtx::takeCallbackArgs(JSGlobalObject* globalObject, EncodedJSValue* args)
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -210,21 +212,13 @@ void GeneratePrimeJobCtx::runFromJS(JSGlobalObject* globalObject, JSValue callba
     if (scope.exception()) [[unlikely]] {
         auto* err = scope.exception();
         (void)scope.tryClearException();
-        Bun__EventLoop__runCallback1(
-            globalObject,
-            JSValue::encode(callback),
-            JSValue::encode(jsUndefined()),
-            JSValue::encode(err));
-        return;
+        args[0] = JSValue::encode(err);
+        return 1;
     }
 
-    Bun__EventLoop__runCallback2(
-        globalObject,
-        JSValue::encode(callback),
-        JSValue::encode(jsUndefined()),
-        JSValue::encode(jsUndefined()),
-        JSValue::encode(result));
-    return;
+    args[0] = JSValue::encode(jsUndefined());
+    args[1] = JSValue::encode(result);
+    return 2;
 }
 
 extern "C" void Bun__GeneratePrimeJobCtx__deinit(GeneratePrimeJobCtx* ctx)

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
@@ -210,7 +210,8 @@ uint32_t GeneratePrimeJobCtx::takeCallbackArgs(JSGlobalObject* globalObject, Enc
     JSValue result = GeneratePrimeJob::result(globalObject, scope, m_prime, m_bigint);
     EXCEPTION_ASSERT(result.isEmpty() == !!scope.exception());
     if (scope.exception()) [[unlikely]] {
-        auto* err = scope.exception();
+        // The thrown value, not the Exception cell (see KeyPairJobCtx).
+        JSValue err = scope.exception()->value();
         (void)scope.tryClearException();
         args[0] = JSValue::encode(err);
         return 1;

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.h
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.h
@@ -11,7 +11,7 @@ struct CheckPrimeJobCtx {
     ~CheckPrimeJobCtx();
 
     void runTask(JSC::JSGlobalObject* lexicalGlobalObject);
-    void runFromJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue* args);
     void deinit();
 
     int32_t m_checks;
@@ -35,7 +35,7 @@ struct GeneratePrimeJobCtx {
     ~GeneratePrimeJobCtx();
 
     void runTask(JSC::JSGlobalObject* lexicalGlobalObject);
-    void runFromJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue* args);
     void deinit();
 
     int32_t m_size;

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.h
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "root.h"
+#include "JSCallbackArgs.h"
 #include "helpers.h"
 #include "ncrypto.h"
 
@@ -11,7 +12,7 @@ struct CheckPrimeJobCtx {
     ~CheckPrimeJobCtx();
 
     void runTask(JSC::JSGlobalObject* lexicalGlobalObject);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject* lexicalGlobalObject);
     void deinit();
 
     int32_t m_checks;
@@ -35,7 +36,7 @@ struct GeneratePrimeJobCtx {
     ~GeneratePrimeJobCtx();
 
     void runTask(JSC::JSGlobalObject* lexicalGlobalObject);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject* lexicalGlobalObject);
     void deinit();
 
     int32_t m_size;

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -215,11 +215,11 @@ void SignJobCtx::runTask(JSGlobalObject* globalObject)
     }
 }
 
-extern "C" uint32_t Bun__SignJobCtx__takeCallbackArgs(SignJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
+extern "C" void Bun__SignJobCtx__runFromJS(SignJobCtx* ctx, JSGlobalObject* globalObject, JSCallbackArgs* out)
 {
-    return ctx->takeCallbackArgs(globalObject, args);
+    *out = ctx->runFromJS(globalObject);
 }
-uint32_t SignJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
+JSCallbackArgs SignJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject)
 {
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -230,9 +230,8 @@ uint32_t SignJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
             JSValue err = m_unsupportedContext
                 ? createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Context parameter is unsupported"_s)
                 : createCryptoError(lexicalGlobalObject, scope, m_opensslError, "sign operation failed"_s);
-            RETURN_IF_EXCEPTION(scope, 0);
-            args[0] = JSValue::encode(err);
-            return 1;
+            RETURN_IF_EXCEPTION(scope, {});
+            return { err };
         }
 
         auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
@@ -240,28 +239,23 @@ uint32_t SignJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
         auto sigBuf = ArrayBuffer::createUninitialized(m_signResult->size(), 1);
         memcpy(sigBuf->data(), m_signResult->data(), m_signResult->size());
         auto* signature = JSUint8Array::create(lexicalGlobalObject, globalObject->JSBufferSubclassStructure(), WTF::move(sigBuf), 0, m_signResult->size());
-        RETURN_IF_EXCEPTION(scope, 0);
+        RETURN_IF_EXCEPTION(scope, {});
 
-        args[0] = JSValue::encode(jsNull());
-        args[1] = JSValue::encode(signature);
-        return 2;
+        return { jsNull(), signature };
     }
     case Mode::Verify: {
         if (!m_verifyResult) {
             JSValue err = m_unsupportedContext
                 ? createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Context parameter is unsupported"_s)
                 : createCryptoError(lexicalGlobalObject, scope, m_opensslError, "verify operation failed"_s);
-            RETURN_IF_EXCEPTION(scope, 0);
-            args[0] = JSValue::encode(err);
-            return 1;
+            RETURN_IF_EXCEPTION(scope, {});
+            return { err };
         }
 
-        args[0] = JSValue::encode(jsNull());
-        args[1] = JSValue::encode(jsBoolean(*m_verifyResult));
-        return 2;
+        return { jsNull(), jsBoolean(*m_verifyResult) };
     }
     }
-    return 0;
+    return {};
 }
 
 extern "C" SignJob* Bun__SignJob__create(JSGlobalObject* globalObject, SignJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -230,6 +230,7 @@ uint32_t SignJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
             JSValue err = m_unsupportedContext
                 ? createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Context parameter is unsupported"_s)
                 : createCryptoError(lexicalGlobalObject, scope, m_opensslError, "sign operation failed"_s);
+            RETURN_IF_EXCEPTION(scope, 0);
             args[0] = JSValue::encode(err);
             return 1;
         }
@@ -250,6 +251,7 @@ uint32_t SignJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, Encod
             JSValue err = m_unsupportedContext
                 ? createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Context parameter is unsupported"_s)
                 : createCryptoError(lexicalGlobalObject, scope, m_opensslError, "verify operation failed"_s);
+            RETURN_IF_EXCEPTION(scope, 0);
             args[0] = JSValue::encode(err);
             return 1;
         }

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -215,11 +215,11 @@ void SignJobCtx::runTask(JSGlobalObject* globalObject)
     }
 }
 
-extern "C" void Bun__SignJobCtx__runFromJS(SignJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue callback)
+extern "C" uint32_t Bun__SignJobCtx__takeCallbackArgs(SignJobCtx* ctx, JSGlobalObject* globalObject, EncodedJSValue* args)
 {
-    ctx->runFromJS(globalObject, JSValue::decode(callback));
+    return ctx->takeCallbackArgs(globalObject, args);
 }
-void SignJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback)
+uint32_t SignJobCtx::takeCallbackArgs(JSGlobalObject* lexicalGlobalObject, EncodedJSValue* args)
 {
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -230,8 +230,8 @@ void SignJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback
             JSValue err = m_unsupportedContext
                 ? createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Context parameter is unsupported"_s)
                 : createCryptoError(lexicalGlobalObject, scope, m_opensslError, "sign operation failed"_s);
-            Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-            return;
+            args[0] = JSValue::encode(err);
+            return 1;
         }
 
         auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
@@ -239,35 +239,27 @@ void SignJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject, JSValue callback
         auto sigBuf = ArrayBuffer::createUninitialized(m_signResult->size(), 1);
         memcpy(sigBuf->data(), m_signResult->data(), m_signResult->size());
         auto* signature = JSUint8Array::create(lexicalGlobalObject, globalObject->JSBufferSubclassStructure(), WTF::move(sigBuf), 0, m_signResult->size());
-        RETURN_IF_EXCEPTION(scope, );
+        RETURN_IF_EXCEPTION(scope, 0);
 
-        Bun__EventLoop__runCallback2(
-            lexicalGlobalObject,
-            JSValue::encode(callback),
-            JSValue::encode(jsUndefined()),
-            JSValue::encode(jsNull()),
-            JSValue::encode(signature));
-
-        break;
+        args[0] = JSValue::encode(jsNull());
+        args[1] = JSValue::encode(signature);
+        return 2;
     }
     case Mode::Verify: {
         if (!m_verifyResult) {
             JSValue err = m_unsupportedContext
                 ? createError(lexicalGlobalObject, ErrorCode::ERR_CRYPTO_OPERATION_FAILED, "Context parameter is unsupported"_s)
                 : createCryptoError(lexicalGlobalObject, scope, m_opensslError, "verify operation failed"_s);
-            Bun__EventLoop__runCallback1(lexicalGlobalObject, JSValue::encode(callback), JSValue::encode(jsUndefined()), JSValue::encode(err));
-            return;
+            args[0] = JSValue::encode(err);
+            return 1;
         }
 
-        Bun__EventLoop__runCallback2(
-            lexicalGlobalObject,
-            JSValue::encode(callback),
-            JSValue::encode(jsUndefined()),
-            JSValue::encode(jsNull()),
-            JSValue::encode(jsBoolean(*m_verifyResult)));
-        break;
+        args[0] = JSValue::encode(jsNull());
+        args[1] = JSValue::encode(jsBoolean(*m_verifyResult));
+        return 2;
     }
     }
+    return 0;
 }
 
 extern "C" SignJob* Bun__SignJob__create(JSGlobalObject* globalObject, SignJobCtx* ctx, EncodedJSValue callback);

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.h
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.h
@@ -49,7 +49,7 @@ public:
         JSValue algorithmValue, JSValue dataValue, JSValue keyValue, JSValue signatureValue, JSValue callbackValue);
 
     void runTask(JSC::JSGlobalObject*);
-    void runFromJS(JSC::JSGlobalObject*, JSC::JSValue callback);
+    uint32_t takeCallbackArgs(JSC::JSGlobalObject*, JSC::EncodedJSValue* args);
     void deinit();
 
     Mode m_mode;

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.h
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "root.h"
+#include "JSCallbackArgs.h"
 #include "CryptoUtil.h"
 #include "KeyObject.h"
 
@@ -49,7 +50,7 @@ public:
         JSValue algorithmValue, JSValue dataValue, JSValue keyValue, JSValue signatureValue, JSValue callbackValue);
 
     void runTask(JSC::JSGlobalObject*);
-    uint32_t takeCallbackArgs(JSC::JSGlobalObject*, JSC::EncodedJSValue* args);
+    JSCallbackArgs runFromJS(JSC::JSGlobalObject*);
     void deinit();
 
     Mode m_mode;

--- a/src/jsc/bindings/node/crypto/JSCallbackArgs.h
+++ b/src/jsc/bindings/node/crypto/JSCallbackArgs.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "root.h"
+
+namespace Bun {
+
+// The arguments an async crypto job's completion callback will be invoked
+// with, returned by value from the ctx's JS-thread half (`runFromJS`). The
+// native side only builds this value; the job plumbing in
+// node_crypto_binding.rs frees the ctx and then calls the JS callback with it
+// (mirrored there as `JsCallbackArgs`). The default-constructed value (no
+// arguments) is the discard returned alongside a pending exception.
+struct JSCallbackArgs {
+    JSCallbackArgs() = default;
+    JSCallbackArgs(JSC::JSValue arg0)
+        : m_argv { JSC::JSValue::encode(arg0) }
+        , m_argc(1)
+    {
+    }
+    JSCallbackArgs(JSC::JSValue arg0, JSC::JSValue arg1)
+        : m_argv { JSC::JSValue::encode(arg0), JSC::JSValue::encode(arg1) }
+        , m_argc(2)
+    {
+    }
+    JSCallbackArgs(JSC::JSValue arg0, JSC::JSValue arg1, JSC::JSValue arg2)
+        : m_argv { JSC::JSValue::encode(arg0), JSC::JSValue::encode(arg1), JSC::JSValue::encode(arg2) }
+        , m_argc(3)
+    {
+    }
+
+private:
+    JSC::EncodedJSValue m_argv[3] = { 0, 0, 0 };
+    // Read on the Rust side only (node_crypto_binding.rs).
+    [[maybe_unused]] uint32_t m_argc = 0;
+};
+
+static_assert(std::is_trivially_copyable_v<JSCallbackArgs>, "copied through an extern \"C\" out-pointer");
+
+} // namespace Bun

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1223,19 +1223,6 @@ extern "C" fn noop_forever_timer(_: *mut uws::Timer) {
     // do nothing
 }
 
-// HOST_EXPORT(Bun__EventLoop__runCallback1, c)
-pub fn event_loop_run_callback1(
-    global: &JSGlobalObject,
-    callback: JSValue,
-    this_value: JSValue,
-    arg0: JSValue,
-) {
-    global
-        .bun_vm()
-        .event_loop_mut()
-        .run_callback(callback, global, this_value, &[arg0]);
-}
-
 // HOST_EXPORT(Bun__EventLoop__runCallback2, c)
 pub fn event_loop_run_callback2(
     global: &JSGlobalObject,
@@ -1248,23 +1235,6 @@ pub fn event_loop_run_callback2(
         .bun_vm()
         .event_loop_mut()
         .run_callback(callback, global, this_value, &[arg0, arg1]);
-}
-
-// HOST_EXPORT(Bun__EventLoop__runCallback3, c)
-pub fn event_loop_run_callback3(
-    global: &JSGlobalObject,
-    callback: JSValue,
-    this_value: JSValue,
-    arg0: JSValue,
-    arg1: JSValue,
-    arg2: JSValue,
-) {
-    global.bun_vm().event_loop_mut().run_callback(
-        callback,
-        global,
-        this_value,
-        &[arg0, arg1, arg2],
-    );
 }
 
 // HOST_EXPORT(Bun__EventLoop__enter, c)

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -743,9 +743,11 @@ impl EventLoop {
     ///
     /// Tags `__bun_release_task_at_shutdown` doesn't claim are likewise
     /// re-queued so they remain reachable from the static-rooted VM box (the
-    /// pre-`532a5411961b` state). Consuming them silently here unhooked that
-    /// root and surfaced the boxes as direct leaks (e.g. `AnyTaskJob<_>`); the
-    /// definer can't safely dispatch every erased callback at shutdown.
+    /// pre-`532a5411961b` state). Consuming them without freeing unhooked that
+    /// root and surfaced the boxes as direct leaks; the definer can't safely
+    /// dispatch every erased callback at shutdown. `AnyTaskJob` is claimed
+    /// with a real free (`release_erased`): parking it instead would strand
+    /// the C++ ctx's resources behind LSan-invisible memory.
     pub fn release_queued_tasks_for_shutdown(&mut self) {
         self.drop_concurrent_cpp_tasks();
         let mut requeue: Vec<bun_event_loop::Task> = Vec::new();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -745,9 +745,7 @@ impl EventLoop {
     /// re-queued so they remain reachable from the static-rooted VM box (the
     /// pre-`532a5411961b` state). Consuming them without freeing unhooked that
     /// root and surfaced the boxes as direct leaks; the definer can't safely
-    /// dispatch every erased callback at shutdown. `AnyTaskJob` is claimed
-    /// with a real free (`release_erased`): parking it instead would strand
-    /// the C++ ctx's resources behind LSan-invisible memory.
+    /// dispatch every erased callback at shutdown.
     pub fn release_queued_tasks_for_shutdown(&mut self) {
         self.drop_concurrent_cpp_tasks();
         let mut requeue: Vec<bun_event_loop::Task> = Vec::new();

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1355,11 +1355,8 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
             unsafe { Bun__deleteEventLoopTask(task.ptr.cast::<CppTask>()) };
             true
         }
-        // The work-pool phase finished (it posted this entry), so the queue
-        // held exclusive ownership. Free the job without running `then`: the
-        // ctx `Drop` releases native resources and JSC handles, which must
-        // happen while the VM is live — a C++-backed ctx parked in the queue
-        // would strand its OpenSSL allocations past the leak check.
+        // Queue presence means the work-pool phase finished and the queue
+        // owned the job; parking it would strand the ctx's native resources.
         task_tag::AnyTaskJob => {
             // SAFETY: every queued AnyTaskJob payload is the live heap job
             // created by `AnyTaskJob::create`; we own it once popped.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1355,6 +1355,17 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
             unsafe { Bun__deleteEventLoopTask(task.ptr.cast::<CppTask>()) };
             true
         }
+        // The work-pool phase finished (it posted this entry), so the queue
+        // held exclusive ownership. Free the job without running `then`: the
+        // ctx `Drop` releases native resources and JSC handles, which must
+        // happen while the VM is live — a C++-backed ctx parked in the queue
+        // would strand its OpenSSL allocations past the leak check.
+        task_tag::AnyTaskJob => {
+            // SAFETY: every queued AnyTaskJob payload is the live heap job
+            // created by `AnyTaskJob::create`; we own it once popped.
+            unsafe { bun_jsc::any_task_job::release_erased(task.ptr) };
+            true
+        }
         // Re-queued by the caller; the box stays reachable from the
         // static-rooted VM queue, because running these callbacks
         // is not generally safe at shutdown (e.g. `AsyncModule::on_done`,

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -66,18 +66,35 @@ macro_rules! extern_crypto_job {
             // to a non-null pointer and discharges the validity proof at the
             // type level. `global` in `runTask` is forwarded raw (the trait
             // hands us `*mut`; C++ never reads through it off-thread).
+            //
+            // `takeCallbackArgs` writes the completion callback's arguments
+            // into `args[..argc]` and returns `argc` (≤ 3). The C++ side never
+            // sees the callback value, so it cannot run user JS; invocation
+            // happens in `then` below, after the ctx is freed.
             unsafe extern "C" {
                 #[link_name = concat!("Bun__", $name_str, "Ctx__runTask")]
                 safe fn ctx_run_task(ctx: &Ctx, global: *mut JSGlobalObject);
-                #[link_name = concat!("Bun__", $name_str, "Ctx__runFromJS")]
-                safe fn ctx_run_from_js(ctx: &Ctx, global: &JSGlobalObject, callback: JSValue);
+                #[link_name = concat!("Bun__", $name_str, "Ctx__takeCallbackArgs")]
+                safe fn ctx_take_callback_args(
+                    ctx: &Ctx,
+                    global: &JSGlobalObject,
+                    args: &mut [JSValue; 3],
+                ) -> u32;
                 #[link_name = concat!("Bun__", $name_str, "Ctx__deinit")]
                 safe fn ctx_deinit(ctx: &Ctx);
             }
 
             pub(crate) struct ExternCtx {
+                // Null once `then` has freed it.
                 ctx: *mut Ctx,
                 callback: StrongOptional,
+            }
+
+            impl ExternCtx {
+                fn deinit_ctx(&mut self) {
+                    ctx_deinit(Ctx::opaque_ref(self.ctx));
+                    self.ctx = core::ptr::null_mut();
+                }
             }
 
             impl AnyTaskJobCtx for ExternCtx {
@@ -88,11 +105,25 @@ macro_rules! extern_crypto_job {
                     let Some(callback) = self.callback.try_swap() else {
                         return Ok(());
                     };
-                    let ctx = Ctx::opaque_ref(self.ctx);
-                    if let Err(err) = jsc::from_js_host_call_generic(global, || {
-                        ctx_run_from_js(ctx, global, callback);
-                    }) {
-                        global.report_active_exception_as_unhandled(err);
+                    let mut args = [JSValue::UNDEFINED; 3];
+                    let argc = jsc::from_js_host_call_generic(global, || {
+                        ctx_take_callback_args(Ctx::opaque_ref(self.ctx), global, &mut args)
+                    });
+                    // Free the ctx BEFORE any user JS runs (the callback, or an
+                    // uncaughtException handler): user code may never return
+                    // (`process.exit()`), which would strand everything the ctx
+                    // still owns.
+                    self.deinit_ctx();
+                    match argc {
+                        Ok(argc) => {
+                            global.bun_vm().event_loop_mut().run_callback(
+                                callback,
+                                global,
+                                JSValue::UNDEFINED,
+                                &args[..(argc as usize).min(args.len())],
+                            );
+                        }
+                        Err(err) => global.report_active_exception_as_unhandled(err),
                     }
                     Ok(())
                 }
@@ -100,7 +131,11 @@ macro_rules! extern_crypto_job {
 
             impl Drop for ExternCtx {
                 fn drop(&mut self) {
-                    ctx_deinit(Ctx::opaque_ref(self.ctx));
+                    // Non-null when the job dies without completing (shutdown
+                    // early-out, `init` failure, missing callback).
+                    if !self.ctx.is_null() {
+                        self.deinit_ctx();
+                    }
                     self.callback.deinit();
                 }
             }

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -54,6 +54,27 @@ impl JSValueCryptoExt for JSValue {
 // ExternCryptoJob — token-pastes C symbol names (`Bun__<name>Ctx__runTask`
 // etc.), so a `macro_rules!` is the right shape.
 // ───────────────────────────────────────────────────────────────────────────
+
+/// Completion-callback arguments produced by a job ctx's JS-thread half
+/// (`runFromJS`). Layout mirrors `Bun::JSCallbackArgs` (JSCallbackArgs.h),
+/// which fills it through the extern "C" out-pointer.
+#[repr(C)]
+struct JsCallbackArgs {
+    argv: [JSValue; 3],
+    argc: u32,
+}
+
+impl JsCallbackArgs {
+    const EMPTY: Self = Self {
+        argv: [JSValue::UNDEFINED; 3],
+        argc: 0,
+    };
+
+    fn as_slice(&self) -> &[JSValue] {
+        &self.argv[..(self.argc as usize).min(self.argv.len())]
+    }
+}
+
 macro_rules! extern_crypto_job {
     ($Name:ident, $name_str:literal) => {
         pub mod $Name {
@@ -67,19 +88,19 @@ macro_rules! extern_crypto_job {
             // type level. `global` in `runTask` is forwarded raw (the trait
             // hands us `*mut`; C++ never reads through it off-thread).
             //
-            // `takeCallbackArgs` writes the completion callback's arguments
-            // into `args[..argc]` and returns `argc` (≤ 3). The C++ side never
-            // sees the callback value, so it cannot run user JS; invocation
-            // happens in `then` below, after the ctx is freed.
+            // `runFromJS` (the JS-thread half; `runTask` is the work-pool
+            // half) returns the completion callback's arguments by value. It
+            // never sees the callback, so it cannot run user JS; `then` frees
+            // the ctx and then invokes.
             unsafe extern "C" {
                 #[link_name = concat!("Bun__", $name_str, "Ctx__runTask")]
                 safe fn ctx_run_task(ctx: &Ctx, global: *mut JSGlobalObject);
-                #[link_name = concat!("Bun__", $name_str, "Ctx__takeCallbackArgs")]
-                safe fn ctx_take_callback_args(
+                #[link_name = concat!("Bun__", $name_str, "Ctx__runFromJS")]
+                safe fn ctx_run_from_js(
                     ctx: &Ctx,
                     global: &JSGlobalObject,
-                    args: &mut [JSValue; 3],
-                ) -> u32;
+                    out: &mut JsCallbackArgs,
+                );
                 #[link_name = concat!("Bun__", $name_str, "Ctx__deinit")]
                 safe fn ctx_deinit(ctx: &Ctx);
             }
@@ -105,22 +126,21 @@ macro_rules! extern_crypto_job {
                     let Some(callback) = self.callback.try_swap() else {
                         return Ok(());
                     };
-                    let mut args = [JSValue::UNDEFINED; 3];
-                    let argc = jsc::from_js_host_call_generic(global, || {
-                        ctx_take_callback_args(Ctx::opaque_ref(self.ctx), global, &mut args)
+                    let mut args = JsCallbackArgs::EMPTY;
+                    let produced = jsc::from_js_host_call_generic(global, || {
+                        ctx_run_from_js(Ctx::opaque_ref(self.ctx), global, &mut args);
                     });
-                    // Free the ctx BEFORE any user JS runs (the callback, or an
-                    // uncaughtException handler): user code may never return
-                    // (`process.exit()`), which would strand everything the ctx
-                    // still owns.
+                    // Free the ctx before user JS (the callback, or an
+                    // uncaughtException handler) — user code may never return
+                    // (`process.exit()`).
                     self.deinit_ctx();
-                    match argc {
-                        Ok(argc) => {
+                    match produced {
+                        Ok(()) => {
                             global.bun_vm().event_loop_mut().run_callback(
                                 callback,
                                 global,
                                 JSValue::UNDEFINED,
-                                &args[..(argc as usize).min(args.len())],
+                                args.as_slice(),
                             );
                         }
                         Err(err) => global.report_active_exception_as_unhandled(err),

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -23,7 +23,7 @@ import {
   verify,
 } from "crypto";
 import fs from "fs";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows } from "harness";
 import { createContext, runInContext, runInThisContext, Script } from "node:vm";
 import path from "path";
 
@@ -1800,3 +1800,70 @@ test("ECDSA should work", async () => {
 function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
+
+// The async crypto jobs (generateKeyPair, sign, diffieHellman, hkdf, ...) run
+// on the work pool and complete on the JS thread. The native job ctx must be
+// freed before the JS callback is invoked: a callback that never returns
+// (process.exit()) would otherwise strand everything the ctx still owns (the
+// generated EVP_PKEY, key refs, BIGNUMs). These children run with leak
+// checking on, so a stranded OpenSSL allocation fails the child with a
+// LeakSanitizer report.
+describe.skipIf(!isASAN)("async crypto jobs: process.exit() in the callback leaks nothing", () => {
+  const lsanEnv = {
+    ...bunEnv,
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
+  };
+  // LSan symbolizes any report through llvm-symbolizer against the debug
+  // binary, which takes several seconds.
+  const timeout = 30_000;
+
+  const cases = {
+    "generateKeyPair (KeyObject output)": `crypto.generateKeyPair("rsa", { modulusLength: 512 }, done);`,
+    "generateKeyPair (encrypted PEM output)": `crypto.generateKeyPair("rsa", {
+        modulusLength: 512,
+        publicKeyEncoding: { type: "spki", format: "pem" },
+        privateKeyEncoding: { type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase: "secret" },
+      }, done);`,
+    "sign": `{
+        const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+        crypto.sign("sha256", Buffer.from("data"), privateKey, done);
+      }`,
+    "diffieHellman": `{
+        const a = crypto.generateKeyPairSync("x25519", {});
+        const b = crypto.generateKeyPairSync("x25519", {});
+        crypto.diffieHellman({ privateKey: a.privateKey, publicKey: b.publicKey }, done);
+      }`,
+    "hkdf": `crypto.hkdf("sha256", "key", "salt", "info", 32, done);`,
+    "checkPrime": `crypto.checkPrime(7n, done);`,
+    "generateKey (secret)": `crypto.generateKey("hmac", { length: 256 }, done);`,
+  };
+
+  for (const [name, snippet] of Object.entries(cases)) {
+    test.concurrent(
+      name,
+      async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const crypto = require("crypto");
+             const done = err => {
+               if (err) { console.error(err); process.exit(2); }
+               process.exit(0);
+             };
+             ${snippet}`,
+          ],
+          env: lsanEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("LeakSanitizer");
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+      },
+      timeout,
+    );
+  }
+});

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1801,6 +1801,25 @@ function randomProp() {
   return "prop" + crypto.randomUUID().replace(/-/g, "");
 }
 
+test("generateKeyPair passes the thrown Error to the callback when key export fails", async () => {
+  const { promise, resolve } = Promise.withResolvers<Error & { code?: string }>();
+  // P-224 keygen succeeds, JWK export does not, driving the caught-exception
+  // branch of the async completion. Node surfaces the Error object itself.
+  generateKeyPair(
+    "ec",
+    {
+      namedCurve: "secp224r1",
+      publicKeyEncoding: { format: "jwk" },
+      privateKeyEncoding: { format: "jwk" },
+    } as any,
+    err => resolve(err as any),
+  );
+  const err = await promise;
+  expect(err).toBeInstanceOf(Error);
+  expect(err.code).toBe("ERR_CRYPTO_JWK_UNSUPPORTED_CURVE");
+  expect(err.message).toContain("Unsupported JWK EC curve");
+});
+
 // The async crypto jobs (generateKeyPair, sign, diffieHellman, hkdf, ...) run
 // on the work pool and complete on the JS thread. The native job ctx must be
 // freed before the JS callback is invoked: a callback that never returns
@@ -1838,6 +1857,15 @@ describe.skipIf(!isASAN)("async crypto jobs: process.exit() in the callback leak
     "hkdf": `crypto.hkdf("sha256", "key", "salt", "info", 32, done);`,
     "checkPrime": `crypto.checkPrime(7n, done);`,
     "generateKey (secret)": `crypto.generateKey("hmac", { length: 256 }, done);`,
+    // The second path to the same leak: the completion task is enqueued but
+    // never dispatched (the spin keeps the JS thread busy until exit), so the
+    // shutdown release of queued jobs must free the ctx.
+    "generateKeyPair (exit before completion dispatch)": `{
+        crypto.generateKeyPair("rsa", { modulusLength: 512 }, () => {});
+        const end = Bun.nanoseconds() + 1_000_000_000;
+        while (Bun.nanoseconds() < end) {}
+        process.exit(0);
+      }`,
   };
 
   for (const [name, snippet] of Object.entries(cases)) {

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1834,10 +1834,6 @@ describe.skipIf(!isASAN)("async crypto jobs: process.exit() in the callback leak
     ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
     LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
   };
-  // LSan symbolizes any report through llvm-symbolizer against the debug
-  // binary, which takes several seconds.
-  const timeout = 30_000;
-
   const cases = {
     "generateKeyPair (KeyObject output)": `crypto.generateKeyPair("rsa", { modulusLength: 512 }, done);`,
     "generateKeyPair (encrypted PEM output)": `crypto.generateKeyPair("rsa", {
@@ -1869,29 +1865,25 @@ describe.skipIf(!isASAN)("async crypto jobs: process.exit() in the callback leak
   };
 
   for (const [name, snippet] of Object.entries(cases)) {
-    test.concurrent(
-      name,
-      async () => {
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "-e",
-            `const crypto = require("crypto");
+    test.concurrent(name, async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const crypto = require("crypto");
              const done = err => {
                if (err) { console.error(err); process.exit(2); }
                process.exit(0);
              };
              ${snippet}`,
-          ],
-          env: lsanEnv,
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).not.toContain("LeakSanitizer");
-        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
-      },
-      timeout,
-    );
+        ],
+        env: lsanEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("LeakSanitizer");
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    });
   }
 });

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -1852,6 +1852,7 @@ describe.skipIf(!isASAN)("async crypto jobs: process.exit() in the callback leak
       }`,
     "hkdf": `crypto.hkdf("sha256", "key", "salt", "info", 32, done);`,
     "checkPrime": `crypto.checkPrime(7n, done);`,
+    "generatePrime": `crypto.generatePrime(64, done);`,
     "generateKey (secret)": `crypto.generateKey("hmac", { length: 256 }, done);`,
     // The second path to the same leak: the completion task is enqueued but
     // never dispatched (the spin keeps the JS thread busy until exit), so the

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -446,6 +446,11 @@ test/js/bun/test/parallel/test-http-should-not-accept-untrusted-certificates.ts
 
 # Need to run the event loop once more to ensure sockets close
 test/js/node/test/parallel/test-https-localaddress-bind-error.js
+
+# process.exit() can race the work pool: a keygen finishing after the shutdown
+# drain posts a completion task nothing can free (joining the pool at exit
+# would block exit). Completions already queued at exit are released at
+# shutdown; that path is covered in crypto.key-objects.test.ts.
 test/js/node/test/parallel/test-crypto-op-during-process-exit.js
 
 test/js/third_party/prisma/prisma.test.ts


### PR DESCRIPTION
## What

`test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts` (the crypto-generateKeyPair fixture) fails on every Linux x64-asan run since #36598 landed (builds [89023](https://buildkite.com/bun/bun/builds/89023), [89031](https://buildkite.com/bun/bun/builds/89031)):

```
direct leak of 24b in run (src/runtime/node/node_crypto_binding.rs:85:21) +34 more
SUMMARY: AddressSanitizer: 1480 byte(s) leaked in 35 allocation(s).
  #6 EVP_PKEY_keygen vendor/boringssl/crypto/evp/evp_ctx.cc
  #7 Bun::KeyPairJobCtx::runTask src/jsc/bindings/node/crypto/CryptoGenKeyPair.cpp:23
  #8 Bun__RsaKeyPairJobCtx__runTask src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.cpp:26
```

## Cause

The 11 extern crypto job ctxs (generateKeyPair x5, sign/verify, diffieHellman, hkdf, generatePrime, checkPrime, generateKey) completed by invoking the JS callback from inside C++ `runFromJS` while the ctx was still alive; the ctx was freed only after `then()` returned. A callback that never returns (the fixture calls `process.exit(0)` inside it) stranded everything the ctx still owned: the generated `EVP_PKEY`, `KeyObjectData` refs, `BIGNUM`s.

The leak is pre-existing; #36598 made it observable by routing `OPENSSL_malloc` through libc under ASAN. Whether LSan reported the other job types too was codegen luck (their pointers happened to be reachable by the conservative stack scan); `generateKeyPair`'s `EVP_PKEY` sits behind two FastMalloc indirections and was reported deterministically.

## Fix

Make it structurally impossible for a job ctx to hold native resources across user JS: the native side never sees the callback.

- `runFromJS` keeps its name (the JS-thread half, paired with the work-pool half `runTask`) but no longer receives the callback. It returns `JSCallbackArgs`, a small by-value type whose constructors are the only producers, so bodies read `return { err };` or `return { jsNull(), publicKey, privateKey };`. The extern "C" shims copy it through a typed out-pointer (C linkage cannot return a class type); the Rust side consumes it as a slice.
- The Rust `extern_crypto_job!` plumbing does, in order: run `runFromJS` to produce the arguments, free the ctx (`ctx_deinit`), invoke the callback. The invariant lives in one place and applies to every job type.
- Shutdown release: a completion task enqueued but not yet dispatched when `process.exit()` runs (exit racing the work pool) used to be re-queued at shutdown, stranding the ctx the same way. `AnyTaskJob` now carries an erased release entry and the shutdown release frees the job without running its completion. A completion posted after the final drain is not recoverable without joining the work pool (which would block exit); `test-crypto-op-during-process-exit.js` stays in `no-validate-leaksan.txt` for that sliver, now with an accurate comment.
- The caught-export-exception paths encoded the `JSC::Exception` cell itself, so the callback's err argument was not the thrown Error (not `instanceof Error`, no `code`). They now use `Exception::value()`, matching node: JWK export of an unsupported curve surfaces `ERR_CRYPTO_JWK_UNSUPPORTED_CURVE`.

No behavior change otherwise:

- `Bun__EventLoop__runCallback{1,2,3}` were Rust's `EventLoop::run_callback` exported to C++. The plumbing now calls `run_callback` directly: same enter/exit bracketing, same pending-exception gate, same unhandled-exception reporting, same synchronous timing. This made `runCallback1`/`runCallback3` dead (the crypto bodies were their last callers), so their exports and declarations are deleted; `runCallback2` stays for the webview backends.
- Callback arity is preserved per path (observable via `arguments.length`): error paths pass 1 arg, results 2, generateKeyPair success 3.
- Exception paths are preserved: a throw out of argument production skips the callback and reports unhandled, as before. Each `runFromJS` checks its `ThrowScope` after every call that can throw (`RETURN_IF_EXCEPTION`), since the check that used to happen inside the nested `runCallbackN` call now happens after the C++ scope destructs; `BUN_JSC_validateExceptionChecks` verifies this on the asan lane.
- The produced `JSValue`s live on the `then()` stack frame between production and invocation, which JSC's conservative scan covers; they are JS-heap values, so freeing the ctx first cannot invalidate them.
- Perf: same number of FFI crossings, no allocation added.

The Rust-native crypto jobs (pbkdf2, scrypt, random) already had the ordering property: they resolve promises or queue the callback via nextTick, so their ctx drops before user JS runs. The synchronous-callback extern jobs were the gap.

## Verification

New tests in `crypto.key-objects.test.ts`:

- `isASAN`-gated leak suite: children run with `BUN_DESTRUCT_VM_ON_EXIT=1` and `detect_leaks=1` (the asan lane's configuration) and call `process.exit(0)` from the callback of each job type: generateKeyPair (KeyObject and encrypted PEM outputs), sign, diffieHellman, hkdf, checkPrime, generateKey, plus an exit-before-completion-dispatch case (busy-spin so the queued completion is never dispatched).
- An export-error test: `generateKeyPair('ec', { namedCurve: 'secp224r1', ...jwk encodings })` asserts the callback err is `instanceof Error` with code `ERR_CRYPTO_JWK_UNSUPPORTED_CURVE` (matches node; fails on main, which passes the Exception cell).

Results:

- unfixed build (src stashed): both generateKeyPair leak tests fail with the exact CI signature (`Direct leak of 24 byte(s)` in `EVP_PKEY_keygen` via `KeyPairJobCtx::runTask`)
- fixed build: all pass, including under `BUN_JSC_validateExceptionChecks=1`, and ec/ed25519 keypair and verify probes run leak-clean as well
- `AsyncLocalStorage-tracking.test.ts`: 74 pass, 0 fail (all async-context crypto fixtures, against both bun and node)
- `crypto.test.ts` (369), `crypto.key-objects.test.ts` (117), and 37 node parallel files (`test-crypto-keygen*`, `test-crypto-sign-verify`, `test-crypto-hkdf`, `test-crypto-dh-stateless`, `test-crypto-*prime*`) all pass

The break landed with #36598 (which made the leak visible); #36657 proposed clearing individual ctx fields before the callback, and this PR supersedes that approach with the ordering guarantee in the job plumbing instead of per-field resets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts test/js/node/crypto/crypto.key-objects.test.ts

<!-- robobun:evidence:end -->