### PR TITLE
transpiler: remove write-only ParseResult::input_fd plumbing

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -848,7 +848,6 @@ pub struct ParseResult<'a> {
     pub loader: options::Loader,
     pub ast: bun_ast::Ast<'a>,
     pub already_bundled: AlreadyBundled,
-    pub input_fd: Option<FD>,
     pub empty: bool,
     // `PendingResolution` does not yet
     // derive `MultiArrayElement` (lives in `bun_resolver`, derive macro is in
@@ -890,7 +889,6 @@ impl<'a> ParseResult<'a> {
             loader: options::Loader::File,
             ast: bun_ast::Ast::empty_in(arena),
             already_bundled: Default::default(),
-            input_fd: None,
             empty: true,
             pending_imports: Default::default(),
             runtime_transpiler_cache: None,
@@ -905,7 +903,6 @@ impl<'a> ParseResult<'a> {
         arena: &'a bun_alloc::Arena,
         source: bun_ast::Source,
         loader: options::Loader,
-        input_fd: Option<FD>,
         source_contents_backing: resolver::cache::Contents,
     ) -> Self {
         ParseResult {
@@ -913,7 +910,6 @@ impl<'a> ParseResult<'a> {
             loader,
             ast: bun_ast::Ast::empty_in(arena),
             already_bundled: AlreadyBundled::None,
-            input_fd,
             empty: true,
             pending_imports: Default::default(),
             runtime_transpiler_cache: None,
@@ -1353,7 +1349,6 @@ impl<'a> Transpiler<'a> {
         // the unique live `&mut Log` for the duration of the parse.
         let log: &mut bun_ast::Log = self.log_mut();
 
-        let mut input_fd: Option<FD> = None;
         // Owns the heap allocation backing `source.contents` for the
         // non-shared-buffer file-read and `data:` URL paths. Threaded into the
         // returned `ParseResult` so it drops with the result instead of being
@@ -1453,7 +1448,6 @@ impl<'a> Transpiler<'a> {
                     return None;
                 }
             };
-            input_fd = Some(entry.fd);
             if let Some(file_fd_ptr) = this_parse.file_fd_ptr {
                 *file_fd_ptr = entry.fd;
             }
@@ -1487,7 +1481,6 @@ impl<'a> Transpiler<'a> {
                 arena,
                 source.clone(),
                 loader,
-                input_fd,
                 source_backing,
             ));
         }
@@ -1500,7 +1493,6 @@ impl<'a> Transpiler<'a> {
                     arena,
                     source.clone(),
                     loader,
-                    input_fd,
                     source_backing,
                 ));
             }
@@ -1517,7 +1509,6 @@ impl<'a> Transpiler<'a> {
                         arena,
                         source.clone(),
                         options::Loader::Wasm,
-                        input_fd,
                         source_backing,
                     ));
                 }
@@ -1680,7 +1671,6 @@ impl<'a> Transpiler<'a> {
                         ast: *value,
                         source: source.clone(),
                         loader,
-                        input_fd,
                         runtime_transpiler_cache: rtc_ptr,
                         already_bundled: AlreadyBundled::None,
                         pending_imports: Default::default(),
@@ -1692,7 +1682,6 @@ impl<'a> Transpiler<'a> {
                         runtime_transpiler_cache: rtc_ptr,
                         source: source.clone(),
                         loader,
-                        input_fd,
                         already_bundled: AlreadyBundled::None,
                         pending_imports: Default::default(),
                         empty: false,
@@ -1763,7 +1752,6 @@ impl<'a> Transpiler<'a> {
                         },
                         source: source.clone(),
                         loader,
-                        input_fd,
                         pending_imports: Default::default(),
                         runtime_transpiler_cache: None,
                         empty: false,
@@ -1780,7 +1768,6 @@ impl<'a> Transpiler<'a> {
                 return parse_data_loader(
                     source,
                     loader,
-                    input_fd,
                     source_backing,
                     arena,
                     log,
@@ -1788,16 +1775,15 @@ impl<'a> Transpiler<'a> {
                 );
             }
             options::Loader::Text => {
-                return parse_text_loader(source, loader, input_fd, source_backing, arena);
+                return parse_text_loader(source, loader, source_backing, arena);
             }
             options::Loader::Md => {
-                return parse_md_loader(source, loader, input_fd, source_backing, arena, log);
+                return parse_md_loader(source, loader, source_backing, arena, log);
             }
             options::Loader::Wasm => {
                 return parse_wasm_loader(
                     source,
                     loader,
-                    input_fd,
                     source_backing,
                     arena,
                     &path,
@@ -1832,7 +1818,6 @@ impl<'a> Transpiler<'a> {
 fn parse_data_loader<'a>(
     source: &bun_ast::Source,
     loader: options::Loader,
-    input_fd: Option<FD>,
     source_backing: resolver::cache::Contents,
     arena: &'a Arena,
     log: &mut bun_ast::Log,
@@ -2070,7 +2055,6 @@ fn parse_data_loader<'a>(
         ast,
         source: source.clone(),
         loader,
-        input_fd,
         already_bundled: AlreadyBundled::None,
         pending_imports: Default::default(),
         runtime_transpiler_cache: None,
@@ -2084,7 +2068,6 @@ fn parse_data_loader<'a>(
 fn parse_text_loader<'a>(
     source: &bun_ast::Source,
     loader: options::Loader,
-    input_fd: Option<FD>,
     source_backing: resolver::cache::Contents,
     arena: &'a Arena,
 ) -> Option<ParseResult<'a>> {
@@ -2112,7 +2095,6 @@ fn parse_text_loader<'a>(
         ast: bun_ast::Ast::from_parts(parts, arena),
         source: source.clone(),
         loader,
-        input_fd,
         already_bundled: AlreadyBundled::None,
         pending_imports: Default::default(),
         runtime_transpiler_cache: None,
@@ -2126,7 +2108,6 @@ fn parse_text_loader<'a>(
 fn parse_md_loader<'a>(
     source: &bun_ast::Source,
     loader: options::Loader,
-    input_fd: Option<FD>,
     source_backing: resolver::cache::Contents,
     arena: &'a Arena,
     log: &mut bun_ast::Log,
@@ -2170,7 +2151,6 @@ fn parse_md_loader<'a>(
         ast: bun_ast::Ast::from_parts(parts, arena),
         source: source.clone(),
         loader,
-        input_fd,
         already_bundled: AlreadyBundled::None,
         pending_imports: Default::default(),
         runtime_transpiler_cache: None,
@@ -2184,7 +2164,6 @@ fn parse_md_loader<'a>(
 fn parse_wasm_loader<'a>(
     source: &bun_ast::Source,
     loader: options::Loader,
-    input_fd: Option<FD>,
     source_backing: resolver::cache::Contents,
     arena: &'a Arena,
     path: &bun_paths::fs::Path<'static>,
@@ -2208,7 +2187,6 @@ fn parse_wasm_loader<'a>(
             ast: bun_ast::Ast::empty_in(arena),
             source: source.clone(),
             loader,
-            input_fd,
             already_bundled: AlreadyBundled::None,
             pending_imports: Default::default(),
             runtime_transpiler_cache: None,

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1286,7 +1286,7 @@ impl AsyncModule {
         }
 
         // No watcher registration here: `maybe_watch_file` already ran before
-        // the enqueue, and `parse_result.input_fd` may have been closed (and
+        // the enqueue, and the fd the parse opened may have been closed (and
         // the number recycled) by the transpile frame's fd guard.
 
         // SAFETY: per-thread VM.

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { renderToString } from "react-dom/server";
 
 const Markdown = Bun.markdown;
@@ -1337,4 +1337,48 @@ describe("documents whose block metadata the parser cannot address", () => {
     ]);
     expect(exitCode).toBe(0);
   }, 30_000);
+});
+
+// The runtime module loader for .md files (imports, not the Bun.markdown API).
+describe.concurrent("importing .md modules", () => {
+  test("default export is the rendered HTML", async () => {
+    using dir = tempDir("md-import", {
+      "doc.md": "# Hello\n\nSome *text*.\n",
+      "entry.ts": `
+        import html from "./doc.md";
+        const required = require("./doc.md");
+        console.log(JSON.stringify([html, required.default]));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const rendered = "<h1>Hello</h1>\n<p>Some <em>text</em>.</p>\n";
+    expect(JSON.parse(stdout)).toEqual([rendered, rendered]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("empty .md file produces a module with no default export", async () => {
+    using dir = tempDir("md-import-empty", {
+      "empty.md": "",
+      "entry.ts": `
+        import html from "./empty.md";
+        console.log(html);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Missing 'default' export");
+    expect(exitCode).not.toBe(0);
+  });
 });


### PR DESCRIPTION
Follow-up to #37050, requested in https://github.com/oven-sh/bun/pull/37050#issuecomment-5208933671.

## What

#37050 removed the deferred watcher re-add in `AsyncModule::resume_loading_module`, which was the only reader of `ParseResult::input_fd`. That left the field write-only: assigned at every construction site and threaded through `parse_maybe`, `ParseResult::empty_with`, and the four cold loader helpers (`parse_data_loader`, `parse_text_loader`, `parse_md_loader`, `parse_wasm_loader`) without ever being read, as review on that PR pointed out.

This deletes the field, the `parse_maybe` local that fed it, and the pass-through parameters. The fd the parse opened still reaches the watcher handoff sites through `ParseOptions::file_fd_ptr`, which was already written from the same `entry.fd` on the same line. The comment in `AsyncModule.rs` that named the deleted field is reworded.

No behavior change, dead-code removal only, so there is no fail-before test to write. While auditing the touched loader paths, the runtime `.md` module loader turned out to have no coverage at all (the existing md tests only exercise the `Bun.markdown` API), so this adds tests locking it in: `import`/`require` of a `.md` file yields the rendered HTML as the default export, and an empty `.md` file produces a module with no default export (the `empty_with` path).

## Verification

- `cargo check -p bun_bundler` and a full debug build pass.
- On the debug build: `test/js/bun/md/md-edge-cases.test.ts` (84 pass, including the new import tests), `test/cli/hot/watch-many-dirs.test.ts` (2 pass, including the fd-count test added in #37050), `test/cli/hot/hot.test.ts` (12 pass), `test/js/bun/resolve/toml` + `yaml` + `jsonc` (21 pass), `test/bundler/bundler_loader.test.ts` (45 pass).
