### PR TITLE
Unpin ArrayBuffers without classInfo() so blob finalizers are safe during GC sweep

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3609,12 +3609,23 @@ CPP_DECL uint8_t JSC__JSValue__pinArrayBuffer(JSC::EncodedJSValue v)
 // Only for a value `pinStorage` answered `Pinned` for: that buffer still exists (pinned buffers are not detached).
 CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
 {
+    // Reached from finalizers during GC sweep, where classInfo() (and so any
+    // dynamicDowncast) is forbidden; dispatch on JSType like JSC::Weak<T>::get().
     auto value = JSC::JSValue::decode(v);
+    if (!value.isCell())
+        return;
+    JSC::JSCell* cell = value.asCell();
+    JSC::JSType type = cell->type();
     JSC::ArrayBuffer* buf = nullptr;
-    if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value))
-        buf = jb->impl();
-    else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value); view && view->hasArrayBuffer())
-        buf = view->possiblySharedBuffer();
+    if (type == JSC::ArrayBufferType)
+        buf = static_cast<JSC::JSArrayBuffer*>(cell)->impl();
+    else if (type == JSC::DataViewType)
+        buf = static_cast<JSC::JSDataView*>(cell)->possiblySharedBuffer();
+    else if (JSC::isTypedArrayType(type)) {
+        auto* view = static_cast<JSC::JSArrayBufferView*>(cell);
+        if (JSC::isWastefulTypedArray(view->mode()))
+            buf = view->butterfly()->indexingHeader()->arrayBuffer();
+    }
     if (buf && !buf->isShared())
         buf->unpin();
 }

--- a/test/js/bun/s3/s3-stream-error-gc.test.ts
+++ b/test/js/bun/s3/s3-stream-error-gc.test.ts
@@ -1,6 +1,46 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 
+test.concurrent("collecting file blobs with Buffer paths does not crash during GC sweep", async () => {
+  // The S3/file blob store keeps the pinned path buffer until the wrapper is
+  // finalized inside the GC sweep; releasing the pin must not reach
+  // JSCell::classInfo() there (validateIsNotSweeping assert in debug builds).
+  const fixture = `
+    const enc = new TextEncoder();
+    for (let i = 0; i < 50; i++) {
+      new Bun.S3Client({}).file(Buffer.from("key-" + i));
+      new Bun.S3Client({}).file(new DataView(enc.encode("dv-key-" + i).buffer));
+      new Bun.S3Client({}).file(enc.encode("uint8-key-" + i));
+      Bun.file(Buffer.from("/tmp/buffer-path-" + i));
+      Bun.file(enc.encode("/tmp/uint8-path-" + i));
+      Bun.file(enc.encode("/tmp/enc-path-" + i).buffer);
+      Bun.gc(true);
+    }
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({
+    stdout: normalizeBunSnapshot(stdout),
+    stderr: normalizeBunSnapshot(stderr),
+    exitCode,
+  }).toMatchInlineSnapshot(`
+    {
+      "exitCode": 0,
+      "stderr": "",
+      "stdout": "ok",
+    }
+  `);
+});
+
 test("S3 stream error parked before consumption survives GC", async () => {
   const fixture = `
     const stream = Bun.S3Client.file("some-key").stream();


### PR DESCRIPTION
### Crash

Fuzzilli found a flaky abort in debug builds, fingerprint `JSCell.cpp(179)`:

```
ASSERTION FAILED: vm().currentThreadIsHoldingAPILock() => vm().heap.mutatorState() != MutatorState::Sweeping
vendor/WebKit/Source/JavaScriptCore/runtime/JSCell.cpp(179) : bool JSC::JSCell::validateIsNotSweeping() const
```

The fuzzer's minimized script did not reproduce on its own (the crash depends on what earlier programs in the same REPRL child left on the heap; every fuzzed program ends with `Bun.gc(true)`, which is what runs the sweep). Replaying the fuzzer's API surface with ill-typed arguments reproduced it, and this two-liner then crashes a debug build deterministically:

```js
new Bun.S3Client({}).file(Buffer.from("some-key"));
Bun.gc(true);
```

### Root cause

`Bun.file(path)` and `S3Client.file(key)` accept `Buffer`, typed array, and `ArrayBuffer` paths. `PathLike::from_js` pins the backing `JSC::ArrayBuffer` so a transfer cannot move the bytes while native code borrows them, and the blob `Store` keeps that pinned `PathLike` for its whole lifetime. The store is released from the JS wrapper's finalizer, i.e. inside the GC sweep (for `JSS3File`, a precise allocation, that is `Heap::finalize` on every collection). Frame-pointer walk at the assertion:

```
PathLike::drop
  -> JSC__JSValue__unpinArrayBuffer
  -> arrayBufferImpl -> dynamicDowncast<JSArrayBuffer> / JSArrayBufferView::possiblySharedBuffer
  -> JSCell::classInfo()            <- forbidden while mutatorState() == Sweeping
  <- Blob::finalize <- ~JSBlob <- ~JSS3File <- PreciseAllocation::sweep <- Heap::finalize
```

`dynamicDowncast` asserts the JSType check against `classInfo()` in debug builds, and `possiblySharedBufferImpl` has an `uncheckedDowncast<JSDataView>` doing the same, so any unpin that runs during a sweep trips the assertion.

### Fix

`JSC__JSValue__unpinArrayBuffer` now resolves the buffer without `classInfo()`: dispatch on the cell's `JSType` with `static_cast`, read a DataView's buffer field directly, and read a wasteful view's buffer out of the butterfly indexing header. This is the same approach `JSC::Weak<T>::get()` uses for code reachable from finalizers. A view whose mode has no ArrayBuffer (fast or oversize, which `pinStorage` reports as `None`/`Held`) stays a no-op, exactly as the previous `hasArrayBuffer()` check did, since that mode bit is set precisely for the wasteful and DataView modes.

Release builds already compiled the old downcasts to these exact type checks, so non-debug behavior is unchanged.

Rebase note: main has since split pinning into `pinStorage()`/`PinKind` with a separate unpin function, so the original `arrayBufferImpl()` change no longer applied. The pin side runs inside host calls, where `dynamicDowncast` is fine, so the fix is now confined to the unpin function, the only one reachable from a sweep. Re-verified on the rebased main: a debug build aborts on `new Bun.S3Client({}).file(Buffer.from("k")); Bun.file(Buffer.from("/tmp/x")); Bun.gc(true)` without the patch and exits cleanly with it, and the test in this PR passes.

### Verification

- The two-liner above and a 200-iteration loop over all four path shapes (Buffer, Uint8Array, DataView, ArrayBuffer, for both `Bun.file` and `S3Client.file`) crashed before and pass now, including with `BUN_JSC_sweepSynchronously=1`.
- A 3-minute randomized API fuzz with forced synchronous sweeps that previously reproduced the assertion runs clean.
- `bun bd test` passes for the new test plus `bun-write.test.js`, `zlib.test.js`, `compression.test.ts`, and `fs.test.ts` (the other users of the pin/unpin path).
- The new test guards debug/ASAN lanes; release builds never asserted here, so it passes on release bun either way.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3-stream-error-gc.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/bun/s3/s3-stream-error-gc.test.ts:
30 | 
31 |   expect({
32 |     stdout: normalizeBunSnapshot(stdout),
33 |     stderr: normalizeBunSnapshot(stderr),
34 |     exitCode,
35 |   }).toMatchInlineSnapshot(`
          ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": "ok",
+   "exitCode": 134,
+   "stderr": 
+ "ASSERTION FAILED: vm().currentThreadIsHoldingAPILock() => vm().heap.mutatorState() != MutatorState::Sweeping
+ vendor/WebKit/Source/JavaScriptCore/runtime/JSCell.cpp(179) : bool JSC::JSCell::validateIsNotSweeping() const
+ no stacktrace available"
+ ,
+   "stdout": "",
  }
  

- Expected  - 3
+ Received  + 7

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-stream-error-gc.test.ts:35:6)
(fail) collecting file blobs with Buffer paths does not crash during GC sweep [574.78ms]
(pass) S3 stream error parked before consumption survives GC [439.68ms]

 1 pass
 1 fail
snapshots: 1 passed, 
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/s3/s3-stream-error-gc.test.ts:
(pass) collecting file blobs with Buffer paths does not crash during GC sweep [20.51ms]
(pass) S3 stream error parked before consumption survives GC [6.70ms]

 2 pass
 0 fail
 2 snapshots, 2 expect() calls
Ran 2 tests across 1 file. [128.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/s3/s3-stream-error-gc.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/bun/s3/s3-stream-error-gc.test.ts:
(pass) collecting file blobs with Buffer paths does not crash during GC sweep [1787.62ms]
(pass) S3 stream error parked before consumption survives GC [307.72ms]

 2 pass
 0 fail
 2 snapshots, 2 expect() calls
Ran 2 tests across 1 file. [4.36s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     93dda7c00f
  features     baseline

23 deps, 131 codegen, 1176 objects in 823ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [6.00ms]
[2/1248] gen ErrorCode+*.h
[3/1248] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [3.00ms]
[5/1248] gen bindgenv2
[6/1248] fetch tinycc
[tinycc] up to date
[7/1247] fetch zlib
[zlib] up to date
[8/1247] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[9/1247] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1247] gen .bind.ts → GeneratedBindings.cpp
[11/1247] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp             | 19 +++++++++++----
 test/js/bun/s3/s3-stream-error-gc.test.ts | 40 +++++++++++++++++++++++++++++++
 2 files changed, 55 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/bindings.cpp                  9     11     20
test/js/bun/s3/s3-stream-error-gc.test.ts      1      3     18
```

</details>

<!-- robobun:evidence:end -->
