### PR TITLE
bun -e: do not load a builtin module when a top-level binding shares its name

### DIFF
--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -72,12 +72,27 @@ namespace ExposeNodeModuleGlobalGetters {
 FOREACH_EXPOSED_BUILTIN_IMR(DECL_GETTER)
 #undef DECL_GETTER    
 
+// Assigning to one of these globals replaces the lazy accessor with the
+// assigned value, matching Node's lazy builtin globals.
+JSC_DEFINE_CUSTOM_SETTER(exposedBuiltinSetter, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
+{
+    Zig::GlobalObject* thisObject = defaultGlobalObject(lexicalGlobalObject);
+    thisObject->putDirect(thisObject->vm(), propertyName, JSC::JSValue::decode(encodedValue), 0);
+    return true;
+}
+
 } // namespace ExposeNodeModuleGlobalGetters
 
 extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::GlobalObject* globalObject)
 {
 
     auto& vm = JSC::getVM(globalObject);
+    // These must be CustomAccessor, not CustomValue: getOwnPropertyDescriptor on a
+    // CustomValue invokes the getter to produce a data descriptor, and global `const`/
+    // `let` declaration instantiation queries the descriptor of every declared name
+    // (HasRestrictedGlobalProperty), so `bun -e 'const zlib = ...'` would evaluate
+    // node:zlib before the script body runs. An accessor descriptor is built without
+    // calling the getter.
 #define PUT_CUSTOM_GETTER_SETTER(id, field) \
     globalObject->putDirectCustomAccessor( \
         vm, \
@@ -85,8 +100,8 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
         JSC::CustomGetterSetter::create( \
             vm, \
             ExposeNodeModuleGlobalGetters::id, \
-            nullptr), \
-        0 | JSC::PropertyAttribute::CustomValue \
+            ExposeNodeModuleGlobalGetters::exposedBuiltinSetter), \
+        0 | JSC::PropertyAttribute::CustomAccessor \
     );
 
     FOREACH_EXPOSED_BUILTIN_IMR(PUT_CUSTOM_GETTER_SETTER)

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -276,6 +276,61 @@ describe("echo | bun run -", () => {
   group(run);
 });
 
+// https://github.com/oven-sh/bun/issues/36994
+describe.concurrent("builtin module globals in eval mode", () => {
+  test("top-level const with a builtin's name does not load the module before the body runs", async () => {
+    // node:zlib captures buffer.kMaxLength at module load. Patching kMaxLength
+    // before require("node:zlib") only takes effect if declaring `const zlib`
+    // did not already evaluate the module.
+    const code = `
+      const b = require("node:buffer");
+      b.kMaxLength = 64;
+      const zlib = require("node:zlib");
+      try {
+        zlib.inflateSync(Buffer.from("789c4b4c1c58000039743081", "hex"));
+        console.log("no throw");
+      } catch (e) {
+        console.log("threw", e.constructor.name);
+      }
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", code], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("threw RangeError\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("top-level const shadows the builtin global", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "const fs = 1; console.log(fs)"],
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("builtin globals still lazily require the module on read", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log(typeof zlib.inflateSync)"],
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("function\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("assignment replaces the builtin global", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "zlib = 5; console.log(zlib)"],
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("5\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 test("process._eval (undefined for normal run)", async () => {
   const cwd = tmpdirSync();
   const file = join(cwd, "test.js");


### PR DESCRIPTION
Fixes #36994

### Repro

```sh
# node:zlib captures buffer.kMaxLength at module load
bun -e 'const b=require("node:buffer"); b.kMaxLength=64; const zlib=require("node:zlib"); try { zlib.inflateSync(Buffer.from("789c4b4c1c58000039743081","hex")); console.log("no throw"); } catch(e){ console.log("threw", e.constructor.name) }'
# prints "no throw"; renaming the binding to z prints "threw RangeError"; Node prints "threw RangeError" either way
```

### Cause

Eval mode exposes builtin module names as lazy globals (ExposeNodeModuleGlobals.cpp) using `PropertyAttribute::CustomValue`. `getOwnPropertyDescriptor` on a CustomValue invokes the custom getter to produce a data descriptor, and global declaration instantiation queries the descriptor of every lexically declared name (HasRestrictedGlobalProperty in ProgramExecutable::initializeGlobalProperties). Eval scripts run at global scope, so a top-level `const zlib = ...` evaluated node:zlib before the script body ran, and the same applies to `const fs`, `const path`, etc.

### Fix

Install the globals as `PropertyAttribute::CustomAccessor` with a setter that replaces the property with the assigned value. JSC builds an accessor descriptor without invoking the getter, so declaring a binding no longer evaluates the module, while a plain read still lazily requires it. This matches Node, whose builtin globals in `-e` are get/set accessor properties.

### Verification

New tests in test/cli/run/run-eval.test.ts cover: the kMaxLength repro above (fails on current main, passes with this change), `const fs = 1` shadowing, lazy require on read, and assignment replacing the global. Full run-eval.test.ts (39) and repl.test.ts (148) pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->