### PR TITLE
Fix zlib kMaxLength tests failing when run with other zlib tests in one process

### DIFF
--- a/test/js/node/zlib/zlib-kmaxlength-fixture.cjs
+++ b/test/js/node/zlib/zlib-kmaxlength-fixture.cjs
@@ -1,0 +1,27 @@
+// buffer.kMaxLength must be patched before the first require of zlib: zlib
+// captures it at module load (same as Node), which is why this runs in its own
+// process instead of inside the test runner.
+const buffer = require("node:buffer");
+buffer.kMaxLength = 64;
+const assert = require("node:assert");
+const util = require("node:util");
+const zlib = require("node:zlib");
+
+const [fnName, encodedHex, mode] = process.argv.slice(2);
+const encoded = Buffer.from(encodedHex, "hex");
+
+if (mode === "sync") {
+  assert.throws(() => zlib[fnName](encoded), RangeError);
+  console.log("ok");
+} else {
+  util.promisify(zlib[fnName])(encoded).then(
+    () => {
+      console.error(`expected ${fnName} to reject`);
+      process.exit(1);
+    },
+    err => {
+      assert.ok(err instanceof RangeError, `expected RangeError, got ${err}`);
+      console.log("ok");
+    },
+  );
+}

--- a/test/js/node/zlib/zlib-kmaxlength-fixture.cjs
+++ b/test/js/node/zlib/zlib-kmaxlength-fixture.cjs
@@ -7,21 +7,18 @@ const assert = require("node:assert");
 const util = require("node:util");
 const zlib = require("node:zlib");
 
-const [fnName, encodedHex, mode] = process.argv.slice(2);
+const [encodedHex, asyncName, syncName] = process.argv.slice(2);
 const encoded = Buffer.from(encodedHex, "hex");
 
-if (mode === "sync") {
-  assert.throws(() => zlib[fnName](encoded), RangeError);
-  console.log("ok");
-} else {
-  util.promisify(zlib[fnName])(encoded).then(
-    () => {
-      console.error(`expected ${fnName} to reject`);
-      process.exit(1);
-    },
-    err => {
-      assert.ok(err instanceof RangeError, `expected RangeError, got ${err}`);
-      console.log("ok");
-    },
-  );
-}
+assert.throws(() => zlib[syncName](encoded), RangeError, `${syncName} should throw RangeError`);
+
+util.promisify(zlib[asyncName])(encoded).then(
+  () => {
+    console.error(`expected ${asyncName} to reject`);
+    process.exit(1);
+  },
+  err => {
+    assert.ok(err instanceof RangeError, `expected ${asyncName} to reject with RangeError, got ${err}`);
+    console.log("ok");
+  },
+);

--- a/test/js/node/zlib/zlib.kMaxLength.global.test.js
+++ b/test/js/node/zlib/zlib.kMaxLength.global.test.js
@@ -15,27 +15,19 @@ const data = {
   unzip: ["1f8b08000000000000034b4c1c5800008c362bf180000000", "unzip", "unzipSync"],
 };
 
-async function expectFixturePasses(fnName, encodedHex, mode) {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), fixture, fnName, encodedHex, mode],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout).toBe("ok\n");
-  expect(exitCode).toBe(0);
-}
-
 for (const method in data) {
   const [encodedHex, asyncName, syncName] = data[method];
 
-  it.concurrent(`decompress synchronous ${method}`, async () => {
-    await expectFixturePasses(syncName, encodedHex, "sync");
-  });
-
-  it.concurrent(`decompress asynchronous ${method}`, async () => {
-    await expectFixturePasses(asyncName, encodedHex, "async");
+  it.concurrent(`decompress ${method} beyond kMaxLength throws RangeError (sync and async)`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture, encodedHex, asyncName, syncName],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
   });
 }

--- a/test/js/node/zlib/zlib.kMaxLength.global.test.js
+++ b/test/js/node/zlib/zlib.kMaxLength.global.test.js
@@ -1,25 +1,41 @@
 import { expect, it } from "bun:test";
-const util = require("node:util");
-const buffer = require("node:buffer");
-buffer.kMaxLength = 64;
-const zlib = require("node:zlib");
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 
-const data_sync = {
-  brotli: ["1b7f00f825c222b1402003", zlib.brotliDecompress, zlib.brotliDecompressSync],
-  inflate: ["789c4b4c1c58000039743081", zlib.inflate, zlib.inflateSync],
-  gunzip: ["1f8b08000000000000034b4c1c5800008c362bf180000000", zlib.gunzip, zlib.gunzipSync],
-  unzip: ["1f8b08000000000000034b4c1c5800008c362bf180000000", zlib.unzip, zlib.unzipSync],
+// zlib captures buffer.kMaxLength when the module is first loaded (same as
+// Node), so it must be patched before the first require("node:zlib") in the
+// process. Another test file running in this process may have loaded node:zlib
+// already, so each check runs in a fresh child process instead.
+const fixture = join(import.meta.dir, "zlib-kmaxlength-fixture.cjs");
+
+const data = {
+  brotli: ["1b7f00f825c222b1402003", "brotliDecompress", "brotliDecompressSync"],
+  inflate: ["789c4b4c1c58000039743081", "inflate", "inflateSync"],
+  gunzip: ["1f8b08000000000000034b4c1c5800008c362bf180000000", "gunzip", "gunzipSync"],
+  unzip: ["1f8b08000000000000034b4c1c5800008c362bf180000000", "unzip", "unzipSync"],
 };
 
-for (const method in data_sync) {
-  const [encoded_hex, f_async, f_sync] = data_sync[method];
-  const encoded = Buffer.from(encoded_hex, "hex");
+async function expectFixturePasses(fnName, encodedHex, mode) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, fnName, encodedHex, mode],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+}
 
-  it(`decompress synchronous ${method}`, () => {
-    expect(() => f_sync(encoded)).toThrow(RangeError);
+for (const method in data) {
+  const [encodedHex, asyncName, syncName] = data[method];
+
+  it.concurrent(`decompress synchronous ${method}`, async () => {
+    await expectFixturePasses(syncName, encodedHex, "sync");
   });
 
-  it(`decompress asynchronous ${method}`, async () => {
-    expect(async () => await util.promisify(f_async)(encoded)).toThrow(RangeError);
+  it.concurrent(`decompress asynchronous ${method}`, async () => {
+    await expectFixturePasses(asyncName, encodedHex, "async");
   });
 }


### PR DESCRIPTION
## Problem

`bun test test/js/node/zlib/` runs every file in one process and fails all 8 tests in `zlib.kMaxLength.global.test.js`, while running the file alone passes all 8:

```
error: expect(received).toThrow(expected)
Expected constructor: [class RangeError extends Error]
Received function did not throw
      at test/js/node/zlib/zlib.kMaxLength.global.test.js:19:33
```

The test patches `buffer.kMaxLength = 64` and then requires `node:zlib`, expecting small decompressions to exceed the limit. That only works when this is the first `require("node:zlib")` in the process: zlib captures `buffer.kMaxLength` at module load, matching Node (lib/zlib.js destructures `kMaxLength` from `require('buffer')` at load). When another zlib test file has already loaded `node:zlib`, the cached module holds the original limit and nothing throws. CI spawns one process per test file, so this only bites local directory runs.

## Fix

Test-only: each codec's checks now run the patch-then-require sequence in a fresh child process via a small fixture (`zlib-kmaxlength-fixture.cjs`). Coverage is unchanged: brotli/inflate/gunzip/unzip, sync and async. One child per codec keeps the per-test cost around 2s under ASAN debug builds, within the default test timeout even on 2 cores.

Making `src/js/node/zlib.ts` read `buffer.kMaxLength` at call time instead would fix the in-process case but diverge from Node, which captures at load. The ported upstream tests (`test-zlib-kmaxlength-rangeerror.js` and its brotli/zstd variants) depend on capture-at-load: they restore `buffer.kMaxLength` right after loading zlib and still expect `RangeError`, so they would start failing under call-time reads.

The fixture is a file rather than an inline `bun -e` script: eval mode exposes builtin module names as lazy globals, and a top-level `const zlib` in the eval'd source materializes that global during declaration instantiation, loading `node:zlib` before the script body (and before the `kMaxLength` patch) runs. Filed separately as #36994.

## Verification

- Before: `USE_SYSTEM_BUN=1 bun test test/js/node/zlib/` fails 8, the file alone passes 8
- After: directory run passes 457 with 0 fail; the file alone passes under `bun test` and `bun bd test` (ASAN debug), including pinned to 2 CPUs where the per-test margin is about 1s against the 5s default timeout

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/zlib/zlib.kMaxLength.global.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/zlib/zlib.kMaxLength.global.test.js
bun test v1.4.0 (59cd5e82f)

test/js/node/zlib/zlib.kMaxLength.global.test.js:
(pass) decompress gunzip beyond kMaxLength throws RangeError (sync and async) [2314.47ms]
(pass) decompress brotli beyond kMaxLength throws RangeError (sync and async) [2499.14ms]
(pass) decompress inflate beyond kMaxLength throws RangeError (sync and async) [2445.21ms]
(pass) decompress unzip beyond kMaxLength throws RangeError (sync and async) [2787.96ms]

 4 pass
 0 fail
 12 expect() calls
Ran 4 tests across 1 file. [5.40s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/zlib/zlib-kmaxlength-fixture.cjs    | 24 +++++++++++++
 test/js/node/zlib/zlib.kMaxLength.global.test.js | 44 ++++++++++++++----------
 2 files changed, 50 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
test/js/node/zlib/zlib-kmaxlength-fixture.cjs         0      2      0
test/js/node/zlib/zlib.kMaxLength.global.test.js      1      3      0
```

</details>

<!-- robobun:evidence:end -->