### PR TITLE
webcore: copy internal state in new Request(request) instead of calling getters

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1143,11 +1143,12 @@ impl Request {
                 if let Some(request) = request_ptr {
                     // SAFETY: the cast returns a live *mut Request payload (m_ctx)
                     let request = unsafe { &*request };
-                    // Fetch spec: with no body from `init`, a
-                    // disturbed-or-locked input body is unusable.
-                    if is_input_argument
+                    // Fetch spec: `init.body: null`/absent contributes no
+                    // body, so the input's body applies and must be usable.
+                    let input_body_applies = is_input_argument
                         && (!fields.contains(Fields::Body)
-                            || matches!(req.body_value(), BodyValue::Null))
+                            || matches!(req.body_value(), BodyValue::Null));
+                    if input_body_applies
                         && request.body_stream_check(global_this, |s, g| {
                             s.is_disturbed(g) || s.is_locked(g)
                         })
@@ -1206,7 +1207,7 @@ impl Request {
                         }
                     }
 
-                    if !fields.contains(Fields::Body) {
+                    if !fields.contains(Fields::Body) || input_body_applies {
                         match request.body_value() {
                             BodyValue::Null | BodyValue::Used => {}
                             // `Empty` is a non-null body; an input copy keeps

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -18,7 +18,7 @@ use crate::webcore::jsc::{
 };
 use crate::webcore::{AbortSignal, Blob, CookieMap, FetchHeaders, ReadableStream, Response};
 use bun_alloc::AllocError;
-use bun_core::{Output, fmt as bun_fmt};
+use bun_core::{Output, UnwrapOrOom, fmt as bun_fmt};
 use bun_core::{OwnedStringCell, String as BunString, ZigString, strings};
 use bun_http_jsc::fetch_enums_jsc::{
     fetch_cache_mode_to_js, fetch_redirect_to_js, fetch_request_mode_to_js,
@@ -1230,12 +1230,10 @@ impl Request {
                         // Mark every remaining field consumed so the dictionary
                         // fallbacks below never run JS getters against the input.
                         if !fields.contains(Fields::Url) {
-                            // A Bun.serve request materializes its URL lazily
-                            // from the request context; a detached one stays
-                            // empty and reaches the "url is required" throw.
-                            // The field is consumed from internal state either
-                            // way, keeping the getter fallback off.
-                            let _ = request.ensure_url();
+                            // A Bun.serve request materializes its URL lazily;
+                            // a detached one stays empty and reaches the "url
+                            // is required" throw, with the field consumed.
+                            request.ensure_url().unwrap_or_oom();
                             let url = request.url.get();
                             if !url.is_empty() {
                                 req.url.set(url.dupe_ref());
@@ -1610,7 +1608,7 @@ impl Request {
         preserve_url: bool,
     ) -> JsResult<()> {
         // allocator param dropped (global mimalloc)
-        let _ = self.ensure_url();
+        self.ensure_url().unwrap_or_oom();
         let body_ = self.clone_body_value_via_cached_stream(global_this)?;
         // BodyValue's Drop frees `body_` on the `?` error path
         let body = body::hive_alloc(body_);

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1231,13 +1231,16 @@ impl Request {
                         // fallbacks below never run JS getters against the input.
                         if !fields.contains(Fields::Url) {
                             // A Bun.serve request materializes its URL lazily
-                            // from the request context.
+                            // from the request context; a detached one stays
+                            // empty and reaches the "url is required" throw.
+                            // The field is consumed from internal state either
+                            // way, keeping the getter fallback off.
                             let _ = request.ensure_url();
                             let url = request.url.get();
                             if !url.is_empty() {
                                 req.url.set(url.dupe_ref());
-                                fields.insert(Fields::Url);
                             }
+                            fields.insert(Fields::Url);
                         }
                         if !fields.contains(Fields::Signal) {
                             if let Some(signal) = request.signal.get() {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1121,15 +1121,47 @@ impl Request {
         let values_to_try = &values_to_try_[0..((!is_first_argument_a_url) as usize
             + (arguments.len() > 1 && arguments[1].is_object()) as usize)];
 
-        for &value in values_to_try {
+        for (value_index, &value) in values_to_try.iter().enumerate() {
             let value_type = value.js_type();
+            // The last entry carries the constructor's first argument (the
+            // `input` in `new Request(input, init?)`) whenever that argument
+            // was an object rather than a URL; any other entry carries `init`
+            // (dictionary) semantics.
+            let is_input_argument =
+                !is_first_argument_a_url && value_index == values_to_try.len() - 1;
             let explicit_check = values_to_try.len() == 2
                 && value_type == bun_jsc::JSType::FinalObject
                 && values_to_try[1].js_type() == bun_jsc::JSType::DOMWrapper;
             if value_type == bun_jsc::JSType::DOMWrapper {
-                if let Some(request) = value.as_direct::<Request>() {
-                    // SAFETY: as_direct returns a live *mut Request payload (m_ctx)
+                // A Request `input` is copied from internal state without
+                // consulting JS-visible getters (fetch spec: "Set request to
+                // input's request"), so subclass instances and inputs with
+                // shadowing own properties must take this path too; their
+                // transitioned structures make `as_direct` reject them. A
+                // Request used as `init` keeps dictionary semantics: only a
+                // pristine one may skip the getters.
+                let request_ptr = if is_input_argument {
+                    value.as_::<Request>()
+                } else {
+                    value.as_direct::<Request>()
+                };
+                if let Some(request) = request_ptr {
+                    // SAFETY: the cast returns a live *mut Request payload (m_ctx)
                     let request = unsafe { &*request };
+                    // Fetch spec Request(input): when `init` contributed no
+                    // body, a Request input whose body is disturbed or locked
+                    // is unusable and the constructor throws.
+                    if is_input_argument
+                        && (!fields.contains(Fields::Body)
+                            || matches!(req.body_value(), BodyValue::Null))
+                        && request.body_stream_check(global_this, |s, g| {
+                            s.is_disturbed(g) || s.is_locked(g)
+                        })
+                    {
+                        bail!(Err(global_this.throw_type_error(format_args!(
+                            "Cannot construct a Request with a Request object that has already been used."
+                        ))));
+                    }
                     if values_to_try.len() == 1 {
                         match Request::clone_into(
                             request,
@@ -1193,6 +1225,29 @@ impl Request {
                                 fields.insert(Fields::Body);
                             }
                         }
+                    }
+
+                    if is_input_argument {
+                        // The input's remaining members also come from
+                        // internal state; marking every field consumed keeps
+                        // the dictionary fallbacks below from running JS
+                        // getters against the input.
+                        if !fields.contains(Fields::Url) {
+                            let url = request.url.get();
+                            if !url.is_empty() {
+                                req.url.set(url.dupe_ref());
+                                fields.insert(Fields::Url);
+                            }
+                        }
+                        if !fields.contains(Fields::Signal) {
+                            if let Some(signal) = request.signal.get() {
+                                // `AbortSignalRef::clone` is a C++ `ref()`.
+                                req.signal.set(Some(signal.clone()));
+                            }
+                            fields.insert(Fields::Signal);
+                        }
+                        fields.insert(Fields::Headers);
+                        fields.insert(Fields::Body);
                     }
                 }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1208,7 +1208,11 @@ impl Request {
 
                     if !fields.contains(Fields::Body) {
                         match request.body_value() {
-                            BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
+                            BodyValue::Null | BodyValue::Used => {}
+                            // `Empty` is a non-null body; an input copy keeps
+                            // it, while an `init` entry leaves it to the
+                            // dictionary fallback.
+                            BodyValue::Empty if !is_input_argument => {}
                             _ => {
                                 match request.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1233,6 +1233,9 @@ impl Request {
                         // the dictionary fallbacks below from running JS
                         // getters against the input.
                         if !fields.contains(Fields::Url) {
+                            // A Bun.serve request materializes its URL lazily
+                            // from the request context.
+                            let _ = request.ensure_url();
                             let url = request.url.get();
                             if !url.is_empty() {
                                 req.url.set(url.dupe_ref());

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1123,23 +1123,18 @@ impl Request {
 
         for (value_index, &value) in values_to_try.iter().enumerate() {
             let value_type = value.js_type();
-            // The last entry carries the constructor's first argument (the
-            // `input` in `new Request(input, init?)`) whenever that argument
-            // was an object rather than a URL; any other entry carries `init`
-            // (dictionary) semantics.
+            // The last entry is the `input` argument when it was an object
+            // rather than a URL; other entries are `init` dictionaries.
             let is_input_argument =
                 !is_first_argument_a_url && value_index == values_to_try.len() - 1;
             let explicit_check = values_to_try.len() == 2
                 && value_type == bun_jsc::JSType::FinalObject
                 && values_to_try[1].js_type() == bun_jsc::JSType::DOMWrapper;
             if value_type == bun_jsc::JSType::DOMWrapper {
-                // A Request `input` is copied from internal state without
-                // consulting JS-visible getters (fetch spec: "Set request to
-                // input's request"), so subclass instances and inputs with
-                // shadowing own properties must take this path too; their
-                // transitioned structures make `as_direct` reject them. A
-                // Request used as `init` keeps dictionary semantics: only a
-                // pristine one may skip the getters.
+                // Fetch spec: a Request `input` is copied from internal state,
+                // never via JS getters, so subclasses and shadowed instances
+                // (rejected by `as_direct`'s pristine-structure check) must
+                // match too. A Request `init` keeps dictionary semantics.
                 let request_ptr = if is_input_argument {
                     value.as_::<Request>()
                 } else {
@@ -1148,9 +1143,8 @@ impl Request {
                 if let Some(request) = request_ptr {
                     // SAFETY: the cast returns a live *mut Request payload (m_ctx)
                     let request = unsafe { &*request };
-                    // Fetch spec Request(input): when `init` contributed no
-                    // body, a Request input whose body is disturbed or locked
-                    // is unusable and the constructor throws.
+                    // Fetch spec: with no body from `init`, a
+                    // disturbed-or-locked input body is unusable.
                     if is_input_argument
                         && (!fields.contains(Fields::Body)
                             || matches!(req.body_value(), BodyValue::Null))
@@ -1228,10 +1222,8 @@ impl Request {
                     }
 
                     if is_input_argument {
-                        // The input's remaining members also come from
-                        // internal state; marking every field consumed keeps
-                        // the dictionary fallbacks below from running JS
-                        // getters against the input.
+                        // Mark every remaining field consumed so the dictionary
+                        // fallbacks below never run JS getters against the input.
                         if !fields.contains(Fields::Url) {
                             // A Bun.serve request materializes its URL lazily
                             // from the request context.

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -630,18 +630,18 @@ test.each(["Request", "Response"])(
   },
 );
 
-// clone()'s usability check now fires before the stream is teed, so the
-// readableStreamTee C++ bridge's exception propagation (which used to be
-// covered by the test above) is exercised via `new Request(lockedRequest)`,
-// which still tees. It must throw a single catchable TypeError, not also
-// report it as uncaught (exit code 1) or surface a bogus follow-up error.
-test("new Request(request) with a locked stream body throws a catchable TypeError from the tee and does not fail the process", async () => {
+// The usability checks in clone() and in Request(input) fire before the
+// stream is teed, so the readableStreamTee C++ bridge's exception propagation
+// is exercised via a locked Request passed as init (second argument), which
+// still tees. It must throw a single catchable TypeError, not also report it
+// as uncaught (exit code 1) or surface a bogus follow-up error.
+test("new Request(url, lockedRequest) throws a catchable TypeError from the tee and does not fail the process", async () => {
   const script = `
     const stream = new ReadableStream({ start() {} });
     const source = new Request("http://example.com/", { method: "POST", body: stream, duplex: "half" });
     source.body.getReader(); // lock the body stream
     try {
-      new Request(source);
+      new Request("http://other.example/", source);
       console.log("no throw");
     } catch (e) {
       console.log("caught " + e.constructor.name + ": " + e.message);

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -285,6 +285,16 @@ describe("new Request(request) copies internal state without calling getters", (
     expect(await new Request(make(), {}).text()).toBe("real-body");
   });
 
+  test("an empty-string body input copies as a non-null empty body", async () => {
+    const make = () => new Request("http://localhost/", { method: "POST", body: "" });
+    const single = new Request(make());
+    const withInit = new Request(make(), {});
+    expect(single.body).not.toBeNull();
+    expect(withInit.body).not.toBeNull();
+    expect(await single.text()).toBe("");
+    expect(await withInit.text()).toBe("");
+  });
+
   test("the input's signal carries over even when its signal getter is shadowed", () => {
     const ctl = new AbortController();
     const input = new Request("http://localhost/", { signal: ctl.signal });
@@ -307,6 +317,15 @@ describe("new Request(request) copies internal state without calling getters", (
         "Cannot construct a Request with a Request object that has already been used.",
       );
     }
+
+    // Node throws "Request with GET/HEAD method cannot have body." here
+    // because its GET/HEAD-body check precedes the unusable check. Bun has no
+    // constructor-level GET/HEAD-body check (it enforces at fetch() time), so
+    // the unusable error fires; adding that check later must consciously flip
+    // this precedence.
+    expect(() => new Request(input, { method: "GET" })).toThrow(
+      "Cannot construct a Request with a Request object that has already been used.",
+    );
 
     // an init-provided body replaces the input's, so the used input body is
     // never read and nothing throws

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -343,6 +343,31 @@ describe("new Request(request) copies internal state without calling getters", (
     expect(await new Request(input).text()).toBe("st");
   });
 
+  test("a Bun.serve request's lazily materialized url is copied, not read via getter", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        let hits = 0;
+        Object.defineProperty(req, "url", {
+          get() {
+            hits++;
+            return "http://127.0.0.1:9/from-getter";
+          },
+        });
+        const copy = new Request(req, { method: "POST" });
+        const single = new Request(req);
+        return Response.json({ hits, url: copy.url, method: copy.method, single: single.url });
+      },
+    });
+    const res = await fetch(`http://localhost:${server.port}/real-path`);
+    expect(await res.json()).toEqual({
+      hits: 0,
+      url: `http://localhost:${server.port}/real-path`,
+      method: "POST",
+      single: `http://localhost:${server.port}/real-path`,
+    });
+  });
+
   test("a Request passed as init (second argument) keeps dictionary getter semantics", () => {
     let getterHits = 0;
     const asInit = new Request("http://localhost/original", { method: "PUT" });

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -285,6 +285,13 @@ describe("new Request(request) copies internal state without calling getters", (
     expect(await new Request(make(), {}).text()).toBe("real-body");
   });
 
+  test("init body: null contributes no body, so the input's body is copied", async () => {
+    const input = new Request("http://localhost/", { method: "POST", body: "hello" });
+    const copy = new Request(input, { body: null });
+    expect(copy.body).not.toBeNull();
+    expect(await copy.text()).toBe("hello");
+  });
+
   test("an empty-string body input copies as a non-null empty body", async () => {
     const make = () => new Request("http://localhost/", { method: "POST", body: "" });
     const single = new Request(make());

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -175,3 +175,188 @@ describe("RequestInit signal presence", () => {
     });
   });
 });
+
+// The fetch spec copies a Request `input`'s internal state ("Set request to
+// input's request") without consulting JS-visible getters, even when the input
+// is a subclass instance or carries shadowing own properties. Node behaves the
+// same. Only the `init` argument has dictionary (getter) semantics.
+describe("new Request(request) copies internal state without calling getters", () => {
+  test("own-property getters on the input are never called", () => {
+    let getterHits = 0;
+    const input = new Request("http://localhost/original", {
+      method: "PUT",
+      headers: { "x-real": "1" },
+    });
+    for (const name of ["url", "method", "headers", "body", "signal", "redirect", "cache", "mode"]) {
+      Object.defineProperty(input, name, {
+        get() {
+          getterHits++;
+          return undefined;
+        },
+      });
+    }
+
+    const copy = new Request(input);
+    expect({
+      url: copy.url,
+      method: copy.method,
+      headers: [...copy.headers],
+      redirect: copy.redirect,
+      getterHits,
+    }).toEqual({
+      url: "http://localhost/original",
+      method: "PUT",
+      headers: [["x-real", "1"]],
+      redirect: "follow",
+      getterHits: 0,
+    });
+  });
+
+  test("subclass getter overrides on the input are ignored", () => {
+    let getterHits = 0;
+    class MyRequest extends Request {
+      get url() {
+        getterHits++;
+        return "http://localhost/from-getter";
+      }
+      get method() {
+        getterHits++;
+        return "DELETE";
+      }
+      get headers() {
+        getterHits++;
+        return new Headers({ "x-from-getter": "1" });
+      }
+    }
+
+    const copy = new Request(new MyRequest("http://localhost/original", { headers: { "x-real": "1" } }));
+    expect({
+      url: copy.url,
+      method: copy.method,
+      headers: [...copy.headers],
+      getterHits,
+    }).toEqual({
+      url: "http://localhost/original",
+      method: "GET",
+      headers: [["x-real", "1"]],
+      getterHits: 0,
+    });
+  });
+
+  test("init members win; everything else comes from the input's internal state", () => {
+    class MyRequest extends Request {
+      get url() {
+        return "http://localhost/from-getter";
+      }
+      get headers() {
+        return new Headers({ "x-from-getter": "1" });
+      }
+      get redirect() {
+        return "error";
+      }
+    }
+
+    const input = new MyRequest("http://localhost/original", { headers: { "x-real": "1" } });
+    const copy = new Request(input, { method: "POST" });
+    expect({
+      url: copy.url,
+      method: copy.method,
+      headers: [...copy.headers],
+      redirect: copy.redirect,
+    }).toEqual({
+      url: "http://localhost/original",
+      method: "POST",
+      headers: [["x-real", "1"]],
+      redirect: "follow",
+    });
+  });
+
+  test("body comes from the input's internal state, not the body getter", async () => {
+    const make = () => {
+      const input = new Request("http://localhost/original", { method: "POST", body: "real-body" });
+      Object.defineProperty(input, "body", {
+        get() {
+          return "getter-body";
+        },
+      });
+      return input;
+    };
+    expect(await new Request(make()).text()).toBe("real-body");
+    expect(await new Request(make(), {}).text()).toBe("real-body");
+  });
+
+  test("the input's signal carries over even when its signal getter is shadowed", () => {
+    const ctl = new AbortController();
+    const input = new Request("http://localhost/", { signal: ctl.signal });
+    Object.defineProperty(input, "signal", {
+      get() {
+        return undefined;
+      },
+    });
+    const copy = new Request(input, {});
+    ctl.abort();
+    expect(copy.signal.aborted).toBe(true);
+  });
+
+  test("throws TypeError when the input's body is already used", async () => {
+    const input = new Request("http://localhost/", { method: "POST", body: "x" });
+    await input.text();
+    expect(() => new Request(input)).toThrow(TypeError);
+    for (const init of [undefined, {}, { body: null }] as const) {
+      expect(() => new Request(input, init)).toThrow(
+        "Cannot construct a Request with a Request object that has already been used.",
+      );
+    }
+
+    // an init-provided body replaces the input's, so the used input body is
+    // never read and nothing throws
+    const replaced = new Request(input, { body: "fresh" });
+    expect(await replaced.text()).toBe("fresh");
+  });
+
+  test("throws TypeError when the input's body stream is locked", () => {
+    const input = new Request("http://localhost/", {
+      method: "POST",
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new Uint8Array([97]));
+          c.close();
+        },
+      }),
+    });
+    input.body!.getReader();
+    expect(() => new Request(input)).toThrow(
+      "Cannot construct a Request with a Request object that has already been used.",
+    );
+  });
+
+  test("an unlocked stream-body input still copies fine", async () => {
+    const input = new Request("http://localhost/", {
+      method: "POST",
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("st"));
+          c.close();
+        },
+      }),
+    });
+    expect(await new Request(input).text()).toBe("st");
+  });
+
+  test("a Request passed as init (second argument) keeps dictionary getter semantics", () => {
+    let getterHits = 0;
+    const asInit = new Request("http://localhost/original", { method: "PUT" });
+    Object.defineProperty(asInit, "method", {
+      get() {
+        getterHits++;
+        return "PATCH";
+      },
+    });
+    const built = new Request("http://localhost/base", asInit);
+    expect({ url: built.url, method: built.method, getterHits }).toEqual({
+      url: "http://localhost/base",
+      method: "PATCH",
+      getterHits: 1,
+    });
+  });
+});

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -244,6 +244,8 @@ describe("new Request(request) copies internal state without calling getters", (
   });
 
   test("init members win; everything else comes from the input's internal state", () => {
+    // Internal values differ from both the defaults and the getter values, so
+    // this discriminates "getter ignored" and "internal value actually copied".
     class MyRequest extends Request {
       get url() {
         return "http://localhost/from-getter";
@@ -252,22 +254,37 @@ describe("new Request(request) copies internal state without calling getters", (
         return new Headers({ "x-from-getter": "1" });
       }
       get redirect() {
-        return "error";
+        return "manual";
+      }
+      get cache() {
+        return "force-cache";
+      }
+      get mode() {
+        return "no-cors";
       }
     }
 
-    const input = new MyRequest("http://localhost/original", { headers: { "x-real": "1" } });
+    const input = new MyRequest("http://localhost/original", {
+      headers: { "x-real": "1" },
+      redirect: "error",
+      cache: "no-store",
+      mode: "same-origin",
+    });
     const copy = new Request(input, { method: "POST" });
     expect({
       url: copy.url,
       method: copy.method,
       headers: [...copy.headers],
       redirect: copy.redirect,
+      cache: copy.cache,
+      mode: copy.mode,
     }).toEqual({
       url: "http://localhost/original",
       method: "POST",
       headers: [["x-real", "1"]],
-      redirect: "follow",
+      redirect: "error",
+      cache: "no-store",
+      mode: "same-origin",
     });
   });
 
@@ -392,6 +409,44 @@ describe("new Request(request) copies internal state without calling getters", (
       method: "POST",
       single: `http://localhost:${server.port}/real-path`,
     });
+  });
+
+  test("a detached Bun.serve request never falls back to its url getter", async () => {
+    // A handler that responds synchronously without touching req.url leaves
+    // the internal url empty forever once the request context is torn down.
+    let saved: Request | undefined;
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        saved = req;
+        return new Response("ok");
+      },
+    });
+    const res = await fetch(`http://localhost:${server.port}/x`);
+    expect(await res.text()).toBe("ok");
+
+    let hits = 0;
+    Object.defineProperty(saved!, "url", {
+      get() {
+        hits++;
+        return "http://localhost/from-getter";
+      },
+    });
+    expect(() => new Request(saved!, {})).toThrow("url is required");
+    expect(hits).toBe(0);
+  });
+
+  test('init body: "" is a real empty body and replaces the input body', async () => {
+    const fresh = new Request("http://localhost/", { method: "POST", body: "hello" });
+    const replaced = new Request(fresh, { body: "" });
+    expect(replaced.body).not.toBeNull();
+    expect(await replaced.text()).toBe("");
+
+    // a non-null init body means the used input body is never read: no throw
+    const used = new Request("http://localhost/", { method: "POST", body: "x" });
+    await used.text();
+    const afterUsed = new Request(used, { body: "" });
+    expect(await afterUsed.text()).toBe("");
   });
 
   test("a Request passed as init (second argument) keeps dictionary getter semantics", () => {


### PR DESCRIPTION
### Problem

`new Request(input)` only took the internal-state copy path when the input Request's Structure was pristine. A `class extends Request` instance, or a genuine Request that gained any own property, fell through to the dictionary path and was read through JS-visible getters:

```js
let getterHits = 0;
const r = new Request("http://127.0.0.1:1/original", { headers: { "x-real": "1" } });
Object.defineProperty(r, "url", { get() { getterHits++; return "http://127.0.0.1:2/FROM-GETTER"; } });
const r2 = new Request(r);
console.log(r2.url, getterHits);
// bun:  http://127.0.0.1:2/FROM-GETTER  1
// node: http://127.0.0.1:1/original     0
```

The fetch spec's Request constructor sets the new request from the input's request directly ("Set request to input's request"), and Node v26/undici never consults getters for a Request passed as `input`. Getters are only correct for the `init` dictionary argument.

Relatedly, the spec's unusable-input check was missing: `new Request(usedRequest)` silently copied a disturbed body where Node throws `TypeError: Cannot construct a Request with a Request object that has already been used.` (it only threw incidentally, with a different message, when an init object happened to route the disturbed stream through the getter path).

### Cause

In `Request::construct_into`, both constructor arguments flow through the same `values_to_try` loop, and the internal-state branch was gated on `as_direct::<Request>()`, whose generated check requires the cell's structure ID to equal the global pristine `JSRequest` structure. Any structure transition (subclass prototype, added own property) returned null, so the input was parsed as a dictionary.

### Fix

The loop now knows which entry is the `input` argument (always the last entry when the first argument was not a URL):

- the input uses the inherits-based `as_::<Request>()` cast, so subclass instances and transitioned structures still take the internal-state copy
- for the input, url and signal are also copied from internal state, and all fields are marked consumed so none of the dictionary fallbacks run getters against it
- the input's URL is materialized with `ensure_url()` first, since a Bun.serve request builds it lazily from the request context (its signal is set eagerly at creation, so no equivalent step is needed there). A detached server request whose context is already gone keeps its empty url and hits the existing "url is required" throw instead of the getter fallback; the one-argument form's silent empty-url copy there is a pre-existing wart shared with `Request.clone()` and is not changed here
- an `Empty` input body (extracted from an empty string) is copied as the non-null empty body it is, instead of being dropped to null
- when init contributed no body (absent, `undefined`, or `null`), a disturbed-or-locked input body now throws the same TypeError as Node, before the tee
- a Request passed as `init` (second argument) keeps dictionary semantics, where only a pristine instance may skip the getter path

Same bug class as #37027, which covers the `fetch(request)` call site; this PR covers the `Request` constructor.

### Verification

These now match Node v26 (url/method/headers/body/signal from internal state, 0 getter hits, same throw behavior for used/locked/replaced bodies, init getter semantics unchanged), with one pinned exception: when init changes the method to GET/HEAD on a used-body input, Node throws its `Request with GET/HEAD method cannot have body.` error first. That constructor-level GET/HEAD-body check does not exist in bun (bun enforces it at fetch() time), predates this PR, and is a compat-sensitive change of its own, so the unusable-input error fires there instead; a test pins the current precedence.

- new tests in `test/js/web/request/request.test.ts`: own-property and subclass getter shadowing (one-arg and two-arg forms), init-wins semantics, internal body/signal copy, a Bun.serve handler request with a shadowed url getter, empty-string-body copy, used/locked-body throws, and the preserved init-position getter semantics. 7 of them fail on bun 1.3.6 and pass with this change
- `test/js/web/fetch/body-clone.test.ts`'s tee-propagation test now uses a locked Request as `init`, the remaining path that still tees a locked stream; the input-position form it used before is covered by the new constructor tests
- `request-subclass.test.ts` (fetch()-getter behavior from #4718), `body-clone.test.ts`, `response.test.ts`, `fetch.test.ts`, undici tests: no new failures

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body-clone.test.ts test/js/web/request/request.test.ts
bun test v1.4.0 (0855f3fa2)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [3.72ms]
(pass) request can receive undefined signal [8.41ms]
(pass) request can receive null signal [7.29ms]
(pass) clone() does not lock original body when body was accessed before clone [18.82ms]
(pass) RequestInit signal presence > new Request(request, { signal: null }) detaches from input's signal [5.01ms]
(pass) RequestInit signal presence > new Request(request, { signal: undefined }) inherits input's signal [3.16ms]
(pass) RequestInit signal presence > new Request(request, {}) inherits input's signal [3.12ms]
(pass) RequestInit signal presence > signal: "" throws TypeError [3.61ms]
(pass) RequestInit signal presence > signal: {} throws TypeError [0.83ms]
(pass) RequestInit signal presence > signal: 0 throws TypeError [0.51ms]
(pass) RequestInit signal presence > signal: false throws TypeError [0.46ms]
(pass) RequestInit signal presence > signal: true throws T
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [0.11ms]
(pass) request can receive undefined signal [0.20ms]
(pass) request can receive null signal [0.09ms]
(pass) clone() does not lock original body when body was accessed before clone [0.38ms]
(pass) RequestInit signal presence > new Request(request, { signal: null }) detaches from input's signal [0.07ms]
(pass) RequestInit signal presence > new Request(request, { signal: undefined }) inherits input's signal [0.03ms]
(pass) RequestInit signal presence > new Request(request, {}) inherits input's signal [0.03ms]
(pass) RequestInit signal presence > signal: "" throws TypeError [0.06ms]
(pass) RequestInit signal presence > signal: {} throws TypeError
(pass) RequestInit signal presence > signal: 0 throws TypeError
(pass) RequestInit signal presence > signal: false throws TypeError
(pass) RequestInit signal presence > signal: true throws TypeError [0.02ms]
(pass) RequestInit signal presence > signal: null does not throw [0.04ms]
(pass) RequestInit signal presence > signal: undefined does not throw
(pass) RequestInit signal presence > fetch(new Request(request,
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/body-clone.test.ts test/js/web/request/request.test.ts
bun test v1.4.0 (0855f3fa2)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [3.95ms]
(pass) request can receive undefined signal [9.00ms]
(pass) request can receive null signal [7.09ms]
(pass) clone() does not lock original body when body was accessed before clone [18.79ms]
(pass) RequestInit signal presence > new Request(request, { signal: null }) detaches from input's signal [5.06ms]
(pass) RequestInit signal presence > new Request(request, { signal: undefined }) inherits input's signal [3.20ms]
(pass) RequestInit signal presence > new Request(request, {}) inherits input's signal [2.83ms]
(pass) RequestInit signal presence > signal: "" throws TypeError [3.69ms]
(pass) RequestInit signal presence > signal: {} throws TypeError [0.85ms]
(pass) RequestInit signal presence > signal: 0 throws TypeError [0.48ms]
(pass) RequestInit signal presence > signal: false throws TypeError [0.45ms]
(pass) RequestInit signal presence > signal: true throws T
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0855f3fa22
  features     baseline

22 deps, 106 codegen, 1175 objects in 867ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b58cd4685)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b58cd4685)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch zlib
[zlib] up to date
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] fetch picohttpparser
[picohttpparser] up to date
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b58cd4685)

Checked 129 installs across 147 packages (no changes) [21.00ms]
[11/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Request.rs       |  70 ++++++++-
 test/js/web/fetch/body-clone.test.ts |  14 +-
 test/js/web/request/request.test.ts  | 291 +++++++++++++++++++++++++++++++++++
 3 files changed, 361 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/runtime/webcore/Request.rs           11     18      0
test/js/web/fetch/body-clone.test.ts      1      1      0
test/js/web/request/request.test.ts       1     11      0
```

</details>

<!-- robobun:evidence:end -->