### PR TITLE
Error on URLs with an unparseable port instead of silently connecting to 80/443

### DIFF
--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -494,6 +494,20 @@ impl HttpThread {
                 .connect_socket(client, unix_path.slice());
         }
 
+        // A `:port` that fails to parse must not collapse into the scheme
+        // default via `get_port_auto()` below, or the request is silently
+        // sent to port 80/443 of that host. The WHATWG parser never produces
+        // these, but env-proxy values (`HTTP_PROXY=http://host:107688`) and
+        // S3/registry endpoints reach here unvalidated.
+        if client.url.has_invalid_port() {
+            return Err(crate::Error::InvalidPort);
+        }
+        if let Some(proxy) = &client.http_proxy {
+            if proxy.has_invalid_port() {
+                return Err(crate::Error::InvalidProxyPort);
+            }
+        }
+
         if IS_SSL {
             'custom_ctx: {
                 let Some(tls) = client.tls_props.clone() else {

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -33,6 +33,10 @@ pub enum Error {
     AbortedBeforeConnecting,
     #[error("InvalidURL")]
     InvalidURL,
+    #[error("InvalidPort")]
+    InvalidPort,
+    #[error("InvalidProxyPort")]
+    InvalidProxyPort,
     #[error("ERR_TLS_CERT_ALTNAME_INVALID")]
     ERR_TLS_CERT_ALTNAME_INVALID,
     #[error("ClientAborted")]
@@ -276,6 +280,8 @@ impl Error {
             Self::Timeout => "Timeout",
             Self::AbortedBeforeConnecting => "AbortedBeforeConnecting",
             Self::InvalidURL => "InvalidURL",
+            Self::InvalidPort => "InvalidPort",
+            Self::InvalidProxyPort => "InvalidProxyPort",
             Self::ERR_TLS_CERT_ALTNAME_INVALID => "ERR_TLS_CERT_ALTNAME_INVALID",
             Self::ClientAborted => "ClientAborted",
             Self::HTTP2Unsupported => "HTTP2Unsupported",

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1387,6 +1387,12 @@ impl FetchTasklet {
             http::Error::RedirectURLInvalid => {
                 BunString::static_("Redirect URL in Location header is invalid.")
             }
+            http::Error::InvalidPort => BunString::static_(
+                "Invalid port number in URL. Ports must be a number between 0 and 65535.",
+            ),
+            http::Error::InvalidProxyPort => BunString::static_(
+                "Invalid port number in proxy URL. Ports must be a number between 0 and 65535.",
+            ),
 
             http::Error::Cert(http::CertError::UNABLE_TO_GET_ISSUER_CERT) => {
                 BunString::static_("unable to get issuer certificate")

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -117,6 +117,20 @@ pub(crate) fn get_credentials_with_options(
                             let utf8 = str.to_utf8();
                             let endpoint = utf8.slice();
                             let url = URL::parse(endpoint);
+                            // `get_port_auto()` would silently turn an
+                            // unparseable port into 80/443 and send signed
+                            // requests there; reject it up front.
+                            if url.has_invalid_port() {
+                                str.deref();
+                                return Err(global_object
+                                    .err(
+                                        bun_jsc::ErrorCode::INVALID_ARG_VALUE,
+                                        format_args!(
+                                            "endpoint port must be a number between 0 and 65535"
+                                        ),
+                                    )
+                                    .throw());
+                            }
                             let normalized_endpoint = url.host_with_path();
                             if !normalized_endpoint.is_empty() {
                                 new_credentials.credentials.endpoint =

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -391,6 +391,9 @@ impl S3Credentials {
                     host = &self.endpoint[..index];
                     extra_path = &self.endpoint[index..];
                 }
+                if host_has_invalid_port(host) {
+                    return Err(SignError::InvalidEndpoint);
+                }
                 // only the host part is needed here
                 break 'brk_host Box::<[u8]>::from(host);
             } else {
@@ -1435,4 +1438,22 @@ fn is_valid_host_component(value: &[u8]) -> bool {
         && value
             .iter()
             .all(|&c| c.is_ascii_alphanumeric() || c == b'-' || c == b'.' || c == b'_')
+}
+
+/// `host` is `hostname[:port]` or `[ipv6][:port]`. Returns `true` when a
+/// `:port` is present but does not parse as a u16; connecting with such a
+/// host silently targets the scheme default port (80/443) instead.
+fn host_has_invalid_port(host: &[u8]) -> bool {
+    let port: &[u8] = if host.first() == Some(&b'[') {
+        match strings::index_of(host, b"]:") {
+            Some(i) => &host[i + 2..],
+            None => return false,
+        }
+    } else {
+        match strings::index_of_char(host, b':') {
+            Some(i) => &host[i as usize + 1..],
+            None => return false,
+        }
+    };
+    !port.is_empty() && bun_core::fmt::parse_int::<u16>(port, 10).is_err()
 }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -420,6 +420,14 @@ impl<'a> URL<'a> {
         bun_core::fmt::parse_int::<u16>(self.port, 10).ok()
     }
 
+    /// `true` when the URL carries a `:port` component whose text does not
+    /// parse as a u16 (`:107688`, `:9000abc`). `get_port_auto()` silently
+    /// substitutes the scheme default for these, so consumers that connect
+    /// with user-supplied URLs must reject them first.
+    pub fn has_invalid_port(&self) -> bool {
+        !self.port.is_empty() && self.get_port().is_none()
+    }
+
     pub fn get_port_auto(&self) -> u16 {
         self.get_port().unwrap_or_else(|| self.get_default_port())
     }

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -2320,3 +2320,47 @@ describe("http_proxy env var scheme is case-insensitive", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// An env proxy whose `:port` text does not parse as a u16 (overflow like
+// 107688 or 4295009448, out of range 99999, trailing garbage 9000abc) used to
+// collapse into the scheme default via get_port_auto(): every proxied request
+// was silently sent to port 80/443 of the proxy host. It must be rejected
+// before any connection is attempted; curl and Node (ERR_PROXY_INVALID_CONFIG)
+// both error on these.
+describe("env proxy with unparseable port is rejected", () => {
+  const cases = [
+    ["HTTP_PROXY", "107688", "http"], // 42152 + 2^16
+    ["HTTP_PROXY", "4295009448", "http"], // 42152 + 2^32
+    ["http_proxy", "99999", "http"],
+    ["HTTP_PROXY", "9000abc", "http"],
+    ["HTTPS_PROXY", "107688", "https"],
+  ] as const;
+
+  test.concurrent.each(cases)("%s=http://127.0.0.1:%s", async (envKey, badPort, targetScheme) => {
+    // Target is port 1 on loopback: the fetch must fail on the proxy URL
+    // before any connection is attempted, so nothing ever dials the target.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try { await fetch(${JSON.stringify(`${targetScheme}://127.0.0.1:1/x`)}); console.log("OK"); } catch (e) { console.log("ERR", e?.code ?? e?.name); }`,
+      ],
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+        [envKey]: `http://127.0.0.1:${badPort}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ERR InvalidProxyPort");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1786,7 +1786,9 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The fixture's S3 endpoint is a loopback server; ambient proxy env
+      // (set in some CI/dev containers) must not intercept it.
+      env: { ...bunEnv, HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1844,7 +1846,9 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The fixture's S3 endpoint is a loopback server; ambient proxy env
+      // (set in some CI/dev containers) must not intercept it.
+      env: { ...bunEnv, HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1904,7 +1908,9 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The fixture's S3 endpoint is a loopback server; ambient proxy env
+      // (set in some CI/dev containers) must not intercept it.
+      env: { ...bunEnv, HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1984,7 +1990,9 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The fixture's S3 endpoint is a loopback server; ambient proxy env
+      // (set in some CI/dev containers) must not intercept it.
+      env: { ...bunEnv, HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -2041,5 +2049,64 @@ describe("presigned url signature", () => {
       const { signature, expected } = verifyPresignedUrl(presigned, credentials);
       expect(signature).toBe(expected);
     }
+  });
+});
+
+// An endpoint whose `:port` text does not parse as a u16 used to collapse
+// into the scheme default via get_port_auto(): the SigV4-signed request was
+// silently sent to port 80/443 of the endpoint host, and presign() emitted a
+// URL carrying the bogus port verbatim.
+describe.concurrent("s3 endpoint with unparseable port", () => {
+  const base = { accessKeyId: "a", secretAccessKey: "b", bucket: "bk" };
+  const badPorts = ["107688", "4295009448", "99999", "9000abc"];
+
+  it("S3Client constructor rejects it", () => {
+    for (const port of badPorts) {
+      try {
+        new Bun.S3Client({ ...base, endpoint: `http://127.0.0.1:${port}` });
+        expect.unreachable();
+      } catch (e: any) {
+        expect(e?.code).toBe("ERR_INVALID_ARG_VALUE");
+        expect(e?.message).toContain("endpoint port");
+      }
+    }
+  });
+
+  it("per-file endpoint option rejects it", () => {
+    try {
+      Bun.s3.file("key", { ...base, endpoint: "http://127.0.0.1:107688" });
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e?.code).toBe("ERR_INVALID_ARG_VALUE");
+    }
+  });
+
+  it("valid ports still work", () => {
+    expect(() => new Bun.S3Client({ ...base, endpoint: "http://127.0.0.1" })).not.toThrow();
+    const presigned = new Bun.S3Client({ ...base, endpoint: "http://127.0.0.1:9000" }).presign("k");
+    expect(new URL(presigned).port).toBe("9000");
+  });
+
+  it("S3_ENDPOINT env var: presign errors instead of emitting the URL", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try { console.log("URL", Bun.s3.presign("k")); } catch (e) { console.log("ERR", e?.code); }`,
+      ],
+      env: {
+        ...bunEnv,
+        S3_ENDPOINT: "http://127.0.0.1:107688",
+        S3_BUCKET: "bk",
+        S3_ACCESS_KEY_ID: "a",
+        S3_SECRET_ACCESS_KEY: "b",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ERR ERR_S3_INVALID_ENDPOINT");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

A URL port that fails to parse as a u16 (`:107688`, `:4295009448`, `:99999`, `:9000abc`) silently collapses into the scheme default: `URL::get_port_auto()` (src/url/lib.rs) maps "present but unparseable" to `None` and then substitutes 80/443. Everything that goes through the WHATWG parser first (`fetch(url)`, `fetch(url, { proxy })`, `new WebSocket`) rejects these strings, but two public surfaces skip it:

- `S3Client` `endpoint`: the SigV4-signed request is sent to port 80/443 of the endpoint host (the `Authorization` header is delivered to whatever listens there), and `presign()` emits a URL carrying the bogus port verbatim.
- `HTTP_PROXY` / `HTTPS_PROXY`: every proxied fetch is sent to port 80/443 of the proxy host.

```js
// listener on 127.0.0.1:80 observes: GET /bk/k HTTP/1.1 (with SigV4 Authorization header)
const s3 = new Bun.S3Client({ endpoint: "http://127.0.0.1:107688", accessKeyId: "a", secretAccessKey: "b", bucket: "bk" });
await s3.file("k").text();

// HTTP_PROXY=http://127.0.0.1:107688 bun app.js
// listener on 127.0.0.1:80 observes: GET http://127.0.0.1:9/t HTTP/1.1
await fetch("http://127.0.0.1:9/t");
```

curl errors on these ("Port number was not a decimal number between 0 and 65535"), and Node with `NODE_USE_ENV_PROXY=1` throws `ERR_PROXY_INVALID_CONFIG`.

### Fix

- `bun_url::URL::has_invalid_port()`: true when the port text is non-empty and does not parse as a u16.
- `HTTPThread::connect` rejects before dialing: `InvalidPort` for the request URL, `InvalidProxyPort` for the proxy. This is the single choke point for every TCP connect (direct, proxied, custom TLS contexts, per redirect hop), so it also covers env-proxy re-resolution after a cross-scheme redirect and the install/registry paths. The unix-socket path is unaffected.
- S3 signing (`S3Credentials::sign`) rejects an endpoint host with an unparseable port with `ERR_S3_INVALID_ENDPOINT`. This covers endpoints from `S3_ENDPOINT` / `AWS_ENDPOINT` env vars and `presign()`, which never reaches the connect path.
- The `S3Client` `endpoint` option now throws `ERR_INVALID_ARG_VALUE` ("endpoint port must be a number between 0 and 65535") at construction, matching how `fetch(url, { proxy })` rejects invalid proxy URLs.

Fetch rejections get explicit messages: "Invalid port number in [proxy ]URL. Ports must be a number between 0 and 65535."

### Tests

- `test/js/bun/s3/s3.test.ts`: constructor and per-file `endpoint` options throw for all four port shapes, valid ports still construct and presign with the port intact, and `S3_ENDPOINT` env var makes `presign()` throw `ERR_S3_INVALID_ENDPOINT` instead of emitting the URL.
- `test/js/bun/http/proxy.test.ts`: `HTTP_PROXY`/`http_proxy`/`HTTPS_PROXY` with each bad-port shape rejects the fetch with `InvalidProxyPort` before any connection is attempted.

All fail on the unfixed build (the proxy ones fail with `ConnectionRefused` from the silent port-80 dial; presign emits the URL) and pass with the fix. Also patched the four existing loopback-S3 fixtures in s3.test.ts to stop inheriting ambient `HTTP_PROXY` from the environment, which broke them in containers that set one.

`bun install --registry http://host:99999/` already failed URL joining before this change; the connect-layer check adds depth there rather than changing behavior.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 failed, 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy.test.ts "test/js/bun/s3/s3.test.ts"
bun test v1.4.0 (4b7f963a4)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client >
... (truncated)

release without fix: 8 failed, 287 skipped
bun test v1.4.0-canary.1 (b58cd4685)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key does not exist
(skip) R2 > s3 > Bun.S3Client > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy.test.ts "test/js/bun/s3/s3.test.ts"
bun test v1.4.0 (4b7f963a4)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client >
... (truncated)

release with fix: 287 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4b7f963a43
  features     baseline

22 deps, 106 codegen, 1175 objects in 914ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b58cd4685)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b58cd4685)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1238] gen ErrorCode+*.h
[4/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b58cd4685)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[5/1238] gen bindgenv2
[6/1238] fetch picohttpparser
[picohttpparser] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] fetch zlib
[zlib] up to date
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1237] subst deps/zlib/zconf.h
[12/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h fr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPThread.rs                    | 14 ++++++
 src/http/error.rs                         |  6 +++
 src/runtime/webcore/fetch/FetchTasklet.rs |  6 +++
 src/runtime/webcore/s3/credentials_jsc.rs | 14 ++++++
 src/s3_signing/credentials.rs             | 21 +++++++++
 src/url/lib.rs                            |  8 ++++
 test/js/bun/http/proxy.test.ts            | 44 ++++++++++++++++++
 test/js/bun/s3/s3.test.ts                 | 75 +++++++++++++++++++++++++++++--
 8 files changed, 184 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/HTTPThread.rs                         1      1      0
src/http/error.rs                              1      2      0
src/runtime/webcore/fetch/FetchTasklet.rs      5      1      0
src/runtime/webcore/s3/credentials_jsc.rs      3      3      0
src/s3_signing/credentials.rs                  1      3      0
src/url/lib.rs                                 5      1      0
test/js/bun/http/proxy.test.ts                 0      0      0
test/js/bun/s3/s3.test.ts                      1      1      0
```

</details>

<!-- robobun:evidence:end -->