### PR TITLE
Fix abort when using spyOn on a function's prototype property

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1555,6 +1555,14 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
 
             pushImpl(mock, globalObject, JSMockImplementation::Kind::Call, value);
         } else {
+            // JSFunction::getOwnPropertySlot serves `prototype` straight from property storage,
+            // ignoring the Accessor attribute, so a GetterSetter installed here would escape to
+            // script as a raw cell. Refuse, like Jest.
+            if (propertyKey == vm.propertyNames->prototype && object->inherits<JSC::JSFunction>()) {
+                throwVMError(globalObject, scope, "Cannot spy on the `prototype` property because it is not a function"_s);
+                return {};
+            }
+
             if (hasValue)
                 attributes = slot.attributes();
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1555,9 +1555,8 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
 
             pushImpl(mock, globalObject, JSMockImplementation::Kind::Call, value);
         } else {
-            // JSFunction::getOwnPropertySlot serves `prototype` straight from property storage,
-            // ignoring the Accessor attribute, so a GetterSetter installed here would escape to
-            // script as a raw cell. Refuse, like Jest.
+            // JSFunction::getOwnPropertySlot serves `prototype` straight from property storage, ignoring
+            // the Accessor attribute, so a GetterSetter installed here would escape to script as a raw cell.
             if (propertyKey == vm.propertyNames->prototype && object->inherits<JSC::JSFunction>()) {
                 throwVMError(globalObject, scope, "Cannot spy on the `prototype` property because it is not a function"_s);
                 return {};

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1079,11 +1079,12 @@ describe("spyOn", () => {
     // replaced with a getter/setter spy; historically this crashed the process.
     test("spyOn on a function's prototype property throws instead of crashing", () => {
       function Foo() {}
+      const fooPrototype = Foo.prototype;
       expect(() => spyOn(Foo, "prototype")).toThrow(
         "Cannot spy on the `prototype` property because it is not a function",
       );
       // the function is left untouched
-      expect(Object.keys(Foo.prototype)).toEqual([]);
+      expect(Foo.prototype).toBe(fooPrototype);
       expect(new Foo()).toBeInstanceOf(Foo);
 
       class K {
@@ -1091,9 +1092,11 @@ describe("spyOn", () => {
           return 42;
         }
       }
+      const kPrototype = K.prototype;
       expect(() => spyOn(K, "prototype")).toThrow(
         "Cannot spy on the `prototype` property because it is not a function",
       );
+      expect(K.prototype).toBe(kPrototype);
       expect(new K().m()).toBe(42);
 
       // arrow functions have no prototype property at all
@@ -1101,6 +1104,7 @@ describe("spyOn", () => {
       expect(() => spyOn(arrow, "prototype")).toThrow(
         "Cannot spy on the `prototype` property because it is not a function",
       );
+      expect(Object.hasOwn(arrow, "prototype")).toBe(false);
     });
 
     test("spyOn still works when a function's prototype is itself a function", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1074,6 +1074,48 @@ describe("spyOn", () => {
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    // The engine serves a function's `prototype` property specially, so it cannot be
+    // replaced with a getter/setter spy; historically this crashed the process.
+    test("spyOn on a function's prototype property throws instead of crashing", () => {
+      function Foo() {}
+      expect(() => spyOn(Foo, "prototype")).toThrow(
+        "Cannot spy on the `prototype` property because it is not a function",
+      );
+      // the function is left untouched
+      expect(Object.keys(Foo.prototype)).toEqual([]);
+      expect(new Foo()).toBeInstanceOf(Foo);
+
+      class K {
+        m() {
+          return 42;
+        }
+      }
+      expect(() => spyOn(K, "prototype")).toThrow(
+        "Cannot spy on the `prototype` property because it is not a function",
+      );
+      expect(new K().m()).toBe(42);
+
+      // arrow functions have no prototype property at all
+      const arrow = () => {};
+      expect(() => spyOn(arrow, "prototype")).toThrow(
+        "Cannot spy on the `prototype` property because it is not a function",
+      );
+    });
+
+    test("spyOn still works when a function's prototype is itself a function", () => {
+      function Bar() {}
+      Bar.prototype = function original() {
+        return 7;
+      };
+      const fn = spyOn(Bar, "prototype");
+      expect(Bar.prototype).toBe(fn);
+      expect(Bar.prototype()).toBe(7);
+      expect(fn).toHaveBeenCalledTimes(1);
+      fn.mockRestore();
+      expect(Bar.prototype()).toBe(7);
+      expect(fn).not.toHaveBeenCalled();
+    });
   }
 
   // spyOn does not work with getters/setters yet.


### PR DESCRIPTION
### Repro

```ts
import { test, spyOn } from "bun:test";
test("spyOn prototype", () => {
  function Foo() {}
  spyOn(Foo, "prototype");
  Object.keys(Foo.prototype); // abort
});
```

On bun 1.4.0 this aborts the process with exit code 134 (`panic(main thread): abort() called`), with no test failure output. On a debug build it asserts:

```
ASSERTION FAILED: !(attributes & PropertyAttribute::Accessor)
PropertySlot.h(226)
```

Same outcome for class constructors (`spyOn(K, "prototype")` then `new K()` or `instanceof`).

### Cause

`spyOn`'s accessor branch (`JSMock__jsSpyOn` in `src/jsc/bindings/JSMockFunction.cpp`) handles non-callable values by writing a `GetterSetter` into the target with `putDirectAccessor`. For a `JSFunction` target, the `prototype` property is served by `JSFunction::getOwnPropertySlot`'s special case, which returns the stored slot as a plain value and ignores the `Accessor` attribute. The raw `GetterSetter` cell therefore escapes to script as the value of `Foo.prototype`, and anything that touches it crashes.

Other targets are unaffected: the same accessor install on plain objects, module namespaces, and host constructors goes through the normal property path and behaves.

### Fix

In the accessor branch, refuse when the target is a `JSFunction` and the key is `prototype`, matching Jest:

```
error: Cannot spy on the `prototype` property because it is not a function
```

A function whose `prototype` has been reassigned to a function value is unaffected: that case takes the data-property spy path (`putDirect`), which the special-cased read handles fine, so it keeps working.

### Verification

New tests in `test/js/bun/test/mock-fn.test.js` cover: function and class constructor targets throw and are left intact (`new Foo()`, methods still work), arrow functions (no prototype property) throw, and a function-valued `prototype` can still be spied on and restored. The throw test fails on unfixed bun (spyOn succeeds there) and passes with the fix; the full file (79 tests) passes, and spying on plain objects with a `prototype`-named property and on host constructors like `Array` is unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (4537f5d5f)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.74ms]
(pass) mock() > mock [6.57ms]
(pass) mock() > checks the this value > mock [6.96ms]
(pass) mock() > checks the this value > _protoImpl [0.75ms]
(pass) mock() > checks the this value > getMockImplementation [1.51ms]
(pass) mock() > checks the this value > getMockName [0.80ms]
(pass) mock() > checks the this value > mockClear [0.64ms]
(pass) mock() > checks the this value > mockReset [0.67ms]
(pass) mock() > checks the this value > mockRestore [0.62ms]
(pass) mock() > checks the this value > mockImplementation [0.62ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.82ms]
(pass) mock() > checks the this value > withImplementation [0.68ms]
(pass) mock() > checks the this value > mockName [0.58ms]
(pass) mock() > checks the this value > mockReturnThis [0.55ms]
(pass) mock() > checks the this value > mockReturnValue [0.53ms]
(pass) mock() > checks the this value
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (b58cd4685)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.02ms]
(pass) mock() > mock [0.09ms]
(pass) mock() > checks the this value > mock [0.11ms]
(pass) mock() > checks the this value > _protoImpl
(pass) mock() > checks the this value > getMockImplementation [0.03ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue [0.01ms]
(pass) mock() > checks the this value > mockRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (4537f5d5f)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.78ms]
(pass) mock() > mock [6.68ms]
(pass) mock() > checks the this value > mock [7.05ms]
(pass) mock() > checks the this value > _protoImpl [0.77ms]
(pass) mock() > checks the this value > getMockImplementation [1.49ms]
(pass) mock() > checks the this value > getMockName [0.81ms]
(pass) mock() > checks the this value > mockClear [0.61ms]
(pass) mock() > checks the this value > mockReset [0.65ms]
(pass) mock() > checks the this value > mockRestore [0.62ms]
(pass) mock() > checks the this value > mockImplementation [0.67ms]
(pass) mock() > checks the this value > mockImplementationOnce [0.82ms]
(pass) mock() > checks the this value > withImplementation [0.71ms]
(pass) mock() > checks the this value > mockName [0.62ms]
(pass) mock() > checks the this value > mockReturnThis [0.58ms]
(pass) mock() > checks the this value > mockReturnValue [0.52ms]
(pass) mock() > checks the this value
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 666ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/114] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[2/114] gen cpp.rs (cppbind)
[2/114] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp |  7 ++++++
 test/js/bun/test/mock-fn.test.js    | 46 +++++++++++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp      2      3      0
test/js/bun/test/mock-fn.test.js         1      2      0
```

</details>

<!-- robobun:evidence:end -->