### PR TITLE
Reject unix socket paths containing interior NUL bytes

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1300,6 +1300,20 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_unix_socket_address(const char *path, 
         return LIBUS_SOCKET_ERROR;
     }
 
+    // The kernel reads a filesystem sun_path as a NUL-terminated string, so an
+    // interior NUL would silently truncate the path and bind/connect a
+    // different socket. Abstract names (leading NUL, Linux) are
+    // length-delimited and may contain NUL bytes.
+    if (path[0] != '\0' && memchr(path, '\0', path_len) != NULL) {
+        #if defined(_WIN32)
+            // simulate EINVAL
+            SetLastError(ERROR_INVALID_PARAMETER);
+        #else
+            errno = EINVAL;
+        #endif
+        return LIBUS_SOCKET_ERROR;
+    }
+
     *addrlen = sizeof(struct sockaddr_un);
 
     #if defined(__linux__)

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -50,7 +50,7 @@ const ArrayPrototypePush = Array.prototype.push;
 const MathMax = Math.max;
 const MathMin = Math.min;
 
-const { UV_ECANCELED, UV_ENOBUFS, UV_ETIMEDOUT } = process.binding("uv");
+const { UV_ECANCELED, UV_EINVAL, UV_ENOBUFS, UV_ETIMEDOUT } = process.binding("uv");
 const isWindows = process.platform === "win32";
 
 const getDefaultAutoSelectFamily = $rust("node_net_binding.rs", "getDefaultAutoSelectFamily");
@@ -3136,6 +3136,11 @@ function internalConnect(self, options, address, port, addressType, localAddress
         detail: { host: address, port },
       });
     }
+  } else if (address.includes("\0") && address.charCodeAt(0) !== 0) {
+    // Match libuv (uv_pipe_connect2): a non-abstract path with an interior NUL
+    // would be silently truncated at the NUL by the kernel and connect a
+    // different socket.
+    err = UV_EINVAL;
   } else {
     const req: any = {};
     req.address = address;
@@ -3837,6 +3842,16 @@ Server.prototype[kRealListen] = function (
   // (hardcoded below); the stream layer implements allowHalfOpen=false
   // semantics itself, so the server option is consumed in JS only.
   if (path) {
+    if (path.includes("\0") && path.charCodeAt(0) !== 0) {
+      // Match libuv (uv_pipe_bind2): a non-abstract path with an interior NUL
+      // would be silently truncated at the NUL by the kernel and bind a
+      // different socket. formatListenError rewrites this into Node's
+      // "listen EINVAL: invalid argument <path>".
+      const err: any = new Error();
+      err.code = "EINVAL";
+      err.errno = UV_EINVAL;
+      throw err;
+    }
     this._handle = Bun.listen({
       unix: path,
       tls,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3137,9 +3137,7 @@ function internalConnect(self, options, address, port, addressType, localAddress
       });
     }
   } else if (address.includes("\0") && address.charCodeAt(0) !== 0) {
-    // Match libuv (uv_pipe_connect2): a non-abstract path with an interior NUL
-    // would be silently truncated at the NUL by the kernel and connect a
-    // different socket.
+    // Interior NUL in a non-abstract path: EINVAL, as libuv's uv_pipe_connect2.
     err = UV_EINVAL;
   } else {
     const req: any = {};
@@ -3843,10 +3841,8 @@ Server.prototype[kRealListen] = function (
   // semantics itself, so the server option is consumed in JS only.
   if (path) {
     if (path.includes("\0") && path.charCodeAt(0) !== 0) {
-      // Match libuv (uv_pipe_bind2): a non-abstract path with an interior NUL
-      // would be silently truncated at the NUL by the kernel and bind a
-      // different socket. formatListenError rewrites this into Node's
-      // "listen EINVAL: invalid argument <path>".
+      // Interior NUL in a non-abstract path: EINVAL, as libuv's uv_pipe_bind2;
+      // formatListenError rewrites this into Node's listen error message.
       const err: any = new Error();
       err.code = "EINVAL";
       err.errno = UV_EINVAL;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3136,8 +3136,7 @@ function internalConnect(self, options, address, port, addressType, localAddress
         detail: { host: address, port },
       });
     }
-  } else if (address.includes("\0") && address.charCodeAt(0) !== 0) {
-    // Interior NUL in a non-abstract path: EINVAL, as libuv's uv_pipe_connect2.
+  } else if (pipePathHasInteriorNul(address)) {
     err = UV_EINVAL;
   } else {
     const req: any = {};
@@ -3840,8 +3839,7 @@ Server.prototype[kRealListen] = function (
   // (hardcoded below); the stream layer implements allowHalfOpen=false
   // semantics itself, so the server option is consumed in JS only.
   if (path) {
-    if (path.includes("\0") && path.charCodeAt(0) !== 0) {
-      // Interior NUL in a non-abstract path: EINVAL, as libuv's uv_pipe_bind2;
+    if (pipePathHasInteriorNul(path)) {
       // formatListenError rewrites this into Node's listen error message.
       const err: any = new Error();
       err.code = "EINVAL";
@@ -4182,6 +4180,13 @@ function checkBindError(err, port, handle) {
 
 function isPipeName(s) {
   return typeof s === "string" && toNumber(s) === false;
+}
+
+// A non-abstract pipe path (leading NUL = abstract socket, Linux) with an
+// interior NUL would be silently truncated by the kernel; libuv's
+// uv_pipe_connect2/uv_pipe_bind2 reject it with EINVAL.
+function pipePathHasInteriorNul(path: string): boolean {
+  return path.charCodeAt(0) !== 0 && path.includes("\0");
 }
 
 function toNumber(x) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4182,9 +4182,7 @@ function isPipeName(s) {
   return typeof s === "string" && toNumber(s) === false;
 }
 
-// A non-abstract pipe path (leading NUL = abstract socket, Linux) with an
-// interior NUL would be silently truncated by the kernel; libuv's
-// uv_pipe_connect2/uv_pipe_bind2 reject it with EINVAL.
+// libuv rejects these with EINVAL; abstract names (leading NUL, Linux) are exempt.
 function pipePathHasInteriorNul(path: string): boolean {
   return path.charCodeAt(0) !== 0 && path.includes("\0");
 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1248,7 +1248,18 @@ impl ServerConfig {
                     )));
                 }
 
-                args.address = Address::Unix(bun_core::ZBox::from_bytes(unix_str.slice()));
+                let slice = unix_str.slice();
+                // The kernel reads a filesystem sun_path as a NUL-terminated
+                // string, so an interior NUL would silently truncate the path.
+                // Abstract names (leading NUL, Linux) are length-delimited and
+                // may contain NUL bytes.
+                if slice.first().is_some_and(|&b| b != 0) && slice.contains(&0) {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "\"unix\" must not contain null bytes"
+                    )));
+                }
+
+                args.address = Address::Unix(bun_core::ZBox::from_bytes(slice));
             }
         }
         if global.has_exception() {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1249,11 +1249,7 @@ impl ServerConfig {
                 }
 
                 let slice = unix_str.slice();
-                // The kernel reads a filesystem sun_path as a NUL-terminated
-                // string, so an interior NUL would silently truncate the path.
-                // Abstract names (leading NUL, Linux) are length-delimited and
-                // may contain NUL bytes.
-                if slice.first().is_some_and(|&b| b != 0) && slice.contains(&0) {
+                if crate::socket::unix_path_has_interior_nul(slice) {
                     return Err(global.throw_invalid_arguments(format_args!(
                         "\"unix\" must not contain null bytes"
                     )));

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -540,12 +540,7 @@ impl SocketConfig {
                 let without_prefix = slice[7..].to_vec();
                 result.hostname_or_unix = ZigStringSlice::init_owned(without_prefix);
             }
-            let slice = result.hostname_or_unix.slice();
-            // The kernel reads a filesystem sun_path as a NUL-terminated
-            // string, so an interior NUL would silently truncate the path.
-            // Abstract names (leading NUL, Linux) are length-delimited and may
-            // contain NUL bytes.
-            if slice.first().is_some_and(|&b| b != 0) && slice.contains(&0) {
+            if crate::socket::unix_path_has_interior_nul(result.hostname_or_unix.slice()) {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "\"unix\" must not contain null bytes"
                 )));

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -540,6 +540,16 @@ impl SocketConfig {
                 let without_prefix = slice[7..].to_vec();
                 result.hostname_or_unix = ZigStringSlice::init_owned(without_prefix);
             }
+            let slice = result.hostname_or_unix.slice();
+            // The kernel reads a filesystem sun_path as a NUL-terminated
+            // string, so an interior NUL would silently truncate the path.
+            // Abstract names (leading NUL, Linux) are length-delimited and may
+            // contain NUL bytes.
+            if slice.first().is_some_and(|&b| b != 0) && slice.contains(&0) {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "\"unix\" must not contain null bytes"
+                )));
+            }
         } else if let Some(hostname) = generated.hostname.get() {
             if hostname.length() == 0 {
                 return Err(global

--- a/src/runtime/socket/mod.rs
+++ b/src/runtime/socket/mod.rs
@@ -32,6 +32,14 @@ pub mod windows_named_pipe;
 #[path = "WindowsNamedPipeContext.rs"]
 pub mod windows_named_pipe_context;
 
+/// True when a unix socket path would be silently truncated by the kernel: a
+/// filesystem `sun_path` is read as a NUL-terminated string, so an interior
+/// NUL would bind/connect a different path. Abstract names (leading NUL,
+/// Linux) are length-delimited and may contain NUL bytes, so they are exempt.
+pub fn unix_path_has_interior_nul(path: &[u8]) -> bool {
+    path.first().is_some_and(|&b| b != 0) && path.contains(&0)
+}
+
 /// Re-export of the canonical `bun_uws::ssl_wrapper` plus the runtime-tier
 /// `init(&SSLConfig, ..)` constructor that the lower tier can't see (it would
 /// need to name `crate::server::server_config::SSLConfig`). The body is the

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -803,7 +803,21 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             if !obj.is_empty() {
                 if let Some(socket_path) = obj.get(global_this, "unix")? {
                     if socket_path.is_string() && socket_path.get_length(ctx)? > 0 {
-                        break 'extract_unix_socket_path socket_path.to_slice_clone(global_this)?;
+                        let path_slice = socket_path.to_slice_clone(global_this)?;
+                        {
+                            let bytes = path_slice.slice();
+                            // The kernel reads a filesystem sun_path as a
+                            // NUL-terminated string, so an interior NUL would
+                            // silently truncate the path. Abstract names
+                            // (leading NUL, Linux) are length-delimited and may
+                            // contain NUL bytes.
+                            if bytes.first().is_some_and(|&b| b != 0) && bytes.contains(&0) {
+                                return Err(global_this.throw_invalid_arguments(format_args!(
+                                    "\"unix\" must not contain null bytes"
+                                )));
+                            }
+                        }
+                        break 'extract_unix_socket_path path_slice;
                     }
                 }
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -804,18 +804,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 if let Some(socket_path) = obj.get(global_this, "unix")? {
                     if socket_path.is_string() && socket_path.get_length(ctx)? > 0 {
                         let path_slice = socket_path.to_slice_clone(global_this)?;
-                        {
-                            let bytes = path_slice.slice();
-                            // The kernel reads a filesystem sun_path as a
-                            // NUL-terminated string, so an interior NUL would
-                            // silently truncate the path. Abstract names
-                            // (leading NUL, Linux) are length-delimited and may
-                            // contain NUL bytes.
-                            if bytes.first().is_some_and(|&b| b != 0) && bytes.contains(&0) {
-                                return Err(global_this.throw_invalid_arguments(format_args!(
-                                    "\"unix\" must not contain null bytes"
-                                )));
-                            }
+                        if crate::socket::unix_path_has_interior_nul(path_slice.slice()) {
+                            return Err(global_this.throw_invalid_arguments(format_args!(
+                                "\"unix\" must not contain null bytes"
+                            )));
                         }
                         break 'extract_unix_socket_path path_slice;
                     }

--- a/test/js/bun/net/unix-socket-nul-byte.test.ts
+++ b/test/js/bun/net/unix-socket-nul-byte.test.ts
@@ -134,7 +134,7 @@ describe("unix socket paths with interior NUL bytes are rejected", () => {
 describe.skipIf(!isLinux)("abstract socket names keep working", () => {
   test("Bun.listen/Bun.connect roundtrip, including interior NUL in the name", async () => {
     for (const name of [`\0bun-nul-test-${process.pid}`, `\0bun-nul-test-${process.pid}\0x`]) {
-      const { promise, resolve } = Promise.withResolvers<string>();
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
       const listener = Bun.listen({
         unix: name,
         socket: {
@@ -142,19 +142,35 @@ describe.skipIf(!isLinux)("abstract socket names keep working", () => {
             socket.end("hello");
           },
           data() {},
+          error(_socket, error) {
+            reject(error);
+          },
         },
       });
       try {
-        await Bun.connect({
+        const client = await Bun.connect({
           unix: name,
           socket: {
             data(_socket, data) {
               resolve(String(data));
             },
             open() {},
+            error(_socket, error) {
+              reject(error);
+            },
+            close() {
+              reject(new Error("closed before data"));
+            },
+            connectError(_socket, error) {
+              reject(error);
+            },
           },
         });
-        expect(await promise).toBe("hello");
+        try {
+          expect(await promise).toBe("hello");
+        } finally {
+          client.end();
+        }
       } finally {
         listener.stop(true);
       }

--- a/test/js/bun/net/unix-socket-nul-byte.test.ts
+++ b/test/js/bun/net/unix-socket-nul-byte.test.ts
@@ -121,6 +121,22 @@ describe("unix socket paths with interior NUL bytes are rejected", () => {
     expect(result.code).toBe("EINVAL");
   });
 
+  test("http.createServer().listen", async () => {
+    // Routes through Bun.serve, not net.Server, so it is a separate entry point.
+    const server = http.createServer(() => {});
+    try {
+      const result: any = await new Promise(resolve => {
+        server.on("error", e => resolve(e));
+        server.listen(D + "/h\0x", () => resolve("listening"));
+      });
+      expect(result).not.toBe("listening");
+      expect(result?.message).toContain('"unix" must not contain null bytes');
+    } finally {
+      server.close();
+    }
+    expect(fs.readdirSync(D)).not.toContain("h");
+  });
+
   test("trailing NUL is rejected too", () => {
     expect(() => Bun.listen({ unix: D + "/t\0", socket: { data() {} } })).toThrow('"unix" must not contain null bytes');
     expect(fs.readdirSync(D)).not.toContain("t");

--- a/test/js/bun/net/unix-socket-nul-byte.test.ts
+++ b/test/js/bun/net/unix-socket-nul-byte.test.ts
@@ -32,6 +32,7 @@ const decoy = isPosix
 
 afterAll(() => {
   decoy?.stop(true);
+  dir[Symbol.dispose]();
 });
 
 const nulPath = D + "/a\0b";

--- a/test/js/bun/net/unix-socket-nul-byte.test.ts
+++ b/test/js/bun/net/unix-socket-nul-byte.test.ts
@@ -1,0 +1,183 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { isLinux, isPosix, tempDir } from "harness";
+import fs from "node:fs";
+import http from "node:http";
+import net from "node:net";
+
+// A unix socket path with an interior NUL byte used to be passed through to
+// the kernel, which reads sun_path as a NUL-terminated string: the
+// connect/listen silently happened on the truncated prefix path (a different
+// socket) while the API reported the full path. Every surface must reject the
+// path instead. Abstract socket names (leading NUL, Linux) are
+// length-delimited and may legitimately contain NUL bytes.
+
+const dir = tempDir("unix-nul", {});
+const D = String(dir);
+
+// A decoy server at the truncated prefix: before the fix, every client
+// surface asked for `D/a\0...` and reached this socket instead.
+let decoyConnections = 0;
+const decoy = isPosix
+  ? Bun.listen({
+      unix: D + "/a",
+      socket: {
+        open(socket) {
+          decoyConnections++;
+          socket.end();
+        },
+        data() {},
+      },
+    })
+  : null;
+
+afterAll(() => {
+  decoy?.stop(true);
+});
+
+const nulPath = D + "/a\0b";
+
+describe("unix socket paths with interior NUL bytes are rejected", () => {
+  test("Bun.connect", async () => {
+    let err: any;
+    try {
+      await Bun.connect({ unix: nulPath, socket: { data() {}, open() {} } });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toContain('"unix" must not contain null bytes');
+  });
+
+  test("Bun.listen", () => {
+    let listener: any;
+    try {
+      expect(() => {
+        listener = Bun.listen({ unix: D + "/q\0c", socket: { data() {} } });
+      }).toThrow('"unix" must not contain null bytes');
+    } finally {
+      listener?.stop(true);
+    }
+    expect(fs.readdirSync(D)).not.toContain("q");
+  });
+
+  test("Bun.serve", () => {
+    let server: any;
+    try {
+      expect(() => {
+        server = Bun.serve({ unix: D + "/s\0d", fetch: () => new Response("x") });
+      }).toThrow('"unix" must not contain null bytes');
+    } finally {
+      server?.stop(true);
+    }
+    expect(fs.readdirSync(D)).not.toContain("s");
+  });
+
+  test("fetch", async () => {
+    let err: any;
+    try {
+      await fetch("http://localhost/", { unix: nulPath });
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toContain('"unix" must not contain null bytes');
+  });
+
+  test("net.connect", async () => {
+    const socket = net.connect({ path: nulPath });
+    const result: any = await new Promise(resolve => {
+      socket.on("error", e => resolve(e));
+      socket.on("connect", () => resolve("connected"));
+    });
+    socket.destroy();
+    expect(result).not.toBe("connected");
+    expect(result.code).toBe("EINVAL");
+    expect(result.syscall).toBe("connect");
+    expect(result.message).toStartWith("connect EINVAL");
+  });
+
+  test("net.Server.listen", async () => {
+    const server = net.createServer(() => {});
+    try {
+      const result: any = await new Promise(resolve => {
+        server.on("error", e => resolve(e));
+        server.listen(D + "/z\0w", () => resolve("listening"));
+      });
+      expect(result).not.toBe("listening");
+      expect(result.code).toBe("EINVAL");
+      expect(result.message).toBe(`listen EINVAL: invalid argument ${D + "/z\0w"}`);
+    } finally {
+      server.close();
+    }
+    expect(fs.readdirSync(D)).not.toContain("z");
+  });
+
+  test("http.request socketPath", async () => {
+    const result: any = await new Promise(resolve => {
+      const req = http.request({ socketPath: nulPath, path: "/" }, () => resolve("response"));
+      req.on("error", e => resolve(e));
+      req.end();
+    });
+    expect(result).not.toBe("response");
+    expect(result.code).toBe("EINVAL");
+  });
+
+  test("trailing NUL is rejected too", () => {
+    expect(() => Bun.listen({ unix: D + "/t\0", socket: { data() {} } })).toThrow('"unix" must not contain null bytes');
+    expect(fs.readdirSync(D)).not.toContain("t");
+  });
+
+  test.skipIf(!isPosix)("the truncated-prefix socket was never contacted", () => {
+    expect(decoyConnections).toBe(0);
+  });
+});
+
+describe.skipIf(!isLinux)("abstract socket names keep working", () => {
+  test("Bun.listen/Bun.connect roundtrip, including interior NUL in the name", async () => {
+    for (const name of [`\0bun-nul-test-${process.pid}`, `\0bun-nul-test-${process.pid}\0x`]) {
+      const { promise, resolve } = Promise.withResolvers<string>();
+      const listener = Bun.listen({
+        unix: name,
+        socket: {
+          open(socket) {
+            socket.end("hello");
+          },
+          data() {},
+        },
+      });
+      try {
+        await Bun.connect({
+          unix: name,
+          socket: {
+            data(_socket, data) {
+              resolve(String(data));
+            },
+            open() {},
+          },
+        });
+        expect(await promise).toBe("hello");
+      } finally {
+        listener.stop(true);
+      }
+    }
+  });
+
+  test("node:net abstract listen/connect roundtrip", async () => {
+    const name = `\0bun-nul-test-net-${process.pid}`;
+    const server = net.createServer(socket => socket.end("hi"));
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.on("error", reject);
+        server.listen(name, () => resolve());
+      });
+      const received = await new Promise<string>((resolve, reject) => {
+        const client = net.connect({ path: name });
+        let buf = "";
+        client.on("data", d => (buf += d));
+        client.on("end", () => resolve(buf));
+        client.on("error", reject);
+      });
+      expect(received).toBe("hi");
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Repro

```js
import net from "node:net";
import fs from "node:fs";
const D = fs.mkdtempSync("/tmp/nul-");
const decoy = net.createServer(s => s.end("DECOY\n"));
await new Promise(r => decoy.listen(D + "/a", r));

// ask for D/a\0b, a DIFFERENT path
net.connect({ path: D + "/a\0b" }).on("data", d => console.log(String(d))); // before: "DECOY"  after: error event, code EINVAL
const l = Bun.listen({ unix: D + "/q\0c", socket: { data() {} } });         // before: creates file "q", reports "q\0c"  after: throws
```

Before this change, a unix socket path with an embedded NUL was silently truncated at the NUL on every surface (node:net connect/listen, node:http `socketPath`, `Bun.connect`, `Bun.listen`, `Bun.serve`, `fetch({ unix })`): the connect/listen happened on the prefix path, a different socket, while the API reported the full path. Node rejects all of these with `EINVAL`. A path assembled from untrusted input (`${dir}/${name}` with `name = "x\0..."`) would connect to or serve on `${dir}/x`, the unix-socket analogue of NUL injection in file paths, which Bun's fs layer already rejects.

## Cause

Nothing between the JS string and the `memcpy` into `sun_path` (`bsd_create_unix_socket_address` in `packages/bun-usockets/src/bsd.c`) rejected interior NULs, and the kernel reads a filesystem `sun_path` as a NUL-terminated string. `SocketConfig` only checked for an empty `unix` string while the adjacent `hostname` arm already rejects NUL bytes.

## Fix

- `bsd_create_unix_socket_address` fails with `EINVAL` on an interior NUL in a non-abstract path. This is the choke point every unix connect and listen funnels through, so internal clients (redis, sql) are covered too.
- `SocketConfig` (Bun.connect / Bun.listen), `ServerConfig` (Bun.serve), and the fetch `unix` option throw `ERR_INVALID_ARG_TYPE` (`"unix" must not contain null bytes`), mirroring the existing hostname check.
- node:net matches libuv (`uv_pipe_connect2` / `uv_pipe_bind2` with `UV_PIPE_NO_TRUNCATE`): connect emits an error event `connect EINVAL <path>` and listen emits `listen EINVAL: invalid argument <path>`, same codes and messages as Node v26. node:http `socketPath` flows through the same path.

Abstract socket names (leading NUL, Linux) are length-delimited and may legitimately contain NUL bytes; they are exempt and covered by regression tests, including a name with an interior NUL.

## Verification

`test/js/bun/net/unix-socket-nul-byte.test.ts` covers all 7 surfaces plus abstract-socket roundtrips: 9 of 11 tests fail on bun 1.4.0 (a decoy listener at the truncated prefix receives 4 connections), all pass with this change. `unix-socket-long-path`, `unix-socket-unlink`, `bun-listen-connect-args`, `fetch.unix`, `serve-listen`, `bun-serve-args`, and `fetch-args` suites pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/unix-socket-nul-byte.test.ts

<!-- robobun:evidence:end -->