### PR TITLE
Fix exception handling in unwrapBoxedPrimitive

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2260,13 +2260,19 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__unwrapBoxedPrimitive(JSGlobalObject
         return JSValue::encode(value);
     }
 
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = asObject(value);
 
     if (object->inherits<NumberObject>()) {
-        return JSValue::encode(jsNumber(object->toNumber(globalObject)));
+        double number = object->toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(jsNumber(number));
     }
-    if (object->inherits<StringObject>())
-        return JSValue::encode(object->toString(globalObject));
+    if (object->inherits<StringObject>()) {
+        JSString* string = object->toString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(string);
+    }
     if (object->inherits<BooleanObject>() || object->inherits<BigIntObject>())
         return JSValue::encode(uncheckedDowncast<JSWrapperObject>(object)->internalValue());
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -4273,6 +4273,36 @@ refs:
         expect(YAML.stringify(obj, null, 2)).toBe("normal: value");
       });
 
+      // Unwrapping a String/Number wrapper re-enters JS via Symbol.toPrimitive,
+      // which can throw; debug builds abort if that exception is dropped, so
+      // this must run in a subprocess.
+      test("boxed primitive whose Symbol.toPrimitive throws propagates the error", async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const s = new String();
+             s[Symbol.toPrimitive] = () => String;
+             try { Bun.YAML.stringify(s); } catch (e) { console.log("string:", e.message); }
+             const n = new Number(1);
+             n[Symbol.toPrimitive] = () => Number;
+             try { Bun.YAML.stringify({ a: n }); } catch (e) { console.log("number:", e.message); }
+             try { Bun.YAML.stringify({ a: 1 }, null, s); } catch (e) { console.log("space:", e.message); }`,
+          ],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+        expect(stdout).toBe(
+          "string: Symbol.toPrimitive returned an object\n" +
+            "number: Symbol.toPrimitive returned an object\n" +
+            "space: Symbol.toPrimitive returned an object\n",
+        );
+        expect(exitCode).toBe(0);
+      });
+
       test("handles Intl objects", () => {
         const dateFormat = new Intl.DateTimeFormat("en-US");
         const numberFormat = new Intl.NumberFormat("en-US");

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -4293,11 +4293,7 @@ refs:
           stderr: "pipe",
         });
 
-        const [stdout, stderr, exitCode] = await Promise.all([
-          proc.stdout.text(),
-          proc.stderr.text(),
-          proc.exited,
-        ]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
         expect(stdout).toBe(
           "string: Symbol.toPrimitive returned an object\n" +

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -4293,13 +4293,18 @@ refs:
           stderr: "pipe",
         });
 
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        const [stdout, stderr, exitCode] = await Promise.all([
+          proc.stdout.text(),
+          proc.stderr.text(),
+          proc.exited,
+        ]);
 
         expect(stdout).toBe(
           "string: Symbol.toPrimitive returned an object\n" +
             "number: Symbol.toPrimitive returned an object\n" +
             "space: Symbol.toPrimitive returned an object\n",
         );
+        expect(stderr).toBe("");
         expect(exitCode).toBe(0);
       });
 


### PR DESCRIPTION
Fixes a fuzzer-found abort (fingerprint `2f7e21cbc0aaac7b`).

`JSC__JSValue__unwrapBoxedPrimitive` calls `toString`/`toNumber` on String and Number wrapper objects. Those re-enter JS when the wrapper has a `Symbol.toPrimitive` (or overridden `valueOf`/`toString`), so they can throw, for example when `Symbol.toPrimitive` returns an object. The binding ignored the pending exception and returned a value anyway, violating the zero-is-throw contract checked on the Rust side and tripping `releaseAssertNoException` in debug builds:

```js
const s = new String();
s[Symbol.toPrimitive] = () => String;
Bun.YAML.stringify(s); // ASSERTION FAILED: Unexpected exception observed
```

WebKit's `unwrapBoxedPrimitive` in JSONObject.cpp (which this was copied from) relies on its callers doing `RETURN_IF_EXCEPTION` right after; our extern C copy returns straight to Rust, so the check has to live in the binding itself. This adds a throw scope and returns empty when `toNumber`/`toString` throws, so the error surfaces as a normal JS exception from `Bun.YAML.stringify`, `Bun.TOML.stringify`, and `Bun.JSON5.stringify` (all reach this through `unwrap_boxed_primitive`).

The regression test runs in a subprocess because the unfixed binary aborts the whole process in debug builds. Verified the spawned script exits 134 on the unfixed build and exits 0 with the expected TypeError output on the fixed one; yaml, toml, and json5 suites pass.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 21 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (31a8c450d)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.13ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.12ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.10ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.95ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.05ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.21ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.07ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.01ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.84ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.11ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.97ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.58ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.99ms]
(pass) Bu
... (truncated)

release without fix: 21 skipped
bun test v1.4.0-canary.1 (726a839a8)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.09ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.04ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.30ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 21 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (31a8c450d)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.41ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.13ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.17ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.97ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.11ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.22ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.18ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.86ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.08ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.96ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.65ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [3.06ms]
(pass) Bu
... (truncated)

release with fix: 21 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 01s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+31a8c450d
[build] done
bun test v1.4.0-canary.1 (31a8c450d)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.11ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.04ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.06ms]
(
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp | 12 +++++++++---
 test/js/bun/yaml/yaml.test.ts | 31 +++++++++++++++++++++++++++++++
 2 files changed, 40 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/jsc/bindings/bindings.cpp      1      1      0
test/js/bun/yaml/yaml.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->