### PR TITLE
bundler: use React Compiler client mode for the browser graph of full-stack builds

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1530,9 +1530,8 @@ pub mod bv2_impl {
                 unsafe { Transpiler::for_worker(this_transpiler, arena, this_transpiler.log) };
 
             ct.options.target = Target::Browser;
-            // The clone inherits the server target's SSR react-compiler mode;
-            // the browser graph must use client mode or the SSR pass inlines
-            // hooks and leaves dangling setter references in the client bundle.
+            // Don't inherit SSR mode from the server target: the SSR pass
+            // drops hook setter bindings, which is invalid for browser code.
             if ct.options.react_compiler.is_ssr() {
                 ct.options.react_compiler = bun_ast::runtime::ReactCompilerMode::Client;
             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1530,6 +1530,12 @@ pub mod bv2_impl {
                 unsafe { Transpiler::for_worker(this_transpiler, arena, this_transpiler.log) };
 
             ct.options.target = Target::Browser;
+            // The clone inherits the server target's SSR react-compiler mode;
+            // the browser graph must use client mode or the SSR pass inlines
+            // hooks and leaves dangling setter references in the client bundle.
+            if ct.options.react_compiler.is_ssr() {
+                ct.options.react_compiler = bun_ast::runtime::ReactCompilerMode::Client;
+            }
             ct.options.main_fields = Target::Browser
                 .default_main_fields()
                 .iter()

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test";
+import { readdirSync } from "node:fs";
 import { itBundled } from "../expectBundled";
 
 // The React Compiler emits `import { c as _c } from "react/compiler-runtime"` and
@@ -128,6 +129,58 @@ describe("bundler", () => {
       // no compiler-runtime import; useState lowered to its initial value).
       expect(out).not.toContain("react/compiler-runtime");
       expect(out).not.toMatch(/\b_c\(\d+\)/);
+    },
+  });
+
+  // https://github.com/oven-sh/bun/issues/37022
+  // A full-stack build (--target=bun with an HTML import) bundles the browser
+  // graph through a separate client transpiler. That transpiler must run the
+  // React Compiler in client mode: the SSR pass inlines useState and drops the
+  // setter binding, leaving `setIsAuth` as a dangling identifier in the client
+  // bundle (ReferenceError at render).
+  itBundled("react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode", {
+    outdir: "/out",
+    entryPoints: ["/server.ts"],
+    files: {
+      "/server.ts": `
+        import index from "./index.html";
+        console.log(typeof index);
+      `,
+      "/index.html": `<!DOCTYPE html><html><head><script type="module" src="./main.jsx"></script></head><body><div id="root"></div></body></html>`,
+      "/main.jsx": /* jsx */ `
+        import { useState } from "react";
+        function Login({ setAuth }) {
+          return <button onClick={() => setAuth(true)}>login</button>;
+        }
+        export function App() {
+          const [isAuth, setIsAuth] = useState(false);
+          return isAuth === false ? <Login setAuth={setIsAuth} /> : <div>in</div>;
+        }
+        globalThis.App = App;
+      `,
+      "/node_modules/react/index.js": `exports.useState = i => [i, () => {}]; exports.default = exports;`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = (t, p) => ({ t, p }); exports.jsxs = exports.jsx;`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (t, p) => ({ t, p });`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "bun",
+    backend: "cli",
+    onAfterBundle(api) {
+      const chunks = readdirSync(api.outdir)
+        .filter(f => f.endsWith(".js"))
+        .map(f => api.readFile("/out/" + f));
+      const chunk = chunks.find(c => c.includes("setIsAuth"));
+      expect(chunk).toBeDefined();
+      // Client mode keeps the useState destructure, so the setter has a
+      // declaration in addition to its prop use. In SSR mode the destructure
+      // is inlined away and only the dangling use remains.
+      expect(chunk!).toMatch(/\[isAuth,\s*setIsAuth\]/);
+      expect(chunk!.match(/\bsetIsAuth\b/g)!.length).toBeGreaterThanOrEqual(2);
+      // Client mode memoizes through the compiler runtime; the SSR pass never
+      // references the memo cache sentinel.
+      expect(chunk!).toContain("react.memo_cache_sentinel");
     },
   });
 


### PR DESCRIPTION
Fixes #37022

### Repro

```
bun build --target=bun --react-compiler --outdir=dist ./src/server.ts
```

where `server.ts` imports an HTML file whose script uses `useState` and passes the setter to a child component:

```jsx
const [isAuth, setIsAuth] = useState(false);
return isAuth === false ? <Login setAuth={setIsAuth} /> : ...;
```

The browser chunk throws `Uncaught ReferenceError: setIsAuth is not defined` at render. The emitted client code contains `let isAuth = false` (the `useState` call inlined away) while still referencing `setIsAuth` as a prop value, with no declaration anywhere in the bundle.

### Cause

A full-stack build lazily creates a client transpiler for the browser graph (`initialize_client_transpiler` in `src/bundler/bundle_v2.rs`) by deep-cloning the server transpiler's options. The clone inherited `ReactCompilerMode::Ssr` (derived from the top-level `--target=bun`), so the React Compiler ran its SSR optimization pass on browser-bound code. That pass inlines `useState`/`useReducer` and drops the setter binding, which is only valid for server rendering.

### Fix

When initializing the client transpiler, re-derive the React Compiler mode: a browser graph compiles in client mode. A direct `bun build --target=browser --react-compiler` was already correct; this aligns the full-stack path with it.

### Verification

New test `react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode` in `test/bundler/transpiler/react-compiler.test.ts` builds a server entry with an HTML import and asserts the client chunk keeps the `[isAuth, setIsAuth]` destructure and memoizes via the compiler runtime. Fails on current canary (client chunk has exactly one `setIsAuth` occurrence, the dangling use), passes with this change. All 36 tests in the file and the three HTML bundler suites pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.0 (f79d00c0a)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [651.08ms]
(pass) bundler > react-compiler/ComponentWithHooks [300.86ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [310.29ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [162.71ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [101.28ms]
174 |       const chunk = chunks.find(c => c.includes("setIsAuth"));
175 |       expect(chunk).toBeDefined();
176 |       // Client mode keeps the useState destructure, so the setter has a
177 |       // declaration in addition to its prop use. In SSR mode the destructure
178 |       // is inlined away and only the dangling use remains.
179 |       expect(chunk!).toMatch(/\[isAuth,\s*setIsAuth\]/);
                           ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /\[isAuth,\s*setIsAuth\]/
Received: "var __create = Object.create;\nvar __getProt
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5afa7bef0)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [14.36ms]
(pass) bundler > react-compiler/ComponentWithHooks [5.67ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [5.27ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [5.50ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.78ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [7.81ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [4.27ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [3.34ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [4.08ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [6.91ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [11.63ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [5.96ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [5.19ms]
(pass) bundler > react-compiler/ForwardRefSiblingFn [5.16ms]
(pass) bundler > react-compiler/SelfRefConstArrow [5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.0 (f79d00c0a)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [655.69ms]
(pass) bundler > react-compiler/ComponentWithHooks [301.20ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [303.27ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [163.58ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [89.22ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [392.41ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [91.11ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [104.11ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [85.24ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [319.71ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [431.13ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [336.38ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 613ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs                       |  5 +++
 test/bundler/transpiler/react-compiler.test.ts | 53 ++++++++++++++++++++++++++
 2 files changed, 58 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/bundler/bundle_v2.rs                            4      3      0
test/bundler/transpiler/react-compiler.test.ts      1      3      0
```

</details>

**root cause** · written by the author bot

When the bundler cloned the server transpiler to build the browser graph, the clone inherited the server target's SSR react-compiler mode, so the client bundle was compiled with the SSR pass that inlines hooks and drops setter bindings, leaving dangling references like setIsAuth. The fix explicitly resets the cloned transpiler's options for the browser target so the client graph runs the react-compiler in client mode, preserving the hook state and setter bindings that the emitted code references.

<!-- robobun:evidence:end -->