### PR TITLE
bun:test: implement proper construct semantics for mock functions

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -834,6 +834,20 @@ static JSC::EncodedJSValue jsMockFunctionCallImpl(Zig::GlobalObject* globalObjec
         fn->contexts.set(vm, fn, contexts);
     }
 
+    JSC::JSArray* instances = fn->instances.get();
+    if (instances) {
+        instances->push(globalObject, thisValue);
+        RETURN_IF_EXCEPTION(scope, {});
+    } else {
+        JSC::ObjectInitializationScope object(vm);
+        instances = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            1);
+        instances->initializeIndex(object, 0, thisValue);
+        fn->instances.set(vm, fn, instances);
+    }
+
     auto invocationId = JSMockModule::nextInvocationId();
     JSC::JSArray* invocationCallOrder = fn->invocationCallOrder.get();
     if (invocationCallOrder) {
@@ -974,13 +988,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     JSObject* thisObject = prototype.isObject()
         ? JSC::constructEmptyObject(globalObject, asObject(prototype))
         : JSC::constructEmptyObject(globalObject);
-
-    JSC::JSArray* instances = fn->getInstances();
-    RETURN_IF_EXCEPTION(scope, {});
-    if (instances) {
-        instances->push(globalObject, thisObject);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
 
     JSValue result = JSValue::decode(jsMockFunctionCallImpl(globalObject, fn, callframe, thisObject));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -87,6 +87,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -450,7 +451,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -787,19 +788,12 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(Zig::GlobalObject* globalObject, JSMockFunction* fn, CallFrame* callframe, JSValue thisValue)
 {
-    Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
-    JSMockFunction* fn = dynamicDowncast<JSMockFunction>(callframe->jsCallee());
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!fn) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Expected callee to be mock function"_s);
-        return {};
-    }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -945,6 +939,57 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSMockFunction* fn = dynamicDowncast<JSMockFunction>(callframe->jsCallee());
+    if (!fn) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Expected callee to be mock function"_s);
+        return {};
+    }
+
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
+    RELEASE_AND_RETURN(scope, jsMockFunctionCallImpl(globalObject, fn, callframe, thisValue));
+}
+
+// JSC requires a native [[Construct]] to return an object, so this cannot share jsMockFunctionCall.
+// Matches ordinary function construct semantics (and Jest): create `this` from newTarget's prototype,
+// run the mock with it, and return the mock's result if it is an object, the new instance otherwise.
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSMockFunction* fn = dynamicDowncast<JSMockFunction>(callframe->jsCallee());
+    if (!fn) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Expected callee to be mock function"_s);
+        return {};
+    }
+
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSValue prototype = newTarget->get(globalObject, vm.propertyNames->prototype);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* thisObject = prototype.isObject()
+        ? JSC::constructEmptyObject(globalObject, asObject(prototype))
+        : JSC::constructEmptyObject(globalObject);
+
+    JSC::JSArray* instances = fn->getInstances();
+    RETURN_IF_EXCEPTION(scope, {});
+    if (instances) {
+        instances->push(globalObject, thisObject);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    JSValue result = JSValue::decode(jsMockFunctionCallImpl(globalObject, fn, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (result.isObject())
+        return JSValue::encode(result);
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -983,11 +983,11 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     }
 
     JSObject* newTarget = asObject(callframe->newTarget());
-    JSValue prototype = newTarget->get(globalObject, vm.propertyNames->prototype);
+    JSGlobalObject* functionGlobalObject = getFunctionRealm(globalObject, newTarget);
     RETURN_IF_EXCEPTION(scope, {});
-    JSObject* thisObject = prototype.isObject()
-        ? JSC::constructEmptyObject(globalObject, asObject(prototype))
-        : JSC::constructEmptyObject(globalObject);
+    Structure* structure = InternalFunction::createSubclassStructure(globalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* thisObject = JSC::constructEmptyObject(vm, structure);
 
     JSValue result = JSValue::decode(jsMockFunctionCallImpl(globalObject, fn, callframe, thisObject));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -956,9 +956,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     RELEASE_AND_RETURN(scope, jsMockFunctionCallImpl(globalObject, fn, callframe, thisValue));
 }
 
-// JSC requires a native [[Construct]] to return an object, so this cannot share jsMockFunctionCall.
-// Matches ordinary function construct semantics (and Jest): create `this` from newTarget's prototype,
-// run the mock with it, and return the mock's result if it is an object, the new instance otherwise.
+// A native [[Construct]] must return an object (Interpreter::executeConstruct calls asObject on the result).
 JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -885,6 +885,76 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  describe("construct", () => {
+    test("new on a mock with no implementation returns a new object", () => {
+      const fn = jest.fn();
+      const instance = new fn(1, 2);
+      expect(typeof instance).toBe("object");
+      expect(instance).not.toBe(null);
+      expect(fn.mock.calls).toEqual([[1, 2]]);
+      expect(fn.mock.contexts[0]).toBe(instance);
+      expect(fn.mock.instances[0]).toBe(instance);
+      expect(fn.mock.results).toEqual([{ type: "return", value: undefined }]);
+    });
+
+    test("implementation runs with `this` set to the new instance", () => {
+      const fn = jest.fn(function (value) {
+        this.value = value;
+      });
+      const instance = new fn(42);
+      expect(instance.value).toBe(42);
+    });
+
+    test("object returned by the implementation replaces the instance", () => {
+      const obj = { a: 1 };
+      const fn = jest.fn(() => obj);
+      expect(new fn()).toBe(obj);
+    });
+
+    test("non-object return values are ignored under new", () => {
+      const fn = jest.fn();
+      fn.mockReturnValue(42);
+      const instance = new fn();
+      expect(typeof instance).toBe("object");
+      expect(fn()).toBe(42);
+    });
+
+    test("uses the prototype property of the constructor", () => {
+      const fn = jest.fn();
+      fn.prototype = { marker: true };
+      const instance = new fn();
+      expect(Object.getPrototypeOf(instance)).toBe(fn.prototype);
+      expect(instance.marker).toBe(true);
+    });
+
+    test("Reflect.construct uses newTarget's prototype", () => {
+      const fn = jest.fn();
+      function NewTarget() {}
+      NewTarget.prototype = { fromNewTarget: true };
+      const instance = Reflect.construct(fn, [], NewTarget);
+      expect(Object.getPrototypeOf(instance)).toBe(NewTarget.prototype);
+    });
+
+    test("throwing implementation propagates and records the result", () => {
+      const error = new Error("construct error");
+      const fn = jest.fn(() => {
+        throw error;
+      });
+      expect(() => new fn()).toThrow("construct error");
+      expect(fn.mock.results).toEqual([{ type: "throw", value: error }]);
+    });
+
+    if (isBun) {
+      test("constructing a spy on a missing property does not crash", () => {
+        const target = {};
+        const spy = spyOn(target, 9);
+        const instance = Reflect.construct(spy, []);
+        expect(typeof instance).toBe("object");
+        spy.mockRestore();
+      });
+    }
+  });
 });
 
 describe("resetAllMocks", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -4,6 +4,7 @@
  *  `bunx vitest test/js/bun/test/mock-fn.test.js`
  *  `NODE_OPTIONS=--experimental-vm-modules npx jest test/js/bun/test/mock-fn.test.js`
  */
+import { runInNewContext } from "node:vm";
 import test_interop from "./test-interop.js";
 var { isBun, describe, test, it, expect, jest, vi, mock, spyOn } = await test_interop();
 
@@ -964,6 +965,17 @@ describe("mock()", () => {
         expect(fn.mock.instances[0]).toBeUndefined();
         expect(fn.mock.instances[1]).toBe(obj);
         expect(fn.mock.instances[2]).toBe(instance);
+      });
+
+      test("falls back to Object.prototype of newTarget's realm when its prototype is not an object", () => {
+        const fn = jest.fn();
+        const { NewTarget, otherObjectPrototype } = runInNewContext(
+          "({ NewTarget: function NewTarget() {}, otherObjectPrototype: Object.prototype })",
+        );
+        expect(otherObjectPrototype).not.toBe(Object.prototype);
+        NewTarget.prototype = null;
+        const instance = Reflect.construct(fn, [], NewTarget);
+        expect(Object.getPrototypeOf(instance)).toBe(otherObjectPrototype);
       });
     }
   });

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -953,6 +953,18 @@ describe("mock()", () => {
         expect(typeof instance).toBe("object");
         spy.mockRestore();
       });
+
+      test("instances records `this` for every invocation, in call order", () => {
+        const fn = jest.fn();
+        const obj = { fn };
+        fn();
+        obj.fn();
+        const instance = new fn();
+        expect(fn.mock.instances).toHaveLength(fn.mock.calls.length);
+        expect(fn.mock.instances[0]).toBeUndefined();
+        expect(fn.mock.instances[1]).toBe(obj);
+        expect(fn.mock.instances[2]).toBe(instance);
+      });
     }
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (assertion `isCell()` in `JSCJSValue.h:766`, reachable from plain `bun:test` usage).

`JSMockFunction` passed `jsMockFunctionCall` as both the call and the construct callback. JSC requires a native `[[Construct]]` callback to return an object (`Interpreter::executeConstruct` does `asObject(result)` on the return value), but the call handler returns whatever the mock implementation returns. So `new (jest.fn())`, or `Reflect.construct` on any mock or spy whose implementation yields a non-object, failed the assertion in debug builds. In release builds the non-object value escaped the `new` expression (`new (jest.fn())` evaluated to `undefined`), and C++ callers of `JSC::construct` would treat those value bits as a `JSObject*`.

Repro on release or debug builds before this change:

```js
import { mock } from "bun:test";
const fn = mock();
console.log(new fn()); // undefined on release builds, assertion failure on debug builds
```

The fix gives mock functions a real construct handler with ordinary-function semantics, which is also what Jest's mocks do (they are plain JS functions):

- create the instance from `newTarget.prototype`, falling back to the `Object.prototype` of newTarget's own realm when that is not an object (via `getFunctionRealm` and `InternalFunction::createSubclassStructure`, the same path JSC's `Object` constructor and the napi class constructor use)
- run the mock body with the instance as `this`, so `jest.fn(function () { this.x = 1; })` works with `new`
- return the body's result when it is an object, the new instance otherwise

While here, `mock.instances` is now populated. It was always empty before. It records `this` on every invocation, next to `calls` and `contexts`, which is what jest-mock does, so `instances[i]` lines up with `calls[i]` whether the mock was called or constructed. The rest of the shared recording logic (calls, contexts, results, invocation order, implementation dispatch) is unchanged.

Rebase note: #39509 landed on main in the meantime. It converts a scope-object receiver to `undefined` with `toThis(..., ECMAMode::strict())` on the line in `jsMockFunctionCall` that read `callframe->thisValue()`. This PR turns that receiver into a parameter of the shared body, so the conversion now lives in the call wrapper, right where the receiver is read. The construct wrapper passes the new instance and needs no conversion. A bare call through a captured scope records `undefined` in `contexts` and in `instances`, and the three tests from #39509 pass together with the ones added here.

### How did you verify your code works?

- The fuzzer's crash script and minimized variants no longer crash on a debug+ASAN build (clean exit, correct values).
- New tests in `test/js/bun/test/mock-fn.test.js` covering construct with no implementation, `this` binding, object vs non-object return values, custom `prototype`, `Reflect.construct` with a separate `newTarget`, throwing implementations, constructing a spy, `instances` staying aligned with `calls` across mixed calls and constructs, and a cross-realm `newTarget` (via `node:vm`) with a null `prototype` getting its own realm's `Object.prototype`. 8 of them fail on the current release build.
- Full `mock-fn.test.js`, `mock-disposable.test.ts`, `spyMatchers.test.ts`, and `test/js/bun/test/mock/` pass (269 tests after the rebase onto #39509), as does the `ERR_INVALID_THIS` test in `globals.test.js` that #39509 extended. The construct path is clean under `BUN_JSC_validateExceptionChecks=1`, including the throwing path for a revoked Proxy as `newTarget`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (ce822ed8b)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.13ms]
(pass) mock() > mock [6.47ms]
(pass) mock() > checks the this value > mock [7.44ms]
(pass) mock() > checks the this value > _protoImpl [0.78ms]
(pass) mock() > checks the this value > getMockImplementation [1.61ms]
(pass) mock() > checks the this value > getMockName [0.83ms]
(pass) mock() > checks the this value > mockClear [0.66ms]
(pass) mock() > checks the this value > mockReset [0.67ms]
(pass) mock() > checks the this value > mockRestore [0.61ms]
(pass) mock() > checks the this value > mockImplementation [0.58ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.87ms]
(pass) mock() > checks the this value > withImplementation [0.62ms]
(pass) mock() > checks the this value > mockName [0.62ms]
(pass) mock() > checks the this value > mockReturnThis [0.53ms]
(pass) mock() > checks the this value > mockReturnValue [1.71ms]
(pass) mock() > checks the this value
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.04ms]
(pass) mock() > mock [0.17ms]
(pass) mock() > checks the this value > mock [0.17ms]
(pass) mock() > checks the this value > _protoImpl [0.01ms]
(pass) mock() > checks the this value > getMockImplementation [0.03ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.01ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName [0.02ms]
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (ce822ed8b)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.99ms]
(pass) mock() > mock [6.20ms]
(pass) mock() > checks the this value > mock [6.85ms]
(pass) mock() > checks the this value > _protoImpl [0.77ms]
(pass) mock() > checks the this value > getMockImplementation [1.48ms]
(pass) mock() > checks the this value > getMockName [0.79ms]
(pass) mock() > checks the this value > mockClear [0.59ms]
(pass) mock() > checks the this value > mockReset [0.68ms]
(pass) mock() > checks the this value > mockRestore [0.62ms]
(pass) mock() > checks the this value > mockImplementation [0.58ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.81ms]
(pass) mock() > checks the this value > withImplementation [0.59ms]
(pass) mock() > checks the this value > mockName [0.65ms]
(pass) mock() > checks the this value > mockReturnThis [1.71ms]
(pass) mock() > checks the this value > mockReturnValue [0.51ms]
(pass) mock() > checks the this value
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ce822ed8b7
  features     baseline

22 deps, 123 codegen, 1176 objects in 671ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [8.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1238] gen bindgenv2
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp | 67 ++++++++++++++++++++++++++----
 test/js/bun/test/mock-fn.test.js    | 82 +++++++++++++++++++++++++++++++++++++
 2 files changed, 140 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp      8      7      0
test/js/bun/test/mock-fn.test.js         5      2      0
```

</details>

<!-- robobun:evidence:end -->


