### PR TITLE
bake: print CSS chunks with browser targets

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1256,6 +1256,12 @@ pub struct LinkerOptions {
     pub(crate) css_chunking: bool,
     pub(crate) source_maps: SourceMapOption,
     pub(crate) target: Target,
+    /// Target CSS chunks are printed for. In bake builds `target` is the
+    /// server target while stylesheets still ship to the browser, so
+    /// print-gated CSS transforms key off this instead. Copied from
+    /// `BundleOptions::css_target`, which documents why the minify targets
+    /// must agree with it.
+    pub(crate) css_target: Target,
     pub(crate) compile_mode: CompileMode,
     pub(crate) metafile: bool,
     /// Path to write JSON metafile (for Bun.build API)
@@ -1284,6 +1290,7 @@ impl Default for LinkerOptions {
             css_chunking: false,
             source_maps: SourceMapOption::None,
             target: Target::Browser,
+            css_target: Target::Browser,
             compile_mode: CompileMode::None,
             metafile: false,
             metafile_json_path: b"",

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2805,6 +2805,7 @@ pub mod bv2_impl {
             this.linker.options.public_path =
                 unsafe { interned_slice(&this.transpiler.options.public_path) };
             this.linker.options.target = this.transpiler.options.target;
+            this.linker.options.css_target = this.transpiler.options.css_target();
             this.linker.options.output_format = this.transpiler.options.output_format;
             this.linker.options.generate_bytecode_cache = this.transpiler.options.bytecode;
             this.linker.options.compile_mode = this.transpiler.options.compile_mode;

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -108,7 +108,7 @@ fn generate_compile_result_for_css_chunk_impl(
             let printer_options = PrinterOptions {
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace,
-                targets: Targets::for_bundler_target(c.options.target),
+                targets: Targets::for_bundler_target(c.options.css_target),
                 ..Default::default()
             };
             match css.to_css_with_writer(
@@ -151,7 +151,7 @@ fn generate_compile_result_for_css_chunk_impl(
             let printer_options = PrinterOptions {
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace,
-                targets: Targets::for_bundler_target(c.options.target),
+                targets: Targets::for_bundler_target(c.options.css_target),
                 ..Default::default()
             };
             match css.to_css_with_writer(
@@ -184,7 +184,7 @@ fn generate_compile_result_for_css_chunk_impl(
         }
         CssImportOrderKind::SourceIndex(idx) => {
             let printer_options = PrinterOptions {
-                targets: Targets::for_bundler_target(c.options.target),
+                targets: Targets::for_bundler_target(c.options.css_target),
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace
                     || c.options.minify_syntax

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -221,7 +221,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                             });
 
                             let printer_options = PrinterOptions {
-                                targets: Targets::for_bundler_target(c.options.target),
+                                targets: Targets::for_bundler_target(c.options.css_target),
                                 // TODO: make this more configurable
                                 minify: c.options.minify_whitespace
                                     || c.options.minify_syntax

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1565,10 +1565,12 @@ impl<'a> BundleOptions<'a> {
         self.framework.is_some() || self.has_dev_server()
     }
 
-    /// The target whose CSS feature set (vendor prefixing, selector
-    /// downleveling) stylesheets are minified for. Bake builds emit every
-    /// stylesheet into the client bundle, so CSS is compiled for the browser
-    /// even when the importing graph is a server one.
+    /// The target whose CSS feature set stylesheets are minified and printed
+    /// for. Bake builds emit every stylesheet into the client bundle, so CSS
+    /// compiles for the browser even when the importing graph is a server
+    /// one. Minify and print must both resolve targets here: the
+    /// `light-dark()` polyfill injects definitions at minify and rewrites
+    /// references at print, and either half alone is broken.
     #[inline]
     pub(crate) fn css_target(&self) -> Target {
         if self.is_bake_build() {

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -720,6 +720,168 @@ devTest("css imported on the server gets browser-target processing", {
   },
 });
 
+devTest("css chunks are printed with browser targets", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: `<div class="a"><div class="b">hello</div></div>`,
+    }),
+    "styles.css": `
+      .a {
+        .b {
+          color: light-dark(white, black);
+        }
+      }
+    `,
+  },
+  async test(dev) {
+    const html = await (await dev.fetch("/")).text();
+    const href = html.match(/href="([^"]+\.css[^"]*)"/)?.[1];
+    expect(href).toBeDefined();
+    const css = await (await dev.fetch(href!)).text();
+    // Stylesheets are served to the browser, so print-gated downleveling for
+    // the default browser targets must apply even though the primary
+    // transpiler targets the server: nesting is flattened and light-dark()
+    // is replaced with a fallback.
+    expect(css).toContain(".a .b");
+    expect(css).not.toContain("light-dark(");
+  },
+});
+
+devTest("external css imports are printed with browser targets", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: `<div class="a">hello</div>`,
+    }),
+    // The URL stays an external @import in the output; nothing fetches it.
+    "styles.css": `
+      @import url("https://example.com/x.css") screen and (width >= 500px);
+      .a {
+        color: red;
+      }
+    `,
+  },
+  async test(dev) {
+    const html = await (await dev.fetch("/")).text();
+    const href = html.match(/href="([^"]+\.css[^"]*)"/)?.[1];
+    expect(href).toBeDefined();
+    const css = await (await dev.fetch(href!)).text();
+    // The external import is preserved, and media range syntax in its
+    // condition is downleveled for the default browser targets.
+    expect(css).toContain('@import "https://example.com/x.css" screen and (min-width: 500px)');
+    expect(css).not.toContain(">=");
+  },
+});
+
+devTest("nested external css import conditions are printed with browser targets", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: `<div class="a">hello</div>`,
+    }),
+    // An external import reached through a conditional internal import keeps
+    // its nesting via a data: URL stylesheet wrapper; the wrapper's contents
+    // are printed separately from the chunk body.
+    "styles.css": `
+      @import "./mid.css" screen and (width >= 500px);
+      .a {
+        color: red;
+      }
+    `,
+    "mid.css": `
+      @import url("https://example.com/x.css") (width <= 300px);
+    `,
+  },
+  async test(dev) {
+    const html = await (await dev.fetch("/")).text();
+    const href = html.match(/href="([^"]+\.css[^"]*)"/)?.[1];
+    expect(href).toBeDefined();
+    const css = await (await dev.fetch(href!)).text();
+    // Both the outer condition and the inner condition inside the data: URL
+    // wrapper are downleveled for the default browser targets.
+    expect(css).toContain("data:text/css");
+    expect(css).toContain("(min-width: 500px)");
+    expect(css).toContain("max-width");
+    expect(css).not.toContain(">=");
+    expect(css).not.toContain("<=");
+  },
+});
+
+devTest("css layer statements are printed with browser targets", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: `<div class="b">hello</div>`,
+    }),
+    // The duplicated conditional import leaves a bare "@layer foo;" statement
+    // (wrapped in the import's media condition) for the deduplicated copy,
+    // which prints through the layer-statement path.
+    "styles.css": `
+      @import "./dup.css" layer(foo) screen and (width >= 500px);
+      @import "./other.css";
+      @import "./dup.css" layer(foo) screen and (width >= 500px);
+    `,
+    "dup.css": `
+      .b {
+        color: blue;
+      }
+    `,
+    "other.css": `
+      .c {
+        color: green;
+      }
+    `,
+  },
+  async test(dev) {
+    const html = await (await dev.fetch("/")).text();
+    const href = html.match(/href="([^"]+\.css[^"]*)"/)?.[1];
+    expect(href).toBeDefined();
+    const css = await (await dev.fetch(href!)).text();
+    // The bare layer statement's wrapping media condition is downleveled for
+    // the default browser targets.
+    expect(css).toContain("@layer foo;");
+    expect(css).toContain("(min-width: 500px)");
+    expect(css).not.toContain(">=");
+  },
+});
+
+devTest("light-dark() polyfill spans minify and print for server-imported css", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      import "../styles.css";
+      export default function (req, meta) {
+        return new Response(JSON.stringify(meta.styles), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    `,
+    "styles.css": `
+      :root {
+        color-scheme: light dark;
+      }
+      .a {
+        color: light-dark(white, black);
+      }
+    `,
+  },
+  async test(dev) {
+    const styles = await (await dev.fetch("/")).json();
+    expect(styles).toHaveLength(1);
+    const css = await (await dev.fetch(styles[0])).text();
+    // The polyfill has two halves: the variable definitions and the
+    // prefers-color-scheme toggle are injected at minify time, the
+    // light-dark() references are rewritten at print time. Both halves must
+    // be present; references without definitions compute to an invalid value
+    // and drop the declaration in every browser.
+    expect(css).toMatch(/--buncss-light:\s*initial/);
+    expect(css).toMatch(/prefers-color-scheme:\s*dark/);
+    expect(css).toContain("var(--buncss-light");
+    expect(css).not.toContain("light-dark(");
+  },
+});
+
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);
   if (!url) {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -718,4 +718,52 @@ export default function Client() {
     const css = await Bun.file(path.join(dir, "dist", cssFiles[0])).text();
     expect(css).toContain(":-webkit-full-screen");
   });
+
+  test("css is printed with browser targets", async () => {
+    const dir = await tempDirWithBakeDeps("bake-production-css-print-targets", {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/index.tsx": `
+import "../styles.css";
+export default function IndexPage() {
+  return <div className="a"><div className="b">Hello World</div></div>;
+}`,
+      "styles.css": `
+:root {
+  color-scheme: light dark;
+}
+.a {
+  .b {
+    color: light-dark(white, black);
+  }
+}`,
+      "package.json": JSON.stringify({
+        "name": "test-app",
+        "version": "1.0.0",
+        "devDependencies": {
+          "react": "^18.0.0",
+          "react-dom": "^18.0.0",
+        },
+      }),
+    });
+
+    const { exitCode } = await Bun.$`${bunExe()} build --app ./src/index.tsx --outdir ./dist`
+      .cwd(dir)
+      .env(bunEnv)
+      .throws(false);
+    expect(exitCode).toBe(0);
+
+    const cssFiles = await Array.fromAsync(new Bun.Glob("**/*.css").scan(path.join(dir, "dist")));
+    expect(cssFiles).toHaveLength(1);
+    const css = await Bun.file(path.join(dir, "dist", cssFiles[0])).text();
+    // The emitted stylesheet is a browser asset, so downleveling for the
+    // default browser targets must apply even though the build's primary
+    // transpiler targets the server: nesting is flattened and light-dark()
+    // becomes the full variable polyfill (definitions and toggle injected at
+    // minify, references rewritten at print).
+    expect(css).toContain(".a .b");
+    expect(css).toMatch(/--buncss-light:\s*initial/);
+    expect(css).toMatch(/prefers-color-scheme:\s*dark/);
+    expect(css).toContain("var(--buncss-light");
+    expect(css).not.toContain("light-dark(");
+  });
 });


### PR DESCRIPTION
Stacked on #37051 (the diff below is relative to that branch; merge that PR first). The two fix the two halves of the same divergence, and the light-dark() polyfill is only correct with both halves in place, so this one must not land alone.

### Problem

Every stylesheet served by the bake dev server or emitted by `bun build --app` skips the CSS downleveling that a plain `bun build index.html` applies for the default browser targets.

Repro (`index.html` linking `styles.css`):

```css
.a {
  .b {
    color: light-dark(white, black);
  }
}
```

`bun build index.html` emits the downleveled form:

```css
.a .b {
  color: var(--buncss-light, #fff) var(--buncss-dark, #000);
}
```

while `bun index.html` (dev server) serves the stylesheet raw:

```css
.a {
  & .b {
    color: light-dark(#fff, #000);
  }
}
```

The default browser targets (chrome87/safari14/firefox78/edge88) support neither CSS nesting nor `light-dark()`, so the served stylesheet is broken in the browsers those targets claim to support. The same applies to media range syntax: a preserved `@import url(...) screen and (width >= 500px)` keeps the range syntax in bake builds but is rewritten to `(min-width: 500px)` in plain browser builds.

### Cause

Several CSS transforms are decided at print time against `PrinterOptions.targets`: nesting compilation (`StyleRule::to_css_base`), `light-dark()` reference rewriting and hex-alpha color fallbacks, and media interval syntax downleveling. The linker's four CSS print sites (three arms in `generateCompileResultForCssChunk.rs`, plus the nested-condition `data:` URL wrapper in `prepareCssAstsForChunk.rs`) built those options from `Targets::for_bundler_target(c.options.target)`, and `LinkerOptions.target` is copied from the bundle's primary transpiler. In bake builds the primary transpiler is the server one, whose target maps to runtime targets (`browsers: None`), under which every feature counts as supported and none of the print-gated transforms fire.

This is the print-time half of the divergence fixed at minify time by #37051 (vendor prefixing, selector downleveling, and the injected half of the light-dark polyfill), whose description explicitly defers this print-side inconsistency.

### Why this is stacked on #37051

The `light-dark()` polyfill spans both phases: `StyleSheet::minify` injects the `--buncss-light`/`--buncss-dark` definitions and the `@media (prefers-color-scheme: dark)` toggle rule (gated on the minify targets), and printing rewrites `light-dark(a, b)` to `var(--buncss-light, a) var(--buncss-dark, b)` (gated on the print targets). If the phases disagree, the output is a half-polyfill: on this change alone, a server-imported stylesheet with `color-scheme: light dark` would emit references with no definitions, and `var(--buncss-light, #fff) var(--buncss-dark, #000)` substitutes to the invalid `#fff #000`, dropping the declaration in every browser (worse than the raw `light-dark()`, which at least works in browsers that support it). With #37051 underneath, minify and print resolve targets through the same `BundleOptions::css_target()` and the full polyfill is emitted. The new polyfill test pins exactly this: it fails on current releases, on #37051 alone, and on this change alone.

### Fix

- `LinkerOptions.css_target`, populated from `BundleOptions::css_target()` (from #37051) at the existing option-copy site, used by the four CSS print sites. `LinkerOptions.target` is untouched: JS decisions (`postProcessJSChunk`, HMR runtime selection) still key off it.
- Doc comments on `css_target()` and the new field state the minify/print agreement requirement.

Plain `bun build` is unchanged: without a framework or dev server, `css_target()` returns the bundle target, so `--target=browser` prints as before and `--target=bun`/`--target=node` keep runtime targets for both minify and print.

### Verification

New tests, one per print site plus the cross-phase polyfill, all failing on the current release and passing with this branch:

- `test/bake/dev/css.test.ts` "css chunks are printed with browser targets": dev-server-served CSS has nesting flattened and no `light-dark()` (the per-source print site).
- `test/bake/dev/css.test.ts` "external css imports are printed with browser targets": media range syntax in a preserved external `@import` condition is downleveled (the external-path arm).
- `test/bake/dev/css.test.ts` "nested external css import conditions are printed with browser targets": an external import reached through a conditional internal import is wrapped in a `data:` URL stylesheet, and the condition inside the wrapper is downleveled (the `prepareCssAstsForChunk` wrapper site).
- `test/bake/dev/css.test.ts` "css layer statements are printed with browser targets": a duplicated conditional layer import leaves a bare `@layer foo;` statement whose wrapping media condition is downleveled (the layer-statement arm).
- `test/bake/dev/css.test.ts` "light-dark() polyfill spans minify and print for server-imported css": with `color-scheme: light dark` declared, the served CSS contains the variable definitions, the `prefers-color-scheme` toggle, and the rewritten references. This is the test that requires #37051 and this change together.
- `test/bake/dev/production.test.ts` "css is printed with browser targets": `bun build --app` output has nesting flattened and the full light-dark polyfill.

`test/bake/dev/css.test.ts` (21), `test/bake/dev/production.test.ts` (13), `test/bake/dev/html.test.ts`, `test/bake/dev/bundle.test.ts`, `test/bake/dev/sourcemap.test.ts`, `test/bake/dev-and-prod.test.ts`, and the `test/bundler/css` suite pass with a debug build of this branch.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->