### PR TITLE
valkey: keep pending exceptions out of the command rejection drain

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1946,7 +1946,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
             p.update_poll_ref();
         });
 
-        let _ = this.client_mut().on_close(); // TODO: properly propagate exception upwards
+        if this.client_mut().on_close().is_err() && this.global_object.has_exception() {
+            this.global_object
+                .report_active_exception_as_unhandled(jsc::JsError::Thrown);
+        }
     }
 
     pub(crate) fn on_end(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -1986,7 +1989,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.client_mut().socket = Self::socket(socket);
 
         let _guard = this.ref_scope();
-        let _ = this.client_mut().on_data(data); // TODO: properly propagate exception upwards
+        if this.client_mut().on_data(data).is_err() && this.global_object.has_exception() {
+            this.global_object
+                .report_active_exception_as_unhandled(jsc::JsError::Thrown);
+        }
         this.update_poll_ref();
     }
 

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -508,13 +508,31 @@ impl ValkeyClient {
 
         // Reject commands in the command queue
         while let Some(mut command_pair) = pending.read_item() {
-            command_pair.reject_command(global_this, jsvalue)?;
+            if command_pair.reject_command(global_this, jsvalue).is_err() {
+                Self::report_failed_settle(global_this)?;
+            }
         }
 
         // Reject commands in the offline queue
         while let Some(mut cmd) = entries.read_item() {
             // Note: `defer cmd.deinit(allocator)` — Entry should impl Drop.
-            cmd.promise.reject(global_this, Ok(jsvalue))?;
+            if cmd.promise.reject(global_this, Ok(jsvalue)).is_err() {
+                Self::report_failed_settle(global_this)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// A failed settle left an exception pending on the VM. Report it so the
+    /// drain can keep settling the remaining promises without entering the
+    /// next JSC call with a stale exception; stop only for termination.
+    fn report_failed_settle(global_this: &JSGlobalObject) -> JsTerminated<()> {
+        if global_this.has_exception() {
+            global_this.report_active_exception_as_unhandled(bun_jsc::JsError::Thrown);
+            if global_this.has_exception() {
+                // Only a termination exception survives the report.
+                return Err(bun_jsc::JsError::Terminated);
+            }
         }
         Ok(())
     }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -3,6 +3,31 @@ import { describe, expect, mock, test } from "bun:test";
 import net from "net";
 import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, delay, isEnabled } from "../test-utils";
 
+// A connection failure settles every queued command promise in one native
+// callback. All of them must reject; none may stay pending. Needs no Redis
+// server, so this block is not gated on isEnabled.
+describe("Valkey: Connection Failures (no server)", () => {
+  test.concurrent("a connection dropped before the handshake rejects every queued command", async () => {
+    const server = net.createServer(socket => socket.destroy());
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, {
+      autoReconnect: false,
+      connectionTimeout: 1000,
+    });
+    try {
+      const settled = await Promise.allSettled(Array.from({ length: 32 }, (_, i) => client.get(`key-${i}`)));
+      expect(settled.map(result => result.status)).toEqual(Array(32).fill("rejected"));
+      for (const result of settled) {
+        expect((result as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+      }
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
 /**
  * Test suite for connection failures, reconnection, and error handling
  * - Connection failures


### PR DESCRIPTION
### What

Fuzzing hit the same flaky assertion as #37004, in a script with no DNS but with a RedisClient whose connection fails:

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JavaScriptCore/JSObjectInlines.h(137) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName)
```

The script constructs `new Bun.RedisClient()` with no server available and calls commands inside try/catch, so the queued command promises are settled by the native connection-failure path.

That path had the same defect class as the DNS drains:

- `reject_all_pending_commands` used `?` on each reject, so the first settle error aborted the loop with the exception still pending and the remaining queued promises never settled.
- The socket callbacks discarded that error: `let _ = this.client_mut().on_close()` and `let _ = ... on_data(data)` (both carried a `// TODO: properly propagate exception upwards`), and the generated FFI wrapper reports a pending exception without clearing it.
- With the exception still on the VM, the rest of the tick runs unhandled rejection processing, and `Bun__handleUncaughtException` does `process->get(globalObject, "_fatalException")`, a property that exists, which is exactly the asserted condition. In release builds the stale exception gets misattributed instead.

An extra wrinkle: `JSPromise::resolve/reject` map every FFI failure to `JsTerminated`, so the error label cannot be trusted to distinguish a thrown exception from termination. The fix inspects the VM instead of the label.

### Fix

- `reject_all_pending_commands` keeps draining after a failed settle: a helper reports a pending non-termination exception as unhandled (`report_active_exception_as_unhandled`, the idiom already used for the onclose callback in this file) and only stops for termination, which stays pending by convention.
- `on_close` and `on_data` report a pending non-termination exception instead of discarding the error, so nothing valkey does can leave the VM dirty for the rest of the tick.

### Verification

Same situation as #37004: the crash is flaky and did not reproduce standalone (15 direct runs, 150 REPRL iterations in one process), so there is no fail-before repro for the assertion itself. The new test runs without a Redis server: it accepts and immediately drops the connection, then checks that all 32 queued command promises reject through the drain loop this change touches. The valkey suites that run without docker pass, and the fuzzer script runs clean on the fixed debug build.

Sibling of #37004, which fixed the same fingerprint in the DNS drains.