### PR TITLE
console.takeHeapSnapshot: report snapshot parse failures instead of aborting

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -261,6 +261,8 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
+    // Debug-only fault injection for test/js/bun/console/console-take-heap-snapshot.test.ts.
+    new_feature_flag!(pub BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT, "BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -6013,15 +6013,11 @@ pub(crate) extern "C" fn Bun__ConsoleObject__takeHeapSnapshot(
 ) {
     // No exception may stay pending when this hook returns: JSC's
     // `consoleProtoFuncTakeHeapSnapshot` performs no exception check after the
-    // client call, so report failures as uncaught instead (termination just
-    // stops the print and keeps the VM unwinding).
+    // client call, so report failures as uncaught instead.
     // TODO: this does an extra JSONStringify and we don't need it to!
     let snapshot: [JSValue; 1] = match global_this.generate_heap_snapshot() {
         Ok(snapshot) => [snapshot],
-        Err(err) => {
-            let _ = crate::task::report_error_or_terminate(global_this, err);
-            return;
-        }
+        Err(err) => return global_this.report_active_exception_as_unhandled(err),
     };
     if let Err(err) = message_with_type_and_level_(
         core::ptr::null_mut(), // unused by the callee
@@ -6031,7 +6027,7 @@ pub(crate) extern "C" fn Bun__ConsoleObject__takeHeapSnapshot(
         snapshot.as_ptr(),
         1,
     ) {
-        let _ = crate::task::report_error_or_terminate(global_this, err);
+        global_this.report_active_exception_as_unhandled(err);
     }
 }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -6011,28 +6011,27 @@ pub(crate) extern "C" fn Bun__ConsoleObject__takeHeapSnapshot(
     _chars: *const u8,
     _len: usize,
 ) {
+    // No exception may stay pending when this hook returns: JSC's
+    // `consoleProtoFuncTakeHeapSnapshot` performs no exception check after the
+    // client call, so report failures as uncaught instead (termination just
+    // stops the print and keeps the VM unwinding).
     // TODO: this does an extra JSONStringify and we don't need it to!
     let snapshot: [JSValue; 1] = match global_this.generate_heap_snapshot() {
         Ok(snapshot) => [snapshot],
-        // The exception must not stay pending: JSC's
-        // `consoleProtoFuncTakeHeapSnapshot` performs no exception check after
-        // this client call, so report it as uncaught instead (termination just
-        // stops the print and keeps the VM unwinding).
         Err(err) => {
             let _ = crate::task::report_error_or_terminate(global_this, err);
             return;
         }
     };
-    // SAFETY: re-entry into our own host shim with a stack-local args slice.
-    unsafe {
-        message_with_type_and_level(
-            core::ptr::null_mut(), // unused by the callee
-            MessageType::Log,
-            MessageLevel::Debug,
-            global_this,
-            snapshot.as_ptr(),
-            1,
-        );
+    if let Err(err) = message_with_type_and_level_(
+        core::ptr::null_mut(), // unused by the callee
+        MessageType::Log,
+        MessageLevel::Debug,
+        global_this,
+        snapshot.as_ptr(),
+        1,
+    ) {
+        let _ = crate::task::report_error_or_terminate(global_this, err);
     }
 }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -6012,7 +6012,17 @@ pub(crate) extern "C" fn Bun__ConsoleObject__takeHeapSnapshot(
     _len: usize,
 ) {
     // TODO: this does an extra JSONStringify and we don't need it to!
-    let snapshot: [JSValue; 1] = [global_this.generate_heap_snapshot()];
+    let snapshot: [JSValue; 1] = match global_this.generate_heap_snapshot() {
+        Ok(snapshot) => [snapshot],
+        // The exception must not stay pending: JSC's
+        // `consoleProtoFuncTakeHeapSnapshot` performs no exception check after
+        // this client call, so report it as uncaught instead (termination just
+        // stops the print and keeps the VM unwinding).
+        Err(err) => {
+            let _ = crate::task::report_error_or_terminate(global_this, err);
+            return;
+        }
+    };
     // SAFETY: re-entry into our own host shim with a stack-local args slice.
     unsafe {
         message_with_type_and_level(

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -966,8 +966,8 @@ impl JSGlobalObject {
         })
     }
 
-    pub(crate) fn generate_heap_snapshot(&self) -> JSValue {
-        JSC__JSGlobalObject__generateHeapSnapshot(self)
+    pub(crate) fn generate_heap_snapshot(&self) -> JsResult<JSValue> {
+        crate::from_js_host_call(self, || JSC__JSGlobalObject__generateHeapSnapshot(self))
     }
 
     /// DEPRECATED — use [`TopExceptionScope`](crate::TopExceptionScope) to check for exceptions

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -967,6 +967,18 @@ impl JSGlobalObject {
     }
 
     pub(crate) fn generate_heap_snapshot(&self) -> JsResult<JSValue> {
+        // Debug-only fault injection for
+        // test/js/bun/console/console-take-heap-snapshot.test.ts: a real
+        // out-of-memory inside the snapshot's JSONParse cannot be staged from
+        // JS (constrained memory fails the earlier WTF-side snapshot
+        // allocations non-recoverably), so the console hook's error path is
+        // exercised this way.
+        #[cfg(debug_assertions)]
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT.get()
+            == Some(true)
+        {
+            return Err(self.throw_out_of_memory());
+        }
         crate::from_js_host_call(self, || JSC__JSGlobalObject__generateHeapSnapshot(self))
     }
 

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -840,6 +840,14 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
     JSC::HeapSnapshotBuilder builder(heapProfiler);
     builder.buildSnapshot();
     auto json = builder.json();
+    if (json.isNull()) [[unlikely]] {
+        // HeapSnapshotBuilder::json() returns the null string when the snapshot
+        // overflowed the maximum string length or its allocation failed;
+        // JSONParseWithException maps a null string to an empty value without
+        // throwing, which is not a valid host function result.
+        throwOutOfMemoryError(globalObject, throwScope);
+        return {};
+    }
     // Returning an object was a bad idea but it's a breaking change
     // so we'll just keep it for now.
     JSC::JSValue jsonValue = JSONParseWithException(globalObject, json);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3930,9 +3930,14 @@ JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObjec
     snapshotBuilder.buildSnapshot();
 
     WTF::String jsonString = snapshotBuilder.json();
-    JSC::EncodedJSValue result = JSC::JSValue::encode(JSONParse(globalObject, jsonString));
-    scope.releaseAssertNoException();
-    return result;
+    RETURN_IF_EXCEPTION(scope, {});
+    if (jsonString.isNull()) [[unlikely]] {
+        // HeapSnapshotBuilder::json() returns the null string when the snapshot
+        // overflowed the maximum string length or its allocation failed.
+        throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSONParseWithException(globalObject, jsonString)));
 }
 
 // One load. always_inline so ThinLTO importers and the inliner never leave

--- a/test/js/bun/console/console-take-heap-snapshot.test.ts
+++ b/test/js/bun/console/console-take-heap-snapshot.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
+
+// Lines printed by BUN_JSC_validateExceptionChecks=1 when a throw scope is
+// left unchecked (the option aborts on debug builds; release builds ignore it).
+function uncheckedScopes(stderr: string): string[] {
+  return stderr
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+}
 
 describe.concurrent("console.takeHeapSnapshot", () => {
   it("prints the parsed snapshot and survives BUN_JSC_validateExceptionChecks", async () => {
@@ -8,9 +17,7 @@ describe.concurrent("console.takeHeapSnapshot", () => {
     // hook instead of releaseAssertNoException()-crashing, and the hook must
     // report it rather than leave it pending under JSC's
     // consoleProtoFuncTakeHeapSnapshot, whose scope performs no exception
-    // check after the client call. validateExceptionChecks aborts on debug
-    // builds if any scope is left unchecked; on release builds the option is
-    // a no-op and this just exercises the snapshot path.
+    // check after the client call.
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `console.takeHeapSnapshot(); console.takeHeapSnapshot("label"); console.log("done");`],
       env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
@@ -18,13 +25,9 @@ describe.concurrent("console.takeHeapSnapshot", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const uncheckedScopes = stderr
-      .split("\n")
-      .map(line => line.trim())
-      .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
     expect(stdout).toContain(`type: "Inspector"`);
     expect(stdout.endsWith("done\n")).toBe(true);
-    expect(uncheckedScopes).toEqual([]);
+    expect(uncheckedScopes(stderr)).toEqual([]);
     expect(exitCode).toBe(0);
   });
 
@@ -49,6 +52,46 @@ describe.concurrent("console.takeHeapSnapshot", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("caught: boom\n");
     expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // A real out-of-memory inside the snapshot's JSONParse cannot be staged from
+  // JS (constrained memory fails the earlier WTF-side snapshot allocations
+  // non-recoverably), so a debug-only fault-injection env var forces
+  // generate_heap_snapshot to throw at the same seam; before the fix the same
+  // pending exception aborted the process in releaseAssertNoException().
+  it.skipIf(!isDebug)("reports a failed snapshot as an uncaught exception", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.takeHeapSnapshot(); console.log("after");`],
+      env: { ...bunEnv, BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT: "1", BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Out of memory");
+    expect(uncheckedScopes(stderr)).toEqual([]);
+    // The console call does not abort or rethrow; execution continues and the
+    // process exits 1 because the error went through the uncaught path.
+    expect(stdout).toBe("after\n");
+    expect(exitCode).toBe(1);
+  });
+
+  it.skipIf(!isDebug)("a failed snapshot error is interceptable via process.on(uncaughtException)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("uncaughtException", e => console.log("handled:", e.message));
+         console.takeHeapSnapshot();
+         console.log("after");`,
+      ],
+      env: { ...bunEnv, BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT: "1", BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(uncheckedScopes(stderr)).toEqual([]);
+    expect(stdout).toBe("handled: Out of memory\nafter\n");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/console/console-take-heap-snapshot.test.ts
+++ b/test/js/bun/console/console-take-heap-snapshot.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe.concurrent("console.takeHeapSnapshot", () => {
+  it("prints the parsed snapshot and survives BUN_JSC_validateExceptionChecks", async () => {
+    // JSONParse of the snapshot JSON can throw (out of memory building the
+    // parse tree), so the binding must hand the exception back to the console
+    // hook instead of releaseAssertNoException()-crashing, and the hook must
+    // report it rather than leave it pending under JSC's
+    // consoleProtoFuncTakeHeapSnapshot, whose scope performs no exception
+    // check after the client call. validateExceptionChecks aborts on debug
+    // builds if any scope is left unchecked; on release builds the option is
+    // a no-op and this just exercises the snapshot path.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.takeHeapSnapshot(); console.takeHeapSnapshot("label"); console.log("done");`],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const uncheckedScopes = stderr
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+    expect(stdout).toContain(`type: "Inspector"`);
+    expect(stdout.endsWith("done\n")).toBe(true);
+    expect(uncheckedScopes).toEqual([]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("propagates exceptions thrown while coercing the label", async () => {
+    // The label toString runs before the snapshot is taken; the console
+    // function checks for the exception and rethrows it.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try {
+          console.takeHeapSnapshot({ toString() { throw new Error("boom"); } });
+          console.log("did not throw");
+        } catch (e) {
+          console.log("caught:", e.message);
+        }`,
+      ],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("caught: boom\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

`JSC__JSGlobalObject__generateHeapSnapshot` (`src/jsc/bindings/bindings.cpp`, behind `console.takeHeapSnapshot()`) ended with:

```cpp
WTF::String jsonString = snapshotBuilder.json();
JSC::EncodedJSValue result = JSC::JSValue::encode(JSONParse(globalObject, jsonString));
scope.releaseAssertNoException();
return result;
```

`JSONParse` can throw, realistically an out-of-memory error while building the parse tree for a large heap's snapshot JSON. When it does, the process aborts:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Out of memory
!exception()
JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

via `JSC__JSGlobalObject__generateHeapSnapshot`. The fuzzer crash that motivated #30460 hit this same assert with an exception leaked from elsewhere, so the assert also turns unrelated pending exceptions into aborts.

There is a second failure mode with no assert at all: `HeapSnapshotBuilder::json()` returns the null string when the snapshot JSON overflows the maximum string length or its buffer allocation fails, and `JSONParse` maps a null string to an empty `JSValue` without throwing, so the old code passed an empty value into the console formatter. The same hole existed in `Bun.generateHeapSnapshot()`'s JSC branch (`BunObject.cpp`), where `JSONParseWithException` on a null string returns empty without throwing, which is not a valid host function result. Snapshots of multi-gigabyte heaps are where this lands, matching the crash pattern reported in #23393.

This is the same bug class as #37065 (`samplingProfilerStackTraces`) and #36857 (`generateHeapSnapshotForDebugging`). This call site was intentionally excluded from #37065 because the two-line reorder is not enough here: the result feeds the console formatter through the Rust caller, and the exception would then surface under JSC's `consoleProtoFuncTakeHeapSnapshot`, whose throw scope performs no exception check after the client call.

### Fix

- **`bindings.cpp`**: check for a pending exception after building the JSON, throw an out-of-memory error when `json()` returned the null string, and parse with `JSONParseWithException` + `RELEASE_AND_RETURN`. The function now returns empty if and only if an exception is pending.
- **`BunObject.cpp`**: give `Bun.generateHeapSnapshot()`'s JSC branch the same null-string guard (its parse-exception handling was already correct).
- **`JSGlobalObject.rs`**: `generate_heap_snapshot()` returns `JsResult<JSValue>` via `from_js_host_call`, so the empty-means-thrown contract is checked at the FFI boundary.
- **`ConsoleObject.rs`**: on error, the `takeHeapSnapshot` hook reports the exception with `report_active_exception_as_unhandled` instead of printing the snapshot, and routes formatter errors from `message_with_type_and_level_` the same way (the previous code re-entered the host shim, which intentionally leaves formatter errors pending for C++ callers that check). The hook cannot leave an exception pending: `consoleProtoFuncTakeHeapSnapshot` does not check for exceptions after the client call (the console API is void), and with `BUN_JSC_validateExceptionChecks=1` its unreleased scope would abort in `VM::verifyExceptionCheckNeedIsSatisfied`. `report_active_exception_as_unhandled` is the runtime's method for exactly this situation (an exception raised in a native context with nowhere to propagate), keeps the error visible to `process.on("uncaughtException")` and the test runner, and skips reporting when the pending exception is a termination.

So a failed snapshot now behaves like an error thrown at the `console.takeHeapSnapshot()` call site that nothing caught: reported with a stack, interceptable, exit code 1 by default, instead of `SIGABRT`.

### Test

The real triggers cannot be staged from JS: forcing an OOM inside `JSONParse` with constrained memory makes the earlier WTF-side snapshot allocations fail first (a non-recoverable crash, not a JS exception; #30460 was closed after reaching the same conclusion), and the null-string path needs a snapshot over the 2 GiB string limit. So the failure is injected at the seam where it would surface: a debug-only fault-injection env var, `BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT`, makes `generate_heap_snapshot()` throw an out-of-memory error, following the existing `BUN_INTERNAL_FAIL_PIPE_READER_START` convention.

`test/js/bun/console/console-take-heap-snapshot.test.ts` (this API had no coverage):

- `console.takeHeapSnapshot()` and the labeled variant print the parsed snapshot and exit cleanly under `BUN_JSC_validateExceptionChecks=1`.
- An exception thrown while coercing the label argument propagates to the caller.
- With the injected failure (debug builds): the error is reported as uncaught, execution continues, and the process exits 1; `process.on("uncaughtException")` intercepts it and the process exits 0. Both stay clean under the exception-check validator. These two tests fail on the previous code and pass with this change.

The unfixed abort itself was reproduced by temporarily forcing a throw at the parse site in a local build:

<details>
<summary>Transcript of the previous behavior with a simulated parse failure</summary>

```
$ bun -e 'process.on("uncaughtException", e => console.log("handled:", e.message)); console.takeHeapSnapshot(); console.log("after")'
ASSERTION FAILED: Unexpected exception observed on thread Thread:0x7b61290000c0 at:
The exception was thrown from thread Thread:0x7b61290000c0 at:
Error Exception: Out of memory

!exception()
JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
(exit 134, the handler never runs)
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-take-heap-snapshot.test.ts
bun test v1.4.0 (56cf03b9b)

test/js/bun/console/console-take-heap-snapshot.test.ts:
(pass) console.takeHeapSnapshot > propagates exceptions thrown while coercing the label [276.52ms]
23 |       env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
24 |       stdout: "pipe",
25 |       stderr: "pipe",
26 |     });
27 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
28 |     expect(stdout).toContain(`type: "Inspector"`);
                        ^
error: expect(received).toContain(expected)

Expected to contain: "type: \"Inspector\""
Received: ""

      at <anonymous> (/workspace/bun/test/js/bun/console/console-take-heap-snapshot.test.ts:28:20)
(fail) console.takeHeapSnapshot > prints the parsed snapshot and survives BUN_JSC_validateExceptionChecks [519.46ms]
66 |       env: { ...bunEnv, BUN_INTERNAL_FAIL_TAKE_HEAP_SNAPSHOT: "1", BUN_JSC_validateExceptionChecks: "1" },
67 |       stdout: "pipe",
68 |       stderr: 
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (7a093dbb7)

test/js/bun/console/console-take-heap-snapshot.test.ts:
(skip) console.takeHeapSnapshot > reports a failed snapshot as an uncaught exception
(skip) console.takeHeapSnapshot > a failed snapshot error is interceptable via process.on(uncaughtException)
(pass) console.takeHeapSnapshot > propagates exceptions thrown while coercing the label [5.59ms]
(pass) console.takeHeapSnapshot > prints the parsed snapshot and survives BUN_JSC_validateExceptionChecks [13.39ms]

 2 pass
 2 skip
 0 fail
 7 expect() calls
Ran 4 tests across 1 file. [177.00ms]
__F:0:S:2
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/console/console-take-heap-snapshot.test.ts
bun test v1.4.0 (56cf03b9b)

test/js/bun/console/console-take-heap-snapshot.test.ts:
(pass) console.takeHeapSnapshot > propagates exceptions thrown while coercing the label [285.37ms]
(pass) console.takeHeapSnapshot > reports a failed snapshot as an uncaught exception [278.56ms]
(pass) console.takeHeapSnapshot > a failed snapshot error is interceptable via process.on(uncaughtException) [276.57ms]
(pass) console.takeHeapSnapshot > prints the parsed snapshot and survives BUN_JSC_validateExceptionChecks [510.62ms]

 4 pass
 0 fail
 14 expect() calls
Ran 4 tests across 1 file. [2.53s]
__F:0:S:0

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 668ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[2/25] gen cpp.rs (cppbind)
[3/25] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[4/25] gen JS modules (bundle-modules)
Preprocess modules (8840ms)
Bundle modules (43ms)
Postprocesss modules (31ms)
Bundle Functions (633ms)
Generate Code (28ms)

[9.59s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  84 internal functions across 17 files
[4/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                            |  2 +
 src/jsc/ConsoleObject.rs                           | 27 +++---
 src/jsc/JSGlobalObject.rs                          | 16 +++-
 src/jsc/bindings/BunObject.cpp                     |  8 ++
 src/jsc/bindings/bindings.cpp                      | 11 ++-
 .../bun/console/console-take-heap-snapshot.test.ts | 97 ++++++++++++++++++++++
 6 files changed, 145 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bun_core/env_var.rs                                     1      2      0
src/jsc/ConsoleObject.rs                                    2      4      0
src/jsc/JSGlobalObject.rs                                   2      3      0
src/jsc/bindings/BunObject.cpp                              1      2      0
src/jsc/bindings/bindings.cpp                               2      3      0
test/js/bun/console/console-take-heap-snapshot.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->