### PR TITLE
Fix Bun.concatArrayBuffers maxLength wrapping modulo 2^32

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -269,8 +269,6 @@ JSC_DEFINE_HOST_FUNCTION(functionConcatTypedArrays, (JSGlobalObject * globalObje
             throwRangeError(globalObject, throwScope, "Maximum length must be >= 0"_s);
             return {};
         }
-        // Saturate instead of toUInt32, which wraps values >= 2^32 and
-        // silently truncates the result.
         maxLength = clampTo<size_t>(number);
     }
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -35,6 +35,7 @@
 #include "JSDOMException.h"
 #include "JSDOMConvert.h"
 #include "wtf/Compiler.h"
+#include <wtf/MathExtras.h>
 #include "PathInlines.h"
 #include "wtf/text/ASCIILiteral.h"
 #include "BunObject+exports.h"
@@ -268,9 +269,9 @@ JSC_DEFINE_HOST_FUNCTION(functionConcatTypedArrays, (JSGlobalObject * globalObje
             throwRangeError(globalObject, throwScope, "Maximum length must be >= 0"_s);
             return {};
         }
-        if (!std::isinf(number)) {
-            maxLength = arg1.toUInt32(globalObject);
-        }
+        // Saturate instead of toUInt32, which wraps values >= 2^32 and
+        // silently truncates the result.
+        maxLength = clampTo<size_t>(number);
     }
 
     bool asUint8Array = false;

--- a/test/js/bun/util/concat.test.js
+++ b/test/js/bun/util/concat.test.js
@@ -52,4 +52,17 @@ describe("concat", () => {
     const b = Uint8Array.from([4, 5, 6]);
     expect(concatArrayBuffers([a, b], 4)).toEqual(Uint8Array.from([1, 2, 3, 4]).buffer);
   });
+
+  it("maxLength >= 2^32 saturates instead of wrapping", () => {
+    const a = Uint8Array.from([1, 2, 3, 4, 5]);
+    const b = Uint8Array.from([6, 7, 8, 9, 10]);
+    const all = Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    // These used to be read with ToUint32: 2^32 became 0 and 2^32+3 became 3,
+    // silently truncating the result.
+    for (const maxLength of [2 ** 32, 2 ** 32 + 3, 2 ** 33 + 7, 2 ** 53, Number.MAX_VALUE, Infinity]) {
+      expect(concatArrayBuffers([a, b], maxLength, true)).toEqual(all);
+    }
+    expect(concatArrayBuffers([a, b], 2 ** 32 - 1, true)).toEqual(all);
+    expect(concatArrayBuffers([a, b], 3, true)).toEqual(Uint8Array.from([1, 2, 3]));
+  });
 });


### PR DESCRIPTION
### Problem

`Bun.concatArrayBuffers(buffers, maxLength)` validates `maxLength` as a double but then reads it with `toUInt32`, which wraps modulo 2^32. Any finite byte budget of 4 GiB or more silently truncates the result instead of meaning "everything":

```js
const a = new Uint8Array([1, 2, 3, 4, 5]), b = new Uint8Array([6, 7, 8, 9, 10]);
for (const m of [10, 2 ** 31, 2 ** 32 - 1, 2 ** 32, 2 ** 32 + 3, 2 ** 33 + 7, Infinity])
  console.log(m, '->', Bun.concatArrayBuffers([a, b], m).byteLength);
// before: 2^32 -> 0, 2^32+3 -> 3, 2^33+7 -> 7 (wrapped)
// after:  all -> 10
```

### Cause

In `functionConcatTypedArrays` (src/jsc/bindings/BunObject.cpp), the argument is range-checked as a double (RangeError on NaN or negative) but finite values are converted with `arg1.toUInt32(globalObject)`, so `2**32` becomes 0, `2**32 + 3` becomes 3, and so on. The result is `min(total, wrapped maxLength)`, so this is memory-safe, but data is silently dropped.

### Fix

Convert with `clampTo<size_t>(number)` so out-of-range values saturate to `size_t` max instead of wrapping. This also covers `Infinity`, which previously needed a separate branch. Behavior for values below 2^32 is unchanged.

### Verification

Added a test to `test/js/bun/util/concat.test.js` covering `2**32`, `2**32 + 3`, `2**33 + 7`, `2**53`, `Number.MAX_VALUE`, and `Infinity`. It fails on bun 1.4.0 (returns 0-byte and truncated buffers) and passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/concat.test.js
bun test v1.4.0 (462b81adc)

test/js/bun/util/concat.test.js:
(pass) concat > works with one element [31.22ms]
(pass) concat > works with two elements [8.11ms]
(pass) concat > works with mix of ArrayBuffer and TypedArray elements [3.09ms]
(pass) concat > can be trimmed to a max length [1.88ms]
(pass) concat > can be trimmed to a max length (ArrayBuffer) [2.24ms]
58 |     const b = Uint8Array.from([6, 7, 8, 9, 10]);
59 |     const all = Uint8Array.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
60 |     // These used to be read with ToUint32: 2^32 became 0 and 2^32+3 became 3,
61 |     // silently truncating the result.
62 |     for (const maxLength of [2 ** 32, 2 ** 32 + 3, 2 ** 33 + 7, 2 ** 53, Number.MAX_VALUE, Infinity]) {
63 |       expect(concatArrayBuffers([a, b], maxLength, true)).toEqual(all);
                                                               ^
error: expect(received).toEqual(expected)

- Uint8Array [
-   1,
-   2,
-   3,
-   4,
-   5,
-   6,
-   7,
-   8,
-   9,
-   10,
- ]
+ Uint8Array []


... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (77df3e7ee)

test/js/bun/util/concat.test.js:
(pass) concat > works with one element [0.32ms]
(pass) concat > works with two elements [0.18ms]
(pass) concat > works with mix of ArrayBuffer and TypedArray elements [0.06ms]
(pass) concat > can be trimmed to a max length [0.05ms]
(pass) concat > can be trimmed to a max length (ArrayBuffer) [0.03ms]
(pass) concat > maxLength >= 2^32 saturates instead of wrapping [0.08ms]

 6 pass
 0 fail
 13 expect() calls
Ran 6 tests across 1 file. [153.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/concat.test.js
bun test v1.4.0 (462b81adc)

test/js/bun/util/concat.test.js:
(pass) concat > works with one element [22.73ms]
(pass) concat > works with two elements [8.17ms]
(pass) concat > works with mix of ArrayBuffer and TypedArray elements [3.11ms]
(pass) concat > can be trimmed to a max length [1.84ms]
(pass) concat > can be trimmed to a max length (ArrayBuffer) [2.26ms]
(pass) concat > maxLength >= 2^32 saturates instead of wrapping [5.43ms]

 6 pass
 0 fail
 13 expect() calls
Ran 6 tests across 1 file. [2.06s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 677ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/9] gen cpp.rs (cppbind)
[2/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunObject.cpp  |  5 ++---
 test/js/bun/util/concat.test.js | 13 +++++++++++++
 2 files changed, 15 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/jsc/bindings/BunObject.cpp       3      4      0
test/js/bun/util/concat.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->