### PR TITLE
Make a too-deep TOML import throw a RangeError instead of panicking

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2739,11 +2739,8 @@ fn transpile_source_code_inner(
                         };
                         match bun_js_parser_jsc::expr_to_js(&s_expr.value, global) {
                             Ok(v) => v,
-                            // A deep document (e.g. TOML dotted keys) can
-                            // overflow `expr_to_js`'s recursion guard, which
-                            // throws a RangeError. Propagate it so the caller
-                            // surfaces the pending exception as the module
-                            // error instead of panicking.
+                            // Reachable: a deep document (e.g. TOML dotted keys)
+                            // overflows `expr_to_js`'s recursion guard.
                             Err(e) => {
                                 return Err(match e {
                                     bun_ast::ToJSError::JSError => bun_jsc::JsError::Thrown,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2737,12 +2737,28 @@ fn transpile_source_code_inner(
                             // `SExpr` part; anything else is a parser bug.
                             unreachable!("JSON/TOML/YAML parse result is always SExpr")
                         };
-                        bun_js_parser_jsc::expr_to_js(&s_expr.value, global).unwrap_or_else(|e| {
-                            bun_core::Output::panic(format_args!(
-                                "Unexpected JS error: {}",
-                                <&'static str>::from(e)
-                            ))
-                        })
+                        match bun_js_parser_jsc::expr_to_js(&s_expr.value, global) {
+                            Ok(v) => v,
+                            // A deep document (e.g. TOML dotted keys) can
+                            // overflow `expr_to_js`'s recursion guard, which
+                            // throws a RangeError. Propagate it so the caller
+                            // surfaces the pending exception as the module
+                            // error instead of panicking.
+                            Err(e) => {
+                                return Err(match e {
+                                    bun_ast::ToJSError::JSError => bun_jsc::JsError::Thrown,
+                                    bun_ast::ToJSError::JSTerminated => {
+                                        bun_jsc::JsError::Terminated
+                                    }
+                                    bun_ast::ToJSError::OutOfMemory => global.throw_out_of_memory(),
+                                    e => global.throw_error(
+                                        bun_jsc::CrateError::from(e),
+                                        "converting module to JavaScript",
+                                    ),
+                                }
+                                .into());
+                            }
+                        }
                     };
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
                         specifier: input_specifier.dupe_ref(),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2739,8 +2739,6 @@ fn transpile_source_code_inner(
                         };
                         match bun_js_parser_jsc::expr_to_js(&s_expr.value, global) {
                             Ok(v) => v,
-                            // Reachable: a deep document (e.g. TOML dotted keys)
-                            // overflows `expr_to_js`'s recursion guard.
                             Err(e) => {
                                 return Err(match e {
                                     bun_ast::ToJSError::JSError => bun_jsc::JsError::Thrown,

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -133,7 +133,7 @@ it.concurrent("importing a deeply nested table header throws instead of crashing
   expect(stdout).toBe("");
   expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
   expect(exitCode).toBe(1);
-});
+}, 30_000);
 
 it.concurrent("dynamic import of a deeply nested table header is catchable", async () => {
   using dir = tempDir("toml-deep-dynamic", {
@@ -156,4 +156,4 @@ it.concurrent("dynamic import of a deeply nested table header is catchable", asy
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("caught: RangeError\n");
   expect(exitCode).toBe(0);
-});
+}, 30_000);

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -114,9 +114,11 @@ it("Bun.TOML.parse throws on deeply nested inline tables instead of crashing", (
   expect(() => Bun.TOML.parse(deepToml)).toThrow(RangeError);
 });
 
-// Dotted table headers nest iteratively in the parser, so the depth limit is
-// only hit when the parsed AST is converted to a JS object at import time.
+// Dotted paths (table headers and keys) nest iteratively in the parser, so the
+// depth limit is only hit when the parsed AST is converted to a JS object at
+// import time.
 const deepDottedToml = "[" + Buffer.alloc(250_000 * 2, "a.").toString() + "a]\nd = 1\n";
+const deepDottedKeyToml = Buffer.alloc(250_000 * 2, "a.").toString() + "a = 1\n";
 
 it.concurrent("importing a deeply nested table header throws instead of crashing", async () => {
   using dir = tempDir("toml-deep-import", {
@@ -155,5 +157,52 @@ it.concurrent("dynamic import of a deeply nested table header is catchable", asy
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("caught: RangeError\n");
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("importing a deeply nested dotted key throws instead of crashing", async () => {
+  using dir = tempDir("toml-deep-key", {
+    "deep.toml": deepDottedKeyToml,
+    "main.js": `import d from "./deep.toml";\nconsole.log("unreachable");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+  expect(exitCode).toBe(1);
+});
+
+it.concurrent("a moderately nested table header imports correctly", async () => {
+  // 1000 segments: comfortably below every stack limit, far above any real
+  // document. Pins the success side so a future parse-time cap can't regress
+  // legitimate depth.
+  const depth = 1000;
+  using dir = tempDir("toml-deep-ok", {
+    "deep.toml": "[" + Buffer.alloc((depth - 1) * 2, "a.").toString() + "a]\nd = 1\n",
+    "main.js": `
+      import root from "./deep.toml";
+      let o = root;
+      let hops = 0;
+      while (o.a !== undefined) {
+        o = o.a;
+        hops++;
+      }
+      console.log(hops, o.d);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(`${depth} 1\n`);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -118,27 +118,33 @@ it("Bun.TOML.parse throws on deeply nested inline tables instead of crashing", (
 // only hit when the parsed AST is converted to a JS object at import time.
 const deepDottedToml = "[" + Buffer.alloc(250_000 * 2, "a.").toString() + "a]\nd = 1\n";
 
-it.concurrent("importing a deeply nested table header throws instead of crashing", async () => {
-  using dir = tempDir("toml-deep-import", {
-    "deep.toml": deepDottedToml,
-    "main.js": `import d from "./deep.toml";\nconsole.log("unreachable");`,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
-  expect(exitCode).toBe(1);
-}, 30_000);
+it.concurrent(
+  "importing a deeply nested table header throws instead of crashing",
+  async () => {
+    using dir = tempDir("toml-deep-import", {
+      "deep.toml": deepDottedToml,
+      "main.js": `import d from "./deep.toml";\nconsole.log("unreachable");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+    expect(exitCode).toBe(1);
+  },
+  30_000,
+);
 
-it.concurrent("dynamic import of a deeply nested table header is catchable", async () => {
-  using dir = tempDir("toml-deep-dynamic", {
-    "deep.toml": deepDottedToml,
-    "main.js": `
+it.concurrent(
+  "dynamic import of a deeply nested table header is catchable",
+  async () => {
+    using dir = tempDir("toml-deep-dynamic", {
+      "deep.toml": deepDottedToml,
+      "main.js": `
       try {
         await import("./deep.toml");
         console.log("no-throw");
@@ -146,14 +152,16 @@ it.concurrent("dynamic import of a deeply nested table header is catchable", asy
         console.log("caught:", e.name);
       }
     `,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("caught: RangeError\n");
-  expect(exitCode).toBe(0);
-}, 30_000);
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("caught: RangeError\n");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -118,33 +118,27 @@ it("Bun.TOML.parse throws on deeply nested inline tables instead of crashing", (
 // only hit when the parsed AST is converted to a JS object at import time.
 const deepDottedToml = "[" + Buffer.alloc(250_000 * 2, "a.").toString() + "a]\nd = 1\n";
 
-it.concurrent(
-  "importing a deeply nested table header throws instead of crashing",
-  async () => {
-    using dir = tempDir("toml-deep-import", {
-      "deep.toml": deepDottedToml,
-      "main.js": `import d from "./deep.toml";\nconsole.log("unreachable");`,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("");
-    expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
-    expect(exitCode).toBe(1);
-  },
-  30_000,
-);
+it.concurrent("importing a deeply nested table header throws instead of crashing", async () => {
+  using dir = tempDir("toml-deep-import", {
+    "deep.toml": deepDottedToml,
+    "main.js": `import d from "./deep.toml";\nconsole.log("unreachable");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+  expect(exitCode).toBe(1);
+});
 
-it.concurrent(
-  "dynamic import of a deeply nested table header is catchable",
-  async () => {
-    using dir = tempDir("toml-deep-dynamic", {
-      "deep.toml": deepDottedToml,
-      "main.js": `
+it.concurrent("dynamic import of a deeply nested table header is catchable", async () => {
+  using dir = tempDir("toml-deep-dynamic", {
+    "deep.toml": deepDottedToml,
+    "main.js": `
       try {
         await import("./deep.toml");
         console.log("no-throw");
@@ -152,16 +146,14 @@ it.concurrent(
         console.log("caught:", e.name);
       }
     `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("caught: RangeError\n");
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("caught: RangeError\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/resolve/toml/toml.test.js
+++ b/test/js/bun/resolve/toml/toml.test.js
@@ -1,4 +1,5 @@
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import emptyToml from "./toml-empty.toml";
 import tomlFromCustomTypeAttribute from "./toml-fixture.toml.txt" with { type: "toml" };
 
@@ -111,4 +112,48 @@ it("Bun.TOML.parse throws on deeply nested inline tables instead of crashing", (
   const deepToml =
     "a = " + Buffer.alloc(depth * 6, "{ b = ").toString() + "1" + Buffer.alloc(depth * 2, " }").toString();
   expect(() => Bun.TOML.parse(deepToml)).toThrow(RangeError);
+});
+
+// Dotted table headers nest iteratively in the parser, so the depth limit is
+// only hit when the parsed AST is converted to a JS object at import time.
+const deepDottedToml = "[" + Buffer.alloc(250_000 * 2, "a.").toString() + "a]\nd = 1\n";
+
+it.concurrent("importing a deeply nested table header throws instead of crashing", async () => {
+  using dir = tempDir("toml-deep-import", {
+    "deep.toml": deepDottedToml,
+    "main.js": `import d from "./deep.toml";\nconsole.log("unreachable");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+  expect(exitCode).toBe(1);
+});
+
+it.concurrent("dynamic import of a deeply nested table header is catchable", async () => {
+  using dir = tempDir("toml-deep-dynamic", {
+    "deep.toml": deepDottedToml,
+    "main.js": `
+      try {
+        await import("./deep.toml");
+        console.log("no-throw");
+      } catch (e) {
+        console.log("caught:", e.name);
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("caught: RangeError\n");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

Importing a TOML file whose dotted table header nests deeply enough crashes the whole process:

```
python3 -c "print('[' + 'a.'*250000 + 'a]'); print('d = 1')" > deep.toml
echo 'import d from "./deep.toml"; console.log("ok")' > rt.js
bun rt.js
```

```
panic: Unexpected JS error: JSError
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

The TOML parser builds dotted-key table chains iteratively, so there is no parse-time depth limit. The depth is first noticed when the module fetch hook converts the parsed AST to a JS object: `expr_to_js`'s recursion guard throws a RangeError on the VM and returns an error, which the hook consumed with a panic (`src/runtime/jsc_hooks.rs`, the JSON/TOML/YAML/JSON5 `ExportsObject` arm).

### Fix

Return the error from the hook instead of panicking. The callers (`transpile_file`, `transpile_virtual_module`) already have a path for `Err(Js(_))` that takes the pending exception off the VM and surfaces it as the module error; this is the same idiom the `.napi` arm of the same function uses. A too-deep document in any of the object-exporting loaders (json/jsonc/toml/yaml/json5) now fails the import with a catchable RangeError, consistent with how `Bun.TOML.parse` reports too-deep inline tables.

After the fix:

```
$ bun rt.js
RangeError: Maximum call stack size exceeded.
$ echo $?
1
```

and `try { await import("./deep.toml") } catch (e) {}` observes the RangeError and the process continues.

### Tests

Four cases in `test/js/bun/resolve/toml/toml.test.js`; the crash cases spawn a child (the unfixed bug kills the process):

- static import of a deep dotted-header TOML exits 1 with `RangeError: Maximum call stack size exceeded` on stderr
- dynamic import of the same file is catchable; the child logs the caught error name and exits 0
- static import of a deep dotted key in value position (`a.a.a... = 1`), the second iterative nesting syntax, exits 1 with the same RangeError
- a 1000-segment header imports successfully with the full nesting intact, pinning the success side so a future parse-time cap can't regress legitimate depth

The three crash cases fail on the unfixed build (child aborts with the panic banner, exit 134) and pass with the fix.

### Why only TOML imports hit this

TOML dotted paths are the syntax among the object-exporting loaders where nesting depth is built iteratively: `navigate_header` (table headers) and `assign_path` (dotted keys in value position) in `src/parsers/toml.rs` walk the `a.b.c...` segments in plain loops, creating one nested object per segment with no recursion and no stack check, so the document parses at any depth and the first recursion over the result is the AST-to-JS conversion at import time. Both vectors panicked before this change and both throw RangeError after it.

Every other way to nest is parsed recursively under a parse-time stack check and fails with an ordinary parse error long before the conversion could overflow (probed on the unfixed build at depths from 1k to 8M, no panic at any depth):

- YAML: parse ceiling around 9k levels, error `ParseError while building ...`
- JSON5: parse ceiling around 35k levels, same error
- JSONC: explicit `JSON document is too deeply nested` around 65k levels
- TOML inline tables: guarded in `parse_value`, which is why `Bun.TOML.parse` already threw RangeError for deep inline tables (existing test)
- plain JSON: never reaches this code path at all (raw source bytes go to JSC's JSON parser)

The parser recursion frames are several times larger than the conversion's, so the parse ceilings sit far below the roughly 200k levels the conversion needs to overflow: any document those parsers accept also converts. Tests for deep YAML/JSON5/JSONC documents would pin those parsers' existing parse-time limits, not this change, so the new tests cover the two TOML dotted-path vectors that actually reach the fixed code. Within the runtime import pipeline the fix sits at the conversion step shared by all five loaders, so a parser change that opened a new window there would throw instead of panicking.

Scope note: the bundler consumes the same TOML AST through a separate pipeline (`js_printer`, not this hook), where a deep dotted document currently produces a silently truncated bundle because the linker discards the printer's stack-overflow error. That is a pre-existing bug, not affected by this change, and is being addressed separately.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/toml/toml.test.js
bun test v1.4.0 (b3003d928)

test/js/bun/resolve/toml/toml.test.js:
(pass) via dynamic import [22.51ms]
(pass) via import type toml [4.88ms]
(pass) via dynamic import with type attribute [19.58ms]
(pass) empty via import statement [1.45ms]
(pass) inline table followed by table array [4.11ms]
(pass) array followed by table array [2.93ms]
(pass) nested inline tables [2.87ms]
(pass) Bun.TOML.parse throws on deeply nested inline tables instead of crashing [42.46ms]
(pass) a moderately nested table header imports correctly [345.08ms]
(fail) importing a deeply nested table header throws instead of crashing [5004.21ms]
  ^ this test timed out after 5000ms.
(fail) dynamic import of a deeply nested table header is catchable [5000.18ms]
  ^ this test timed out after 5000ms.
(fail) importing a deeply nested dotted key throws instead of crashing [5000.18ms]
  ^ this test timed out after 5000ms.

 9 pass
 3 fail
 62 expect() calls
Ran 12 tests across 1 file. [7.33s]
error: script "bd" exited with code 1
__F:3:S:0

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/bun/resolve/toml/toml.test.js:
(pass) via dynamic import [0.29ms]
(pass) via import type toml [0.03ms]
(pass) via dynamic import with type attribute [0.30ms]
(pass) empty via import statement [0.07ms]
(pass) inline table followed by table array [0.10ms]
(pass) array followed by table array [0.05ms]
(pass) nested inline tables [0.04ms]
(pass) Bun.TOML.parse throws on deeply nested inline tables instead of crashing [9.46ms]
(pass) a moderately nested table header imports correctly [7.79ms]
171 |     cwd: String(dir),
172 |     stderr: "pipe",
173 |   });
174 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
175 |   expect(stdout).toBe("");
176 |   expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
                       ^
error: expect(received).toContain(expected)

Expected to contain: "RangeError: Maximum call stack size exceeded"
Received: "============================================================\nBun Canary v1.4.0-canary.1 (b58cd4685) Linux x64\nLinux Kernel v6.17.0 | glibc v2.41\nCPU: sse42 popcnt avx avx2 avx512\nArgs: \"/worksp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/toml/toml.test.js
bun test v1.4.0 (b3003d928)

test/js/bun/resolve/toml/toml.test.js:
(pass) via dynamic import [22.98ms]
(pass) via import type toml [4.57ms]
(pass) via dynamic import with type attribute [23.94ms]
(pass) empty via import statement [1.14ms]
(pass) inline table followed by table array [3.70ms]
(pass) array followed by table array [2.78ms]
(pass) nested inline tables [3.19ms]
(pass) Bun.TOML.parse throws on deeply nested inline tables instead of crashing [39.88ms]
(pass) a moderately nested table header imports correctly [342.19ms]
(pass) importing a deeply nested table header throws instead of crashing [2751.12ms]
(pass) importing a deeply nested dotted key throws instead of crashing [2706.69ms]
(pass) dynamic import of a deeply nested table header is catchable [2842.32ms]

 12 pass
 0 fail
 70 expect() calls
Ran 12 tests across 1 file. [5.12s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b3003d9286
  features     baseline

22 deps, 106 codegen, 1175 objects in 760ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b58cd4685)

Checked 124 installs across 170 packages (no changes) [5.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b58cd4685)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1238] gen bindgenv2
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b58cd4685)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[6/1238] fetch zlib
[zlib] up to date
[7/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1238] gen .bind.ts → GeneratedBindings.cpp
[9/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1238] fetch tinycc
[tinycc] up to date
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/jsc_hooks.rs              | 23 ++++++---
 test/js/bun/resolve/toml/toml.test.js | 94 +++++++++++++++++++++++++++++++++++
 2 files changed, 111 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/jsc_hooks.rs                   3      6      0
test/js/bun/resolve/toml/toml.test.js      3      5      0
```

</details>

<!-- robobun:evidence:end -->