### PR TITLE
bun:sqlite: fix use-after-free closing a database with FTS5 tables

### DIFF
--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1554,7 +1554,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
                 SQLiteBindingsMap bindings { static_cast<uint16_t>(count > -1 ? count : 0), strict };
                 JSC::JSValue reb = rebindStatement(lexicalGlobalObject, bindingsAliveScope.value(), scope, db, versionDB, sql.stmt, bindings, safeIntegers, nullptr);
                 if (versionDB->handle() != db) [[unlikely]] {
-                    sql.stmt = nullptr; // close() during binding already finalized it via the sqlite3_next_stmt() sweep
+                    // close() during binding deferred sqlite3_close via close_v2;
+                    // finalizing sql.stmt on scope exit completes it.
                     if (!scope.exception())
                         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Database has closed"_s));
                     return {};
@@ -1861,34 +1862,36 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // close(false) keeps db.prepare() statements usable and defers sqlite3_close until they drain; everything else is finalized now.
-    WTF::HashSet<sqlite3_stmt*> kept;
+    // close(false) keeps db.prepare() statements usable and defers sqlite3_close until they drain; everything else bun owns is finalized now.
+    bool keptAny = false;
     for (auto* statement : versionDB->statements) {
         if (!statement->stmt)
             continue;
         if (!force && !statement->ownedByDatabase) {
-            kept.add(statement->stmt);
+            keptAny = true;
             continue;
         }
         sqlite3_finalize(statement->stmt);
         statement->stmt = nullptr;
         statement->finalizedByClose = true;
     }
-    for (sqlite3_stmt* stmt = sqlite3_next_stmt(db, nullptr); stmt;) {
-        sqlite3_stmt* next = sqlite3_next_stmt(db, stmt);
-        if (!kept.contains(stmt))
-            sqlite3_finalize(stmt);
-        stmt = next;
-    }
 
     versionDB->closed = true;
-    if (!kept.isEmpty()) {
+    if (keptAny) {
         return JSValue::encode(jsUndefined());
     }
 
+    // Statements bun doesn't track may still be live on the connection:
+    // virtual-table modules (e.g. FTS5) cache their own prepared statements
+    // and finalize them during vtab disconnect inside sqlite3_close*, and a
+    // re-entrant close() from a bound-parameter getter leaves db.run()'s
+    // transient statement alive on this stack. Never finalize those behind
+    // their owner's back; on SQLITE_BUSY, close_v2 defers the close until
+    // they drain.
     int statusCode = force ? sqlite3_close(db) : sqlite3_close_v2(db);
-    if (statusCode != SQLITE_OK && force) {
+    if (statusCode == SQLITE_BUSY) {
         sqlite3_close_v2(db);
+        statusCode = SQLITE_OK;
     }
     versionDB->db = nullptr;
 

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1878,13 +1878,10 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // Statements bun doesn't track may still be live on the connection:
-    // virtual-table modules (e.g. FTS5) cache their own prepared statements
-    // and finalize them during vtab disconnect inside sqlite3_close*, and a
-    // re-entrant close() from a bound-parameter getter leaves db.run()'s
-    // transient statement alive on this stack. Never finalize those behind
-    // their owner's back; on SQLITE_BUSY, close_v2 defers the close until
-    // they drain.
+    // Remaining statements are not bun's to finalize: vtab modules (FTS5)
+    // finalize their cached statements during disconnect inside sqlite3_close*,
+    // and a re-entrant close() from a bound-parameter getter leaves db.run()'s
+    // transient statement live on this stack (close_v2 defers until it drains).
     int statusCode = force ? sqlite3_close(db) : sqlite3_close_v2(db);
     if (statusCode == SQLITE_BUSY) {
         sqlite3_close_v2(db);
@@ -3003,9 +3000,8 @@ JSValue createJSSQLStatementConstructor(Zig::GlobalObject* globalObject)
 
 } // namespace WebCore
 
-// Drained means every statement bun tracks is finalized. Statements sqlite3
-// still knows about (virtual-table modules' cached statements) don't count:
-// sqlite3_close_v2 finalizes them via vtab disconnect.
+// Drained = every bun-tracked statement finalized. Statements sqlite3 still
+// holds (vtab modules' cached ones) don't count; close_v2 finalizes those.
 void VersionSqlite3::closeIfDrained()
 {
     if (!closed || !db)

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -230,11 +230,8 @@ public:
             sqlite3_close_v2(std::exchange(db, nullptr));
     }
 
-    void closeIfDrained()
-    {
-        if (closed && db && !sqlite3_next_stmt(db, nullptr))
-            closeHandle();
-    }
+    // Defined after JSSQLStatement: needs its definition to inspect `stmt`.
+    void closeIfDrained();
 
     void release()
     {
@@ -3005,3 +3002,17 @@ JSValue createJSSQLStatementConstructor(Zig::GlobalObject* globalObject)
 }
 
 } // namespace WebCore
+
+// Drained means every statement bun tracks is finalized. Statements sqlite3
+// still knows about (virtual-table modules' cached statements) don't count:
+// sqlite3_close_v2 finalizes them via vtab disconnect.
+void VersionSqlite3::closeIfDrained()
+{
+    if (!closed || !db)
+        return;
+    for (auto* statement : statements) {
+        if (statement->stmt)
+            return;
+    }
+    closeHandle();
+}

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1793,7 +1793,7 @@ it("close() does not crash with FTS5 virtual tables (#37044)", async () => {
   // close() must not finalize FTS5's internal prepared statements behind the
   // vtab's back; doing so use-after-frees in sqlite3_close's vtab disconnect.
   const src = `
-    const { Database } = require("bun:sqlite");
+    import { Database } from "bun:sqlite";
     for (let i = 0; i < 10; i++) {
       const db = new Database(":memory:");
       db.exec("CREATE VIRTUAL TABLE notes_fts USING fts5(body)");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1789,6 +1789,35 @@ it("close() releases the database file when only query() statements are outstand
   expect(existsSync(file)).toBe(false);
 });
 
+it("close() does not crash with FTS5 virtual tables (#37044)", async () => {
+  // close() must not finalize FTS5's internal prepared statements behind the
+  // vtab's back; doing so use-after-frees in sqlite3_close's vtab disconnect.
+  const src = `
+    const { Database } = require("bun:sqlite");
+    for (let i = 0; i < 10; i++) {
+      const db = new Database(":memory:");
+      db.exec("CREATE VIRTUAL TABLE notes_fts USING fts5(body)");
+      db.exec("INSERT INTO notes_fts(body) VALUES ('hello world'), ('goodbye moon')");
+      db.query("SELECT rowid FROM notes_fts WHERE notes_fts MATCH 'hello'").all();
+      db.query("SELECT count(*) c FROM notes_fts").get();
+      db.close(i % 2 === 0);
+    }
+    console.log("survived");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("survived");
+  expect(exitCode).toBe(0);
+});
+
 it("should dispose even if a prepared statement is still live", () => {
   let prepared;
   expect(() => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1818,6 +1818,22 @@ it("close() does not crash with FTS5 virtual tables (#37044)", async () => {
   expect(exitCode).toBe(0);
 });
 
+it("close() releases an FTS5 database file once the last prepare() statement is finalized (#37044)", () => {
+  using dir = tempDir("sqlite-close-unlink-fts5", {});
+  const file = path.join(String(dir), "x.sqlite");
+  const db = new Database(file);
+  db.exec("CREATE VIRTUAL TABLE t USING fts5(a)");
+  // FTS5 caches internal prepared statements on the connection; they must not
+  // keep the deferred close from ever happening.
+  db.query("SELECT rowid FROM t WHERE t MATCH 'x'").all();
+  const stmt = db.prepare("SELECT 1");
+  db.close();
+  stmt.finalize();
+  // On Windows rmSync throws EBUSY if the handle stayed open past the last finalize.
+  rmSync(file);
+  expect(existsSync(file)).toBe(false);
+});
+
 it("should dispose even if a prepared statement is still live", () => {
   let prepared;
   expect(() => {


### PR DESCRIPTION
Fixes #37044

## Repro

```ts
import { Database } from 'bun:sqlite';

const db = new Database(':memory:');
db.exec('CREATE VIRTUAL TABLE notes_fts USING fts5(body)');
db.query("SELECT rowid FROM notes_fts WHERE notes_fts MATCH 'hello'").all();
db.close(); // panic(main thread): Segmentation fault at address 0x28
```

Crashes in `sqlite3Fts5IndexClose` / `fts5DisconnectMethod` under `sqlite3_close`. Reproduces on Linux and macOS; ASAN reports a heap-use-after-free with `sqlite3_finalize` (from `jsSQLStatementCloseStatementFunction`) as the free site and `sqlite3Fts5IndexClose` as the read.

## Cause

Regression from #36573. `close()` sweeps every prepared statement on the connection via `sqlite3_next_stmt()` and finalizes the ones bun isn't keeping. Virtual-table modules like FTS5 cache their own internal prepared statements and finalize them themselves during vtab disconnect inside `sqlite3_close*`, so the sweep finalized them first and the disconnect then called `sqlite3_finalize` on dangling pointers. This also matches the reporter's observations: `DROP TABLE` before `close()` avoids it (teardown goes through xDestroy while the statements are still valid), as does never calling `close()`.

Since #36573, every bun-created statement wrapper is tracked in `VersionSqlite3::statements`, so the sweep's only remaining job was the transient statement in `db.run()` when a bound-parameter getter re-entrantly closes the database mid-bind.

## Fix

Only finalize the statements bun tracks. If untracked statements still make `sqlite3_close()` return `SQLITE_BUSY` (the re-entrant `db.run()` case), retire the handle with `sqlite3_close_v2()`, which defers the close until the owner finalizes them, instead of finalizing other code's statements behind its back. The `db.run()` path now lets its transient statement be finalized by its scoped owner, which completes the deferred close.

## Verification

New test fails on the unfixed build (segfault) and passes with the fix. `bun bd test test/js/bun/sqlite/sqlite.test.js` 114 pass (including the #36573/#36793 close semantics tests), `test/js/node/sqlite/` 115 pass, `test/regression/issue/14709.test.ts` 5 pass. The reporter's 500-iteration loop prints `survived` under the ASAN debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->