### PR TITLE
Bun.plugin: fix segfault when an object loader result's exports getter throws

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -139,6 +139,7 @@ static OnLoadResult handleOnLoadObjectResult(Zig::GlobalObject* globalObject, JS
     auto& builtinNames = WebCore::builtinNames(vm);
     auto exportsValue = object->getIfPropertyExists(globalObject, builtinNames.exportsPublicName());
     if (scope.exception()) [[unlikely]] {
+        result.type = OnLoadResultTypeError;
         result.value.error = scope.exception();
         (void)scope.tryClearException();
         return result;

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -198,7 +198,7 @@ plugin({
 });
 
 // This is to test that it works when imported from a separate file
-import { bunEnv, bunExe, tempDir } from "harness";
+import { tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
 import "../../third_party/svelte";
 import "./module-plugins";

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -569,6 +569,7 @@ describe("object loader with a throwing exports getter", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("failed: exports getter threw\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { resolve } from "path";
 
 declare global {
@@ -542,6 +543,85 @@ describe("errors", () => {
       sleep(2_500),
     ]);
     expect(text).toBe(result);
+  });
+});
+
+describe("object loader with a throwing exports getter", () => {
+  // The result object's "exports" getter throws while the module loader reads
+  // it. Run in a subprocess: the unfixed runtime segfaults instead of
+  // surfacing the getter's error.
+  const throwingExportsResult = `
+    const result = { loader: "object" };
+    Object.defineProperty(result, "exports", {
+      enumerable: true,
+      get() {
+        throw new Error("exports getter threw");
+      },
+    });
+    return result;
+  `;
+
+  async function expectCleanFailure(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("failed: exports getter threw\n");
+    expect(exitCode).toBe(0);
+  }
+
+  it.concurrent("rejects import() of a build.module result", async () => {
+    await expectCleanFailure(`
+      Bun.plugin({
+        name: "virt",
+        setup(build) {
+          build.module("virt-mod", () => { ${throwingExportsResult} });
+        },
+      });
+      try {
+        await import("virt-mod");
+        console.log("imported");
+      } catch (e) {
+        console.log("failed:", e?.message);
+      }
+    `);
+  });
+
+  it.concurrent("throws from require() of a build.module result", async () => {
+    await expectCleanFailure(`
+      Bun.plugin({
+        name: "virt",
+        setup(build) {
+          build.module("virt-mod", () => { ${throwingExportsResult} });
+        },
+      });
+      try {
+        require("virt-mod");
+        console.log("required");
+      } catch (e) {
+        console.log("failed:", e?.message);
+      }
+    `);
+  });
+
+  it.concurrent("rejects import() of a build.onLoad result", async () => {
+    await expectCleanFailure(`
+      Bun.plugin({
+        name: "virt",
+        setup(build) {
+          build.onResolve({ filter: /.*/, namespace: "virtns" }, args => ({ path: args.path, namespace: "virtns" }));
+          build.onLoad({ filter: /.*/, namespace: "virtns" }, () => { ${throwingExportsResult} });
+        },
+      });
+      try {
+        await import("virtns:mod");
+        console.log("imported");
+      } catch (e) {
+        console.log("failed:", e?.message);
+      }
+    `);
   });
 });
 


### PR DESCRIPTION
## Repro

```js
Bun.plugin({
  name: "virt",
  setup(build) {
    build.module("virt-mod", () => {
      const result = { loader: "object" };
      Object.defineProperty(result, "exports", {
        get() { throw new Error("exports getter threw"); },
      });
      return result;
    });
  },
});
await import("virt-mod");
```

```
panic(main thread): Segmentation fault at address 0x0
```

Deterministic on 1.4.0 and main. The same crash happens through `build.onLoad` returning a `loader: "object"` result, and through `require()` of the virtual module (there the fault address is the `getIfPropertyExists` call on the null object). UBSan on a debug build reports `src/jsc/modules/ObjectModule.cpp:20:17: runtime error: member call on null pointer of type 'JSC::JSCell'`.

## Cause

`handleOnLoadObjectResult` in `src/jsc/bindings/ModuleLoader.cpp` sets `result.type = OnLoadResultTypeObject` before reading the `exports` property off the plugin's result object. When that property read throws (a user-defined getter, or a Proxy trap), the exception branch stored the exception in `result.value.error` but returned with the type still `OnLoadResultTypeObject`. `handleVirtualModuleResult` then took the Object case, `value.object.getObject()` on the stored exception cell returned nullptr, and the null object was dereferenced: immediately via `getIfPropertyExists` on the `require()` path, or inside `generateObjectModuleSourceCode`'s source generator on the `import()` path.

## Fix

Set `result.type = OnLoadResultTypeError` in the exception branch, matching every other error path in the function. The import now rejects (and `require()` throws) with the getter's error.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/plugin/plugins.test.ts -t "throwing exports getter"
  -> 3 fail (child process segfaults)

bun bd test test/js/bun/plugin/plugins.test.ts
  -> 38 pass, 0 fail
```

New tests cover all three faces: `build.module` + `import()`, `build.module` + `require()`, and `build.onLoad` + `import()`. Each spawns a subprocess and asserts the process exits 0 after printing the getter's error message.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (113ff8b97)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1142.00ms]
(pass) require > beep:boop returns 42 [9.21ms]
(pass) require > object module works [8.22ms]
(pass) module > throws with require() [13.05ms]
(pass) module > async module works with async import [27.21ms]
(pass) module > sync module module works with require() [4.35ms]
(pass) module > sync module module works with require.resolve() [2.91ms]
(pass) module > sync module module works with import [6.30ms]
(pass) module > modules are overridable [88.62ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [5.71ms]
(pass) dynamic import > beep:boop returns 42 [4.12ms]
(pass) dynamic import > async:onLoad returns
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [30.13ms]
(pass) require > beep:boop returns 42 [0.18ms]
(pass) require > object module works [0.12ms]
(pass) module > throws with require() [0.15ms]
(pass) module > async module works with async import [1.27ms]
(pass) module > sync module module works with require() [0.09ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.07ms]
(pass) module > modules are overridable [0.19ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.08ms]
(pass) dynamic import > beep:boop returns 42 [0.05ms]
(pass) dynamic import > async:onLoad returns 42 [1.37ms]
(pass) dynamic import > async object loader returns 42 [1.29ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [1.64ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (113ff8b97)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1124.06ms]
(pass) require > beep:boop returns 42 [9.79ms]
(pass) require > object module works [8.10ms]
(pass) module > throws with require() [13.06ms]
(pass) module > async module works with async import [24.45ms]
(pass) module > sync module module works with require() [5.10ms]
(pass) module > sync module module works with require.resolve() [2.96ms]
(pass) module > sync module module works with import [6.19ms]
(pass) module > modules are overridable [24.83ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [84.32ms]
(pass) dynamic import > beep:boop returns 42 [4.81ms]
(pass) dynamic import > async:onLoad return
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 624ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8842ms)
Bundle modules (48ms)
Postprocesss modules (32ms)
Bundle Functions (611ms)
Generate Code (17ms)

[9.57s] Bundled "src/js" for production
  2573 kb
  193 internal modules
  13 native modules
  84 internal functions across 17 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 56s
[3/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[4/7] link bun-profile
[6/7] strip bun
[6/7] bun-profile --revision
1.4.0-canary.1+113ff8b97
[build] done
bun test v1.4.0-canary.1 (113ff8b97)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should includ
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp  |  1 +
 test/js/bun/plugin/plugins.test.ts | 83 +++++++++++++++++++++++++++++++++++++-
 2 files changed, 83 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp       3      1      0
test/js/bun/plugin/plugins.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->