### PR TITLE
crypto: fix property attributes of X509Certificate validFromDate/validToDate

### DIFF
--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -82,9 +82,9 @@ static const HashTableValue JSX509CertificatePrototypeTableValues[] = {
     { "toLegacyObject"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsX509CertificateProtoFuncToLegacyObject, 0 } },
     { "toString"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsX509CertificateProtoFuncToString, 0 } },
     { "validFrom"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsX509CertificateGetter_validFrom, 0 } },
-    { "validFromDate"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessorOrValue), NoIntrinsic, { HashTableValue::GetterSetterType, jsX509CertificateGetter_validFromDate, 0 } },
+    { "validFromDate"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsX509CertificateGetter_validFromDate, 0 } },
     { "validTo"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsX509CertificateGetter_validTo, 0 } },
-    { "validToDate"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessorOrValue), NoIntrinsic, { HashTableValue::GetterSetterType, jsX509CertificateGetter_validToDate, 0 } },
+    { "validToDate"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsX509CertificateGetter_validToDate, 0 } },
     { "verify"_s, static_cast<unsigned>(PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsX509CertificateProtoFuncVerify, 1 } },
 };
 

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -104,3 +104,33 @@ describe("X509Certificate.subjectAltName", () => {
     expect(cert.toLegacyObject().subjectaltname).toBe("");
   });
 });
+
+describe("X509Certificate.prototype property descriptors", () => {
+  // validFromDate/validToDate were registered as CustomAccessorOrValue instead of
+  // CustomAccessor, so reading their descriptors asserted in debug builds.
+  test("validFromDate and validToDate descriptors read like their siblings", () => {
+    const proto = X509Certificate.prototype;
+    for (const name of ["validFromDate", "validToDate", "validFrom", "validTo"] as const) {
+      const desc = Object.getOwnPropertyDescriptor(proto, name)!;
+      expect({ ...desc, get: typeof desc.get }).toEqual({
+        get: "function",
+        set: undefined,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+
+    const all = Object.getOwnPropertyDescriptors(proto);
+    expect(typeof all.validFromDate.get).toBe("function");
+    expect(typeof all.validToDate.get).toBe("function");
+  });
+
+  test("extracted validFromDate/validToDate getters work on an instance", () => {
+    const cert = new X509Certificate(wildcardSanCertPem);
+    const getFrom = Object.getOwnPropertyDescriptor(X509Certificate.prototype, "validFromDate")!.get!;
+    const getTo = Object.getOwnPropertyDescriptor(X509Certificate.prototype, "validToDate")!.get!;
+    expect(getFrom.call(cert)).toBeInstanceOf(Date);
+    expect(getFrom.call(cert)).toEqual(cert.validFromDate);
+    expect(getTo.call(cert)).toEqual(cert.validToDate);
+  });
+});


### PR DESCRIPTION
### Problem

Reading a property descriptor of `X509Certificate.prototype.validFromDate` or `.validToDate` aborts assert-enabled (debug/ASAN) builds. No certificate needed:

```js
Object.getOwnPropertyDescriptor(require("node:crypto").X509Certificate.prototype, "validFromDate");
```

```
ASSERTION FAILED: !(attributes & PropertyAttribute::CustomAccessorOrValue)
JavaScriptCore/runtime/PropertyDescriptor.cpp(183) JSC::PropertyDescriptor::setAccessorDescriptor
```

Anything that walks descriptors hits it too: `Object.getOwnPropertyDescriptors(X509Certificate.prototype)`, `util.inspect(proto, { showHidden: true })`, test utilities that snapshot descriptors. Release builds are unaffected because get/put check the `CustomAccessor` bit first.

### Cause

The `validFromDate` and `validToDate` rows in `JSX509CertificatePrototypeTableValues` used the attribute mask `CustomAccessorOrValue` (= `CustomAccessor | CustomValue`) instead of `CustomAccessor`. Every neighbouring accessor row (`validFrom`, `validTo`, `ca`, `fingerprint`, ...) uses `CustomAccessor`. When `getOwnPropertyDescriptor` reifies the accessor it strips the `CustomAccessor` bit, but the stray `CustomValue` bit survives and trips the assertion in `setAccessorDescriptor`.

### Fix

Use `CustomAccessor` on both rows, matching the rest of the table.

### Verification

- Repro above aborts a debug build on main (exit 134) and is fine after the fix.
- New tests in `test/js/node/crypto/x509.test.ts` read the descriptors (single and whole-prototype walk) and call the extracted getters on an instance; they abort the debug build before the fix and pass after.
- `test/js/node/crypto/x509.test.ts`, `x509-subclass.test.ts`, `test-crypto-x509.js`, and `test-tls-getcertificate-x509.js` all pass with the fix.