### PR TITLE
bun -e: don't load a builtin module when a top-level const/let shadows its global

### DIFF
--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -6,6 +6,7 @@
 #include "JSCommonJSModule.h"
 
 #include <JavaScriptCore/JSBoundFunction.h>
+#include <JavaScriptCore/JSGlobalProxyInlines.h>
 #include <JavaScriptCore/PropertySlot.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/JSMap.h>
@@ -74,14 +75,18 @@ FOREACH_EXPOSED_BUILTIN_IMR(DECL_GETTER)
 
 } // namespace ExposeNodeModuleGlobalGetters
 
-// Writing to one of these globals replaces the lazy accessor with a plain data
-// property, the same reification a null-setter CustomValue property gets from
-// JSObject::putInlineSlow.
-JSC_DEFINE_CUSTOM_SETTER(exposedNodeModuleGlobalSetter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
+// Assignment puts a plain data property on the receiver (the old null-setter
+// CustomValue behavior): writes through `globalThis` replace the lazy
+// accessor, writes through an inheriting object shadow it.
+JSC_DEFINE_CUSTOM_SETTER(exposedNodeModuleGlobalSetter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
 {
-    Zig::GlobalObject* thisObject = defaultGlobalObject(lexicalGlobalObject);
-    JSC::VM& vm = thisObject->vm();
-    thisObject->putDirect(vm, propertyName, JSC::JSValue::decode(encodedValue), 0);
+    JSC::JSValue decodedThis = JSC::JSValue::decode(thisValue);
+    if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(decodedThis))
+        decodedThis = proxy->target();
+    JSC::JSObject* thisObject = decodedThis.getObject();
+    if (!thisObject)
+        return false;
+    thisObject->putDirect(JSC::getVM(lexicalGlobalObject), propertyName, JSC::JSValue::decode(encodedValue), 0);
     return true;
 }
 
@@ -89,12 +94,10 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
 {
 
     auto& vm = JSC::getVM(globalObject);
-    // CustomAccessor, not CustomValue: [[GetOwnProperty]] on a CustomValue
-    // property computes its value, so GlobalDeclarationInstantiation's
-    // hasRestrictedGlobalProperty check for a top-level `const zlib = ...` in
-    // `bun -e` would load node:zlib before the first statement runs (visibly
-    // wrong for load-order-sensitive code like buffer.kMaxLength patching).
-    // An accessor's descriptor is built without invoking the getter.
+    // CustomAccessor, not CustomValue: JSC computes a CustomValue during
+    // [[GetOwnProperty]], so the global-declaration shadow check for a
+    // top-level `const zlib = ...` would load node:zlib before the script's
+    // first statement. An accessor's descriptor never invokes the getter.
 #define PUT_CUSTOM_GETTER_SETTER(id, field) \
     globalObject->putDirectCustomAccessor( \
         vm, \

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -74,10 +74,27 @@ FOREACH_EXPOSED_BUILTIN_IMR(DECL_GETTER)
 
 } // namespace ExposeNodeModuleGlobalGetters
 
+// Writing to one of these globals replaces the lazy accessor with a plain data
+// property, the same reification a null-setter CustomValue property gets from
+// JSObject::putInlineSlow.
+JSC_DEFINE_CUSTOM_SETTER(exposedNodeModuleGlobalSetter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
+{
+    Zig::GlobalObject* thisObject = defaultGlobalObject(lexicalGlobalObject);
+    JSC::VM& vm = thisObject->vm();
+    thisObject->putDirect(vm, propertyName, JSC::JSValue::decode(encodedValue), 0);
+    return true;
+}
+
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::GlobalObject* globalObject)
 {
 
     auto& vm = JSC::getVM(globalObject);
+    // CustomAccessor, not CustomValue: [[GetOwnProperty]] on a CustomValue
+    // property computes its value, so GlobalDeclarationInstantiation's
+    // hasRestrictedGlobalProperty check for a top-level `const zlib = ...` in
+    // `bun -e` would load node:zlib before the first statement runs (visibly
+    // wrong for load-order-sensitive code like buffer.kMaxLength patching).
+    // An accessor's descriptor is built without invoking the getter.
 #define PUT_CUSTOM_GETTER_SETTER(id, field) \
     globalObject->putDirectCustomAccessor( \
         vm, \
@@ -85,8 +102,8 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
         JSC::CustomGetterSetter::create( \
             vm, \
             ExposeNodeModuleGlobalGetters::id, \
-            nullptr), \
-        0 | JSC::PropertyAttribute::CustomValue \
+            exposedNodeModuleGlobalSetter), \
+        0 | JSC::PropertyAttribute::CustomAccessor \
     );
 
     FOREACH_EXPOSED_BUILTIN_IMR(PUT_CUSTOM_GETTER_SETTER)

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -7,6 +7,7 @@
 
 #include <JavaScriptCore/JSBoundFunction.h>
 #include <JavaScriptCore/JSGlobalProxyInlines.h>
+#include <JavaScriptCore/PropertyDescriptor.h>
 #include <JavaScriptCore/PropertySlot.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/JSMap.h>
@@ -75,19 +76,43 @@ FOREACH_EXPOSED_BUILTIN_IMR(DECL_GETTER)
 
 } // namespace ExposeNodeModuleGlobalGetters
 
-// Assignment puts a plain data property on the receiver (the old null-setter
-// CustomValue behavior): writes through `globalThis` replace the lazy
-// accessor, writes through an inheriting object shadow it.
+// Assignment behaves like writing to a writable data property (the old
+// null-setter CustomValue behavior): a receiver that owns the configurable
+// lazy accessor gets it replaced with a plain data property; any other
+// receiver gets an ordinary data property defined on it, which honors
+// extensibility and Proxy traps. Custom setters cannot see the caller's
+// strict mode, so failures are silent instead of strict-mode TypeErrors.
 JSC_DEFINE_CUSTOM_SETTER(exposedNodeModuleGlobalSetter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
 {
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue decodedThis = JSC::JSValue::decode(thisValue);
     if (auto* proxy = dynamicDowncast<JSC::JSGlobalProxy>(decodedThis))
         decodedThis = proxy->target();
     JSC::JSObject* thisObject = decodedThis.getObject();
     if (!thisObject)
         return false;
-    thisObject->putDirect(JSC::getVM(lexicalGlobalObject), propertyName, JSC::JSValue::decode(encodedValue), 0);
-    return true;
+    JSC::JSValue value = JSC::JSValue::decode(encodedValue);
+
+    JSC::PropertySlot slot(thisObject, JSC::PropertySlot::InternalMethodType::GetOwnProperty);
+    bool hasProperty = thisObject->methodTable()->getOwnPropertySlot(thisObject, lexicalGlobalObject, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (hasProperty) {
+        if (slot.attributes() & static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor)) {
+            // The lazy accessor itself, normally on the global object. Frozen
+            // (DontDelete) means it can no longer be replaced.
+            if (slot.attributes() & static_cast<unsigned>(JSC::PropertyAttribute::DontDelete))
+                return false;
+            thisObject->putDirect(vm, propertyName, value, 0);
+            return true;
+        }
+        if (slot.attributes() & (static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly) | static_cast<unsigned>(JSC::PropertyAttribute::Accessor)))
+            return false;
+        JSC::PropertyDescriptor descriptor;
+        descriptor.setValue(value);
+        RELEASE_AND_RETURN(scope, thisObject->methodTable()->defineOwnProperty(thisObject, lexicalGlobalObject, propertyName, descriptor, false));
+    }
+    RELEASE_AND_RETURN(scope, thisObject->createDataProperty(lexicalGlobalObject, propertyName, value, false));
 }
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::GlobalObject* globalObject)

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -175,6 +175,74 @@ describe("--print for cjs/esm", () => {
   });
 });
 
+describe.concurrent("-e builtin module globals", () => {
+  async function runEval(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // zlib captures buffer.kMaxLength when its module first loads (same as
+  // Node). A top-level `const zlib = ...` must not make the lazy `zlib`
+  // global load node:zlib during declaration instantiation, before the
+  // kMaxLength patch has run.
+  const probes = {
+    "const zlib = require(...)": 'const zlib = require("node:zlib");',
+    "const zlib = <plain value>": "const zlib = 123;",
+    "let zlib = <plain value>": "let zlib = 123;",
+  };
+  for (const [name, decl] of Object.entries(probes)) {
+    test(`top-level ${name} does not eagerly load the module`, async () => {
+      const { stdout, stderr, exitCode } = await runEval(
+        'const b = require("node:buffer");' +
+          "b.kMaxLength = 64;" +
+          decl +
+          'try { require("node:zlib").inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex")); console.log("no-throw"); }' +
+          "catch (e) { console.log(e.constructor.name); }",
+      );
+      expect(stderr).toBe("");
+      expect(stdout).toBe("RangeError\n");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("the same script behaves identically with top-level await", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      "await 0;" +
+        'const b = require("node:buffer");' +
+        "b.kMaxLength = 64;" +
+        'const zlib = require("node:zlib");' +
+        'try { zlib.inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex")); console.log("no-throw"); }' +
+        "catch (e) { console.log(e.constructor.name); }",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("RangeError\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("module globals resolve on access", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      'console.log(typeof zlib, typeof path.join, typeof fs.readFileSync, path.basename("a/b"));',
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("object function function b\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("assignment replaces a module global", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      "zlib = 5; globalThis.util = 7; var assert = 9; console.log(zlib, util, assert, typeof require('node:zlib').inflateSync);",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("5 7 9 function\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {
   test("it works", async () => {
     const { stdout } = run('console.log("hello world")');
@@ -218,6 +286,19 @@ function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {
     } else {
       expect(stdout.toString("utf8")).toEqual(code + "\n");
     }
+  });
+
+  // stdin entries get the same lazy builtin-module globals as -e; a top-level
+  // `const zlib` must not load node:zlib before the kMaxLength patch runs.
+  test("top-level const naming a builtin module does not eagerly load it", async () => {
+    const { stdout } = run(
+      'const b = require("node:buffer");' +
+        "b.kMaxLength = 64;" +
+        'const zlib = require("node:zlib");' +
+        'try { zlib.inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex")); console.log("no-throw"); }' +
+        "catch (e) { console.log(e.constructor.name); }",
+    );
+    expect(stdout.toString("utf8")).toEqual("RangeError\n");
   });
 }
 

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -243,6 +243,17 @@ describe.concurrent("-e builtin module globals", () => {
     expect(stdout).toBe("5 7 9 function\n");
     expect(exitCode).toBe(0);
   });
+
+  test("assignment through an inheriting object shadows on the receiver", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      "const obj = Object.create(globalThis); obj.zlib = 5;" +
+        'const r = {}; Reflect.set(globalThis, "util", 6, r);' +
+        'console.log(Object.hasOwn(obj, "zlib"), obj.zlib, typeof globalThis.zlib, Object.hasOwn(r, "util"), r.util, typeof globalThis.util);',
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("true 5 object true 6 object\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -187,13 +187,15 @@ describe.concurrent("-e builtin module globals", () => {
   }
 
   // zlib captures buffer.kMaxLength when its module first loads (same as
-  // Node). A top-level `const zlib = ...` must not make the lazy `zlib`
+  // Node). A top-level declaration named `zlib` must not make the lazy `zlib`
   // global load node:zlib during declaration instantiation, before the
   // kMaxLength patch has run.
   const probes = {
     "const zlib = require(...)": 'const zlib = require("node:zlib");',
     "const zlib = <plain value>": "const zlib = 123;",
     "let zlib = <plain value>": "let zlib = 123;",
+    "class zlib {}": "class zlib {}",
+    "function zlib() {}": "function zlib() {}",
   };
   for (const [name, decl] of Object.entries(probes)) {
     test(`top-level ${name} does not eagerly load the module`, async () => {

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -176,9 +176,9 @@ describe("--print for cjs/esm", () => {
 });
 
 describe.concurrent("-e builtin module globals", () => {
-  async function runEval(code: string) {
+  async function runEval(code: string, flag: "-e" | "-p" = "-e") {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", code],
+      cmd: [bunExe(), flag, code],
       env: bunEnv,
       stderr: "pipe",
     });
@@ -211,6 +211,41 @@ describe.concurrent("-e builtin module globals", () => {
       expect(exitCode).toBe(0);
     });
   }
+
+  test("fetching a global's property descriptor does not load the module", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      'const d = Object.getOwnPropertyDescriptor(globalThis, "zlib");' +
+        "Object.getOwnPropertyDescriptors(globalThis);" +
+        'const b = require("node:buffer"); b.kMaxLength = 64;' +
+        'const z = require("node:zlib");' +
+        'try { z.inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex")); console.log("no-throw"); }' +
+        "catch (e) { console.log(e.constructor.name); }" +
+        "console.log(typeof d.get, typeof d.set, d.enumerable, d.configurable);",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("RangeError\nfunction function true true\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--print gets the same lazy globals", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      'const b = require("node:buffer"); b.kMaxLength = 64;' +
+        'const zlib = require("node:zlib");' +
+        'try { zlib.inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex")); console.log("no-throw"); }' +
+        "catch (e) { console.log(e.constructor.name); }",
+      "-p",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("RangeError\nundefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--print resolves module globals on access", async () => {
+    const { stdout, stderr, exitCode } = await runEval("typeof zlib", "-p");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("object\n");
+    expect(exitCode).toBe(0);
+  });
 
   test("the same script behaves identically with top-level await", async () => {
     const { stdout, stderr, exitCode } = await runEval(
@@ -252,6 +287,21 @@ describe.concurrent("-e builtin module globals", () => {
     );
     expect(stderr).toBe("");
     expect(stdout).toBe("true 5 object true 6 object\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("assignment honors receiver extensibility and proxy traps", async () => {
+    const { stdout, stderr, exitCode } = await runEval(
+      "const o = Object.create(globalThis); Object.preventExtensions(o);" +
+        "try { o.zlib = 5; } catch {}" +
+        'console.log("nonext", Object.hasOwn(o, "zlib"));' +
+        "let trapped = false;" +
+        "const p = new Proxy({}, { defineProperty(t, k, d) { trapped = true; return Reflect.defineProperty(t, k, d); } });" +
+        'Reflect.set(globalThis, "util", 6, p);' +
+        'console.log("proxy", trapped, Object.hasOwn(p, "util"), p.util);',
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("nonext false\nproxy true true 6\n");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

`bun -e`, `bun --print`, and `bun run -` expose every builtin module as a lazy global (`zlib`, `path`, `fs`, ...). Those globals were installed as `CustomValue` properties, whose value JSC computes during `[[GetOwnProperty]]`. JSC's GlobalDeclarationInstantiation runs a `hasRestrictedGlobalProperty` check for every top-level `const`/`let` in the program, and that check fetches the property descriptor, which for a `CustomValue` invokes the getter, which requires the module.

So declaring `const zlib = ...` at the top level of `-e` code loads `node:zlib` before the first statement of the script runs. That breaks load-order-sensitive code; the observable case is Node's `buffer.kMaxLength` patching (zlib captures `kMaxLength` at module load, in Node and in Bun):

```sh
bun -e 'const b = require("node:buffer"); b.kMaxLength = 64;
const zlib = require("node:zlib");
try { zlib.inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex")); console.log("no-throw") }
catch (e) { console.log(e.constructor.name) }'
```

prints `no-throw`; Node prints `RangeError`. Renaming the variable to `z` (no global named `z` to check against) already printed `RangeError`, as did running the same code from a file. Even `const zlib = 123` with no require was enough to load `node:zlib`. Same behavior for `let` and `class` declarations, for a direct `Object.getOwnPropertyDescriptor(globalThis, "zlib")` call, for any of the ~38 exposed module names, and for `--print` and stdin entries.

## Fix

Install the globals as `CustomAccessor` properties. `PropertyDescriptor::setPropertySlot` builds an accessor's descriptor from wrapper functions without invoking the getter, so descriptor fetches (the declaration check included) no longer load the module; reading the global still does.

A shared custom setter keeps the old write behavior, which was that of a writable data property: a receiver that owns the still-configurable accessor (the global object, reached directly or through its proxy) gets it replaced with a plain data property, and any other receiver (an object inheriting from `globalThis`, or an altered `Reflect.set` receiver) gets an ordinary data property defined on it, which honors extensibility and Proxy `defineProperty` traps. One divergence: custom setters cannot observe the caller's strict mode, so a failed write (frozen global, non-extensible receiver) is a silent no-op where strict-mode code previously threw a TypeError; the resulting state is identical.

`function zlib() {}` declarations were never affected (the can-declare check for global function declarations does not compute the property's value); a probe covers that form anyway.

## Verification

New tests in `test/cli/run/run-eval.test.ts`. These fail on current canary (print `no-throw`) and pass with this change (print `RangeError`), matching Node:

- declaration probes: `const zlib = require(...)`, `const zlib = 123`, `let zlib = 123`, `class zlib {}`
- a descriptor probe: `Object.getOwnPropertyDescriptor(s)` before the kMaxLength patch
- the same kMaxLength probe via `--print` and via stdin (`bun run -`)

Compat guards (pass before and after): `typeof zlib`/`path.join`/`fs.readFileSync` resolve on access in `-e` and `--print`, assignment/`var` reify, writes through an inheriting object or `Reflect.set` receiver shadow on the receiver, non-extensible receivers gain no property, Proxy `defineProperty` traps fire, `function zlib() {}` stays correct, and the top-level-await variant is unchanged.

- `bun bd test test/cli/run/run-eval.test.ts`: 50 pass
- `bun bd test test/js/bun/repl/repl.test.ts` (the REPL installs the same globals): 148 pass
- `bun bd test test/js/node/zlib/zlib.kMaxLength.global.test.js`: 8 pass

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->