### PR TITLE
Deliver FIFO bodies whose writer connects after the reader opens

### DIFF
--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -202,6 +202,8 @@ pub enum Tag {
     CronJob,
     GcRepeating,
     QuicEndpoint,
+    FileResponseStreamFifoProbe,
+    FileReaderFifoProbe,
 }
 
 impl Tag {
@@ -214,6 +216,8 @@ impl Tag {
             | Tag::GcRepeating // internal GC pacing
             | Tag::QuicEndpoint
             | Tag::DnsSdConnection // internal lookup pacing
+            | Tag::FileResponseStreamFifoProbe // internal io pacing
+            | Tag::FileReaderFifoProbe // internal io pacing
             => false,
             _ => true,
         }

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -157,6 +157,13 @@ bitflags::bitflags! {
         const USE_PREAD                = 1 << 8;
         const IS_PAUSED                = 1 << 9;
         const KEEP_ALIVE               = 1 << 10; // default true
+        /// macOS: the fd is a named FIFO opened by path before any writer
+        /// connected. In that state `read()` returns 0 even though no writer
+        /// has come and gone, so a 0-byte read must be treated as not-ready
+        /// rather than EOF until the first writer is observed (an EAGAIN or
+        /// data clears this flag). Owners arm a recovery timer as the wake
+        /// source while this is set; see `retry_stalled_fifo_read`.
+        const FIFO_AWAITING_FIRST_WRITER = 1 << 11;
     }
 }
 
@@ -542,19 +549,24 @@ impl PosixBufferedReader {
     }
 
     /// macOS recovery tick for reading a named FIFO that may not have a
-    /// writer yet. An `EVFILT_READ` knote attached to a FIFO read end while
-    /// the FIFO has zero writers never fires — not even after a writer
-    /// connects and writes — so a reader that registered its kevent before
-    /// the first writer arrived waits forever. (A knote attached while a
-    /// writer exists, or while data/EOF is pending, works.)
+    /// writer yet. Two platform quirks make the descriptor useless for
+    /// waiting in that state:
     ///
-    /// Owners that opened a FIFO by path arm a repeating timer against this
-    /// method until the first byte or EOF is observed. Each tick deletes the
-    /// (possibly dead) kevent registration and reads directly: any bytes the
-    /// poll failed to report are consumed, and the EAGAIN path re-attaches a
-    /// fresh kevent. Once data or EOF has been seen, a writer has existed,
-    /// so every later registration attaches in a reliable state and the
-    /// owner stops the timer.
+    /// - `read()` returns 0 while the FIFO has never had a writer, which is
+    ///   indistinguishable from EOF at the call site;
+    ///   [`PosixFlags::FIFO_AWAITING_FIRST_WRITER`] makes the read loop
+    ///   treat it as not-ready instead (the first EAGAIN or data clears it,
+    ///   since either proves a writer connected).
+    /// - an `EVFILT_READ` filter registered while the FIFO has zero writers
+    ///   does not reliably report the first writer's data (one registered
+    ///   while a writer exists works).
+    ///
+    /// So while waiting for the first writer there is no kernel event to
+    /// wait on, and owners arm a repeating timer against this method
+    /// instead. Each tick drops the kevent registration and reads directly;
+    /// once a writer exists the read comes back as data or EAGAIN, and the
+    /// EAGAIN path re-attaches a fresh kevent in a state where it works.
+    /// Owners stop the timer at the first chunk/EOF.
     ///
     /// # Safety
     /// Same contract as [`Self::read`]: `this` is the live reader; the
@@ -1066,6 +1078,36 @@ impl PosixBufferedReader {
 
                     match sys_fn(fd, buf, offset) {
                         sys::Result::Ok(bytes_read) => {
+                            #[cfg(target_os = "macos")]
+                            {
+                                // SAFETY: caller contract; borrows end at `;`.
+                                let awaiting_first_writer = unsafe {
+                                    !(*this).flags.contains(PosixFlags::IS_DONE)
+                                        && (*this)
+                                            .flags
+                                            .contains(PosixFlags::FIFO_AWAITING_FIRST_WRITER)
+                                };
+                                if awaiting_first_writer {
+                                    if bytes_read == 0 {
+                                        // A FIFO with no writer yet reads as
+                                        // 0 on macOS even though it is not at
+                                        // EOF (see the flag's doc). Not ready
+                                        // — stop without closing; the owner's
+                                        // probe timer retries. No bytes can
+                                        // be buffered: data clears the flag.
+                                        debug_assert!(head_start == 0);
+                                        return;
+                                    }
+                                    // First bytes: a writer exists, so a
+                                    // 0-byte read from here on is a real EOF.
+                                    // SAFETY: caller contract; borrow ends at `;`.
+                                    unsafe {
+                                        (*this)
+                                            .flags
+                                            .remove(PosixFlags::FIFO_AWAITING_FIRST_WRITER);
+                                    }
+                                }
+                            }
                             // SAFETY: caller contract; borrow scoped to the call.
                             let over_budget =
                                 Self::charge_max_buffer(unsafe { &mut *this }, bytes_read);
@@ -1131,6 +1173,17 @@ impl PosixBufferedReader {
                         }
                         sys::Result::Err(err) => {
                             if err.is_retry() {
+                                // EAGAIN from a FIFO means a writer exists
+                                // now (macOS reads 0, not EAGAIN, while the
+                                // FIFO has never had one), so from here on a
+                                // 0-byte read is a real EOF and the kevent
+                                // about to be registered attaches in a
+                                // working state.
+                                #[cfg(target_os = "macos")]
+                                // SAFETY: caller contract; borrow ends at `;`.
+                                unsafe {
+                                    (*this).flags.remove(PosixFlags::FIFO_AWAITING_FIRST_WRITER);
+                                }
                                 if file_type == FileType::File {
                                     bun_core::debug_warn!(
                                         "Received EAGAIN while reading from a file. This is a bug.",

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -541,6 +541,42 @@ impl PosixBufferedReader {
         }
     }
 
+    /// macOS recovery tick for reading a named FIFO that may not have a
+    /// writer yet. An `EVFILT_READ` knote attached to a FIFO read end while
+    /// the FIFO has zero writers never fires — not even after a writer
+    /// connects and writes — so a reader that registered its kevent before
+    /// the first writer arrived waits forever. (A knote attached while a
+    /// writer exists, or while data/EOF is pending, works.)
+    ///
+    /// Owners that opened a FIFO by path arm a repeating timer against this
+    /// method until the first byte or EOF is observed. Each tick deletes the
+    /// (possibly dead) kevent registration and reads directly: any bytes the
+    /// poll failed to report are consumed, and the EAGAIN path re-attaches a
+    /// fresh kevent. Once data or EOF has been seen, a writer has existed,
+    /// so every later registration attaches in a reliable state and the
+    /// owner stops the timer.
+    ///
+    /// # Safety
+    /// Same contract as [`Self::read`]: `this` is the live reader; the
+    /// chunk/done/error dispatches it reaches may re-enter or free the
+    /// parent, so the read runs in tail position.
+    #[cfg(target_os = "macos")]
+    pub unsafe fn retry_stalled_fifo_read(this: *mut Self) {
+        // SAFETY: caller contract; borrow ends at `;`.
+        let skip = unsafe { (*this).flags.contains(PosixFlags::IS_PAUSED) || (*this).is_done() };
+        if skip {
+            return;
+        }
+        // SAFETY: caller contract; pause/unpause only unregister the poll and
+        // flip flags — neither dispatches into the parent.
+        unsafe {
+            (*this).pause();
+            (*this).unpause();
+        }
+        // SAFETY: caller contract; tail position.
+        unsafe { Self::read(this) };
+    }
+
     /// # Safety
     /// `this` is the live reader. Raw (not `&mut self`) because
     /// `on_read_chunk` dispatched from the read loops re-enters JS, which can

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -548,25 +548,15 @@ impl PosixBufferedReader {
         }
     }
 
-    /// macOS recovery tick for reading a named FIFO that may not have a
-    /// writer yet. Two platform quirks make the descriptor useless for
-    /// waiting in that state:
-    ///
-    /// - `read()` returns 0 while the FIFO has never had a writer, which is
-    ///   indistinguishable from EOF at the call site;
-    ///   [`PosixFlags::FIFO_AWAITING_FIRST_WRITER`] makes the read loop
-    ///   treat it as not-ready instead (the first EAGAIN or data clears it,
-    ///   since either proves a writer connected).
-    /// - an `EVFILT_READ` filter registered while the FIFO has zero writers
-    ///   does not reliably report the first writer's data (one registered
-    ///   while a writer exists works).
-    ///
-    /// So while waiting for the first writer there is no kernel event to
-    /// wait on, and owners arm a repeating timer against this method
-    /// instead. Each tick drops the kevent registration and reads directly;
-    /// once a writer exists the read comes back as data or EAGAIN, and the
-    /// EAGAIN path re-attaches a fresh kevent in a state where it works.
-    /// Owners stop the timer at the first chunk/EOF.
+    /// macOS tick for reading a named FIFO still awaiting its first writer
+    /// (see [`PosixFlags::FIFO_AWAITING_FIRST_WRITER`]). That state has no
+    /// kernel event to wait on: `read()` reports a false EOF and an
+    /// `EVFILT_READ` filter registered with zero writers does not reliably
+    /// report the first writer's data, so owners drive this from a repeating
+    /// timer instead. Each tick drops the kevent registration and reads
+    /// directly; once a writer exists, the EAGAIN path re-attaches a fresh
+    /// kevent in a state where it works, and owners stop the timer at the
+    /// first chunk/EOF.
     ///
     /// # Safety
     /// Same contract as [`Self::read`]: `this` is the live reader; the
@@ -1089,17 +1079,13 @@ impl PosixBufferedReader {
                                 };
                                 if awaiting_first_writer {
                                     if bytes_read == 0 {
-                                        // A FIFO with no writer yet reads as
-                                        // 0 on macOS even though it is not at
-                                        // EOF (see the flag's doc). Not ready
-                                        // — stop without closing; the owner's
-                                        // probe timer retries. No bytes can
-                                        // be buffered: data clears the flag.
+                                        // False EOF (see the flag's doc);
+                                        // the owner's probe timer retries.
                                         debug_assert!(head_start == 0);
                                         return;
                                     }
-                                    // First bytes: a writer exists, so a
-                                    // 0-byte read from here on is a real EOF.
+                                    // Data: a writer connected; 0 now means
+                                    // a real EOF.
                                     // SAFETY: caller contract; borrow ends at `;`.
                                     unsafe {
                                         (*this)
@@ -1173,12 +1159,8 @@ impl PosixBufferedReader {
                         }
                         sys::Result::Err(err) => {
                             if err.is_retry() {
-                                // EAGAIN from a FIFO means a writer exists
-                                // now (macOS reads 0, not EAGAIN, while the
-                                // FIFO has never had one), so from here on a
-                                // 0-byte read is a real EOF and the kevent
-                                // about to be registered attaches in a
-                                // working state.
+                                // EAGAIN: a writer connected (see the flag's
+                                // doc); 0 now means a real EOF.
                                 #[cfg(target_os = "macos")]
                                 // SAFETY: caller contract; borrow ends at `;`.
                                 unsafe {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1206,6 +1206,36 @@ pub(crate) unsafe fn __bun_fire_timer(t: *mut EventLoopTimer, now: *const ElTime
                 owner!(crate::node::quic::QuicEndpoint, event_loop_timer);
             crate::node::quic::QuicEndpoint::on_timer_fire(c);
         }
+        EventLoopTimerTag::FileResponseStreamFifoProbe => {
+            #[cfg(target_os = "macos")]
+            {
+                use crate::server::file_response_stream::FileResponseStream;
+                timer_arm!(FileResponseStream, fifo_probe_timer, |c, _now, _vm| {
+                    FileResponseStream::on_fifo_probe(c)
+                })
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                if cfg!(debug_assertions) {
+                    unreachable!("FileResponseStream FIFO probe timer on non-macOS");
+                }
+            }
+        }
+        EventLoopTimerTag::FileReaderFifoProbe => {
+            #[cfg(target_os = "macos")]
+            {
+                use crate::webcore::FileReader;
+                timer_arm!(FileReader, fifo_probe_timer, |c, _now, _vm| {
+                    FileReader::on_fifo_probe(c)
+                })
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                if cfg!(debug_assertions) {
+                    unreachable!("FileReader FIFO probe timer on non-macOS");
+                }
+            }
+        }
     }
 }
 

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -266,6 +266,7 @@ impl DirectoryRoute {
             vm: bun_ptr::BackRef::new(server.vm()),
             file_type: FileType::File,
             pollable: false,
+            fifo_from_path: false,
             offset: body_offset,
             length: Some(body_len),
             idle_timeout: server.config().idle_timeout,

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -265,6 +265,13 @@ impl FileResponseStream {
         // hold a ref for the in-flight read; released in on_reader_done/on_reader_error
         this_ref.hold_read_ref();
         if opts.fifo_from_path {
+            // Must precede the eager read below: without it, the 0-byte read
+            // a writerless FIFO produces on macOS would end the response.
+            #[cfg(target_os = "macos")]
+            this_ref
+                .reader_mut()
+                .flags
+                .insert(ReaderFlags::FIFO_AWAITING_FIRST_WRITER);
             this_ref.arm_fifo_probe();
         }
         // SAFETY: `reader` is live for the stream's lifetime; `read` is the
@@ -394,18 +401,17 @@ impl FileResponseStream {
         Some(unsafe { bun_ptr::ScopedRef::<Self>::adopt(self.as_ptr()) })
     }
 
-    // ───────────────── macOS FIFO poll liveness probe ─────────────────
-    // A kqueue `EVFILT_READ` knote attached to a FIFO read end while the FIFO
-    // has zero writers never fires, even after a writer connects and writes
-    // (one attached while a writer exists works). A fetch handler returning
-    // `Response(Bun.file(fifo))` opens the read end itself, so when the
-    // producer connects only after the request, the poll registered in
-    // `start()` is dead and the response would sit silent until idleTimeout.
-    // While waiting for the first byte we tick
-    // `BufferedReader::retry_stalled_fifo_read` on a backoff timer: each tick
-    // re-creates the kevent and reads directly, so progress does not depend
-    // on the dead knote. The probe stops at the first chunk/EOF — from then
-    // on every registration happens after a writer existed and is reliable.
+    // ───────────────── macOS FIFO first-writer probe ─────────────────
+    // A fetch handler returning `Response(Bun.file(fifo))` opens the FIFO's
+    // read end itself, so when the producer connects only after the request,
+    // the reader starts against a FIFO with zero writers. On macOS that state
+    // cannot be waited on through the descriptor: `read()` returns 0 (which
+    // `FIFO_AWAITING_FIRST_WRITER` stops us from mistaking for EOF), and a
+    // kqueue filter registered then does not reliably report the first
+    // writer's data. Until the first byte we tick
+    // `BufferedReader::retry_stalled_fifo_read` on a backoff timer; see its
+    // doc for the full story. The probe stops at the first chunk/EOF — from
+    // then on the descriptor behaves and kqueue registrations work.
 
     #[cfg(target_os = "macos")]
     const FIFO_PROBE_MIN_MS: u32 = 2;

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -776,9 +776,23 @@ bun_io::impl_buffered_reader_parent! {
 impl Drop for FileResponseStream {
     fn drop(&mut self) {
         bun_output::scoped_log!(FileResponseStream, "deinit");
-        // `self.reader` (BufferedReader) is torn down by its own `Drop` as a
-        // field — closes the poll handle. `bun.destroy(this)` is owned by
-        // `heap::take` in `deref`, not here.
+        #[cfg(not(windows))]
+        {
+            // We cleared CLOSE_HANDLE in start(), so the reader's own Drop
+            // will not tear down the FilePoll. Do it explicitly (without
+            // closing the fd — `auto_close` below owns that), while the fd is
+            // still open so the kernel deregistration works: this unregisters
+            // the poll and returns it to the pool, so an event for it that
+            // the loop already fetched is ignored instead of dispatched into
+            // freed memory, and the poll slot is not leaked.
+            let reader = self.reader_mut();
+            if matches!(reader.handle, bun_io::pipes::PollOrFd::Poll(_)) {
+                reader
+                    .handle
+                    .close_impl(None, None::<fn(*mut c_void)>, false);
+            }
+        }
+        // `bun.destroy(this)` is owned by `heap::take` in `deref`, not here.
         if self.auto_close.get() {
             #[cfg(windows)]
             Closer::close(self.fd.get(), bun_sys::windows::libuv::Loop::get());

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -702,7 +702,11 @@ impl FileResponseStream {
         // Abort/timeout can land while the reader is still waiting for its
         // first byte (e.g. a FIFO with no writer), before any of the
         // dispatches that normally adopt the in-flight read ref have run.
-        // Release it here or the stream (and its fd) never drops.
+        // Release it here or the stream (and its fd) never drops. POSIX only:
+        // on Windows a pending uv read still points at the reader, and its
+        // completion dispatch both needs the stream alive and releases the
+        // ref itself.
+        #[cfg(unix)]
         drop(self.take_read_ref());
         if self.state.get().contains(State::FINISHED) {
             return;

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -11,6 +11,8 @@
 use core::cell::Cell;
 use core::ffi::c_void;
 
+#[cfg(target_os = "macos")]
+use bun_core::{Timespec, TimespecMockMode};
 use bun_io::Closer;
 #[cfg(windows)]
 use bun_io::pipe_reader::WindowsFlags as ReaderFlags;
@@ -22,6 +24,8 @@ use bun_sys::{self as sys, Fd};
 use bun_uws::{AnyResponse, WriteResult};
 
 use crate::server::jsc::{EventLoopHandle, Task, VirtualMachine};
+#[cfg(target_os = "macos")]
+use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 
 bun_output::declare_scope!(FileResponseStream, hidden);
 
@@ -50,6 +54,15 @@ pub(crate) struct FileResponseStream {
     sendfile: JsCell<Sendfile>,
 
     state: Cell<State>,
+
+    /// See `arm_fifo_probe`. `JsCell` so the timer heap's interior pointer
+    /// has write provenance through `as_ptr()` under the `&self` discipline.
+    /// `pub(crate)` for the `offset_of!` in the timer dispatch.
+    #[cfg(target_os = "macos")]
+    pub(crate) fifo_probe_timer: JsCell<EventLoopTimer>,
+    /// 0 = never armed; otherwise the current backoff interval in ms.
+    #[cfg(target_os = "macos")]
+    fifo_probe_interval_ms: Cell<u32>,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, strum::IntoStaticStr)]
@@ -105,6 +118,10 @@ pub(crate) struct StartOptions {
     pub vm: bun_ptr::BackRef<VirtualMachine>,
     pub file_type: FileType,
     pub pollable: bool,
+    /// `fd` is a named FIFO the caller just opened by path, so it may have no
+    /// writer yet. On macOS that makes the kqueue registration unreliable;
+    /// see `arm_fifo_probe`.
+    pub fifo_from_path: bool,
     /// Byte offset into the file to begin reading from.
     pub offset: u64,
     /// Maximum bytes to send; `None` reads to EOF. For regular files this
@@ -149,6 +166,12 @@ impl FileResponseStream {
                 max_size: Cell::new(None),
                 sendfile: JsCell::new(Sendfile::default()),
                 state: Cell::new(State::default()),
+                #[cfg(target_os = "macos")]
+                fifo_probe_timer: JsCell::new(EventLoopTimer::init_paused(
+                    EventLoopTimerTag::FileResponseStreamFifoProbe,
+                )),
+                #[cfg(target_os = "macos")]
+                fifo_probe_interval_ms: Cell::new(0),
             }));
         // SAFETY: `this` is the live allocation above; the guard's ref defers
         // any free until after `this_ref` is dead at the end of this frame.
@@ -241,6 +264,9 @@ impl FileResponseStream {
 
         // hold a ref for the in-flight read; released in on_reader_done/on_reader_error
         this_ref.hold_read_ref();
+        if opts.fifo_from_path {
+            this_ref.arm_fifo_probe();
+        }
         // SAFETY: `reader` is live for the stream's lifetime; `read` is the
         // raw re-entrancy-safe entry (its dispatch runs user JS).
         unsafe { BufferedReader::read(this_ref.reader.as_ptr()) };
@@ -269,6 +295,9 @@ impl FileResponseStream {
     }
 
     fn on_read_chunk(&self, chunk_: &[u8], state_: ReadState) -> bool {
+        // First bytes arrived: the pipe demonstrably has (or had) a writer, so
+        // poll registrations are reliable from here on.
+        self.cancel_fifo_probe();
         if self.state.get().contains(State::RESPONSE_DONE) {
             return false;
         }
@@ -363,6 +392,142 @@ impl FileResponseStream {
         // SAFETY: `self` is the live intrusive allocation; `READ_REF_HELD`
         // witnesses exactly one outstanding ref taken in `hold_read_ref`.
         Some(unsafe { bun_ptr::ScopedRef::<Self>::adopt(self.as_ptr()) })
+    }
+
+    // ───────────────── macOS FIFO poll liveness probe ─────────────────
+    // A kqueue `EVFILT_READ` knote attached to a FIFO read end while the FIFO
+    // has zero writers never fires, even after a writer connects and writes
+    // (one attached while a writer exists works). A fetch handler returning
+    // `Response(Bun.file(fifo))` opens the read end itself, so when the
+    // producer connects only after the request, the poll registered in
+    // `start()` is dead and the response would sit silent until idleTimeout.
+    // While waiting for the first byte we tick
+    // `BufferedReader::retry_stalled_fifo_read` on a backoff timer: each tick
+    // re-creates the kevent and reads directly, so progress does not depend
+    // on the dead knote. The probe stops at the first chunk/EOF — from then
+    // on every registration happens after a writer existed and is reliable.
+
+    #[cfg(target_os = "macos")]
+    const FIFO_PROBE_MIN_MS: u32 = 2;
+    #[cfg(target_os = "macos")]
+    const FIFO_PROBE_MAX_MS: u32 = 64;
+
+    /// Holds one ref while the timer is armed; released when the probe stops
+    /// (`cancel_fifo_probe`, or `on_fifo_probe` deciding not to re-arm).
+    #[cfg(target_os = "macos")]
+    fn arm_fifo_probe(&self) {
+        let timer_all = crate::jsc_hooks::timer_all();
+        if timer_all.is_null() {
+            return;
+        }
+        self.fifo_probe_interval_ms.set(Self::FIFO_PROBE_MIN_MS);
+        self.ref_();
+        // SAFETY: single-threaded event loop; `timer_all` is the live
+        // per-thread heap, and the timer node lives inside `self`, which the
+        // ref above keeps alive while armed.
+        unsafe {
+            (*timer_all).update(
+                self.fifo_probe_timer.as_ptr(),
+                &Timespec::ms_from_now(
+                    TimespecMockMode::ForceRealTime,
+                    i64::from(Self::FIFO_PROBE_MIN_MS),
+                ),
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[inline]
+    fn arm_fifo_probe(&self) {}
+
+    #[cfg(target_os = "macos")]
+    fn cancel_fifo_probe(&self) {
+        if self.fifo_probe_interval_ms.get() == 0 {
+            return; // never armed
+        }
+        let t = self.fifo_probe_timer.as_ptr();
+        // SAFETY: `t` is the embedded timer node; single-threaded event loop.
+        if unsafe { (*t).state } == EventLoopTimerState::ACTIVE {
+            let timer_all = crate::jsc_hooks::timer_all();
+            if !timer_all.is_null() {
+                // SAFETY: as in `arm_fifo_probe`. `remove` marks it CANCELLED.
+                unsafe { (*timer_all).remove(t) };
+            }
+            // Release the ref held while armed. Every path here (chunk
+            // dispatch, finish entry points) holds its own ref, so this is
+            // never the last one while `self` is still on the stack.
+            // SAFETY: adopting the single outstanding armed ref.
+            drop(unsafe { bun_ptr::ScopedRef::<Self>::adopt(self.as_ptr()) });
+            return;
+        }
+        // Probe is mid-fire (state FIRED): tell it not to re-arm. It owns the
+        // armed ref and releases it when it returns.
+        // SAFETY: as above.
+        unsafe { (*t).state = EventLoopTimerState::CANCELLED };
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[inline]
+    fn cancel_fifo_probe(&self) {}
+
+    /// Timer dispatch target (`EventLoopTimerTag::FileResponseStreamFifoProbe`).
+    ///
+    /// # Safety
+    /// `this` is the live stream recovered from its embedded timer node, on
+    /// the event-loop thread, with the armed ref outstanding.
+    #[cfg(target_os = "macos")]
+    pub(crate) unsafe fn on_fifo_probe(this: *mut Self) {
+        // SAFETY: caller contract — adopt the armed ref so `*this` outlives
+        // the read dispatch below.
+        let _guard = unsafe { bun_ptr::ScopedRef::<Self>::adopt(this) };
+        // SAFETY: `this` is live; standard fired-timer bookkeeping before any
+        // re-arm decision.
+        let timer = unsafe {
+            let t = (*this).fifo_probe_timer.as_ptr();
+            (*t).state = EventLoopTimerState::FIRED;
+            (*t).heap = Default::default();
+            t
+        };
+
+        // SAFETY: `this` is live; `Cell` read.
+        let finished = unsafe {
+            (*this)
+                .state
+                .get()
+                .intersects(State::RESPONSE_DONE | State::FINISHED)
+        };
+        if !finished {
+            // SAFETY: the reader cell is live for the stream's lifetime; the
+            // chunk/done dispatches this reaches re-enter `*this` through the
+            // vtable arms, which take their own refs.
+            unsafe { BufferedReader::retry_stalled_fifo_read((*this).reader.as_ptr()) };
+        }
+
+        // SAFETY: `this` is still live (guard). The read above may have
+        // delivered the first chunk (which marks the timer CANCELLED) or
+        // completed the response; only re-arm if neither happened.
+        unsafe {
+            if (*timer).state == EventLoopTimerState::CANCELLED
+                || (*this)
+                    .state
+                    .get()
+                    .intersects(State::RESPONSE_DONE | State::FINISHED)
+            {
+                return;
+            }
+            let timer_all = crate::jsc_hooks::timer_all();
+            if timer_all.is_null() {
+                return;
+            }
+            let next = ((*this).fifo_probe_interval_ms.get() * 2).min(Self::FIFO_PROBE_MAX_MS);
+            (*this).fifo_probe_interval_ms.set(next);
+            // Still waiting: keep the probe armed with a fresh ref.
+            (*this).ref_();
+            (*timer_all).update(
+                timer,
+                &Timespec::ms_from_now(TimespecMockMode::ForceRealTime, i64::from(next)),
+            );
+        }
     }
 
     fn on_writable(&self, _: u64, _: AnyResponse) -> bool {
@@ -532,6 +697,7 @@ impl FileResponseStream {
             "finish (already={})",
             self.state.get().contains(State::FINISHED)
         );
+        self.cancel_fifo_probe();
         if self.state.get().contains(State::FINISHED) {
             return;
         }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -699,6 +699,11 @@ impl FileResponseStream {
             self.state.get().contains(State::FINISHED)
         );
         self.cancel_fifo_probe();
+        // Abort/timeout can land while the reader is still waiting for its
+        // first byte (e.g. a FIFO with no writer), before any of the
+        // dispatches that normally adopt the in-flight read ref have run.
+        // Release it here or the stream (and its fd) never drops.
+        drop(self.take_read_ref());
         if self.state.get().contains(State::FINISHED) {
             return;
         }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -402,16 +402,11 @@ impl FileResponseStream {
     }
 
     // ───────────────── macOS FIFO first-writer probe ─────────────────
-    // A fetch handler returning `Response(Bun.file(fifo))` opens the FIFO's
-    // read end itself, so when the producer connects only after the request,
-    // the reader starts against a FIFO with zero writers. On macOS that state
-    // cannot be waited on through the descriptor: `read()` returns 0 (which
-    // `FIFO_AWAITING_FIRST_WRITER` stops us from mistaking for EOF), and a
-    // kqueue filter registered then does not reliably report the first
-    // writer's data. Until the first byte we tick
-    // `BufferedReader::retry_stalled_fifo_read` on a backoff timer; see its
-    // doc for the full story. The probe stops at the first chunk/EOF — from
-    // then on the descriptor behaves and kqueue registrations work.
+    // A path-opened FIFO with no writer yet cannot be waited on through the
+    // descriptor on macOS (see `retry_stalled_fifo_read` and
+    // `FIFO_AWAITING_FIRST_WRITER` in bun_io), so until the first byte we
+    // tick that recovery read on a backoff timer; it stops at the first
+    // chunk/EOF.
 
     #[cfg(target_os = "macos")]
     const FIFO_PROBE_MIN_MS: u32 = 2;

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -373,11 +373,17 @@ impl FileRoute {
             }
         });
 
-        let (can_serve_file, size, file_type, pollable): (bool, u64, FileType, bool) = 'brk: {
+        let (can_serve_file, size, file_type, pollable, is_fifo): (
+            bool,
+            u64,
+            FileType,
+            bool,
+            bool,
+        ) = 'brk: {
             let stat = match bun_sys::fstat(fd) {
                 Ok(s) => s,
                 // file_type is never read because can_serve_file == false
-                Err(_) => break 'brk (false, 0, FileType::File, false),
+                Err(_) => break 'brk (false, 0, FileType::File, false, false),
             };
 
             let stat_size: u64 = u64::try_from(stat.st_size.max(0)).expect("int cast");
@@ -385,7 +391,7 @@ impl FileRoute {
 
             let mode = stat.st_mode as bun_sys::Mode;
             if bun_sys::S::ISDIR(mode) {
-                break 'brk (false, 0, FileType::File, false);
+                break 'brk (false, 0, FileType::File, false, false);
             }
 
             // `Cell::take` → mutate → `set`: single-threaded event loop, no
@@ -395,14 +401,14 @@ impl FileRoute {
             this.stat_hash.set(sh);
 
             if bun_sys::S::ISFIFO(mode) || bun_sys::S::ISCHR(mode) {
-                break 'brk (true, _size, FileType::Pipe, true);
+                break 'brk (true, _size, FileType::Pipe, true, bun_sys::S::ISFIFO(mode));
             }
 
             if bun_sys::S::ISSOCK(mode) {
-                break 'brk (true, _size, FileType::Socket, true);
+                break 'brk (true, _size, FileType::Socket, true, false);
             }
 
-            break 'brk (true, _size, FileType::File, false);
+            break 'brk (true, _size, FileType::File, false, false);
         };
 
         if !can_serve_file {
@@ -510,6 +516,8 @@ impl FileRoute {
             vm: bun_ptr::BackRef::new(this.server.get().unwrap().vm()),
             file_type,
             pollable,
+            // The fd was opened by path above.
+            fifo_from_path: is_fifo,
             offset: body_offset,
             length: body_len,
             idle_timeout: this.server.get().unwrap().config().idle_timeout,

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1954,6 +1954,8 @@ where
             vm: bun_ptr::BackRef::new(server.vm()),
             file_type,
             pollable,
+            // auto_close ⇔ we opened the path ourselves above.
+            fifo_from_path: auto_close && bun_sys::S::ISFIFO(mode),
             offset: sendfile.offset as u64,
             length: if is_regular {
                 Some(sendfile.remain as u64)

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -682,13 +682,9 @@ impl FileReader {
     }
 
     // ───────────────── macOS FIFO first-writer probe ─────────────────
-    // Twin of `FileResponseStream::arm_fifo_probe` (see the full story there
-    // and on `retry_stalled_fifo_read`): a FIFO with no writer yet cannot be
-    // waited on through the descriptor on macOS, so
-    // `Bun.file(fifo).stream()` started before the first writer connects
-    // would end empty or never deliver anything. While waiting for the first
-    // byte, tick `retry_stalled_fifo_read` on a backoff timer; stop at the
-    // first chunk/EOF.
+    // Twin of `FileResponseStream::arm_fifo_probe`; see
+    // `retry_stalled_fifo_read` and `FIFO_AWAITING_FIRST_WRITER` in bun_io
+    // for why a writerless FIFO needs a timer-driven read on macOS.
 
     #[cfg(target_os = "macos")]
     const FIFO_PROBE_MIN_MS: u32 = 2;

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -2,6 +2,8 @@ use core::cell::{Cell, UnsafeCell};
 use core::mem;
 
 use bun_collections::VecExt;
+#[cfg(target_os = "macos")]
+use bun_core::{Timespec, TimespecMockMode};
 #[cfg(unix)]
 use bun_io as aio;
 #[cfg(not(windows))]
@@ -10,6 +12,9 @@ use bun_io::{BufferedReader, ReadState};
 use bun_jsc::JsCell;
 use bun_ptr::AsCtxPtr;
 use bun_sys::{self as sys, Fd, FdExt};
+
+#[cfg(target_os = "macos")]
+use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 
 use crate::webcore::SinkHandle;
 use crate::webcore::blob;
@@ -71,6 +76,13 @@ pub struct FileReader {
     /// path; `pull_into_sink` is the drain-ack resume.
     pub(crate) sink: JsCell<SinkHandle>,
     pub(crate) sink_paused: Cell<bool>,
+    /// See `arm_fifo_probe`. `pub(crate)` for the `offset_of!` in the timer
+    /// dispatch.
+    #[cfg(target_os = "macos")]
+    pub(crate) fifo_probe_timer: JsCell<EventLoopTimer>,
+    /// 0 = never armed; otherwise the current backoff interval in ms.
+    #[cfg(target_os = "macos")]
+    pub(crate) fifo_probe_interval_ms: Cell<u32>,
 }
 
 impl Default for FileReader {
@@ -96,6 +108,12 @@ impl Default for FileReader {
             flowing: Cell::new(true),
             sink: JsCell::new(SinkHandle::None),
             sink_paused: Cell::new(false),
+            #[cfg(target_os = "macos")]
+            fifo_probe_timer: JsCell::new(EventLoopTimer::init_paused(
+                EventLoopTimerTag::FileReaderFifoProbe,
+            )),
+            #[cfg(target_os = "macos")]
+            fifo_probe_interval_ms: Cell::new(0),
         }
     }
 }
@@ -136,6 +154,10 @@ pub struct OpenedFileBlob {
     pub(crate) nonblocking: bool,
     #[cfg(not(windows))]
     pub(crate) file_type: FileType,
+    /// The fd is a named FIFO we opened by path, so it may have no writer
+    /// yet; see `FileReader::arm_fifo_probe`.
+    #[cfg(not(windows))]
+    pub(crate) fifo_from_path: bool,
 }
 
 impl Default for OpenedFileBlob {
@@ -146,6 +168,8 @@ impl Default for OpenedFileBlob {
             nonblocking: true,
             #[cfg(not(windows))]
             file_type: FileType::File,
+            #[cfg(not(windows))]
+            fifo_from_path: false,
         }
     }
 }
@@ -252,6 +276,8 @@ impl Lazy {
             this.pollable = (sys::S::ISFIFO(mode) || sys::S::ISSOCK(mode))
                 || is_nonblocking
                 || file.is_atty.unwrap_or(false);
+            this.fifo_from_path =
+                sys::S::ISFIFO(mode) && matches!(&file.pathlike, PathOrFileDescriptor::Path(_));
             this.file_type = if sys::S::ISFIFO(mode) {
                 FileType::Pipe
             } else if sys::S::ISSOCK(mode) {
@@ -334,6 +360,8 @@ impl FileReader {
         let mut pollable = false;
         #[cfg(unix)]
         let mut file_type = FileType::File;
+        #[cfg(unix)]
+        let mut fifo_from_path = false;
         // R-2: move the `Lazy` out of the cell up-front (it's reset to `None`
         // on every path through the original `if let` body) so the `StoreRef`
         // is owned locally and the cell borrow is released immediately.
@@ -361,6 +389,7 @@ impl FileReader {
                             #[cfg(unix)]
                             {
                                 file_type = opened.file_type;
+                                fifo_from_path = opened.fifo_from_path;
                             }
                             #[cfg(unix)]
                             {
@@ -515,6 +544,11 @@ impl FileReader {
             }
         }
 
+        #[cfg(unix)]
+        if fifo_from_path && !self.done.get() && !self.reader().is_done() {
+            self.arm_fifo_probe();
+        }
+
         streams::Start::Ready
     }
 
@@ -605,6 +639,7 @@ impl FileReader {
     }
 
     pub(crate) fn on_cancel(&self) {
+        self.cancel_fifo_probe();
         self.unpipe_without_deref();
         if self.done.get() {
             return;
@@ -640,7 +675,135 @@ impl FileReader {
         true
     }
 
+    // ───────────────── macOS FIFO poll liveness probe ─────────────────
+    // Twin of `FileResponseStream::arm_fifo_probe` (see the full story
+    // there): a kqueue `EVFILT_READ` knote attached to a FIFO read end with
+    // zero writers never fires, so `Bun.file(fifo).stream()` started before
+    // the first writer connects would never deliver anything. While waiting
+    // for the first byte, tick `retry_stalled_fifo_read` on a backoff timer;
+    // stop at the first chunk/EOF.
+
+    #[cfg(target_os = "macos")]
+    const FIFO_PROBE_MIN_MS: u32 = 2;
+    #[cfg(target_os = "macos")]
+    const FIFO_PROBE_MAX_MS: u32 = 64;
+
+    /// Holds one count on the parent `Source` while the timer is armed
+    /// (released when the probe stops).
+    #[cfg(target_os = "macos")]
+    fn arm_fifo_probe(&self) {
+        let timer_all = crate::jsc_hooks::timer_all();
+        if timer_all.is_null() {
+            return;
+        }
+        self.fifo_probe_interval_ms.set(Self::FIFO_PROBE_MIN_MS);
+        // SAFETY: see `parent()` — keeps the Source (and the timer node
+        // embedded in `self`) alive while the heap points into it.
+        unsafe { (*self.parent()).increment_count() };
+        // SAFETY: single-threaded event loop; `timer_all` is the live
+        // per-thread heap.
+        unsafe {
+            (*timer_all).update(
+                self.fifo_probe_timer.as_ptr(),
+                &Timespec::ms_from_now(
+                    TimespecMockMode::ForceRealTime,
+                    i64::from(Self::FIFO_PROBE_MIN_MS),
+                ),
+            );
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[inline]
+    fn arm_fifo_probe(&self) {}
+
+    #[cfg(target_os = "macos")]
+    fn cancel_fifo_probe(&self) {
+        if self.fifo_probe_interval_ms.get() == 0 {
+            return; // never armed
+        }
+        let t = self.fifo_probe_timer.as_ptr();
+        // SAFETY: `t` is the embedded timer node; single-threaded event loop.
+        if unsafe { (*t).state } == EventLoopTimerState::ACTIVE {
+            let timer_all = crate::jsc_hooks::timer_all();
+            if !timer_all.is_null() {
+                // SAFETY: as in `arm_fifo_probe`. `remove` marks it CANCELLED.
+                unsafe { (*timer_all).remove(t) };
+            }
+            let parent = self.parent();
+            // SAFETY: releases the count taken in `arm_fifo_probe`; callers
+            // (chunk/done/error dispatches, JS cancel) hold their own counts,
+            // so this does not free. `self` is not accessed after.
+            let _ = unsafe { Source::decrement_count(parent) };
+            return;
+        }
+        // Probe is mid-fire (state FIRED): tell it not to re-arm. It owns the
+        // armed count and releases it when it returns.
+        // SAFETY: as above.
+        unsafe { (*t).state = EventLoopTimerState::CANCELLED };
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[inline]
+    fn cancel_fifo_probe(&self) {}
+
+    /// Timer dispatch target (`EventLoopTimerTag::FileReaderFifoProbe`).
+    ///
+    /// # Safety
+    /// `this` is the live FileReader recovered from its embedded timer node,
+    /// on the event-loop thread, with the armed Source count outstanding.
+    #[cfg(target_os = "macos")]
+    pub(crate) unsafe fn on_fifo_probe(this: *mut Self) {
+        // SAFETY: `this` is live (armed count); standard fired-timer
+        // bookkeeping before any re-arm decision.
+        let timer = unsafe {
+            let t = (*this).fifo_probe_timer.as_ptr();
+            (*t).state = EventLoopTimerState::FIRED;
+            (*t).heap = Default::default();
+            t
+        };
+
+        // SAFETY: `this` is live; `Cell` reads / `reader()` accessor.
+        let waiting = unsafe { !(*this).done.get() && !(&*this).reader().is_done() };
+        if waiting {
+            // SAFETY: the reader cell is live for the Source's lifetime; the
+            // dispatches this reaches may run JS (deliver stream data,
+            // cancel); the armed count keeps `*this` alive through them.
+            unsafe { IOReader::retry_stalled_fifo_read((*this).reader.get()) };
+        }
+
+        // SAFETY: `this` is still live (armed count not released yet). The
+        // read may have delivered the first chunk (which marks the timer
+        // CANCELLED) or finished/cancelled the stream; re-arm only if not.
+        unsafe {
+            if (*timer).state != EventLoopTimerState::CANCELLED
+                && !(*this).done.get()
+                && !(&*this).reader().is_done()
+            {
+                let timer_all = crate::jsc_hooks::timer_all();
+                if !timer_all.is_null() {
+                    let next =
+                        ((*this).fifo_probe_interval_ms.get() * 2).min(Self::FIFO_PROBE_MAX_MS);
+                    (*this).fifo_probe_interval_ms.set(next);
+                    // Still waiting: keep the armed count for the new arming.
+                    (*timer_all).update(
+                        timer,
+                        &Timespec::ms_from_now(TimespecMockMode::ForceRealTime, i64::from(next)),
+                    );
+                    return;
+                }
+            }
+            // Probe stops: release the armed count. May free the Source —
+            // tail position, `this` is not accessed after.
+            let parent = (&*this).parent();
+            let _ = Source::decrement_count(parent);
+        }
+    }
+
     pub(crate) fn on_read_chunk(&self, init_buf: &[u8], state: ReadState) -> bool {
+        // First bytes arrived: the pipe demonstrably has (or had) a writer, so
+        // poll registrations are reliable from here on.
+        self.cancel_fifo_probe();
         let mut buf = init_buf;
         bun_core::scoped_log!(
             FileReader,
@@ -1120,6 +1283,7 @@ impl FileReader {
 
     pub(crate) fn on_reader_done(&self) {
         bun_core::scoped_log!(FileReader, "onReaderDone()");
+        self.cancel_fifo_probe();
         // Pin across `p.run()` and `on_close()`: both can run user JS, and the
         // `self.buffered` / `waiting_for_on_reader_done` reads below must not
         // land on a freed box. Same bracket as on_read_chunk / on_reader_error.
@@ -1173,6 +1337,7 @@ impl FileReader {
     }
 
     pub(crate) fn on_reader_error(&self, err: sys::Error) {
+        self.cancel_fifo_probe();
         self.consume_reader_buffer();
         if self.buffered.get().capacity() > 0 && self.buffered.get().is_empty() {
             self.buffered.set(Vec::new());

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -546,6 +546,12 @@ impl FileReader {
 
         #[cfg(unix)]
         if fifo_from_path && !self.done.get() && !self.reader().is_done() {
+            // Must precede any read: without it, the 0-byte read a writerless
+            // FIFO produces on macOS would end the stream.
+            #[cfg(target_os = "macos")]
+            self.reader()
+                .flags
+                .insert(bun_io::pipe_reader::PosixFlags::FIFO_AWAITING_FIRST_WRITER);
             self.arm_fifo_probe();
         }
 
@@ -675,13 +681,14 @@ impl FileReader {
         true
     }
 
-    // ───────────────── macOS FIFO poll liveness probe ─────────────────
-    // Twin of `FileResponseStream::arm_fifo_probe` (see the full story
-    // there): a kqueue `EVFILT_READ` knote attached to a FIFO read end with
-    // zero writers never fires, so `Bun.file(fifo).stream()` started before
-    // the first writer connects would never deliver anything. While waiting
-    // for the first byte, tick `retry_stalled_fifo_read` on a backoff timer;
-    // stop at the first chunk/EOF.
+    // ───────────────── macOS FIFO first-writer probe ─────────────────
+    // Twin of `FileResponseStream::arm_fifo_probe` (see the full story there
+    // and on `retry_stalled_fifo_read`): a FIFO with no writer yet cannot be
+    // waited on through the descriptor on macOS, so
+    // `Bun.file(fifo).stream()` started before the first writer connects
+    // would end empty or never deliver anything. While waiting for the first
+    // byte, tick `retry_stalled_fifo_read` on a backoff timer; stop at the
+    // first chunk/EOF.
 
     #[cfg(target_os = "macos")]
     const FIFO_PROBE_MIN_MS: u32 = 2;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7500,10 +7500,8 @@ pub fn read_nonblocking(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
             if rc < 0 {
                 let e = last_errno();
                 match e {
-                    // This fd's type does not support RWF_NOWAIT (named FIFOs
-                    // return EOPNOTSUPP). Per-fd, not per-kernel: do NOT
-                    // disable the flag globally, or one FIFO read degrades
-                    // every later pipe read in the process to the fallback.
+                    // Per-fd-type (named FIFOs), not per-kernel: a global
+                    // disable would degrade every later pipe read too.
                     libc::EOPNOTSUPP => break,
                     libc::ENOSYS | libc::EPERM | libc::EACCES => {
                         linux::RWFFlagSupport::disable();
@@ -7515,12 +7513,9 @@ pub fn read_nonblocking(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
             }
             return Ok(rc as usize);
         }
-        // Poll-then-read fallback. Plain read() is not a substitute for
-        // RWF_NOWAIT here for two reasons: a blocking fd would block the
-        // event loop, and a named FIFO opened before any writer returns 0
-        // (EOF) from read() even though poll — which honors the FIFO's
-        // writer-epoch — still reports not-ready until a writer has come
-        // and gone.
+        // Poll first: plain read() would block the event loop on a blocking
+        // fd, and misreport a FIFO that never had a writer as EOF (poll
+        // honors the FIFO's writer epoch; read does not).
         return match bun_core::is_readable(fd) {
             bun_core::Pollable::Ready | bun_core::Pollable::Hup => read(fd, buf),
             _ => Err(Error::retry().with_fd(fd)),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7485,67 +7485,88 @@ unsafe extern "C" {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const RWF_NOWAIT: u32 = 0x00000008;
 
-/// Linux: `preadv2(.., RWF_NOWAIT)`; else plain `read`.
+/// Linux: `preadv2(.., RWF_NOWAIT)`, with a poll-then-read fallback; else
+/// plain `read`.
 pub fn read_nonblocking(fd: Fd, buf: &mut [u8]) -> Maybe<usize> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    while linux::RWFFlagSupport::is_maybe_supported() {
-        let iov = [libc::iovec {
-            iov_base: buf.as_mut_ptr().cast(),
-            iov_len: buf.len(),
-        }];
-        // SAFETY: fd valid; iov points at a live stack array.
-        let rc = unsafe { sys_preadv2(fd.native(), iov.as_ptr(), 1, -1, RWF_NOWAIT) };
-        if rc < 0 {
-            let e = last_errno();
-            match e {
-                libc::EOPNOTSUPP | libc::ENOSYS | libc::EPERM | libc::EACCES => {
-                    linux::RWFFlagSupport::disable();
-                    // Only fall through to BLOCKING read if the fd is
-                    // actually readable now; otherwise return retry (EAGAIN).
-                    return match bun_core::is_readable(fd) {
-                        bun_core::Pollable::Ready | bun_core::Pollable::Hup => read(fd, buf),
-                        _ => Err(Error::retry().with_fd(fd)),
-                    };
+    {
+        while linux::RWFFlagSupport::is_maybe_supported() {
+            let iov = [libc::iovec {
+                iov_base: buf.as_mut_ptr().cast(),
+                iov_len: buf.len(),
+            }];
+            // SAFETY: fd valid; iov points at a live stack array.
+            let rc = unsafe { sys_preadv2(fd.native(), iov.as_ptr(), 1, -1, RWF_NOWAIT) };
+            if rc < 0 {
+                let e = last_errno();
+                match e {
+                    // This fd's type does not support RWF_NOWAIT (named FIFOs
+                    // return EOPNOTSUPP). Per-fd, not per-kernel: do NOT
+                    // disable the flag globally, or one FIFO read degrades
+                    // every later pipe read in the process to the fallback.
+                    libc::EOPNOTSUPP => break,
+                    libc::ENOSYS | libc::EPERM | libc::EACCES => {
+                        linux::RWFFlagSupport::disable();
+                        break;
+                    }
+                    libc::EINTR => continue,
+                    _ => return Err(Error::from_code_int(e, Tag::read).with_fd(fd)),
                 }
-                libc::EINTR => continue,
-                _ => return Err(Error::from_code_int(e, Tag::read).with_fd(fd)),
             }
+            return Ok(rc as usize);
         }
-        return Ok(rc as usize);
+        // Poll-then-read fallback. Plain read() is not a substitute for
+        // RWF_NOWAIT here for two reasons: a blocking fd would block the
+        // event loop, and a named FIFO opened before any writer returns 0
+        // (EOF) from read() even though poll — which honors the FIFO's
+        // writer-epoch — still reports not-ready until a writer has come
+        // and gone.
+        return match bun_core::is_readable(fd) {
+            bun_core::Pollable::Ready | bun_core::Pollable::Hup => read(fd, buf),
+            _ => Err(Error::retry().with_fd(fd)),
+        };
     }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     read(fd, buf)
 }
-/// Linux: `pwritev2(.., RWF_NOWAIT)`; else plain `write`.
+/// Linux: `pwritev2(.., RWF_NOWAIT)`, with a poll-then-write fallback; else
+/// plain `write`.
 pub fn write_nonblocking(fd: Fd, buf: &[u8]) -> Maybe<usize> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    while linux::RWFFlagSupport::is_maybe_supported() {
-        let iov = [libc::iovec {
-            iov_base: buf.as_ptr().cast_mut().cast::<_>(),
-            iov_len: buf.len(),
-        }];
-        // SAFETY: fd valid; iov points at a live stack array.
-        let rc = unsafe { sys_pwritev2(fd.native(), iov.as_ptr(), 1, -1, RWF_NOWAIT) };
-        if rc < 0 {
-            let e = last_errno();
-            match e {
-                libc::EOPNOTSUPP | libc::ENOSYS | libc::EPERM | libc::EACCES => {
-                    linux::RWFFlagSupport::disable();
-                    // Poll before issuing a blocking write.
-                    return match bun_core::is_writable(fd) {
-                        bun_core::Pollable::Ready | bun_core::Pollable::Hup => write(fd, buf),
-                        _ => {
-                            let mut e = Error::retry();
-                            e.syscall = Tag::write;
-                            Err(e.with_fd(fd))
-                        }
-                    };
+    {
+        while linux::RWFFlagSupport::is_maybe_supported() {
+            let iov = [libc::iovec {
+                iov_base: buf.as_ptr().cast_mut().cast::<_>(),
+                iov_len: buf.len(),
+            }];
+            // SAFETY: fd valid; iov points at a live stack array.
+            let rc = unsafe { sys_pwritev2(fd.native(), iov.as_ptr(), 1, -1, RWF_NOWAIT) };
+            if rc < 0 {
+                let e = last_errno();
+                match e {
+                    // Per-fd-type, not per-kernel; see `read_nonblocking`.
+                    libc::EOPNOTSUPP => break,
+                    libc::ENOSYS | libc::EPERM | libc::EACCES => {
+                        linux::RWFFlagSupport::disable();
+                        break;
+                    }
+                    libc::EINTR => continue,
+                    _ => return Err(Error::from_code_int(e, Tag::write).with_fd(fd)),
                 }
-                libc::EINTR => continue,
-                _ => return Err(Error::from_code_int(e, Tag::write).with_fd(fd)),
             }
+            return Ok(rc as usize);
         }
-        return Ok(rc as usize);
+        // Poll before issuing a possibly-blocking write.
+        return match bun_core::is_writable(fd) {
+            bun_core::Pollable::Ready | bun_core::Pollable::Hup => write(fd, buf),
+            _ => {
+                let mut e = Error::retry();
+                e.syscall = Tag::write;
+                Err(e.with_fd(fd))
+            }
+        };
     }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     write(fd, buf)
 }
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -2,7 +2,7 @@ import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows, rmScope, rss, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
-import { closeSync, openSync, unlinkSync, writeSync } from "node:fs";
+import { closeSync, openSync, readdirSync, unlinkSync, writeSync } from "node:fs";
 import { open } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -1441,3 +1441,64 @@ test.skipIf(isWindows)(
     }
   },
 );
+
+// Aborting (or idle-timing-out) a FIFO response that is still waiting for its
+// first writer must drop the stream and close its fd: the abort path is the
+// only terminal one for a FIFO whose producer never connects, and it used to
+// leave the in-flight read ref held forever, leaking the fd and poll.
+test.skipIf(isWindows)("aborted Response(Bun.file(FIFO)) with no writer releases its fd", async () => {
+  using dir = tempDir("serve-fifo-abort-leak", {});
+  const fifoPath = join(String(dir), "unwritten.fifo");
+  mkfifo(fifoPath);
+
+  await using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      return new Response(Bun.file(fifoPath));
+    },
+  });
+
+  const fdDir = process.platform === "linux" ? "/proc/self/fd" : "/dev/fd";
+  const countFds = () => readdirSync(fdDir).length;
+  const baseline = countFds();
+
+  const rounds = 16;
+  for (let i = 0; i < rounds; i++) {
+    const { promise: sawBytes, resolve } = Promise.withResolvers<void>();
+    const client = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        open(s) {
+          s.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+        },
+        // First response bytes prove the server opened the FIFO and is
+        // waiting on it.
+        data() {
+          resolve();
+        },
+        close() {
+          resolve();
+        },
+        error() {
+          resolve();
+        },
+      },
+    });
+    await sawBytes;
+    client.terminate();
+  }
+
+  // Each aborted stream closes its FIFO fd when it drops, shortly after the
+  // server observes the hangup; poll for the count to return toward the
+  // baseline. The unfixed build kept one fd per request (+16 here).
+  const slack = 4;
+  const deadline = Date.now() + 5000;
+  let current = countFds();
+  while (current > baseline + slack && Date.now() < deadline) {
+    await Bun.sleep(10);
+    current = countFds();
+  }
+  expect(current).toBeLessThanOrEqual(baseline + slack);
+});

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test"
 import { bunEnv, bunExe, isASAN, isWindows, rmScope, rss, tempDir, tempDirWithFiles } from "harness";
 import { mkfifo } from "mkfifo";
 import { closeSync, openSync, unlinkSync, writeSync } from "node:fs";
+import { open } from "node:fs/promises";
 import { join } from "node:path";
 
 const LARGE_SIZE = 1024 * 1024 * 8;
@@ -1372,3 +1373,71 @@ test("file route serves a burst of concurrent requests after reloads", async () 
   const a = await fetch(`${server.url}a`).then(r => r.text());
   expect(a).toBe("a-new");
 });
+
+// A FIFO body whose producer connects only after the request is in flight:
+// the server opens the FIFO read end while it has no writer, and must still
+// deliver the bytes once a writer opens the FIFO and writes.
+//
+// Two requests on purpose, each with a fresh FIFO. On Linux the first FIFO
+// read in a process downgrades the RWF_NOWAIT fast path (named FIFOs return
+// EOPNOTSUPP), and the downgraded fallback used plain read(), which reports
+// EOF on a FIFO that has no writer yet — so the first exchange worked and
+// every later one answered with an instant empty body. On macOS a kqueue
+// EVFILT_READ filter registered on a FIFO with zero writers never fires
+// (even after a writer connects), so both exchanges hung until idleTimeout
+// without the recovery probe.
+test.skipIf(isWindows)(
+  "Response(Bun.file(FIFO)) streams bytes from a writer that opens after the request",
+  async () => {
+    using dir = tempDir("serve-fifo-late-writer", {});
+
+    for (let iteration = 0; iteration < 2; iteration++) {
+      const fifoPath = join(String(dir), `late-${iteration}.fifo`);
+      mkfifo(fifoPath);
+
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch() {
+          return new Response(Bun.file(fifoPath));
+        },
+      });
+
+      const { promise: wireDone, resolve: resolveWire, reject: rejectWire } = Promise.withResolvers<string>();
+      let wire = "";
+      let writerAttached = false;
+      const client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        socket: {
+          open(s) {
+            s.write("GET /late HTTP/1.1\r\nHost: x\r\n\r\n");
+          },
+          async data(_s, d) {
+            wire += Buffer.from(d).toString("latin1");
+            // The response head reaching the wire proves the server already
+            // opened the FIFO and started streaming; only now attach a writer.
+            if (!writerAttached && wire.includes("HTTP/1.1 200 OK")) {
+              writerAttached = true;
+              const writer = await open(fifoPath, "w");
+              await writer.write("LATEBYTES!");
+              await writer.close();
+            }
+            if (wire.includes("LATEBYTES!")) resolveWire(wire);
+          },
+          close() {
+            // Surface whatever arrived so a failure shows the truncated wire.
+            resolveWire(wire);
+          },
+          error(_s, err) {
+            rejectWire(err);
+          },
+        },
+      });
+
+      const captured = await wireDone;
+      client.end();
+      expect({ iteration, wire: captured }).toEqual({ iteration, wire: expect.stringContaining("LATEBYTES!") });
+    }
+  },
+);

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1502,3 +1502,68 @@ test.skipIf(isWindows)("aborted Response(Bun.file(FIFO)) with no writer releases
   }
   expect(current).toBeLessThanOrEqual(baseline + slack);
 });
+
+// After an abort frees a pollable file response, an event the loop already
+// has (or later gets) for that stream's poll must not be dispatched into the
+// freed stream. Regression: aborting a fd-backed FIFO response (auto_close
+// off, so the fd outlives the stream) and then making the FIFO readable
+// dispatched into freed memory. The repro runs in a child so the ASAN crash
+// of an unfixed build fails the test instead of taking down the runner.
+test.skipIf(isWindows || !isASAN)("aborted fd-backed FIFO response does not dispatch into freed memory", async () => {
+  using dir = tempDir("serve-fifo-fd-abort", {
+    "repro.ts": `
+        import fs from "node:fs";
+        const fifoPath = "./fd.fifo";
+        const fd = fs.openSync(fifoPath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+        using server = Bun.serve({
+          port: 0,
+          hostname: "127.0.0.1",
+          fetch() {
+            return new Response(Bun.file(fd));
+          },
+        });
+        const { promise: sawBytes, resolve } = Promise.withResolvers();
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            open(s) {
+              s.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+            },
+            data() {
+              resolve();
+            },
+            close() {
+              resolve();
+            },
+            error() {
+              resolve();
+            },
+          },
+        });
+        await sawBytes; // head bytes: the stream is waiting on the FIFO
+        client.terminate();
+        await Bun.sleep(200); // let the abort free the stream
+        const wfd = fs.openSync(fifoPath, "w");
+        fs.writeSync(wfd, "BOOM");
+        fs.closeSync(wfd);
+        await Bun.sleep(300); // let the loop dispatch whatever it thinks is armed
+        console.log("survived");
+        process.exit(0);
+      `,
+  });
+  mkfifo(join(String(dir), "fd.fifo"));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "repro.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode, stderr: exitCode === 0 ? "" : stderr.slice(-800) }).toEqual({
+    stdout: expect.stringContaining("survived"),
+    exitCode: 0,
+    stderr: "",
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -7,9 +7,10 @@ import {
   readableStreamToText,
 } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { createReadStream, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { open as fsPromisesOpen } from "node:fs/promises";
 import { join } from "node:path";
 
 it("TransformStream", async () => {
@@ -425,7 +426,7 @@ it("ReadableStream.prototype.values", async () => {
   expect(chunks.join("")).toBe("helloworld");
 });
 
-it.todoIf(isWindows || isMacOS)("Bun.file() read text from pipe", async () => {
+it.todoIf(isWindows)("Bun.file() read text from pipe", async () => {
   const fifoPath = join(tmpdirSync(), "bun-streams-test-fifo");
   try {
     unlinkSync(fifoPath);
@@ -467,6 +468,48 @@ it.todoIf(isWindows || isMacOS)("Bun.file() read text from pipe", async () => {
   expect(output).toBe(large + "\n");
   expect(status).toBe(0);
 });
+
+// The writer side of the FIFO opens only after the stream already started
+// reading.
+//
+// Two iterations on purpose, each with a fresh FIFO. On Linux the first FIFO
+// read in a process downgrades the RWF_NOWAIT fast path (named FIFOs return
+// EOPNOTSUPP), and the downgraded fallback used plain read(), which reports
+// EOF on a FIFO that has no writer yet — so the first stream worked and every
+// later one ended empty. On macOS a kqueue EVFILT_READ filter registered on a
+// FIFO with zero writers never fires (even after a writer connects), so both
+// iterations hung without the recovery probe.
+it.skipIf(isWindows)(
+  "Bun.file() FIFO stream delivers bytes from a writer that opens after reading starts",
+  async () => {
+    for (let iteration = 0; iteration < 2; iteration++) {
+      const fifoPath = join(tmpdirSync(), `bun-streams-late-writer-fifo-${iteration}`);
+      try {
+        unlinkSync(fifoPath);
+      } catch {}
+      mkfifo(fifoPath, 0o666);
+
+      const reader = Bun.file(fifoPath).stream().getReader();
+      const firstRead = reader.read();
+      // One event-loop turn so the native reader has opened the FIFO and
+      // registered its poll (the pull above runs it); only then attach a writer.
+      // `open` must be the async form: the sync one would block the event loop
+      // if the ordering ever regressed, deadlocking instead of failing.
+      await Bun.sleep(0);
+      const writer = await fsPromisesOpen(fifoPath, "w");
+      await writer.write("LATEBYTES");
+      await writer.close();
+
+      const { value, done } = await firstRead;
+      expect({ iteration, done, text: value && Buffer.from(value).toString() }).toEqual({
+        iteration,
+        done: false,
+        text: "LATEBYTES",
+      });
+      await reader.cancel();
+    }
+  },
+);
 
 it("exists globally", () => {
   expect(typeof ReadableStream).toBe("function");


### PR DESCRIPTION
### Repro

```js
// mkfifo /tmp/p   (no writer attached yet)
const server = Bun.serve({
  port: 0,
  fetch: () => new Response(Bun.file("/tmp/p")),
});
// GET the server; after the response head arrives, open /tmp/p for
// writing, write "hello", close.
```

The producer never gets through. On macOS every such exchange failed (the darwin lanes of build [#89795](https://buildkite.com/bun/bun/builds/89795) show late-writer FIFO tests receiving only headers before "Bun.serve() timed out a request after 10 seconds"); on Linux the first exchange in a process works but every later one answers instantly with an empty body (bare header terminator, no Content-Length, no Transfer-Encoding). `Bun.file(fifo).stream()` started before the first writer fails the same way, which is why the streams test "Bun.file() read text from pipe" has been `todoIf(isMacOS)`.

### Cause

Both platforms reduce to the same trap: plain `read()` on a named FIFO that has never had a writer returns 0, indistinguishable from EOF at the call site. Only the polling interfaces (epoll/poll) honor the FIFO's writer epoch and keep reporting not-ready until a writer has come and gone.

- Linux: `read_nonblocking` tries `preadv2(RWF_NOWAIT)` first, which named FIFOs reject with `EOPNOTSUPP`. That error arm called `RWFFlagSupport::disable()`, permanently downgrading every later pipe read in the process to plain `read()` with no readiness check. So the first FIFO read poisoned the process, and the next FIFO body hit the false EOF at the eager read in `FileResponseStream::start` and completed empty. Which exchange fails depends on process history, which is why the repro passes in isolation and fails after any earlier FIFO traffic.
- macOS: `read_nonblocking` is always plain `read()`, so the eager read hits the false EOF on the very first exchange (confirmed by the darwin lanes on this PR's first revision: the response ended with `end_without_body` immediately). On top of that, a kqueue `EVFILT_READ` filter registered while the FIFO has zero writers does not reliably report the first writer's data (a keeper-vs-late probe on darwin showed registrations made while a writer exists work, ones made without never fire), so there is no kernel event to wait on in that state at all.

### Fix

- `bun_sys::read_nonblocking` / `write_nonblocking` (Linux): `EOPNOTSUPP` is a property of the fd type, not the kernel, so fall back for that call without disabling the RWF fast path globally (anonymous pipes keep `RWF_NOWAIT`). The fallback now always polls before reading/writing: it must not block the event loop on a blocking fd, and it must not mistake a never-had-writer FIFO for EOF. This also covers kernels where `RWF_NOWAIT` is unavailable or disabled, which previously skipped the readiness check entirely.
- macOS: a new reader flag, `FIFO_AWAITING_FIRST_WRITER`, set while a path-opened FIFO is still waiting for its first writer, makes the streaming read loop treat a 0-byte read as not-ready instead of EOF. The first EAGAIN or data proves a writer connected and clears it; from then on 0 means a real EOF, matching Linux. While the flag is set there is no kernel event to wait on, so `FileResponseStream` (serve) and `FileReader` (Bun.file streams) tick a backoff timer (2ms doubling to 64ms) running `PosixBufferedReader::retry_stalled_fifo_read`: drop the kevent registration, read directly, re-attach a fresh kevent via the EAGAIN path once a writer exists. The probe holds a ref on its owner while armed and stops at the first chunk/EOF, completion, error, abort, or stream cancel.

Review findings addressed along the way:

- Aborting (or idle-timing-out) a response stuck in the wait state leaked the stream and its fd: the in-flight read ref was never released once no dispatch remained to adopt it. `finish()` now releases it, on POSIX only: on Windows a pending uv read both needs the stream alive and is what releases the ref (releasing early segfaulted the windows lanes), and POSIX reads are synchronous within their dispatch so nothing is pending there.
- That release exposed a second pre-existing hole: `FileResponseStream` clears the reader's `CLOSE_HANDLE` (it owns the fd), so the reader's Drop never tore down the `FilePoll`. The poll hive slot leaked on every pollable response, and after the ref release a freed stream could still have its poll registered, with a later readiness event dispatched into freed memory (ASAN use-after-free with a fd-backed FIFO body, where the fd outlives the stream). `Drop` now closes the poll handle explicitly before closing the fd, same as the shell `IOReader` teardown, so the poll is unregistered and an already-fetched event for it is ignored.

One knowingly accepted divergence: on macOS a writer that opens and closes without writing, before any other writer, is not detectable through the descriptor (Linux reports EPOLLHUP via the writer epoch), so such a request keeps waiting instead of completing empty, bounded by idleTimeout.

Known gaps left out of scope, both pre-existing:

- Response termination after FIFO EOF: when the pipe's data and EOF arrive as separate events, the chunked body is not terminated with the final `0\r\n\r\n`. That is #37082's bug and fix; the tests here assert byte delivery only, deliberately, so the two PRs stay independent.
- `Bun.file(fifo).text()` (and `.bytes()`/`.json()`) goes through the Blob `ReadFile` path, a third reader with its own kqueue registration on the io thread; a late-writer FIFO still hangs there on macOS. Fixing it needs the same waiting-state treatment in that machinery and is left for a follow-up.

### Verification

Tests in `test/js/bun/http/bun-serve-file.test.ts`: the late-writer exchange twice (the second run is the one the Linux poisoning broke), an abort-the-wait fd-leak check, and a child-process ASAN repro for the freed-stream poll dispatch. A sibling in `test/js/web/streams/streams.test.js` covers `Bun.file(fifo).stream()`, and the previously `todoIf(isMacOS)` streams test "Bun.file() read text from pipe" is enabled on macOS.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/http/bun-serve-file.test.ts -t "writer that opens after"
(fail) Response(Bun.file(FIFO)) streams bytes from a writer that opens after the request [5000.86ms]

$ bun bd test test/js/bun/http/bun-serve-file.test.ts
 108 pass, 0 fail (112 total)
$ bun bd test test/js/web/streams/streams.test.js
 162 pass, 0 fail
```

The fd-leak test fails against this PR's first revision (16 leaked fds) and the ASAN repro fails against the revision before the poll teardown, so each increment is pinned by a test. Also green locally: `filesink.test.ts`, `spawn-maxbuf`, `spawn-streaming-stdout`, `spawn-streaming-stdin`; `spawn-pipe-leak` matches main's debug-build results; `serve.test.ts` and `bun-serve-file.test.ts` verified on a Windows x64 machine. `cargo check`/`clippy` clean for linux, macOS, and Windows targets.

This machine has no darwin hardware, so the darwin CI lanes are the macOS check. The first revision of this PR treated the kqueue registration as the primary macOS bug; the darwin lanes then showed the serve path failing on the false EOF before kqueue ever mattered, and the current revision fixes that state explicitly.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->