### PR TITLE
Fix segfault in toHaveReturned matchers when mock.results is tampered with

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -925,6 +925,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
             }
 
             setReturnValue(createMockResult(vm, globalObject, "incomplete"_s, jsUndefined()));
+            RETURN_IF_EXCEPTION(scope, {});
 
             auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
@@ -954,16 +955,19 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
         case JSMockImplementation::Kind::ReturnValue: {
             JSValue returnValue = impl->underlyingValue.get();
             setReturnValue(createMockResult(vm, globalObject, "return"_s, returnValue));
+            RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(returnValue);
         }
         case JSMockImplementation::Kind::ReturnThis: {
             setReturnValue(createMockResult(vm, globalObject, "return"_s, thisValue));
+            RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(thisValue);
         }
         case JSMockImplementation::Kind::RejectedValue: {
             JSValue rejectedPromise = JSC::JSPromise::rejectedPromise(globalObject, impl->underlyingValue.get());
             RETURN_IF_EXCEPTION(scope, {});
             setReturnValue(createMockResult(vm, globalObject, "return"_s, rejectedPromise));
+            RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(rejectedPromise);
         }
         default: {
@@ -973,6 +977,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -3069,10 +3069,14 @@ pub mod mock {
     }
 
     pub(crate) fn jest_mock_return_object_type(global_this: &JSGlobalObject, value: JSValue) -> JsResult<ReturnStatus> {
-        if let Some(type_string) = value.fast_get(global_this, bun_jsc::BuiltinName::Type)? {
-            if type_string.is_string() {
-                if let Some(val) = RETURN_STATUS_MAP.from_js(global_this, type_string)? {
-                    return Ok(val);
+        // `mock.results` is a user-mutable JSArray, so `value` can be anything
+        // (`fn.mock.results.push(undefined)`); `fast_get` requires an object.
+        if value.is_object() {
+            if let Some(type_string) = value.fast_get(global_this, bun_jsc::BuiltinName::Type)? {
+                if type_string.is_string() {
+                    if let Some(val) = RETURN_STATUS_MAP.from_js(global_this, type_string)? {
+                        return Ok(val);
+                    }
                 }
             }
         }

--- a/test/js/bun/test/expect/toHaveReturnedWith.test.ts
+++ b/test/js/bun/test/expect/toHaveReturnedWith.test.ts
@@ -209,6 +209,29 @@ describe("toHaveReturnedWith Examples", () => {
       expect(mockFunctionFactory).toHaveReturnedWith(expect.any(Function));
       expect(result(5)).toBe(10);
     });
+
+    test("failure message should not crash when mock.results contains non-objects", () => {
+      const fn = jest.fn((causeError: boolean) => {
+        if (causeError) {
+          throw new Error("boom");
+        }
+        return 1;
+      });
+
+      try {
+        fn(true);
+      } catch {
+        // ignore error
+      }
+      fn(false);
+      (fn.mock.results as unknown[]).push(undefined);
+
+      // The "Some calls errored" failure message walks mock.results again;
+      // it must throw a matcher error, not crash on the non-object entry.
+      expect(() => {
+        expect(fn).toHaveReturnedWith(42);
+      }).toThrow();
+    });
   });
 
   describe("Common Mistakes and How to Avoid Them", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -335,6 +335,21 @@ describe("mock()", () => {
     const fn = jest.fn(baddie);
     expect(typeof fn.name).toBe("string");
   });
+  if (isBun) {
+    // bun exposes the live results array, so a full-length array makes the
+    // internal push throw; the call must surface that error, not continue
+    // with it pending.
+    test("throws cleanly when recording the result fails", () => {
+      let called = false;
+      const fn = jest.fn(() => {
+        called = true;
+        return 42;
+      });
+      fn.mock.results.length = 2 ** 32 - 1;
+      expect(() => fn(1)).toThrow(RangeError);
+      expect(called).toBe(false);
+    });
+  }
   test(".length works", () => {
     const fn = jest.fn(function hey(a, b, c) {
       return this;

--- a/test/js/bun/test/spyMatchers.test.ts
+++ b/test/js/bun/test/spyMatchers.test.ts
@@ -722,6 +722,22 @@ describe("toHaveReturned", () => {
 
     fn(3);
   });
+
+  test("throws instead of crashing when mock.results contains non-objects", () => {
+    for (const garbage of [undefined, null, 42, "s"]) {
+      const fn = jest.fn(() => 1);
+      fn();
+      (fn.mock.results as unknown[]).push(garbage);
+      expect(() => jestExpect(fn).toHaveReturned()).toThrow("Expected value must be a mock function with returns");
+    }
+  });
+
+  test("throws instead of crashing when mock.results has holes", () => {
+    const fn = jest.fn(() => 1);
+    fn();
+    fn.mock.results.length = 5;
+    expect(() => jestExpect(fn).toHaveReturned()).toThrow("Expected value must be a mock function with returns");
+  });
 });
 
 describe("toHaveReturnedTimes", () => {
@@ -876,6 +892,13 @@ describe("toHaveReturnedTimes", () => {
     });
 
     fn(3);
+  });
+
+  test("throws instead of crashing when mock.results contains non-objects", () => {
+    const fn = jest.fn(() => 1);
+    fn();
+    (fn.mock.results as unknown[]).push(undefined);
+    expect(() => jestExpect(fn).toHaveReturnedTimes(1)).toThrow("Expected value must be a mock function with returns");
   });
 });
 


### PR DESCRIPTION
### Repro

```ts
import { test, mock, expect } from "bun:test";
test("crash", () => {
  const m = mock(() => 1);
  m();
  m.mock.results.push(undefined); // or null / 42 / "s", or m.mock.results.length = 5
  expect(m).toHaveReturned(); // panic(main thread): Segmentation fault at address 0x0
});
```

Deterministic segfault on 1.4.0 (`panic(main thread): Segmentation fault at address 0x0`, exit 139). Debug builds fail earlier with `panic: assertion failed: self.is_object()`.

### Cause

`mock.results` is the live JSArray the native mock pushes into, so user code can place non-objects (or holes) in it. `jest_mock_return_object_type` in `src/runtime/test_runner/expect.rs` read each entry's `type` property with `fast_get`, which requires an object; for `undefined`/`null`/primitives it dereferences null. This is reachable from:

- `toHaveReturned()` / `toHaveReturnedTimes(n)` (main counting loop)
- `toHaveReturnedWith()` when building the "Some calls errored" failure message, which walks the same entries

A sibling in `jsMockFunctionCall` (`src/jsc/bindings/JSMockFunction.cpp`): recording the call result does `RETURN_IF_EXCEPTION` inside the `setReturnValue` lambda, which only exits the lambda. If the internal push throws (e.g. `m.mock.results.length = 2**32-1` makes the next push exceed the max array length), the call continued with the exception pending, hitting `ASSERTION FAILED: Unexpected exception observed` in debug builds.

### Fix

- Guard `jest_mock_return_object_type` with `is_object()` before the `fast_get`; non-object entries fall through to the existing "Expected value must be a mock function with returns: ..." error, matching how malformed object entries are already handled.
- Add `RETURN_IF_EXCEPTION(scope, {})` after each `setReturnValue(...)` call site so a failed result push surfaces as the thrown RangeError instead of leaving the exception pending (and the implementation no longer runs after the record fails).

### Verification

- Before: repro above segfaults (release) / aborts on `self.is_object()` (debug); the `results.length = 2**32-1; m()` case aborts debug builds with `Unexpected exception observed`.
- After: `bun bd test` passes `test/js/bun/test/spyMatchers.test.ts` (150 pass), `test/js/bun/test/mock-fn.test.js` (78 pass), `test/js/bun/test/expect/toHaveReturnedWith.test.ts` (42 pass), and `test/js/bun/test/expect-toHaveReturnedWith.test.js` (13 pass).
- New tests cover non-object entries, holes, the toHaveReturnedWith failure-message path, and the failed result push.
