### PR TITLE
Bun.plugin: don't leak an unhandled rejection from require() of a promise-returning virtual module

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -451,6 +451,11 @@ static JSValue handleVirtualModuleResult(
 
     case OnLoadResultTypePromise: {
         JSC::JSPromise* promise = uncheckedDowncast<JSC::JSPromise>(onLoadResult.value.promise);
+        // Once chained below, an already-rejected promise would read as Pending and require() would misreport it.
+        if (promise->status() == JSC::JSPromise::Status::Rejected) {
+            promise->markAsHandled();
+            RELEASE_AND_RETURN(scope, reject(promise->result()));
+        }
         JSFunction* performPromiseThenFunction = globalObject->performPromiseThenFunction();
         auto callData = JSC::getCallData(performPromiseThenFunction);
         ASSERT(callData.type != CallData::Type::None);
@@ -699,6 +704,8 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Pending: {
+                // The plugin's promise stays chained here; silence its eventual rejection, require() already threw.
+                promise->markAsHandled();
                 JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
@@ -764,6 +771,8 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, JSValue {});
             }
             case JSPromise::Status::Pending: {
+                // The plugin's promise stays chained here; silence its eventual rejection, require() already threw.
+                promise->markAsHandled();
                 JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
                 RELEASE_AND_RETURN(scope, JSValue {});
             }

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1061,7 +1061,7 @@ it.concurrent(
     }
     rejectAsync(new Error("late failure"));
     resolveInvalid({ loader: "object", exports: 7 });
-    setTimeout(() => console.log("still alive"), 0);
+    setImmediate(() => console.log("still alive"));
   `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -1100,7 +1100,7 @@ it.concurrent("require() of an already-rejected plugin module promise throws its
       () => console.log("import did not reject"),
       e => console.log("import rejected:", e.message),
     );
-    setTimeout(() => console.log("still alive"), 0);
+    setImmediate(() => console.log("still alive"));
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1036,3 +1036,80 @@ it("object loader: an error thrown by a getter on the exports object rejects the
   });
   expect(() => require("object-loader-throwing-esmodule")).toThrow(boom);
 });
+
+it.concurrent(
+  "require() of a pending plugin module promise does not kill the process when it settles later",
+  async () => {
+    // require() throws "async module ... unsupported" synchronously; the plugin's
+    // promise settling afterwards must not surface as an unhandled rejection.
+    const fixture = `
+    let rejectAsync, resolveInvalid;
+    Bun.plugin({
+      name: "p",
+      setup(b) {
+        b.module("virt-async", () => new Promise((_, reject) => { rejectAsync = reject; }));
+        b.module("virt-invalid", () => new Promise(resolve => { resolveInvalid = resolve; }));
+      },
+    });
+    for (const id of ["virt-async", "virt-invalid"]) {
+      try {
+        require(id);
+        console.log("require did not throw:", id);
+      } catch (e) {
+        console.log("caught:", id, /async module/.test(e.message));
+      }
+    }
+    rejectAsync(new Error("late failure"));
+    resolveInvalid({ loader: "object", exports: 7 });
+    setTimeout(() => console.log("still alive"), 0);
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("caught: virt-async true\ncaught: virt-invalid true\nstill alive\n");
+    expect(exitCode).toBe(0);
+  },
+);
+
+it.concurrent("require() of an already-rejected plugin module promise throws its rejection reason", async () => {
+  const fixture = `
+    Bun.plugin({
+      name: "p",
+      setup(b) {
+        const caught = Promise.reject(new Error("boom caught"));
+        caught.catch(() => {});
+        b.module("virt-rejected-handled", () => caught);
+        b.module("virt-rejected-unhandled", () => Promise.reject(new Error("boom unhandled")));
+        b.module("virt-rejected-import", () => Promise.reject(new Error("boom import")));
+      },
+    });
+    for (const id of ["virt-rejected-handled", "virt-rejected-unhandled"]) {
+      try {
+        require(id);
+        console.log("require did not throw:", id);
+      } catch (e) {
+        console.log("caught:", e.message);
+      }
+    }
+    await import("virt-rejected-import").then(
+      () => console.log("import did not reject"),
+      e => console.log("import rejected:", e.message),
+    );
+    setTimeout(() => console.log("still alive"), 0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("caught: boom caught\ncaught: boom unhandled\nimport rejected: boom import\nstill alive\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem

`require()` of a `Bun.plugin` virtual module whose `module()` callback returns a promise throws the documented `require() async module "..." is unsupported. use "await import()" instead.` TypeError synchronously. The caller can catch that, but the loader had already chained the plugin's promise to an internal `PendingVirtualModuleResult` promise. When the plugin's promise later settled by rejecting (or by resolving to a shape the loader rejects, like `exports: 7`), that orphaned internal promise rejected with no handler, so the process reported an unhandled rejection and exited with code 1:

```js
Bun.plugin({ name: "p", setup(b) {
  b.module("virt-async", () => new Promise((_, rej) => setTimeout(() => rej(new Error("late failure")), 10)));
  const p = Promise.reject(new Error("pre-rejected, but handled by the plugin")); p.catch(() => {});
  b.module("virt-rejected", () => p);
}});
try { require("virt-async"); } catch (e) { console.log("require threw (expected, caught):", e.message); }
try { require("virt-rejected"); } catch (e) { console.log("require threw (expected, caught):", e.message); }
setTimeout(() => console.log("still alive after 200ms; exiting normally (expected)"), 200);
```

Expected rc 0 and "still alive"; actual: `error: late failure` banner (or `error: pre-rejected, ...`) and rc 1.

A second symptom in the same path: a plugin promise that has **already rejected** (even one the plugin itself `.catch()`ed) got the misleading "async module" message. `performPromiseThen` defers its reaction to a microtask, so the internal promise still read as `Pending` at the time `require()` inspected it, and the real reason was then orphaned the same way.

### Fix

Two small changes in `src/jsc/bindings/ModuleLoader.cpp`:

- In both `Pending` branches of `fetchCommonJSModule`, call `promise->markAsHandled()` on the internal promise before throwing the "async module" TypeError. The error was already delivered synchronously to the caller; the internal promise's later settlement is unobservable by user code. This matches the `Rejected` branches next to them and the `require(esm)` pending path in `ZigGlobalObject.cpp`, and the unhandled-rejection reporter re-checks `isHandled()` at notification time, so the flag is sufficient.
- In `handleVirtualModuleResult`'s promise case, if the plugin's promise has already rejected, mark it handled and surface its rejection reason directly (same shape as the existing `OnLoadResultTypeError` path) instead of chaining. `require()` now throws the plugin's actual error, and `import()` still rejects with the same reason as before.

`require()` of a genuinely pending plugin promise still throws the documented "async module" error; that behavior is unchanged.

### Verification

Two tests in `test/js/bun/plugin/plugins.test.ts` spawn a child and assert it prints the caught errors plus a still-alive line and exits 0:

- late-settling promise (rejection and invalid-shape resolve): both `require()` calls throw the "async module" error, process exits 0 with no unhandled-rejection banner
- already-rejected promise (plugin-handled, unhandled, and via `import()`): `require()` throws `boom caught` / `boom unhandled` instead of the "async module" text, `import()` still rejects with its reason, process exits 0

Both tests fail on bun 1.4.0 (rc 1, banner in stderr, still-alive line never printed) and pass with this change. The full `plugins.test.ts` (37 tests) and the `mock.module` suites, which share this machinery, pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1297.45ms]
(pass) require > beep:boop returns 42 [10.31ms]
(pass) require > object module works [8.48ms]
(pass) module > throws with require() [13.51ms]
(pass) module > async module works with async import [27.11ms]
(pass) module > sync module module works with require() [4.55ms]
(pass) module > sync module module works with require.resolve() [3.74ms]
(pass) module > sync module module works with import [5.20ms]
(pass) module > modules are overridable [104.13ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [8.76ms]
(pass) dynamic import > beep:boop returns 42 [8.99ms]
(pass) dynamic import > async:onLoad retur
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [27.89ms]
(pass) require > beep:boop returns 42 [0.22ms]
(pass) require > object module works [0.11ms]
(pass) module > throws with require() [0.18ms]
(pass) module > async module works with async import [1.36ms]
(pass) module > sync module module works with require() [0.06ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.08ms]
(pass) module > modules are overridable [0.23ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.09ms]
(pass) dynamic import > beep:boop returns 42 [0.05ms]
(pass) dynamic import > async:onLoad returns 42 [1.35ms]
(pass) dynamic import > async object loader returns 42 [1.28ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [2.12ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1322.37ms]
(pass) require > beep:boop returns 42 [10.65ms]
(pass) require > object module works [7.86ms]
(pass) module > throws with require() [12.71ms]
(pass) module > async module works with async import [26.44ms]
(pass) module > sync module module works with require() [4.12ms]
(pass) module > sync module module works with require.resolve() [3.38ms]
(pass) module > sync module module works with import [4.82ms]
(pass) module > modules are overridable [89.82ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [7.46ms]
(pass) dynamic import > beep:boop returns 42 [4.51ms]
(pass) dynamic import > async:onLoad return
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     73ea58566a
  features     baseline

22 deps, 120 codegen, 1175 objects in 712ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] gen ErrorCode+*.h
[2/1236] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 107 installs across 153 packages (no changes) [10.00ms]
[3/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1236] gen bindgenv2
[5/1236] fetch tinycc
[tinycc] up to date
[6/1235] gen .bind.ts → GeneratedBindings.cpp
[7/1235] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1235] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[9/1235] fetch zlib
[zlib] up to date
[10/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp  |  9 +++++
 test/js/bun/plugin/plugins.test.ts | 77 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 86 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp       7      8      0
test/js/bun/plugin/plugins.test.ts      7      2      0
```

</details>

**root cause** · written by the author bot

When `require()` loaded a `Bun.plugin` virtual module whose `module()` callback returned a promise, `handleVirtualModuleResult` chained that promise onto an internal pending-module promise and then `require()` threw its synchronous "async module is unsupported" error without ever attaching a handler to that internal promise, so a later rejection from the plugin surfaced as a process-level unhandled rejection and exited with code 1. The fix marks the internal promise as handled in both `Pending` branches before the synchronous error is thrown, and short-circuits plugin promises that are alre…

<!-- robobun:evidence:end -->