### PR TITLE
test(napi): make napi_wrap lifetime collection polls robust to conservative GC pins

### DIFF
--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -5,9 +5,14 @@ const asyncFinalizeAddon = require("./build/Debug/async_finalize_addon.node");
 const testReferenceUnrefInFinalizer = require("./build/Debug/test_reference_unref_in_finalizer.node");
 const testReferenceUnrefInFinalizerExperimental = require("./build/Debug/test_reference_unref_in_finalizer_experimental.node");
 
-async function gcUntil(fn) {
-  const MAX = 100;
-  for (let i = 0; i < MAX; i++) {
+// Returns true once fn() is true, false if it still isn't after `max` GCs.
+// Collection of any *particular* object is not guaranteed under JSC: a
+// conservative stack/register scan can pin one address for the entire process,
+// so callers that need a collection to happen should retry with a freshly
+// allocated object (see test_remove_wrap_lifetime_with_strong_ref) rather
+// than raising `max`.
+async function tryGcUntil(fn, max = 100) {
+  for (let i = 0; i < max; i++) {
     await new Promise(resolve => {
       setTimeout(resolve, 1);
     });
@@ -18,10 +23,16 @@ async function gcUntil(fn) {
       global.gc();
     }
     if (fn()) {
-      return;
+      return true;
     }
   }
-  throw new Error(`Condition was not met after ${MAX} GC attempts`);
+  return false;
+}
+
+async function gcUntil(fn, max = 100) {
+  if (!(await tryGcUntil(fn, max))) {
+    throw new Error(`Condition was not met after ${max} GC attempts`);
+  }
 }
 
 nativeTests.test_napi_class_constructor_handle_scope = () => {
@@ -908,15 +919,8 @@ nativeTests.test_wrap_lifetime_with_strong_ref = async () => {
   assert(nativeTests.get_wrap_data(object) === 42);
 
   object = undefined;
-  // still referenced by native module so this should fail
-  try {
-    await gcUntil(() => nativeTests.was_wrap_finalize_called());
-    throw new Error("object was garbage collected while still referenced by native code");
-  } catch (e) {
-    if (!e.toString().includes("Condition was not met")) {
-      throw e;
-    }
-  }
+  // still referenced by native module, so these GCs must not collect it
+  assert((await tryGcUntil(() => nativeTests.was_wrap_finalize_called(), 10)) === false);
 
   // can still get the value using the ref
   assert(nativeTests.get_wrap_data_from_ref() === 42);
@@ -940,41 +944,52 @@ nativeTests.test_remove_wrap_lifetime_with_weak_ref = async () => {
   object = undefined;
 
   // ref will stop working once the object is collected
-  await gcUntil(() => nativeTests.get_object_from_ref() === undefined);
+  await gcUntil(() => nativeTests.is_wrapped_object_collected());
+  assert(nativeTests.get_object_from_ref() === undefined);
 
   // finalizer shouldn't have been called
   assert(nativeTests.was_wrap_finalize_called() === false);
 };
 
 nativeTests.test_remove_wrap_lifetime_with_strong_ref = async () => {
-  let object = { foo: "bar" };
-  assert(createWrapWithStrongRef(object) === object);
+  // A conservative stack/register scan can pin any one address for the whole
+  // process, so "this object gets collected" is not guaranteed for a
+  // particular object. The pin is address-specific: retry with a freshly
+  // allocated object instead of running more GCs on the same one.
+  const ATTEMPTS = 4;
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    let object = { foo: "bar" };
+    assert(createWrapWithStrongRef(object) === object);
 
-  assert(nativeTests.get_wrap_data(object) === 42);
+    assert(nativeTests.get_wrap_data(object) === 42);
 
-  nativeTests.remove_wrap(object);
-  assert(nativeTests.get_wrap_data(object) === undefined);
-  assert(nativeTests.get_wrap_data_from_ref() === undefined);
-  assert(nativeTests.get_object_from_ref() === object);
+    nativeTests.remove_wrap(object);
+    assert(nativeTests.get_wrap_data(object) === undefined);
+    assert(nativeTests.get_wrap_data_from_ref() === undefined);
+    assert(nativeTests.get_object_from_ref() === object);
 
-  object = undefined;
+    object = undefined;
 
-  // finalizer should not be called and object should not be freed
-  try {
-    await gcUntil(() => nativeTests.was_wrap_finalize_called() || nativeTests.get_object_from_ref() === undefined);
-    throw new Error("finalizer ran");
-  } catch (e) {
-    if (!e.toString().includes("Condition was not met")) {
-      throw e;
+    // finalizer should not be called and object should not be freed
+    const collectedWhileStrong = await tryGcUntil(
+      () => nativeTests.was_wrap_finalize_called() || nativeTests.is_wrapped_object_collected(),
+      10,
+    );
+    assert(collectedWhileStrong === false);
+
+    // native code can still get the object
+    assert(JSON.stringify(nativeTests.get_object_from_ref()) === `{"foo":"bar"}`);
+
+    // now it can be collected. An abandoned ref from a failed attempt leaks,
+    // which is fine in this fixture: its wrap was removed, so no finalizer
+    // will touch the global state.
+    nativeTests.unref_wrapped_value();
+    if (await tryGcUntil(() => nativeTests.is_wrapped_object_collected())) {
+      assert(nativeTests.get_object_from_ref() === undefined);
+      return;
     }
   }
-
-  // native code can still get the object
-  assert(JSON.stringify(nativeTests.get_object_from_ref()) === `{"foo":"bar"}`);
-
-  // now it gets deleted
-  nativeTests.unref_wrapped_value();
-  await gcUntil(() => nativeTests.get_object_from_ref() === undefined);
+  throw new Error(`wrapped object was not collected in any of ${ATTEMPTS} attempts`);
 };
 
 nativeTests.test_ref_deleted_in_cleanup = () => {

--- a/test/napi/napi-app/wrap_tests.cpp
+++ b/test/napi/napi-app/wrap_tests.cpp
@@ -101,6 +101,24 @@ static napi_value get_object_from_ref(const Napi::CallbackInfo &info) {
   return wrapped_object;
 }
 
+// is_wrapped_object_collected(): boolean
+// Checks whether the referent has been collected without materializing it as
+// a JS value. Returning the object to JS (like get_object_from_ref does) puts
+// a pointer to it in stack slots that a conservative GC scan may find, which
+// can keep the object alive indefinitely and make collection polls flaky.
+static napi_value is_wrapped_object_collected(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  napi_value wrapped_object = nullptr;
+  NODE_API_CALL(env, napi_get_reference_value(env, ref_to_wrapped_object,
+                                              &wrapped_object));
+
+  napi_value result;
+  NODE_API_CALL(env,
+                napi_get_boolean(env, wrapped_object == nullptr, &result));
+  return result;
+}
+
 // get_wrap_data_from_ref(): number|undefined
 static napi_value get_wrap_data_from_ref(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
@@ -221,6 +239,7 @@ void register_wrap_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, create_wrap);
   REGISTER_FUNCTION(env, exports, get_wrap_data);
   REGISTER_FUNCTION(env, exports, get_object_from_ref);
+  REGISTER_FUNCTION(env, exports, is_wrapped_object_collected);
   REGISTER_FUNCTION(env, exports, get_wrap_data_from_ref);
   REGISTER_FUNCTION(env, exports, remove_wrap);
   REGISTER_FUNCTION(env, exports, unref_wrapped_value);


### PR DESCRIPTION
## Problem

`test/napi/napi.test.ts > napi_wrap > has the right lifetime` is currently the most frequent flaky test in CI: it produced flaky-test annotations in 119 of the last 400 builds, across 100+ different branches and every platform (Windows x64 and aarch64 are the worst).

Signature:

```
error: Condition was not met after 100 GC attempts
      at gcUntil (test/napi/napi-app/module.js:24:13)
```

Of 136 captured occurrences, 126 point at the final poll of `test_remove_wrap_lifetime_with_strong_ref` (after `napi_reference_unref` drops the refcount to 0, the test polls until the weak ref reports the object as collected) and 10 at the equivalent poll in `test_wrap_lifetime_with_strong_ref`.

## Cause

The object is never collected because it is pinned by JSC's conservative stack/register scan, not because the reference is wrongly strong. Evidence:

- `NapiRef::unref` correctly drops the strong handle at refcount 0.
- A heap snapshot taken inside a failing run shows the `{foo:"bar"}` object alive with zero incoming edges and no labeled GC root: no heap retainer exists.
- The failure is per-process bimodal. Instrumented runs on windows-x64 (where the old fixture fails 19 times in 750 runs, about 2.5% per run, independent of env) show the final poll either succeeds on attempt 0 or fails all 100 attempts.

A pinned address stays pinned no matter how many more GCs run in that loop, so `gcUntil`'s 100 attempts are 100 correlated coin flips of the same coin. JS-level mitigation of the stack state does not work either: the conservative scan covers the region from the GC entry stack pointer up to the stack origin, and JS code can only overwrite stack below its own frames (verified: a stack-clobbering recursion before each GC attempt changed nothing).

Node does not hit this because V8 clears weak handles from precise marking.

## Fix

Test-side, in the shared napi-app fixture (runs identically under Node and Bun, output parity preserved):

- `test_remove_wrap_lifetime_with_strong_ref` now retries with a freshly allocated object, up to 4 attempts. A conservative pin holds one specific address, so attempts are independent (~2.5% each on the worst platform, so 4 attempts put the residual around 4e-7). The abandoned ref from a failed attempt leaks deliberately; its wrap was removed so no finalizer touches the fixture's global state.
- Collection polls use a new native `is_wrapped_object_collected()` which checks `napi_get_reference_value` against NULL in native code instead of materializing the referent as a JS value in every iteration of the poll loop.
- The expected-to-fail GC loops (proving a strongly referenced object is NOT collected) run 10 iterations instead of 100. Ten consecutive full GCs prove non-collection just as well, and this halves the test's wall time: 4.9s to 0.9s with a release build, which also gives slow (debug/ASAN) lanes headroom against the per-test timeout.
- The `try { gcUntil(...) } catch` expected-failure pattern becomes `assert(await tryGcUntil(...) === false)`.

`test_wrap_lifetime_with_strong_ref` (the remaining 10 of 136 occurrences) cannot retry safely because `create_wrap`'s finalizer routes through fixture-global state (`ref_to_wrapped_object`), and a collected leftover object from a previous attempt would delete the current attempt's ref. Making that retry-safe needs the finalizer to carry its own ref, which is a larger fixture refactor; its failure rate is ~2.5% of builds vs ~30% for the test overall, so this PR takes the 93%.

## Verification

- windows-x64, old fixture: 19 failures in 750 runs of `test_remove_wrap_lifetime_with_strong_ref`. Fixed fixture: 0 failures in 600 runs.
- Full `test/napi/napi.test.ts` passes on linux-x64 (release and debug ASAN builds) and windows-x64, including the Node output-parity comparisons.
- `bun bd test test/napi/napi.test.ts --timeout=60000 -t napi_wrap`: 7 pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->