### PR TITLE
mock.module: reject async factory results that are not objects

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -219,6 +219,13 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
     }
 
     if (wasModuleMock) {
+        if (!objectValue.isObject()) [[unlikely]] {
+            scope.throwException(globalObject, JSC::createTypeError(globalObject, "mock(module, fn) requires a function that returns an object"_s));
+            result.value.error = scope.exception();
+            (void)scope.tryClearException();
+            result.type = OnLoadResultTypeError;
+            return result;
+        }
         result.type = OnLoadResultTypeObject;
         result.value.object = objectValue;
         return result;

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -345,6 +345,42 @@ test("a factory promise that resolves to a non-object is rejected like the synch
   expect(ns.default).toBe("real-default");
 });
 
+// The same for a module that is not loaded yet: mock.module() only registers
+// the factory and import() runs it. A factory promise still pending at that
+// point reaches the module loader unvalidated. The unfixed runtime segfaults
+// there, so these run in a subprocess.
+for (const [label, factory] of [
+  ["a number", `() => new Promise(resolve => setTimeout(() => resolve(42), 1))`],
+  ["null", `async () => { await Bun.sleep(1); return null; }`],
+  ["a string", `async () => { await Bun.sleep(1); return "str"; }`],
+] as const) {
+  test.concurrent(
+    `a pending factory promise that resolves to ${label} rejects import() of a module not loaded yet`,
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { mock } from "bun:test";
+        mock.module("mm-async-non-object", ${factory});
+        try {
+          await import("mm-async-non-object");
+          console.log("imported");
+        } catch (e) {
+          console.log("rejected:", e?.message);
+        }`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("rejected: mock(module, fn) requires a function that returns an object\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+  );
+}
+
 test("a later mock.module for the same module is not overwritten when an earlier pending factory settles", async () => {
   using dir = tempDir("mock-module-superseded", {
     "a.ts": `export function a() { return "real-a"; }`,

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -350,6 +350,8 @@ test("a factory promise that resolves to a non-object is rejected like the synch
 // point reaches the module loader unvalidated. The unfixed runtime segfaults
 // there, so these run in a subprocess.
 for (const [label, factory] of [
+  // An async factory with no return statement.
+  ["undefined", `async () => { await 1; }`],
   ["a number", `() => new Promise(resolve => setTimeout(() => resolve(42), 1))`],
   ["null", `async () => { await Bun.sleep(1); return null; }`],
   ["a string", `async () => { await Bun.sleep(1); return "str"; }`],


### PR DESCRIPTION
### Problem

- `await import(spec)` segfaults when the `mock.module(spec, factory)` factory returns a promise that is still pending at import time and resolves to a non-object (undefined, 42, null, a string). Release: `panic(main thread): Segmentation fault at address 0x0`. UBSan: `src/jsc/modules/ObjectModule.cpp:20:17: runtime error: member call on null pointer of type 'JSC::JSCell'`.
- The cause is the `wasModuleMock` branch of `handleOnLoadResultNotPromise` (`src/jsc/bindings/ModuleLoader.cpp:221`). It tags the resolved value as an object with no `isObject()` check. `getObject()` returns null and `generateObjectModuleSourceCode` dereferences it.
- #42287 fixed this for a module that is already loaded. This PR covers a module that is not loaded yet.

### Fix

- Check `isObject()` in that branch. On failure, return `OnLoadResultTypeError` with the TypeError of the sync path: `mock(module, fn) requires a function that returns an object`.
- Correct because all four `runVirtualModule` call sites send a pending promise through this function when it settles. The non-mock branch below uses the same sequence.
- Verified: four new subprocess tests in `test/js/bun/test/mock/mock-module.test.ts`. All fail without the fix on canary 1.4.3 and on an ASAN build of main 09bb546305. Also ran `test/js/bun/test/mock/` and `test/js/bun/plugin/plugins.test.ts`.

### Background

- `mock.module` on a module that is not loaded only registers the factory. The first `import(spec)` runs it through `runVirtualModule` (`src/jsc/bindings/BunPlugin.cpp`).
- `JSModuleMock::executeOnce` validates the immediate return value of the factory. A promise is an object, so it passes.
- `runVirtualModule` unwraps and validates a promise that is already fulfilled. It returns a pending promise as is. The loader attaches `jsFunctionOnLoadObjectResultResolve`, which passes the resolved value to `handleOnLoadResultNotPromise`.

<details><summary>Notes</summary>

**Repro** (`bun test repro.test.mjs`):

```js
import { test, mock } from "bun:test";
test("mock.module async factory resolving to a primitive", async () => {
  mock.module("mm-virt-prim", () => new Promise(r => setTimeout(() => r(42), 5)));
  await import("mm-virt-prim"); // segfault instead of a clean rejection
});
```

**Seen in production.** Sentry BUN-4QGA (1.4.0, `bun test`, macOS arm64, fault address 0x0 in the `generateObjectModuleSourceCode` lambda) is this crash. The shape that real code hits is an async factory with no return statement: `mock.module("virt", async () => { await 1; })`. Its promise is pending at import time and resolves to `undefined`. That shape is the first of the four test cases.

**Specifier matrix.** Each cell registers the pending factory above and then calls `await import(spec)`. Canary 1.4.3 (`b99371011`) segfaults on every cell. With the fix every cell prints `rejected: mock(module, fn) requires a function that returns an object` and exits 0.

| specifier | canary 1.4.3 | with fix |
| --- | --- | --- |
| `./esm.mjs` | SIGSEGV | rejects |
| `./cjs.cjs` | SIGSEGV | rejects |
| `./mod.ts` | SIGSEGV | rejects |
| `./data.json` | SIGSEGV | rejects |
| absolute path | SIGSEGV | rejects |
| bare package `pkg` | SIGSEGV | rejects |
| scoped package `@scope/pkg` | SIGSEGV | rejects |
| unresolvable specifier | SIGSEGV | rejects |
| `node:os` (under `bun test`) | SIGSEGV | rejects |
| `bun:jsc` (under `bun test`) | SIGSEGV | rejects |
| `require("node:os")`, then the mock (under `bun test`) | SIGSEGV | rejects |

The builtin cells need `bun test`. `fetchCommonJSModule` and the ESM fetch path only let a mock override a builtin when `isBunTest` is set, so under `bun -e` they import the real module on both builds.

**A promise that is already fulfilled never crashed.** `mock.module(spec, async () => null)` with no `await` in the factory returns a fulfilled promise. `runVirtualModule` unwraps it and throws `virtual module expects an object returned`. Only a promise that is still pending when `import()` runs the factory reaches the unguarded branch. The tests keep the promise pending with a timer inside the factory. They await the import, not the timer.

**The `require()` consumer.** `require(spec)` of a pending factory throws `require() async module "..." is unsupported. use "await import()" instead.` The resolve reaction is still attached to the factory promise. Without the fix this did not crash, because nothing evaluates the module source that holds the null object. With the fix the orphaned internal promise rejects with the TypeError and the runtime reports it as an unhandled error. A pending factory that rejects is already reported the same way under `require()` on the unfixed build (`error: factory boom`), so both kinds of failing factory now behave alike.

**A second `import()` of the same specifier** after the rejection gets the cached, now fulfilled, promise from `executeOnce`. `runVirtualModule` rejects it with `virtual module expects an object returned`.

**Related.** #37026 (merged) fixed a different producer that ends at the same `ObjectModule.cpp:20` dereference: the `exports` getter of an object loader result. #42287 (merged) added the object check for a module that is already loaded. Its tests for that case sit directly above the four tests this PR adds.

**Suites run on the rebased branch (debug ASAN build):** `test/js/bun/test/mock/` (38 pass, 1 todo), `test/js/bun/plugin/plugins.test.ts` (47 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/test/mock/mock-module.test.ts:
37 |       ],
38 |       env: bunEnv,
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 |     expect(stdout).toBe("rejected: mock(module, fn) requires a function that returns an object\n");
                        ^
error: expect(received).toBe(expected)

- "rejected: mock(module, fn) requires a function that returns an object
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/mock/mock-module.test.ts:42:20)
(fail) mock.module async factory resolving to a number rejects cleanly [316.45ms]
37 |       ],
38 |       env: bunEnv,
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 |     expect(stdout).toBe("rejected: mock(module, fn) requires a function that returns 
... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/test/mock/mock-module.test.ts:
37 |       ],
38 |       env: bunEnv,
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 |     expect(stdout).toBe("rejected: mock(module, fn) requires a function that returns an object\n");
                        ^
error: expect(received).toBe(expected)

- "rejected: mock(module, fn) requires a function that returns an object
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/mock/mock-module.test.ts:42:20)
(fail) mock.module async factory resolving to a string rejects cleanly [119.12ms]
37 |       ],
38 |       env: bunEnv,
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 |     expect(stdout).toBe("rejected: mock(module, fn) requires a function that returns an object\n");
                        ^
error: expect(received).toBe(expected)

- "rejected: mock(module, fn) requires a function that returns an object
- "
+ ""

- 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async factory resolving to null rejects cleanly [366.73ms]
(pass) mock.module async factory resolving to a number rejects cleanly [406.05ms]
(pass) mock.module async factory resolving to a string rejects cleanly [371.00ms]
(pass) mock.module async [22.88ms]
(pass) mock.restore [8.60ms]
(pass) spyOn [3.76ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [12.70ms]
(pass) mocking a non-existant relative file with a file URL [27.26ms]
(pass) mocking a non-existant relative file [20.40ms]
(pass) mocking a local file [38.46ms]
(todo) adding a default on a module with no default
(pass) mocking a package [22.12ms]
(pass) mocking a builtin [27.08ms]

 12 pass
 1 todo
 0 fail
 47 expect() calls
Ran 13 tests across 1 file. [3.86s]
__F:0:S:1

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1354ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
^[[1m^[[92m    Finished^[[0m `release` profile [optimized + debuginfo] target(s) in 3m 21s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+f1433c92e
[build] done
bun test v1.4.0-canary.1 (f1433c92e)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async factory resolving to a number rejects cleanly [9.35ms]
(pass) mock.module async factory resolving to a string rejects cleanly [7.99ms]
(pass) mock.module async factory resolving to null rejects cleanly [8.56ms]
(pass) mock.module async [0.43ms]
(pass) mock.restore [0.09ms]
(pass) spyOn [0.02ms]
(pass) mocking a module that points to a file which does not resolve successfully still 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp         |  7 +++++++
 test/js/bun/test/mock/mock-module.test.ts | 34 +++++++++++++++++++++++++++++++
 2 files changed, 41 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp              3      1      0
test/js/bun/test/mock/mock-module.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->

