### PR TITLE
bun:jsc: propagate JSONParse exceptions from samplingProfilerStackTraces

### DIFF
--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -499,9 +499,8 @@ JSC_DEFINE_HOST_FUNCTION(functionSamplingProfilerStackTraces,
             createError(globalObject, "Sampling profiler was never started"_s)));
 
     WTF::String jsonString = vm.samplingProfiler()->stackTracesAsJSON()->toJSONString();
-    JSC::EncodedJSValue result = JSC::JSValue::encode(JSONParse(globalObject, jsonString));
     scope.releaseAssertNoException();
-    return result;
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSONParse(globalObject, jsonString)));
 }
 
 JSC_DECLARE_HOST_FUNCTION(functionGetRandomSeed);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -567,3 +567,32 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, exitCode }).toEqual({ stdout: "rejected\n65\n", exitCode: 0 });
 });
+
+it("samplingProfilerStackTraces returns parsed traces and survives BUN_JSC_validateExceptionChecks", async () => {
+  // samplingProfilerStackTraces JSON-parses the profiler's stack traces, and
+  // JSONParse can throw (OOM on a large profile), so the enclosing throw scope
+  // must release before returning instead of asserting no exception after the
+  // parse. With validateExceptionChecks enabled the process aborts on unchecked
+  // scopes; on release builds the option is a no-op and this just exercises the
+  // stack-trace path.
+  const script = `
+    const jsc = require("bun:jsc");
+    jsc.startSamplingProfiler();
+    let j = 0;
+    for (let i = 0; i < 999999; i++) j += i % 7;
+    const traces = jsc.samplingProfilerStackTraces();
+    console.log("ok", typeof traces, Array.isArray(traces.traces));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const uncheckedScopes = stderr
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+  expect({ stdout, uncheckedScopes, exitCode }).toEqual({ stdout: "ok object true\n", uncheckedScopes: [], exitCode: 0 });
+});

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -577,6 +577,12 @@ it("samplingProfilerStackTraces returns parsed traces and survives BUN_JSC_valid
   // stack-trace path.
   const script = `
     const jsc = require("bun:jsc");
+    try {
+      jsc.samplingProfilerStackTraces();
+      console.log("no-throw");
+    } catch (e) {
+      console.log("threw", e.message);
+    }
     jsc.startSamplingProfiler();
     let j = 0;
     for (let i = 0; i < 999999; i++) j += i % 7;
@@ -594,5 +600,9 @@ it("samplingProfilerStackTraces returns parsed traces and survives BUN_JSC_valid
     .split("\n")
     .map(line => line.trim())
     .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
-  expect({ stdout, uncheckedScopes, exitCode }).toEqual({ stdout: "ok object true\n", uncheckedScopes: [], exitCode: 0 });
+  expect({ stdout, uncheckedScopes, exitCode }).toEqual({
+    stdout: "threw Sampling profiler was never started\nok object true\n",
+    uncheckedScopes: [],
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
### Problem

`functionSamplingProfilerStackTraces` (bun:jsc's `samplingProfilerStackTraces`) in `src/jsc/modules/BunJSCModule.h` JSON-parses the profiler's stack traces and then asserts that no exception is pending:

```cpp
WTF::String jsonString = vm.samplingProfiler()->stackTracesAsJSON()->toJSONString();
JSC::EncodedJSValue result = JSC::JSValue::encode(JSONParse(globalObject, jsonString));
scope.releaseAssertNoException();
return result;
```

`JSONParse` can throw, realistically an out-of-memory error while building the parse tree for a long-running profile's stack-trace JSON. When that happens, `scope.releaseAssertNoException()` crashes the process with a `RELEASE_ASSERT` in `ThrowScope::releaseAssertNoException` (via `functionSamplingProfilerStackTraces`) instead of propagating the error to the caller, which could otherwise catch it.

### Fix

Move the no-exception assert to before the parse, where nothing can have thrown (the only earlier throw path returns early, and `stackTracesAsJSON()->toJSONString()` is a WTF JSON operation that does not touch the throw scope), and release the scope on return so a `JSONParse` exception propagates:

```cpp
WTF::String jsonString = vm.samplingProfiler()->stackTracesAsJSON()->toJSONString();
scope.releaseAssertNoException();
RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSONParse(globalObject, jsonString)));
```

This is the same shape as #36857, which fixes the identical pattern in `functionGenerateHeapSnapshotForDebugging` in the same file.

### Test

Adds a test to `test/js/bun/jsc/bun-jsc.test.ts` covering both exits of the function: calling `samplingProfilerStackTraces()` before the profiler is started throws "Sampling profiler was never started" (this branch previously had no coverage and goes through the same throw scope), and after `startSamplingProfiler()` plus some work it returns the parsed object. The subprocess runs under `BUN_JSC_validateExceptionChecks=1` and the test asserts the exception-check validator reports no unchecked scopes (the option only has effect on debug builds).

A failing-before test is not possible here: the only real trigger is OOM inside `JSONParse` itself, which a test cannot stage deterministically (constraining memory makes the earlier `toJSONString()` allocation fail first, which is a non-recoverable WTF crash, not a JS exception). The exception-check validator also cannot distinguish the two versions, because the old code's `releaseAssertNoException()` after the parse counts as checking the simulated throw. The test therefore passes before and after this change; it pins the function's behavior, which previously had no coverage at all, and the validator check guards the scope bookkeeping of the new code.

The profiler is started without a directory argument because passing one currently segfaults; that is a separate bug with a separate fix in #32217.

### Sibling sites

Review flagged the remaining instance of this pattern, `JSC__JSGlobalObject__generateHeapSnapshot` in `src/jsc/bindings/bindings.cpp` (behind `console.takeHeapSnapshot()`). It is intentionally excluded: unlike the direct `bun:jsc` host functions fixed here and in #36857, its result feeds the console formatter through the Rust caller, so the reorder alone would pass an empty value into message formatting with an exception pending, and the exception would then surface under JSC's `consoleProtoFuncTakeHeapSnapshot`, whose scope performs no exception check after the client call. That needs caller-side handling and is tracked separately.
