### PR TITLE
watcher: stop serving the watchlist's stored fd to --hot reload reads

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4385,8 +4385,7 @@ pub mod bv2_impl {
                                 Ok(bun_watcher::FdOwnership::Watcher)
                             ) && fd.is_valid()
                             {
-                                // Opened above just for the watcher; it
-                                // wasn't adopted (already watched or error).
+                                // Not adopted; close the fd opened above.
                                 let _ = bun_sys::close(fd);
                             }
                         }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4373,14 +4373,22 @@ pub mod bv2_impl {
                             };
 
                             // Failures to watch are intentionally ignored.
-                            let _ = this.bun_watcher_mut().unwrap().add_file::<true>(
-                                fd,
-                                &load.path,
-                                bun_wyhash::hash(load.path.as_ref()) as u32,
-                                bun_watcher::Loader(code.loader as u8),
-                                bun_sys::Fd::INVALID,
-                                None,
-                            );
+                            if !matches!(
+                                this.bun_watcher_mut().unwrap().add_file::<true>(
+                                    fd,
+                                    &load.path,
+                                    bun_wyhash::hash(load.path.as_ref()) as u32,
+                                    bun_watcher::Loader(code.loader as u8),
+                                    bun_sys::Fd::INVALID,
+                                    None,
+                                ),
+                                Ok(bun_watcher::FdOwnership::Watcher)
+                            ) && fd.is_valid()
+                            {
+                                // Opened above just for the watcher; it
+                                // wasn't adopted (already watched or error).
+                                let _ = bun_sys::close(fd);
+                            }
                         }
                     }
                 }

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1285,12 +1285,9 @@ impl AsyncModule {
             );
         }
 
-        // Note: the original parse already registered this file with the
-        // watcher (`maybe_watch_file` runs before the pending-imports
-        // enqueue), and the descriptor it read from is either owned by the
-        // watchlist or was closed by the transpile frame's fd guard — so
-        // there is nothing to re-register here, and `parse_result.input_fd`
-        // must not be used (the number may have been closed and recycled).
+        // No watcher registration here: `maybe_watch_file` already ran before
+        // the enqueue, and `parse_result.input_fd` may have been closed (and
+        // the number recycled) by the transpile frame's fd guard.
 
         // SAFETY: per-thread VM.
         if unsafe { (*jsc_vm).is_watcher_enabled() } {

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -6,11 +6,7 @@ use bun_core::{OwnedString, String as BunString, ZigString};
 use bun_install::dependency::Dependency;
 use bun_install::{DependencyID, Resolution};
 use bun_io::KeepAlive;
-use bun_options_types::LoaderExt as _;
-use bun_options_types::schema::api;
 use bun_resolver::fs as Fs;
-use bun_resolver::package_json::PackageJSON;
-use bun_sys::Fd;
 
 use crate::virtual_machine::VirtualMachine;
 use crate::{
@@ -26,9 +22,6 @@ pub struct InitOpts<'a> {
     pub specifier: &'a [u8],
     pub path: Fs::Path<'a>,
     pub promise_ptr: Option<*mut *mut JSInternalPromise>,
-    pub package_json: Option<&'a PackageJSON>,
-    pub loader: bun_ast::Loader,
-    pub hash: u32,
     pub arena: Box<ArenaAllocator>,
     /// Backs `parse_result`'s small `AstVec`s (inline bump chunk); must stay
     /// alive alongside `arena` until the module finishes loading.
@@ -45,14 +38,9 @@ pub struct AsyncModule {
     pub(crate) string_buf: Box<[u8]>,
     referrer_len: u32,
     specifier_len: u32,
-    // `?*PackageJSON` / `*JSGlobalObject` — both are VM-lifetime
-    // backrefs (BACKREF/JSC_BORROW class in LIFETIMES.tsv). `package_json` is
-    // stored as a raw ptr so `AsyncModule` is `'static`-embeddable in
-    // `Queue`/`VirtualMachine` without a phantom lifetime; `global_this` uses
-    // [`crate::GlobalRef`] which encapsulates the single audited deref.
-    pub(crate) package_json: Option<core::ptr::NonNull<PackageJSON>>,
-    pub(crate) loader: api::Loader,
-    pub(crate) hash: u32, // default = u32::MAX
+    // `*JSGlobalObject` is a VM-lifetime backref (BACKREF/JSC_BORROW class in
+    // LIFETIMES.tsv); [`crate::GlobalRef`] encapsulates the single audited
+    // deref.
     pub global_this: crate::GlobalRef,
     pub(crate) arena: Box<ArenaAllocator>,
     /// See [`InitOpts::ast_alloc_state`].
@@ -254,7 +242,6 @@ unsafe extern "C" {
 use core::sync::atomic::Ordering;
 use std::io::Write as _;
 
-use bun_core::strings;
 use bun_install::package_manager::run_tasks;
 use bun_install::{self as install, LogLevel, PackageID};
 
@@ -653,9 +640,6 @@ impl AsyncModule {
             string_buf,
             referrer_len,
             specifier_len,
-            package_json: opts.package_json.map(core::ptr::NonNull::from),
-            loader: opts.loader.to_api(),
-            hash: opts.hash,
             // .stmt_blocks = stmt_blocks,
             // .expr_blocks = expr_blocks,
             global_this: crate::GlobalRef::new(global_object),
@@ -1227,11 +1211,10 @@ impl AsyncModule {
         self.parse_result = parse_result;
         // `print_with_source_map` consumes `ParseResult` by
         // value (it moves `ast` into `print_ast`). Hoist the post-print
-        // reads (`is_commonjs_module` / `input_fd`) above the move so we
+        // read (`is_commonjs_module`) above the move so we
         // can `mem::take` instead of cloning.
         let is_commonjs_module = self.parse_result.ast.has_commonjs_export_names
             || self.parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
-        let input_fd = self.parse_result.input_fd;
         let arena = *self.parse_result.ast.parts.allocator();
         let parse_result = core::mem::replace(&mut self.parse_result, ParseResult::empty(arena));
 
@@ -1302,6 +1285,13 @@ impl AsyncModule {
             );
         }
 
+        // Note: the original parse already registered this file with the
+        // watcher (`maybe_watch_file` runs before the pending-imports
+        // enqueue), and the descriptor it read from is either owned by the
+        // watchlist or was closed by the transpile frame's fd guard — so
+        // there is nothing to re-register here, and `parse_result.input_fd`
+        // must not be used (the number may have been closed and recycled).
+
         // SAFETY: per-thread VM.
         if unsafe { (*jsc_vm).is_watcher_enabled() } {
             // SAFETY: per-thread VM.
@@ -1313,45 +1303,6 @@ impl AsyncModule {
                     None,
                 )
             };
-
-            if let Some(fd_) = input_fd {
-                if bun_paths::is_absolute(path.text)
-                    && !strings::contains(path.text, b"node_modules")
-                {
-                    // SAFETY: `bun_watcher` is the `*mut ImportWatcher` set
-                    // when `is_watcher_enabled()`; cast recovers the
-                    // concrete type (matches VirtualMachine.rs:2301).
-                    let watcher = unsafe {
-                        &mut *(*jsc_vm)
-                            .bun_watcher
-                            .cast::<crate::hot_reloader::ImportWatcher>()
-                    };
-                    // `bun_watcher::PackageJSON` is an opaque
-                    // forward-decl of `bun_resolver::PackageJSON`;
-                    // the watcher only stores the pointer, so cast through.
-                    // SAFETY: `package_json` (when set) is a VM-lifetime
-                    // backref — outlives the watcher entry.
-                    let package_json = self
-                        .package_json
-                        .map(|p| unsafe { &*p.as_ptr().cast::<bun_watcher::PackageJSON>() });
-                    if !matches!(
-                        watcher.add_file::<true>(
-                            fd_,
-                            path.text,
-                            self.hash,
-                            bun_ast::Loader::from_api(self.loader),
-                            Fd::INVALID,
-                            package_json,
-                        ),
-                        Ok(bun_watcher::FdOwnership::Watcher)
-                    ) {
-                        // The watcher didn't adopt the parse's descriptor
-                        // (already watched, or add failed); nothing reads it
-                        // after printing.
-                        let _ = bun_sys::close(fd_);
-                    }
-                }
-            }
 
             resolved_source.is_commonjs_module = is_commonjs_module;
 

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -26,7 +26,6 @@ pub struct InitOpts<'a> {
     pub specifier: &'a [u8],
     pub path: Fs::Path<'a>,
     pub promise_ptr: Option<*mut *mut JSInternalPromise>,
-    pub fd: Option<Fd>,
     pub package_json: Option<&'a PackageJSON>,
     pub loader: bun_ast::Loader,
     pub hash: u32,
@@ -1335,14 +1334,22 @@ impl AsyncModule {
                     let package_json = self
                         .package_json
                         .map(|p| unsafe { &*p.as_ptr().cast::<bun_watcher::PackageJSON>() });
-                    let _ = watcher.add_file::<true>(
-                        fd_,
-                        path.text,
-                        self.hash,
-                        bun_ast::Loader::from_api(self.loader),
-                        Fd::INVALID,
-                        package_json,
-                    );
+                    if !matches!(
+                        watcher.add_file::<true>(
+                            fd_,
+                            path.text,
+                            self.hash,
+                            bun_ast::Loader::from_api(self.loader),
+                            Fd::INVALID,
+                            package_json,
+                        ),
+                        Ok(bun_watcher::FdOwnership::Watcher)
+                    ) {
+                        // The watcher didn't adopt the parse's descriptor
+                        // (already watched, or add failed); nothing reads it
+                        // after printing.
+                        let _ = bun_sys::close(fd_);
+                    }
                 }
             }
 

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -710,7 +710,6 @@ impl TranspilerJob {
         // as the `Transpiler<'_>` cast above.
         transpiler.linker.resolver = ptr::addr_of_mut!(transpiler.resolver).cast();
 
-        let mut fd: Option<Fd> = None;
         let mut package_json: Option<&'static bun_watcher::PackageJSON> = None;
         let hash = Watcher::get_hash(path.text);
 
@@ -722,21 +721,10 @@ impl TranspilerJob {
         let import_watcher: Option<bun_ptr::ParentRef<ImportWatcher, bun_ptr::Mut>> =
             unsafe { bun_ptr::ParentRef::from_nullable_mut((*vm).bun_watcher.cast()) };
         if let Some(iw) = import_watcher {
-            // The watchlist *is* mutated cross-thread (the watcher thread's
-            // `flush_evictions` closes fds and `swap_remove`s), so snapshot
-            // under the watcher mutex — see
-            // `ImportWatcher::snapshot_fd_and_package_json` doc for the EBADF
-            // race this closes.
-            (fd, package_json) = iw.snapshot_fd_and_package_json(hash);
-            // On Linux, `addFileByPathSlow` inserts watchlist entries with
-            // `fd = invalid_fd` (only kqueue needs the descriptor). Treat
-            // invalid as "no cached fd" so `readFileWithAllocator` opens the
-            // file instead of calling `seekTo` on a bogus handle. The snapshot
-            // helper already filtered `!is_valid()`; additionally reject
-            // stdio-tagged fds here.
-            if fd.is_some_and(|f| f.stdio_tag().is_some()) {
-                fd = None;
-            }
+            // The file is always (re-)opened by path — never through the
+            // watchlist's stored fd; see `ImportWatcher::snapshot_package_json`
+            // for the EBADF/EISDIR race that reading a stored fd reopens.
+            package_json = iw.snapshot_package_json(hash);
         }
 
         // this should be a cheap lookup because 24 bytes == 8 * 3 so it's read 3 machine words
@@ -769,15 +757,13 @@ impl TranspilerJob {
         // only, so skipping `Drop` is sound.
         let mut fallback_source = core::mem::MaybeUninit::<bun_ast::Source>::uninit();
 
-        // Usually, we want to close the input file automatically.
-        //
-        // If we're re-using the file descriptor from the fs watcher
-        // Do not close it because that will break the kqueue-based watcher
+        // Close the input file automatically unless the watcher adopts the
+        // descriptor after the parse (`add_file` below).
         //
         // Note: stored in a `Cell` so the scopeguard closure can capture
         // `&Cell<bool>` and the post-parse writes are visible to it without
         // raw-pointer laundering (which the unused-assignment lint can't see).
-        let should_close_input_file_fd = Cell::new(fd.is_none());
+        let should_close_input_file_fd = Cell::new(true);
 
         let mut input_file_fd: Fd = Fd::INVALID;
 
@@ -798,7 +784,7 @@ impl TranspilerJob {
             path,
             loader,
             dirname_fd: Fd::INVALID,
-            file_descriptor: fd,
+            file_descriptor: None,
             // SAFETY: `input_file_fd` is a stack local declared above and
             // outlives `parse_options`; `addr_of_mut!` avoids forming an
             // intermediate `&mut` so the close-guard's later borrow stays sound.
@@ -888,12 +874,11 @@ impl TranspilerJob {
                     && bun_paths::is_absolute(path.text)
                     && !strings::contains(path.text, b"node_modules")
                 {
-                    should_close_input_file_fd.set(false);
                     if let Some(iw) = import_watcher {
                         // SAFETY: BACKREF — process-lifetime watcher; no other
                         // `&ImportWatcher` is live here, and `add_file` is
                         // thread-safe via watcher mutex.
-                        let _ = unsafe { iw.assume_mut() }.add_file::<true>(
+                        let added = unsafe { iw.assume_mut() }.add_file::<true>(
                             input_file_fd,
                             path.text,
                             hash,
@@ -901,6 +886,9 @@ impl TranspilerJob {
                             Fd::INVALID,
                             package_json,
                         );
+                        if matches!(added, Ok(bun_watcher::FdOwnership::Watcher)) {
+                            should_close_input_file_fd.set(false);
+                        }
                     }
                 }
             }
@@ -914,12 +902,11 @@ impl TranspilerJob {
                 && bun_paths::is_absolute(path.text)
                 && !strings::contains(path.text, b"node_modules")
             {
-                should_close_input_file_fd.set(false);
                 if let Some(iw) = import_watcher {
                     // SAFETY: BACKREF — process-lifetime watcher; no other
                     // `&ImportWatcher` is live here, and `add_file` is
                     // thread-safe via watcher mutex.
-                    let _ = unsafe { iw.assume_mut() }.add_file::<true>(
+                    let added = unsafe { iw.assume_mut() }.add_file::<true>(
                         input_file_fd,
                         path.text,
                         hash,
@@ -927,6 +914,9 @@ impl TranspilerJob {
                         Fd::INVALID,
                         package_json,
                     );
+                    if matches!(added, Ok(bun_watcher::FdOwnership::Watcher)) {
+                        should_close_input_file_fd.set(false);
+                    }
                 }
             }
         }

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -721,9 +721,8 @@ impl TranspilerJob {
         let import_watcher: Option<bun_ptr::ParentRef<ImportWatcher, bun_ptr::Mut>> =
             unsafe { bun_ptr::ParentRef::from_nullable_mut((*vm).bun_watcher.cast()) };
         if let Some(iw) = import_watcher {
-            // The file is always (re-)opened by path — never through the
-            // watchlist's stored fd; see `ImportWatcher::snapshot_package_json`
-            // for the EBADF/EISDIR race that reading a stored fd reopens.
+            // Never read through the watchlist's stored fd; see
+            // `ImportWatcher::snapshot_package_json`.
             package_json = iw.snapshot_package_json(hash);
         }
 

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -42,18 +42,11 @@ impl ImportWatcher {
     /// Look up the `package_json` column for `hash` under the watcher's
     /// mutex.
     ///
-    /// Deliberately does NOT hand out the stored fd for re-reading the file.
-    /// The stored fd is owned by the watchlist and the watcher thread's
-    /// `flush_evictions` closes it under the mutex (a directory event for an
-    /// edited file evicts its entry, see `on_file_update`); a transpile that
-    /// snapshotted the number here would read from it *after* releasing the
-    /// mutex, surfacing as `EBADF reading "<path>"` — or `EISDIR` once a
-    /// resolver `openat` recycles the number — in
-    /// `transpiler.rs:read_file_with_allocator`
-    /// (watch-many-dirs.test.ts). A stored fd can also point at the
-    /// pre-rename inode after an atomic save and return stale contents.
-    /// Reloads open the file by path instead, and `Watcher::add_file` adopts
-    /// the fresh descriptor afterwards.
+    /// Deliberately does NOT hand out the stored fd: the watchlist owns it
+    /// and `flush_evictions` closes it concurrently, so a reader would hit
+    /// `EBADF`/`EISDIR` after the mutex is released (watch-many-dirs.test.ts)
+    /// or read the stale pre-rename inode after an atomic save. Reloads open
+    /// the file by path; `Watcher::add_file` adopts the fresh descriptor.
     pub fn snapshot_package_json(
         &self,
         hash: bun_watcher::HashType,

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -39,48 +39,33 @@ pub enum ImportWatcher {
 const _: () = assert!(bun_watcher::Loader::File.0 == bun_ast::Loader::File as u8);
 
 impl ImportWatcher {
-    /// Look up the cached fd (and `package_json` column) for `hash` under the
-    /// watcher's mutex, snapshotting both before returning.
+    /// Look up the `package_json` column for `hash` under the watcher's
+    /// mutex.
     ///
-    /// The watcher thread's `flush_evictions` (called from `on_file_update`)
-    /// closes the cached fd in pass 1 and `swap_remove`s the entry in pass 2.
-    /// `on_file_update` orders `flush_evictions` *before* `enqueue` so the JS
-    /// thread cannot observe the closed-fd window for the *same* event, but
-    /// nothing serializes a *subsequent* event's `flush_evictions` against the
-    /// JS thread's previous-event reload that re-added the entry: the JS
-    /// thread can read the cached fd here while the watcher thread is between
-    /// pass 1 (close) and pass 2 (remove), surfacing as `EBADF reading
-    /// "<path>"` in `transpiler.rs:read_file_with_allocator` (hot.test.ts
-    /// "should work with sourcemap generation" on debian-aarch64). The race
-    /// is closed by locking the same mutex `append_file_maybe_lock<true>` and
-    /// `flush_evictions` take.
-    pub fn snapshot_fd_and_package_json(
+    /// Deliberately does NOT hand out the stored fd for re-reading the file.
+    /// The stored fd is owned by the watchlist and the watcher thread's
+    /// `flush_evictions` closes it under the mutex (a directory event for an
+    /// edited file evicts its entry, see `on_file_update`); a transpile that
+    /// snapshotted the number here would read from it *after* releasing the
+    /// mutex, surfacing as `EBADF reading "<path>"` — or `EISDIR` once a
+    /// resolver `openat` recycles the number — in
+    /// `transpiler.rs:read_file_with_allocator`
+    /// (watch-many-dirs.test.ts). A stored fd can also point at the
+    /// pre-rename inode after an atomic save and return stale contents.
+    /// Reloads open the file by path instead, and `Watcher::add_file` adopts
+    /// the fresh descriptor afterwards.
+    pub fn snapshot_package_json(
         &self,
         hash: bun_watcher::HashType,
-    ) -> (
-        Option<bun_sys::Fd>,
-        Option<&'static bun_watcher::PackageJSON>,
-    ) {
+    ) -> Option<&'static bun_watcher::PackageJSON> {
         let w = match self {
             ImportWatcher::Hot(w) | ImportWatcher::Watch(w) => w,
-            ImportWatcher::None => return (None, None),
+            ImportWatcher::None => return None,
         };
         let _guard = w.mutex.lock_guard();
-        let Some(index) = w.index_of(hash) else {
-            return (None, None);
-        };
-        let watcher_fd = w.watchlist.items_fd()[index as usize];
-        let package_json = w
-            .watchlist
-            .items::<"package_json", Option<&'static bun_watcher::PackageJSON>>()[index as usize];
-        (
-            if watcher_fd.is_valid() {
-                Some(watcher_fd)
-            } else {
-                None
-            },
-            package_json,
-        )
+        let index = w.index_of(hash)?;
+        w.watchlist
+            .items::<"package_json", Option<&'static bun_watcher::PackageJSON>>()[index as usize]
     }
 
     #[inline]
@@ -106,7 +91,7 @@ impl ImportWatcher {
         // Note: bun_watcher::PackageJSON is an opaque forward-decl;
         // callers cast from `&bun_resolver::PackageJSON`.
         package_json: Option<&'static bun_watcher::PackageJSON>,
-    ) -> bun_sys::Result<()> {
+    ) -> bun_sys::Result<bun_watcher::FdOwnership> {
         match self {
             ImportWatcher::Hot(watcher) | ImportWatcher::Watch(watcher) => watcher
                 .add_file::<COPY_FILE_PATH>(
@@ -117,7 +102,7 @@ impl ImportWatcher {
                     dir_fd,
                     package_json,
                 ),
-            ImportWatcher::None => Ok(()),
+            ImportWatcher::None => Ok(bun_watcher::FdOwnership::Caller),
         }
     }
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2265,13 +2265,9 @@ fn transpile_source_code_inner(
                 let import_watcher: *mut bun_jsc::ImportWatcher =
                     unsafe { &*jsc_vm }.bun_watcher.cast();
                 if !import_watcher.is_null() {
-                    // SAFETY: non-null per check above. The file is always
-                    // (re-)opened by path — never through the watchlist's
-                    // stored fd; see `ImportWatcher::snapshot_package_json`
-                    // for the EBADF/EISDIR race (and the stale-inode reads
-                    // after an atomic `rename()` save) that reading a stored
-                    // fd reopens. `maybe_watch_file` below re-registers the
-                    // fresh fd with the watcher.
+                    // SAFETY: non-null per check above. Never read through the
+                    // watchlist's stored fd; see
+                    // `ImportWatcher::snapshot_package_json`.
                     let iw = unsafe { &*import_watcher };
                     package_json = iw.snapshot_package_json(hash);
                 }
@@ -3375,10 +3371,8 @@ fn transpile_source_code_inner(
                     ),
                     Ok(bun_watcher::FdOwnership::Watcher)
                 ) {
-                    // Close the fd we just opened on macOS (add_file failed,
-                    // or the file was already watched and kept its stored
-                    // descriptor); not a transpile failure (the user didn't
-                    // open it).
+                    // Not adopted (already watched, or add failed); close the
+                    // fd this arm opened.
                     if input_fd.is_valid() {
                         use bun_sys::FdExt as _;
                         input_fd.close();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2943,23 +2943,16 @@ fn transpile_source_code_inner(
                     // AST's small `AstVec`s live in its inline bump chunk.
                     let ast_alloc_state = ast_alloc_scope.take_state();
                     // SAFETY: per fn contract — `jsc_vm` / `global_object` are the live
-                    // per-thread VM / global; `package_json` is the opaque watcher
-                    // forward-decl of `bun_resolver::package_json::PackageJSON`.
+                    // per-thread VM / global.
                     unsafe {
                         (*jsc_vm).modules.enqueue(
                             &*global_object,
                             bun_jsc::async_module::InitOpts {
                                 parse_result,
                                 path: *path,
-                                loader,
-                                package_json: package_json.map(|p| {
-                                    &*core::ptr::from_ref(p)
-                                        .cast::<bun_resolver::package_json::PackageJSON>()
-                                }),
                                 promise_ptr: Some(promise_ptr),
                                 specifier,
                                 referrer,
-                                hash,
                                 arena,
                                 ast_alloc_state,
                             },

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2257,8 +2257,7 @@ fn transpile_source_code_inner(
             // consume this scope via `take_state()` and ship the box with the
             // arena.
             let ast_alloc_scope = bun_alloc::ast_alloc::ScopedAstAlloc::with_spill(arena_heap);
-            // ── Watcher fd / package_json lookup ────────────────────────────
-            let mut fd: Option<bun_sys::Fd> = None;
+            // ── Watcher package_json lookup ─────────────────────────────────
             let mut package_json: Option<&'static bun_watcher::PackageJSON> = None;
             {
                 // SAFETY: `bun_watcher` is the `*mut ImportWatcher`
@@ -2266,31 +2265,16 @@ fn transpile_source_code_inner(
                 let import_watcher: *mut bun_jsc::ImportWatcher =
                     unsafe { &*jsc_vm }.bun_watcher.cast();
                 if !import_watcher.is_null() {
-                    // SAFETY: non-null per check above. The watchlist *is*
-                    // mutated cross-thread (the watcher thread's
-                    // `flush_evictions` closes fds and `swap_remove`s), so
-                    // snapshot under the watcher mutex — see
-                    // `ImportWatcher::snapshot_fd_and_package_json` doc for
-                    // the EBADF race this closes.
+                    // SAFETY: non-null per check above. The file is always
+                    // (re-)opened by path — never through the watchlist's
+                    // stored fd; see `ImportWatcher::snapshot_package_json`
+                    // for the EBADF/EISDIR race (and the stale-inode reads
+                    // after an atomic `rename()` save) that reading a stored
+                    // fd reopens. `maybe_watch_file` below re-registers the
+                    // fresh fd with the watcher.
                     let iw = unsafe { &*import_watcher };
-                    (fd, package_json) = iw.snapshot_fd_and_package_json(hash);
+                    package_json = iw.snapshot_package_json(hash);
                 }
-            }
-
-            // Note / fix: never reuse the watcher's cached fd for the
-            // `--hot` entrypoint. An atomic `rename()` over the entrypoint (the
-            // common HMR save pattern) replaces its inode; the watcher entry
-            // still holds an fd to the now-unlinked old inode until the
-            // IN_DELETE_SELF event for it is processed and `flush_evictions`
-            // closes it. If a reload's transpile runs first (e.g. the
-            // directory-watch recovery in `hot_reloader` re-fired the reload
-            // before that file event landed under load), reading via the stale
-            // fd returns the OLD file contents — the reload "succeeds" with the
-            // wrong source and `bun --hot` hangs. Re-open the entrypoint by
-            // path so we always see the current inode; `maybe_watch_file` below
-            // re-registers the fresh fd with the watcher.
-            if is_main && fd.is_some() {
-                fd = None;
             }
 
             // ── RuntimeTranspilerCache ──────────────────────────────────────
@@ -2371,7 +2355,7 @@ fn transpile_source_code_inner(
                 }
             };
 
-            let mut should_close_input_file_fd = fd.is_none();
+            let mut should_close_input_file_fd = true;
 
             // Only JS-like loaders get the cjs/esm wrapper hint.
             let module_type_only_for_wrappables = match loader {
@@ -2530,7 +2514,7 @@ fn transpile_source_code_inner(
                     path: parse_path,
                     loader,
                     dirname_fd: bun_sys::Fd::INVALID,
-                    file_descriptor: fd,
+                    file_descriptor: None,
                     // SAFETY: `input_file_fd_ptr` points at this frame's
                     // `input_file_fd`; reborrow through the raw pointer so the
                     // `_fd_guard` scopeguard's tag is not invalidated by a
@@ -2968,7 +2952,6 @@ fn transpile_source_code_inner(
                                 parse_result,
                                 path: *path,
                                 loader,
-                                fd,
                                 package_json: package_json.map(|p| {
                                     &*core::ptr::from_ref(p)
                                         .cast::<bun_resolver::package_json::PackageJSON>()
@@ -3388,20 +3371,21 @@ fn transpile_source_code_inner(
                 // type.
                 let watcher =
                     unsafe { &mut *(*jsc_vm).bun_watcher.cast::<bun_jsc::ImportWatcher>() };
-                if watcher
-                    .add_file::<true>(
+                if !matches!(
+                    watcher.add_file::<true>(
                         input_fd,
                         path.text,
                         hash,
                         loader,
                         bun_sys::Fd::INVALID,
                         None,
-                    )
-                    .is_err()
-                {
-                    // Close the fd we just opened on macOS;
-                    // not a transpile failure (the user didn't open it).
-                    #[cfg(target_os = "macos")]
+                    ),
+                    Ok(bun_watcher::FdOwnership::Watcher)
+                ) {
+                    // Close the fd we just opened on macOS (add_file failed,
+                    // or the file was already watched and kept its stored
+                    // descriptor); not a transpile failure (the user didn't
+                    // open it).
                     if input_fd.is_valid() {
                         use bun_sys::FdExt as _;
                         input_fd.close();
@@ -3500,18 +3484,22 @@ fn maybe_watch_file(
     {
         return;
     }
-    *should_close_input_file_fd = false;
     // SAFETY: `bun_watcher` is the `*mut ImportWatcher` set when
     // `is_watcher_enabled()`; cast recovers the concrete type.
     let watcher = unsafe { &mut *(*jsc_vm).bun_watcher.cast::<bun_jsc::ImportWatcher>() };
-    let _ = watcher.add_file::<true>(
-        input_file_fd,
-        path.text,
-        hash,
-        loader,
-        bun_sys::Fd::INVALID,
-        package_json,
-    );
+    if matches!(
+        watcher.add_file::<true>(
+            input_file_fd,
+            path.text,
+            hash,
+            loader,
+            bun_sys::Fd::INVALID,
+            package_json,
+        ),
+        Ok(bun_watcher::FdOwnership::Watcher)
+    ) {
+        *should_close_input_file_fd = false;
+    }
 }
 
 // Generated `bun:sqlite` import shims.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -372,12 +372,12 @@ impl Watcher {
         if self.evict_list_i == 0 {
             return;
         }
-        // The close+swap_remove below must be serialized against (a) the JS
-        // thread's `ImportWatcher::snapshot_fd_and_package_json` lookup and
-        // (b) the JS thread's `append_file_maybe_lock<true>` re-add — both of
-        // which take `self.mutex`. Otherwise there's a window between pass 1
-        // (`close(fd)`) and pass 2 (`swap_remove`) where the JS thread reads
-        // the still-present entry's now-closed fd → `EBADF reading "<path>"`.
+        // The close+swap_remove below must be serialized against the JS
+        // thread's watchlist lookups (`ImportWatcher::snapshot_package_json`)
+        // and `append_file_maybe_lock<true>` re-adds — both take `self.mutex`.
+        // The close in pass 1 is also why the watchlist's stored fd is never
+        // handed out for reads: a reader that copied the number before this
+        // ran would hit `EBADF`/`EISDIR` after (see `snapshot_package_json`).
         //
         // We do NOT lock here: the only callers are deferred from
         // `WatcherContext::on_file_update`, which is itself invoked from
@@ -841,20 +841,12 @@ impl Watcher {
 
         let res = self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None);
         match res {
-            Ok(()) => {
-                #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-                if fd.is_valid() {
-                    self.mutex.lock();
-                    let maybe_idx = self.index_of(hash);
-                    let stored_fd = if let Some(idx) = maybe_idx {
-                        self.watchlist.items_fd()[idx as usize]
-                    } else {
-                        Fd::INVALID
-                    };
-                    self.mutex.unlock();
-                    if maybe_idx.is_some() && stored_fd.native() != fd.native() {
-                        let _ = bun_sys::close(fd);
-                    }
+            Ok(ownership) => {
+                // Another thread may have added the file between the
+                // `already_watched` check above and `add_file` taking the
+                // mutex; the descriptor opened here is then redundant.
+                if ownership == FdOwnership::Caller && fd.is_valid() {
+                    let _ = bun_sys::close(fd);
                 }
                 true
             }
@@ -875,20 +867,27 @@ impl Watcher {
         loader: Loader,
         dir_fd: Fd,
         package_json: Option<&'static PackageJSON>,
-    ) -> sys::Result<()> {
+    ) -> sys::Result<FdOwnership> {
         // This must lock due to concurrent transpiler
         self.mutex.lock();
 
         if let Some(index) = self.index_of(hash) {
-            if feature_flags::ATOMIC_FILE_WATCHER {
-                // On Linux, the file descriptor might be out of date.
-                if fd.is_valid() {
-                    let fds = self.watchlist.items_fd_mut();
+            let mut ownership = FdOwnership::Caller;
+            if feature_flags::ATOMIC_FILE_WATCHER && fd.is_valid() {
+                // Upgrade an entry inserted fd-less by `add_file_by_path_slow`
+                // (e.g. the `--hot` entrypoint) so the directory-event
+                // recovery in `hot_reloader` sees a valid descriptor for it.
+                // A valid stored fd is never replaced: it is owned by the
+                // watchlist until `flush_evictions`/shutdown closes it, and
+                // replacing it without closing leaked one fd per reload.
+                let fds = self.watchlist.items_fd_mut();
+                if !fds[index as usize].is_valid() {
                     fds[index as usize] = fd;
+                    ownership = FdOwnership::Watcher;
                 }
             }
             self.mutex.unlock();
-            return Ok(());
+            return Ok(ownership);
         }
 
         let r = self.append_file_maybe_lock::<CLONE_FILE_PATH, false>(
@@ -900,7 +899,7 @@ impl Watcher {
             package_json,
         );
         self.mutex.unlock();
-        r
+        r.map(|()| FdOwnership::Watcher)
     }
 
     pub fn index_of(&self, hash: HashType) -> Option<u32> {
@@ -1060,6 +1059,17 @@ pub struct WatchItem {
 pub enum WatchItemKind {
     File,
     Directory,
+}
+
+/// Who owns the `fd` passed to [`Watcher::add_file`] after it returns.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FdOwnership {
+    /// The watchlist stored the descriptor; `flush_evictions`/shutdown will
+    /// close it. The caller must not use or close it afterwards.
+    Watcher,
+    /// The file was already watched with a valid stored descriptor; the
+    /// caller still owns `fd` and must close it (or keep using it).
+    Caller,
 }
 
 /// Typed SoA column accessors — thin safe wrappers over the reflection-backed

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -845,9 +845,8 @@ impl Watcher {
         let res = self.add_file::<true>(fd, file_path, hash, loader, Fd::INVALID, None);
         match res {
             Ok(ownership) => {
-                // Another thread may have added the file between the
-                // `already_watched` check above and `add_file` taking the
-                // mutex; the descriptor opened here is then redundant.
+                // Not adopted (another thread won the add race); close the
+                // fd opened above.
                 if ownership == FdOwnership::Caller && fd.is_valid() {
                     let _ = bun_sys::close(fd);
                 }
@@ -877,12 +876,11 @@ impl Watcher {
         if let Some(index) = self.index_of(hash) {
             let mut ownership = FdOwnership::Caller;
             if feature_flags::ATOMIC_FILE_WATCHER && fd.is_valid() {
-                // Upgrade an entry inserted fd-less by `add_file_by_path_slow`
-                // (e.g. the `--hot` entrypoint) so the directory-event
-                // recovery in `hot_reloader` sees a valid descriptor for it.
-                // A valid stored fd is never replaced: it is owned by the
-                // watchlist until `flush_evictions`/shutdown closes it, and
-                // replacing it without closing leaked one fd per reload.
+                // Upgrade a path-only entry (`add_file_by_path_slow` inserts
+                // fd-less, e.g. the `--hot` entrypoint) so `hot_reloader`'s
+                // directory-event recovery sees a valid fd. A valid stored fd
+                // is never replaced: the watchlist owns it until eviction,
+                // and the old overwrite leaked it.
                 let fds = self.watchlist.items_fd_mut();
                 if !fds[index as usize].is_valid() {
                     fds[index as usize] = fd;

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -511,7 +511,7 @@ impl Watcher {
         loader: Loader,
         parent_hash: HashType,
         package_json: Option<&'static PackageJSON>,
-    ) -> sys::Result<()> {
+    ) -> sys::Result<FdOwnership> {
         #[cfg(windows)]
         {
             // on windows we can only watch items that are in the directory tree of the top level dir
@@ -521,7 +521,7 @@ impl Watcher {
                     "File {} is not in the project directory and will not be watched\n",
                     bstr::BStr::new(file_path)
                 );
-                return Ok(());
+                return Ok(FdOwnership::Caller);
             }
         }
 
@@ -574,7 +574,7 @@ impl Watcher {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index,
         });
-        Ok(())
+        Ok(FdOwnership::Watcher)
     }
 
     fn append_directory_assume_capacity<const CLONE_FILE_PATH: bool>(
@@ -672,7 +672,7 @@ impl Watcher {
         loader: Loader,
         dir_fd: Fd,
         package_json: Option<&'static PackageJSON>,
-    ) -> sys::Result<()> {
+    ) -> sys::Result<FdOwnership> {
         // RAII guard: `lock_guard()` holds the
         // mutex by `BackRef`, not a borrow of `self`, so the `&mut self` calls
         // below are fine and every return path unlocks.
@@ -740,7 +740,10 @@ impl Watcher {
             Err(err) => {
                 return Err(err.with_path(file_path));
             }
-            Ok(()) => {}
+            // Not appended (e.g. outside the project root on Windows); the
+            // caller keeps the descriptor.
+            Ok(FdOwnership::Caller) => return Ok(FdOwnership::Caller),
+            Ok(FdOwnership::Watcher) => {}
         }
 
         if true {
@@ -761,7 +764,7 @@ impl Watcher {
             );
         }
 
-        Ok(())
+        Ok(FdOwnership::Watcher)
     }
 
     #[inline]
@@ -899,7 +902,7 @@ impl Watcher {
             package_json,
         );
         self.mutex.unlock();
-        r.map(|()| FdOwnership::Watcher)
+        r
     }
 
     pub fn index_of(&self, hash: HashType) -> Option<u32> {
@@ -1067,8 +1070,10 @@ pub enum FdOwnership {
     /// The watchlist stored the descriptor; `flush_evictions`/shutdown will
     /// close it. The caller must not use or close it afterwards.
     Watcher,
-    /// The file was already watched with a valid stored descriptor; the
-    /// caller still owns `fd` and must close it (or keep using it).
+    /// The watchlist did not take the descriptor: the file was already
+    /// watched with a valid stored one, or the path is not watchable (e.g.
+    /// outside the project root on Windows). The caller still owns `fd` and
+    /// must close it (or keep using it).
     Caller,
 }
 

--- a/src/watcher/lib.rs
+++ b/src/watcher/lib.rs
@@ -35,9 +35,9 @@ pub use error::{Error, Result};
 
 pub use WatchItemKind as Kind;
 pub use watcher_impl::{
-    AnyResolveWatcher, ChangedFilePath, Event, HashType, MAX_COUNT, MAX_EVICTION_COUNT, Op,
-    PackageJSON, REQUIRES_FILE_DESCRIPTORS, WATCH_OPEN_FLAGS, WatchEvent, WatchItem,
-    WatchItemColumns, WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
+    AnyResolveWatcher, ChangedFilePath, Event, FdOwnership, HashType, MAX_COUNT,
+    MAX_EVICTION_COUNT, Op, PackageJSON, REQUIRES_FILE_DESCRIPTORS, WATCH_OPEN_FLAGS, WatchEvent,
+    WatchItem, WatchItemColumns, WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
 };
 
 // ─── upward-crate placeholders (CYCLEBREAK) ───────────────────────────────

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isASAN, isCI, tempDir } from "harness";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, forEachLine, isASAN, isCI, isLinux, tempDir } from "harness";
+import { mkdirSync, readdirSync, readlinkSync, realpathSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("--hot with many directories", () => {
@@ -98,4 +98,88 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     },
     30000,
   ); // 30 second timeout
+
+  // The watchlist owns one descriptor per watched file, closed only when the
+  // entry is evicted or the watcher shuts down. Re-transpiles during a reload
+  // open the file by path and must not stack additional descriptors on top of
+  // the stored one (previously the entrypoint gained one open fd per reload).
+  // /proc/<pid>/fd is Linux-only.
+  test.skipIf(!isLinux)(
+    "keeps a stable number of file descriptors across reloads",
+    async () => {
+      await using dir = tempDir("hot-fd-stable", {
+        "entry.js": `import { value } from "./lib/dep.js";\nconsole.log("RELOAD", value);`,
+        "lib/dep.js": `export const value = 0;`,
+      });
+      const dirReal = realpathSync(String(dir));
+
+      await using proc = spawn({
+        cmd: [bunExe(), "--hot", "entry.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+
+      const countFileFds = () => {
+        const counts = { entry: 0, dep: 0 };
+        for (const fd of readdirSync(`/proc/${proc.pid}/fd`)) {
+          let target: string;
+          try {
+            target = readlinkSync(`/proc/${proc.pid}/fd/${fd}`);
+          } catch {
+            continue;
+          }
+          if (target === join(dirReal, "entry.js")) counts.entry++;
+          else if (target === join(dirReal, "lib", "dep.js")) counts.dep++;
+        }
+        return counts;
+      };
+
+      const iter = forEachLine(proc.stdout);
+      const waitForReload = async (value: number) => {
+        while (true) {
+          const { value: line, done } = await iter.next();
+          if (done) throw new Error(`--hot exited before RELOAD ${value} (exit ${proc.exitCode})`);
+          if (line === `RELOAD ${value}`) return;
+        }
+      };
+
+      await waitForReload(0);
+      // Warm up so both files reach their steady state in the watchlist (the
+      // entrypoint is added fd-less before its first transpile; dep's stored
+      // fd settles on its first edited reload).
+      for (let i = 1; i <= 2; i++) {
+        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+        await waitForReload(i);
+      }
+      const before = countFileFds();
+      // Guard against a vacuous pass: the entrypoint's stored descriptor must
+      // be visible in the baseline. (dep's can be transiently closed by a
+      // directory-event eviction, so it gets no such guard.)
+      expect(before.entry).toBeGreaterThan(0);
+
+      const reloads = 15;
+      for (let i = 3; i <= reloads + 2; i++) {
+        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+        await waitForReload(i);
+      }
+      const after = countFileFds();
+
+      // One handle's transient presence between samples is not a leak; a
+      // per-reload leak shows up as +reloads.
+      expect({
+        before,
+        after,
+        entryDelta: Math.min(after.entry - before.entry, 1),
+        depDelta: Math.min(after.dep - before.dep, 1),
+      }).toEqual({
+        before,
+        after,
+        entryDelta: after.entry - before.entry,
+        depDelta: after.dep - before.dep,
+      });
+    },
+    60000,
+  );
 });


### PR DESCRIPTION
## What

Fixes `test/cli/hot/watch-many-dirs.test.ts` ("handles 129 directories being updated simultaneously"), which has been failing on main and across PR CI runs on Linux with:

```
error: EISDIR reading "/tmp/.../hot-many-dirs_.../dir-0072/index.js"
error: EBADF reading "/tmp/.../hot-many-dirs_.../dir-0009/index.js"
```

followed by the 30s test timeout (the failed reload never prints the expected output). Seen red on main builds 86133/86209/86347 and in many PR runs, e.g. [build 89567](https://buildkite.com/bun/bun/builds/89567). The race is timing-sensitive: it reproduced once in 80 local runs of an unmodified release build (with the exact EBADF + EISDIR + timeout signature), while loaded CI machines hit it regularly.

## Cause

`bun --hot` re-transpiled a changed module by reading through a file descriptor snapshotted from the watcher's watchlist (`ImportWatcher::snapshot_fd_and_package_json`). The snapshot copies the fd number under the watcher mutex, but the read in `transpiler.rs:read_file_with_allocator` happens after the mutex is released.

Concurrently, the watcher thread's `flush_evictions` closes stored descriptors under that same mutex. On Linux, a write to a file inside a watched directory produces both a file event and a directory event; the directory-event arm in `hot_reloader.rs` evicts the watched file's entry (to handle atomic saves that replace the inode). With 129 directories the inotify events span multiple batches, so a reload triggered by batch N snapshots a descriptor that batch N+1's eviction then closes:

- fd closed before the read: `EBADF reading "<path>"`
- fd number recycled by one of the resolver's many `openat(O_DIRECTORY)` calls: `EISDIR reading "<path>"`

The mutex ordering added previously (`flush_evictions` before `enqueue`, snapshot under the mutex) only closed the same-event window; nothing can serialize a later batch's eviction against a read that happens after the snapshot returns. Reading through the stored fd was also wrong after atomic saves (pre-rename inode, stale contents), which is why the entrypoint already had a workaround skipping it.

## Fix

Reloads now always open the file by path, and the watchlist keeps sole ownership of its stored descriptor:

- `snapshot_fd_and_package_json` becomes `snapshot_package_json`; the stored fd is never handed out for reads. This removes the race structurally and makes the entrypoint's open-by-path workaround universal, so it is deleted.
- `Watcher::add_file` no longer replaces a valid stored fd on the already-watched branch (it only upgrades fd-less entries inserted by `add_file_by_path_slow`, e.g. the `--hot` entrypoint, so the directory-event recovery path keeps working). The old overwrite dropped the replaced descriptor without closing it, leaking one fd on the entrypoint per reload.
- `add_file` now returns `FdOwnership` saying whether it adopted the caller's descriptor; the transpiler handoff sites, `AsyncModule`, the bundler's plugin watch path, and `add_file_by_path_slow` close the descriptor when the watcher did not take it. The bundler's `watcher_data` path intentionally ignores the outcome and keeps today's behavior, since its descriptor can be borrowed from the resolver's entry cache.

The fd-per-reload behavior is locked in by a new deterministic test in `watch-many-dirs.test.ts` that counts `/proc/<pid>/fd` entries for the entrypoint and an edited dependency across 15 reloads. On an unfixed build the entrypoint gains exactly one fd per reload (+15); with the fix both counts are stable. (The remaining per-reload directory-handle growth comes from the resolver's `DirEntry` cache and is addressed separately in #36675.)

## Verification

- New test fails on an unfixed build (`entryDelta: 15`) and passes with the fix.
- The race fix is structural rather than statistical: after this change the transpiler only ever reads descriptors it opened itself, so the closed-by-eviction read cannot occur. Empirically, "handles 129 directories" failed 1/80 runs on an unfixed release build and passed 40/40 (plus 12/12 debug ASAN) runs on a fixed one.
- `test/cli/hot/hot.test.ts` (12), `test/cli/hot/watch.test.ts` (2), `test/cli/watch/` (7), `test/bake/dev/hot.test.ts` (11, including DEV:hot-9), `test/js/bun/util/filesystem_router.test.ts` (33), `test/cli/test/test-changed.test.ts` (20) all pass on a debug ASAN build.
- `bun run rust:check-all`: 10/10 target combos clean.

The race predates any recent change (the fd-reuse pattern and evicting close shipped with #30412 and were inherited from the original design); CI frequency rose recently with timing shifts. The open #36675 fixes the adjacent resolver-side leaks and includes a different change to the same `add_file` branch; this PR supersedes that hunk by never replacing the stored fd at all.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/watch-many-dirs.test.ts

<!-- robobun:evidence:end -->