### PR TITLE
bundler: fail the build when a module fails to print instead of emitting truncated output

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -271,40 +271,50 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // A part that failed to print (e.g. the printer's recursion guard
         // tripping on a deeply nested AST) would otherwise join the chunk as
         // silently truncated output; report it and fail the build instead.
-        let mut had_print_error = false;
-        for chunk in chunks.iter() {
-            for compile_result in chunk.compile_results_for_chunk.iter() {
-                let message: Cow<'static, [u8]> = match compile_result {
-                    crate::CompileResult::Javascript {
-                        result: bun_js_printer::PrintResult::Err(err),
-                        ..
-                    } => match err {
-                        bun_js_printer::Error::StackOverflow => Cow::Borrowed(
-                            b"Maximum call stack size exceeded while generating code for this file"
-                                .as_slice(),
-                        ),
-                        err => Cow::Owned(
-                            format!("Failed to generate code for this file ({})", err.name())
+        //
+        // Not for the dev server: its caller treats any `Err` from this
+        // function as OOM (`finish_from_bake_dev_server` returns
+        // `Result<(), AllocError>` and `on_after_decrement_scan_counter`
+        // does `.expect("oom")`), so failing here would abort the whole
+        // server on one bad file. It keeps its long-standing behavior for
+        // an unprintable part (the part's code is dropped) until print
+        // failures are routed per-file like parse failures.
+        if !IS_DEV_SERVER {
+            let mut had_print_error = false;
+            for chunk in chunks.iter() {
+                for compile_result in chunk.compile_results_for_chunk.iter() {
+                    let message: Cow<'static, [u8]> = match compile_result {
+                        crate::CompileResult::Javascript {
+                            result: bun_js_printer::PrintResult::Err(err),
+                            ..
+                        } => match err {
+                            bun_js_printer::Error::StackOverflow => Cow::Borrowed(
+                                b"Maximum call stack size exceeded while generating code for this file"
+                                    .as_slice(),
+                            ),
+                            err => Cow::Owned(
+                                format!("Failed to generate code for this file ({})", err.name())
+                                    .into_bytes(),
+                            ),
+                        },
+                        crate::CompileResult::Css {
+                            result: Err(err), ..
+                        } => Cow::Owned(
+                            format!("Failed to generate CSS for this file ({})", err.name())
                                 .into_bytes(),
                         ),
-                    },
-                    crate::CompileResult::Css {
-                        result: Err(err), ..
-                    } => Cow::Owned(
-                        format!("Failed to generate CSS for this file ({})", err.name())
-                            .into_bytes(),
-                    ),
-                    _ => continue,
-                };
-                had_print_error = true;
-                let source_index = compile_result.source_index();
-                let source =
-                    (source_index != Index::INVALID.get()).then(|| c.get_source(source_index));
-                c.log_mut().add_error(source, bun_ast::Loc::EMPTY, message);
+                        _ => continue,
+                    };
+                    had_print_error = true;
+                    let source_index = compile_result.source_index();
+                    let source =
+                        (source_index != Index::INVALID.get()).then(|| c.get_source(source_index));
+                    c.log_mut().add_error(source, bun_ast::Loc::EMPTY, message);
+                }
             }
-        }
-        if had_print_error {
-            return Err(crate::Error::PrintError);
+            if had_print_error {
+                return Err(crate::Error::PrintError);
+            }
         }
 
         // For dev server, only post-process CSS + HTML chunks.

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -268,17 +268,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             debug!("  DONE {} source maps (quoted contents)", chunks.len());
         }
 
-        // A part that failed to print (e.g. the printer's recursion guard
-        // tripping on a deeply nested AST) would otherwise join the chunk as
-        // silently truncated output; report it and fail the build instead.
-        //
-        // Not for the dev server: its caller treats any `Err` from this
-        // function as OOM (`finish_from_bake_dev_server` returns
-        // `Result<(), AllocError>` and `on_after_decrement_scan_counter`
-        // does `.expect("oom")`), so failing here would abort the whole
-        // server on one bad file. It keeps its long-standing behavior for
-        // an unprintable part (the part's code is dropped) until print
-        // failures are routed per-file like parse failures.
+        // A part that failed to print (e.g. the recursion guard tripped on a
+        // deeply nested AST) must fail the build instead of joining the chunk
+        // as silently truncated output. Dev server excluded: its callers turn
+        // any `Err` here into an OOM panic (see `finish_from_bake_dev_server`),
+        // so unprintable parts keep the old dropped-code behavior there.
         if !IS_DEV_SERVER {
             let mut had_print_error = false;
             for chunk in chunks.iter() {

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -268,6 +268,45 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             debug!("  DONE {} source maps (quoted contents)", chunks.len());
         }
 
+        // A part that failed to print (e.g. the printer's recursion guard
+        // tripping on a deeply nested AST) would otherwise join the chunk as
+        // silently truncated output; report it and fail the build instead.
+        let mut had_print_error = false;
+        for chunk in chunks.iter() {
+            for compile_result in chunk.compile_results_for_chunk.iter() {
+                let message: Cow<'static, [u8]> = match compile_result {
+                    crate::CompileResult::Javascript {
+                        result: bun_js_printer::PrintResult::Err(err),
+                        ..
+                    } => match err {
+                        bun_js_printer::Error::StackOverflow => Cow::Borrowed(
+                            b"Maximum call stack size exceeded while generating code for this file"
+                                .as_slice(),
+                        ),
+                        err => Cow::Owned(
+                            format!("Failed to generate code for this file ({})", err.name())
+                                .into_bytes(),
+                        ),
+                    },
+                    crate::CompileResult::Css {
+                        result: Err(err), ..
+                    } => Cow::Owned(
+                        format!("Failed to generate CSS for this file ({})", err.name())
+                            .into_bytes(),
+                    ),
+                    _ => continue,
+                };
+                had_print_error = true;
+                let source_index = compile_result.source_index();
+                let source =
+                    (source_index != Index::INVALID.get()).then(|| c.get_source(source_index));
+                c.log_mut().add_error(source, bun_ast::Loc::EMPTY, message);
+            }
+        }
+        if had_print_error {
+            return Err(crate::Error::PrintError);
+        }
+
         // For dev server, only post-process CSS + HTML chunks.
         let chunks_to_do: &mut [Chunk] = if IS_DEV_SERVER {
             &mut chunks[1..]

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -275,6 +275,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // so unprintable parts keep the old dropped-code behavior there.
         if !IS_DEV_SERVER {
             let mut had_print_error = false;
+            // Without code splitting a failing file is printed once per chunk
+            // that includes it; report each file once.
+            let mut reported_sources = AutoBitSet::init_empty(c.parse_graph().input_files.len())?;
             for chunk in chunks.iter() {
                 for compile_result in chunk.compile_results_for_chunk.iter() {
                     let message: Cow<'static, [u8]> = match compile_result {
@@ -301,8 +304,15 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     };
                     had_print_error = true;
                     let source_index = compile_result.source_index();
-                    let source =
-                        (source_index != Index::INVALID.get()).then(|| c.get_source(source_index));
+                    let source = if source_index != Index::INVALID.get() {
+                        if reported_sources.is_set(source_index as usize) {
+                            continue;
+                        }
+                        reported_sources.set(source_index as usize);
+                        Some(c.get_source(source_index))
+                    } else {
+                        None
+                    };
                     c.log_mut().add_error(source, bun_ast::Loc::EMPTY, message);
                 }
             }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2773,6 +2773,7 @@ impl<'a> Transpiler<'a> {
             bun_ast::Stmt::data_store_reset();
             bun_ast::store_ast_alloc_heap::reset();
 
+            let errors_before = self.log().errors;
             let output_file = match self.build_with_resolve_result_eager(
                 &item,
                 import_path_format,
@@ -2780,7 +2781,28 @@ impl<'a> Transpiler<'a> {
                 None,
             ) {
                 Ok(Some(f)) => f,
-                Ok(None) | Err(_) => continue,
+                Ok(None) => continue,
+                Err(err) => {
+                    // An error that was not already reported (e.g. the
+                    // printer's recursion guard tripping on a deeply nested
+                    // AST) must still fail the build instead of silently
+                    // producing no output for this file.
+                    if self.log().errors == errors_before {
+                        let path: &[u8] = item.path_const().map(|p| p.text).unwrap_or(b"");
+                        let message: &str = match err {
+                            crate::Error::JsPrinter(js_printer::Error::StackOverflow) => {
+                                "Maximum call stack size exceeded while generating code for"
+                            }
+                            _ => "Failed to generate code for",
+                        };
+                        self.log_mut().add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!("{} \"{}\"", message, bstr::BStr::new(path)),
+                        );
+                    }
+                    continue;
+                }
             };
             self.output_files.push(output_file);
         }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2783,10 +2783,8 @@ impl<'a> Transpiler<'a> {
                 Ok(Some(f)) => f,
                 Ok(None) => continue,
                 Err(err) => {
-                    // An error that was not already reported (e.g. the
-                    // printer's recursion guard tripping on a deeply nested
-                    // AST) must still fail the build instead of silently
-                    // producing no output for this file.
+                    // Print errors (unlike parse errors) add nothing to the
+                    // log, and an unlogged failure exits 0 with no output.
                     if self.log().errors == errors_before {
                         let path: &[u8] = item.path_const().map(|p| p.text).unwrap_or(b"");
                         let message: &str = match err {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -549,6 +549,25 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toEqual(null);
   });
 
+  test.concurrent("fails instead of truncating when a module is too deeply nested to print", async () => {
+    // A TOML dotted header builds an object nested arbitrarily deep without
+    // recursing in the parser, so the printer's recursion guard is the first
+    // thing to hit it. The printed part used to be silently dropped, leaving
+    // a corrupt bundle and success: true.
+    using dir = tempDir("build-api-deep-toml", {
+      "deep.toml": "[" + Buffer.alloc(200_000, "a.").toString() + "a]\nd = 1\n",
+    });
+    const x = await buildNoThrow({
+      entrypoints: [join(String(dir), "deep.toml")],
+      outdir: join(String(dir), "out"),
+    });
+    expect(x.success).toBe(false);
+    expect(x.outputs).toHaveLength(0);
+    expect(x.logs).toHaveLength(1);
+    expect(x.logs[0].message).toContain("Maximum call stack size exceeded while generating code for this file");
+    expect(x.logs[0].name).toBe("BuildMessage");
+  });
+
   test.concurrent("warnings do not fail a build", async () => {
     const x = await Bun.build({
       entrypoints: [join(import.meta.dir, "./fixtures/jsx-warning/index.jsx")],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -568,6 +568,23 @@ describe("Bun.build", () => {
     expect(x.logs[0].name).toBe("BuildMessage");
   });
 
+  test.concurrent("reports a module that fails to print once across entrypoints", async () => {
+    // Without code splitting the failing file is printed once per entry
+    // chunk; the error is still per-file, like parse errors.
+    using dir = tempDir("build-api-deep-toml-multi", {
+      "deep.toml": "[" + Buffer.alloc(200_000, "a.").toString() + "a]\nd = 1\n",
+      "a.js": `import d from "./deep.toml"; console.log(d);`,
+      "b.js": `import d from "./deep.toml"; console.log(Object.keys(d));`,
+    });
+    const x = await buildNoThrow({
+      entrypoints: [join(String(dir), "a.js"), join(String(dir), "b.js")],
+      outdir: join(String(dir), "out"),
+    });
+    expect(x.success).toBe(false);
+    expect(x.logs).toHaveLength(1);
+    expect(x.logs[0].message).toContain("Maximum call stack size exceeded while generating code for this file");
+  });
+
   test.concurrent("warnings do not fail a build", async () => {
     const x = await Bun.build({
       entrypoints: [join(import.meta.dir, "./fixtures/jsx-warning/index.jsx")],

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -517,3 +517,45 @@ describe("CLI argument error messages", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe.concurrent("modules too deeply nested to print", () => {
+  // A TOML dotted header builds an object nested arbitrarily deep without
+  // recursing in the parser, so the printer's recursion guard is the first
+  // thing to hit it. The build must fail instead of emitting truncated
+  // output with exit code 0.
+  const deepToml = "[" + Buffer.alloc(200_000, "a.").toString() + "a]\nd = 1\n";
+
+  test("bun build fails instead of emitting a truncated bundle", async () => {
+    using dir = tempDir("build-deep-toml", { "deep.toml": deepToml });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "deep.toml"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Maximum call stack size exceeded while generating code for this file");
+    expect(stderr).toContain("deep.toml");
+    // No partial bundle: the printer used to bail mid-print and emit only
+    // the trailing export stub.
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("bun build --no-bundle fails instead of emitting empty output", async () => {
+    using dir = tempDir("build-deep-toml-nb", { "deep.toml": deepToml });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "deep.toml"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain('Maximum call stack size exceeded while generating code for "');
+    expect(stderr).toContain("deep.toml");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -518,7 +518,7 @@ describe("CLI argument error messages", () => {
   });
 });
 
-describe.concurrent("modules too deeply nested to print", () => {
+describe.concurrent("modules that fail to print", () => {
   // A TOML dotted header builds an object nested arbitrarily deep without
   // recursing in the parser, so the printer's recursion guard is the first
   // thing to hit it. The build must fail instead of emitting truncated
@@ -555,6 +555,26 @@ describe.concurrent("modules too deeply nested to print", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain('Maximum call stack size exceeded while generating code for "');
     expect(stderr).toContain("deep.toml");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("bun build fails instead of emitting a truncated stylesheet when CSS cannot be generated", async () => {
+    // `composes` on a non-simple selector makes the CSS printer fail; the
+    // whole stylesheet body used to be dropped while the build exited 0.
+    using dir = tempDir("build-css-print-err", {
+      "styles.module.css": ".b { color: blue }\n.a .c { composes: b; color: red }\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "styles.module.css"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Failed to generate CSS for this file");
+    expect(stderr).toContain("styles.module.css");
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });


### PR DESCRIPTION
### What does this PR do?

Fixes `bun build` silently emitting a truncated bundle (exit code 0) when the printer cannot print a module.

**Repro:**

```sh
python3 -c "print('[' + 'a.'*250000 + 'a]'); print('d = 1')" > deep.toml
bun build deep.toml
```

On current releases this exits 0 and prints only the 43-byte export stub with none of the `var` declarations:

```js
export {
  a,
  deep_default as default
};
```

The bundle is corrupt and importing it throws at runtime. `bun build --no-bundle deep.toml` has the same problem (empty output, exit 0), and `Bun.build` reports `success: true`.

**Cause:**

TOML dotted headers build arbitrarily deep object chains iteratively, so the parser succeeds. The printer's recursion guard then trips while printing and `print_with_writer_and_platform` correctly returns `PrintResult::Err(Error::StackOverflow)`, but every consumer of a `CompileResult` swallowed the error:

- `CompileResult::code()` / `into_code()` in `bundle_v2.rs` mapped `Err` to `b""`
- `print_result_take_code` in `postProcessJSChunk.rs` mapped `Err` to `Box::default()`
- the transform-only path dropped per-file errors entirely (`Ok(None) | Err(_) => continue` in `process_resolve_queue`)

so the linker joined the truncated part into the chunk and reported success.

**Fix:**

- `generateChunksInParallel.rs`: after parallel codegen completes, scan the compile results; any `PrintResult::Err` (or failed CSS result) is logged as a build error on the offending source and the build fails with `Error::PrintError`. This single choke point covers `bun build` and `Bun.build`.
- `transpiler.rs` (`--no-bundle`): an error from `build_with_resolve_result_eager` that was not already logged (print errors, unlike parse errors, add nothing to the log) is reported instead of skipped, so the CLI exits non-zero.

The scan is gated on `!IS_DEV_SERVER`: the bake dev server's caller chain maps any error from this function to `AllocError` and then `.expect("oom")`s (`finish_from_bake_dev_server` / `on_after_decrement_scan_counter`), so failing there would abort the whole server on one unprintable file. The dev server keeps its pre-existing behavior for such a part (the part's code is dropped) until print failures get routed per-file like parse failures.

`StackOverflow` maps to `Maximum call stack size exceeded while generating code for this file`, matching the parser's existing message for too-deep source ([#31242](https://github.com/oven-sh/bun/pull/31242), [#31333](https://github.com/oven-sh/bun/pull/31333)); other printer errors report their error name. Failing the build matches the runtime behavior for the same document (a `RangeError: Maximum call stack size exceeded` from the guarded converters), and mirrors what the parser already does for source that is too deep to parse: the guard makes printing fail, and a failed print must fail the build rather than emit output that does not round-trip.

Errors are deduplicated by source index: without code splitting a failing shared module is printed once per chunk that includes it, and the error should stay per-file like parse errors.

The same scan also catches failed CSS results. Those were swallowed the same way: `composes` on a non-simple selector makes the CSS printer fail, and released builds emit a stylesheet with the entire body dropped (only the `/* file */` banner) and exit 0. That case now fails the build too; the CSS warning that precedes it states the specific reason. Making the error message itself carry the CSS reason (the generation sites currently collapse everything to `PrintError`) is a possible follow-up.

After this change:

```
$ bun build deep.toml
error: Maximum call stack size exceeded while generating code for this file
    at deep.toml
$ echo $?
1
```

### How did you verify your code works?

New tests (all fail on the released binary, pass with this change):

- `test/bundler/cli.test.ts`: `bun build deep.toml` exits 1 with the error and produces no partial output on stdout; same for `--no-bundle`.
- `test/bundler/bun-build-api.test.ts`: `Bun.build` returns `success: false`, zero outputs, and a `BuildMessage` carrying the error.

Full `test/bundler/cli.test.ts`, `bun-build-api.test.ts`, `bundler_edgecase.test.ts`, `bundler_loader.test.ts`, `bundler_splitting.test.ts`, and `css/css-modules.test.ts` pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts test/bundler/cli.test.ts

<!-- robobun:evidence:end -->