### PR TITLE
udp: treat ENOBUFS/ENOMEM from send as backpressure, not a hard error

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -67,6 +67,9 @@ extern int Bun__doesMacOSVersionSupportSendRecvMsgX();
 
 /* We need to emulate sendmmsg, recvmmsg on platform who don't have it */
 int bsd_sendmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_sendbuf* sendbuf, int flags) {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_SENDMSG, fd, injected, unused)) return (int) injected;
+    (void)unused;
 #if defined(_WIN32)// || defined(__APPLE__)
     for (int i = 0; i < sendbuf->num; i++) {
         while (1) {

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1082,6 +1082,17 @@ int bsd_send_is_transient_error() {
 #endif
 }
 
+/* libuv's UDP retry set is exactly EAGAIN/EWOULDBLOCK/ENOBUFS (unix/udp.c);
+ * ENOMEM stays a hard error like Node, so this is narrower than the TCP
+ * helper above. */
+int bsd_udp_send_is_transient_error() {
+#ifdef _WIN32
+    return WSAGetLastError() == WSAENOBUFS;
+#else
+    return errno == ENOBUFS;
+#endif
+}
+
 static int us_internal_bind_and_listen(LIBUS_SOCKET_DESCRIPTOR listenFd, struct sockaddr *listenAddr, socklen_t listenAddrLength, int backlog, int* error) {
     int result;
     do

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -227,6 +227,7 @@ ssize_t bsd_writev(LIBUS_SOCKET_DESCRIPTOR fd, const struct us_iovec_t *iov, int
 ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length);
 int bsd_would_block();
 int bsd_send_is_transient_error();
+int bsd_udp_send_is_transient_error();
 
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -62,11 +62,11 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
         if (sent < 0) {
             /* Linux sendmmsg reports EAGAIN as -1 (per-msg-loop platforms
              * report it as sent==0): re-arm writable so on_drain fires and
-             * report how many earlier batches went out. ENOBUFS/ENOMEM are
-             * transient kernel resource exhaustion (macOS returns ENOBUFS when
-             * bursty sends fill the interface queue); libuv classifies them as
-             * EAGAIN for UDP sends, so a later retry can succeed. */
-            if (bsd_would_block() || bsd_send_is_transient_error()) {
+             * report how many earlier batches went out. ENOBUFS joins the
+             * would-block set because libuv classifies it as EAGAIN for UDP
+             * sends (macOS returns it when bursty sends fill the interface
+             * queue), so a later retry can succeed. */
+            if (bsd_would_block() || bsd_udp_send_is_transient_error()) {
                 us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
                 return total_sent;
             }

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -62,8 +62,11 @@ int us_udp_socket_send(struct us_udp_socket_t *s, void** payloads, size_t* lengt
         if (sent < 0) {
             /* Linux sendmmsg reports EAGAIN as -1 (per-msg-loop platforms
              * report it as sent==0): re-arm writable so on_drain fires and
-             * report how many earlier batches went out. */
-            if (bsd_would_block()) {
+             * report how many earlier batches went out. ENOBUFS/ENOMEM are
+             * transient kernel resource exhaustion (macOS returns ENOBUFS when
+             * bursty sends fill the interface queue); libuv classifies them as
+             * EAGAIN for UDP sends, so a later retry can succeed. */
+            if (bsd_would_block() || bsd_send_is_transient_error()) {
                 us_poll_change((struct us_poll_t *) s, s->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
                 return total_sent;
             }

--- a/test/js/bun/udp/udp-syscall-fault.test.ts
+++ b/test/js/bun/udp/udp-syscall-fault.test.ts
@@ -19,7 +19,7 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
   // report backpressure (false) and arm the drain callback, not throw.
   test.each(["ENOBUFS", "ENOMEM"] as const)("udpSocket.send → %s is backpressure, not an error", async errno => {
     const received = Promise.withResolvers<string>();
-    const server = await Bun.udpSocket({
+    using server = await Bun.udpSocket({
       port: 0,
       hostname: "127.0.0.1",
       socket: {
@@ -29,7 +29,7 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
       },
     });
     let drained = Promise.withResolvers<void>();
-    const client = await Bun.udpSocket({
+    using client = await Bun.udpSocket({
       port: 0,
       hostname: "127.0.0.1",
       socket: {
@@ -50,14 +50,11 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
     await drained.promise;
     expect(client.send("hello", server.port, "127.0.0.1")).toBe(true);
     expect(await received.promise).toBe("hello");
-
-    client.close();
-    server.close();
   });
 
   test("udpSocket.send still throws on a hard errno (EINVAL)", async () => {
-    const server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
-    const client = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+    using server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+    using client = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
 
     fault.set({ syscall: "sendmsg", action: "errno", errno: "EINVAL", repeat: 1 });
     let thrown: any;
@@ -67,9 +64,6 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
       thrown = e;
     }
     expect(thrown?.code).toBe("EINVAL");
-
-    client.close();
-    server.close();
   });
 
   // node:dgram queues a backpressured send and retries it from the drain
@@ -77,11 +71,11 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
   // once the kernel recovers (three consecutive failures here: the initial
   // try plus two drain retries).
   test("dgram send callback succeeds after transient ENOBUFS", async () => {
-    const server = dgram.createSocket("udp4");
+    await using server = dgram.createSocket("udp4");
     const messageP = once(server, "message");
     server.bind(0, "127.0.0.1");
     await once(server, "listening");
-    const client = dgram.createSocket("udp4");
+    await using client = dgram.createSocket("udp4");
 
     fault.set({ syscall: "sendmsg", action: "errno", errno: "ENOBUFS", repeat: 3 });
     const cbErr = Promise.withResolvers<Error | null>();
@@ -90,9 +84,6 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
     expect(await cbErr.promise).toBeNull();
     const [msg] = await messageP;
     expect(msg.toString()).toBe("ping");
-
-    client.close();
-    server.close();
   });
 
   // More packets than one 16 KiB sendbuf batch holds (~200 on Linux), so
@@ -100,9 +91,9 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
   // with ENOBUFS. The partial count must come back without an error and with
   // writable re-armed, so the caller can send the tail from drain.
   test("sendMany resumes after ENOBUFS at a batch boundary", async () => {
-    const server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+    using server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
     let drained = Promise.withResolvers<void>();
-    const client = await Bun.udpSocket({
+    using client = await Bun.udpSocket({
       port: 0,
       hostname: "127.0.0.1",
       socket: {
@@ -132,8 +123,5 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
       total += client.sendMany(parts.slice(total * 3));
     }
     expect(total).toBe(N);
-
-    client.close();
-    server.close();
   });
 });

--- a/test/js/bun/udp/udp-syscall-fault.test.ts
+++ b/test/js/bun/udp/udp-syscall-fault.test.ts
@@ -1,0 +1,139 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
+import dgram from "node:dgram";
+import { once } from "node:events";
+
+// Every Bun.udpSocket / node:dgram send reaches the kernel through
+// bsd_sendmmsg, which the "sendmsg" fault hook intercepts. Windows maps
+// WSAENOBUFS the same way but its errno plumbing differs; land POSIX coverage
+// first, like net-syscall-fault.test.ts.
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+describe.skipIf(skip)("udp send under injected syscall faults", () => {
+  // libuv classifies ENOBUFS/ENOMEM from a UDP send as EAGAIN (transient
+  // kernel resource exhaustion; macOS returns ENOBUFS when bursty sends fill
+  // the interface queue) and retries on the next writable event. send() must
+  // report backpressure (false) and arm the drain callback, not throw.
+  test.each(["ENOBUFS", "ENOMEM"] as const)("udpSocket.send → %s is backpressure, not an error", async errno => {
+    const received = Promise.withResolvers<string>();
+    const server = await Bun.udpSocket({
+      port: 0,
+      hostname: "127.0.0.1",
+      socket: {
+        data(_sock, buf) {
+          received.resolve(buf.toString());
+        },
+      },
+    });
+    let drained = Promise.withResolvers<void>();
+    const client = await Bun.udpSocket({
+      port: 0,
+      hostname: "127.0.0.1",
+      socket: {
+        data() {},
+        drain() {
+          drained.resolve();
+        },
+      },
+    });
+
+    // The poll starts out writable, so one creation-time drain may already
+    // have fired; only a drain after the failed send may resolve this.
+    drained = Promise.withResolvers();
+    fault.set({ syscall: "sendmsg", action: "errno", errno, repeat: 1 });
+    expect(client.send("hello", server.port, "127.0.0.1")).toBe(false);
+
+    // The failed send must re-arm writable; without it this never resolves.
+    await drained.promise;
+    expect(client.send("hello", server.port, "127.0.0.1")).toBe(true);
+    expect(await received.promise).toBe("hello");
+
+    client.close();
+    server.close();
+  });
+
+  test("udpSocket.send still throws on a hard errno (EINVAL)", async () => {
+    const server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+    const client = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+
+    fault.set({ syscall: "sendmsg", action: "errno", errno: "EINVAL", repeat: 1 });
+    let thrown: any;
+    try {
+      client.send("x", server.port, "127.0.0.1");
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown?.code).toBe("EINVAL");
+
+    client.close();
+    server.close();
+  });
+
+  // node:dgram queues a backpressured send and retries it from the drain
+  // handler, so a transient ENOBUFS must complete the callback with no error
+  // once the kernel recovers (three consecutive failures here: the initial
+  // try plus two drain retries).
+  test("dgram send callback succeeds after transient ENOBUFS", async () => {
+    const server = dgram.createSocket("udp4");
+    const messageP = once(server, "message");
+    server.bind(0, "127.0.0.1");
+    await once(server, "listening");
+    const client = dgram.createSocket("udp4");
+
+    fault.set({ syscall: "sendmsg", action: "errno", errno: "ENOBUFS", repeat: 3 });
+    const cbErr = Promise.withResolvers<Error | null>();
+    client.send("ping", server.address().port, "127.0.0.1", err => cbErr.resolve(err ?? null));
+
+    expect(await cbErr.promise).toBeNull();
+    const [msg] = await messageP;
+    expect(msg.toString()).toBe("ping");
+
+    client.close();
+    server.close();
+  });
+
+  // More packets than one 16 KiB sendbuf batch holds (~200 on Linux), so
+  // us_udp_socket_send issues several sendmmsg calls and the second one fails
+  // with ENOBUFS. The partial count must come back without an error and with
+  // writable re-armed, so the caller can send the tail from drain.
+  test("sendMany resumes after ENOBUFS at a batch boundary", async () => {
+    const server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+    let drained = Promise.withResolvers<void>();
+    const client = await Bun.udpSocket({
+      port: 0,
+      hostname: "127.0.0.1",
+      socket: {
+        data() {},
+        drain() {
+          drained.resolve();
+        },
+      },
+    });
+
+    const N = 1000;
+    const parts: (string | number)[] = [];
+    for (let i = 0; i < N; i++) {
+      parts.push("x", server.port, "127.0.0.1");
+    }
+
+    drained = Promise.withResolvers();
+    fault.set({ syscall: "sendmsg", action: "errno", errno: "ENOBUFS", after: 1, repeat: 1 });
+    const first = client.sendMany(parts);
+    expect(first).toBeGreaterThan(0);
+    expect(first).toBeLessThan(N);
+
+    let total = first;
+    while (total < N) {
+      await drained.promise;
+      drained = Promise.withResolvers();
+      total += client.sendMany(parts.slice(total * 3));
+    }
+    expect(total).toBe(N);
+
+    client.close();
+    server.close();
+  });
+});

--- a/test/js/bun/udp/udp-syscall-fault.test.ts
+++ b/test/js/bun/udp/udp-syscall-fault.test.ts
@@ -13,11 +13,11 @@ const skip = !fault.available() || isWindows;
 afterEach(() => fault.clear());
 
 describe.skipIf(skip)("udp send under injected syscall faults", () => {
-  // libuv classifies ENOBUFS/ENOMEM from a UDP send as EAGAIN (transient
-  // kernel resource exhaustion; macOS returns ENOBUFS when bursty sends fill
-  // the interface queue) and retries on the next writable event. send() must
-  // report backpressure (false) and arm the drain callback, not throw.
-  test.each(["ENOBUFS", "ENOMEM"] as const)("udpSocket.send → %s is backpressure, not an error", async errno => {
+  // libuv's UDP send retry set is exactly EAGAIN/EWOULDBLOCK/ENOBUFS (macOS
+  // returns ENOBUFS when bursty sends fill the interface queue). All of them
+  // must report backpressure (false) and arm the drain callback, not throw;
+  // the EWOULDBLOCK cell pins the baseline ENOBUFS is specified against.
+  test.each(["ENOBUFS", "EWOULDBLOCK"] as const)("udpSocket.send → %s is backpressure, not an error", async errno => {
     const received = Promise.withResolvers<string>();
     using server = await Bun.udpSocket({
       port: 0,
@@ -40,36 +40,43 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
       },
     });
 
-    // The poll starts out writable, so one creation-time drain may already
-    // have fired; only a drain after the failed send may resolve this.
+    // The poll starts out writable, so one creation-time drain fires on the
+    // first loop turn. Consume it now; otherwise it would satisfy the await
+    // below even if the failed send never re-armed writable.
+    await drained.promise;
     drained = Promise.withResolvers();
+
     fault.set({ syscall: "sendmsg", action: "errno", errno, repeat: 1 });
     expect(client.send("hello", server.port, "127.0.0.1")).toBe(false);
 
-    // The failed send must re-arm writable; without it this never resolves.
+    // The creation-time drain is spent, so this only resolves if the failed
+    // send re-armed writable.
     await drained.promise;
     expect(client.send("hello", server.port, "127.0.0.1")).toBe(true);
     expect(await received.promise).toBe("hello");
   });
 
-  test("udpSocket.send still throws on a hard errno (EINVAL)", async () => {
+  // ENOMEM is deliberately not in the retry set: libuv surfaces it for UDP
+  // sends and so does Node (only the TCP path treats it as transient).
+  test.each(["EINVAL", "ENOMEM"] as const)("udpSocket.send still throws on a hard errno (%s)", async errno => {
     using server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
     using client = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
 
-    fault.set({ syscall: "sendmsg", action: "errno", errno: "EINVAL", repeat: 1 });
+    fault.set({ syscall: "sendmsg", action: "errno", errno, repeat: 1 });
     let thrown: any;
     try {
       client.send("x", server.port, "127.0.0.1");
     } catch (e) {
       thrown = e;
     }
-    expect(thrown?.code).toBe("EINVAL");
+    expect(thrown?.code).toBe(errno);
   });
 
   // node:dgram queues a backpressured send and retries it from the drain
   // handler, so a transient ENOBUFS must complete the callback with no error
   // once the kernel recovers (three consecutive failures here: the initial
-  // try plus two drain retries).
+  // try plus two drain retries, so at least two of the drains require the
+  // failed send to re-arm writable).
   test("dgram send callback succeeds after transient ENOBUFS", async () => {
     await using server = dgram.createSocket("udp4");
     const messageP = once(server, "message");
@@ -110,7 +117,11 @@ describe.skipIf(skip)("udp send under injected syscall faults", () => {
       parts.push("x", server.port, "127.0.0.1");
     }
 
+    // Consume the creation-time drain (see above) so the loop below only
+    // advances on drains the failed batch re-armed.
+    await drained.promise;
     drained = Promise.withResolvers();
+
     fault.set({ syscall: "sendmsg", action: "errno", errno: "ENOBUFS", after: 1, repeat: 1 });
     const first = client.sendMany(parts);
     expect(first).toBeGreaterThan(0);


### PR DESCRIPTION
#### Repro

On macOS, flooding `send()` with large datagrams routinely fails with `ENOBUFS` once the interface queue fills (transient; the same burst completes under Node). Deterministically, with the syscall fault hooks in a debug build:

```ts
import { socketFaultInjection as fault } from "bun:internal-for-testing";
const server = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
const client = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
fault.set({ syscall: "sendmsg", action: "errno", errno: "ENOBUFS", repeat: 1 });
client.send("hello", server.port, "127.0.0.1");
// ENOBUFS: No buffer space available (syscall: "send", errno: 55/105)
```

`node:dgram`'s send callback gets the same `send ENOBUFS` error. Under Node/libuv neither happens: the datagram is retried on the next writable event and the callback completes without an error.

#### Cause

`us_udp_socket_send` classified only `EWOULDBLOCK` as retryable (`bsd_would_block()`), so `ENOBUFS` from `sendmmsg` fell through to the error return with no writable re-arm. libuv's UDP send retry set is exactly `EAGAIN`/`EWOULDBLOCK`/`ENOBUFS` (`uv__udp_sendmsg` / `uv__udp_try_send`; ENOBUFS was added in libuv v1.15.0 because macOS reports it for transient interface-queue fullness), and it retries on `POLLOUT`.

#### Fix

- `packages/bun-usockets/src/udp.c`: route `ENOBUFS` through the same path as would-block: re-arm writable (so `on_drain` fires) and report the packets already accepted. `Bun.udpSocket.send` then returns `false` (resend on `drain`), and `node:dgram`'s existing queue/drain machinery retries automatically. Hard errnos still surface as errors.
- `packages/bun-usockets/src/bsd.c`: new `bsd_udp_send_is_transient_error()` with exactly libuv's set. It is deliberately narrower than `bsd_send_is_transient_error()` (the TCP drain-path helper from #33803, which also treats `ENOMEM` as transient): libuv and Node surface `ENOMEM` for UDP sends, so Bun does too.
- `packages/bun-usockets/src/bsd.c`: hook `bsd_sendmmsg` into the existing `sendmsg` fault-injection chokepoint so the UDP send path can be tested deterministically (it was the only send path without a hook).

Matching libuv here is the whole argument: Node applications never observe transient `ENOBUFS` as a send failure, so code ported to Bun errored (or crashed, with no callback) on a condition it was never written to handle, and there was no writable event to recover with even for callers that did handle it.

#### Verification

`test/js/bun/udp/udp-syscall-fault.test.ts` (POSIX, skipped when fault injection is compiled out):

- `udpSocket.send` under injected `ENOBUFS` returns `false`, fires `drain`, and the retry delivers the datagram; an `EWOULDBLOCK` cell pins the would-block baseline the new classification is specified against
- hard errnos still throw: `EINVAL`, and `ENOMEM` (not in libuv's UDP retry set)
- `node:dgram` send callback completes without error after three consecutive transient failures (initial try + two drain retries, so at least two drains require the failed send's re-arm)
- `sendMany` hitting `ENOBUFS` at a batch boundary (>1 sendbuf batch) returns the partial count and re-arms writable so the tail drains, instead of stranding it
- the tests consume the creation-time writable drain before injecting, so the post-send drain awaits genuinely require the re-arm: deleting the `us_poll_change` re-arm makes four of the six tests fail

With `packages/` reverted to the merge base (test file kept), 5 of 6 tests fail; with the fix the file passes. Also green: `test/js/bun/udp/` (276 tests), all 76 `test/js/node/test/parallel/test-dgram-*.js`, `net-syscall-fault.test.ts`, `socket-fault-injection.test.ts`, `fetch-http3-syscall-fault.test.ts`.

Related: #36249 handles the hard-errno case at a batch boundary (stale ICMP `sk_err`); this PR only reclassifies `ENOBUFS`, so the two compose.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/udp-syscall-fault.test.ts

<!-- robobun:evidence:end -->