### PR TITLE
Reject interior null bytes in Bun.which, resolver directories, and Bun.build output paths

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1052,6 +1052,12 @@ pub mod fs {
 
         /// `open(path, O_DIRECTORY)`.
         pub(crate) fn open_dir(&self, unsafe_dir_string: &[u8]) -> crate::CrateResult<Fd> {
+            // A path with an interior NUL cannot name a real directory; the
+            // C-string open would act on the path's prefix and read the wrong
+            // directory. Report it as nonexistent instead.
+            if strings::index_of_char(unsafe_dir_string, 0).is_some() {
+                return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT));
+            }
             #[cfg(windows)]
             {
                 // NtCreateFile with FILE_DIRECTORY_FILE/FILE_LIST_DIRECTORY so

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1052,9 +1052,7 @@ pub mod fs {
 
         /// `open(path, O_DIRECTORY)`.
         pub(crate) fn open_dir(&self, unsafe_dir_string: &[u8]) -> crate::CrateResult<Fd> {
-            // A path with an interior NUL cannot name a real directory; the
-            // C-string open would act on the path's prefix and read the wrong
-            // directory. Report it as nonexistent instead.
+            // A path with an interior NUL cannot exist; C-string open would truncate at the NUL.
             if strings::index_of_char(unsafe_dir_string, 0).is_some() {
                 return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT));
             }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1388,7 +1388,9 @@ impl<'a> Resolver<'a> {
 
         // A path with a null byte cannot exist on the filesystem. Continuing
         // anyways would cause assertion failures.
-        if strings::index_of_char(import_path, 0).is_some() {
+        if strings::index_of_char(import_path, 0).is_some()
+            || strings::index_of_char(source_dir_normalized, 0).is_some()
+        {
             let _ = self.flush_debug_logs(FlushMode::Fail);
             self.extension_order = original_order;
             return ResultUnion::NotFound;
@@ -4054,6 +4056,13 @@ impl<'a> Resolver<'a> {
         // so return it here instead of walking the cache with an empty key.
         // https://github.com/oven-sh/bun/issues/30429
         if input_path.is_empty() {
+            return Ok(None);
+        }
+
+        // A path with an interior null byte cannot name a real directory.
+        // The open(2) below reads a C string, so it would open the path's
+        // prefix and cache the wrong directory's entries under the full key.
+        if strings::index_of_char(input_path, 0).is_some() {
             return Ok(None);
         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4059,9 +4059,7 @@ impl<'a> Resolver<'a> {
             return Ok(None);
         }
 
-        // A path with an interior null byte cannot name a real directory.
-        // The open(2) below reads a C string, so it would open the path's
-        // prefix and cache the wrong directory's entries under the full key.
+        // A path with an interior NUL cannot exist; C-string open would truncate at the NUL.
         if strings::index_of_char(input_path, 0).is_some() {
             return Ok(None);
         }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -525,11 +525,7 @@ pub(crate) fn braces(
 
 /// `Bun.which` hands its inputs to C-string syscalls, which stop at the first
 /// NUL. Reject interior NULs up front like `Bun.spawn` and `node:fs` do.
-fn which_check_null_bytes(
-    global_this: &JSGlobalObject,
-    name: &str,
-    slice: &[u8],
-) -> JsResult<()> {
+fn which_check_null_bytes(global_this: &JSGlobalObject, name: &str, slice: &[u8]) -> JsResult<()> {
     if strings::index_of_char(slice, 0).is_some() {
         return Err(global_this
             .err(

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -523,6 +523,27 @@ pub(crate) fn braces(
     bun_string_jsc::to_js_array(global, &out_strings[..])
 }
 
+/// `Bun.which` hands its inputs to C-string syscalls, which stop at the first
+/// NUL. Reject interior NULs up front like `Bun.spawn` and `node:fs` do.
+fn which_check_null_bytes(
+    global_this: &JSGlobalObject,
+    name: &str,
+    slice: &[u8],
+) -> JsResult<()> {
+    if strings::index_of_char(slice, 0).is_some() {
+        return Err(global_this
+            .err(
+                jsc::ErrCode::INVALID_ARG_VALUE,
+                format_args!(
+                    "The {name} must be a string without null bytes. Received {}",
+                    bun_core::fmt::quote(slice)
+                ),
+            )
+            .throw());
+    }
+    Ok(())
+}
+
 #[bun_jsc::host_fn]
 fn which(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     let mut path_buf = bun_paths::path_buffer_pool::get();
@@ -550,6 +571,8 @@ fn which(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValu
         return Ok(JSValue::NULL);
     }
 
+    which_check_null_bytes(global_this, "argument 'command'", bin_str.slice())?;
+
     // SAFETY: `transpiler.env` / `.fs` are process-lifetime singletons set during VM init.
     let mut path_str =
         ZigStringSlice::from_utf8_never_free(vm.env_loader().get(b"PATH").unwrap_or(b""));
@@ -559,10 +582,12 @@ fn which(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValu
         if !arg.is_empty_or_undefined_or_null() && arg.is_object() {
             if let Some(str_) = arg.get(global_this, "PATH")? {
                 path_str = str_.to_slice(global_this)?;
+                which_check_null_bytes(global_this, "property 'options.PATH'", path_str.slice())?;
             }
 
             if let Some(str_) = arg.get(global_this, "cwd")? {
                 cwd_str = str_.to_slice(global_this)?;
+                which_check_null_bytes(global_this, "property 'options.cwd'", cwd_str.slice())?;
             }
         }
     }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -523,8 +523,7 @@ pub(crate) fn braces(
     bun_string_jsc::to_js_array(global, &out_strings[..])
 }
 
-/// `Bun.which` hands its inputs to C-string syscalls, which stop at the first
-/// NUL. Reject interior NULs up front like `Bun.spawn` and `node:fs` do.
+/// The lookup's C-string syscalls stop at the first NUL; reject like `Bun.spawn` does.
 fn which_check_null_bytes(global_this: &JSGlobalObject, name: &str, slice: &[u8]) -> JsResult<()> {
     if strings::index_of_char(slice, 0).is_some() {
         return Err(global_this

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -340,6 +340,7 @@ pub mod js_bundler {
                 object.get_own(global_this, &BunString::static_str("executablePath"))?
             {
                 let slice = executable_path.to_slice(global_this)?;
+                check_path_null_bytes(global_this, "compile.executablePath", slice.slice())?;
                 let path_z = bun_core::ZBox::from_bytes(slice.slice());
                 if bun_sys::exists_at_type(bun_sys::Fd::cwd(), path_z.as_zstr())
                     .unwrap_or(bun_sys::ExistsAtType::Directory)
@@ -369,6 +370,7 @@ pub mod js_bundler {
                     windows.get_own(global_this, &BunString::static_str("icon"))?
                 {
                     let slice = windows_icon_path.to_slice(global_this)?;
+                    check_path_null_bytes(global_this, "compile.windows.icon", slice.slice())?;
                     let path_z = bun_core::ZBox::from_bytes(slice.slice());
                     if bun_sys::exists_at_type(bun_sys::Fd::cwd(), path_z.as_zstr())
                         .unwrap_or(bun_sys::ExistsAtType::Directory)
@@ -1027,6 +1029,7 @@ pub mod js_bundler {
                     }
                 };
                 let validate = |option: &str, s: &[u8]| -> JsResult<()> {
+                    check_path_null_bytes(global_this, option, s)?;
                     if let Some((pos, tail)) = options::find_unterminated_placeholder(s) {
                         return Err(global_this.throw_invalid_arguments(format_args!(
                             "{}: unterminated \"{}\" placeholder (missing \"]\") at position {}",

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -30,6 +30,28 @@ pub mod js_bundler {
 
     type OwnedString = MutableString;
 
+    /// Output-path options end up in C-string syscalls (mkdir/open), which
+    /// stop at the first NUL and write to the path's prefix while the build
+    /// reports the full string. Reject interior NULs at config parse.
+    fn check_path_null_bytes(
+        global_this: &JSGlobalObject,
+        name: &str,
+        slice: &[u8],
+    ) -> JsResult<()> {
+        if bun_core::strings::index_of_char(slice, 0).is_some() {
+            return Err(global_this
+                .err(
+                    jsc::ErrCode::INVALID_ARG_VALUE,
+                    format_args!(
+                        "The property '{name}' must be a string without null bytes. Received {}",
+                        bun_core::fmt::quote(slice)
+                    ),
+                )
+                .throw());
+        }
+        Ok(())
+    }
+
     /// `options::JSX::Runtime` → `api::JsxRuntime` (only the reverse `From`
     /// exists upstream).
     fn jsx_runtime_to_api(r: options::JSX::Runtime) -> api::JsxRuntime {
@@ -400,6 +422,7 @@ pub mod js_bundler {
 
             if let Some(outfile) = object.get_own(global_this, &BunString::static_str("outfile"))? {
                 let slice = outfile.to_slice(global_this)?;
+                check_path_null_bytes(global_this, "compile.outfile", slice.slice())?;
                 this.outfile.append_slice_exact(slice.slice())?;
             }
 
@@ -631,6 +654,7 @@ pub mod js_bundler {
 
             let mut has_out_dir = false;
             if let Some(slice) = config.get_optional_slice(global_this, b"outdir")? {
+                check_path_null_bytes(global_this, "outdir", slice.slice())?;
                 this.outdir.append_slice_exact(slice.slice())?;
                 has_out_dir = true;
                 drop(slice);
@@ -858,6 +882,7 @@ pub mod js_bundler {
             {
                 let path: ZigStringSlice = 'brk: {
                     if let Some(slice) = config.get_optional_slice(global_this, b"root")? {
+                        check_path_null_bytes(global_this, "root", slice.slice())?;
                         break 'brk slice;
                     }
 
@@ -1149,18 +1174,21 @@ pub mod js_bundler {
                     // metafile: "path/to/meta.json" - shorthand for { json: "..." }
                     this.metafile = true;
                     let slice = metafile_value.to_slice(global_this)?;
+                    check_path_null_bytes(global_this, "metafile", slice.slice())?;
                     this.metafile_json_path.append_slice_exact(slice.slice())?;
                     drop(slice);
                 } else if metafile_value.is_object() {
                     // metafile: { json?: string, markdown?: string }
                     this.metafile = true;
                     if let Some(slice) = metafile_value.get_optional_slice(global_this, b"json")? {
+                        check_path_null_bytes(global_this, "metafile.json", slice.slice())?;
                         this.metafile_json_path.append_slice_exact(slice.slice())?;
                         drop(slice);
                     }
                     if let Some(slice) =
                         metafile_value.get_optional_slice(global_this, b"markdown")?
                     {
+                        check_path_null_bytes(global_this, "metafile.markdown", slice.slice())?;
                         this.metafile_markdown_path
                             .append_slice_exact(slice.slice())?;
                         drop(slice);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -922,8 +922,7 @@ pub mod js_bundler {
                     );
                 };
 
-                // Covers an explicit `root` and the root derived from
-                // entrypoint directories.
+                // Also covers the root derived from the entrypoint directories.
                 check_path_null_bytes(global_this, "root", path.slice())?;
 
                 let dir = match bun_sys::open_dir_at(bun_sys::Fd::cwd(), path.slice()) {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -882,7 +882,6 @@ pub mod js_bundler {
             {
                 let path: ZigStringSlice = 'brk: {
                     if let Some(slice) = config.get_optional_slice(global_this, b"root")? {
-                        check_path_null_bytes(global_this, "root", slice.slice())?;
                         break 'brk slice;
                     }
 
@@ -922,6 +921,10 @@ pub mod js_bundler {
                             .unwrap_or(b"."),
                     );
                 };
+
+                // Covers an explicit `root` and the root derived from
+                // entrypoint directories.
+                check_path_null_bytes(global_this, "root", path.slice())?;
 
                 let dir = match bun_sys::open_dir_at(bun_sys::Fd::cwd(), path.slice()) {
                     Ok(d) => d,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -882,6 +882,7 @@ pub mod js_bundler {
             {
                 let path: ZigStringSlice = 'brk: {
                     if let Some(slice) = config.get_optional_slice(global_this, b"root")? {
+                        check_path_null_bytes(global_this, "root", slice.slice())?;
                         break 'brk slice;
                     }
 
@@ -922,8 +923,8 @@ pub mod js_bundler {
                     );
                 };
 
-                // Also covers the root derived from the entrypoint directories.
-                check_path_null_bytes(global_this, "root", path.slice())?;
+                // Past this point `path` derives from the entrypoint directories.
+                check_path_null_bytes(global_this, "entrypoints", path.slice())?;
 
                 let dir = match bun_sys::open_dir_at(bun_sys::Fd::cwd(), path.slice()) {
                     Ok(d) => d,

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -30,9 +30,7 @@ pub mod js_bundler {
 
     type OwnedString = MutableString;
 
-    /// Output-path options end up in C-string syscalls (mkdir/open), which
-    /// stop at the first NUL and write to the path's prefix while the build
-    /// reports the full string. Reject interior NULs at config parse.
+    /// Output paths reach C-string syscalls (mkdir/open) that stop at the first NUL; reject early.
     fn check_path_null_bytes(
         global_this: &JSGlobalObject,
         name: &str,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -204,7 +204,7 @@ describe("Bun.build", () => {
       Bun.build({
         entrypoints: [join(String(dir), "sub\0zz", "e.mjs")],
       }),
-    ).toThrow("The property 'root' must be a string without null bytes");
+    ).toThrow("The property 'entrypoints' must be a string without null bytes");
     expect(() =>
       Bun.build({
         entrypoints: [entry],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -213,6 +213,34 @@ describe("Bun.build", () => {
         metafile: join(String(dir), "meta\0.json"),
       } as any),
     ).toThrow("The property 'metafile' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        naming: "[name]\0-REQUESTED.[ext]",
+      }),
+    ).toThrow("The property 'naming' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        naming: { chunk: "[name]\0-REQUESTED.[ext]" },
+      }),
+    ).toThrow("The property 'naming.chunk' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        compile: {
+          executablePath: join(String(dir), "bun\0zz"),
+        },
+      } as any),
+    ).toThrow("The property 'compile.executablePath' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        compile: {
+          windows: { icon: join(String(dir), "icon\0.ico") },
+        },
+      } as any),
+    ).toThrow("The property 'compile.windows.icon' must be a string without null bytes");
     // the truncated "out" directory must not have been created
     expect(readdirSync(String(dir)).sort()).toEqual(["e.mjs"]);
   });

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -198,6 +198,13 @@ describe("Bun.build", () => {
         root: String(dir) + "\0zz",
       }),
     ).toThrow("The property 'root' must be a string without null bytes");
+    // with no explicit root, the root derived from the entrypoint's directory
+    // must get the same check
+    expect(() =>
+      Bun.build({
+        entrypoints: [join(String(dir), "sub\0zz", "e.mjs")],
+      }),
+    ).toThrow("The property 'root' must be a string without null bytes");
     expect(() =>
       Bun.build({
         entrypoints: [entry],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -178,6 +178,43 @@ describe("Bun.build", () => {
         sourcemap: "invalid",
       } as any),
     ).toThrow();
+  });
+
+  test("output paths with interior null bytes throw and write nothing", () => {
+    using dir = tempDir("bun-build-nul-path", {
+      "e.mjs": "export default 1;",
+    });
+    const entry = join(String(dir), "e.mjs");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        outdir: join(String(dir), "out\0-REQUESTED"),
+      }),
+    ).toThrow("The property 'outdir' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        outdir: join(String(dir), "out"),
+        root: String(dir) + "\0zz",
+      }),
+    ).toThrow("The property 'root' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        compile: {
+          outfile: join(String(dir), "app\0zz"),
+        },
+      } as any),
+    ).toThrow("The property 'compile.outfile' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        outdir: join(String(dir), "out"),
+        metafile: join(String(dir), "meta\0.json"),
+      } as any),
+    ).toThrow("The property 'metafile' must be a string without null bytes");
+    // the truncated "out" directory must not have been created
+    expect(readdirSync(String(dir)).sort()).toEqual(["e.mjs"]);
   });
 
   test("returns errors properly", async () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -223,15 +223,41 @@ describe("Bun.build", () => {
     expect(() =>
       Bun.build({
         entrypoints: [entry],
+        outdir: join(String(dir), "out"),
+        metafile: { json: join(String(dir), "meta\0.json") },
+      } as any),
+    ).toThrow("The property 'metafile.json' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        outdir: join(String(dir), "out"),
+        metafile: { markdown: join(String(dir), "meta\0.md") },
+      } as any),
+    ).toThrow("The property 'metafile.markdown' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
         naming: "[name]\0-REQUESTED.[ext]",
       }),
     ).toThrow("The property 'naming' must be a string without null bytes");
     expect(() =>
       Bun.build({
         entrypoints: [entry],
+        naming: { entry: "[name]\0-REQUESTED.[ext]" },
+      }),
+    ).toThrow("The property 'naming.entry' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
         naming: { chunk: "[name]\0-REQUESTED.[ext]" },
       }),
     ).toThrow("The property 'naming.chunk' must be a string without null bytes");
+    expect(() =>
+      Bun.build({
+        entrypoints: [entry],
+        naming: { asset: "[name]\0-REQUESTED.[ext]" },
+      }),
+    ).toThrow("The property 'naming.asset' must be a string without null bytes");
     expect(() =>
       Bun.build({
         entrypoints: [entry],

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from "bun";
 import { describe, expect, it } from "bun:test";
 import { chmodSync, chownSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
+import { createRequire } from "node:module";
 import { join, resolve, sep } from "path";
 
 const fixture = (...segs: string[]) => resolve(import.meta.dir, "fixtures", ...segs);
@@ -1100,4 +1101,22 @@ it.skipIf(isWindows)("reports a resolution error for an absolute specifier of th
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("ResolveMessage ERR_MODULE_NOT_FOUND\n");
   expect(exitCode).toBe(0);
+});
+
+it("does not resolve through a parent directory containing an interior null byte", () => {
+  using dir = tempDir("resolver-nul-parent", {
+    "sub/m.cjs": "module.exports = 1;",
+  });
+  const sub = join(String(dir), "sub");
+  expect(Bun.resolveSync("./m.cjs", sub)).toBe(join(sub, "m.cjs"));
+  expect(() => Bun.resolveSync("./m.cjs", sub + "\0zz")).toThrow("Cannot find module");
+
+  const req = createRequire(join(String(dir), "x.js"));
+  expect(req.resolve("./m.cjs", { paths: [sub] })).toBe(join(sub, "m.cjs"));
+  try {
+    req.resolve("./m.cjs", { paths: [sub + "\0zz"] });
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("MODULE_NOT_FOUND");
+  }
 });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1113,10 +1113,7 @@ it("does not resolve through a parent directory containing an interior null byte
 
   const req = createRequire(join(String(dir), "x.js"));
   expect(req.resolve("./m.cjs", { paths: [sub] })).toBe(join(sub, "m.cjs"));
-  try {
-    req.resolve("./m.cjs", { paths: [sub + "\0zz"] });
-    expect.unreachable();
-  } catch (e: any) {
-    expect(e.code).toBe("MODULE_NOT_FOUND");
-  }
+  expect(() => req.resolve("./m.cjs", { paths: [sub + "\0zz"] })).toThrow(
+    expect.objectContaining({ code: "MODULE_NOT_FOUND" }),
+  );
 });

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -279,10 +279,5 @@ test("which rejects strings with interior null bytes", () => {
   expect(() => which("env", { cwd: "/tmp\0zz" })).toThrow(
     "The property 'options.cwd' must be a string without null bytes",
   );
-  try {
-    which("env\0zz");
-    expect.unreachable();
-  } catch (e: any) {
-    expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
-  }
+  expect(() => which("env\0zz")).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }));
 });

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -270,3 +270,19 @@ test("Bun.which can find executables in a non-ascii directory", async () => {
     process.chdir(cwd);
   }
 });
+
+test("which rejects strings with interior null bytes", () => {
+  expect(() => which("env\0zz")).toThrow("The argument 'command' must be a string without null bytes");
+  expect(() => which("env", { PATH: "/usr/bin\0zz" })).toThrow(
+    "The property 'options.PATH' must be a string without null bytes",
+  );
+  expect(() => which("env", { cwd: "/tmp\0zz" })).toThrow(
+    "The property 'options.cwd' must be a string without null bytes",
+  );
+  try {
+    which("env\0zz");
+    expect.unreachable();
+  } catch (e: any) {
+    expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+  }
+});


### PR DESCRIPTION
### Problem

A JavaScript string can contain interior NUL bytes, but the C-string syscalls underneath stop at the first NUL. Three path consumers skipped the interior-NUL guard that `node:fs`, `Bun.file` and `Bun.spawn` already apply, so they acted on the truncated prefix while reporting the full string:

```js
import fs from "node:fs";
import { createRequire } from "node:module";
const S = fs.mkdtempSync("/tmp/nul-");
fs.mkdirSync(S + "/sub");
fs.writeFileSync(S + "/sub/e.mjs", "export default 1;");
fs.writeFileSync(S + "/sub/m.cjs", "module.exports=1;");

const r = await Bun.build({ entrypoints: [S + "/sub/e.mjs"], outdir: S + "/out\0-REQUESTED" });
console.log(r.success, fs.readdirSync(S)); // true [ "sub", "out" ]  <- wrote into "out", reported success
console.log(Bun.which("env\0zz"));         // "/usr/bin/env\0zz"    <- found via prefix, suffix re-appended
console.log(Bun.resolveSync("./m.cjs", S + "/sub\0zz"));            // ".../sub\0zz/m.cjs" (phantom path)
createRequire(S + "/x.js").resolve("./m.cjs", { paths: [S + "/sub\0zz"] }); // same; Node throws MODULE_NOT_FOUND
```

Besides the phantom successes (e.g. `Bun.which` used as an existence oracle answering yes for a nonexistent name), the resolver case aborts debug builds with `panic: ZStr::as_cstr: interior NUL would truncate the C view` because the NUL-bearing directory path reaches the C-string boundary.

### Cause

- `Bun.which` passed the command name and the `PATH`/`cwd` options to the lookup without the NUL check that `Bun.spawn` applies to its inputs.
- The resolver checks the import specifier for NUL (returns not-found) but not the source directory, and `custom_dir_paths` (`require.resolve` `paths`) bypasses that check entirely. The directory then gets opened via a C string, truncating at the NUL, and its entries are cached under the full NUL-bearing key, producing a phantom resolved path.
- `Bun.build` accepted `outdir` (and `root`, `compile.outfile`, `metafile`, `naming` templates, `compile.executablePath`, `compile.windows.icon`) containing NULs; the C-string syscalls later truncate. `executablePath` and `windows.icon` hit an fstatat through a C string during config parse itself, which aborts debug builds via the same `ZStr::as_cstr` assertion.

### Fix

- `Bun.which` throws `ERR_INVALID_ARG_VALUE` ("must be a string without null bytes") for `command`, `options.PATH` and `options.cwd`, same message shape as `Bun.spawn`.
- The resolver treats any directory path containing an interior NUL as nonexistent: the existing specifier check in `resolve_and_auto_install` now also covers the source dir, and both directory-open mechanisms (`dir_info_cached` and `FileSystem::open_dir` used by the entries cache) short-circuit before the syscall. `Bun.resolveSync` with a NUL-bearing `from` now throws `ERR_MODULE_NOT_FOUND`, and `require.resolve(..., { paths })` throws `MODULE_NOT_FOUND`, matching Node. This also removes the debug-build abort.
- `Bun.build` rejects `outdir`, `root` (explicit or derived from the entrypoint directories), `compile.outfile`, `metafile`, `naming`/`naming.entry`/`naming.chunk`/`naming.asset`, `compile.executablePath` and `compile.windows.icon` values with interior NULs at config parse with `ERR_INVALID_ARG_VALUE`, before anything is written.

Specifier forms with NULs (`require`/`import`/`Worker`/`Bun.build` entrypoints) already failed with MODULE_NOT_FOUND and are unchanged.

### Verification

New tests (all fail on the unfixed build, where the phantom values come back, and pass with the fix):

- `test/js/bun/util/which.test.ts`: `which` throws for NUL in command/options.PATH/options.cwd, code `ERR_INVALID_ARG_VALUE`.
- `test/js/bun/resolve/resolve.test.ts`: `Bun.resolveSync` and `createRequire().resolve({ paths })` fail with `Cannot find module` / `MODULE_NOT_FOUND` for a parent dir containing a NUL; the same paths without the NUL still resolve.
- `test/bundler/bun-build-api.test.ts`: `Bun.build` throws for NUL in `outdir`/`root`/`compile.outfile`/`metafile`/`naming`/`naming.chunk`/`compile.executablePath`/`compile.windows.icon` and creates nothing on disk.

Full `which.test.ts` (6), `resolve.test.ts` (49), `bun-build-api.test.ts` (51), `node-module-module.test.js`, `module-resolve-filename-paths.test.js` and `import-meta.test.js` suites pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts test/js/bun/resolve/resolve.test.ts test/js/bun/util/which.test.ts

<!-- robobun:evidence:end -->
