### PR TITLE
tls: stop the event-loop spin when a handshake stalls on WANT_READ

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2032,7 +2032,19 @@ static void ssl_update_handshake(struct us_socket_t *s) {
     }
     s->ssl_handshake_state = HANDSHAKE_PENDING;
     s->ssl_write_wants_read = 1;
-    s->flags.last_write_failed = 1;
+    /* Only a blocked write justifies keeping writable interest armed. For
+     * WANT_READ no write failed — progress comes from the read side — and
+     * setting last_write_failed here kept EPOLLOUT / the EVFILT_WRITE
+     * one-shot re-armed on an always-writable socket: every tick re-entered
+     * this function with zero progress, spinning the loop at 100% CPU
+     * whenever writable interest existed while the handshake stalled
+     * (us_socket_pause arms writable, so pause() mid-handshake spun until
+     * resume). WANT_WRITE's blocked BIO write already set the flag inside
+     * us_socket_raw_write; keep this for the BIO retry paths that buffer
+     * without issuing a send. */
+    if (err == SSL_ERROR_WANT_WRITE) {
+      s->flags.last_write_failed = 1;
+    }
     return;
   }
 

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2032,16 +2032,12 @@ static void ssl_update_handshake(struct us_socket_t *s) {
     }
     s->ssl_handshake_state = HANDSHAKE_PENDING;
     s->ssl_write_wants_read = 1;
-    /* Only a blocked write justifies keeping writable interest armed. For
-     * WANT_READ no write failed — progress comes from the read side — and
-     * setting last_write_failed here kept EPOLLOUT / the EVFILT_WRITE
-     * one-shot re-armed on an always-writable socket: every tick re-entered
-     * this function with zero progress, spinning the loop at 100% CPU
-     * whenever writable interest existed while the handshake stalled
-     * (us_socket_pause arms writable, so pause() mid-handshake spun until
-     * resume). WANT_WRITE's blocked BIO write already set the flag inside
-     * us_socket_raw_write; keep this for the BIO retry paths that buffer
-     * without issuing a send. */
+    /* Keep writable interest only for a blocked write. Setting this for
+     * WANT_READ too kept the always-writable socket's writable event firing
+     * every tick with zero progress (100% CPU) whenever writable interest
+     * existed while the handshake stalled, e.g. pause() mid-handshake.
+     * WANT_WRITE's blocked BIO write normally sets it in us_socket_raw_write
+     * already; kept for BIO retry paths that buffer without a send. */
     if (err == SSL_ERROR_WANT_WRITE) {
       s->flags.last_write_failed = 1;
     }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -362,6 +362,13 @@ describe.concurrent("socket", () => {
     expect(await bunRun(fileURLToPath(new URL("./kqueue-filter-coalesce-fixture.ts", import.meta.url)))).toSpawn();
   });
 
+  // ssl_update_handshake set last_write_failed on SSL_ERROR_WANT_READ, so a
+  // paused (writable-armed) socket with a stalled handshake re-fired writable
+  // every tick at 100% CPU until the peer's handshake bytes arrived.
+  it("paused TLS socket with a stalled handshake must not spin the event loop", async () => {
+    expect(await bunRun(fileURLToPath(new URL("./tls-handshake-pause-spin-fixture.ts", import.meta.url)))).toSpawn();
+  });
+
   it("reload() should preserve active_connections (no UAF / counter underflow)", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), fileURLToPath(new URL("./socket-reload-fixture.ts", import.meta.url))],

--- a/test/js/bun/net/tls-handshake-pause-spin-fixture.ts
+++ b/test/js/bun/net/tls-handshake-pause-spin-fixture.ts
@@ -1,0 +1,42 @@
+// A paused mid-handshake TLS socket must not spin the event loop.
+//
+// ssl_update_handshake used to set last_write_failed on SSL_ERROR_WANT_READ,
+// so any writable interest on a socket whose handshake stalled (pause() arms
+// writable) re-fired every tick: writable -> SSL_do_handshake -> WANT_READ ->
+// keep writable armed -> immediately writable again, at 100% CPU until the
+// peer's handshake bytes arrived. With reads paused they never do.
+//
+// The server here is plain TCP and never sends a ServerHello, so the client
+// handshake stays pending; pause() in open() then holds the stall window.
+
+using server = Bun.listen({
+  hostname: "127.0.0.1",
+  port: 0,
+  socket: { open() {}, data() {}, end() {}, error() {}, close() {} },
+});
+
+const client = await Bun.connect({
+  hostname: "127.0.0.1",
+  port: server.port,
+  tls: { rejectUnauthorized: false },
+  socket: { open(s) { s.pause(); }, handshake() {}, data() {}, end() {}, error() {}, close() {} },
+});
+
+// Let the pause-time writable event and handshake kick settle first.
+await Bun.sleep(100);
+
+const before = process.cpuUsage();
+await Bun.sleep(2000);
+const delta = process.cpuUsage(before);
+const cpuMs = (delta.user + delta.system) / 1000;
+
+console.log(`cpu over 2000ms stall window: ${Math.round(cpuMs)}ms`);
+client.terminate();
+
+// Spinning burns roughly the whole window; a quiet loop stays far below this
+// even under debug+ASAN on a loaded CI machine.
+if (cpuMs > 800) {
+  console.error(`SPIN: ${Math.round(cpuMs)}ms CPU while a paused TLS handshake idled`);
+  process.exit(1);
+}
+process.exit(0);

--- a/test/js/bun/net/tls-handshake-pause-spin-fixture.ts
+++ b/test/js/bun/net/tls-handshake-pause-spin-fixture.ts
@@ -15,15 +15,41 @@ using server = Bun.listen({
   socket: { open() {}, data() {}, end() {}, error() {}, close() {} },
 });
 
+// Any of these firing means the stall precondition broke and the CPU check
+// below would be measuring the wrong state.
+let preconditionFailure: string | undefined;
+const opened = Promise.withResolvers<void>();
+
 const client = await Bun.connect({
   hostname: "127.0.0.1",
   port: server.port,
   tls: { rejectUnauthorized: false },
-  socket: { open(s) { s.pause(); }, handshake() {}, data() {}, end() {}, error() {}, close() {} },
+  socket: {
+    open(s) {
+      s.pause();
+      opened.resolve();
+    },
+    handshake() {
+      preconditionFailure ??= "handshake completed";
+    },
+    data() {},
+    end() {
+      preconditionFailure ??= "socket ended";
+    },
+    error(_s, err) {
+      preconditionFailure ??= `socket error: ${err}`;
+    },
+    close() {
+      preconditionFailure ??= "socket closed";
+    },
+  },
 });
 
-// Let the pause-time writable event and handshake kick settle first.
-await Bun.sleep(100);
+// Wait for open (where pause() armed writable), then yield one macrotask so
+// the pause-time writable dispatch and handshake kick land outside the
+// measurement window.
+await opened.promise;
+await Bun.sleep(0);
 
 const before = process.cpuUsage();
 await Bun.sleep(2000);
@@ -31,7 +57,13 @@ const delta = process.cpuUsage(before);
 const cpuMs = (delta.user + delta.system) / 1000;
 
 console.log(`cpu over 2000ms stall window: ${Math.round(cpuMs)}ms`);
+const failure = preconditionFailure;
 client.terminate();
+
+if (failure) {
+  console.error(`TLS stall precondition failed: ${failure}`);
+  process.exit(1);
+}
 
 // Spinning burns roughly the whole window; a quiet loop stays far below this
 // even under debug+ASAN on a loaded CI machine.


### PR DESCRIPTION
### What

A TLS socket whose handshake is stalled on `SSL_ERROR_WANT_READ` spins the event loop at 100% CPU whenever writable interest is armed. `pause()` before the handshake finishes is the unbounded case (writable is armed by pause and the ServerHello can never be consumed), measured at 2798ms CPU over a 2s idle window; a peer that stalls its next flight behind one blocked server write gets the bounded-but-renewable variant until the idle timeout.

### Why

`ssl_update_handshake` set `s->flags.last_write_failed = 1` for both `SSL_ERROR_WANT_READ` and `SSL_ERROR_WANT_WRITE`. The flag means "the last write would have blocked", and the writable dispatch (loop.c) uses it to keep EPOLLOUT / the kqueue `EVFILT_WRITE` one-shot armed. For WANT_READ no write failed, so the socket is immediately writable again: writable event, `SSL_do_handshake`, WANT_READ, re-arm, forever.

WANT_WRITE keeps the flag (its blocked BIO write normally sets it itself inside `us_socket_raw_write`).

### Fix

Set `last_write_failed` only for `SSL_ERROR_WANT_WRITE` (packages/bun-usockets/src/crypto/openssl.c, `ssl_update_handshake`).

### Verification

New fixture `test/js/bun/net/tls-handshake-pause-spin-fixture.ts` (plain TCP server that never sends a ServerHello, TLS client pauses in `open()`, CPU measured over a 2s window): fails on current bun with `SPIN: 2798ms`, passes with this change.

`test/js/node/tls/node-tls-connect.test.ts` (53 tests) passes; `socket.test.ts` / `tcp-server.test.ts` show only the failures already present on main in this environment.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->