### PR TITLE
tls: reject keyFile/certFile/caFile/dhParamsFile paths with embedded NUL bytes

### DIFF
--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -297,8 +297,7 @@ fn handle_path(
     string: &bun_core::String,
 ) -> JsResult<*const c_char> {
     let name = string.to_owned_slice_z();
-    // An interior NUL would truncate the path at the C-string boundary
-    // (`access` below, BoringSSL loaders), silently loading the prefix file.
+    // An interior NUL would truncate the C string (access, BoringSSL loaders) to the prefix path.
     if bun_core::strings::index_of_char(name.as_bytes(), 0).is_some() {
         return Err(global
             .err(

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -297,6 +297,22 @@ fn handle_path(
     string: &bun_core::String,
 ) -> JsResult<*const c_char> {
     let name = string.to_owned_slice_z();
+    // An embedded NUL would truncate the path at the C-string boundary
+    // (`access` below and the BoringSSL file loaders), silently loading the
+    // file named by the prefix instead of the configured path. Reject it,
+    // like the `Bun.file()` path guard (`Valid::path_null_bytes`).
+    if bun_core::strings::index_of_char(name.as_bytes(), 0).is_some() {
+        return Err(global
+            .err(
+                jsc::ErrorCode::INVALID_ARG_VALUE,
+                format_args!(
+                    "TLSOptions.{} must be a path without null bytes. Received {}",
+                    field,
+                    bun_core::fmt::quote(name.as_bytes())
+                ),
+            )
+            .throw());
+    }
     // `bun_sys::access` routes to `access(2)` on POSIX and
     // `GetFileAttributesW` on Windows (via `sys_uv`), so this is the
     // cross-platform existence probe.

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -297,10 +297,8 @@ fn handle_path(
     string: &bun_core::String,
 ) -> JsResult<*const c_char> {
     let name = string.to_owned_slice_z();
-    // An embedded NUL would truncate the path at the C-string boundary
-    // (`access` below and the BoringSSL file loaders), silently loading the
-    // file named by the prefix instead of the configured path. Reject it,
-    // like the `Bun.file()` path guard (`Valid::path_null_bytes`).
+    // An interior NUL would truncate the path at the C-string boundary
+    // (`access` below, BoringSSL loaders), silently loading the prefix file.
     if bun_core::strings::index_of_char(name.as_bytes(), 0).is_some() {
         return Err(global
             .err(

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
+import { tempDir, tls as tlsCert } from "harness";
 import tls from "node:tls";
 import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
@@ -252,5 +253,80 @@ describe("Bun.serve per-serverName client certificate policy", () => {
       defaultResumed: "HTTP/1.1 200 OK",
       gatedResumed: "connection closed without a response",
     });
+  });
+});
+
+// A path with an embedded NUL byte used to be truncated at the NUL by the
+// C-string layer, so the file named by the prefix was loaded silently.
+describe("TLS file path options with embedded NUL bytes", () => {
+  const nulSuffix = "\0-does-not-exist";
+  const thrown = expect.objectContaining({
+    code: "ERR_INVALID_ARG_VALUE",
+    message: expect.stringContaining("null bytes"),
+  });
+  function certDir() {
+    return tempDir("bun-serve-ssl-nul", {
+      "key.pem": tlsCert.key,
+      "cert.pem": tlsCert.cert,
+    });
+  }
+
+  test("Bun.serve rejects keyFile/certFile/caFile/dhParamsFile paths containing NUL", () => {
+    using dir = certDir();
+    const keyFile = join(String(dir), "key.pem");
+    const certFile = join(String(dir), "cert.pem");
+    const cases = [
+      { keyFile: keyFile + nulSuffix, certFile },
+      { keyFile, certFile: certFile + nulSuffix },
+      { keyFile, certFile, caFile: certFile + nulSuffix },
+      { keyFile, certFile, dhParamsFile: certFile + nulSuffix },
+    ];
+    for (const tlsOptions of cases) {
+      expect(() => {
+        Bun.serve({
+          port: 0,
+          tls: tlsOptions,
+          fetch: () => new Response("unreachable"),
+        });
+      }).toThrow(thrown);
+    }
+  });
+
+  test("Bun.listen rejects keyFile paths containing NUL", () => {
+    using dir = certDir();
+    const keyFile = join(String(dir), "key.pem");
+    const certFile = join(String(dir), "cert.pem");
+    expect(() => {
+      Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { keyFile: keyFile + nulSuffix, certFile },
+        socket: { data() {} },
+      });
+    }).toThrow(thrown);
+  });
+
+  test("tls.createSecureContext rejects keyFile paths containing NUL", () => {
+    using dir = certDir();
+    const keyFile = join(String(dir), "key.pem");
+    const certFile = join(String(dir), "cert.pem");
+    expect(() => {
+      tls.createSecureContext({ keyFile: keyFile + nulSuffix, certFile } as tls.SecureContextOptions);
+    }).toThrow(thrown);
+  });
+
+  test("valid keyFile/certFile paths still serve TLS", async () => {
+    using dir = certDir();
+    using server = Bun.serve({
+      port: 0,
+      tls: {
+        keyFile: join(String(dir), "key.pem"),
+        certFile: join(String(dir), "cert.pem"),
+      },
+      fetch: () => new Response("TLS-OK"),
+    });
+    const res = await fetch(server.url, { tls: { rejectUnauthorized: false } });
+    expect(await res.text()).toBe("TLS-OK");
+    expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
### Problem

The TLS file path options `keyFile`, `certFile`, `caFile` and `dhParamsFile` (accepted by `Bun.serve`, `Bun.listen` and `tls.createSecureContext`) truncate a path containing an embedded NUL byte at the NUL. The prefix file is loaded and the server starts and serves TLS with it, so a different key/cert/CA than the one configured is used silently. The `Bun.file()` forms of the same options already reject such paths with `ERR_INVALID_ARG_VALUE`.

```js
const keyFile = dir + "/k.pem\0-DOES-NOT-EXIST";   // fs.existsSync(keyFile) === false
const certFile = dir + "/c.pem\0-DOES-NOT-EXIST";
const srv = Bun.serve({ port: 0, tls: { keyFile, certFile }, fetch: () => new Response("ok") });
// before: server starts and serves TLS using dir + "/k.pem" and dir + "/c.pem"
```

### Cause

`handle_path` in `src/runtime/socket/SSLConfig.rs` converts the JS string with `to_owned_slice_z()` and hands the NUL-terminated buffer to `access()` and then to the BoringSSL file loaders. Both treat it as a C string, so everything after the first interior NUL is ignored.

### Fix

Reject any path containing a NUL byte in `handle_path` before touching the filesystem, throwing `ERR_INVALID_ARG_VALUE`:

```
TLSOptions.keyFile must be a path without null bytes. Received "/tmp/x/k.pem\^@-DOES-NOT-EXIST"
```

This is the same constraint `Valid::path_null_bytes` enforces for fs paths (what `Bun.file()` hits). All four options and all three entry points parse through `SSLConfig::from_generated`, so one check covers them.

Note: `tls.createServer(options)` does not forward the `keyFile`/`certFile` path options to the native layer at all (only `key`/`cert` content), so no file was ever loaded on that surface; it is unaffected by this change.

### Verification

New tests in `test/js/bun/http/bun-serve-ssl.test.ts`:

- `Bun.serve` rejects NUL in `keyFile`, `certFile`, `caFile`, `dhParamsFile`
- `Bun.listen` rejects NUL in `keyFile`
- `tls.createSecureContext` rejects NUL in `keyFile`
- valid `keyFile`/`certFile` paths still serve TLS (fetch round-trip)

The three rejection tests fail on bun 1.3.6 (no throw, server starts) and pass with this change; the whole file passes (22/22).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-ssl.test.ts
bun test v1.4.0 (2f5d82cfd)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [7.33ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.35ms]
(pass) Bun.serve SSL validations > invalid cert development [1.64ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [85.44ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.90ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [1.92ms]
(pass) Bun.serve SSL validations > invalid key production [2.28ms]
(pass) Bun.serve SSL validations > invalid key #2 production [2.25ms]
(pass) Bun.serve SSL validations > invalid cert production [1.82ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.30ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.83ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [1.62ms]
(pass) Bun.s
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (93f0428b6)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [0.22ms]
(pass) Bun.serve SSL validations > invalid key #2 development [0.06ms]
(pass) Bun.serve SSL validations > invalid cert development [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [8.08ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [0.03ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [0.02ms]
(pass) Bun.serve SSL validations > invalid key production [0.05ms]
(pass) Bun.serve SSL validations > invalid key #2 production [0.03ms]
(pass) Bun.serve SSL validations > invalid cert production [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [0.31ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [0.01ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production
(pass) Bun.serve SSL validations > valid development [5.04ms]
(pass) Bun.serve SSL validations > valid 2 development [4.57ms]
(pass) Bun.serve SSL validations > valid production [2.79ms
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-ssl.test.ts
bun test v1.4.0 (2f5d82cfd)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [7.89ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.00ms]
(pass) Bun.serve SSL validations > invalid cert development [1.87ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [71.80ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [3.52ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [1.94ms]
(pass) Bun.serve SSL validations > invalid key production [1.99ms]
(pass) Bun.serve SSL validations > invalid key #2 production [1.76ms]
(pass) Bun.serve SSL validations > invalid cert production [2.50ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.45ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.57ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [1.90ms]
(pass) Bun.s
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 650ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/socket/SSLConfig.rs        | 13 ++++++
 test/js/bun/http/bun-serve-ssl.test.ts | 76 ++++++++++++++++++++++++++++++++++
 2 files changed, 89 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/socket/SSLConfig.rs             4      3      0
test/js/bun/http/bun-serve-ssl.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->