### PR TITLE
dev server: hot updates to toml/json/cjs imports never reach importers

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -313,8 +313,12 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     } catch (e) {
       mod.state = State.Stale;
       mod.cjs.exports = {};
+      mod.exports = null;
       throw e;
     }
+    // Discard the cached ESM view so `getEsmExports` re-converts the fresh
+    // `cjs.exports` on reload (mirrors `mod.cjs = null` in the ESM branch).
+    mod.exports = null;
     mod.state = State.Loaded;
   } else {
     // ESM
@@ -413,8 +417,12 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     } catch (e) {
       mod.state = State.Stale;
       mod.cjs.exports = {};
+      mod.exports = null;
       throw e;
     }
+    // Discard the cached ESM view so `getEsmExports` re-converts the fresh
+    // `cjs.exports` on reload (mirrors `mod.cjs = null` in the ESM branch).
+    mod.exports = null;
     mod.state = State.Loaded;
     return mod;
   } else {
@@ -750,13 +758,21 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
+  // Mark every module stale before reloading any of them, so that a module
+  // re-evaluated first pulls in fresh copies of co-updated dependencies
+  // instead of their previous evaluation.
+  const selfAccepts = new Map<HMRModule, HotAcceptFunction | null>();
+  for (const mod of toReload) {
+    mod.state = State.Stale;
+    selfAccepts.set(mod, mod.selfAccept);
+    mod.selfAccept = null;
+    mod.depAccepts = null;
+  }
+
   // Reload all modules
   const promises: Promise<HMRModule>[] = [];
   for (const mod of toReload) {
-    mod.state = State.Stale;
-    const selfAccept = mod.selfAccept;
-    mod.selfAccept = null;
-    mod.depAccepts = null;
+    const selfAccept = selfAccepts.get(mod)!;
 
     const modOrPromise = loadModuleAsync(mod.id, false, null);
     if (modOrPromise === mod) {

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -565,3 +565,86 @@ devTest("html routes reject requests whose host header does not match the dev se
     expect(normal.status).toBe(200);
   },
 });
+
+// Non-JS loaders (toml, json, ...) and CommonJS files are represented as CJS
+// modules in the HMR runtime. Reloading one must invalidate the cached ESM
+// view of its exports, or importers keep reading the first evaluation.
+devTest("server route sees updates to an imported toml file", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      import config from "../deep.toml";
+      export default function (req, meta) {
+        return new Response("value: " + config.d);
+      }
+    `,
+    "deep.toml": "d = 1\n",
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("value: 1");
+    await dev.write("deep.toml", "d = 4\n", { dedent: false });
+    await dev.fetch("/").equals("value: 4");
+    // Editing the importer picks up the current value, not the initial one.
+    await dev.patch("routes/index.ts", { find: "value", replace: "v" });
+    await dev.fetch("/").equals("v: 4");
+    await dev.write("deep.toml", "d = 9\n", { dedent: false });
+    await dev.fetch("/").equals("v: 9");
+  },
+});
+devTest("server route sees updates to an imported toml file after a parse error", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      import config from "../deep.toml";
+      export default function (req, meta) {
+        return new Response("value: " + config.d);
+      }
+    `,
+    "deep.toml": "d = 1\n",
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("value: 1");
+    await dev.write("deep.toml", "d = \n", {
+      dedent: false,
+      errors: ["deep.toml:1:5: error: Missing value after '='; values must be on the same line"],
+    });
+    await dev.write("deep.toml", "d = 2\n", { dedent: false });
+    await dev.fetch("/").equals("value: 2");
+  },
+});
+devTest("server route sees updates to an imported commonjs file", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      import db from "../db.cjs";
+      export default function (req, meta) {
+        return new Response("value: " + db.abc);
+      }
+    `,
+    "db.cjs": `module.exports = { abc: "123" };`,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("value: 123");
+    await dev.write("db.cjs", `module.exports = { abc: "456" };`);
+    await dev.fetch("/").equals("value: 456");
+  },
+});
+devTest("client sees updates to an imported toml file", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import config from "./data.toml";
+      console.log("value: " + config.d);
+      import.meta.hot.accept();
+    `,
+    "data.toml": "d = 1\n",
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("value: 1");
+    await dev.write("data.toml", "d = 2\n", { dedent: false });
+    await c.expectMessage("value: 2");
+  },
+});


### PR DESCRIPTION
### Problem

In a bake dev server app, a module that imports a TOML (or JSON, or CommonJS) file never sees updates to that file. The rebundle runs and the dev server logs `Reloaded: deep.toml`, but the importer keeps reading the value from the first evaluation, forever. Editing the importer afterwards, or round-tripping the file through a parse error, still serves the original value. Plain JS/TS (ESM) imports on the same graph update fine.

```ts
// routes/index.ts
import config from "../deep.toml";
export default function (req, meta) {
  return new Response("value: " + config.d);
}
```

Writing `d = 4` to `deep.toml` keeps serving `value: 1`.

### Cause

Two bugs in the HMR module runtime (`src/runtime/bake/hmr-module.ts`), which both the server and client runtimes share.

1. Non-JS loaders and CJS files are represented as CommonJS modules. ESM importers read them through `getEsmExports`, which caches the converted view: `m.exports ??= toESM(m.cjs.exports)`. Re-evaluating the module replaces `cjs.exports`, but nothing ever cleared the cached `m.exports`, so every later read (including `patchImporters` after a hot update) returned the snapshot of the first evaluation. The ESM branch already resets its mirror cache (`mod.cjs = null`) after every load; the CJS branch was missing the symmetric reset.

2. `replaceModules` marked each reloaded module stale only in its own loop iteration. When an update round re-bundles both an importer and its dependency (the client graph does this for non-JS files), an importer that happens to re-evaluate first sees the dependency still `Loaded` and captures its previous exports at evaluation time. Marking everything stale up front makes the first re-evaluation pull fresh co-updated dependencies inline; the later iteration for the already-reloaded dependency is a no-op.

### Fix

- Reset `mod.exports = null` after (re)evaluating a CommonJS module, and on the failure path next to the existing `mod.cjs.exports = {}` reset.
- Split the reload loop in `replaceModules`: first mark every module stale (capturing the old accept callbacks so re-registration during evaluation is preserved), then reload.

### Verification

New tests in `test/bake/dev/esm.test.ts`, all failing before this change and passing after:

- server route sees updates to an imported toml file (plus importer edit and a second update)
- server route sees updates to an imported toml file after a parse error round-trip
- server route sees updates to an imported commonjs file
- client sees updates to an imported toml file (via `import.meta.hot.accept`)

`test/bake/dev/{esm,hot,bundle,css,html,react-spa}.test.ts` all pass with the change.