### PR TITLE
node:crypto: fix Certificate spkac validation for KeyObject input

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -103,28 +103,13 @@ var Buffer = globalThis.Buffer;
 const { isAnyArrayBuffer, isArrayBufferView } = require("node:util/types");
 
 function getArrayBufferOrView(buffer, name, encoding?) {
-  if (buffer instanceof KeyObject) {
-    if (buffer.type !== "secret") {
-      const error = new TypeError(
-        `ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE: Invalid key object type ${key.type}, expected secret`,
-      );
-      error.code = "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE";
-      throw error;
-    }
-    buffer = buffer.export();
-  }
   if (isAnyArrayBuffer(buffer)) return buffer;
   if (typeof buffer === "string") {
     if (encoding === "buffer") encoding = "utf8";
     return Buffer.from(buffer, encoding);
   }
   if (!isArrayBufferView(buffer)) {
-    var error = new TypeError(
-      `ERR_INVALID_ARG_TYPE: The "${name}" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received ` +
-        buffer,
-    );
-    error.code = "ERR_INVALID_ARG_TYPE";
-    throw error;
+    throw $ERR_INVALID_ARG_TYPE(name, ["string", "ArrayBuffer", "Buffer", "TypedArray", "DataView"], buffer);
   }
   return buffer;
 }

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1182,3 +1182,44 @@ describe("KeyObject raw-public / raw-private / raw-seed formats", () => {
     expect(pt.toString()).toBe("hello");
   });
 });
+
+// Certificate.{verifySpkac,exportPublicKey,exportChallenge} share getArrayBufferOrView,
+// which previously threw "ReferenceError: key is not defined" for public/private
+// KeyObjects and silently accepted secret ones. Node rejects every KeyObject here.
+describe("Certificate spkac argument validation", () => {
+  const argTypeMessage =
+    'The "spkac" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView.';
+  const keys = () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    return [publicKey, privateKey, crypto.createSecretKey(Buffer.from("secret"))];
+  };
+
+  for (const fn of ["verifySpkac", "exportPublicKey", "exportChallenge"]) {
+    it(`Certificate.${fn} rejects KeyObject input with ERR_INVALID_ARG_TYPE`, () => {
+      for (const key of keys()) {
+        expect(() => crypto.Certificate[fn](key)).toThrow(
+          expect.objectContaining({
+            name: "TypeError",
+            code: "ERR_INVALID_ARG_TYPE",
+            message: expect.stringContaining(argTypeMessage),
+          }),
+        );
+      }
+    });
+  }
+
+  it("Certificate.verifySpkac rejects non-buffer input with node's message", () => {
+    expect(() => crypto.Certificate.verifySpkac(42)).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `${argTypeMessage} Received type number (42)`,
+      }),
+    );
+  });
+
+  it("Certificate.verifySpkac still returns false for a well-typed but invalid spkac", () => {
+    expect(crypto.Certificate.verifySpkac(Buffer.from("not a spkac"))).toBe(false);
+    expect(new crypto.Certificate().verifySpkac("not a spkac", "utf8")).toBe(false);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes `node:crypto`'s `getArrayBufferOrView` helper (used by `Certificate.verifySpkac`, `Certificate.exportPublicKey`, and `Certificate.exportChallenge`), which threw `ReferenceError: key is not defined` when given a public or private `KeyObject`:

```js
const crypto = require("node:crypto");
const { publicKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
crypto.Certificate.verifySpkac(publicKey);
// before: ReferenceError: key is not defined
// after:  TypeError [ERR_INVALID_ARG_TYPE]: The "spkac" argument must be of type string
//         or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received an instance of KeyObject
```

The helper had a `KeyObject` branch whose error message interpolated `key.type`, but the parameter is named `buffer`; `key` does not exist in that scope. The branch appears to have been copied from Node's `prepareSecretKey` (where the parameter is named `key`) without renaming.

### Why remove the branch instead of fixing the variable name?

Node's `getArrayBufferOrView` in `lib/internal/crypto/util.js` has no `KeyObject` handling at all (checked v16.20.2, v18.19.0, v20.19.4, v22.16.0, v24.13.0, v26.3.0): every `KeyObject`, secret ones included, falls through to `ERR_INVALID_ARG_TYPE`. On Node v26.3.0:

```
> crypto.Certificate.verifySpkac(publicKey)
TypeError [ERR_INVALID_ARG_TYPE]: The "spkac" argument must be of type string or an instance of ArrayBuffer, Buffer, TypedArray, or DataView. Received an instance of PublicKeyObject
```

Keeping a repaired branch would still diverge from Node twice over: secret `KeyObject`s would be silently accepted and non-secret ones would get `ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE` instead of `ERR_INVALID_ARG_TYPE`. So the helper now mirrors Node's line for line, with the hand-rolled `new TypeError` + `error.code` replaced by the shared `$ERR_INVALID_ARG_TYPE` constructor. That also fixes the message format for non-KeyObject junk input: `Received type number (42)` instead of `Received 42`, without the nonstandard `ERR_INVALID_ARG_TYPE:` message prefix.

This helper has no other callers; cipher/hash/sign paths use the separate C++ `getArrayBufferOrView` and are unaffected.

### How did you verify your code works?

Added tests in `test/js/node/crypto/node-crypto.test.js` covering all three `Certificate` methods with public, private, and secret `KeyObject`s, the non-buffer error message, and the still-working `Buffer`/string happy path. They fail on `USE_SYSTEM_BUN=1` (4 of 5; the happy-path one guards against regression) and pass with the debug build. `test/js/node/test/parallel/test-crypto-certificate.js` (real spkac fixtures) still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (01c25487e)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.41ms]
(pass) crypto.randomInt should return a number [1.83ms]
(pass) crypto.randomInt with no arguments [4.10ms]
(pass) crypto.randomInt with one argument [2.29ms]
(pass) crypto.randomInt with a callback [36.35ms]
(pass) createHash > rsa-md5 - "Hello World" [7.52ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.39ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.76ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.89ms]
(pass) createHash > rsa-sha1 - "Hello World" [7.91ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.18ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.67ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.71ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.51ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.73ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.67ms]
(pass) create
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.10ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.06ms]
(pass) crypto.randomInt with one argument [0.03ms]
(pass) crypto.randomInt with a callback [0.55ms]
(pass) createHash > rsa-md5 - "Hello World" [0.14ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.05ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.02ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha1 - "Hello World" [0.14ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.04ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha224 - "Hello World" [0.05ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha256 - "Hello World" [0.05ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha3-224 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha3-224 - "Hello World" -> bi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (01c25487e)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.43ms]
(pass) crypto.randomInt should return a number [1.83ms]
(pass) crypto.randomInt with no arguments [3.72ms]
(pass) crypto.randomInt with one argument [2.28ms]
(pass) crypto.randomInt with a callback [36.23ms]
(pass) createHash > rsa-md5 - "Hello World" [7.53ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.39ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.82ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.84ms]
(pass) createHash > rsa-sha1 - "Hello World" [7.72ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.19ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.64ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.73ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.48ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.72ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.67ms]
(pass) create
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     01c25487e1
  features     baseline

22 deps, 106 codegen, 1175 objects in 683ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b58cd4685)

Checked 124 installs across 170 packages (no changes) [9.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b58cd4685)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b58cd4685)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[7/1237] fetch picohttpparser
[picohttpparser] up to date
[8/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] subst deps/zlib/zlib.h
[12/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Proc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/crypto.ts                   | 17 +-------------
 test/js/node/crypto/node-crypto.test.js | 41 +++++++++++++++++++++++++++++++++
 2 files changed, 42 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js/node/crypto.ts                        1      2      0
test/js/node/crypto/node-crypto.test.js      0      0      0
```

</details>

**self-review** · no surviving concerns

10 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->