### PR TITLE
fix(bun:test): wrap indexed non-callable spies in a GetterSetter instead of storing the mock under an Accessor attribute

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1564,8 +1564,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
-                // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1055,6 +1055,49 @@ describe("spyOn", () => {
       expect(arr[0]).toBe(original);
     });
 
+    // Non-callable indexed properties get the same getter/setter spy as named ones
+    // ("spyOn works on object" above).
+    test("spyOn on a missing indexed property installs a getter/setter spy", () => {
+      const obj = {};
+      const fn = spyOn(obj, 9);
+      expect(fn).not.toHaveBeenCalled();
+      expect(obj[9]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(1);
+      obj[9] = 5;
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn.mock.calls[1]).toEqual([5]);
+      expect(obj[9]).toBeUndefined();
+      // Same as named keys: the property is an accessor now, so it can't be spied again.
+      expect(() => spyOn(obj, 9)).toThrow();
+    });
+
+    test("spyOn on an existing non-callable indexed property returns the original and can be restored", () => {
+      const obj = { 1: "original" };
+      const fn = spyOn(obj, 1);
+      expect(obj[1]).toBe("original");
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(Object.getOwnPropertyDescriptor(obj, 1)).toHaveProperty("get");
+      fn.mockRestore();
+      expect(obj[1]).toBe("original");
+      expect(Object.getOwnPropertyDescriptor(obj, 1)).toEqual({
+        value: "original",
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("spyOn on a non-callable array element returns the original and can be restored", () => {
+      const arr = [1, 2, 3];
+      const fn = spyOn(arr, 1);
+      expect(arr[1]).toBe(2);
+      expect(fn).toHaveBeenCalledTimes(1);
+      fn.mockRestore();
+      expect(arr[1]).toBe(2);
+      expect(arr).toEqual([1, 2, 3]);
+    });
+
     test("spyOn works with indexed properties using BigInt keys", () => {
       function original() {
         return 456;

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1067,8 +1067,11 @@ describe("spyOn", () => {
       expect(fn).toHaveBeenCalledTimes(2);
       expect(fn.mock.calls[1]).toEqual([5]);
       expect(obj[9]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(3);
       // Same as named keys: the property is an accessor now, so it can't be spied again.
-      expect(() => spyOn(obj, 9)).toThrow();
+      expect(() => spyOn(obj, 9)).toThrow("does not support accessor properties");
+      expect(obj[9]).toBeUndefined();
+      expect(fn).toHaveBeenCalledTimes(4);
     });
 
     test("spyOn on an existing non-callable indexed property returns the original and can be restored", () => {
@@ -1094,7 +1097,12 @@ describe("spyOn", () => {
       expect(arr[1]).toBe(2);
       expect(fn).toHaveBeenCalledTimes(1);
       fn.mockRestore();
-      expect(arr[1]).toBe(2);
+      expect(Object.getOwnPropertyDescriptor(arr, 1)).toEqual({
+        value: 2,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
       expect(arr).toEqual([1, 2, 3]);
     });
 


### PR DESCRIPTION
Fixes a crash found by fuzzing (assertion at `PropertySlot.h(226)` in debug builds, segfault in release builds). Same fix as #31628, which predates this PR but has gone stale; see the note at the end.

### Repro

```js
import { spyOn } from "bun:test";
const obj = {};
spyOn(obj, 9);
obj[9];     // debug: assertion failure
obj[9] = 5; // release: segfault
```

### Root cause

In `JSMock__jsSpyOn`, the branch for non-callable or missing values sets `PropertyAttribute::Accessor` and then, for a named key, installs a `GetterSetter` wrapping the mock. For an indexed key it instead stored the mock cell itself via `putDirectIndex`, still with the Accessor attribute.

On a non-array object that produces a sparse-map entry flagged as an accessor whose value is not a `GetterSetter`:

- debug: the next lookup reaches `PropertySlot::setValue` with accessor attributes and trips `ASSERTION FAILED: attributes == attributesForStructure(attributes) && !(attributes & PropertyAttribute::Accessor)`
- release: reads hand back the mock cell itself as the property value, and writes run `SparseArrayEntry::put`, which `jsCast`s the cell to `GetterSetter` and segfaults at 0x38

Array targets did not crash, because JSC routes indexed puts on arrays through the descriptor path, but they had the same wrong read behavior (the element read back as the mock cell).

The `Bun.jest()` object is a per-process singleton, which is why the fuzzer kept reporting this as flaky: one `spyOn(jest, n)` corrupted it for every later script in the same process.

### Fix

Store a `GetterSetter` on the indexed path too, matching what the named-key path already does. Non-callable indexed spies now behave like non-callable named spies: reads return the original value and are recorded, writes are recorded, spying the same index again throws the same "accessor properties" error named keys throw, and `mockRestore` puts the data property back (`clearSpy` restores through `putDirectIndex` with the pre-spy attributes, which replaces the accessor entry).

One-line change.

### Tests

Three tests added next to the existing indexed-property spy tests in `test/js/bun/test/mock-fn.test.js`, asserting the same contract as the named-key test `spyOn works on object`:

- missing index on a plain object: read returns `undefined` and is recorded, a write is recorded with its value, spying again throws
- existing non-callable index on a plain object: read returns the original and is recorded, the descriptor becomes an accessor, restore brings back the exact original data descriptor
- non-callable array element: read returns the original, restore leaves the array intact

Each fails on the current release build on its own (`USE_SYSTEM_BUN=1`, reads come back as `[class mockedFunction]`) and passes with the fix. The full file passes (80 tests).

### Relation to other PRs

- #31628 is the same one-line fix with a similar test, opened in May for the same fingerprint; it passed CI but was never merged and now conflicts with main. This PR supersedes it; I will close it once this one is reviewed.
- #36395 proposes making `spyOn` throw on missing properties. If it lands first, the missing-index test here needs to become a throw assertion; the fix itself is unaffected.
