### PR TITLE
js_parser: don't fold [x][0] in call position so `this` stays the array

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1085,7 +1085,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return;
                             }
                         }
-                    } else if let Some(array) = target.data.as_e_array() {
+                    } else if !is_call_target && let Some(array) = target.data.as_e_array() {
+                        // `[x][0]()` calls `x` with `this` bound to the array
+                        // literal itself (GetThisValue of the Reference), which
+                        // neither `x()` nor `(0, x)()` reproduces, so the fold
+                        // must not fire for call targets.
                         let int: usize = number.value() as usize;
                         // [x][0] -> x
                         // ['a', 'b', 'c'][1] -> 'b'
@@ -1105,13 +1109,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return;
                             }
                             if inlined.can_be_inlined_from_property_access() {
-                                // "[obj.m][0]()" => "(0, obj.m)()"
-                                *e = if is_call_target && inlined.has_value_for_this_in_call() {
-                                    p.new_expr(E::Number::new(0.0), expr.loc)
-                                        .join_with_comma(inlined)
-                                } else {
-                                    inlined
-                                };
+                                *e = inlined;
                                 return;
                             }
                         }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: The `[x][0] -> x` fold no longer fires in call position, so
+/// `[obj.m][0]()` keeps the array literal as `this` instead of `(0, obj.m)()`.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -192,15 +192,23 @@ describe("Bun.Transpiler", () => {
       ts.expectPrintedMin_("x = ({f: y}).f", "x = y");
       ts.expectPrintedMin_("x = new ({f: C}).f()", "x = new C");
     });
-    it("bails out or strips `this` when the index is a call/assignment target", () => {
+    it("bails out when the index is a call/assignment target", () => {
       // `[obj.m][0]()` calls through a Reference into the temporary array,
-      // so `this` is the array; inlining to `obj.m()` would bind `this` to
-      // `obj`. Match the sibling folds and emit `(0, obj.m)()`.
-      ts.expectPrintedMin_("x = [obj.m][0]()", "x = (0, obj.m)()");
-      ts.expectPrintedMin_("x = [obj[m]][0]()", "x = (0, obj[m])()");
+      // so `this` is the array literal itself. Neither `obj.m()` nor
+      // `(0, obj.m)()` reproduces that, so the fold must not fire in call
+      // position at all. That includes plain identifiers and function
+      // expressions: `[y][0]()` calls `y` with `this` set to the array.
+      ts.expectPrintedMin_("x = [obj.m][0]()", "x = [obj.m][0]()");
+      ts.expectPrintedMin_("x = [obj[m]][0]()", "x = [obj[m]][0]()");
       ts.expectPrintedMin_("x = [obj.m][0]", "x = obj.m");
-      ts.expectPrintedMin_("x = [y][0]()", "x = y()");
-      ts.expectPrintedMin_("x = [() => y][0]()", "x = (() => y)()");
+      ts.expectPrintedMin_("x = [y][0]()", "x = [y][0]()");
+      ts.expectPrintedMin_("x = [() => y][0]()", "x = [() => y][0]()");
+      ts.expectPrintedMin_("x = [obj.m][0]?.()", "x = [obj.m][0]?.()");
+      ts.expectPrintedMin_("x = [obj.m]?.[0]()", "x = [obj.m][0]()");
+      ts.expectPrintedMin_("x = [0, y][1]()", "x = [0, y][1]()");
+      // `new` does not thread `this` through the callee Reference, so the
+      // fold still fires there.
+      ts.expectPrintedMin_("x = new [C][0]()", "x = new C");
 
       // `[x][0] = v` writes into the temporary, not `x`. Same for `"s"[n]`.
       ts.expectPrintedMin_("[obj.p][0] = 5", "[obj.p][0] = 5");
@@ -230,6 +238,13 @@ describe("Bun.Transpiler", () => {
         check("chain pure", () => [[0, /* @__PURE__ */ a?.()]][0]?.[1].c, "TypeError");
         var obj = { n: "obj", m() { return this === obj; } };
         check("this",       () => [obj.m][0](), "=> false");
+        obj.who = function () { return Array.isArray(this); };
+        var who = obj.who;
+        check("this arr dot",   () => [obj.who][0](), "=> true");
+        check("this arr ident", () => [who][0](), "=> true");
+        check("this arr opt",   () => [obj.who][0]?.(), "=> true");
+        check("this arr multi", () => [0, who][1](), "=> true");
+        check("this arr fn",    () => [function () { return Array.isArray(this); }][0](), "=> true");
         var o2 = { p: 1 };
         check("assign",     () => ([o2.p][0] = 5, o2.p), "=> 1");
         var ab = { b: class {} };
@@ -252,6 +267,11 @@ describe("Bun.Transpiler", () => {
         "chain cont: ok",
         "chain pure: ok",
         "this: ok",
+        "this arr dot: ok",
+        "this arr ident: ok",
+        "this arr opt: ok",
+        "this arr multi: ok",
+        "this arr fn: ok",
         "assign: ok",
         "new obj: ok",
       ]);


### PR DESCRIPTION
## Problem

With `minify_syntax` on (the default for `bun run`), the `[x][0] -> x` fold rebinds `this` when the folded expression is the callee of a call:

```js
function f() { return this === undefined ? "undefined" : Array.isArray(this) ? "array" : "obj:" + this.tag; }
const o = { tag: "o", f };
console.log([o.f][0](), [0, o.f][1](), [o.f][0]?.(), [o.f]?.[0](), [function () { return Array.isArray(this); }][0]());
```

Node prints `array array array array true`. Bun prints `undefined array undefined undefined false`.

Per ECMA-262 EvaluateCall, when the callee is a property Reference like `[o.f][0]`, thisValue is GetThisValue of that Reference, i.e. the array literal itself. #36730 changed the fold to emit `(0, o.f)()` for member-expression items "so this is not rebound", but that binds `this` to undefined, not the array. Items that are plain identifiers or function expressions were inlined bare (`[y][0]()` -> `y()`), which is wrong the same way.

## Fix

No folded form can reproduce "`this` is the array literal", so the `e_index` array fold now bails out entirely when the index expression is a call target. This covers optional calls (`[o.f][0]?.()`) since `e_call` sets the same `call_target`. The multi-item path (`[0, y][1]()`) goes through the same gate.

Unaffected on purpose:

- `new [C][0]()` still folds to `new C`: `e_new` does not mark a call target and `new` does not thread `this` through the callee Reference.
- The `"foo"[2] -> "o"` string fold still fires in call position: a primitive callee throws TypeError either way.
- The sibling `{f: x}.f` fold already bails on call targets.
- The sibling comma/`??`/`||`/`&&`/ternary folds keep emitting `(0, x)()`: their bases are values, not References, so undefined is the correct receiver there.

Bumps the runtime transpiler cache version since cached minified output changes.

Tagged templates (`[o.f][0]` followed by a template literal) have the same receiver rule but need the `template_tag` tracking from #36735; that PR also bails this fold in tag position. Whichever lands first, the other rebases with a trivial conflict here and in the cache version.

## Verification

```
# fail-before (system bun 1.4.0)
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t "property access inlining"
  (fail) bails out when the index is a call/assignment target
    Expected: "x = [obj.m][0]()"  Received: "x = (0, obj.m)()"
  (fail) preserves runtime semantics when inlining from a literal index
    + "this arr dot: => false (want => true)" (and 4 more)
  6 pass, 2 fail

# pass-after
$ bun bd test test/bundler/transpiler/transpiler.test.js
  187 pass, 0 fail
```

Also green with the fix: `bundler_minify.test.ts` (42 pass), `esbuild/default.test.ts` (192 tests), `esbuild/dce.test.ts` (95 tests), `runtime-transpiler.test.ts` (15 pass), `transpiler-cache.test.ts` (11 pass). The repro above prints `array array array array true`, matching Node.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (2dfd467fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.65ms]
(pass) Bun.Transpiler > normalizes \r\n [6.25ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [12.51ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.72ms]
(pass) Bun.Transpiler > property access inlining > works [4.67ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.49ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [59.98ms]
76 |     transpiledOutput: code => {
77 |       return ts.parsed(code, false, false);
78 |     },
79 | 
80 |     expectPrintedMin_: (code, out) => {
81 |       expect(ts.parsedMin(code, !out.endsWith(";\n"), false)).toBe(out);
                                                                   ^
error: expect(received).toBe(ex
... (truncated)

release without fix: 3 failed, 22 skipped
bun test v1.4.0-canary.1 (0ffabf64d)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.15ms]
(pass) Bun.Transpiler > normalizes \r\n [0.22ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.13ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.23ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.06ms]
(pass) Bun.Transpiler > property access inlining > works [0.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.04ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.17ms]
76 |     transpiledOutput: code => {
77 |       return ts.parsed(code, false, false);
78 |     },
79 | 
80 |     expectPrintedMin_: (code, out) => {
81 |       expect(ts.parsedMin(code, !out.endsWith(";\n"), false)).toBe(out);
                                                                   ^
error: expect(received).toBe(expected)

Expected: "x = [obj.m][0]()"
Received: "x = (0, obj.m)()"

      at expectPrintedMin_ (/workspace/bun/test/bundler/transpiler/transpiler.test.js:81:63)
      at
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (2dfd467fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.94ms]
(pass) Bun.Transpiler > normalizes \r\n [9.52ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.42ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [11.20ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.72ms]
(pass) Bun.Transpiler > property access inlining > works [3.90ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.35ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [53.72ms]
(pass) Bun.Transpiler > property access inlining > bails out when the index is a call/assignment target [30.80ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [406.62ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index int
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2dfd467fc6
  features     baseline

22 deps, 106 codegen, 1175 objects in 1000ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 124 installs across 170 packages (no changes) [14.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 1 install across 2 packages (no changes) [12.00ms]
[5/1238] fetch picohttpparser
[picohttpparser] up to date
[6/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 129 installs across 147 packages (no changes) [15.00ms]
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] fetch zlib
[zlib] up to date
[11/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h fro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_expr.rs          | 14 ++++++------
 src/jsc/RuntimeTranspilerCache.rs          |  4 +++-
 test/bundler/transpiler/transpiler.test.js | 34 ++++++++++++++++++++++++------
 3 files changed, 36 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/visit/visit_expr.rs               5      1      0
src/jsc/RuntimeTranspilerCache.rs               1      1      0
test/bundler/transpiler/transpiler.test.js      1      3      0
```

</details>

<!-- robobun:evidence:end -->