### PR TITLE
Propagate exceptions from boxed primitive unwrapping in YAML/TOML/JSON5 stringify

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2337,13 +2337,19 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__unwrapBoxedPrimitive(JSGlobalObject
         return JSValue::encode(value);
     }
 
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     JSObject* object = asObject(value);
 
     if (object->inherits<NumberObject>()) {
-        return JSValue::encode(jsNumber(object->toNumber(globalObject)));
+        double number = object->toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(jsNumber(number));
     }
-    if (object->inherits<StringObject>())
-        return JSValue::encode(object->toString(globalObject));
+    if (object->inherits<StringObject>()) {
+        JSString* string = object->toString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(string);
+    }
     if (object->inherits<BooleanObject>() || object->inherits<BigIntObject>())
         return JSValue::encode(uncheckedDowncast<JSWrapperObject>(object)->internalValue());
 

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -3484,6 +3484,22 @@ config:
         expect(YAML.stringify(obj, null, 2)).toBe("num: \n  3.14\nstr: world\nbool: \n  false");
       });
 
+      test("propagates exceptions thrown while unwrapping boxed primitives", () => {
+        const boxedString = new String("x");
+        boxedString.toString = () => {
+          throw new Error("boom string");
+        };
+        expect(() => YAML.stringify(boxedString)).toThrow("boom string");
+        expect(() => YAML.stringify({ a: boxedString })).toThrow("boom string");
+
+        const boxedNumber = new Number(5);
+        boxedNumber.valueOf = () => {
+          throw new Error("boom number");
+        };
+        expect(() => YAML.stringify(boxedNumber)).toThrow("boom number");
+        expect(() => YAML.stringify([boxedNumber])).toThrow("boom number");
+      });
+
       test("handles Date objects", () => {
         // Date objects get converted to ISO string via toString()
         const date = new Date("2024-01-15T10:30:00Z");


### PR DESCRIPTION
Fixes a Fuzzilli-found abort (fingerprint `daec39a4e7f75e61`): `Bun.YAML.stringify(new String())` called with a nearly exhausted stack tripped `ExceptionScope::releaseAssertNoException` with a pending "Maximum call stack size exceeded" exception.

### Root cause

`JSC__JSValue__unwrapBoxedPrimitive` in `bindings.cpp` (used by the YAML, TOML, and JSON5 stringifiers through `JSValue::unwrap_boxed_primitive`) calls `object->toNumber()` / `object->toString()` on Number and String wrapper objects. Both can run user JavaScript (`valueOf` / `toString` / `Symbol.toPrimitive`) and can throw, including a stack overflow when the stack is nearly gone. The function ignored the exception and returned a non-empty encoded value, violating the zero-is-throw convention the Rust `from_js_host_call` wrapper validates. Debug builds abort on the exception scope assertion; release builds kept stringifying with an exception pending.

The WebKit helper this was copied from (`unwrapBoxedPrimitive` in `JSONObject.cpp`) relies on its callers doing `RETURN_IF_EXCEPTION` right after; the FFI version has to do that itself.

A stack overflow isn't needed to hit this. The deterministic repro used for the regression test:

```js
const s = new String("x");
s.toString = () => { throw new Error("boom"); };
Bun.YAML.stringify(s); // aborted debug builds
```

### Fix

Add a throw scope and return the empty value when `toNumber()` / `toString()` throws, so the Rust side propagates the error normally.

### Testing

- Original fuzzer script and the minimized repros now exit cleanly or throw the JS error on both the debug and fuzzilli builds.
- New test in `test/js/bun/yaml/yaml.test.ts` covering throwing `toString`/`valueOf` on boxed primitives at the root and nested. The assertion only exists in debug builds (release already surfaced the error because the pending exception was noticed once the host function returned), so the test guards the regression by aborting the debug test runner if it comes back.
- `test/js/bun/yaml/`, `test/js/bun/toml/`, `test/js/bun/json5/` all pass with the debug build.
