### PR TITLE
usockets(macOS): stop leaking the loop wakeup port's receive right on loop teardown

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -782,13 +782,16 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
     kern_return_t kr = mach_port_allocate(self, MACH_PORT_RIGHT_RECEIVE, &cb->port);
 
     if (UNLIKELY(kr != KERN_SUCCESS)) {
-        return NULL;
+        // The loop is unusable without wakeup_async and the sole caller
+        // doesn't NULL-check. Crash loudly like the eventfd arm above rather
+        // than NULL-deref in the caller.
+        BUN_PANIC("mach_port_allocate() failed during loop init (mach port space exhausted?)");
     }
 
     // Insert a send right into the port since we also use this to send
     kr = mach_port_insert_right(self, cb->port, cb->port, MACH_MSG_TYPE_MAKE_SEND);
     if (UNLIKELY(kr != KERN_SUCCESS)) {
-        return NULL;
+        BUN_PANIC("mach_port_insert_right() failed during loop init");
     }
 
     // Modify the port queue size to be 1 because we are only
@@ -797,7 +800,7 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
     kr = mach_port_set_attributes(self, cb->port, MACH_PORT_LIMITS_INFO, (mach_port_info_t)&limits, MACH_PORT_LIMITS_INFO_COUNT);
 
     if (UNLIKELY(kr != KERN_SUCCESS)) {
-        return NULL;
+        BUN_PANIC("mach_port_set_attributes() failed during loop init");
     }
 
     return (struct us_internal_async *) cb;
@@ -807,16 +810,24 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
 void us_internal_async_close(struct us_internal_async *a) {
     struct us_internal_callback_t *internal_cb = (struct us_internal_callback_t *) a;
 
+    /* kqueue keys knotes by (ident, filter) and us_internal_async_set
+     * registered with the mach port as ident - deleting by the callback
+     * pointer misses, leaving a knote that points at the freed machport_buf.
+     * The receipt is ignored: ENOENT just means the async was never set. */
     struct kevent64_s event;
-    uint64_t ptr = (uint64_t)(void*)internal_cb;
-    EV_SET64(&event, ptr, EVFILT_MACHPORT, EV_DELETE, 0, 0, (uint64_t)(void*)internal_cb, 0,0);
+    EV_SET64(&event, internal_cb->port, EVFILT_MACHPORT, EV_DELETE, 0, 0, (uint64_t)(void*)internal_cb, 0, 0);
 
     int ret;
     do {
         ret = kevent64(internal_cb->loop->fd, &event, 1, &event, 1, KEVENT_FLAG_ERROR_EVENTS, NULL);
     } while (IS_EINTR(ret));
 
-    mach_port_deallocate(mach_task_self(), internal_cb->port);
+    /* mach_port_deallocate only drops the send right inserted at creation;
+     * the receive right allocated there must be destroyed separately or
+     * every destroyed loop leaks its kernel port. */
+    mach_port_t self = mach_task_self();
+    mach_port_deallocate(self, internal_cb->port);
+    mach_port_mod_refs(self, internal_cb->port, MACH_PORT_RIGHT_RECEIVE, -1);
     us_free(internal_cb->machport_buf);
 
     /* (regular) sockets are the only polls which are not freed immediately */
@@ -847,8 +858,11 @@ void us_internal_async_set(struct us_internal_async *a, void (*cb)(struct us_int
         ret = kevent64(internal_cb->loop->fd, &event, 1, &event, 1, KEVENT_FLAG_ERROR_EVENTS, NULL);
     } while (IS_EINTR(ret));
 
-    if (UNLIKELY(ret == -1)) {
-       abort();
+    /* With KEVENT_FLAG_ERROR_EVENTS a failed change comes back as an EV_ERROR
+     * receipt (ret == 1, errno in .data), not ret == -1. Either way the loop
+     * would be left with no cross-thread wakeup channel, so fail loudly. */
+    if (UNLIKELY(ret != 0)) {
+        BUN_PANIC("kevent64() failed to register the loop's wakeup mach port");
     }
 }
 
@@ -863,34 +877,40 @@ void us_internal_async_wakeup(struct us_internal_async *a) {
         .msgh_id = 0,
     };
 
-    mach_msg_return_t kr = mach_msg(
-        &msg,
-        MACH_SEND_MSG | MACH_SEND_TIMEOUT,
-        msg.msgh_size,
-        0,
-        MACH_PORT_NULL,
-        0, // Fail instantly if the port is full
-        MACH_PORT_NULL
-    );
+    for (;;) {
+        mach_msg_return_t kr = mach_msg(
+            &msg,
+            MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+            msg.msgh_size,
+            0,
+            MACH_PORT_NULL,
+            0, // Fail instantly if the port is full
+            MACH_PORT_NULL
+        );
 
-    switch (kr) {
-        case KERN_SUCCESS: {
-            break;
-        }
+        switch (kr) {
+            case KERN_SUCCESS: {
+                return;
+            }
 
-        // This means that the send would've blocked because the
-        // queue is full. We assume success because the port is full.
-        case MACH_SEND_TIMED_OUT: {
-            break;
-        }
+            // The queue is full (qlimit is 1), so a wakeup is already
+            // pending and the loop is guaranteed to run.
+            case MACH_SEND_TIMED_OUT: {
+                return;
+            }
 
-        // No space means it will wake up.
-        case MACH_SEND_NO_BUFFER: {
-            break;
-        }
+            // The kernel couldn't allocate the message, so nothing was
+            // queued. Returning would silently lose the wakeup and stall
+            // the loop; retry until it queues or the queue reports full.
+            case MACH_SEND_NO_BUFFER: {
+                continue;
+            }
 
-        default: {
-            break;
+            default: {
+                // MACH_SEND_INVALID_DEST and friends mean the port is gone
+                // and this loop can never be woken again.
+                BUN_PANIC("mach_msg() failed to post a loop wakeup");
+            }
         }
     }
 }

--- a/src/io/io_darwin.cpp
+++ b/src/io/io_darwin.cpp
@@ -90,8 +90,7 @@ extern "C" bool io_darwin_schedule_wakeup(mach_port_t waker)
             return true;
         }
 
-        // Kernel couldn't allocate the message: nothing was queued, so
-        // returning here would lose the wakeup.
+        // Nothing was queued (no kernel buffer): retry or the wakeup is lost.
         case MACH_SEND_NO_BUFFER: {
             continue;
         }

--- a/src/io/io_darwin.cpp
+++ b/src/io/io_darwin.cpp
@@ -85,22 +85,19 @@ extern "C" bool io_darwin_schedule_wakeup(mach_port_t waker)
             return true;
         }
 
-        // The queue is full (qlimit is 1), so a wakeup is already
-        // pending and the receiver is guaranteed to run.
+        // Queue full (qlimit is 1): a wakeup is already pending.
         case MACH_SEND_TIMED_OUT: {
             return true;
         }
 
-        // The kernel couldn't allocate the message, so nothing was queued.
-        // Returning would silently lose the wakeup; retry until it queues
-        // or the queue reports full.
+        // Kernel couldn't allocate the message: nothing was queued, so
+        // returning here would lose the wakeup.
         case MACH_SEND_NO_BUFFER: {
             continue;
         }
 
         default: {
-            // The port is created once per process and never destroyed, so
-            // MACH_SEND_INVALID_DEST and friends are structurally impossible.
+            // This port is never destroyed, so dead-port errors can't happen.
             ASSERT_NOT_REACHED_WITH_MESSAGE("mach_msg failed with %x", kr);
             return false;
         }

--- a/src/io/io_darwin.cpp
+++ b/src/io/io_darwin.cpp
@@ -74,37 +74,38 @@ extern "C" bool io_darwin_schedule_wakeup(mach_port_t waker)
         .msgh_id = 0,
     };
 
-    mach_msg_return_t kr = mach_msg(&msg, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
-        msg.msgh_size, 0, MACH_PORT_NULL,
-        0, // Fail instantly if the port is full
-        MACH_PORT_NULL);
+    while (true) {
+        mach_msg_return_t kr = mach_msg(&msg, MACH_SEND_MSG | MACH_SEND_TIMEOUT,
+            msg.msgh_size, 0, MACH_PORT_NULL,
+            0, // Fail instantly if the port is full
+            MACH_PORT_NULL);
 
-    switch (kr) {
-    case MACH_MSG_SUCCESS: {
-        return true;
-    }
+        switch (kr) {
+        case MACH_MSG_SUCCESS: {
+            return true;
+        }
 
-    // This means that the send would've blocked because the
-    // queue is full. We assume success because the port is full.
-    case MACH_SEND_TIMED_OUT: {
-        return true;
-    }
+        // The queue is full (qlimit is 1), so a wakeup is already
+        // pending and the receiver is guaranteed to run.
+        case MACH_SEND_TIMED_OUT: {
+            return true;
+        }
 
-    // No space means it will wake up.
-    case MACH_SEND_NO_BUFFER: {
-        return true;
-    }
+        // The kernel couldn't allocate the message, so nothing was queued.
+        // Returning would silently lose the wakeup; retry until it queues
+        // or the queue reports full.
+        case MACH_SEND_NO_BUFFER: {
+            continue;
+        }
 
-    default: {
-        ASSERT_NOT_REACHED_WITH_MESSAGE("mach_msg failed with %x", kr);
-        return false;
+        default: {
+            // The port is created once per process and never destroyed, so
+            // MACH_SEND_INVALID_DEST and friends are structurally impossible.
+            ASSERT_NOT_REACHED_WITH_MESSAGE("mach_msg failed with %x", kr);
+            return false;
+        }
+        }
     }
-    }
-}
-
-extern "C" void io_darwin_close_machport(mach_port_t port)
-{
-    mach_port_deallocate(mach_task_self(), port);
 }
 
 #else
@@ -119,7 +120,5 @@ extern "C" int io_darwin_create_machport(int fd,
 
 // stub out these symbols
 extern "C" bool io_darwin_schedule_wakeup(void* waker) { return false; }
-
-extern "C" void io_darwin_close_machport(unsigned port) {}
 
 #endif

--- a/test/js/web/workers/worker-machport-leak.test.ts
+++ b/test/js/web/workers/worker-machport-leak.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS, tempDir } from "harness";
+
+// Worker VM startup/teardown is much slower under debug and/or ASAN; the leak
+// is exactly one port per cycle, so fewer cycles are still a clear signal.
+const slow = isDebug || isASAN;
+const cycles = slow ? 6 : 10;
+const timeout = slow ? 90_000 : 30_000;
+
+// On macOS every us_loop allocates a mach port as its cross-thread wakeup
+// channel (registered with kqueue via EVFILT_MACHPORT). us_internal_async_close
+// released only the port's send right, so the receive right (and with it the
+// kernel port) leaked on every destroyed loop: each Worker create/terminate
+// cycle grew the process's mach port table by one, marching long-lived
+// processes toward port-space exhaustion.
+//
+// The child counts its own receive rights via mach_port_names (self-inspection
+// needs no privileges) across Worker churn. Unfixed, the delta equals the
+// cycle count; fixed, it stays near zero.
+test.skipIf(!isMacOS)(
+  "terminated Workers do not leak mach receive rights",
+  async () => {
+    using dir = tempDir("worker-machport-leak", {
+      "worker.js": `postMessage("ready");\nsetInterval(() => {}, 1e9);\n`,
+      "main.js": `
+        import { dlopen, ptr, toArrayBuffer } from "bun:ffi";
+
+        const { symbols } = dlopen("/usr/lib/libSystem.B.dylib", {
+          task_self_trap: { args: [], returns: "u32" },
+          mach_port_names: { args: ["u32", "ptr", "ptr", "ptr", "ptr"], returns: "i32" },
+        });
+
+        const task = symbols.task_self_trap();
+        const MACH_PORT_TYPE_RECEIVE = 1 << 17;
+
+        function countReceiveRights() {
+          const names = new BigUint64Array(1);
+          const namesCnt = new Uint32Array(1);
+          const types = new BigUint64Array(1);
+          const typesCnt = new Uint32Array(1);
+          const kr = symbols.mach_port_names(task, ptr(names), ptr(namesCnt), ptr(types), ptr(typesCnt));
+          if (kr !== 0) throw new Error("mach_port_names failed: " + kr);
+          const cnt = typesCnt[0];
+          const arr = new Uint32Array(toArrayBuffer(Number(types[0]), 0, cnt * 4));
+          let n = 0;
+          for (let i = 0; i < cnt; i++) {
+            if (arr[i] & MACH_PORT_TYPE_RECEIVE) n++;
+          }
+          return n;
+        }
+
+        const workerUrl = new URL("./worker.js", import.meta.url).href;
+
+        async function cycle() {
+          const w = new Worker(workerUrl);
+          await new Promise((resolve, reject) => {
+            w.onmessage = resolve;
+            w.onerror = e => reject(new Error("worker error: " + (e && e.message)));
+          });
+          await w.terminate();
+        }
+
+        // Warm up lazy one-time allocations (thread pools, dispatch state).
+        for (let i = 0; i < 3; i++) await cycle();
+
+        const CYCLES = ${cycles};
+        const baseline = countReceiveRights();
+        for (let i = 0; i < CYCLES; i++) await cycle();
+
+        // The wakeup port is released on the worker thread's exit path, which
+        // can lag terminate() resolving; poll with a deadline instead of
+        // asserting once.
+        const deadline = Date.now() + 15_000;
+        let current = countReceiveRights();
+        while (current - baseline > CYCLES / 2 && Date.now() < deadline) {
+          await Bun.sleep(50);
+          current = countReceiveRights();
+        }
+
+        if (current - baseline > CYCLES / 2) {
+          console.log("LEAK baseline=" + baseline + " final=" + current + " cycles=" + CYCLES);
+          process.exit(1);
+        }
+        console.log("OK baseline=" + baseline + " final=" + current);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toStartWith("OK ");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);


### PR DESCRIPTION
### Leak

On macOS every `us_loop_t` allocates a mach port as its cross-thread wakeup channel (`us_internal_create_async`, registered with kqueue via `EVFILT_MACHPORT`). `us_internal_async_close` in `packages/bun-usockets/src/eventing/epoll_kqueue.c` had two bugs, one live and one latent:

1. **Receive-right leak (live).** Teardown called only `mach_port_deallocate`, which releases the send right inserted at creation and does not affect receive rights. The receive right allocated with `mach_port_allocate(MACH_PORT_RIGHT_RECEIVE, ...)`, and with it the kernel port, outlived the loop. Every destroyed loop leaks one mach port: each Worker create/terminate cycle (worker thread exit frees its loop via `us_loop_free`) grows the process port table by one, marching long-lived processes toward mach port-space exhaustion.

2. **`EV_DELETE` with the wrong ident (latent use-after-free).** `us_internal_async_set` registers the knote under `ident = internal_cb->port`, but close deleted with the callback struct pointer as ident. kqueue keys knotes by (ident, filter), so the delete always missed with ENOENT (invisible: `KEVENT_FLAG_ERROR_EVENTS` reports it as a receipt and `ret` was ignored), leaving a knote whose `ext[0]` points at the freed `machport_buf` and whose udata is the freed callback struct. Today the stale knote cannot fire because the only close caller tears down the kqueue fd immediately afterwards; it becomes heap corruption the day an async is closed on a still-polling loop.

### Fix

`us_internal_async_close` now deletes the knote under the mach port ident, releases the send right, and destroys the receive right with `mach_port_mod_refs(self, port, MACH_PORT_RIGHT_RECEIVE, -1)`.

The adjacent failure paths in the same function family were silent; they now fail loudly:

- `us_internal_create_async` panics with a message when mach port setup fails instead of returning NULL, which the sole caller (`us_internal_loop_data_init`) dereferences unchecked. Matches the deliberate choice the eventfd arm already made.
- `us_internal_async_set`: with `KEVENT_FLAG_ERROR_EVENTS` a failed `EV_ADD` comes back as an `EV_ERROR` receipt (`ret == 1`, errno in `.data`), never `ret == -1`, so the existing `abort()` was unreachable and a failed wakeup-port registration left the loop with no cross-thread wakeup channel (cross-thread callbacks stall until unrelated I/O). Now checked like `kqueue_change` does.
- `us_internal_async_wakeup`: `MACH_SEND_NO_BUFFER` means the kernel queued nothing (the removed comment claimed the opposite), so retry rather than silently dropping the wakeup; unexpected send failures such as `MACH_SEND_INVALID_DEST` panic instead of being ignored, like libuv's async send path does for unexpected `write()` errors. No legitimate caller can reach that panic during teardown: `us_wakeup_loop` dereferences `loop->pending_wakeups` and `loop->data.wakeup_async` before sending, so a thread that could observe a destroyed port is already reading a freed loop struct; the panic turns that pre-existing UAF into a loud crash instead of a lost wakeup.

### Same-class sibling

`src/io/io_darwin.cpp` copies this machport wakeup pattern for the IO thread's `KEventWaker` and shared the `MACH_SEND_NO_BUFFER` misconception; `io_darwin_schedule_wakeup` now retries the same way. Its `io_darwin_close_machport` had no callers at all (the waker lives in the process-lifetime `IoRequestLoop` singleton and is never torn down) and embodied the same receive-right leak, so it is deleted rather than left around to be copied.

Heads up for merge ordering: #36253 gives `io_darwin_close_machport` its first caller (`KEventWatcher::stop`) and carries its own correct version of the function (same `mach_port_mod_refs(RECEIVE, -1)` fix). Whichever PR lands second resolves the trivial conflict: with a caller the function stays, in #36253's fixed form; without one it stays deleted.

### Test

`test/js/web/workers/worker-machport-leak.test.ts` (macOS only): a child process counts its own mach receive rights via `mach_port_names` self-inspection (needs no privileges) across Worker create/terminate cycles, polling with a deadline since the port is released on the worker thread's exit path. Without the fix the count grows by one per cycle and the test fails with `LEAK baseline=N final=N+cycles`; with the fix the delta stays near zero. On a mac:

```sh
USE_SYSTEM_BUN=1 bun test test/js/web/workers/worker-machport-leak.test.ts  # released bun: LEAK
bun bd test test/js/web/workers/worker-machport-leak.test.ts                # with fix: OK
```

Verification notes: this was developed on a Linux box, so I could not execute the darwin arm locally. The leak itself follows directly from documented mach semantics (`mach_port_deallocate` operates on send/send-once/dead-name rights only) and the ident mismatch is visible by comparing the registration and delete calls. I type-checked the exact `__APPLE__` arm against SDK-faithful declarations with `-Wall -Wextra -Werror`, and macOS CI compiles and runs the fixed build against the new test. The test skips on non-darwin platforms, so a Linux-side fail-before check cannot observe it; on macOS the fail-before is reproducible against any released bun with the command above.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-machport-leak.test.ts

<!-- robobun:evidence:end -->