### PR TITLE
fetch: read a Request argument through its internal state, not JS-visible getters

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3187,12 +3187,12 @@ function internalConnectMultiple(context, canceled?) {
 
   if (localPort) {
     if (addressType === 4) {
-      localAddress = DEFAULT_IPV4_ADDR;
+      localAddress = "0.0.0.0";
       // TODO:
       // err = self._handle.bind(localAddress, localPort);
     } else {
       // addressType === 6
-      localAddress = DEFAULT_IPV6_ADDR;
+      localAddress = "::";
       // TODO:
       // err = self._handle.bind6(localAddress, localPort, flags);
     }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3187,12 +3187,12 @@ function internalConnectMultiple(context, canceled?) {
 
   if (localPort) {
     if (addressType === 4) {
-      localAddress = "0.0.0.0";
+      localAddress = DEFAULT_IPV4_ADDR;
       // TODO:
       // err = self._handle.bind(localAddress, localPort);
     } else {
       // addressType === 6
-      localAddress = "::";
+      localAddress = DEFAULT_IPV6_ADDR;
       // TODO:
       // err = self._handle.bind6(localAddress, localPort, flags);
     }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -485,25 +485,25 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     // kept as raw `*mut Request` because the body re-borrows it
     // multiple times across long-lived option/init reads.
-    let request: Option<*mut Request> = 'brk: {
-        if first_arg.is_cell() {
-            if let Some(request_) = first_arg.as_direct::<Request>() {
-                break 'brk Some(request_);
-            }
-        }
-        break 'brk None;
-    };
+    //
+    // `as_` (ClassInfo cast), not `as_direct` (pristine-Structure cast): per
+    // the fetch spec a Request input is read through its internal state, even
+    // when it is a subclass instance or has own properties added. With
+    // `as_direct`, any Structure transition sent the Request down the
+    // RequestInit-dictionary arm below, re-reading url/method/headers/body
+    // through JS-visible getters.
+    let request: Option<*mut Request> = first_arg.as_::<Request>();
     // Helper macro: short-lived `&mut Request` reborrow of the optional pointer.
     macro_rules! request_mut {
         () => {
             // SAFETY: `request` was obtained from a live JS-owned Request via
-            // `as_direct`; each reborrow is non-overlapping at the call site.
+            // `as_`; each reborrow is non-overlapping at the call site.
             request.map(|p| unsafe { &mut *p })
         };
     }
 
     // If it's NOT a Request or a subclass of Request, treat the first argument as a URL.
-    let url_str_optional = if first_arg.as_::<Request>().is_none() {
+    let url_str_optional = if request.is_none() {
         StringOrURL::from_js(first_arg, global_this)?
     } else {
         None

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -486,12 +486,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // kept as raw `*mut Request` because the body re-borrows it
     // multiple times across long-lived option/init reads.
     //
-    // `as_` (ClassInfo cast), not `as_direct` (pristine-Structure cast): per
-    // the fetch spec a Request input is read through its internal state, even
-    // when it is a subclass instance or has own properties added. With
-    // `as_direct`, any Structure transition sent the Request down the
-    // RequestInit-dictionary arm below, re-reading url/method/headers/body
-    // through JS-visible getters.
+    // `as_`, not `as_direct`: a subclassed Request, or one with own properties
+    // added, must still be read through its internal state per the fetch spec,
+    // and `as_direct` rejects any transitioned Structure.
     let request: Option<*mut Request> = first_arg.as_::<Request>();
     // Helper macro: short-lived `&mut Request` reborrow of the optional pointer.
     macro_rules! request_mut {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -485,25 +485,18 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     // kept as raw `*mut Request` because the body re-borrows it
     // multiple times across long-lived option/init reads.
-    let request: Option<*mut Request> = 'brk: {
-        if first_arg.is_cell() {
-            if let Some(request_) = first_arg.as_direct::<Request>() {
-                break 'brk Some(request_);
-            }
-        }
-        break 'brk None;
-    };
+    let request: Option<*mut Request> = first_arg.as_::<Request>();
     // Helper macro: short-lived `&mut Request` reborrow of the optional pointer.
     macro_rules! request_mut {
         () => {
             // SAFETY: `request` was obtained from a live JS-owned Request via
-            // `as_direct`; each reborrow is non-overlapping at the call site.
+            // `as_`; each reborrow is non-overlapping at the call site.
             request.map(|p| unsafe { &mut *p })
         };
     }
 
     // If it's NOT a Request or a subclass of Request, treat the first argument as a URL.
-    let url_str_optional = if first_arg.as_::<Request>().is_none() {
+    let url_str_optional = if request.is_none() {
         StringOrURL::from_js(first_arg, global_this)?
     } else {
         None

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -485,18 +485,25 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     // kept as raw `*mut Request` because the body re-borrows it
     // multiple times across long-lived option/init reads.
-    let request: Option<*mut Request> = first_arg.as_::<Request>();
+    let request: Option<*mut Request> = 'brk: {
+        if first_arg.is_cell() {
+            if let Some(request_) = first_arg.as_direct::<Request>() {
+                break 'brk Some(request_);
+            }
+        }
+        break 'brk None;
+    };
     // Helper macro: short-lived `&mut Request` reborrow of the optional pointer.
     macro_rules! request_mut {
         () => {
             // SAFETY: `request` was obtained from a live JS-owned Request via
-            // `as_`; each reborrow is non-overlapping at the call site.
+            // `as_direct`; each reborrow is non-overlapping at the call site.
             request.map(|p| unsafe { &mut *p })
         };
     }
 
     // If it's NOT a Request or a subclass of Request, treat the first argument as a URL.
-    let url_str_optional = if request.is_none() {
+    let url_str_optional = if first_arg.as_::<Request>().is_none() {
         StringOrURL::from_js(first_arg, global_this)?
     } else {
         None

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -485,8 +485,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     // kept as raw `*mut Request` because the body re-borrows it
     // multiple times across long-lived option/init reads.
-    // `as_` (not `as_direct`) so a subclassed or expando'd Request still
-    // takes the internal-state path required by the fetch spec.
     let request: Option<*mut Request> = first_arg.as_::<Request>();
     // Helper macro: short-lived `&mut Request` reborrow of the optional pointer.
     macro_rules! request_mut {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -485,10 +485,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     // kept as raw `*mut Request` because the body re-borrows it
     // multiple times across long-lived option/init reads.
-    //
-    // `as_`, not `as_direct`: a subclassed Request, or one with own properties
-    // added, must still be read through its internal state per the fetch spec,
-    // and `as_direct` rejects any transitioned Structure.
+    // `as_` (not `as_direct`) so a subclassed or expando'd Request still
+    // takes the internal-state path required by the fetch spec.
     let request: Option<*mut Request> = first_arg.as_::<Request>();
     // Helper macro: short-lived `&mut Request` reborrow of the optional pointer.
     macro_rules! request_mut {

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -383,7 +383,6 @@ describe("fetch(request) reads internal state, not JS-visible getters", () => {
     expect(new URL(seen.url).pathname).toBe("/sub");
     expect(seen.method).toBe("POST");
     expect(seen.headers["x-real"]).toBe("1");
-    expect(seen.headers["x-from-getter"]).toBeUndefined();
     expect(seen.body).toBe("real-body");
   });
 

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -305,3 +305,126 @@ describe("does not send a request when", () => {
     });
   }
 });
+
+// Per the fetch spec, a Request input is read through its internal state, even
+// when it is a subclass instance or has own properties added (a transitioned
+// Structure). JS-visible getters must never be consulted.
+describe("fetch(request) reads internal state, not JS-visible getters", () => {
+  type Seen = { url: string; method: string; headers: Record<string, string>; body: string };
+  let echo: Bun.Server;
+  beforeAll(() => {
+    echo = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        return Response.json({
+          url: req.url,
+          method: req.method,
+          headers: Object.fromEntries(req.headers),
+          body: await req.text(),
+        } satisfies Seen);
+      },
+    });
+  });
+  afterAll(() => {
+    echo.stop(true);
+  });
+
+  test.concurrent("own url getter on a genuine Request is ignored", async () => {
+    const request = new Request(new URL("/original", echo.url));
+    let getterCalls = 0;
+    Object.defineProperty(request, "url", {
+      get() {
+        getterCalls++;
+        return new URL("/from-getter", echo.url).href;
+      },
+    });
+    const seen = (await (await fetch(request)).json()) as Seen;
+    expect(new URL(seen.url).pathname).toBe("/original");
+    expect(getterCalls).toBe(0);
+  });
+
+  test.concurrent("own url data property does not redirect the fetch", async () => {
+    const request = new Request(new URL("/original", echo.url));
+    Object.defineProperty(request, "url", { value: new URL("/rewritten", echo.url).href });
+    const seen = (await (await fetch(request)).json()) as Seen;
+    expect(new URL(seen.url).pathname).toBe("/original");
+  });
+
+  test.concurrent("subclass overriding every getter fetches via internal state", async () => {
+    class Evil extends Request {
+      get url(): string {
+        throw new Error("url getter called");
+      }
+      get method(): string {
+        throw new Error("method getter called");
+      }
+      get headers(): Headers {
+        throw new Error("headers getter called");
+      }
+      get body(): ReadableStream<Uint8Array<ArrayBuffer>> | null {
+        throw new Error("body getter called");
+      }
+      get signal(): AbortSignal {
+        throw new Error("signal getter called");
+      }
+      get redirect(): RequestRedirect {
+        throw new Error("redirect getter called");
+      }
+      get keepalive(): boolean {
+        throw new Error("keepalive getter called");
+      }
+    }
+    const request = new Evil(new URL("/sub", echo.url), {
+      method: "POST",
+      headers: { "x-real": "1" },
+      body: "real-body",
+    });
+    const seen = (await (await fetch(request)).json()) as Seen;
+    expect(new URL(seen.url).pathname).toBe("/sub");
+    expect(seen.method).toBe("POST");
+    expect(seen.headers["x-real"]).toBe("1");
+    expect(seen.headers["x-from-getter"]).toBeUndefined();
+    expect(seen.body).toBe("real-body");
+  });
+
+  test.concurrent("fetch(subclassRequest, init) still honors init overrides", async () => {
+    class Sub extends Request {
+      get headers(): Headers {
+        throw new Error("headers getter called");
+      }
+    }
+    const request = new Sub(new URL("/override", echo.url), { method: "POST", body: "from-request" });
+    const seen = (await (await fetch(request, { headers: { "x-extra": "1" } })).json()) as Seen;
+    expect(new URL(seen.url).pathname).toBe("/override");
+    expect(seen.method).toBe("POST");
+    expect(seen.headers["x-extra"]).toBe("1");
+    expect(seen.body).toBe("from-request");
+  });
+
+  test.concurrent("Bun.serve request with a rewritten url own property proxies its internal url", async () => {
+    let depth = 0;
+    let getterCalls = 0;
+    await using proxy = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        if (++depth > 1) {
+          return Response.json({ url: req.url, depth });
+        }
+        Object.defineProperty(req, "url", {
+          get() {
+            getterCalls++;
+            return new URL("/from-getter", echo.url).href;
+          },
+        });
+        const inner = await (await fetch(req)).json();
+        return Response.json({ ...inner, getterCalls });
+      },
+    });
+    const seen = await (await fetch(new URL("/loopback", proxy.url))).json();
+    // The inner fetch(req) must go to req's internal url (the proxy itself),
+    // not the echo server the getter points at.
+    expect(seen.depth).toBe(2);
+    expect(seen.getterCalls).toBe(0);
+    expect(new URL(seen.url).pathname).toBe("/loopback");
+  });
+});

--- a/test/js/web/request/request-subclass.test.ts
+++ b/test/js/web/request/request-subclass.test.ts
@@ -1,58 +1,67 @@
 import { expect, test } from "bun:test";
-import { RequestInit } from "undici-types";
+import type { RequestInit } from "undici-types";
 
 // https://github.com/oven-sh/bun/issues/4718
-test("fetch() calls request.method & request.url getters on subclass", async () => {
+// A Request subclass is still a Request: fetch() reads its internal state
+// (the url, method, and headers captured by the constructor) and never
+// consults JS-visible getter overrides, matching the fetch spec and Node.
+test("fetch() uses a subclass Request's internal state, not getter overrides", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.method, { headers: req.headers });
+    },
+  });
+
+  let getterCalls = 0;
   class MyRequest extends Request {
-    constructor(input: string, init?: RequestInit, actual_url?: string) {
+    constructor(input: string | URL, init?: RequestInit, decoy_url?: string) {
       super(input, init);
 
       Object.defineProperty(this, "url", {
         get() {
-          return actual_url;
+          getterCalls++;
+          return decoy_url;
         },
       });
 
       Object.defineProperty(this, "headers", {
         get() {
-          return {
-            "X-My-Header": "123",
-          };
+          getterCalls++;
+          return { "x-decoy": "1" };
         },
       });
     }
 
     // @ts-ignore
     get method() {
-      return "POST";
+      getterCalls++;
+      return "DELETE";
     }
   }
 
-  using server = Bun.serve({
-    fetch(req) {
-      return new Response(req.method, { headers: req.headers });
-    },
-    port: 0,
-  });
+  // port 1 refuses connections, so the old getter-reading behavior fails fast
+  // without touching the network.
+  const request = new MyRequest(server.url, { method: "POST", headers: { "x-my-header": "123" } }, "http://127.0.0.1:1/decoy");
 
-  const request = new MyRequest("https://example.com", {}, server.url.href);
-
-  expect(request.method).toBe("POST");
   const response = await fetch(request);
   expect(await response.text()).toBe("POST");
-  expect(response.headers.get("X-My-Header")).toBe("123");
+  expect(response.headers.get("x-my-header")).toBe("123");
+  expect(response.headers.get("x-decoy")).toBeNull();
+  expect(getterCalls).toBe(0);
 });
 
-test("fetch() with subclass containing invalid HTTP headers throws without crashing", async () => {
-  class MyRequest extends Request {
-    constructor(input: string, init?: RequestInit, actual_url?: string) {
-      super(input, init);
+test("fetch() ignores a subclass headers getter returning invalid header names", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response("ok", { headers: req.headers });
+    },
+  });
 
-      Object.defineProperty(this, "url", {
-        get() {
-          return actual_url;
-        },
-      });
+  class MyRequest extends Request {
+    constructor(input: string | URL, init?: RequestInit) {
+      super(input, init);
 
       Object.defineProperty(this, "headers", {
         get() {
@@ -62,22 +71,10 @@ test("fetch() with subclass containing invalid HTTP headers throws without crash
         },
       });
     }
-
-    // @ts-ignore
-    get method() {
-      return "POST";
-    }
   }
 
-  const request = new MyRequest("https://example.com", {}, "https://example.com");
-  expect(request.method).toBe("POST");
-  await expect(fetch(request)).rejects.toThrow("Invalid header name");
-
-  // quick gc test; 1e3 iterations since each now allocates a rejected Promise
-  // (previously 1e4 sync throws, which allocated nothing).
-  for (let i = 0; i < 1e3; i++) {
-    fetch(request).catch(() => {});
-  }
-
-  await expect(fetch(request)).rejects.toThrow("Invalid header name");
+  const request = new MyRequest(server.url, { headers: { "x-ok": "1" } });
+  const response = await fetch(request);
+  expect(await response.text()).toBe("ok");
+  expect(response.headers.get("x-ok")).toBe("1");
 });

--- a/test/js/web/request/request-subclass.test.ts
+++ b/test/js/web/request/request-subclass.test.ts
@@ -42,7 +42,11 @@ test("fetch() uses a subclass Request's internal state, not getter overrides", a
 
   // port 1 refuses connections, so the old getter-reading behavior fails fast
   // without touching the network.
-  const request = new MyRequest(server.url, { method: "POST", headers: { "x-my-header": "123" } }, "http://127.0.0.1:1/decoy");
+  const request = new MyRequest(
+    server.url,
+    { method: "POST", headers: { "x-my-header": "123" } },
+    "http://127.0.0.1:1/decoy",
+  );
 
   const response = await fetch(request);
   expect(await response.text()).toBe("POST");


### PR DESCRIPTION
### Problem

`fetch(request)` only used the Request's internal state when the Request cell's Structure was pristine. Any Structure transition, meaning a `class extends Request` instance or a genuine Request that gained an own property (for example a router-style `req.url` rewrite), sent the Request down the RequestInit-dictionary path, which re-reads `url`, `method`, `headers`, `body`, `signal`, `redirect`, and `keepalive` through JS-visible getters.

The fetch spec says "if input is a Request object, set request to input's request", and Node v26/undici behaves that way: getters on a Request input are never invoked.

```js
const r = new Request(url1);
Object.defineProperty(r, "url", { get() { return url2; } });
await fetch(r); // Bun sent "GET /FROM-GETTER" to url2; Node sends "GET /original" to url1

class R extends Request {
  get url() { return url2; }
  get headers() { return new Headers({ "x-from-getter": "1" }); }
}
await fetch(new R(url1, { headers: { "x-real": "1" } }));
// Bun hit url2 and dropped the constructor's x-real header; Node hits url1 with x-real
```

Loopback wire capture on 1.4.0 showed `[L2]GET /FROM-GETTER HTTP/1.1` for both cases, with the subclass request carrying only `x-from-getter` and losing `x-real`.

### Cause

`fetch_impl` downcast the first argument with `as_direct::<Request>()`, whose generated `Request__fromJSDirect` requires `cell->structureID()` to equal the global `JSRequest` structure id. Any transitioned Structure returns null, `request` stays `None`, and the Request object lands in the `request_init_object` dictionary arm.

This getter-reading path was introduced deliberately in #10543 and #10969 to fix #4718 (SvelteKit dropping init headers when its Request subclass was passed to `fetch()`). At the time the subclass fell through to the URL/dictionary handling, so reading getters was the way to recover the data. Reading the input through internal state fixes the same scenario (the constructor captured those headers), and it is how undici behaves on Node, where SvelteKit's wrapper works. The #4718 regression scenario stays covered by the updated `request-subclass.test.ts`.

### Fix

Bind `request` with the ClassInfo-based cast (`as_::<Request>()`, generated `Request__fromJS`, a plain `dynamicDowncast`), which matches subclass instances and transitioned Structures. Everything downstream of that binding already reads internal slots only (`req.method`, `req.flags.redirect`, `req.signal`, the body value, the fetch headers), and `fetch(request, init)` continues to apply init overrides on top.

Behavior note: code that added an own `url` property to a Request and relied on `fetch(request)` honoring it now gets the spec and Node behavior, fetching the internal URL. The supported way to retarget a request is `fetch(newUrl, request)` or `fetch(new Request(newUrl, request))`.

`new Request(modifiedRequest)` has a similar divergence; it is tracked separately since the constructor's second argument legitimately has dictionary semantics.

### Tests

Five cases added to `test/js/web/fetch/fetch-args.test.ts`: own `url` getter ignored, own `url` data property ignored, a subclass overriding every getter (all throwing, so any getter read fails the test) fetches via internal state with constructor headers and body intact, `fetch(subclassRequest, init)` still honors init overrides, and a `Bun.serve` request with a rewritten `url` own property proxies to its internal URL. Four of the five fail on the unmodified build and all pass with the fix; the existing `fetch-args.test.ts` suite (66 tests) passes.

`test/js/web/request/request-subclass.test.ts` asserted the #10543/#10969 getter-reading behavior and is updated to the internal-state semantics while keeping its intent: constructor-set headers reach the wire (the #4718 scenario) and a headers getter returning invalid header names cannot make the fetch throw. Both updated tests fail on the unmodified build and pass with the fix. The tests also no longer contact example.com.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-args.test.ts test/js/web/request/request-subclass.test.ts
bun test v1.4.0 (62ef1ce75)

test/js/web/request/request-subclass.test.ts:
46 |     server.url,
47 |     { method: "POST", headers: { "x-my-header": "123" } },
48 |     "http://127.0.0.1:1/decoy",
49 |   );
50 | 
51 |   const response = await fetch(request);
                              ^
TypeError: Unable to connect. Is the computer able to access the url?
  path: "http://127.0.0.1:1/decoy",
 errno: 0,
  code: "ConnectionRefused"

      at async <anonymous> (/workspace/bun/test/js/web/request/request-subclass.test.ts:51:26)
(fail) fetch() uses a subclass Request's internal state, not getter overrides [56.07ms]
76 |       });
77 |     }
78 |   }
79 | 
80 |   const request = new MyRequest(server.url, { headers: { "x-ok": "1" } });
81 |   const response = await fetch(request);
                              ^
TypeError: Invalid header name: '[I am not a valid header]!'
      at <anonymous> (/workspace/bun/test/js/web/request/request-subclass.test.ts:81:26)

... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (62f0b274e)

test/js/web/request/request-subclass.test.ts:
(pass) fetch() uses a subclass Request's internal state, not getter overrides [1.88ms]
(pass) fetch() ignores a subclass headers getter returning invalid header names [1.08ms]

test/js/web/fetch/fetch-args.test.ts:
(pass) fetch(request subclass with headers) [0.55ms]
(pass) fetch(RequestInit, headers) [0.17ms]
(pass) fetch(url, RequestSubclass) [0.20ms]
(pass) fetch({toString throwing}, {headers} isn't accessed) [0.18ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > url toString() throws [0.09ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.headers iterable throws [0.17ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.body getter throws [0.08ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.decompress getter throws [0.01ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.headers getter throws
(pass) fetch() rejects instead of throwing synchronously when 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-args.test.ts test/js/web/request/request-subclass.test.ts
bun test v1.4.0 (62ef1ce75)

test/js/web/request/request-subclass.test.ts:
(pass) fetch() uses a subclass Request's internal state, not getter overrides [47.24ms]
(pass) fetch() ignores a subclass headers getter returning invalid header names [24.44ms]

test/js/web/fetch/fetch-args.test.ts:
(pass) fetch(request subclass with headers) [17.91ms]
(pass) fetch(RequestInit, headers) [8.33ms]
(pass) fetch(url, RequestSubclass) [10.42ms]
(pass) fetch({toString throwing}, {headers} isn't accessed) [11.56ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > url toString() throws [7.27ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.headers iterable throws [14.54ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.body getter throws [6.82ms]
(pass) fetch() rejects instead of throwing synchronously when option conversion throws > init.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 641ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9012ms)
Bundle modules (49ms)
Postprocesss modules (171ms)
Bundle Functions (859ms)
Generate Code (20ms)

[10.13s] Bundled "src/js" for production
  2573 kb
  193 internal modules
  13 native modules
  84 internal functions across 17 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/fetch.rs                 |  13 +--
 test/js/web/fetch/fetch-args.test.ts         | 122 +++++++++++++++++++++++++++
 test/js/web/request/request-subclass.test.ts |  85 ++++++++++---------
 3 files changed, 168 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/runtime/webcore/fetch.rs                      5      5      0
test/js/web/fetch/fetch-args.test.ts              1      2      0
test/js/web/request/request-subclass.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->