### PR TITLE
Suppress the LSan false positive from Temporal's ICU calendar template cache

### DIFF
--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+import path from "node:path";
 
 // https://github.com/oven-sh/bun/issues/15853
 // The default-on/opt-out subprocess tests live in
@@ -86,3 +88,60 @@ describe("Temporal core operations", () => {
     expect(() => structuredClone(Temporal.Instant.from("2024-06-15T00:00Z"))).toThrow(DOMException);
   });
 });
+
+// Non-ISO calendar arithmetic opens ICU UCalendar templates that
+// TemporalCore::withCalendar caches for the process lifetime. The cache entry
+// owning them lives in bmalloc memory LeakSanitizer cannot scan, so without
+// the matching test/leaksan.supp entry LSan nondeterministically reports them
+// as direct leaks at exit (whether a stale stack pointer still reaches the
+// UCalendar decides each run). Pins the suppression: a calendar-heavy
+// workload must exit leak-clean under the repo suppression file.
+test.skipIf(!isASAN)(
+  "non-ISO calendar arithmetic is leak-clean under LeakSanitizer",
+  async () => {
+    // The workload runs in a timer callback: a top-level (module) stack puts
+    // JSC::JSModuleLoader::evaluateNonVirtual in every allocation stack, which
+    // the suppression file already covers wholesale. bun:test callbacks run
+    // via JSValue::call with no module-loader frame (how CI hit this); a timer
+    // callback has the same shape.
+    const code = `
+      setTimeout(() => {
+        const calendars = ["hebrew", "chinese", "indian", "persian", "coptic", "buddhist", "japanese", "roc"];
+        for (const calendar of calendars) {
+          const date = Temporal.PlainDate.from("2024-06-15[u-ca=" + calendar + "]");
+          if (typeof (date.year + date.month + date.day) !== "number" || !date.monthCode) throw new Error(calendar);
+          Temporal.PlainYearMonth.from("2024-06-15[u-ca=" + calendar + "]").toString();
+          Temporal.PlainMonthDay.from("2024-06-15[u-ca=" + calendar + "]").toString();
+        }
+        // Scrub the stack so no stale pointer to an ICU object survives for
+        // LSan's conservative scan; staying clean is on the suppression alone.
+        (function burn(n) { return n > 0 ? burn(n - 1) : JSON.parse(JSON.stringify({ n })); })(2000);
+        console.log("OK");
+      }, 0);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: {
+        ...bunEnv,
+        // An order of magnitude slower on debug builds, and unrelated to leaks.
+        BUN_JSC_validateExceptionChecks: undefined,
+        BUN_JSC_dumpSimulatedThrows: undefined,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
+        LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${path.join(import.meta.dir, "..", "..", "..", "leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // LSan writes its leak report to stderr and SIGABRTs; stdout holds the
+    // workload's OK line either way, so assert exitCode/signal explicitly.
+    expect({ stdout, stderr, signal: proc.signalCode, exitCode }).toEqual({
+      stdout: "OK\n",
+      stderr: expect.not.stringContaining("LeakSanitizer"),
+      signal: null,
+      exitCode: 0,
+    });
+  },
+  20_000,
+);

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -89,15 +89,15 @@ describe("Temporal core operations", () => {
   });
 });
 
-// Non-ISO calendar arithmetic opens ICU UCalendar templates that
-// TemporalCore::withCalendar caches for the process lifetime. The cache entry
-// owning them lives in bmalloc memory LeakSanitizer cannot scan, so without
-// the matching test/leaksan.supp entry LSan nondeterministically reports them
-// as direct leaks at exit (whether a stale stack pointer still reaches the
-// UCalendar decides each run). Pins the suppression: a calendar-heavy
-// workload must exit leak-clean under the repo suppression file.
+// Calendar and named-time-zone arithmetic opens ICU UCalendar templates that
+// TemporalCore::withCalendar / withTimeZone cache for the process lifetime.
+// The cache entries owning them live in bmalloc memory LeakSanitizer cannot
+// scan, so without the matching test/leaksan.supp entries LSan
+// nondeterministically reports them as direct leaks at exit (whether a stale
+// stack pointer still reaches the UCalendar decides each run). Pins both
+// suppressions: this workload must exit leak-clean under the repo file.
 test.skipIf(!isASAN)(
-  "non-ISO calendar arithmetic is leak-clean under LeakSanitizer",
+  "Temporal's ICU calendar and time zone caches are leak-clean under LeakSanitizer",
   async () => {
     // The workload runs in a timer callback: a top-level (module) stack puts
     // JSC::JSModuleLoader::evaluateNonVirtual in every allocation stack, which
@@ -113,8 +113,15 @@ test.skipIf(!isASAN)(
           Temporal.PlainYearMonth.from("2024-06-15[u-ca=" + calendar + "]").toString();
           Temporal.PlainMonthDay.from("2024-06-15[u-ca=" + calendar + "]").toString();
         }
+        // Pure-ISO PlainDateTime.with opens the iso8601 calendar template too.
+        Temporal.PlainDateTime.from("2024-06-15T10:00").with({ day: 1 }).toString();
+        // Named zones (not UTC offsets) populate the withTimeZone twin cache.
+        for (const zone of ["America/New_York", "Asia/Tokyo"]) {
+          const zdt = Temporal.ZonedDateTime.from("2024-06-15T12:34:56[" + zone + "]");
+          if (typeof (zdt.offsetNanoseconds + zdt.hoursInDay) !== "number") throw new Error(zone);
+        }
         // Scrub the stack so no stale pointer to an ICU object survives for
-        // LSan's conservative scan; staying clean is on the suppression alone.
+        // LSan's conservative scan; staying clean is on the suppressions alone.
         (function burn(n) { return n > 0 ? burn(n - 1) : JSON.parse(JSON.stringify({ n })); })(2000);
         console.log("OK");
       }, 0);

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
-import path from "node:path";
 
 // https://github.com/oven-sh/bun/issues/15853
 // The default-on/opt-out subprocess tests live in
@@ -88,67 +86,3 @@ describe("Temporal core operations", () => {
     expect(() => structuredClone(Temporal.Instant.from("2024-06-15T00:00Z"))).toThrow(DOMException);
   });
 });
-
-// Calendar and named-time-zone arithmetic opens ICU UCalendar templates that
-// TemporalCore::withCalendar / withTimeZone cache for the process lifetime.
-// The cache entries owning them live in bmalloc memory LeakSanitizer cannot
-// scan, so without the matching test/leaksan.supp entries LSan
-// nondeterministically reports them as direct leaks at exit (whether a stale
-// stack pointer still reaches the UCalendar decides each run). Pins both
-// suppressions: this workload must exit leak-clean under the repo file.
-test.skipIf(!isASAN)(
-  "Temporal's ICU calendar and time zone caches are leak-clean under LeakSanitizer",
-  async () => {
-    // The workload runs in a timer callback: a top-level (module) stack puts
-    // JSC::JSModuleLoader::evaluateNonVirtual in every allocation stack, which
-    // the suppression file already covers wholesale. bun:test callbacks run
-    // via JSValue::call with no module-loader frame (how CI hit this); a timer
-    // callback has the same shape.
-    const code = `
-      setTimeout(() => {
-        const calendars = ["hebrew", "chinese", "indian", "persian", "coptic", "buddhist", "japanese", "roc"];
-        for (const calendar of calendars) {
-          const date = Temporal.PlainDate.from("2024-06-15[u-ca=" + calendar + "]");
-          if (typeof (date.year + date.month + date.day) !== "number" || !date.monthCode) throw new Error(calendar);
-          Temporal.PlainYearMonth.from("2024-06-15[u-ca=" + calendar + "]").toString();
-          Temporal.PlainMonthDay.from("2024-06-15[u-ca=" + calendar + "]").toString();
-        }
-        // Pure-ISO PlainDateTime.with opens the iso8601 calendar template too.
-        Temporal.PlainDateTime.from("2024-06-15T10:00").with({ day: 1 }).toString();
-        // Named zones (not UTC offsets) populate the withTimeZone twin cache.
-        for (const zone of ["America/New_York", "Asia/Tokyo"]) {
-          const zdt = Temporal.ZonedDateTime.from("2024-06-15T12:34:56[" + zone + "]");
-          if (typeof (zdt.offsetNanoseconds + zdt.hoursInDay) !== "number") throw new Error(zone);
-        }
-        // Scrub the stack so no stale pointer to an ICU object survives for
-        // LSan's conservative scan; staying clean is on the suppressions alone.
-        (function burn(n) { return n > 0 ? burn(n - 1) : JSON.parse(JSON.stringify({ n })); })(2000);
-        console.log("OK");
-      }, 0);
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", code],
-      env: {
-        ...bunEnv,
-        // An order of magnitude slower on debug builds, and unrelated to leaks.
-        BUN_JSC_validateExceptionChecks: undefined,
-        BUN_JSC_dumpSimulatedThrows: undefined,
-        BUN_DESTRUCT_VM_ON_EXIT: "1",
-        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
-        LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${path.join(import.meta.dir, "..", "..", "..", "leaksan.supp")}`,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // LSan writes its leak report to stderr and SIGABRTs; stdout holds the
-    // workload's OK line either way, so assert exitCode/signal explicitly.
-    expect({ stdout, stderr, signal: proc.signalCode, exitCode }).toEqual({
-      stdout: "OK\n",
-      stderr: expect.not.stringContaining("LeakSanitizer"),
-      signal: null,
-      exitCode: 0,
-    });
-  },
-  20_000,
-);

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -136,3 +136,12 @@ leak:napi_internal_enqueue_finalizer
 # region, so the libc-allocated UCalendar it holds is reported as a direct
 # leak even though it is reachable and bounded.
 leak:TemporalCore::withTimeZone
+# test/js/web/temporal/temporal.test.ts
+# TemporalCore::withCalendar is withTimeZone's calendar twin: up to 8 open
+# UCalendars in a process-lifetime LazyNeverDestroyed TinyLRUCache, one per
+# non-ISO calendar ID (ISO arithmetic never opens one); LRU eviction
+# ucal_closes them. The CalendarCacheEntry that owns each UCalendar is
+# WTF_MAKE_TZONE_ALLOCATED (bmalloc), which LSAN does not scan as a root
+# region, so the libc-allocated UCalendar (and the ICU TimeZone inside it)
+# is reported as a direct leak even though it is reachable and bounded.
+leak:TemporalCore::withCalendar

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -137,11 +137,14 @@ leak:napi_internal_enqueue_finalizer
 # leak even though it is reachable and bounded.
 leak:TemporalCore::withTimeZone
 # test/js/web/temporal/temporal.test.ts
-# TemporalCore::withCalendar is withTimeZone's calendar twin: up to 8 open
-# UCalendars in a process-lifetime LazyNeverDestroyed TinyLRUCache, one per
-# non-ISO calendar ID (ISO arithmetic never opens one); LRU eviction
-# ucal_closes them. The CalendarCacheEntry that owns each UCalendar is
-# WTF_MAKE_TZONE_ALLOCATED (bmalloc), which LSAN does not scan as a root
+# The calendar twin of withTimeZone above: up to 8 open UCalendars in a
+# process-lifetime LazyNeverDestroyed TinyLRUCache, one per calendar ID
+# (non-ISO arithmetic, plus pure-ISO PlainDateTime.prototype.with); LRU
+# eviction ucal_closes them. The CalendarCacheEntry that owns each UCalendar
+# is WTF_MAKE_TZONE_ALLOCATED (bmalloc), which LSAN does not scan as a root
 # region, so the libc-allocated UCalendar (and the ICU TimeZone inside it)
 # is reported as a direct leak even though it is reachable and bounded.
-leak:TemporalCore::withCalendar
+# Anchored on the builder frame, not withCalendar itself, so a real leak in
+# one of the op lambdas withCalendar runs would still be reported
+# (withTimeZone has no builder frame; its ucal_open is inline).
+leak:TemporalCore::buildCalendarTemplate

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -136,7 +136,7 @@ leak:napi_internal_enqueue_finalizer
 # region, so the libc-allocated UCalendar it holds is reported as a direct
 # leak even though it is reachable and bounded.
 leak:TemporalCore::withTimeZone
-# test/js/web/temporal/temporal.test.ts
+# test/js/bun/bun-object/deep-equals-temporal.test.ts
 # The calendar twin of withTimeZone above: up to 8 open UCalendars in a
 # process-lifetime LazyNeverDestroyed TinyLRUCache, one per calendar ID
 # (non-ISO arithmetic, plus pure-ISO PlainDateTime.prototype.with); LRU

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -3,10 +3,6 @@
 test/cli/install/bun-security-scanner-matrix-with-node-modules.test.ts
 test/cli/install/bun-security-scanner-matrix-without-node-modules.test.ts
 
-# Expect wrappers not yet finalized at process exit report as direct leaks;
-# the sibling deep-equals/deep-match spec files show the same class locally.
-test/js/bun/bun-object/deep-equals-temporal.test.ts
-
 test/js/node/test/parallel/test-worker-abort-on-uncaught-exception.js
 test/js/node/test/parallel/test-worker-arraybuffer-zerofill.js
 test/js/node/test/parallel/test-worker-cjs-workerdata.js


### PR DESCRIPTION
### Problem

On the `13 x64-asan` lane, a test that exercises non-ISO Temporal calendars from a test callback can abort after a fully green run with a LeakSanitizer report. Seen in build 89504 on #37024, whose `test/js/bun/bun-object/deep-equals-temporal.test.ts` uses `[u-ca=hebrew]`:

```
Direct leak of 624 byte(s) in 1 object(s) allocated from:
    #1 icu_75::HebrewCalendar::clone() const
    #2 icu_75::Calendar::createInstance(icu_75::TimeZone*, icu_75::Locale const&, UErrorCode&)
    #3 ucal_open_75
    #4 JSC::TemporalCore::buildCalendarTemplate(WTF::AbstractLocker const&, unsigned int)
    #5 JSC::TemporalCore::withCalendar<JSC::TemporalCore::calendarYear(...)::$_0>(...)
```

The CI annotation titles this `direct leak of 624b in {closure#0} (src/jsc/JSValue.rs:1664:22)` because that is the first in-repo frame (the test-runner's `JSValue::call`); everything below it is WebKit/ICU.

### Cause

`TemporalCore::withCalendar` (`vendor/WebKit/.../temporal/core/CalendarICUBridge.cpp`) keeps up to 8 open `UCalendar` templates in a process-lifetime `LazyNeverDestroyed` `TinyLRUCache`, one per calendar ID (non-ISO arithmetic, plus pure-ISO `PlainDateTime.prototype.with`, which reaches the same path unguarded); LRU eviction `ucal_close`s them, so the set is bounded. The `CalendarCacheEntry` that owns each `UCalendar` is `WTF_MAKE_TZONE_ALLOCATED` (bmalloc), which LSan does not scan, so the libc-allocated `UCalendar` (and the ICU `TimeZone` inside it) is reported as a direct leak even though it is reachable. Whether a given run aborts depends on whether some stale stack or register value still points at the ICU object when LSan scans at exit, hence the intermittence.

This is the calendar twin of the already-suppressed `TemporalCore::withTimeZone` entry (same cache design, same TZone-allocated owner).

### Fix

- Add a `leak:TemporalCore::buildCalendarTemplate` suppression to `test/leaksan.supp`, mirroring the `withTimeZone` entry. The pattern anchors on the template builder rather than `withCalendar` itself so that a future real leak inside one of the many op lambdas `withCalendar` runs would still be reported; every cached-template allocation carries the builder frame. (`withTimeZone` has no such builder frame, its `ucal_open` is inline, so that entry keeps its existing pattern.)
- Drop the `test/no-validate-leaksan.txt` escape hatch #37024 added for `deep-equals-temporal.test.ts`, re-enabling leak validation for it; that file exercises the suppressed path on the asan lane.

### Verification

On a debug ASAN build, running `bun test test/js/bun/bun-object/deep-equals-temporal.test.ts` under the CI leak-validation env (`BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1:abort_on_error=1`, repo suppression file):

- with the new entry: clean exit, 5/5 runs
- without it: LSan abort with the calendar-template stacks above, 3/3 runs

A standalone probe exercising 8 non-ISO calendars plus pure-ISO `PlainDateTime.with` from a timer callback shows the same split (10/10 aborts without, 10/10 clean with; `print_suppressions=1` attributes exactly the ICU template allocations to the new entry). Top-level module code cannot reproduce this: its allocation stacks carry `JSC::JSModuleLoader::evaluateNonVirtual`, which the suppression file already covers wholesale. An ASAN-gated test pinning the entry was part of an earlier revision and was dropped per review; the re-enabled `deep-equals-temporal.test.ts` covers the path in CI instead.

The Expect-wrapper shutdown leak mentioned in the dropped no-validate comment is a separate issue tracked in #32180: that is `bun test`'s own finalizer-owned memory, while this cache deliberately survives VM teardown, so #32180 would not prevent this report.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->