### PR TITLE
Fix assertion failure when constructing a mock function that returns a primitive

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -87,6 +87,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -463,7 +464,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -798,7 +799,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -810,7 +811,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -956,6 +956,40 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue().toThis(lexicalGlobalObject, ECMAMode::strict()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue newTarget = callframe->newTarget();
+    JSObject* prototype = nullptr;
+    if (newTarget.isObject()) {
+        JSValue prototypeValue = newTarget.get(lexicalGlobalObject, vm.propertyNames->prototype);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (prototypeValue.isObject())
+            prototype = asObject(prototypeValue);
+    }
+
+    JSObject* thisObject = prototype
+        ? JSC::constructEmptyObject(lexicalGlobalObject, prototype)
+        : JSC::constructEmptyObject(lexicalGlobalObject);
+
+    JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    // A native [[Construct]] must return an object (JSC casts the result with
+    // asObject). Match JS `new` semantics: a primitive return value is
+    // discarded in favor of the newly created `this`.
+    if (result && result.isObject())
+        return JSValue::encode(result);
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -984,8 +984,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
     RETURN_IF_EXCEPTION(scope, {});
 
-    // JSC requires a native [[Construct]] to return an object, so like JS `new`,
-    // a primitive result is replaced with the created `this`.
     if (result && result.isObject())
         return JSValue::encode(result);
     return JSValue::encode(thisObject);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -984,9 +984,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     JSValue result = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
     RETURN_IF_EXCEPTION(scope, {});
 
-    // A native [[Construct]] must return an object (JSC casts the result with
-    // asObject). Match JS `new` semantics: a primitive return value is
-    // discarded in favor of the newly created `this`.
+    // JSC requires a native [[Construct]] to return an object, so like JS `new`,
+    // a primitive result is replaced with the created `this`.
     if (result && result.isObject())
         return JSValue::encode(result);
     return JSValue::encode(thisObject);

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1170,3 +1170,40 @@ describe("spyOn", () => {
 
   // spyOn does not work with getters/setters yet.
 });
+
+describe("constructing a mock", () => {
+  test("returns the created instance when the implementation returns a primitive", () => {
+    const fn = jest.fn(() => 42);
+    const instance = new fn();
+    expect(typeof instance).toBe("object");
+    expect(fn.mock.calls).toEqual([[]]);
+    expect(fn()).toBe(42);
+  });
+
+  test("with no implementation returns an object", () => {
+    const fn = jest.fn();
+    expect(typeof Reflect.construct(fn, [])).toBe("object");
+  });
+
+  test("returns the implementation's return value when it is an object", () => {
+    const result = { ok: true };
+    const fn = jest.fn(() => result);
+    expect(new fn()).toBe(result);
+  });
+
+  test("calls the implementation with the created instance as this", () => {
+    const fn = jest.fn(function (value) {
+      this.value = value;
+    });
+    const instance = new fn(42);
+    expect(instance.value).toBe(42);
+  });
+
+  test("spy on a function returning a symbol returns the instance", () => {
+    const obj = { sym: Symbol };
+    const spy = spyOn(obj, "sym");
+    const instance = Reflect.construct(spy, []);
+    expect(typeof instance).toBe("object");
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (fingerprint `JSObject.h(1081)`, assertion `cell->isObjectSlow()` in `JSC::asObject`).

`JSMockFunction` registered `jsMockFunctionCall` as both its call and construct handler. A native [[Construct]] callback must return an object: JSC's `Interpreter::executeConstruct` runs `asObject()` on the result without a check. The mock forwarded whatever the wrapped implementation returned. So a constructed mock whose implementation returns a primitive handed a non-object to `asObject`. In debug builds that is an assertion failure. The face of the assertion depends on the value: a Symbol or string trips `isObjectSlow()`, and `undefined` or a number trips the sibling `isCell()` check in `asObject(JSValue)`. In release builds `Reflect.construct()` returns the primitive. For example, `Reflect.construct(spy, [])` on a spy of a function that returns 42 returns `42` on current main.

Repro on current main:

```js
const obj = { sym: Symbol };
const spy = Bun.jest(path).spyOn(obj, "sym");
Reflect.construct(spy, []); // ASSERTION FAILED: cell->isObjectSlow()
```

The fuzzer reports the same crash through every way to make a mock: `spyOn` on a function, `spyOn` on a missing property, `mock()` with no implementation, and `mock(value)` with a non-callable value. All of them go through the same construct slot.

The fix gives the mock a dedicated construct handler. It follows ordinary JS constructor semantics, which is what jest's plain-function `mockConstructor` does under `new`:

- create `this` from `newTarget.prototype`, or from a plain object if there is no usable prototype
- run the existing mock call logic with that `this`
- return the implementation's result if it is an object, otherwise return the created instance

Calls, contexts and results are recorded as before. A throwing implementation still propagates, and `mock.results` records the throw.

### Rebase note

The branch was rebased over #39509 (`ec7a24ba6c`). That change converts a raw scope-object receiver to `undefined` with `toThis(globalObject, ECMAMode::strict())` at the top of `jsMockFunctionCall`. This PR splits that function into a shared `jsMockFunctionCallImpl` that takes `this` as a parameter. The `toThis` conversion now lives in the call wrapper, which reads `this` from the frame. The construct wrapper passes the object it creates, which does not need the conversion. The three receiver tests from #39509 pass on the rebased branch.

### How did you verify your code works?

- The fuzzer script and the minimized variants of every reported shape exit cleanly on a debug ASAN build.
- New tests in `test/js/bun/test/mock-fn.test.js` fail on the current release build (construct returns primitives) and pass with this change.
- `bun bd test` on `mock-fn.test.js` (88 tests after the rebase, with `BUN_JSC_validateExceptionChecks=1`), `mock-disposable.test.ts` and `spyMatchers.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (8326d1bd3)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.71ms]
(pass) mock() > mock [10.45ms]
(pass) mock() > checks the this value > mock [7.85ms]
(pass) mock() > checks the this value > _protoImpl [0.82ms]
(pass) mock() > checks the this value > getMockImplementation [1.53ms]
(pass) mock() > checks the this value > getMockName [0.78ms]
(pass) mock() > checks the this value > mockClear [0.69ms]
(pass) mock() > checks the this value > mockReset [0.68ms]
(pass) mock() > checks the this value > mockRestore [0.78ms]
(pass) mock() > checks the this value > mockImplementation [0.69ms]
(pass) mock() > checks the this value > mockImplementationOnce [2.03ms]
(pass) mock() > checks the this value > withImplementation [0.66ms]
(pass) mock() > checks the this value > mockName [0.59ms]
(pass) mock() > checks the this value > mockReturnThis [0.57ms]
(pass) mock() > checks the this value > mockReturnValue [0.53ms]
(pass) mock() > checks the this valu
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.02ms]
(pass) mock() > mock [0.10ms]
(pass) mock() > checks the this value > mock [0.11ms]
(pass) mock() > checks the this value > _protoImpl [0.01ms]
(pass) mock() > checks the this value > getMockImplementation [0.03ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.01ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis [0.01ms]
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (8326d1bd3)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [2.09ms]
(pass) mock() > mock [6.26ms]
(pass) mock() > checks the this value > mock [7.22ms]
(pass) mock() > checks the this value > _protoImpl [0.85ms]
(pass) mock() > checks the this value > getMockImplementation [1.87ms]
(pass) mock() > checks the this value > getMockName [0.78ms]
(pass) mock() > checks the this value > mockClear [0.73ms]
(pass) mock() > checks the this value > mockReset [0.73ms]
(pass) mock() > checks the this value > mockRestore [0.72ms]
(pass) mock() > checks the this value > mockImplementation [0.73ms]
(pass) mock() > checks the this value > mockImplementationOnce [2.24ms]
(pass) mock() > checks the this value > withImplementation [0.73ms]
(pass) mock() > checks the this value > mockName [0.65ms]
(pass) mock() > checks the this value > mockReturnThis [0.59ms]
(pass) mock() > checks the this value > mockReturnValue [0.57ms]
(pass) mock() > checks the this value
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 724ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen ErrorCode+*.h
[2/125] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/125] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameP
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp | 37 ++++++++++++++++++++++++++++++++++---
 test/js/bun/test/mock-fn.test.js    | 37 +++++++++++++++++++++++++++++++++++++
 2 files changed, 71 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp     13     11      0
test/js/bun/test/mock-fn.test.js         2      1      0
```

</details>

<!-- robobun:evidence:end -->
