### PR TITLE
bun:jsc: add missing exception checks in heapStats()

### DIFF
--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -227,6 +227,7 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
 {
 
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (vm.heap.size() == 0) {
         vm.heap.collectNow(Sync, CollectionScope::Full);
@@ -375,6 +376,7 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
     if (char* json = mi_stats_get_json(0, nullptr)) {
         JSValue parsed = JSONParse(globalObject, String::fromUTF8(json));
         mi_free(json);
+        RETURN_IF_EXCEPTION(scope, {});
         object->putDirect(vm, Identifier::fromString(vm, "mimalloc"_s),
             parsed.isEmpty() ? jsNull() : parsed);
     }
@@ -383,8 +385,10 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
     JSValue arg0 = callFrame->argument(0);
     if (arg0.isObject()) {
         JSValue dump = arg0.getObject()->get(globalObject, Identifier::fromString(vm, "dump"_s));
+        RETURN_IF_EXCEPTION(scope, {});
         if (dump.toBoolean(globalObject)) {
             const bool includeBlocks = dump.isString() && dump.toWTFString(globalObject) == "blocks"_s;
+            RETURN_IF_EXCEPTION(scope, {});
 #if BUN_DEBUG
             const bool hashAddresses = false;
 #else
@@ -393,6 +397,7 @@ JSC_DEFINE_HOST_FUNCTION(functionMemoryUsageStatistics,
             if (char* json = mi_heap_dump_json(includeBlocks, hashAddresses)) {
                 JSValue parsed = JSONParse(globalObject, String::fromUTF8(json));
                 mi_free(json);
+                RETURN_IF_EXCEPTION(scope, {});
                 object->putDirect(vm, Identifier::fromString(vm, "mimallocDump"_s),
                     parsed.isEmpty() ? jsNull() : parsed);
             }

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -91,3 +91,55 @@ describe("heapStats() mimalloc integration", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("heapStats() exception safety", () => {
+  // heapStats() JSON-parses mimalloc stats and reads the dump option off its
+  // argument; each of those can throw. BUN_JSC_validateExceptionChecks=1 makes
+  // a debug build abort if one of those throws could go unchecked (release
+  // builds ignore the option and just exercise the paths). The getter/Proxy
+  // cases pin that a user exception from the dump lookup propagates instead of
+  // taking the dump with an exception pending.
+  test("dump option reads and JSON parses keep no pending exception", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const jsc = require("bun:jsc");
+         jsc.heapStats();
+         jsc.heapStats({ dump: true });
+
+         // A rope string reaches the rope-resolving path of the dump mode read.
+         let suffix = "cks";
+         const mode = "blo" + suffix;
+         if (!jsc.isRope(mode)) throw new Error("expected a rope string");
+         const blocks = jsc.heapStats({ dump: mode });
+         if (!Array.isArray(blocks.mimallocDump.heaps)) throw new Error("expected heaps in blocks dump");
+
+         let caught;
+         try {
+           jsc.heapStats({ get dump() { throw new Error("boom"); } });
+         } catch (e) { caught = e.message; }
+         if (caught !== "boom") throw new Error("dump getter error did not propagate: " + caught);
+
+         let trapCaught;
+         try {
+           jsc.heapStats(new Proxy({}, { get() { throw new Error("trap"); } }));
+         } catch (e) { trapCaught = e.message; }
+         if (trapCaught !== "trap") throw new Error("proxy trap error did not propagate: " + trapCaught);
+
+         const after = jsc.heapStats({ dump: true });
+         if (!after.mimallocDump) throw new Error("heapStats broken after thrown dump read");
+         console.log("OK");`,
+      ],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const uncheckedScopes = stderr
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+    expect({ stdout, uncheckedScopes, exitCode }).toEqual({ stdout: "OK\n", uncheckedScopes: [], exitCode: 0 });
+  });
+});


### PR DESCRIPTION
`bun:jsc`'s `heapStats()` (`functionMemoryUsageStatistics` in `src/jsc/modules/BunJSCModule.h`) declared no throw scope and never checked for pending exceptions:

- `JSONParse(globalObject, String::fromUTF8(json))` over the mimalloc stats JSON can throw (out of memory while building the parse tree). Only `parsed.isEmpty()` was handled; a pending exception was not.
- `arg0.getObject()->get(globalObject, "dump")` then ran with that exception pending. When the caller passed `{ dump: ... }` the property exists, which is exactly the condition asserted by `JSC::JSObject::get`, and the assert that keeps showing up in fuzzing on assert-enabled builds:

  ```
  ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
  JSObjectInlines.h(137) : JSC::JSObject::get(JSGlobalObject *, PropertyName)
  ```

  On release builds the same state runs the user's `dump` getter with an exception pending.
- A throwing `dump` accessor (or Proxy trap) left its exception pending through `toBoolean`, the `mi_heap_dump_json` branch, and the second `JSONParse`, and the function returned a normal object with the exception still set.

### Fix

Declare a throw scope at the top and `RETURN_IF_EXCEPTION` after the four calls that can throw: both `JSONParse` calls, the `dump` property read, and the dump mode string read (`toWTFString` resolves ropes and can throw on OOM). A parse failure that does not throw still takes the existing `jsNull()` fallback. On a throw the function now propagates the error instead of continuing into property reads and user JS with an exception pending, matching the neighboring functions in this file (`functionSetRandomSeed`, `functionDrainMicrotasks`).

### Verification

The new test runs every `heapStats()` path (plain, `{dump: true}`, a rope `"blocks"` string, a throwing getter, a throwing Proxy trap) in a child process with `BUN_JSC_validateExceptionChecks=1`. Now that the function declares a throw scope, that option makes debug builds abort on any unchecked throw here. Removing the check after the property read reproduces the abort deterministically:

```
This scope can throw a JS exception: get @ JSObjectInlines.h:133
But the exception was unchecked as of this scope: functionMemoryUsageStatistics @ BunJSCModule.h:230
ASSERTION FAILED: exception check validation failed
```

The `JSONParse` checks are policed by the same mechanism (`LiteralParser`'s scopes simulate a throw into this function's scope). The getter and Proxy cases additionally pin that a user exception from the dump lookup propagates to the caller and that `heapStats()` keeps working afterwards. On release builds the option is a no-op and the test just exercises the paths.

A note on reproducing the original assert: the unfixed function declares no throw scope, and JSC's exception check validation only polices functions that declare one (a callee's simulated throw is skipped when the next scope down sits across the VM entry frame, see `ThrowScope::~ThrowScope`). The only real trigger on the unfixed code is OOM inside `JSONParse` of mimalloc's own small, valid stats JSON, which a test cannot stage. Throwing accessors and Proxy traps complete cleanly end to end on the unfixed build because the pending exception surfaces at the host call boundary (verified against an unfixed debug build, with and without `BUN_JSC_validateExceptionChecks=1`). So the test guards the fixed shape, and fails if any of the now-checked throws goes unchecked again, rather than reproducing the OOM-only assert.

Related: #36857 fixes the same pattern in `generateHeapSnapshotForDebugging`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/heapStats-mimalloc.test.ts

<!-- robobun:evidence:end -->