### PR TITLE
Reject interior NUL bytes in hostnames, IP addresses, and SNI servernames

### DIFF
--- a/src/bun_core/ip_address.rs
+++ b/src/bun_core/ip_address.rs
@@ -46,7 +46,9 @@ mod sys {
 
 pub fn is_ip_address(input: &[u8]) -> bool {
     let mut buf = [0u8; 512];
-    if input.len() >= buf.len() {
+    // An embedded NUL would truncate at the C parser below, classifying
+    // "127.0.0.1\0junk" as the IP "127.0.0.1". No IP literal contains a NUL.
+    if input.len() >= buf.len() || input.contains(&0) {
         return false;
     }
     buf[..input.len()].copy_from_slice(input);
@@ -57,7 +59,7 @@ pub fn is_ip_address(input: &[u8]) -> bool {
 /// A strict parse, never a `contains(':')` heuristic — that mis-bracketed Windows paths like `C:/Windows/Temp/…` as `unix://[C:/…]`.
 pub fn is_ipv6_address(input: &[u8]) -> bool {
     let mut buf = [0u8; 512];
-    if input.len() >= buf.len() {
+    if input.len() >= buf.len() || input.contains(&0) {
         return false;
     }
     buf[..input.len()].copy_from_slice(input);
@@ -68,7 +70,7 @@ pub fn is_ipv6_address(input: &[u8]) -> bool {
 /// Parses what the platform resolver treats as a numeric host: dotted-quad, IPv6 (an optional `%zone` is stripped, not validated), and the `inet_aton` shorthand `getaddrinfo` accepts but `is_ip_address` rejects (`127.1`, `2130706433`, `0x7f000001`, `0177.0.0.1`).
 pub fn to_ip_address(input: &[u8]) -> Option<IpAddr> {
     let mut buf = [0u8; 512];
-    if input.is_empty() || input.len() >= buf.len() {
+    if input.is_empty() || input.len() >= buf.len() || input.contains(&0) {
         return None;
     }
     // A `%zone` suffix belongs to a numeric v6 host; resolving the zone is the caller's business.

--- a/src/bun_core/ip_address.rs
+++ b/src/bun_core/ip_address.rs
@@ -47,7 +47,7 @@ mod sys {
 pub fn is_ip_address(input: &[u8]) -> bool {
     let mut buf = [0u8; 512];
     // The C parser below stops at the first NUL; no IP literal contains one.
-    if input.len() >= buf.len() || input.contains(&0) {
+    if input.len() >= buf.len() || crate::strings::contains_char(input, 0) {
         return false;
     }
     buf[..input.len()].copy_from_slice(input);
@@ -58,7 +58,7 @@ pub fn is_ip_address(input: &[u8]) -> bool {
 /// A strict parse, never a `contains(':')` heuristic — that mis-bracketed Windows paths like `C:/Windows/Temp/…` as `unix://[C:/…]`.
 pub fn is_ipv6_address(input: &[u8]) -> bool {
     let mut buf = [0u8; 512];
-    if input.len() >= buf.len() || input.contains(&0) {
+    if input.len() >= buf.len() || crate::strings::contains_char(input, 0) {
         return false;
     }
     buf[..input.len()].copy_from_slice(input);
@@ -69,7 +69,7 @@ pub fn is_ipv6_address(input: &[u8]) -> bool {
 /// Parses what the platform resolver treats as a numeric host: dotted-quad, IPv6 (an optional `%zone` is stripped, not validated), and the `inet_aton` shorthand `getaddrinfo` accepts but `is_ip_address` rejects (`127.1`, `2130706433`, `0x7f000001`, `0177.0.0.1`).
 pub fn to_ip_address(input: &[u8]) -> Option<IpAddr> {
     let mut buf = [0u8; 512];
-    if input.is_empty() || input.len() >= buf.len() || input.contains(&0) {
+    if input.is_empty() || input.len() >= buf.len() || crate::strings::contains_char(input, 0) {
         return None;
     }
     // A `%zone` suffix belongs to a numeric v6 host; resolving the zone is the caller's business.

--- a/src/bun_core/ip_address.rs
+++ b/src/bun_core/ip_address.rs
@@ -46,8 +46,7 @@ mod sys {
 
 pub fn is_ip_address(input: &[u8]) -> bool {
     let mut buf = [0u8; 512];
-    // An embedded NUL would truncate at the C parser below, classifying
-    // "127.0.0.1\0junk" as the IP "127.0.0.1". No IP literal contains a NUL.
+    // The C parser below stops at the first NUL; no IP literal contains one.
     if input.len() >= buf.len() || input.contains(&0) {
         return false;
     }

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -802,6 +802,22 @@ impl Channel {
         hints: &[AddrInfo_hints],
         ctx: &mut T,
     ) {
+        // Same contract as `resolve` below: a name that cannot round-trip
+        // through a C string (interior NUL truncates, overlong truncates at the
+        // buffer) is a bad name, not a shorter one.
+        if host.len() >= 1023 || host.contains(&0) {
+            // SAFETY: thunk handles the ARES_EBADNAME path.
+            unsafe {
+                AddrInfo::callback_wrapper::<T>(
+                    std::ptr::from_mut::<T>(ctx).cast::<c_void>(),
+                    ARES_EBADNAME,
+                    0,
+                    ptr::null_mut(),
+                )
+            };
+            return;
+        }
+
         let mut host_buf = [0u8; 1024];
         let mut port_buf = [0u8; 21];
         let host_ptr = copy_nul_terminated(&mut host_buf, host);
@@ -873,7 +889,9 @@ impl Channel {
         const BUF_SIZE: usize = 46;
         let mut addr_buf = [0u8; BUF_SIZE];
         let addr_ptr: *const c_char = 'brk: {
-            if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE {
+            // Interior NUL: reject rather than truncate at `copy_nul_terminated`
+            // (a PTR lookup for "8.8.8.8\0evil" must not resolve "8.8.8.8").
+            if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE || ip_addr.contains(&0) {
                 break 'brk ptr::null();
             }
             copy_nul_terminated(&mut addr_buf, ip_addr)
@@ -1959,7 +1977,9 @@ pub fn get_sockaddr(addr: &[u8], port: u16, sa: &mut sockaddr) -> c_int {
     const BUF_SIZE: usize = 128;
 
     let mut buf = [0u8; BUF_SIZE];
-    if addr.is_empty() || addr.len() >= BUF_SIZE {
+    // An interior NUL would truncate at `copy_nul_terminated`, silently parsing
+    // only the prefix (e.g. "127.0.0.1\0evil.example.com" as "127.0.0.1").
+    if addr.is_empty() || addr.len() >= BUF_SIZE || addr.contains(&0) {
         return -1;
     }
     let addr_ptr = copy_nul_terminated(&mut buf, addr);

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -802,9 +802,6 @@ impl Channel {
         hints: &[AddrInfo_hints],
         ctx: &mut T,
     ) {
-        // Same contract as `resolve` below: a name that cannot round-trip
-        // through a C string (interior NUL truncates, overlong truncates at the
-        // buffer) is a bad name, not a shorter one.
         if host.len() >= 1023 || host.contains(&0) {
             // SAFETY: thunk handles the ARES_EBADNAME path.
             unsafe {
@@ -889,8 +886,6 @@ impl Channel {
         const BUF_SIZE: usize = 46;
         let mut addr_buf = [0u8; BUF_SIZE];
         let addr_ptr: *const c_char = 'brk: {
-            // Interior NUL: reject rather than truncate at `copy_nul_terminated`
-            // (a PTR lookup for "8.8.8.8\0evil" must not resolve "8.8.8.8").
             if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE || ip_addr.contains(&0) {
                 break 'brk ptr::null();
             }
@@ -1977,8 +1972,6 @@ pub fn get_sockaddr(addr: &[u8], port: u16, sa: &mut sockaddr) -> c_int {
     const BUF_SIZE: usize = 128;
 
     let mut buf = [0u8; BUF_SIZE];
-    // An interior NUL would truncate at `copy_nul_terminated`, silently parsing
-    // only the prefix (e.g. "127.0.0.1\0evil.example.com" as "127.0.0.1").
     if addr.is_empty() || addr.len() >= BUF_SIZE || addr.contains(&0) {
         return -1;
     }

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -802,7 +802,7 @@ impl Channel {
         hints: &[AddrInfo_hints],
         ctx: &mut T,
     ) {
-        if host.len() >= 1023 || host.contains(&0) {
+        if host.len() >= 1023 || bun_core::strings::contains_char(host, 0) {
             // SAFETY: thunk handles the ARES_EBADNAME path.
             unsafe {
                 AddrInfo::callback_wrapper::<T>(
@@ -886,7 +886,7 @@ impl Channel {
         const BUF_SIZE: usize = 46;
         let mut addr_buf = [0u8; BUF_SIZE];
         let addr_ptr: *const c_char = 'brk: {
-            if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE || ip_addr.contains(&0) {
+            if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE || bun_core::strings::contains_char(ip_addr, 0) {
                 break 'brk ptr::null();
             }
             copy_nul_terminated(&mut addr_buf, ip_addr)
@@ -1972,7 +1972,7 @@ pub fn get_sockaddr(addr: &[u8], port: u16, sa: &mut sockaddr) -> c_int {
     const BUF_SIZE: usize = 128;
 
     let mut buf = [0u8; BUF_SIZE];
-    if addr.is_empty() || addr.len() >= BUF_SIZE || addr.contains(&0) {
+    if addr.is_empty() || addr.len() >= BUF_SIZE || bun_core::strings::contains_char(addr, 0) {
         return -1;
     }
     let addr_ptr = copy_nul_terminated(&mut buf, addr);

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -886,7 +886,10 @@ impl Channel {
         const BUF_SIZE: usize = 46;
         let mut addr_buf = [0u8; BUF_SIZE];
         let addr_ptr: *const c_char = 'brk: {
-            if ip_addr.is_empty() || ip_addr.len() >= BUF_SIZE || bun_core::strings::contains_char(ip_addr, 0) {
+            if ip_addr.is_empty()
+                || ip_addr.len() >= BUF_SIZE
+                || bun_core::strings::contains_char(ip_addr, 0)
+            {
                 break 'brk ptr::null();
             }
             copy_nul_terminated(&mut addr_buf, ip_addr)

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2955,8 +2955,6 @@ pub mod internal {
             );
         };
 
-        // The cache key keeps the full bytes but the worker hands `key.host` to
-        // getaddrinfo as a C string, which would resolve only the pre-NUL prefix.
         if hostname_slice.slice().contains(&0) {
             return Err(global_this
                 .throw_invalid_arguments(format_args!("hostname must not contain null bytes")));
@@ -5528,8 +5526,6 @@ impl Resolver {
         // ZigStringSlice has no `into_owned_slice_z`; build the
         // NUL-terminated buffer inline.
         let bytes = str_.slice();
-        // `ares_inet_pton` reads to the first NUL, so "127.0.0.1\0junk" would
-        // silently parse as "127.0.0.1". A valid IP never contains a NUL.
         if bytes.contains(&0) {
             return Err(jsc::Error::INVALID_IP_ADDRESS.throw(
                 global_this,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -5649,6 +5649,16 @@ impl Resolver {
             );
             let address_slice = address_string.to_owned_slice();
 
+            if address_slice.contains(&0) {
+                return Err(jsc::Error::INVALID_IP_ADDRESS.throw(
+                    global_this,
+                    format_args!(
+                        "Invalid IP address: \"{}\"",
+                        bstr::BStr::new(&address_slice)
+                    ),
+                ));
+            }
+
             let mut address_buffer = vec![0u8; address_slice.len() + 1];
             let _ = strings::copy(&mut address_buffer, &address_slice);
             address_buffer[address_slice.len()] = 0;

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2955,6 +2955,13 @@ pub mod internal {
             );
         };
 
+        // The cache key keeps the full bytes but the worker hands `key.host` to
+        // getaddrinfo as a C string, which would resolve only the pre-NUL prefix.
+        if hostname_slice.slice().contains(&0) {
+            return Err(global_this
+                .throw_invalid_arguments(format_args!("hostname must not contain null bytes")));
+        }
+
         let hostname_z = bun::ZBox::from_bytes(hostname_slice.slice());
 
         let port: u16 = if arguments.len() > 1 && !arguments[1].is_undefined_or_null() {
@@ -5521,6 +5528,14 @@ impl Resolver {
         // ZigStringSlice has no `into_owned_slice_z`; build the
         // NUL-terminated buffer inline.
         let bytes = str_.slice();
+        // `ares_inet_pton` reads to the first NUL, so "127.0.0.1\0junk" would
+        // silently parse as "127.0.0.1". A valid IP never contains a NUL.
+        if bytes.contains(&0) {
+            return Err(jsc::Error::INVALID_IP_ADDRESS.throw(
+                global_this,
+                format_args!("Invalid IP address: \"{}\"", bstr::BStr::new(bytes)),
+            ));
+        }
         let mut slice = bytes.to_vec();
         slice.push(0);
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2955,7 +2955,7 @@ pub mod internal {
             );
         };
 
-        if hostname_slice.slice().contains(&0) {
+        if strings::contains_char(hostname_slice.slice(), 0) {
             return Err(global_this
                 .throw_invalid_arguments(format_args!("hostname must not contain null bytes")));
         }
@@ -5526,7 +5526,7 @@ impl Resolver {
         // ZigStringSlice has no `into_owned_slice_z`; build the
         // NUL-terminated buffer inline.
         let bytes = str_.slice();
-        if bytes.contains(&0) {
+        if strings::contains_char(bytes, 0) {
             return Err(jsc::Error::INVALID_IP_ADDRESS.throw(
                 global_this,
                 format_args!("Invalid IP address: \"{}\"", bstr::BStr::new(bytes)),
@@ -5649,7 +5649,7 @@ impl Resolver {
             );
             let address_slice = address_string.to_owned_slice();
 
-            if address_slice.contains(&0) {
+            if strings::contains_char(&address_slice, 0) {
                 return Err(jsc::Error::INVALID_IP_ADDRESS.throw(
                     global_this,
                     format_args!(

--- a/src/runtime/node/quic/tls.rs
+++ b/src/runtime/node/quic/tls.rs
@@ -115,8 +115,6 @@ impl TlsConfig {
         }
         if let Some(v) = tls.get(global, "servername")?.filter(|v| v.is_string()) {
             let mut bytes = bun_core::String::from_js(v, global)?.to_utf8_bytes();
-            // Passed to lsquic as a C string; an embedded NUL would silently
-            // truncate the SNI sent on the wire.
             if bytes.contains(&0) {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "servername must not contain null bytes"

--- a/src/runtime/node/quic/tls.rs
+++ b/src/runtime/node/quic/tls.rs
@@ -115,6 +115,13 @@ impl TlsConfig {
         }
         if let Some(v) = tls.get(global, "servername")?.filter(|v| v.is_string()) {
             let mut bytes = bun_core::String::from_js(v, global)?.to_utf8_bytes();
+            // Passed to lsquic as a C string; an embedded NUL would silently
+            // truncate the SNI sent on the wire.
+            if bytes.contains(&0) {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "servername must not contain null bytes"
+                )));
+            }
             bytes.push(0);
             config.servername = Some(bytes);
         }

--- a/src/runtime/node/quic/tls.rs
+++ b/src/runtime/node/quic/tls.rs
@@ -115,7 +115,7 @@ impl TlsConfig {
         }
         if let Some(v) = tls.get(global, "servername")?.filter(|v| v.is_string()) {
             let mut bytes = bun_core::String::from_js(v, global)?.to_utf8_bytes();
-            if bytes.contains(&0) {
+            if bun_core::strings::contains_char(&bytes, 0) {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "servername must not contain null bytes"
                 )));

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -716,11 +716,15 @@ impl Listener {
                 global.throw_invalid_arguments(format_args!("hostname pattern cannot be empty"))
             );
         }
-        // NUL-terminate for the C `const char*` parameter. Interior NULs are
-        // tolerated — the C SNI tree just truncates at the first one. Build the
-        // `&CStr` via `from_ptr` to allow that instead of asserting via
-        // `ZStr::as_cstr()`. `server_name_z` must outlive the
-        // remove_server_name/add_server_name calls below.
+        // The C SNI tree truncates at the first NUL, so an embedded NUL would
+        // register a certificate under the truncated prefix.
+        if server_name_bytes.contains(&0) {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "hostname pattern must not contain null bytes"
+            )));
+        }
+        // NUL-terminate for the C `const char*` parameter. `server_name_z`
+        // must outlive the remove_server_name/add_server_name calls below.
         let server_name_z = bun_core::ZBox::from_bytes(server_name_bytes);
         // SAFETY: `server_name_z` is NUL-terminated and lives to end of scope.
         let server_name = unsafe { core::ffi::CStr::from_ptr(server_name_z.as_ptr()) };

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -716,7 +716,7 @@ impl Listener {
                 global.throw_invalid_arguments(format_args!("hostname pattern cannot be empty"))
             );
         }
-        if server_name_bytes.contains(&0) {
+        if bun_core::strings::contains_char(server_name_bytes, 0) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "hostname pattern must not contain null bytes"
             )));

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -716,18 +716,15 @@ impl Listener {
                 global.throw_invalid_arguments(format_args!("hostname pattern cannot be empty"))
             );
         }
-        // The C SNI tree truncates at the first NUL, so an embedded NUL would
-        // register a certificate under the truncated prefix.
         if server_name_bytes.contains(&0) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "hostname pattern must not contain null bytes"
             )));
         }
-        // NUL-terminate for the C `const char*` parameter. `server_name_z`
-        // must outlive the remove_server_name/add_server_name calls below.
+        // `server_name_z` must outlive the remove_server_name/add_server_name
+        // calls below.
         let server_name_z = bun_core::ZBox::from_bytes(server_name_bytes);
-        // SAFETY: `server_name_z` is NUL-terminated and lives to end of scope.
-        let server_name = unsafe { core::ffi::CStr::from_ptr(server_name_z.as_ptr()) };
+        let server_name = server_name_z.as_zstr().as_cstr();
 
         let ListenerType::Uws(ls) = this.listener.get() else {
             return Ok(JSValue::UNDEFINED);

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -721,8 +721,6 @@ impl Listener {
                 "hostname pattern must not contain null bytes"
             )));
         }
-        // `server_name_z` must outlive the remove_server_name/add_server_name
-        // calls below.
         let server_name_z = bun_core::ZBox::from_bytes(server_name_bytes);
         let server_name = server_name_z.as_zstr().as_cstr();
 

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -163,6 +163,14 @@ impl SSLConfigFromJs for SSLConfig {
             any = true;
         }
         if let Some(server_name) = generated.server_name.get() {
+            // Becomes the C string handed to SSL_set_tlsext_host_name / the SNI
+            // tree; an embedded NUL would silently truncate the name on the wire
+            // while JS-level checks see the full string.
+            if server_name.to_utf8().slice().contains(&0) {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "\"serverName\" must not contain null bytes"
+                )));
+            }
             result.server_name = zbox_into_raw(&server_name.to_owned_slice_z());
             result.requires_custom_request_ctx = true;
         }

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -163,9 +163,6 @@ impl SSLConfigFromJs for SSLConfig {
             any = true;
         }
         if let Some(server_name) = generated.server_name.get() {
-            // Becomes the C string handed to SSL_set_tlsext_host_name / the SNI
-            // tree; an embedded NUL would silently truncate the name on the wire
-            // while JS-level checks see the full string.
             if server_name.to_utf8().slice().contains(&0) {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "\"serverName\" must not contain null bytes"

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -163,7 +163,7 @@ impl SSLConfigFromJs for SSLConfig {
             any = true;
         }
         if let Some(server_name) = generated.server_name.get() {
-            if server_name.to_utf8().slice().contains(&0) {
+            if bun_core::strings::contains_char(server_name.to_utf8().slice(), 0) {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "\"serverName\" must not contain null bytes"
                 )));

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -387,6 +387,22 @@ impl SocketAddress {
     pub(crate) fn init_js(global: &JSGlobalObject, options: Options) -> JsResult<SocketAddress> {
         let mut presentation: BunString = BunString::empty();
 
+        // Checked on the original bytes: `to_owned_slice_z` below absorbs one
+        // trailing NUL, and `ares_inet_pton` stops at the first interior one.
+        if let Some(address_str) = &options.address {
+            if address_str.to_utf8().slice().contains(&0) {
+                use bun_jsc::js_global_object::SysErrOptions;
+                return Err(global.throw_sys_error(
+                    &SysErrOptions {
+                        code: bun_jsc::ErrorCode::ERR_INVALID_IP_ADDRESS,
+                        errno: None,
+                        name: None,
+                    },
+                    format_args!("Invalid socket address"),
+                ));
+            }
+        }
+
         // We need a zero-terminated cstring for `ares_inet_pton`, which forces us to
         // copy the string.
         // PERF: could use a small stack buffer with heap fallback.

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -385,11 +385,13 @@ impl SocketAddress {
     }
 
     pub(crate) fn init_js(global: &JSGlobalObject, options: Options) -> JsResult<SocketAddress> {
-        let mut presentation: BunString = BunString::empty();
+        // `OwnedString` releases the +1 from `BunString::from_js` on every
+        // error path below; `into_inner()` transfers it to `_presentation`.
+        let mut owned_address = options.address.map(OwnedString::new);
 
         // Checked pre-slice_z: that conversion absorbs one trailing NUL.
-        if let Some(address_str) = &options.address {
-            if strings::contains_char(address_str.to_utf8().slice(), 0) {
+        if let Some(address_str) = &owned_address {
+            if strings::contains_char(address_str.to_utf8_without_ref().slice(), 0) {
                 use bun_jsc::js_global_object::SysErrOptions;
                 return Err(global.throw_sys_error(
                     &SysErrOptions {
@@ -406,6 +408,7 @@ impl SocketAddress {
         // copy the string.
         // PERF: could use a small stack buffer with heap fallback.
 
+        let mut presentation: BunString = BunString::empty();
         let addr: sockaddr = match options.family {
             AF::INET => {
                 let mut sin: inet::sockaddr_in = inet::sockaddr_in {
@@ -414,9 +417,8 @@ impl SocketAddress {
                     addr: 0, // undefined → overwritten below
                     ..inet::sockaddr_in::ZEROED
                 };
-                if let Some(address_str) = options.address {
-                    presentation = address_str;
-                    let slice = presentation.to_owned_slice_z();
+                if let Some(address_str) = owned_address.take() {
+                    let slice = address_str.get().to_owned_slice_z();
                     // Box<ZStr> drops at scope exit
                     pton(
                         global,
@@ -424,6 +426,7 @@ impl SocketAddress {
                         &slice,
                         (&raw mut sin.addr).cast::<c_void>(),
                     )?;
+                    presentation = address_str.into_inner();
                 } else {
                     sin.addr = sockaddr::LOOPBACK_V4.as_sin().unwrap().addr;
                 }
@@ -438,15 +441,15 @@ impl SocketAddress {
                     scope_id: 0,
                     ..inet::sockaddr_in6::ZEROED
                 };
-                if let Some(address_str) = options.address {
-                    presentation = address_str;
-                    let slice = presentation.to_owned_slice_z();
+                if let Some(address_str) = owned_address.take() {
+                    let slice = address_str.get().to_owned_slice_z();
                     pton(
                         global,
                         inet::AF_INET6,
                         &slice,
                         (&raw mut sin6.addr).cast::<c_void>(),
                     )?;
+                    presentation = address_str.into_inner();
                 } else {
                     sin6.addr = inet::IN6ADDR_ANY_INIT;
                 }

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -389,7 +389,7 @@ impl SocketAddress {
 
         // Checked pre-slice_z: that conversion absorbs one trailing NUL.
         if let Some(address_str) = &options.address {
-            if address_str.to_utf8().slice().contains(&0) {
+            if strings::contains_char(address_str.to_utf8().slice(), 0) {
                 use bun_jsc::js_global_object::SysErrOptions;
                 return Err(global.throw_sys_error(
                     &SysErrOptions {

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -385,8 +385,7 @@ impl SocketAddress {
     }
 
     pub(crate) fn init_js(global: &JSGlobalObject, options: Options) -> JsResult<SocketAddress> {
-        // `OwnedString` releases the +1 from `BunString::from_js` on every
-        // error path below; `into_inner()` transfers it to `_presentation`.
+        // OwnedString releases the from_js +1 on error paths; into_inner() transfers it.
         let mut owned_address = options.address.map(OwnedString::new);
 
         // Checked pre-slice_z: that conversion absorbs one trailing NUL.

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -387,8 +387,7 @@ impl SocketAddress {
     pub(crate) fn init_js(global: &JSGlobalObject, options: Options) -> JsResult<SocketAddress> {
         let mut presentation: BunString = BunString::empty();
 
-        // Checked on the original bytes: `to_owned_slice_z` below absorbs one
-        // trailing NUL, and `ares_inet_pton` stops at the first interior one.
+        // Checked pre-slice_z: that conversion absorbs one trailing NUL.
         if let Some(address_str) = &options.address {
             if address_str.to_utf8().slice().contains(&0) {
                 use bun_jsc::js_global_object::SysErrOptions;

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -331,8 +331,6 @@ pub(super) fn set_servername(
         .get_zig_string(global)?
         .to_owned_slice()
         .into_boxed_slice();
-    // SSL_set_tlsext_host_name reads a C string; an embedded NUL would
-    // silently truncate the SNI sent on the wire.
     if slice.contains(&0) {
         return Err(global.throw(format_args!("\"serverName\" must not contain null bytes")));
     }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -334,9 +334,7 @@ pub(super) fn set_servername(
     // SSL_set_tlsext_host_name reads a C string; an embedded NUL would
     // silently truncate the SNI sent on the wire.
     if slice.contains(&0) {
-        return Err(global.throw(format_args!(
-            "\"serverName\" must not contain null bytes"
-        )));
+        return Err(global.throw(format_args!("\"serverName\" must not contain null bytes")));
     }
     // Drop replaces the old value.
     this.server_name.set(Some(slice));

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -331,6 +331,13 @@ pub(super) fn set_servername(
         .get_zig_string(global)?
         .to_owned_slice()
         .into_boxed_slice();
+    // SSL_set_tlsext_host_name reads a C string; an embedded NUL would
+    // silently truncate the SNI sent on the wire.
+    if slice.contains(&0) {
+        return Err(global.throw(format_args!(
+            "\"serverName\" must not contain null bytes"
+        )));
+    }
     // Drop replaces the old value.
     this.server_name.set(Some(slice));
 

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -331,7 +331,7 @@ pub(super) fn set_servername(
         .get_zig_string(global)?
         .to_owned_slice()
         .into_boxed_slice();
-    if slice.contains(&0) {
+    if strings::contains_char(&slice, 0) {
         return Err(global.throw(format_args!("\"serverName\" must not contain null bytes")));
     }
     // Drop replaces the old value.

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -490,7 +490,8 @@ impl UDPSocketConfig {
             }
 
             // Coerce once; a repeated coercion could observe a different value.
-            let connect_host = bun_core::OwnedString::new(connect_host_js.to_bun_string(global_this)?);
+            let connect_host =
+                bun_core::OwnedString::new(connect_host_js.to_bun_string(global_this)?);
             if connect_host.to_utf8_without_ref().slice().contains(&0) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "\"connect.hostname\" must not contain null bytes"

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1871,12 +1871,18 @@ impl UDPSocket {
             return Err(global_this.throw_invalid_arguments(format_args!("Expected 2 arguments")));
         }
 
-        if args[0].to_slice(global_this)?.slice().contains(&0) {
-            return Err(global_this
-                .throw_invalid_arguments(format_args!("\"address\" must not contain null bytes")));
-        }
-
+        // Coerce once and validate the coerced bytes: a second coercion of a
+        // non-string argument could observe a different value than the one
+        // that was checked.
         let str = bun_core::OwnedString::new(args[0].to_bun_string(global_this)?);
+        {
+            let host_utf8 = str.to_utf8_without_ref();
+            if host_utf8.slice().contains(&0) {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "\"address\" must not contain null bytes"
+                )));
+            }
+        }
         let connect_host = str.to_owned_slice_z();
 
         let connect_port_js = args[1];

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1878,9 +1878,8 @@ impl UDPSocket {
         // `us_udp_socket_connect` takes a C string; an embedded NUL would
         // silently connect to the truncated prefix.
         if args[0].to_slice(global_this)?.slice().contains(&0) {
-            return Err(global_this.throw_invalid_arguments(format_args!(
-                "\"address\" must not contain null bytes"
-            )));
+            return Err(global_this
+                .throw_invalid_arguments(format_args!("\"address\" must not contain null bytes")));
         }
 
         let str = bun_core::OwnedString::new(args[0].to_bun_string(global_this)?);

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -394,9 +394,7 @@ impl UDPSocketConfig {
                         "Expected \"hostname\" to be a string"
                     )));
                 }
-                // Coerce once and validate the coerced bytes: `is_string`
-                // admits String objects, whose toString could return a
-                // different value on a repeated coercion.
+                // Coerce once; a repeated coercion could observe a different value.
                 let host_str = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
                 if host_str.to_utf8_without_ref().slice().contains(&0) {
                     return Err(global_this.throw_invalid_arguments(format_args!(
@@ -491,9 +489,7 @@ impl UDPSocketConfig {
                 )));
             }
 
-            // Coerce once and validate the coerced bytes: `is_string` admits
-            // String objects, whose toString could return a different value on
-            // a repeated coercion.
+            // Coerce once; a repeated coercion could observe a different value.
             let connect_host = bun_core::OwnedString::new(connect_host_js.to_bun_string(global_this)?);
             if connect_host.to_utf8_without_ref().slice().contains(&0) {
                 return Err(global_this.throw_invalid_arguments(format_args!(

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1575,6 +1575,11 @@ impl UDPSocket {
     ) -> JsResult<bool> {
         let _ = self;
         let str = bun_core::OwnedString::new(address_val.to_bun_string(global_this)?);
+        // Check the original string: the slice_z conversion below absorbs one
+        // trailing NUL, so "1.2.3.4\0" would otherwise pass as "1.2.3.4".
+        if str.to_utf8_without_ref().slice().contains(&0) {
+            return Ok(false);
+        }
         let address_slice: Vec<u8> = str.to_owned_slice_z().into_vec_with_nul();
         let bytes_len = address_slice.len() - 1; // exclude trailing NUL
 
@@ -2269,6 +2274,14 @@ pub(crate) fn js_dgram_bind_fd(global: &JSGlobalObject, frame: &CallFrame) -> Js
     {
         let fd = dgram_owned_fd_arg(global, frame.argument(0))?;
         let address = bun_core::OwnedString::new(frame.argument(1).to_bun_string(global)?);
+        // Check the original string: the slice_z conversion absorbs one
+        // trailing NUL, so "1.2.3.4\0" would otherwise pass as "1.2.3.4".
+        if address.to_utf8_without_ref().slice().contains(&0) {
+            return Err(global.throw_value(
+                bun_sys::Error::from_code_int(SystemErrno::EINVAL as c_int, bun_sys::Tag::bind2)
+                    .to_js(global),
+            ));
+        }
         let address_z = address.to_owned_slice_z();
         let port_num = frame.argument(2).coerce_to_i32(global)?;
         let port: u16 = if (0..=0xffff).contains(&port_num) {

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -394,6 +394,13 @@ impl UDPSocketConfig {
                         "Expected \"hostname\" to be a string"
                     )));
                 }
+                // The bind path hands this to C as a NUL-terminated string;
+                // an embedded NUL would silently bind the truncated prefix.
+                if value.to_slice(global_this)?.slice().contains(&0) {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "\"hostname\" must not contain null bytes"
+                    )));
+                }
                 break 'brk value.to_bun_string(global_this)?;
             } else {
                 break 'brk BunString::static_("0.0.0.0");
@@ -479,6 +486,14 @@ impl UDPSocketConfig {
             if connect_port.fract() != 0.0 || !(1.0..=65535.0).contains(&connect_port) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "Expected \"connect.port\" to be an integer between 1 and 65535"
+                )));
+            }
+
+            // `us_udp_socket_connect` takes a C string; an embedded NUL would
+            // silently connect to the truncated prefix.
+            if connect_host_js.to_slice(global_this)?.slice().contains(&0) {
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "\"connect.hostname\" must not contain null bytes"
                 )));
             }
 
@@ -1858,6 +1873,14 @@ impl UDPSocket {
 
         if call_frame.arguments_count() < 2 {
             return Err(global_this.throw_invalid_arguments(format_args!("Expected 2 arguments")));
+        }
+
+        // `us_udp_socket_connect` takes a C string; an embedded NUL would
+        // silently connect to the truncated prefix.
+        if args[0].to_slice(global_this)?.slice().contains(&0) {
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "\"address\" must not contain null bytes"
+            )));
         }
 
         let str = bun_core::OwnedString::new(args[0].to_bun_string(global_this)?);

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -394,12 +394,16 @@ impl UDPSocketConfig {
                         "Expected \"hostname\" to be a string"
                     )));
                 }
-                if value.to_slice(global_this)?.slice().contains(&0) {
+                // Coerce once and validate the coerced bytes: `is_string`
+                // admits String objects, whose toString could return a
+                // different value on a repeated coercion.
+                let host_str = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
+                if host_str.to_utf8_without_ref().slice().contains(&0) {
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "\"hostname\" must not contain null bytes"
                     )));
                 }
-                break 'brk value.to_bun_string(global_this)?;
+                break 'brk host_str.into_inner();
             } else {
                 break 'brk BunString::static_("0.0.0.0");
             }
@@ -487,17 +491,19 @@ impl UDPSocketConfig {
                 )));
             }
 
-            if connect_host_js.to_slice(global_this)?.slice().contains(&0) {
+            // Coerce once and validate the coerced bytes: `is_string` admits
+            // String objects, whose toString could return a different value on
+            // a repeated coercion.
+            let connect_host = bun_core::OwnedString::new(connect_host_js.to_bun_string(global_this)?);
+            if connect_host.to_utf8_without_ref().slice().contains(&0) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "\"connect.hostname\" must not contain null bytes"
                 )));
             }
 
-            let connect_host = connect_host_js.to_bun_string(global_this)?;
-
             config.connect = Some(ConnectConfig {
                 port: connect_port as u16,
-                address: connect_host,
+                address: connect_host.into_inner(),
             });
         }
 
@@ -1871,9 +1877,7 @@ impl UDPSocket {
             return Err(global_this.throw_invalid_arguments(format_args!("Expected 2 arguments")));
         }
 
-        // Coerce once and validate the coerced bytes: a second coercion of a
-        // non-string argument could observe a different value than the one
-        // that was checked.
+        // Coerce once; a repeated coercion could observe a different value.
         let str = bun_core::OwnedString::new(args[0].to_bun_string(global_this)?);
         {
             let host_utf8 = str.to_utf8_without_ref();

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -394,8 +394,6 @@ impl UDPSocketConfig {
                         "Expected \"hostname\" to be a string"
                     )));
                 }
-                // The bind path hands this to C as a NUL-terminated string;
-                // an embedded NUL would silently bind the truncated prefix.
                 if value.to_slice(global_this)?.slice().contains(&0) {
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "\"hostname\" must not contain null bytes"
@@ -489,8 +487,6 @@ impl UDPSocketConfig {
                 )));
             }
 
-            // `us_udp_socket_connect` takes a C string; an embedded NUL would
-            // silently connect to the truncated prefix.
             if connect_host_js.to_slice(global_this)?.slice().contains(&0) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "\"connect.hostname\" must not contain null bytes"
@@ -1875,8 +1871,6 @@ impl UDPSocket {
             return Err(global_this.throw_invalid_arguments(format_args!("Expected 2 arguments")));
         }
 
-        // `us_udp_socket_connect` takes a C string; an embedded NUL would
-        // silently connect to the truncated prefix.
         if args[0].to_slice(global_this)?.slice().contains(&0) {
             return Err(global_this
                 .throw_invalid_arguments(format_args!("\"address\" must not contain null bytes")));

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -396,7 +396,7 @@ impl UDPSocketConfig {
                 }
                 // Coerce once; a repeated coercion could observe a different value.
                 let host_str = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
-                if host_str.to_utf8_without_ref().slice().contains(&0) {
+                if bun_core::strings::contains_char(host_str.to_utf8_without_ref().slice(), 0) {
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "\"hostname\" must not contain null bytes"
                     )));
@@ -492,7 +492,7 @@ impl UDPSocketConfig {
             // Coerce once; a repeated coercion could observe a different value.
             let connect_host =
                 bun_core::OwnedString::new(connect_host_js.to_bun_string(global_this)?);
-            if connect_host.to_utf8_without_ref().slice().contains(&0) {
+            if bun_core::strings::contains_char(connect_host.to_utf8_without_ref().slice(), 0) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "\"connect.hostname\" must not contain null bytes"
                 )));
@@ -1576,7 +1576,7 @@ impl UDPSocket {
         let _ = self;
         let str = bun_core::OwnedString::new(address_val.to_bun_string(global_this)?);
         // Checked pre-slice_z: that conversion absorbs one trailing NUL.
-        if str.to_utf8_without_ref().slice().contains(&0) {
+        if bun_core::strings::contains_char(str.to_utf8_without_ref().slice(), 0) {
             return Ok(false);
         }
         let address_slice: Vec<u8> = str.to_owned_slice_z().into_vec_with_nul();
@@ -1882,7 +1882,7 @@ impl UDPSocket {
         let str = bun_core::OwnedString::new(args[0].to_bun_string(global_this)?);
         {
             let host_utf8 = str.to_utf8_without_ref();
-            if host_utf8.slice().contains(&0) {
+            if bun_core::strings::contains_char(host_utf8.slice(), 0) {
                 return Err(global_this.throw_invalid_arguments(format_args!(
                     "\"address\" must not contain null bytes"
                 )));
@@ -2274,7 +2274,7 @@ pub(crate) fn js_dgram_bind_fd(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let fd = dgram_owned_fd_arg(global, frame.argument(0))?;
         let address = bun_core::OwnedString::new(frame.argument(1).to_bun_string(global)?);
         // Checked pre-slice_z: that conversion absorbs one trailing NUL.
-        if address.to_utf8_without_ref().slice().contains(&0) {
+        if bun_core::strings::contains_char(address.to_utf8_without_ref().slice(), 0) {
             return Err(global.throw_value(
                 bun_sys::Error::from_code_int(SystemErrno::EINVAL as c_int, bun_sys::Tag::bind2)
                     .to_js(global),

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1575,8 +1575,7 @@ impl UDPSocket {
     ) -> JsResult<bool> {
         let _ = self;
         let str = bun_core::OwnedString::new(address_val.to_bun_string(global_this)?);
-        // Check the original string: the slice_z conversion below absorbs one
-        // trailing NUL, so "1.2.3.4\0" would otherwise pass as "1.2.3.4".
+        // Checked pre-slice_z: that conversion absorbs one trailing NUL.
         if str.to_utf8_without_ref().slice().contains(&0) {
             return Ok(false);
         }
@@ -2274,8 +2273,7 @@ pub(crate) fn js_dgram_bind_fd(global: &JSGlobalObject, frame: &CallFrame) -> Js
     {
         let fd = dgram_owned_fd_arg(global, frame.argument(0))?;
         let address = bun_core::OwnedString::new(frame.argument(1).to_bun_string(global)?);
-        // Check the original string: the slice_z conversion absorbs one
-        // trailing NUL, so "1.2.3.4\0" would otherwise pass as "1.2.3.4".
+        // Checked pre-slice_z: that conversion absorbs one trailing NUL.
         if address.to_utf8_without_ref().slice().contains(&0) {
             return Err(global.throw_value(
                 bun_sys::Error::from_code_int(SystemErrno::EINVAL as c_int, bun_sys::Tag::bind2)

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -73,7 +73,7 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
         let hostname_str = bun_core::OwnedString::new(arguments[0].to_bun_string(global_object)?);
         {
             let hostname_utf8 = hostname_str.to_utf8_without_ref();
-            if hostname_utf8.slice().contains(&0) {
+            if bun_core::strings::contains_char(hostname_utf8.slice(), 0) {
                 return Err(global_object.throw_invalid_arguments(format_args!(
                     "hostname must not contain null bytes"
                 )));

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -72,8 +72,6 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
     ) -> JsResult<Option<Self>> {
         let hostname_str = bun_core::OwnedString::new(arguments[0].to_bun_string(global_object)?);
         {
-            // The connect path hands the hostname to getaddrinfo as a C string;
-            // an embedded NUL would silently resolve the truncated prefix.
             let hostname_utf8 = hostname_str.to_utf8_without_ref();
             if hostname_utf8.slice().contains(&0) {
                 return Err(global_object.throw_invalid_arguments(format_args!(

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -71,6 +71,16 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
         arguments: &[JSValue],
     ) -> JsResult<Option<Self>> {
         let hostname_str = bun_core::OwnedString::new(arguments[0].to_bun_string(global_object)?);
+        {
+            // The connect path hands the hostname to getaddrinfo as a C string;
+            // an embedded NUL would silently resolve the truncated prefix.
+            let hostname_utf8 = hostname_str.to_utf8_without_ref();
+            if hostname_utf8.slice().contains(&0) {
+                return Err(global_object.throw_invalid_arguments(format_args!(
+                    "hostname must not contain null bytes"
+                )));
+            }
+        }
         let port = arguments[1].coerce::<i32>(global_object)?;
         let username_str = bun_core::OwnedString::new(arguments[2].to_bun_string(global_object)?);
         let password_str = bun_core::OwnedString::new(arguments[3].to_bun_string(global_object)?);

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -41,6 +41,12 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
 });
 
 describe("dns.prefetch", () => {
+  it("rejects a hostname containing a NUL byte", () => {
+    // The worker hands the hostname to getaddrinfo as a C string; an embedded
+    // NUL would silently resolve only the prefix.
+    expect(() => dns.prefetch("localhost\0.example.invalid", 443)).toThrow("must not contain null bytes");
+  });
+
   it("should prefetch", async () => {
     // A local server keeps the test off the external network. "localhost" is a
     // real DNS lookup, so prefetch and fetch share the same cache entry.

--- a/test/js/bun/net/nul-byte-addresses.test.ts
+++ b/test/js/bun/net/nul-byte-addresses.test.ts
@@ -1,0 +1,74 @@
+// Hostnames, IP addresses, and SNI servernames become NUL-terminated C
+// strings at the resolver/connect boundary (getaddrinfo, ares_inet_pton,
+// SSL_set_tlsext_host_name). A JS string containing an embedded NUL
+// ("127.0.0.1\0evil.example.com") would silently truncate there, so the
+// socket goes to "127.0.0.1" while JS-level allow/deny-list checks see the
+// full string. Every entry point must reject instead.
+//
+// Unix socket paths have the same defect; that surface is fixed separately
+// with an EINVAL at the usockets layer.
+//
+// These tests are hermetic (no external DNS, no internet): after the fix each
+// rejection is pure input validation that fires before any I/O.
+import { connect } from "bun";
+import { describe, expect, it } from "bun:test";
+import dns from "node:dns";
+
+describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => {
+  it("dns.promises.lookupService rejects an address containing a NUL", async () => {
+    // "127.0.0.1\0..." must not be treated as "127.0.0.1" (node throws
+    // ERR_INVALID_ARG_VALUE for any address that is not an IP literal).
+    let err: any;
+    try {
+      await dns.promises.lookupService("127.0.0.1\0.example.invalid", 80);
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
+  });
+
+  it("dns.lookupService (callback) rejects an address containing a NUL", () => {
+    expect(() => dns.lookupService("127.0.0.1\0.example.invalid", 80, () => {})).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    );
+  });
+
+  it("dns.promises.reverse rejects an IP containing a NUL", async () => {
+    // Must fail like any other unparseable IP (dns.reverse("zzz") -> ENOTIMP),
+    // not PTR-query the "8.8.8.8" prefix.
+    let err: any;
+    try {
+      await dns.promises.reverse("8.8.8.8\0.example.invalid");
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("ENOTIMP");
+  });
+
+  it("resolver.setLocalAddress rejects an IP containing a NUL", () => {
+    const resolver = new dns.Resolver();
+    expect(() => resolver.setLocalAddress("127.0.0.1\0.example.invalid")).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
+    );
+  });
+
+  it("Bun.connect({ tls: { serverName } }) rejects a serverName containing a NUL byte", async () => {
+    // The serverName becomes the C string handed to SSL_set_tlsext_host_name,
+    // so "good.example\0evil" would silently send "good.example" on the wire.
+    // Reserved port 1: nothing listens there in CI, and the check must refuse
+    // before any connection attempt anyway.
+    let err: any;
+    try {
+      const socket = await connect({
+        hostname: "127.0.0.1",
+        port: 1,
+        tls: { serverName: "localhost\0.example.invalid", rejectUnauthorized: false },
+        socket: { data() {} },
+      });
+      socket.end();
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toContain("must not contain null bytes");
+  });
+});

--- a/test/js/bun/net/nul-byte-addresses.test.ts
+++ b/test/js/bun/net/nul-byte-addresses.test.ts
@@ -56,9 +56,7 @@ describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => 
   it("resolver.setServers rejects an IP containing a NUL", () => {
     const resolver = new dns.Resolver();
     for (const address of ["8.8.8.8\0.example.invalid", "8.8.8.8\0"]) {
-      expect(() => resolver.setServers([address])).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
-      );
+      expect(() => resolver.setServers([address])).toThrow(expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }));
     }
   });
 

--- a/test/js/bun/net/nul-byte-addresses.test.ts
+++ b/test/js/bun/net/nul-byte-addresses.test.ts
@@ -14,6 +14,7 @@ import { connect } from "bun";
 import { describe, expect, it } from "bun:test";
 import { tls as certs } from "harness";
 import dns from "node:dns";
+import net from "node:net";
 
 describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => {
   it("dns.promises.lookupService rejects an address containing a NUL", async () => {
@@ -60,6 +61,32 @@ describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => 
     for (const address of ["8.8.8.8\0.example.invalid", "8.8.8.8\0"]) {
       expect(() => resolver.setServers([address])).toThrow(expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }));
     }
+  });
+
+  it.each([
+    ["127.0.0.1\0evil.example.invalid", "ipv4"],
+    ["127.0.0.1\0", "ipv4"],
+    ["::1\0evil.example.invalid", "ipv6"],
+  ] as const)("new net.SocketAddress rejects address %j", (address, family) => {
+    // init_js hands the address to ares_inet_pton as a C string; without the
+    // check it parses the pre-NUL prefix while .address reports the full string.
+    expect(() => new net.SocketAddress({ address, family })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
+    );
+  });
+
+  it("BlockList rejects addresses containing a NUL", () => {
+    // Without the check, addAddress("127.0.0.1\0evil") registers an entry
+    // that matches 127.0.0.1.
+    const blockList = new net.BlockList();
+    expect(() => blockList.addAddress("127.0.0.1\0evil.example.invalid", "ipv4")).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
+    );
+    // check() swallows parse errors like any other invalid input.
+    expect({
+      nul: blockList.check("127.0.0.1\0evil.example.invalid", "ipv4"),
+      truncated: blockList.check("127.0.0.1", "ipv4"),
+    }).toEqual({ nul: false, truncated: false });
   });
 
   it("Bun.connect({ tls: { serverName } }) rejects a serverName containing a NUL byte", async () => {

--- a/test/js/bun/net/nul-byte-addresses.test.ts
+++ b/test/js/bun/net/nul-byte-addresses.test.ts
@@ -12,6 +12,7 @@
 // rejection is pure input validation that fires before any I/O.
 import { connect } from "bun";
 import { describe, expect, it } from "bun:test";
+import { tls as certs } from "harness";
 import dns from "node:dns";
 
 describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => {
@@ -52,23 +53,37 @@ describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => 
     );
   });
 
+  it("resolver.setServers rejects an IP containing a NUL", () => {
+    const resolver = new dns.Resolver();
+    expect(() => resolver.setServers(["8.8.8.8\0.example.invalid"])).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
+    );
+  });
+
   it("Bun.connect({ tls: { serverName } }) rejects a serverName containing a NUL byte", async () => {
     // The serverName becomes the C string handed to SSL_set_tlsext_host_name,
     // so "good.example\0evil" would silently send "good.example" on the wire.
-    // Reserved port 1: nothing listens there in CI, and the check must refuse
-    // before any connection attempt anyway.
+    // A real local TLS server: without the check, the handshake COMPLETES with
+    // the truncated SNI, so a successful connect fails the assertion below.
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: certs,
+      socket: { data() {} },
+    });
     let err: any;
+    let socket: Awaited<ReturnType<typeof connect>> | undefined;
     try {
-      const socket = await connect({
+      socket = await connect({
         hostname: "127.0.0.1",
-        port: 1,
+        port: listener.port,
         tls: { serverName: "localhost\0.example.invalid", rejectUnauthorized: false },
         socket: { data() {} },
       });
-      socket.end();
     } catch (e) {
       err = e;
     }
+    socket?.end();
     expect(err?.message).toContain("must not contain null bytes");
   });
 });

--- a/test/js/bun/net/nul-byte-addresses.test.ts
+++ b/test/js/bun/net/nul-byte-addresses.test.ts
@@ -55,9 +55,11 @@ describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => 
 
   it("resolver.setServers rejects an IP containing a NUL", () => {
     const resolver = new dns.Resolver();
-    expect(() => resolver.setServers(["8.8.8.8\0.example.invalid"])).toThrow(
-      expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
-    );
+    for (const address of ["8.8.8.8\0.example.invalid", "8.8.8.8\0"]) {
+      expect(() => resolver.setServers([address])).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }),
+      );
+    }
   });
 
   it("Bun.connect({ tls: { serverName } }) rejects a serverName containing a NUL byte", async () => {

--- a/test/js/bun/net/nul-byte-addresses.test.ts
+++ b/test/js/bun/net/nul-byte-addresses.test.ts
@@ -54,6 +54,8 @@ describe.concurrent("NUL bytes in addresses are rejected, not truncated", () => 
   });
 
   it("resolver.setServers rejects an IP containing a NUL", () => {
+    // Contract test: this rejection comes from the JS layer's pre-existing
+    // isIP validation; the native guard behind it is unreachable depth.
     const resolver = new dns.Resolver();
     for (const address of ["8.8.8.8\0.example.invalid", "8.8.8.8\0"]) {
       expect(() => resolver.setServers([address])).toThrow(expect.objectContaining({ code: "ERR_INVALID_IP_ADDRESS" }));

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -926,3 +926,31 @@ test("a worker exiting from its first 'message' of a batch does not crash", asyn
     worker.terminate();
   }
 });
+
+describe("custom lookup results containing NUL bytes", () => {
+  // dgram's default lookup (dns.lookup) already rejects NUL hostnames, but a
+  // custom lookup can hand connect() an arbitrary string, which flows straight
+  // to the native connect. The native guard must reject it rather than let the
+  // C string truncate at the NUL.
+  test.concurrent.each(["127.0.0.1\0.example.invalid", "127.0.0.1\0"])(
+    "connect() rejects a lookup result of %j",
+    async address => {
+      const socket = createSocket({
+        type: "udp4",
+        // The implicit bind resolves through this lookup too; give it a clean
+        // address so the connect path's native guard is the one exercised.
+        lookup: (hostname, _options, callback) =>
+          (callback as any)(null, hostname === "placeholder.example.invalid" ? address : "127.0.0.1", 4),
+      });
+      const err: any = await new Promise(resolve => {
+        try {
+          socket.connect(53, "placeholder.example.invalid", (e?: Error) => resolve(e));
+        } catch (e) {
+          resolve(e);
+        }
+      });
+      socket.close();
+      expect(err?.message).toContain("must not contain null bytes");
+    },
+  );
+});

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -688,3 +688,18 @@ test.concurrent("bind hostname is coerced exactly once", async () => {
   socket.close();
   expect({ calls, bound }).toEqual({ calls: 1, bound: "127.0.0.1" });
 });
+
+test.concurrent("send() rejects an address containing a NUL byte", async () => {
+  // parse_addr feeds ip_address::to_ip_address, whose C parser reads to the
+  // first NUL: "127.0.0.1\0evil" must not send to 127.0.0.1.
+  const receiver = await udpSocket({ socket: { data() {} } });
+  const sender = await udpSocket({});
+  try {
+    for (const address of ["127.0.0.1\0evil.example.invalid", "127.0.0.1\0"]) {
+      expect(() => sender.send("x", receiver.port, address)).toThrow("Invalid address");
+    }
+  } finally {
+    sender.close();
+    receiver.close();
+  }
+});

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -645,28 +645,33 @@ test("sendMany() sends every packet of a larger-than-one-batch call", async () =
 });
 
 describe("hostnames containing NUL bytes", () => {
-  // Bind/connect hostnames become C strings; an embedded NUL would silently
-  // bind or connect to the truncated prefix ("127.0.0.1\0evil" -> 127.0.0.1)
-  // while JS-level checks see the full string.
-  test.concurrent("bind hostname is rejected", async () => {
+  // Bind/connect hostnames become C strings; a NUL would silently bind or
+  // connect to the truncated prefix ("127.0.0.1\0evil" -> 127.0.0.1) while
+  // JS-level checks see the full string. A trailing NUL is the same bypass:
+  // "127.0.0.1\0" !== "127.0.0.1" in JS but reaches C as "127.0.0.1".
+  const hostnames = ["127.0.0.1\0.example.invalid", "127.0.0.1\0"];
+
+  test.concurrent.each(hostnames)("bind hostname %j is rejected", async hostname => {
     let err;
+    let socket;
     try {
-      const socket = await udpSocket({ hostname: "127.0.0.1\0.example.invalid", port: 0 });
-      socket.close();
+      socket = await udpSocket({ hostname, port: 0 });
     } catch (e) {
       err = e;
     }
+    socket?.close();
     expect(err?.message).toContain("must not contain null bytes");
   });
 
-  test.concurrent("connect hostname is rejected", async () => {
+  test.concurrent.each(hostnames)("connect hostname %j is rejected", async hostname => {
     let err;
+    let socket;
     try {
-      const socket = await udpSocket({ connect: { hostname: "127.0.0.1\0.example.invalid", port: 53 } });
-      socket.close();
+      socket = await udpSocket({ connect: { hostname, port: 53 } });
     } catch (e) {
       err = e;
     }
+    socket?.close();
     expect(err?.message).toContain("must not contain null bytes");
   });
 });

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -693,13 +693,14 @@ test.concurrent("send() rejects an address containing a NUL byte", async () => {
   // parse_addr feeds ip_address::to_ip_address, whose C parser reads to the
   // first NUL: "127.0.0.1\0evil" must not send to 127.0.0.1.
   const receiver = await udpSocket({ socket: { data() {} } });
-  const sender = await udpSocket({});
+  let sender;
   try {
+    sender = await udpSocket({});
     for (const address of ["127.0.0.1\0evil.example.invalid", "127.0.0.1\0"]) {
       expect(() => sender.send("x", receiver.port, address)).toThrow("Invalid address");
     }
   } finally {
-    sender.close();
+    sender?.close();
     receiver.close();
   }
 });

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -675,3 +675,16 @@ describe("hostnames containing NUL bytes", () => {
     expect(err?.message).toContain("must not contain null bytes");
   });
 });
+
+test.concurrent("bind hostname is coerced exactly once", async () => {
+  // `is_string` admits String objects; a stateful toString must not be able to
+  // show the validator a clean value and hand the bind a different one.
+  let calls = 0;
+  const host = new String("placeholder");
+  // @ts-expect-error deliberate override
+  host.toString = () => (++calls === 1 ? "127.0.0.1" : "127.0.0.1\0evil.example.invalid");
+  const socket = await udpSocket({ hostname: host as any, port: 0 });
+  const bound = socket.hostname;
+  socket.close();
+  expect({ calls, bound }).toEqual({ calls: 1, bound: "127.0.0.1" });
+});

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -643,3 +643,30 @@ test("sendMany() sends every packet of a larger-than-one-batch call", async () =
     server.close();
   }
 });
+
+describe("hostnames containing NUL bytes", () => {
+  // Bind/connect hostnames become C strings; an embedded NUL would silently
+  // bind or connect to the truncated prefix ("127.0.0.1\0evil" -> 127.0.0.1)
+  // while JS-level checks see the full string.
+  test.concurrent("bind hostname is rejected", async () => {
+    let err;
+    try {
+      const socket = await udpSocket({ hostname: "127.0.0.1\0.example.invalid", port: 0 });
+      socket.close();
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toContain("must not contain null bytes");
+  });
+
+  test.concurrent("connect hostname is rejected", async () => {
+    let err;
+    try {
+      const socket = await udpSocket({ connect: { hostname: "127.0.0.1\0.example.invalid", port: 53 } });
+      socket.close();
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toContain("must not contain null bytes");
+  });
+});

--- a/test/js/node/quic/quic-sni.test.ts
+++ b/test/js/node/quic/quic-sni.test.ts
@@ -141,3 +141,25 @@ test("opened reports the X509 code name for validationErrorCode", async () => {
     reason: "unable to get local issuer certificate",
   });
 });
+
+test("connect() rejects a servername containing a NUL byte", async () => {
+  // The servername becomes the C string handed to lsquic, so
+  // "agent2.example\0evil" would silently send "agent2.example" on the wire
+  // (and be served that certificate) while JS-level checks see the full string.
+  await using server = await listen(ignoreErrors, { sni: { "*": identity1 }, alpn: ["quic-test"] });
+
+  let err: any;
+  try {
+    const session = await connect(server.address, {
+      alpn: "quic-test",
+      servername: "agent2.example\0evil.example.invalid",
+      verifyPeer: "manual",
+    });
+    ignoreErrors(session);
+    await session.opened;
+    await session.close();
+  } catch (e) {
+    err = e;
+  }
+  expect(err?.message).toContain("must not contain null bytes");
+});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1325,9 +1325,7 @@ describe("servernames containing NUL bytes", () => {
     const server = tls.createServer(COMMON_CERT_);
     await once(server.listen(0, "127.0.0.1"), "listening");
     try {
-      expect(() => server.addContext("a.example.invalid\0evil", COMMON_CERT_)).toThrow(
-        "must not contain null bytes",
-      );
+      expect(() => server.addContext("a.example.invalid\0evil", COMMON_CERT_)).toThrow("must not contain null bytes");
     } finally {
       server.close();
     }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1292,3 +1292,44 @@ describe("throwing 'secureConnect' listener", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("servernames containing NUL bytes", () => {
+  // The SNI servername becomes the C string handed to
+  // SSL_set_tlsext_host_name, so "good.example\0evil" would silently send
+  // "good.example" on the wire while JS-level checks see the full string.
+  it("tls.connect rejects a servername containing a NUL byte", async () => {
+    // Reserved port 1: nothing listens there in CI, and the servername check
+    // must refuse before any connection is attempted anyway.
+    let err: any;
+    try {
+      const socket = tls.connect({
+        host: "127.0.0.1",
+        port: 1,
+        servername: "localhost\0.example.invalid",
+        rejectUnauthorized: false,
+      });
+      err = await new Promise((resolve, reject) => {
+        socket.on("error", resolve);
+        socket.on("secureConnect", () => reject(new Error("handshake completed")));
+      });
+      socket.destroy();
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.message).toContain("must not contain null bytes");
+  });
+
+  it("server.addContext rejects a hostname pattern containing a NUL byte", async () => {
+    // The SNI tree registers the C string, so "a.example\0evil" would
+    // register a certificate under "a.example".
+    const server = tls.createServer(COMMON_CERT_);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      expect(() => server.addContext("a.example.invalid\0evil", COMMON_CERT_)).toThrow(
+        "must not contain null bytes",
+      );
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1297,31 +1297,36 @@ describe("servernames containing NUL bytes", () => {
   // The SNI servername becomes the C string handed to
   // SSL_set_tlsext_host_name, so "good.example\0evil" would silently send
   // "good.example" on the wire while JS-level checks see the full string.
-  it("tls.connect rejects a servername containing a NUL byte", async () => {
-    // A real local TLS server: without the check, the handshake COMPLETES with
-    // the truncated SNI, which the sentinel below turns into a failure.
-    const server = tls.createServer(COMMON_CERT_);
-    await once(server.listen(0, "127.0.0.1"), "listening");
-    let err: any;
-    try {
-      const socket = tls.connect({
-        host: "127.0.0.1",
-        port: (server.address() as AddressInfo).port,
-        servername: "localhost\0.example.invalid",
-        rejectUnauthorized: false,
-      });
-      err = await new Promise((resolve, reject) => {
-        socket.on("error", resolve);
-        socket.on("secureConnect", () => reject(new Error("handshake completed with a truncated SNI")));
-      });
-      socket.destroy();
-    } catch (e) {
-      err = e;
-    } finally {
-      server.close();
-    }
-    expect(err?.message).toContain("must not contain null bytes");
-  });
+  it.each(["localhost\0.example.invalid", "localhost\0"])(
+    "tls.connect rejects servername %j",
+    async servername => {
+      // A real local TLS server: without the check, the handshake COMPLETES
+      // with the truncated SNI, which the sentinel below turns into a failure.
+      const server = tls.createServer(COMMON_CERT_);
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      let err: any;
+      let socket: ReturnType<typeof tls.connect> | undefined;
+      try {
+        socket = tls.connect({
+          host: "127.0.0.1",
+          port: (server.address() as AddressInfo).port,
+          servername,
+          rejectUnauthorized: false,
+        });
+        const client = socket;
+        err = await new Promise((resolve, reject) => {
+          client.on("error", resolve);
+          client.on("secureConnect", () => reject(new Error("handshake completed with a truncated SNI")));
+        });
+      } catch (e) {
+        err = e;
+      } finally {
+        socket?.destroy();
+        server.close();
+      }
+      expect(err?.message).toContain("must not contain null bytes");
+    },
+  );
 
   it("socket.setServername rejects a servername containing a NUL byte", async () => {
     // A plain server that never responds keeps the handshake pending, so the
@@ -1337,9 +1342,9 @@ describe("servernames containing NUL bytes", () => {
     socket.on("error", () => {});
     try {
       await once(socket, "connect");
-      expect(() => socket.setServername("localhost\0.example.invalid")).toThrow(
-        '"serverName" must not contain null bytes',
-      );
+      for (const servername of ["localhost\0.example.invalid", "localhost\0"]) {
+        expect(() => socket.setServername(servername)).toThrow('"serverName" must not contain null bytes');
+      }
     } finally {
       socket.destroy();
       server.close();

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1337,7 +1337,9 @@ describe("servernames containing NUL bytes", () => {
     socket.on("error", () => {});
     try {
       await once(socket, "connect");
-      expect(() => socket.setServername("localhost\0.example.invalid")).toThrow("must not contain null bytes");
+      expect(() => socket.setServername("localhost\0.example.invalid")).toThrow(
+        '"serverName" must not contain null bytes',
+      );
     } finally {
       socket.destroy();
       server.close();

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1298,25 +1298,50 @@ describe("servernames containing NUL bytes", () => {
   // SSL_set_tlsext_host_name, so "good.example\0evil" would silently send
   // "good.example" on the wire while JS-level checks see the full string.
   it("tls.connect rejects a servername containing a NUL byte", async () => {
-    // Reserved port 1: nothing listens there in CI, and the servername check
-    // must refuse before any connection is attempted anyway.
+    // A real local TLS server: without the check, the handshake COMPLETES with
+    // the truncated SNI, which the sentinel below turns into a failure.
+    const server = tls.createServer(COMMON_CERT_);
+    await once(server.listen(0, "127.0.0.1"), "listening");
     let err: any;
     try {
       const socket = tls.connect({
         host: "127.0.0.1",
-        port: 1,
+        port: (server.address() as AddressInfo).port,
         servername: "localhost\0.example.invalid",
         rejectUnauthorized: false,
       });
       err = await new Promise((resolve, reject) => {
         socket.on("error", resolve);
-        socket.on("secureConnect", () => reject(new Error("handshake completed")));
+        socket.on("secureConnect", () => reject(new Error("handshake completed with a truncated SNI")));
       });
       socket.destroy();
     } catch (e) {
       err = e;
+    } finally {
+      server.close();
     }
     expect(err?.message).toContain("must not contain null bytes");
+  });
+
+  it("socket.setServername rejects a servername containing a NUL byte", async () => {
+    // A plain server that never responds keeps the handshake pending, so the
+    // native setServername path is reachable without racing secureConnect.
+    const server = net.createServer(s => s.on("error", () => {}));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const socket = tls.connect({
+      host: "127.0.0.1",
+      port: (server.address() as AddressInfo).port,
+      servername: "initial.example.invalid",
+      rejectUnauthorized: false,
+    });
+    socket.on("error", () => {});
+    try {
+      await once(socket, "connect");
+      expect(() => socket.setServername("localhost\0.example.invalid")).toThrow("must not contain null bytes");
+    } finally {
+      socket.destroy();
+      server.close();
+    }
   });
 
   it("server.addContext rejects a hostname pattern containing a NUL byte", async () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1297,36 +1297,33 @@ describe("servernames containing NUL bytes", () => {
   // The SNI servername becomes the C string handed to
   // SSL_set_tlsext_host_name, so "good.example\0evil" would silently send
   // "good.example" on the wire while JS-level checks see the full string.
-  it.each(["localhost\0.example.invalid", "localhost\0"])(
-    "tls.connect rejects servername %j",
-    async servername => {
-      // A real local TLS server: without the check, the handshake COMPLETES
-      // with the truncated SNI, which the sentinel below turns into a failure.
-      const server = tls.createServer(COMMON_CERT_);
-      await once(server.listen(0, "127.0.0.1"), "listening");
-      let err: any;
-      let socket: ReturnType<typeof tls.connect> | undefined;
-      try {
-        socket = tls.connect({
-          host: "127.0.0.1",
-          port: (server.address() as AddressInfo).port,
-          servername,
-          rejectUnauthorized: false,
-        });
-        const client = socket;
-        err = await new Promise((resolve, reject) => {
-          client.on("error", resolve);
-          client.on("secureConnect", () => reject(new Error("handshake completed with a truncated SNI")));
-        });
-      } catch (e) {
-        err = e;
-      } finally {
-        socket?.destroy();
-        server.close();
-      }
-      expect(err?.message).toContain("must not contain null bytes");
-    },
-  );
+  it.each(["localhost\0.example.invalid", "localhost\0"])("tls.connect rejects servername %j", async servername => {
+    // A real local TLS server: without the check, the handshake COMPLETES
+    // with the truncated SNI, which the sentinel below turns into a failure.
+    const server = tls.createServer(COMMON_CERT_);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    let err: any;
+    let socket: ReturnType<typeof tls.connect> | undefined;
+    try {
+      socket = tls.connect({
+        host: "127.0.0.1",
+        port: (server.address() as AddressInfo).port,
+        servername,
+        rejectUnauthorized: false,
+      });
+      const client = socket;
+      err = await new Promise((resolve, reject) => {
+        client.on("error", resolve);
+        client.on("secureConnect", () => reject(new Error("handshake completed with a truncated SNI")));
+      });
+    } catch (e) {
+      err = e;
+    } finally {
+      socket?.destroy();
+      server.close();
+    }
+    expect(err?.message).toContain("must not contain null bytes");
+  });
 
   it("socket.setServername rejects a servername containing a NUL byte", async () => {
     // A plain server that never responds keeps the handshake pending, so the

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12685,6 +12685,22 @@ describe("shared createInstance validation (no server)", () => {
     },
   );
 
+  test.concurrent.each(["postgres", "mysql"] as const)(
+    "%s: rejects hostname containing null bytes",
+    async adapter => {
+      // The hostname becomes the C string handed to getaddrinfo, so
+      // "127.0.0.1\0evil" would silently connect to 127.0.0.1 while JS-level
+      // checks (allow/deny lists) see the full string.
+      await using sql = new SQL({ ...base, adapter, hostname: "127.0.0.1\0evil.example.invalid", username: "u" });
+      const err: any = await sql`select 1`.then(
+        () => null,
+        e => e,
+      );
+      expect(err?.message).toBe("hostname must not contain null bytes");
+      expect(err?.code).toBe("ERR_INVALID_ARG_TYPE");
+    },
+  );
+
   test.concurrent("SSL_CTX creation failure throws the structured BoringSSL error", async () => {
     // An unparseable CA makes `SSL_CTX` creation fail synchronously inside
     // createInstance, before any socket exists. The failure carries

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12688,14 +12688,18 @@ describe("shared createInstance validation (no server)", () => {
   test.concurrent.each(["postgres", "mysql"] as const)("%s: rejects hostname containing null bytes", async adapter => {
     // The hostname becomes the C string handed to getaddrinfo, so
     // "127.0.0.1\0evil" would silently connect to 127.0.0.1 while JS-level
-    // checks (allow/deny lists) see the full string.
-    await using sql = new SQL({ ...base, adapter, hostname: "127.0.0.1\0evil.example.invalid", username: "u" });
-    const err: any = await sql`select 1`.then(
-      () => null,
-      e => e,
-    );
-    expect(err?.message).toBe("hostname must not contain null bytes");
-    expect(err?.code).toBe("ERR_INVALID_ARG_TYPE");
+    // checks (allow/deny lists) see the full string. A trailing NUL is the
+    // same bypass: "127.0.0.1\0" !== "127.0.0.1" in JS but reaches C as
+    // "127.0.0.1".
+    for (const hostname of ["127.0.0.1\0evil.example.invalid", "127.0.0.1\0"]) {
+      await using sql = new SQL({ ...base, adapter, hostname, username: "u" });
+      const err: any = await sql`select 1`.then(
+        () => null,
+        e => e,
+      );
+      expect(err?.message).toBe("hostname must not contain null bytes");
+      expect(err?.code).toBe("ERR_INVALID_ARG_TYPE");
+    }
   });
 
   test.concurrent("SSL_CTX creation failure throws the structured BoringSSL error", async () => {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12685,21 +12685,18 @@ describe("shared createInstance validation (no server)", () => {
     },
   );
 
-  test.concurrent.each(["postgres", "mysql"] as const)(
-    "%s: rejects hostname containing null bytes",
-    async adapter => {
-      // The hostname becomes the C string handed to getaddrinfo, so
-      // "127.0.0.1\0evil" would silently connect to 127.0.0.1 while JS-level
-      // checks (allow/deny lists) see the full string.
-      await using sql = new SQL({ ...base, adapter, hostname: "127.0.0.1\0evil.example.invalid", username: "u" });
-      const err: any = await sql`select 1`.then(
-        () => null,
-        e => e,
-      );
-      expect(err?.message).toBe("hostname must not contain null bytes");
-      expect(err?.code).toBe("ERR_INVALID_ARG_TYPE");
-    },
-  );
+  test.concurrent.each(["postgres", "mysql"] as const)("%s: rejects hostname containing null bytes", async adapter => {
+    // The hostname becomes the C string handed to getaddrinfo, so
+    // "127.0.0.1\0evil" would silently connect to 127.0.0.1 while JS-level
+    // checks (allow/deny lists) see the full string.
+    await using sql = new SQL({ ...base, adapter, hostname: "127.0.0.1\0evil.example.invalid", username: "u" });
+    const err: any = await sql`select 1`.then(
+      () => null,
+      e => e,
+    );
+    expect(err?.message).toBe("hostname must not contain null bytes");
+    expect(err?.code).toBe("ERR_INVALID_ARG_TYPE");
+  });
 
   test.concurrent("SSL_CTX creation failure throws the structured BoringSSL error", async () => {
     // An unparseable CA makes `SSL_CTX` creation fail synchronously inside


### PR DESCRIPTION
## Repro

```js
// bun 1.4.0: resolves as if the address were "127.0.0.1" (returns "localhost")
require("dns").lookupService("127.0.0.1\0evil.example.com", 80, console.log);

// bun 1.4.0: connects to 127.0.0.1:4444
await Bun.udpSocket({ connect: { hostname: "127.0.0.1\0evil.example.com", port: 4444 } });

// bun 1.4.0: the ClientHello carries SNI "good.example.com"; the bytes after
// the NUL are silently dropped on the wire (verified with an SNICallback server)
tls.connect({ host, port, servername: "good.example.com\0evil.example.com" });
```

A JS string can contain U+0000, but hostnames, IP address strings, and SNI servernames become NUL-terminated C strings at the resolver/connect boundary (getaddrinfo, ares_inet_pton, SSL_set_tlsext_host_name, lsquic). Everything after the first NUL was silently dropped, so the socket went to the truncated prefix while JS-level allow/deny-list checks saw the full string, the classic NUL-byte validation bypass (same class as Node's hostname NUL handling advisories).

`dns.lookup`, `net.connect(host)`, `Bun.connect({hostname})`, `fetch` URL hosts, and `dgram` hostnames already reject embedded NULs (#31417 established the policy: slightly stricter than Node, never affects a valid name). This applies the same policy to the entry points that still truncated.

## Cause

Each site converted the JS string with a NUL-appending helper (`ZBox::from_bytes`, `to_owned_slice_z`, `copy_nul_terminated`) and handed the pointer to a C API with no interior-NUL check. `Listener::add_server_name` even documented the truncation as tolerated.

## Fix

Reject with the existing invalid-input error for each API instead of truncating:

- c-ares: `get_sockaddr` (dns.lookupService, now ERR_INVALID_ARG_VALUE like Node), `get_host_by_addr` (dns.reverse, same ENOTIMP as any unparseable IP), `get_addr_info` (the guard `resolve` already had)
- dns: `Bun.dns.prefetch`, `resolver.setLocalAddress` (ERR_INVALID_IP_ADDRESS)
- udp: `Bun.udpSocket` bind and connect hostnames, `UDPSocket.jsConnect` (reachable via a user-supplied dgram `lookup`), and the send/sendMany/multicast address parse via `bun_core::ip_address`
- net: `net.SocketAddress` construction and `net.BlockList` addresses (without the check, an entry added as "127.0.0.1\0evil" matches 127.0.0.1)
- tls: `SSLConfig.serverName` (covers `Bun.connect`/`Bun.serve`/`tls.connect`/`fetch` tls options), `socket.setServername`, and server-side SNI registration (`tls` server `addContext`)
- sql: postgres/mysql connection hostname (joins the existing username/password/database NUL checks)
- quic: `connect({ servername })`

All checks run on the pre-conversion JS string bytes, so a trailing NUL ("evil.com\0", which defeats exact-match denylists the same way) is caught too.

Not in this PR: unix socket paths (#37002 fixes that surface at the usockets layer, including `Bun.serve({unix})` and node:net pipe semantics) and the `Bun.serve({hostname})` bind path (#32318).

Two of the native guards are defense-in-depth with no direct test coverage, because the public API rejects the input one layer earlier: the c-ares `get_addr_info` guard (dns.lookup pre-checks the name) and the `setServers` triple guard (the JS layer's isIP validation rejects first; the setServers test locks that user-visible contract).

## Verification

New tests fail on the unfixed build and pass with this change:

- `test/js/bun/net/nul-byte-addresses.test.ts` (lookupService, reverse, setLocalAddress, Bun.connect serverName; hermetic, no external DNS)
- `test/js/bun/udp/udp_socket.test.ts` (bind and connect hostnames)
- `test/js/node/tls/node-tls-connect.test.ts` (tls.connect servername, server.addContext)
- `test/js/node/quic/quic-sni.test.ts` (connect servername; on the unfixed build the session opens and is served the truncated name's certificate)
- `test/js/sql/sql.test.ts` (postgres and mysql hostname)
- `test/js/bun/dns/dns-prefetch.test.ts` (prefetch)

Re-ran the SNI observation against a local TLS server with an SNICallback: before, the server saw `"good.example.com"` for a client servername of `"good.example.com\0evil.example.com"`; after, both `tls.connect` and `Bun.connect` throw `"serverName" must not contain null bytes` and no connection is attempted. The Linux abstract-namespace socket test suite (`fetch.unix.test.ts`) passes unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/dgram.test.ts test/js/bun/udp/udp_socket.test.ts

<!-- robobun:evidence:end -->
