### PR TITLE
Fix stale-structure abort when a lazy Bun property builder throws mid-lookup

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,12 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+// Preview of oven-sh/WebKit#390 (rebased on ceb9f90f, the previous pin here):
+// JSObject::getPropertySlot reloads the structure before the prototype step, so
+// a static-table lazy property builder that transitions the object and then
+// throws no longer trips ASSERT(object->structure() == this) in
+// Structure::storedPrototype.
+export const WEBKIT_VERSION = "autobuild-preview-pr-390-22905e76";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -61,48 +61,6 @@ console.log("caught:", caught, "phase:", phase);`,
   });
 });
 
-// No hooks: first-touching Bun.sql with almost no stack left makes the builder
-// throw a RangeError. The Bun object does not transition here; this guards the
-// builder, which used to report the exception while it was still pending. That
-// report's read of process._fatalException reified the property but counted as
-// a miss because of the pending exception, hitting the same assert on the
-// process object, and the report also consumed the exception the builder then
-// relied on.
-test("lazy property builder that throws from stack overflow does not abort", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `let result = "not attempted";
-function f() {
-  try {
-    f();
-  } catch {}
-  if (result === "not attempted") {
-    try {
-      Bun.sql;
-      result = "no throw";
-    } catch (e) {
-      result = e.name;
-    }
-  }
-}
-f();
-console.log(result);`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: "RangeError\n",
-    stderr: "",
-    exitCode: 0,
-  });
-});
-
 test("require('bun')", () => {
   const str = eval("'bun'");
   expect(require(str)).toBe(Bun);

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -15,6 +15,49 @@ test("hasNonReifiedStatic", () => {
   expect(hasNonReifiedStatic(Bun)).toBe(false);
 });
 
+// A lazy static-table property builder that reifies another lazy property on
+// Bun (transitioning the object) and then throws used to trip
+// ASSERT(object->structure() == this) in JSC::Structure::storedPrototype,
+// because JSObject::getPropertySlot kept using the pre-transition structure
+// for the prototype step. Here the bun:sql module evaluation inside the
+// Bun.sql builder reads Error.prototype, which the proxy intercepts.
+test("lazy property builder that transitions Bun and throws does not abort", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let phase = 0;
+globalThis.Error = new Proxy(function () {}, {
+  get(target, key, receiver) {
+    if (key === "prototype" && phase === 0) {
+      phase = 1;
+      Bun.semver;
+      throw "boom";
+    }
+    return Reflect.get(target, key, receiver);
+  },
+});
+let caught;
+try {
+  Bun.sql;
+} catch (e) {
+  caught = e;
+}
+console.log("caught:", caught, "phase:", phase);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  // "phase: 1" proves the builder re-entered the Bun object mid-lookup; if the
+  // sql module stops reading Error.prototype at evaluation time, this test no
+  // longer exercises the code path and needs a new trigger.
+  expect(stdout).toBe("caught: boom phase: 1\n");
+  expect(exitCode).toBe(0);
+});
+
 test("require('bun')", () => {
   const str = eval("'bun'");
   expect(require(str)).toBe(Bun);

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -85,17 +85,15 @@ test("a lazy property whose builtin fails to load throws from the read", async (
   // The shell builtin ($) and the sql module body (sql, SQL, postgres) call Symbol(), so
   // breaking it makes each builder throw. The read must throw that error (debug builds used to
   // report the still-pending exception from inside the sql builders and abort) and the slot
-  // must stay unreified so a later read runs the builder again.
-  //
-  // process.env is read first because the shell builtin reads it before calling Symbol(), and
-  // building it on Windows reifies another property of the Bun object; doing that in the middle
-  // of the throwing read trips a separate structure assertion in debug builds.
+  // must stay unreified so a later read runs the builder again. On Windows the shell builtin also
+  // builds process.env before it calls Symbol(), which reifies Bun.inspect, so there the throwing
+  // read transitions the Bun object mid-lookup as well, the case the Error proxy test above sets
+  // up by hand.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `process.env;
-       globalThis.Symbol = NaN;
+      `globalThis.Symbol = NaN;
        const results = {};
        for (const name of ["$", "sql", "SQL", "postgres"]) {
          results[name] = [];

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -61,8 +61,13 @@ console.log("caught:", caught, "phase:", phase);`,
   });
 });
 
-// Same assert, no hooks: first-touching Bun.sql with almost no stack left makes
-// the builder's module evaluation throw a RangeError after the transition.
+// No hooks: first-touching Bun.sql with almost no stack left makes the builder
+// throw a RangeError. The Bun object does not transition here; this guards the
+// builder, which used to report the exception while it was still pending. That
+// report's read of process._fatalException reified the property but counted as
+// a miss because of the pending exception, hitting the same assert on the
+// process object, and the report also consumed the exception the builder then
+// relied on.
 test("lazy property builder that throws from stack overflow does not abort", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -49,13 +49,16 @@ console.log("caught:", caught, "phase:", phase);`,
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // "phase: 1" proves the builder re-entered the Bun object mid-lookup; if the
   // sql module stops reading Error.prototype at evaluation time, this test no
   // longer exercises the code path and needs a new trigger.
-  expect(stdout).toBe("caught: boom phase: 1\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "caught: boom phase: 1\n",
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 test("require('bun')", () => {

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -61,6 +61,43 @@ console.log("caught:", caught, "phase:", phase);`,
   });
 });
 
+// Same assert, no hooks: first-touching Bun.sql with almost no stack left makes
+// the builder's module evaluation throw a RangeError after the transition.
+test("lazy property builder that throws from stack overflow does not abort", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let result = "not attempted";
+function f() {
+  try {
+    f();
+  } catch {}
+  if (result === "not attempted") {
+    try {
+      Bun.sql;
+      result = "no throw";
+    } catch (e) {
+      result = e.name;
+    }
+  }
+}
+f();
+console.log(result);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "RangeError\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 test("require('bun')", () => {
   const str = eval("'bun'");
   expect(require(str)).toBe(Bun);


### PR DESCRIPTION
### What

Fuzzilli kept hitting a flaky abort on debug builds (fingerprint `StructureInlinesLight.h(56)`):

```
ASSERTION FAILED: isCompilationThread() || Thread::mayBeGCThread() || object->structure() == this
JSValue JSC::Structure::storedPrototype(const JSObject *) const
```

The fuzzer sample tripped it while reading every property on the `Bun` object, which first-touches all of its lazy static-table properties.

### Root cause

The inlined prototype-chain loop in `JSObject::getPropertySlot` (JSObject.h) reads the object's `Structure*` once, calls `getOwnNonIndexPropertySlot`, and on a miss uses that same pointer for `structure->storedPrototype(object)`. A miss is not side-effect free for static-table objects: reifying a lazy `PropertyCallback` property transitions the object, and with our fork's throwing builders, `setUpStaticFunctionSlot` can return false after the transition happened (the builder threw, so the slot is reported as not found and the caller observes the exception). The prototype step then runs on the stale pre-transition structure. Release builds read the prototype off the old structure, which happens to be harmless for mono-proto objects, so only asserts builds crash.

Deterministic trigger: a first read of `Bun.sql` evaluates the sql internal modules, whose `class SQLError extends Error` reads `Error.prototype` at module scope. Hooking that with a proxy that first touches another lazy `Bun` property (transitioning the Bun object) and then throws reproduces the abort every time, on current main included:

```js
let phase = 0;
globalThis.Error = new Proxy(function () {}, {
  get(target, key, receiver) {
    if (key === "prototype" && phase === 0) {
      phase = 1;
      Bun.semver;
      throw "boom";
    }
    return Reflect.get(target, key, receiver);
  },
});
try { Bun.sql; } catch (e) {}
```

Most of the fuzzer's later samples reached the same assert by a second route that did not involve a transition of the object being read: the sql builders in `BunObject.cpp` had a debug-only `reportUncaughtExceptionAtEventLoop` call that ran while the builder's exception was still pending (stack overflow next to the `Bun.sql` read, or a broken global `Symbol`), and that report's read of `process._fatalException` reified a property that was then counted as a miss, so the prototype step asserted on the process object. This PR originally removed that report as well; #29642 has since landed the same removal on main with its own test, so that hunk dropped out of this branch on rebase and those sample shapes no longer abort on main. What is left here is the engine half, which main still needs: any builder that re-enters the object being read and then throws (the proxy above; #29642's test also notes a Windows-only case of it, where building `process.env` inside a throwing read reifies another `Bun` property) still aborts with main's current pin.

### Fix

**WebKit** (oven-sh/WebKit#390, pinned here as its preview autobuild): reload the structure before the prototype step in `JSObject::getPropertySlot`. The megamorphic slow paths in JITOperations.cpp already do exactly this reload, with the comment "Reload it again since static-class-table can cause transition", and `getNonIndexPropertySlot` uses `getPrototypeDirect()` which re-reads it. This was the one caller left reusing the stale pointer. The change is 4 lines and has been carried unchanged across every pin bump since it was written.

### Verification

- Regression test in `test/js/bun/util/BunObject.test.ts` ("lazy property builder that transitions Bun and throws does not abort"). On a debug ASAN build of this exact branch with only the pin set back to `eeab0404`, the pin main used at the time (sources identical to main, #29642 included), the spawned process exits 134 with this assertion from `webkit-eeab04040fa61fd5-debug-asan/.../StructureInlinesLight.h(56)` and the test fails; with the preview pin it passes, and so does #29642's own test next to it. The `phase: 1` check makes the test self-invalidating if the sql module ever stops reading `Error.prototype` at evaluation time. Release builds never fired the assert, so the test passes under `USE_SYSTEM_BUN=1` by design; it guards the debug and ASAN lanes the fuzzer runs. The separate stack overflow test this PR used to carry covered the BunObject.cpp route and was dropped once #29642 landed that fix with its own coverage.
- #29642's test next to it ("a lazy property whose builtin fails to load throws from the read") pre-read `process.env` to step around this same assertion on Windows: the shell builtin builds `process.env` before it calls `Symbol()`, and on Windows that reifies `Bun.inspect`, so the throwing `Bun.$` read transitions the Bun object mid-lookup. This PR drops that pre-read and its comment, since the engine change is what makes them unnecessary. Checked on a Windows x64 debug build of this branch: with the pin set back to `eeab0404` both that test and the Error proxy test fail (each child aborts with this assertion, exit code 3), and with the preview pin the whole file passes; on Linux the pre-read never mattered and the file passes either way with the preview.
- Scope check of the engine change: with the same re-entrant builder (proxy above), I tried every way of reaching the lazy property. On a build of this branch with the pin set back to `eeab0404`, five forms still abort, and they are exactly the entry points of the `getPropertySlot` loop: a plain read, a call, `"sql" in Bun`, a read through an object that inherits from `Bun`, and a `with (Bun)` lookup. All five exit cleanly with the preview pin (the builder throws and the exception propagates). Own-property paths (`hasOwnProperty`, `getOwnPropertyDescriptor`, `defineProperty`), spread, and enumeration already behaved on plain `eeab0404` since #29642, and assignment or `delete` on an unreified static property never runs the builder, so no second reload is needed anywhere else.
- Related but separate: with `BUN_JSC_validateExceptionChecks=1`, the same throwing builder looked up while `Bun`'s prototype is a Proxy reports the builder's exception as unchecked at `getNonIndexPropertySlot`, because the loop still walks to the prototype after the miss. Without the validator the exception propagates normally (the Proxy path checks for it before it calls a trap), and this PR's reload is what lets execution get that far at all. It is tracked on its own and is not changed here, since it needs a decision about where the walk should stop.
- The original fuzzer sample no longer aborts across repeated runs, including with `BUN_JSC_collectContinuously=1`. The later samples I re-ran (explore walks over `Bun`, `new Archive(Bun)`, `new CookieMap(Bun)`, spreads, first touches of `Bun.sql` / `Bun.SQL` / `Bun.postgres`, the stack overflow variants) all run clean on debug ASAN builds of this branch; the deterministic ones still abort on the unfixed baseline binaries they were found on.
- SQL adapter tests (`test/js/sql/adapter-env-var-precedence.test.ts`), `test/js/bun/util/BunObject.test.ts`, `test/js/bun/globals.test.js`, and `test/js/bun/namespace-prototype-pollution.test.ts` pass against a local build of the patched WebKit.
- Pin history. Each time main moved its WebKit pin, the WebKit change was rebased onto the new pin and this branch was re-pinned to the matching preview. The only conflict was the `WEBKIT_VERSION` line every time.
  - `0cbb4a19` (WebKit side `9add1ce5`): CI build 99490 green on every lane.
  - `c6cfe90c` (`d0e68f3d`): builds 99678 and 99744 green on every lane.
  - `eeab0404` from #39371 (`5b4dfb37`): clean cherry-pick. The 846 upstream commits in that merge do not touch `getPropertySlot` or the static-table reification code. The fail-before run above against `eeab0404` confirms that.
  - `0f966e81` from #39614 (`277189f4`): clean cherry-pick. `JSObject.h`, `Lookup.h` and `StructureInlines*.h` are identical between `eeab0404` and `0f966e81`, so the fail-before runs above still describe this pin. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch. CI build 101209 green on every lane.
  - `b7f217b4` from #39829 (`78b9b769`): the same 4-line patch, applied as the identical `JSObject.h` blob because only FFI and FTL files changed between `0f966e81` and `b7f217b4`. The preview build for it needed several attempts: each time one job in a matrix died about a minute into `release.sh` and cancelled its siblings, while the same jobs passed for other branches. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch. CI build 102432: 177 of 179 jobs passed. The two failed jobs are failures that main has as well. `test/js/bun/http/bun-server.test.ts` failed on Windows 2019 x64, as it did in the final builds of #39732, #39867 and #39880. The stream release test in `test/js/node/http2/h2-conformance.test.ts` failed on macOS aarch64, as it did in the final build of #39633. This branch does not touch either file. Both tests pass on a debug ASAN build of this branch.
  - `aea1f010` from #35343 (`504873a9`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The seven WebKit commits between `b7f217b4` and `aea1f010` (the oven-sh/WebKit#330 buffer accessor nodes, the assembler buffer cache cap, the heap scheduler headroom, the Windows unwind records, the microtask termination handler and two CI changes) do not touch `JSObject.h`, `Lookup.h` or `StructureInlines*.h`. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`7aac06cf73`). CI build 104067 green on every lane (181 jobs).
  - `c148a12d` from #40201 (`fd0eceb3`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The 13 WebKit commits between `aea1f010` and `c148a12d` are bytecode cache, `SourceProvider` and WTF hash table changes. None of them touches `JSObject.h`, `Lookup.h` or `StructureInlines*.h`. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`0f1dd6ec0b`). CI build 104875: 180 of 181 jobs passed. The one failed job is a failure that main has as well: the `files transpiled and loaded don't leak file paths` tests in `test/cli/run/require-cache.test.ts` time out on the Debian x64 ASAN lane, as they did in the final build of #40272. This branch does not touch that file, and a main build with the stock pin behaves the same way locally (the fixture takes about 40 seconds and reports the same RSS growth).
  - `cb61607f` from #40276 (`c836313b`): the same 4-line patch, again applied as the identical `JSObject.h` blob. This pin is the upstream merge oven-sh/WebKit#503 (412 upstream commits, 90 of them in JavaScriptCore, WTF or bmalloc). It does not touch `JSObject.h`, `Lookup.cpp`, `Lookup.h`, `JSObjectInlines.h` or `StructureInlinesLight.h`, so the fail-before runs above still describe this pin. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`916e8c74e7`). CI build 105551 green on every lane (181 jobs).
  - `1cb96a7b` from #40417 (`a65ca749`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The two WebKit commits between `cb61607f` and `1cb96a7b` (oven-sh/WebKit#515 and #513) only touch the bytecode cache and `CodeCache`. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`63839ae696`). CI build 105885: 180 of 181 jobs passed. The one failed job is the same main failure as before: the `require-cache.test.ts` leak tests time out on the Debian x64 ASAN lane, as they did in the final build of #40272.
  - `76882271` from #40507 (`6815686e`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The three WebKit commits between `1cb96a7b` and `76882271` touch the sampling profiler's stack walk (oven-sh/WebKit#395) and the bytecode cache record layout. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`fca84468af`). CI build 106142 green on every lane (181 jobs).
  - `2da33d53` from #40570 (`31409f3e`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The one WebKit commit between `76882271` and `2da33d53` (oven-sh/WebKit#519) only touches `CachedTypes.cpp` and `CachedTypes.h`. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`b5378dbbbd`). CI build 106396: 169 of 181 jobs passed. The two red tests are failures that main has as well, both visible in main's own build 106385 (`fb657755e9`, the base of this head) and in other branches' builds from the same hour: the `BuildArtifact` hash snapshots in `test/bundler/bun-build-api.test.ts` changed after the bundler commits #40518, #40519, #40547 and #40569 landed, and the Unicode 16 IDNA case in `test/js/web/url/url.test.ts` throws `Invalid URL` on the macOS x64 lane. This branch does not touch either file.
  - `72597399` from #40270 (`5242a091`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The two WebKit commits between `2da33d53` and `72597399` (oven-sh/WebKit#505 and #521) touch the bytecode cache, the parser's source provider cache and `SymbolImpl.cpp`. The preview build needed a workflow dispatch from the branch of oven-sh/WebKit#523, because the stock workflow's Windows arm64 job fails in its Scoop install step for every run since Aug 27 (including WebKit main's own CI). The release still builds this PR's head. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`2ca8cf7b79`). CI build 106926: 179 of 181 jobs passed. The two red tests are failures that main has as well, both failing on every branch's build that day: `test/bundler/transpiler/macro-test.test.ts` reports a LeakSanitizer leak of the `node_fs_binding` Box on the Debian x64 ASAN lane, and the Unicode 16 IDNA case in `test/js/web/url/url.test.ts` throws `Invalid URL` on the macOS x64 lane. This branch does not touch either file.
  - `0bb01ed5` from #40643 (`168fe18a`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The WebKit commits between `72597399` and `0bb01ed5` are the module loading support for ahead-of-time embedders, `ModuleRegistryEntry::provideModule` and the CI fix oven-sh/WebKit#523; none touches `JSObject.h`. With #523 merged the normal preview run works again. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`1a42296843`). CI build 107113: 180 of 181 jobs passed. The one red test is main's: the RSS check in `test/cli/run/require-cache.test.ts` reports `Memory leak detected` on the Windows 2019 x64 lane, the same failure that lane showed on a retry in build 105885 and that the Debian ASAN lane shows as a timeout. This branch does not touch that file.
  - `f5deafe0` from #40674 (`28e2d2a8`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The two WebKit commits between `0bb01ed5` and `f5deafe0` only touch the module loader (`ModuleRegistryEntry`, `JSModuleLoader`, `AbstractModuleRecord`, `JSMicrotask`). The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`8b5d2fcb09`). CI build 107205: 181 of 182 jobs passed. The one red test is main's: the Unicode 16 IDNA case in `test/js/web/url/url.test.ts` throws `Invalid URL` on the macOS x64 lane, as it has on every build there since Aug 26 (including main's own build 106385). This branch does not touch that file.
  - `1817c3c3` from #40681 (`ebee9eee`): the same 4-line patch, again applied as the identical `JSObject.h` blob. This pin is the upstream merge oven-sh/WebKit#528 (345 commits). It does not touch `JSObject.h`, `Lookup.cpp`, `Lookup.h`, `JSObjectInlines.h` or `StructureInlinesLight.h`. Main moved its pin again while this preview was building, so this branch never ran CI on it.
  - `c4ddc0cf` from #40677 (`41813b80`): the same 4-line patch, again applied as the identical `JSObject.h` blob. The one WebKit commit between `1817c3c3` and `c4ddc0cf` (oven-sh/WebKit#527) only touches `CachedTypes` and `ExternalStringImpl`. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`e1aee47412`). This head had no CI build: its push landed while the PR was closed for an hour by my own mistake (see the comments of Aug 28).
  - `ceb9f90f` from #40767 (`22905e76`, current): the same 4-line patch, again applied as the identical `JSObject.h` blob. The four WebKit commits between `c4ddc0cf` and `ceb9f90f` (oven-sh/WebKit#530 and #531) touch the DFG integer range optimization, the bytecode cache constant decode, `RegExp` and `JSString.h`. The five tests in `BunObject.test.ts` pass on a debug ASAN build of the rebased branch (`33d0c02b6f`). CI build 107725: 180 of 181 jobs passed. The one red test is main's: the Unicode 16 IDNA case in `test/js/web/url/url.test.ts` throws `Invalid URL` on the macOS x64 lane, as on every build of that lane since Aug 26. This branch does not touch that file.

### Landing sequence

The `autobuild-preview-pr-390-*` pin exists so CI on this branch can fetch the patched WebKit. It must not reach main: GitHub deletes the preview release once oven-sh/WebKit#390 merges or closes (`scripts/build/download.ts` documents exactly this failure mode), which would leave main commits that 404 on vendor fetch. So the order is: land oven-sh/WebKit#390 first, then swap `WEBKIT_VERSION` here to the merged sha (the durable `autobuild-<sha>` release, after its prebuilt assets exist for every platform and flavor), then merge this PR. The swap should also delete the comment block above `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts`, which only describes the preview pin.


<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 24 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/util/BunObject.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/util/BunObject.test.ts
bun test v1.4.1 (33d0c02b6)

test/js/bun/util/BunObject.test.ts:
(pass) hasNonReifiedStatic [262.23ms]
(pass) lazy property builder that transitions Bun and throws does not abort [511.33ms]
(pass) require('bun') [4.67ms]
Module {
  $: [Function: BunShell2],
  Archive: [class Archive],
  ArrayBufferSink: [class ArrayBufferSink],
  CSRF: {
    generate: [Function: generate],
    verify: [Function: verify],
  },
  Cookie: [class Cookie],
  CookieMap: [class CookieMap],
  CryptoHasher: [class CryptoHasher],
  FFI: {
    viewSource: [Function: viewSource],
    dlopen: [Function: dlopen],
    callback: [Function: callback],
    linkSymbols: [Function: linkSymbols],
    toBuffer: [Function: toBuffer],
    toArrayBuffer: [Function: toArrayBuffer],
    closeCallback: [Function: closeCallback],
    cfunction: [Function: cfunction],
    CString: [class CString],
    ptr: [Function: ptr],
    read: {
      u8: [Function: u8],
      u16: [Function: u16],
      u32: [Function: u32],
      ptr: [Function: ptr],
      i8: [Function: i8],
      i16: [Function: i16],
      i32: [Function: i32],
      i64: [Function: i64],
      u64: [Function: u64],
      intptr: [Function: intptr],
      f32: [Function: f32],
      f64: [Function: f64],
    },
  },
  FileSystemRouter: [class FileSystemRouter],
  Glob: [class Glob],
  Image: [class Image],
  JSON5: {
    parse: [Function: parse],
    stringify: [Function: stringify],
  },
  JSONC: {
    parse: [Function: parse],
  },
  JSONL: JSONL {
    parse: [Function: parse],
    parseChunk: [Function: parseChunk],
  },
  MD4: [class MD4],
  MD5: [class MD5],
  RedisClient: [class RedisClient],
  S3Client: [class S3Client],
  SHA1: [class SHA1],
  SHA224: [class SHA224],
  SHA256: [class SHA256],
  SHA384: [class SHA384],
  SHA512: [class SHA512],
  SHA512_256: [class SHA512_256],
  SQL: [Function: SQL2],
  TOML: {
    par
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts       |  7 ++++-
 test/js/bun/util/BunObject.test.ts | 58 +++++++++++++++++++++++++++++++++-----
 2 files changed, 57 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 25 passed · 3 rejected · iteration 24

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
scripts/build/deps/webkit.ts           12     12      0
test/js/bun/util/BunObject.test.ts      7      9      0
```

</details>

<!-- robobun:evidence:end -->
































