### PR TITLE
Report failed promise settles in event-loop completions (subprocess, streams, blob, s3, valkey)

### DIFF
--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1119,34 +1119,35 @@ impl Subprocess<'_> {
                         did_update_has_pending_activity = true;
                     }
 
-                    match status {
-                        Status::Exited(exited) => {
-                            let _ = promise
-                                .as_any_promise()
-                                .unwrap()
-                                .resolve(global_this, JSValue::js_number(exited.code as f64));
-                            // TODO: properly propagate exception upwards
-                        }
+                    let settled = match status {
+                        Status::Exited(exited) => promise
+                            .as_any_promise()
+                            .unwrap()
+                            .resolve(global_this, JSValue::js_number(exited.code as f64)),
                         Status::Err(err) => {
                             let js_err = err.to_js(global_this);
-                            let _ = promise
+                            promise
                                 .as_any_promise()
                                 .unwrap()
-                                .reject_with_async_stack(global_this, js_err);
-                            // TODO: properly propagate exception upwards
+                                .reject_with_async_stack(global_this, js_err)
                         }
-                        Status::Signaled(signaled) => {
-                            let _ = promise.as_any_promise().unwrap().resolve(
-                                global_this,
-                                JSValue::js_number(128u8.wrapping_add(*signaled) as f64),
-                            );
-                            // TODO: properly propagate exception upwards
-                        }
+                        Status::Signaled(signaled) => promise.as_any_promise().unwrap().resolve(
+                            global_this,
+                            JSValue::js_number(128u8.wrapping_add(*signaled) as f64),
+                        ),
                         _ => {
                             // crash in debug mode
                             #[cfg(debug_assertions)]
                             unreachable!();
+                            #[cfg(not(debug_assertions))]
+                            Ok(())
                         }
+                    };
+                    if settled.is_err() {
+                        // A failed settle leaves an exception pending on the VM;
+                        // the exit callback below must not run with it (the
+                        // error label erases Thrown, so probe the VM instead).
+                        global_this.report_active_exception_as_unhandled(jsc::JsError::Thrown);
                     }
                 }
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1165,8 +1165,11 @@ impl JSValkeyClient {
                 .expect("unreachable");
                 let len = start - cur.len();
                 let msg = &buf[..len];
-                let _ = self.client_fail(msg, protocol::RedisError::IdleTimeout);
-                // TODO: properly propagate exception upwards
+                if let Err(e) = self.client_fail(msg, protocol::RedisError::IdleTimeout) {
+                    // A failed settle inside `fail` leaves an exception pending
+                    // on the VM; this timer callback has nowhere to bubble it.
+                    self.global_object.report_active_exception_as_unhandled(e);
+                }
             }
             valkey::Status::Disconnected | valkey::Status::Connecting => {
                 use std::io::Write;
@@ -1180,8 +1183,10 @@ impl JSValkeyClient {
                 .expect("unreachable");
                 let len = start - cur.len();
                 let msg = &buf[..len];
-                let _ = self.client_fail(msg, protocol::RedisError::ConnectionTimeout);
-                // TODO: properly propagate exception upwards
+                if let Err(e) = self.client_fail(msg, protocol::RedisError::ConnectionTimeout) {
+                    // See the idle-timeout arm above.
+                    self.global_object.report_active_exception_as_unhandled(e);
+                }
             }
         }
     }

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -620,11 +620,17 @@ impl ByteStream {
 
         if let Some(mut action) = self.buffer_action.replace(None) {
             let global = self.parent_const().global_this();
-            // TODO: properly propagate exception upwards
-            let _ = action.reject(
-                global,
-                &streams::StreamError::AbortReason(jsc::CommonAbortReason::UserAbort),
-            );
+            if action
+                .reject(
+                    global,
+                    &streams::StreamError::AbortReason(jsc::CommonAbortReason::UserAbort),
+                )
+                .is_err()
+            {
+                // A failed settle leaves an exception pending on the VM (the
+                // error label erases Thrown, so probe the VM instead).
+                global.report_active_exception_as_unhandled(jsc::JsError::Thrown);
+            }
             self.buffer_action.set(None);
         }
     }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -137,7 +137,14 @@ impl<'a> CopyFile<'a> {
         if let Some(store) = self.store.take() {
             drop(store); // deref()
         }
-        promise.reject(global_this, Ok(instance))
+        if promise.reject(global_this, Ok(instance)).is_err() {
+            // The settle error label erases Thrown, so probe the VM: report a
+            // pending non-termination exception instead of letting the task
+            // channel treat it as termination, and keep real termination as
+            // the `Err` that unwinds the tick loop.
+            return jsc::task::report_error_or_terminate(global_this, jsc::JsError::Thrown);
+        }
+        Ok(())
     }
 
     pub(crate) fn then(&mut self, promise: &mut JSPromise) -> Result<(), jsc::JsTerminated> {
@@ -147,10 +154,17 @@ impl<'a> CopyFile<'a> {
             return self.reject(promise);
         }
 
-        promise.resolve(
-            self.global_this,
-            JSValue::js_number_from_uint64(self.read_len as u64),
-        )
+        if promise
+            .resolve(
+                self.global_this,
+                JSValue::js_number_from_uint64(self.read_len as u64),
+            )
+            .is_err()
+        {
+            // See `reject` above.
+            return jsc::task::report_error_or_terminate(self.global_this, jsc::JsError::Thrown);
+        }
+        Ok(())
     }
 
     #[cfg(not(windows))]

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1642,7 +1642,12 @@ impl<'a> CopyFileWindows<'a> {
         // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
         unsafe { Self::destroy(core::ptr::from_mut(self)) };
         // `promise` points to a GC-owned `JSPromise` cell, not into `self`; valid after `destroy`.
-        let _ = promise.reject(global_this, err_instance); // TODO: properly propagate exception upwards
+        if promise.reject(global_this, err_instance).is_err() {
+            // A failed settle leaves an exception pending on the VM; report it
+            // so it cannot ride the tick into unrelated JS (the error label
+            // erases Thrown, so probe the VM instead).
+            global_this.report_active_exception_as_unhandled(jsc::JsError::Thrown);
+        }
     }
 
     pub(crate) fn on_complete(&mut self, written_actual: usize) {
@@ -1729,7 +1734,13 @@ impl<'a> CopyFileWindows<'a> {
         // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
         unsafe { Self::destroy(core::ptr::from_mut(self)) };
         // `promise` points to a GC-owned `JSPromise` cell, not into `self`; valid after `destroy`.
-        let _ = promise.resolve(global_this, JSValue::js_number_from_uint64(written as u64)); // TODO: properly propagate exception upwards
+        if promise
+            .resolve(global_this, JSValue::js_number_from_uint64(written as u64))
+            .is_err()
+        {
+            // See `throw` above: keep a failed settle's exception off the tick.
+            global_this.report_active_exception_as_unhandled(jsc::JsError::Thrown);
+        }
     }
 
     #[cold]

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -927,7 +927,8 @@ mod windows_impl {
                     )
                 } {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    // `run_from_js_thread` already reported the failed settle.
+                    // The completion callback reported any failed settle;
+                    // JSTerminated is real termination, left pending.
                     WriteFileWindowsError::JSTerminated => {}
                 }
                 return;
@@ -941,7 +942,8 @@ mod windows_impl {
             if let Err(e) = unsafe { Self::do_write_loop(this, (*this).loop_()) } {
                 match e {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    // `run_from_js_thread` already reported the failed settle.
+                    // The completion callback reported any failed settle;
+                    // JSTerminated is real termination, left pending.
                     WriteFileWindowsError::JSTerminated => {}
                 }
             }
@@ -991,7 +993,8 @@ mod windows_impl {
                 // SAFETY: caller contract — `this` is live; `throw` consumes it.
                 match unsafe { Self::throw(this, err_) } {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    // `run_from_js_thread` already reported the failed settle.
+                    // The completion callback reported any failed settle;
+                    // JSTerminated is real termination, left pending.
                     WriteFileWindowsError::JSTerminated => {}
                 }
                 return;
@@ -1001,7 +1004,8 @@ mod windows_impl {
             if let Err(e) = unsafe { Self::open(this) } {
                 match e {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    // `run_from_js_thread` already reported the failed settle.
+                    // The completion callback reported any failed settle;
+                    // JSTerminated is real termination, left pending.
                     WriteFileWindowsError::JSTerminated => {}
                 }
             }
@@ -1009,7 +1013,7 @@ mod windows_impl {
 
         /// `ManagedTask`-shaped trampoline for [`on_mkdirp_complete`]: takes
         /// `*mut Self` and returns the event-loop `JsResult<()>` (always `Ok`;
-        /// a failed settle is reported inside `run_from_js_thread`).
+        /// a failed settle is reported inside the completion callback).
         fn on_mkdirp_complete_task(this: *mut WriteFileWindows) -> bun_event_loop::JsResult<()> {
             // SAFETY: `this` is the live Box-allocated `WriteFileWindows` whose
             // pointer was stashed in `on_mkdirp_complete_concurrent` below;
@@ -1063,7 +1067,8 @@ mod windows_impl {
                     )
                 } {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    // `run_from_js_thread` already reported the failed settle.
+                    // The completion callback reported any failed settle;
+                    // JSTerminated is real termination, left pending.
                     WriteFileWindowsError::JSTerminated => {}
                 }
                 return;
@@ -1075,7 +1080,8 @@ mod windows_impl {
             if let Err(e) = unsafe { Self::do_write_loop(this, (*this).loop_()) } {
                 match e {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    // `run_from_js_thread` already reported the failed settle.
+                    // The completion callback reported any failed settle;
+                    // JSTerminated is real termination, left pending.
                     WriteFileWindowsError::JSTerminated => {}
                 }
             }
@@ -1102,19 +1108,12 @@ mod windows_impl {
             // SAFETY: caller contract — `this` is live; copy out everything we
             // need before `deinit` frees the allocation.
             let (cb, cb_ctx) = unsafe { ((*this).on_complete_callback, (*this).on_complete_ctx) };
-            // SAFETY: caller contract — `this` is live; the VM-owned event
-            // loop (and its global) outlives the request.
-            let global = unsafe { (*(*this).event_loop).global_ref() };
 
             // SAFETY: caller contract — `this` is live.
             if let Some(err) = unsafe { (*this).to_system_error() } {
                 // SAFETY: caller contract — `this` is live; consumed here.
                 unsafe { Self::deinit(this) };
                 if let Err(e) = cb(cb_ctx, WriteFileResultType::Err(Box::new(err))) {
-                    // A failed settle leaves an exception pending on the VM;
-                    // report it so it cannot ride the tick into unrelated JS
-                    // (the error label erases Thrown, so probe the VM instead).
-                    global.report_active_exception_as_unhandled(jsc::JsError::Thrown);
                     return e.into();
                 }
             } else {
@@ -1123,8 +1122,6 @@ mod windows_impl {
                 // SAFETY: caller contract — `this` is live; consumed here.
                 unsafe { Self::deinit(this) };
                 if let Err(e) = cb(cb_ctx, WriteFileResultType::Result(wrote as SizeType)) {
-                    // See the error arm above.
-                    global.report_active_exception_as_unhandled(jsc::JsError::Thrown);
                     return e.into();
                 }
             }
@@ -1318,22 +1315,28 @@ impl WriteFilePromise {
         // SAFETY: GC-owned cell (kept alive below); scoped shared access.
         let value = unsafe { (*promise).to_js() };
         value.ensure_still_alive();
-        match count {
+        let settled = match count {
             WriteFileResultType::Err(err) => {
                 // SAFETY: GC-owned cell; the error build's shared borrow ends before the
                 // scoped exclusive `reject` borrow.
                 unsafe {
                     let err_js = err.to_error_instance_with_async_stack(global_this, &*promise);
-                    (*promise).reject(global_this, Ok(err_js))?;
+                    (*promise).reject(global_this, Ok(err_js))
                 }
             }
             WriteFileResultType::Result(wrote) => {
                 // SAFETY: GC-owned cell; exclusive borrow scoped to the call.
                 unsafe {
-                    (*promise)
-                        .resolve(global_this, JSValue::js_number_from_uint64(wrote as u64))?;
+                    (*promise).resolve(global_this, JSValue::js_number_from_uint64(wrote as u64))
                 }
             }
+        };
+        if settled.is_err() {
+            // The settle error label erases Thrown, so probe the VM: report a
+            // pending non-termination exception instead of letting the task
+            // channel treat it as termination, and keep real termination as
+            // the `Err` that unwinds the tick loop.
+            return jsc::task::report_error_or_terminate(global_this, jsc::JsError::Thrown);
         }
         Ok(())
     }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -927,7 +927,8 @@ mod windows_impl {
                     )
                 } {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    WriteFileWindowsError::JSTerminated => {} // TODO: properly propagate exception upwards
+                    // `run_from_js_thread` already reported the failed settle.
+                    WriteFileWindowsError::JSTerminated => {}
                 }
                 return;
             }
@@ -940,7 +941,8 @@ mod windows_impl {
             if let Err(e) = unsafe { Self::do_write_loop(this, (*this).loop_()) } {
                 match e {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    WriteFileWindowsError::JSTerminated => {} // TODO: properly propagate exception upwards
+                    // `run_from_js_thread` already reported the failed settle.
+                    WriteFileWindowsError::JSTerminated => {}
                 }
             }
         }
@@ -989,7 +991,8 @@ mod windows_impl {
                 // SAFETY: caller contract — `this` is live; `throw` consumes it.
                 match unsafe { Self::throw(this, err_) } {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    WriteFileWindowsError::JSTerminated => {} // TODO: properly propagate exception upwards
+                    // `run_from_js_thread` already reported the failed settle.
+                    WriteFileWindowsError::JSTerminated => {}
                 }
                 return;
             }
@@ -998,14 +1001,15 @@ mod windows_impl {
             if let Err(e) = unsafe { Self::open(this) } {
                 match e {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    WriteFileWindowsError::JSTerminated => {} // TODO: properly propagate exception upwards
+                    // `run_from_js_thread` already reported the failed settle.
+                    WriteFileWindowsError::JSTerminated => {}
                 }
             }
         }
 
         /// `ManagedTask`-shaped trampoline for [`on_mkdirp_complete`]: takes
         /// `*mut Self` and returns the event-loop `JsResult<()>` (always `Ok`;
-        /// the inner body already swallows `JSTerminated`).
+        /// a failed settle is reported inside `run_from_js_thread`).
         fn on_mkdirp_complete_task(this: *mut WriteFileWindows) -> bun_event_loop::JsResult<()> {
             // SAFETY: `this` is the live Box-allocated `WriteFileWindows` whose
             // pointer was stashed in `on_mkdirp_complete_concurrent` below;
@@ -1059,7 +1063,8 @@ mod windows_impl {
                     )
                 } {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    WriteFileWindowsError::JSTerminated => {} // TODO: properly propagate exception upwards
+                    // `run_from_js_thread` already reported the failed settle.
+                    WriteFileWindowsError::JSTerminated => {}
                 }
                 return;
             }
@@ -1070,7 +1075,8 @@ mod windows_impl {
             if let Err(e) = unsafe { Self::do_write_loop(this, (*this).loop_()) } {
                 match e {
                     WriteFileWindowsError::WriteFileWindowsDeinitialized => {}
-                    WriteFileWindowsError::JSTerminated => {} // TODO: properly propagate exception upwards
+                    // `run_from_js_thread` already reported the failed settle.
+                    WriteFileWindowsError::JSTerminated => {}
                 }
             }
         }
@@ -1096,12 +1102,19 @@ mod windows_impl {
             // SAFETY: caller contract — `this` is live; copy out everything we
             // need before `deinit` frees the allocation.
             let (cb, cb_ctx) = unsafe { ((*this).on_complete_callback, (*this).on_complete_ctx) };
+            // SAFETY: caller contract — `this` is live; the VM-owned event
+            // loop (and its global) outlives the request.
+            let global = unsafe { (*(*this).event_loop).global_ref() };
 
             // SAFETY: caller contract — `this` is live.
             if let Some(err) = unsafe { (*this).to_system_error() } {
                 // SAFETY: caller contract — `this` is live; consumed here.
                 unsafe { Self::deinit(this) };
                 if let Err(e) = cb(cb_ctx, WriteFileResultType::Err(Box::new(err))) {
+                    // A failed settle leaves an exception pending on the VM;
+                    // report it so it cannot ride the tick into unrelated JS
+                    // (the error label erases Thrown, so probe the VM instead).
+                    global.report_active_exception_as_unhandled(jsc::JsError::Thrown);
                     return e.into();
                 }
             } else {
@@ -1110,6 +1123,8 @@ mod windows_impl {
                 // SAFETY: caller contract — `this` is live; consumed here.
                 unsafe { Self::deinit(this) };
                 if let Err(e) = cb(cb_ctx, WriteFileResultType::Result(wrote as SizeType)) {
+                    // See the error arm above.
+                    global.report_active_exception_as_unhandled(jsc::JsError::Thrown);
                     return e.into();
                 }
             }
@@ -1343,8 +1358,16 @@ impl WriteFileWaitFromLockedValueTask {
         let this = unsafe {
             bun_core::heap::take(this.cast::<WriteFileWaitFromLockedValueTask>().as_ptr())
         };
-        let _ = Self::then(this, value);
-        // TODO: properly propagate exception upwards
+        // `BackRef` is `Copy`; keep the global past the consuming call.
+        let global_ref = this.global_this;
+        if Self::then(this, value).is_err() {
+            // A failed settle leaves an exception pending on the VM; report it
+            // so it cannot ride the tick into unrelated JS (the error label
+            // erases Thrown, so probe the VM instead).
+            global_ref
+                .get()
+                .report_active_exception_as_unhandled(jsc::JsError::Thrown);
+        }
     }
 
     pub(crate) fn then(

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -990,7 +990,7 @@ impl MultiPartUpload {
             self.state.set(State::SinglefileStarted);
             // we can do only 1 request
             self.ref_();
-            let _ = execute_simple_s3_request(
+            let started = execute_simple_s3_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
                     path: &self.path,
@@ -1007,10 +1007,21 @@ impl MultiPartUpload {
                 },
                 s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
                 self.as_ctx_ptr(),
-            ); // TODO: properly propagate exception upwards
+            );
+            if started.is_err() {
+                // A failed settle leaves an exception pending on the VM; report
+                // it so it cannot ride the tick into unrelated JS (the error
+                // label erases Thrown, so probe the VM instead).
+                self.global_this
+                    .report_active_exception_as_unhandled(bun_jsc::JsError::Thrown);
+            }
         } else {
             // we need to split
-            let _ = self.process_multi_part(part_size); // TODO: properly propagate exception upwards
+            if self.process_multi_part(part_size).is_err() {
+                // See the single-request arm above.
+                self.global_this
+                    .report_active_exception_as_unhandled(bun_jsc::JsError::Thrown);
+            }
         }
     }
 

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -950,7 +950,7 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
   // `Object.prototype.then` accessor installed, mirroring the
   // prototype-pollution state fuzzer processes run in.
   it("write completions settle under Object.prototype.then pollution", async () => {
-    using dir = tempDir("bun-write-pollution", {});
+    using dir = tempDir("bun-write-pollution", { "src.txt": "copy me" });
     const fixture = `
       const fs = require("fs");
       const dir = ${JSON.stringify(String(dir))};
@@ -968,7 +968,6 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         },
       });
       const resp = await fetch("http://localhost:" + server.port + "/");
-      fs.writeFileSync(dir + "/src.txt", "copy me");
 
       Object.defineProperty(Object.prototype, "then", {
         configurable: true,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -979,14 +979,16 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       // Body still streaming: Bun.write waits on the locked body, then
       // resolves its promise with the inner write's promise.
       const wroteStream = await Bun.write(dir + "/a.txt", resp);
-      // copy_file completion resolves with the byte count.
+      // copy_file completion. The resolved count is backend-dependent on
+      // Windows (uv_fs_copyfile reports none, the fallback loop the real
+      // count), so pin only its type; the content check below is the proof.
       const wroteCopy = await Bun.write(Bun.file(dir + "/dst.txt"), Bun.file(dir + "/src.txt"));
       delete Object.prototype.then;
 
       const results = [
         wroteStream,
         fs.readFileSync(dir + "/a.txt", "utf8"),
-        wroteCopy,
+        typeof wroteCopy,
         fs.readFileSync(dir + "/dst.txt", "utf8"),
       ];
       server.stop(true);
@@ -1000,9 +1002,7 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    // uv_fs_copyfile does not report a byte count, so the Windows copyfile
-    // completion resolves 0 when the size is not known up front.
-    expect(JSON.parse(stdout)).toEqual([11, "hello world", isWindows ? 0 : 7, "copy me"]);
+    expect(JSON.parse(stdout)).toEqual([11, "hello world", "number", "copy me"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -943,4 +943,63 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
 
     expect(f.name).toBe(filePath);
   });
+
+  // The native write completions (copy_file, write_file, and the locked-body
+  // wait task) settle their promises from the event loop and must never leave
+  // an exception riding the tick. Pin both paths with a hostile
+  // `Object.prototype.then` accessor installed, mirroring the
+  // prototype-pollution state fuzzer processes run in.
+  it("write completions settle under Object.prototype.then pollution", async () => {
+    const fixture = `
+      const fs = require("fs");
+      const dir = fs.mkdtempSync(require("os").tmpdir() + "/bun-write-pollution-");
+      const server = Bun.serve({
+        port: 0,
+        async fetch() {
+          return new Response(new ReadableStream({
+            async pull(c) {
+              c.enqueue(new TextEncoder().encode("hello "));
+              await Bun.sleep(10);
+              c.enqueue(new TextEncoder().encode("world"));
+              c.close();
+            },
+          }));
+        },
+      });
+      const resp = await fetch("http://localhost:" + server.port + "/");
+      fs.writeFileSync(dir + "/src.txt", "copy me");
+
+      Object.defineProperty(Object.prototype, "then", {
+        configurable: true,
+        get() {
+          throw new Error("boom");
+        },
+      });
+      // Body still streaming: Bun.write waits on the locked body, then
+      // resolves its promise with the inner write's promise.
+      const wroteStream = await Bun.write(dir + "/a.txt", resp);
+      // copy_file completion resolves with the byte count.
+      const wroteCopy = await Bun.write(Bun.file(dir + "/dst.txt"), Bun.file(dir + "/src.txt"));
+      delete Object.prototype.then;
+
+      const results = [
+        wroteStream,
+        fs.readFileSync(dir + "/a.txt", "utf8"),
+        wroteCopy,
+        fs.readFileSync(dir + "/dst.txt", "utf8"),
+      ];
+      server.stop(true);
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([11, "hello world", 7, "copy me"]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -950,9 +950,10 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
   // `Object.prototype.then` accessor installed, mirroring the
   // prototype-pollution state fuzzer processes run in.
   it("write completions settle under Object.prototype.then pollution", async () => {
+    using dir = tempDir("bun-write-pollution", {});
     const fixture = `
       const fs = require("fs");
-      const dir = fs.mkdtempSync(require("os").tmpdir() + "/bun-write-pollution-");
+      const dir = ${JSON.stringify(String(dir))};
       const server = Bun.serve({
         port: 0,
         async fetch() {
@@ -999,7 +1000,9 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual([11, "hello world", 7, "copy me"]);
+    // uv_fs_copyfile does not report a byte count, so the Windows copyfile
+    // completion resolves 0 when the size is not known up front.
+    expect(JSON.parse(stdout)).toEqual([11, "hello world", isWindows ? 0 : 7, "copy me"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1536,3 +1536,40 @@ describe("uid/gid", () => {
     expect(thrown?.code).toBe("EPERM");
   });
 });
+
+// The native exit completion settles the cached `exited` promise and then
+// immediately runs more JS (onExit callback, IPC teardown) in the same task,
+// so a failed settle must never leave its exception pending on the VM. The
+// settle values are primitives, so a hostile `Object.prototype.then` accessor
+// (prototype pollution persists across scripts in fuzzer processes) must not
+// be consulted and both the exit-code and signal paths must stay healthy.
+it.if(isPosix)("exited settles under Object.prototype.then pollution", async () => {
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        Object.defineProperty(Object.prototype, "then", {
+          configurable: true,
+          get() {
+            throw new Error("boom");
+          },
+        });
+        const exited7 = Bun.spawn({ cmd: ["sh", "-c", "exit 7"] }).exited;
+        const killed = Bun.spawn({ cmd: ["sleep", "1000"] });
+        const exitedKilled = killed.exited;
+        killed.kill("SIGKILL");
+        const codes = [await exited7, await exitedKilled];
+        delete Object.prototype.then;
+        console.log(JSON.stringify(codes));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual([7, 137]);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What

Fuzzing (Fuzzilli) keeps hitting a flaky debug assertion whose trigger moves between modules:

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JavaScriptCore/JSObjectInlines.h(137) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName)
```

It fires when a native `get()` runs while a JS exception is already pending. The producer is a recurring defect class in event-loop completion code: a native completion settles a promise (or runs a completion callback), discards the result with `let _ =` and a `// TODO: properly propagate exception upwards`, and the pending exception rides the tick until some later native property read trips the assert. On release builds the stale exception instead gets misattributed to whatever JS runs next. #37004 (open) covers this class in the DNS drains; this PR covers the following sites from the same audit:

- `subprocess.rs` exit path: the `exited` promise settle (exit code, signal, waitpid error) runs right before the `onExit` callback in the same task, so a failed settle fed its exception into the user's callback invocation.
- `ByteStream.rs` `on_cancel`: the buffer-action reject (pending `text()`/`arrayBuffer()` on a native stream).
- `blob/copy_file.rs` and `blob/write_file.rs`, both platforms:
  - The POSIX completions (`CopyFile::then`/`reject`, `WriteFilePromise::run`) run inside the task dispatch channel, whose error type is the terminated sentinel; the promise FFI wrappers collapse every settle failure to that sentinel, so a thrown exception was mislabeled as termination, stopped the tick drain early, and stayed pending. These now consult the VM via `report_error_or_terminate` (the dispatcher's designed reporter, previously unreachable because the label was erased upstream): a pending non-termination exception is reported and the task returns `Ok`, while real termination still unwinds the tick loop.
  - The Windows completions (`CopyFileWindows::throw`/`resolve_promise`, and the `WriteFileWindows` uv callbacks, which funnel through the same `WriteFilePromise::run`) are fire-and-forget; the copyfile ones report via `report_active_exception_as_unhandled`.
  - The cross-platform locked-body wait task (`then_wrap`) reports the same way.
- `s3/multipart.rs` `process_buffered`: the single-request and multipart upload starts.
- `valkey_jsc/js_valkey.rs` connection/idle timeout timers (the drain rewrite in #34829 covers the socket callbacks but not these two timer arms).

### Fix

Check the settle result and, on failure, report the pending non-termination exception instead of discarding it: `report_active_exception_as_unhandled` in fire-and-forget completions (the idiom the socket, IPC, and http2 completions already use), `report_error_or_terminate` in completions that return into the task dispatch channel. The error label is never trusted, because the promise FFI wrappers collapse every failure to the terminated sentinel; the VM state decides, and termination exceptions stay pending as the event loop expects.

### Scope

This PR does not exhaust the class. Sites with the same shape that remain, deliberately out of scope here and candidates for follow-ups in the same idiom: the `streams.rs` server-sink family (`flush_promise`/`fulfill_promise` discards in `HTTPServerWritable`/`NetworkSink`/`Writable`), `ipc.rs:753`, `node_fs.rs:1746`, `node_fs_watcher.rs:877`, `ArrayBufferSink.rs:55`, and the `socket_body.rs` sites (owned by a separate in-flight fix).

Sites audited and deliberately left alone because they are not in the class: `Sink.rs` `js_close`/`js_end_with_sink` (the generated JSSink.cpp callers check `scope.exception()` immediately after, so the exception does propagate), `ReadableStream.rs` `Strong::get`/`to_any_blob` (held values are always real stream cells, which take the throw-free tag path), and the `JSValue::then` registrations in `FileSink.rs`/`bun_test.rs` (the wrapper debug-asserts no non-termination exception internally).

An alternative worth noting for the maintainers: a single guard at `JSC__JSPromise__resolve` entry (bindings.cpp) converting a resolve-with-pending-exception into a rejection would close the whole class at once, at the cost of masking caller bugs. This PR keeps the per-site idiom #37004 established instead.

### Why there is no failing-first test

A settle can only fail here with the VM already in an exceptional state, and none of these sites can be driven there from plain JS:

- The settle values are primitives (exit codes, byte counts) or engine-created errors, and JSC's `resolvePromise` only consults user code (`then` lookup) for object resolutions; when that lookup throws, JSC catches it and converts it into a rejection of the same promise (JSPromise.cpp:693), leaving the VM clean, so hostile `Object.prototype.then` / `Promise.prototype.then` accessors cannot make these settles return an error.
- The remaining producers are OOM mid-settle, a termination exception (behavior deliberately unchanged), or an exception leaked by some other buggy completion, which is the state this PR removes.

Empirically: running the touched flows (subprocess exit and signal settles, locked-body `Bun.write`, file-to-file copy) under a throwing `Object.prototype.then` accessor behaves identically on the unfixed release build and this branch's debug+ASAN build, settling correctly with no assert. The new tests pin that behavior so these completions stay healthy under the prototype-pollution state fuzzer processes run in; they are hardening pins, not fail-before reproductions, because the fixed branch is unreachable without an already-dirty VM.

### Verification

- `bun bd` (debug+ASAN) and `cargo check --release`; `rust:check-all` (all six target combos) for the platform-gated code in `write_file.rs`/`copy_file.rs`.
- `test/js/bun/spawn/spawn.test.ts`, `test/js/bun/io/bun-write.test.js` (including the two new pollution tests, in both copyfile backends: default and `BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE=1`, on Linux and Windows), `test/js/web/streams/streams.test.js`, `test/js/bun/s3/s3-connection-close.test.ts`, `test/js/valkey/reliability/connection-failures.test.ts` all pass on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->