### PR TITLE
dns: keep pending exceptions out of coalesced lookup promise resolves

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -650,6 +650,27 @@ impl c_ares::HostentHandler for GetHostByAddrInfoRequest {
     }
 }
 
+/// Settle a DNS request promise with the converted JS result. An empty
+/// `result` means the conversion threw and left the exception pending on the
+/// VM; reject with that exception instead of resolving. If settling itself
+/// leaves an exception pending, report it so it cannot leak into the next
+/// promise settled in the same task (the drain loops settle several in a row,
+/// and `JSPromise::resolve` must not be entered with an exception pending).
+fn settle_lookup_promise(
+    promise: &mut JSPromiseStrong,
+    global_this: &JSGlobalObject,
+    result: JSValue,
+) {
+    let settled = if result.is_empty() {
+        promise.reject(global_this, Err(jsc::JsError::Thrown))
+    } else {
+        promise.resolve_task(global_this, result)
+    };
+    if settled.is_err() {
+        global_this.report_active_exception_as_unhandled(jsc::JsError::Thrown);
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // CAresNameInfo
 // ──────────────────────────────────────────────────────────────────────────
@@ -725,8 +746,10 @@ impl CAresNameInfo {
             }
             return;
         };
+        // Empty on conversion failure; `settle_lookup_promise` rejects with
+        // the pending exception.
         let array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, global_this)
-            .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+            .unwrap_or(JSValue::ZERO);
         // SAFETY: see fn contract.
         unsafe { Self::on_complete(this, array) };
     }
@@ -737,7 +760,7 @@ impl CAresNameInfo {
         let mut promise = unsafe { core::mem::take(&mut (*this).promise) };
         // SAFETY: see fn contract — `this` is a live node.
         let global_this = unsafe { (*this).global_this() };
-        let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
+        settle_lookup_promise(&mut promise, global_this, result);
         // SAFETY: see fn contract.
         unsafe { Self::destroy(this) };
     }
@@ -1503,9 +1526,11 @@ impl CAresReverse {
                 Self::destroy(this);
                 return;
             };
-            // node is a valid c-ares hostent for the callback's duration
+            // node is a valid c-ares hostent for the callback's duration.
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let array = super::cares_jsc::hostent_to_js_response(&mut *node, global_this, b"")
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                .unwrap_or(JSValue::ZERO);
             Self::on_complete(this, array);
         }
     }
@@ -1516,7 +1541,7 @@ impl CAresReverse {
         unsafe {
             let mut promise = core::mem::take(&mut (*this).promise);
             let global_this = (*this).global_this();
-            let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
+            settle_lookup_promise(&mut promise, global_this, result);
             if let Some(resolver) = (*this).resolver.as_ref() {
                 // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
                 (*resolver.as_ptr()).request_completed();
@@ -1653,9 +1678,11 @@ impl<T: CAresRecordType> CAresLookup<T> {
             };
 
             // node is a valid c-ares reply for the callback's duration; freed by `_free` guard.
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let array = (*node)
                 .to_js_response(global_this, T::TYPE_NAME)
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                .unwrap_or(JSValue::ZERO);
             Self::on_complete(this, array);
         }
     }
@@ -1666,7 +1693,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
         unsafe {
             let mut promise = core::mem::take(&mut (*this).promise);
             let global_this = (*this).global_this();
-            let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
+            settle_lookup_promise(&mut promise, global_this, result);
             if let Some(resolver) = (*this).resolver.as_ref() {
                 // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
                 (*resolver.as_ptr()).request_completed();
@@ -1753,10 +1780,24 @@ impl DNSLookup {
         bun_output::scoped_log!(DNSLookup, "onCompleteNative");
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
-            let array = super::options_jsc::result_any_to_js(result, (*this).global_this())
-                .ok()
-                .flatten()
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+            let array = match super::options_jsc::result_any_to_js(result, (*this).global_this())
+            {
+                Ok(Some(array)) => array,
+                Ok(None) => {
+                    error_to_deferred(
+                        c_ares::Error::ENOTFOUND,
+                        b"getaddrinfo",
+                        None,
+                        &mut (*this).promise,
+                    )
+                    .reject_later((*this).global_this());
+                    Self::destroy(this);
+                    return;
+                }
+                // Conversion threw; the empty sentinel makes
+                // `settle_lookup_promise` reject with the pending exception.
+                Err(_) => JSValue::ZERO,
+            };
             Self::on_complete_with_array(this, array);
         }
     }
@@ -1826,9 +1867,11 @@ impl DNSLookup {
         // SAFETY: caller contract — `this` is live; result is a live c-ares AddrInfo
         // owned by the caller's scopeguard; JSGlobalObject outlives the request.
         unsafe {
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let array =
                 super::cares_jsc::addr_info_to_js_array(&mut *result, (*this).global_this())
-                    .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                    .unwrap_or(JSValue::ZERO);
             Self::on_complete_with_array(this, array);
         }
     }
@@ -1840,7 +1883,7 @@ impl DNSLookup {
         unsafe {
             let mut promise = core::mem::take(&mut (*this).promise);
             let global_this = (*this).global_this();
-            let _ = promise.resolve_task(global_this, result); // TODO: properly propagate exception upwards
+            settle_lookup_promise(&mut promise, global_this, result);
             if let Some(resolver) = (*this).resolver.as_ref() {
                 // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
                 (*resolver.as_ptr()).request_completed();
@@ -4185,9 +4228,11 @@ impl Resolver {
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let mut array = (*addr)
                 .to_js_response(prev_global, T::TYPE_NAME)
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                .unwrap_or(JSValue::ZERO);
             // SAFETY: addr is the c-ares-allocated reply; freed once after all consumers run.
             let _free_addr = scopeguard::guard(addr, |a| T::destroy(a));
             array.ensure_still_alive();
@@ -4198,10 +4243,12 @@ impl Resolver {
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
+                // Re-convert after a failure: the previous settle consumed the
+                // pending exception, so the empty sentinel must not be reused.
+                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
                     array = (*addr)
                         .to_js_response(new_global, T::TYPE_NAME)
-                        .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                        .unwrap_or(JSValue::ZERO);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
@@ -4251,8 +4298,10 @@ impl Resolver {
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let mut array = super::cares_jsc::addr_info_to_js_array(&mut *addr, prev_global)
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                .unwrap_or(JSValue::ZERO);
             // SAFETY: addr is the c-ares-allocated AddrInfo; freed once after all consumers run.
             // Move the raw pointer into the guard so the loop body can keep borrowing `*addr`.
             let _free_addr = scopeguard::guard(addr, |a| c_ares::AddrInfo::destroy(a));
@@ -4264,9 +4313,11 @@ impl Resolver {
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
+                // Re-convert after a failure: the previous settle consumed the
+                // pending exception, so the empty sentinel must not be reused.
+                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
                     array = super::cares_jsc::addr_info_to_js_array(&mut *addr, new_global)
-                        .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                        .unwrap_or(JSValue::ZERO);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
@@ -4292,11 +4343,12 @@ impl Resolver {
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
         let mut array: JSValue = match super::options_jsc::result_any_to_js(result, global_object)
-            .unwrap_or(None)
         {
-            // TODO: properly propagate exception upwards
-            Some(a) => a,
-            None => {
+            Ok(Some(a)) => a,
+            // Conversion threw; the empty sentinel makes
+            // `settle_lookup_promise` reject with the pending exception.
+            Err(_) => JSValue::ZERO,
+            Ok(None) => {
                 // SAFETY: `key.lookup` is the heap-allocated request stored in the
                 // pending-cache slot; consumed via `heap::take` below.
                 unsafe {
@@ -4335,10 +4387,14 @@ impl Resolver {
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
                 pending = (*value.as_ptr()).next;
-                if !core::ptr::eq(prev_global, new_global) {
+                // Re-convert after a failure: the previous settle consumed the
+                // pending exception, so the empty sentinel must not be reused.
+                // `Ok(None)` is unreachable here (the head already classified
+                // `result` as non-null), so it folds into the empty sentinel.
+                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
                     array = super::options_jsc::result_any_to_js(result, new_global)
                         .unwrap_or(None)
-                        .unwrap(); // TODO: properly propagate exception upwards
+                        .unwrap_or(JSValue::ZERO);
                     prev_global = new_global;
                 }
 
@@ -4390,8 +4446,10 @@ impl Resolver {
             //  The callback need not and should not attempt to free the memory
             //  pointed to by hostent; the ares library will free it when the
             //  callback returns.
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let mut array = super::cares_jsc::hostent_to_js_response(&mut *addr, prev_global, b"")
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                .unwrap_or(JSValue::ZERO);
             array.ensure_still_alive();
             CAresReverse::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
@@ -4400,9 +4458,11 @@ impl Resolver {
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
+                // Re-convert after a failure: the previous settle consumed the
+                // pending exception, so the empty sentinel must not be reused.
+                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
                     array = super::cares_jsc::hostent_to_js_response(&mut *addr, new_global, b"")
-                        .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                        .unwrap_or(JSValue::ZERO);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
@@ -4453,8 +4513,10 @@ impl Resolver {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
 
+            // Empty on conversion failure; `settle_lookup_promise` rejects with
+            // the pending exception.
             let mut array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, prev_global)
-                .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                .unwrap_or(JSValue::ZERO);
             array.ensure_still_alive();
             CAresNameInfo::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
@@ -4463,9 +4525,11 @@ impl Resolver {
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                if !core::ptr::eq(prev_global, new_global) {
+                // Re-convert after a failure: the previous settle consumed the
+                // pending exception, so the empty sentinel must not be reused.
+                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
                     array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, new_global)
-                        .unwrap_or(JSValue::ZERO); // TODO: properly propagate exception upwards
+                        .unwrap_or(JSValue::ZERO);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1780,8 +1780,7 @@ impl DNSLookup {
         bun_output::scoped_log!(DNSLookup, "onCompleteNative");
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
-            let array = match super::options_jsc::result_any_to_js(result, (*this).global_this())
-            {
+            let array = match super::options_jsc::result_any_to_js(result, (*this).global_this()) {
                 Ok(Some(array)) => array,
                 Ok(None) => {
                     error_to_deferred(
@@ -4342,8 +4341,7 @@ impl Resolver {
         // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
-        let mut array: JSValue = match super::options_jsc::result_any_to_js(result, global_object)
-        {
+        let mut array: JSValue = match super::options_jsc::result_any_to_js(result, global_object) {
             Ok(Some(a)) => a,
             // Conversion threw; the empty sentinel makes
             // `settle_lookup_promise` reject with the pending exception.

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -650,24 +650,26 @@ impl c_ares::HostentHandler for GetHostByAddrInfoRequest {
     }
 }
 
-/// Settle a DNS request promise with the converted JS result. An empty
-/// `result` means the conversion threw and left the exception pending on the
-/// VM; reject with that exception instead of resolving. If settling itself
-/// leaves an exception pending, report it so it cannot leak into the next
-/// promise settled in the same task (the drain loops settle several in a row,
-/// and `JSPromise::resolve` must not be entered with an exception pending).
+/// Resolve a DNS request promise with the converted result, or reject it with
+/// the conversion error. An exception left pending by the settle is reported
+/// as unhandled so the drain loops never carry it into the next settle.
 fn settle_lookup_promise(
     promise: &mut JSPromiseStrong,
     global_this: &JSGlobalObject,
-    result: JSValue,
+    result: JsResult<JSValue>,
 ) {
-    let settled = if result.is_empty() {
-        promise.reject(global_this, Err(jsc::JsError::Thrown))
-    } else {
-        promise.resolve_task(global_this, result)
+    let settled = match result {
+        Ok(value) => promise.resolve_task(global_this, value),
+        Err(err) => promise.swap().reject(global_this, Err(err)),
     };
     if settled.is_err() {
         global_this.report_active_exception_as_unhandled(jsc::JsError::Thrown);
+    }
+}
+
+fn ensure_result_still_alive(result: JsResult<JSValue>) {
+    if let Ok(value) = result {
+        value.ensure_still_alive();
     }
 }
 
@@ -746,16 +748,13 @@ impl CAresNameInfo {
             }
             return;
         };
-        // Empty on conversion failure; `settle_lookup_promise` rejects with
-        // the pending exception.
-        let array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, global_this)
-            .unwrap_or(JSValue::ZERO);
+        let array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, global_this);
         // SAFETY: see fn contract.
         unsafe { Self::on_complete(this, array) };
     }
 
     /// SAFETY: see `process_resolve`.
-    unsafe fn on_complete(this: *mut Self, result: JSValue) {
+    unsafe fn on_complete(this: *mut Self, result: JsResult<JSValue>) {
         // SAFETY: see fn contract — `this` is a live node.
         let mut promise = unsafe { core::mem::take(&mut (*this).promise) };
         // SAFETY: see fn contract — `this` is a live node.
@@ -1526,17 +1525,14 @@ impl CAresReverse {
                 Self::destroy(this);
                 return;
             };
-            // node is a valid c-ares hostent for the callback's duration.
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
-            let array = super::cares_jsc::hostent_to_js_response(&mut *node, global_this, b"")
-                .unwrap_or(JSValue::ZERO);
+            // node is a valid c-ares hostent for the callback's duration
+            let array = super::cares_jsc::hostent_to_js_response(&mut *node, global_this, b"");
             Self::on_complete(this, array);
         }
     }
 
     /// SAFETY: see `process_resolve`.
-    unsafe fn on_complete(this: *mut Self, result: JSValue) {
+    unsafe fn on_complete(this: *mut Self, result: JsResult<JSValue>) {
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
             let mut promise = core::mem::take(&mut (*this).promise);
@@ -1678,17 +1674,13 @@ impl<T: CAresRecordType> CAresLookup<T> {
             };
 
             // node is a valid c-ares reply for the callback's duration; freed by `_free` guard.
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
-            let array = (*node)
-                .to_js_response(global_this, T::TYPE_NAME)
-                .unwrap_or(JSValue::ZERO);
+            let array = (*node).to_js_response(global_this, T::TYPE_NAME);
             Self::on_complete(this, array);
         }
     }
 
     /// SAFETY: see `process_resolve`.
-    unsafe fn on_complete(this: *mut Self, result: JSValue) {
+    unsafe fn on_complete(this: *mut Self, result: JsResult<JSValue>) {
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
             let mut promise = core::mem::take(&mut (*this).promise);
@@ -1780,22 +1772,18 @@ impl DNSLookup {
         bun_output::scoped_log!(DNSLookup, "onCompleteNative");
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
-            let array = match super::options_jsc::result_any_to_js(result, (*this).global_this()) {
-                Ok(Some(array)) => array,
-                Ok(None) => {
-                    error_to_deferred(
-                        c_ares::Error::ENOTFOUND,
-                        b"getaddrinfo",
-                        None,
-                        &mut (*this).promise,
-                    )
-                    .reject_later((*this).global_this());
-                    Self::destroy(this);
-                    return;
-                }
-                // Conversion threw; the empty sentinel makes
-                // `settle_lookup_promise` reject with the pending exception.
-                Err(_) => JSValue::ZERO,
+            let Some(array) =
+                super::options_jsc::result_any_to_js(result, (*this).global_this()).transpose()
+            else {
+                error_to_deferred(
+                    c_ares::Error::ENOTFOUND,
+                    b"getaddrinfo",
+                    None,
+                    &mut (*this).promise,
+                )
+                .reject_later((*this).global_this());
+                Self::destroy(this);
+                return;
             };
             Self::on_complete_with_array(this, array);
         }
@@ -1866,17 +1854,14 @@ impl DNSLookup {
         // SAFETY: caller contract — `this` is live; result is a live c-ares AddrInfo
         // owned by the caller's scopeguard; JSGlobalObject outlives the request.
         unsafe {
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
             let array =
-                super::cares_jsc::addr_info_to_js_array(&mut *result, (*this).global_this())
-                    .unwrap_or(JSValue::ZERO);
+                super::cares_jsc::addr_info_to_js_array(&mut *result, (*this).global_this());
             Self::on_complete_with_array(this, array);
         }
     }
 
     /// SAFETY: see `on_complete_native`.
-    unsafe fn on_complete_with_array(this: *mut Self, result: JSValue) {
+    unsafe fn on_complete_with_array(this: *mut Self, result: JsResult<JSValue>) {
         bun_output::scoped_log!(DNSLookup, "onCompleteWithArray");
         // SAFETY: caller contract — `this` is live; JSGlobalObject outlives the request.
         unsafe {
@@ -4227,34 +4212,27 @@ impl Resolver {
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
-            let mut array = (*addr)
-                .to_js_response(prev_global, T::TYPE_NAME)
-                .unwrap_or(JSValue::ZERO);
+            let mut array = (*addr).to_js_response(prev_global, T::TYPE_NAME);
             // SAFETY: addr is the c-ares-allocated reply; freed once after all consumers run.
             let _free_addr = scopeguard::guard(addr, |a| T::destroy(a));
-            array.ensure_still_alive();
+            ensure_result_still_alive(array);
             CAresLookup::<T>::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
 
-            array.ensure_still_alive();
+            ensure_result_still_alive(array);
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                // Re-convert after a failure: the previous settle consumed the
-                // pending exception, so the empty sentinel must not be reused.
-                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
-                    array = (*addr)
-                        .to_js_response(new_global, T::TYPE_NAME)
-                        .unwrap_or(JSValue::ZERO);
+                // The settle consumed an Err's pending exception; never reuse it.
+                if array.is_err() || !core::ptr::eq(prev_global, new_global) {
+                    array = (*addr).to_js_response(new_global, T::TYPE_NAME);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
 
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
                 CAresLookup::<T>::on_complete(value.as_ptr(), array);
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
             }
         }
     }
@@ -4297,33 +4275,28 @@ impl Resolver {
         unsafe {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
-            let mut array = super::cares_jsc::addr_info_to_js_array(&mut *addr, prev_global)
-                .unwrap_or(JSValue::ZERO);
+            let mut array = super::cares_jsc::addr_info_to_js_array(&mut *addr, prev_global);
             // SAFETY: addr is the c-ares-allocated AddrInfo; freed once after all consumers run.
             // Move the raw pointer into the guard so the loop body can keep borrowing `*addr`.
             let _free_addr = scopeguard::guard(addr, |a| c_ares::AddrInfo::destroy(a));
-            array.ensure_still_alive();
+            ensure_result_still_alive(array);
             DNSLookup::on_complete_with_array(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
 
-            array.ensure_still_alive();
+            ensure_result_still_alive(array);
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                // Re-convert after a failure: the previous settle consumed the
-                // pending exception, so the empty sentinel must not be reused.
-                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
-                    array = super::cares_jsc::addr_info_to_js_array(&mut *addr, new_global)
-                        .unwrap_or(JSValue::ZERO);
+                // The settle consumed an Err's pending exception; never reuse it.
+                if array.is_err() || !core::ptr::eq(prev_global, new_global) {
+                    array = super::cares_jsc::addr_info_to_js_array(&mut *addr, new_global);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
 
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
                 DNSLookup::on_complete_with_array(value.as_ptr(), array);
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
             }
         }
     }
@@ -4341,33 +4314,25 @@ impl Resolver {
         // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
         let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
-        let mut array: JSValue = match super::options_jsc::result_any_to_js(result, global_object) {
-            Ok(Some(a)) => a,
-            // Conversion threw; the empty sentinel makes
-            // `settle_lookup_promise` reject with the pending exception.
-            Err(_) => JSValue::ZERO,
-            Ok(None) => {
-                // SAFETY: `key.lookup` is the heap-allocated request stored in the
-                // pending-cache slot; consumed via `heap::take` below.
-                unsafe {
-                    let mut pending = (*key.lookup).head.next;
-                    // Consume the request and move `head` out by value;
-                    // `ptr::read` + `heap::take` would double-Drop `DNSLookup`.
-                    let owned = *bun_core::heap::take(key.lookup);
-                    let mut head = owned.head;
-                    DNSLookup::process_get_addr_info_native(&raw mut head, err, ptr::null_mut());
+        let Some(mut array) =
+            super::options_jsc::result_any_to_js(result, global_object).transpose()
+        else {
+            // SAFETY: `key.lookup` is the heap-allocated request stored in the
+            // pending-cache slot; consumed via `heap::take` below.
+            unsafe {
+                let mut pending = (*key.lookup).head.next;
+                // Consume the request and move `head` out by value;
+                // `ptr::read` + `heap::take` would double-Drop `DNSLookup`.
+                let owned = *bun_core::heap::take(key.lookup);
+                let mut head = owned.head;
+                DNSLookup::process_get_addr_info_native(&raw mut head, err, ptr::null_mut());
 
-                    while let Some(value) = pending {
-                        pending = (*value.as_ptr()).next;
-                        DNSLookup::process_get_addr_info_native(
-                            value.as_ptr(),
-                            err,
-                            ptr::null_mut(),
-                        );
-                    }
+                while let Some(value) = pending {
+                    pending = (*value.as_ptr()).next;
+                    DNSLookup::process_get_addr_info_native(value.as_ptr(), err, ptr::null_mut());
                 }
-                return;
             }
+            return;
         };
         // SAFETY: `key.lookup` is the heap-allocated request stored in the
         // pending-cache slot; consumed via `heap::take` below.
@@ -4376,29 +4341,27 @@ impl Resolver {
             let mut prev_global = (*key.lookup).head.global_this();
 
             {
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
                 DNSLookup::on_complete_with_array(ptr::addr_of_mut!((*key.lookup).head), array);
                 drop(bun_core::heap::take(key.lookup));
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
             }
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
                 pending = (*value.as_ptr()).next;
-                // Re-convert after a failure: the previous settle consumed the
-                // pending exception, so the empty sentinel must not be reused.
-                // `Ok(None)` is unreachable here (the head already classified
-                // `result` as non-null), so it folds into the empty sentinel.
-                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
+                // The settle consumed an Err's pending exception; never reuse it.
+                if array.is_err() || !core::ptr::eq(prev_global, new_global) {
+                    // The head conversion proved `result` is non-null.
                     array = super::options_jsc::result_any_to_js(result, new_global)
-                        .unwrap_or(None)
-                        .unwrap_or(JSValue::ZERO);
+                        .transpose()
+                        .unwrap();
                     prev_global = new_global;
                 }
 
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
                 DNSLookup::on_complete_with_array(value.as_ptr(), array);
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
             }
         }
     }
@@ -4444,30 +4407,25 @@ impl Resolver {
             //  The callback need not and should not attempt to free the memory
             //  pointed to by hostent; the ares library will free it when the
             //  callback returns.
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
-            let mut array = super::cares_jsc::hostent_to_js_response(&mut *addr, prev_global, b"")
-                .unwrap_or(JSValue::ZERO);
-            array.ensure_still_alive();
+            let mut array = super::cares_jsc::hostent_to_js_response(&mut *addr, prev_global, b"");
+            ensure_result_still_alive(array);
             CAresReverse::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
 
-            array.ensure_still_alive();
+            ensure_result_still_alive(array);
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                // Re-convert after a failure: the previous settle consumed the
-                // pending exception, so the empty sentinel must not be reused.
-                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
-                    array = super::cares_jsc::hostent_to_js_response(&mut *addr, new_global, b"")
-                        .unwrap_or(JSValue::ZERO);
+                // The settle consumed an Err's pending exception; never reuse it.
+                if array.is_err() || !core::ptr::eq(prev_global, new_global) {
+                    array = super::cares_jsc::hostent_to_js_response(&mut *addr, new_global, b"");
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
 
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
                 CAresReverse::on_complete(value.as_ptr(), array);
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
             }
         }
     }
@@ -4511,30 +4469,25 @@ impl Resolver {
             let mut pending = (*key.lookup).head.next;
             let mut prev_global = (*key.lookup).head.global_this();
 
-            // Empty on conversion failure; `settle_lookup_promise` rejects with
-            // the pending exception.
-            let mut array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, prev_global)
-                .unwrap_or(JSValue::ZERO);
-            array.ensure_still_alive();
+            let mut array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, prev_global);
+            ensure_result_still_alive(array);
             CAresNameInfo::on_complete(ptr::addr_of_mut!((*key.lookup).head), array);
             drop(bun_core::heap::take(key.lookup));
 
-            array.ensure_still_alive();
+            ensure_result_still_alive(array);
 
             while let Some(value) = pending {
                 let new_global = (*value.as_ptr()).global_this();
-                // Re-convert after a failure: the previous settle consumed the
-                // pending exception, so the empty sentinel must not be reused.
-                if array.is_empty() || !core::ptr::eq(prev_global, new_global) {
-                    array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, new_global)
-                        .unwrap_or(JSValue::ZERO);
+                // The settle consumed an Err's pending exception; never reuse it.
+                if array.is_err() || !core::ptr::eq(prev_global, new_global) {
+                    array = super::cares_jsc::nameinfo_to_js_response(&mut name_info, new_global);
                     prev_global = new_global;
                 }
                 pending = (*value.as_ptr()).next;
 
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
                 CAresNameInfo::on_complete(value.as_ptr(), array);
-                array.ensure_still_alive();
+                ensure_result_still_alive(array);
             }
         }
     }

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -223,6 +223,62 @@ describe("dns", () => {
     expect(isIP(result[0].address)).toBeGreaterThan(0);
   });
 
+  // The native completion callbacks settle several coalesced lookup promises
+  // in one task. Resolving a promise reads `then` off the result array, so a
+  // hostile `Object.prototype.then` accessor throws inside every resolve in
+  // the loop; each promise must reject with that error and the next promise
+  // in the drain must still settle, with no pending exception carried over.
+  test.concurrent("coalesced lookups settle when the result array is a hostile thenable", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          Object.defineProperty(Object.prototype, "then", {
+            configurable: true,
+            get() {
+              throw new Error("boom");
+            },
+          });
+          const lookups = [];
+          for (let i = 0; i < 8; i++) {
+            lookups.push(Bun.dns.lookup("localhost", { backend: "system" }));
+            lookups.push(Bun.dns.lookup("localhost", { backend: "libc" }));
+            lookups.push(Bun.dns.lookup("0.0.0.0", { backend: "c-ares" }));
+          }
+          // Promise.allSettled would resolve its result promise with an array
+          // and trip the accessor itself, so count rejections by hand.
+          let remaining = lookups.length;
+          for (const promise of lookups) {
+            promise.then(
+              () => {
+                console.log("expected rejection");
+                process.exit(1);
+              },
+              reason => {
+                if (reason?.message !== "boom") {
+                  console.log("unexpected reason: " + reason);
+                  process.exit(1);
+                }
+                if (--remaining === 0) {
+                  delete Object.prototype.then;
+                  console.log("ok");
+                }
+              },
+            );
+          }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
   describe("setServers", () => {
     test("triple with non-int32 family (double) throws TypeError", () => {
       // @ts-expect-error


### PR DESCRIPTION
### What

Fuzzing (Fuzzilli) hit a flaky debug assertion in a process that was hammering `Bun.dns.lookup`:

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JavaScriptCore/JSObjectInlines.h(137) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName)
```

That assertion fires when `JSObject::get` is entered while a JS exception is already pending and the property exists. The only native caller of that `get` on this workload is `JSPromise::resolvePromise` reading `then` off the resolution value, reached from `JSC__JSPromise__resolve`, which has no entry exception check.

The DNS completion code is the path that drives those resolves with an exception left pending:

- Every result conversion swallowed failure with `unwrap_or(JSValue::ZERO)` and a `// TODO: properly propagate exception upwards`, then resolved anyway. That leaves the conversion's exception pending on the VM and resolves with an empty JSValue (itself an `ASSERT(!target.isEmpty())` in debug builds).
- The `drain_pending_*` loops settle several coalesced promises in one native task, each with `let _ = promise.resolve_task(...)`. The generated `check_slow` wrapper surfaces a pending exception as `Err` but does not clear it, so a discarded error from one settle stays on the VM and the next settle in the same loop enters `JSPromise::resolve` with it, which is exactly the asserted invariant. In release builds the stale exception instead gets misattributed: `resolvePromise` catches it and rejects an unrelated lookup's promise with it.
- `drain_pending_host_native` additionally conflated `Err` (conversion threw) with `Ok(None)` (null addrinfo) at the head, and had a bare `.unwrap()` on the re-conversion in its waiter loop.

### Fix

All five settle sites go through one helper, `settle_lookup_promise`:

- an empty result (conversion threw) rejects the promise with the pending exception instead of resolving,
- a settle that leaves an exception pending reports it as unhandled (`report_active_exception_as_unhandled`, the same idiom the socket/ipc/h2/watcher completions use) so it cannot leak into the next promise settled in the same task; termination exceptions stay pending as the event loop expects,
- the drain waiter loops re-convert the result after a failure instead of reusing the empty sentinel, since the previous settle consumed that exception (this also removes the `.unwrap()` panic path),
- `on_complete_native` routes a null getaddrinfo result list to a `DNS_ENOTFOUND` rejection, matching the c-ares path, instead of resolving with an empty value.

### Verification

The fuzzer crash is timing and process-history dependent (it needs an exception, e.g. OOM under memory pressure, to land between two settles in one drain, plus a reachable `then` on the result's prototype chain left by an earlier script in the reused fuzzer process). It did not reproduce standalone here in 180 direct runs, nor in 300 iterations of the script replayed through a REPRL harness in one process, before or after the fix, so there is no fail-before repro for the assertion itself.

What was verified with the debug (ASAN, assertions on) build:

- the fuzzer script and several adversarial variants (throwing `then` accessors on `Object.prototype`, throwing microtasks between coalesced settles, `Error.prepareStackTrace` hooks, Bun-object getter sweeps) run clean before and after,
- the new test drives the coalesced drain loops on all three backends with a hostile `Object.prototype.then` accessor, so every resolve in a drain throws while fetching `then`; each promise must reject with that error and the process must exit cleanly,
- `test/js/bun/dns/` and the non-network `test/js/node/dns/` tests pass, with the same set of network-dependent failures as a baseline build in this sandboxed environment (29, identical list, no external DNS available).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/dns/resolve-dns.test.ts

<!-- robobun:evidence:end -->