### PR TITLE
tls: fix renegotiation leaving the handshake state latched (lost drain, bogus ECONNRESET on close)

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2293,6 +2293,25 @@ restart:
       if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE &&
           err != SSL_ERROR_PENDING_CERTIFICATE) {
         if (err == SSL_ERROR_WANT_RENEGOTIATE) {
+          /* The initial handshake can complete inside this same SSL_read with
+           * the HelloRequest coalesced into the batch right behind the
+           * server's Finished. None of the completion checks have run yet and
+           * ssl_renegotiate is about to overwrite the state, so report the
+           * initial handshake first or its dispatch is lost for good. The
+           * save/restore mirrors the app-data branch below: the BIO still
+           * holds the renegotiation records and a JS write from the callback
+           * must not clobber them. */
+          if (s->ssl_handshake_state == HANDSHAKE_PENDING && SSL_is_init_finished(s_ssl(s))) {
+            char *saved_input = loop_ssl_data->ssl_read_input;
+            unsigned int saved_length = loop_ssl_data->ssl_read_input_length;
+            unsigned int saved_offset = loop_ssl_data->ssl_read_input_offset;
+            ssl_trigger_handshake(s, 1);
+            if (ssl_gone(s)) return NULL;
+            loop_ssl_data->ssl_read_input = saved_input;
+            loop_ssl_data->ssl_read_input_length = saved_length;
+            loop_ssl_data->ssl_read_input_offset = saved_offset;
+            loop_ssl_data->ssl_socket = s;
+          }
           if (ssl_renegotiate(s)) continue;
           if (ssl_gone(s)) return NULL;
           err = SSL_ERROR_SSL;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1938,10 +1938,25 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
   ssl_update_handshake(s);
   if (ssl_gone(s)) return s;
 
-  if (s->ssl_handshake_state != HANDSHAKE_COMPLETED) {
+  if (s->ssl_handshake_state == HANDSHAKE_PENDING) {
     /* Surface ECONNRESET-style handshake failure exactly once so callers
      * (fetch, sockets) don't each have to check on_close themselves. */
     ssl_trigger_handshake_econnreset(s);
+    if (ssl_gone(s)) return s;
+  } else if (s->ssl_handshake_state == HANDSHAKE_RENEGOTIATION_PENDING) {
+    /* The initial handshake completed long ago: this close must not be
+     * reported as a pre-handshake ECONNRESET. A renegotiation that finished
+     * inside the same SSL_read as the peer's close_notify still gets its
+     * success dispatch (same init-finished rule ssl_update_handshake applies
+     * to the initial handshake); one cut short by the close surfaces a
+     * protocol reason SSL_read parked, or stays silent like any other
+     * post-handshake failure. */
+    if (SSL_is_init_finished(s_ssl(s))) {
+      ssl_trigger_handshake(s, 1);
+    } else {
+      s->ssl_handshake_state = HANDSHAKE_COMPLETED;
+      ssl_dispatch_parked_reason(s);
+    }
     if (ssl_gone(s)) return s;
   }
 
@@ -2194,7 +2209,12 @@ struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
    * direction. */
   if (ssl_wants_eof_dispatch(s) && us_internal_ssl_is_shut_down(s)) return s;
 
-  if (s->ssl_handshake_state == HANDSHAKE_COMPLETED) {
+  /* Suppress write-completion dispatch only while the INITIAL handshake is
+   * in flight (the app hasn't been told the socket is up yet). During a
+   * renegotiation the connection is established and SSL_write still accepts
+   * app data, so a backpressured write's drain callback must flow or it is
+   * lost until the peer happens to send something. */
+  if (s->ssl_handshake_state != HANDSHAKE_PENDING) {
     s = us_dispatch_writable(s);
   }
   return s;
@@ -2336,8 +2356,11 @@ restart:
          * (SSL_in_init throttles to 5/tick) reorder the server's
          * secureConnection event past the client's close under fan-out
          * loads. The save/restore below makes this safe even if the JS
-         * callback writes; with read==0 the buffer is empty anyway. */
-        if (s->ssl_handshake_state == HANDSHAKE_PENDING && SSL_is_init_finished(s_ssl(s))) {
+         * callback writes; with read==0 the buffer is empty anyway.
+         * RENEGOTIATION_PENDING takes the same path: node re-emits 'secure'
+         * per completed handshake, and without the dispatch the state stays
+         * latched (no drain dispatch, and close misreports ECONNRESET). */
+        if (s->ssl_handshake_state != HANDSHAKE_COMPLETED && SSL_is_init_finished(s_ssl(s))) {
           ssl_trigger_handshake(s, 1);
           if (ssl_gone(s)) return NULL;
           loop_ssl_data->ssl_socket = s;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2211,9 +2211,13 @@ struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
 
   /* Suppress write-completion dispatch only while the INITIAL handshake is
    * in flight (the app hasn't been told the socket is up yet). During a
-   * renegotiation the connection is established and SSL_write still accepts
-   * app data, so a backpressured write's drain callback must flow or it is
-   * lost until the peer happens to send something. */
+   * renegotiation the drain being signaled belongs to bytes SSL accepted
+   * before the renegotiation began, and loop.c consumes the writable event
+   * on dispatch, so suppressing it loses that drain until the peer happens
+   * to send. Mid-renegotiation writes themselves park on WANT_READ (BoringSSL
+   * rejects app data for the whole window) and resume via
+   * ssl_retry_parked_write at completion, which is what makes dispatching
+   * during the window safe as well as necessary. */
   if (s->ssl_handshake_state != HANDSHAKE_PENDING) {
     s = us_dispatch_writable(s);
   }

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1154,7 +1154,16 @@ impl<const SSL: bool> Handler<SSL> {
             // handshake completed but we may have ssl errors
             client.flags.did_have_handshaking_error = handshake_error.error_no != 0;
             if handshake_success {
-                if client.flags.reject_unauthorized {
+                // A TLS 1.2 renegotiation re-dispatches on_handshake with the
+                // same pinned certificate; the verification below is
+                // first-dispatch work (its JS checkServerIdentity path parks
+                // the request while waiting for approval).
+                let initial_dispatch = matches!(
+                    client.state.request_stage,
+                    crate::internal_state::HTTPStage::Pending
+                        | crate::internal_state::HTTPStage::Opened
+                );
+                if initial_dispatch && client.flags.reject_unauthorized {
                     // only reject the connection if reject_unauthorized == true
                     if client.flags.did_have_handshaking_error {
                         client.close_and_fail::<SSL>(

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -353,9 +353,14 @@ fn on_handshake(
     scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake");
     // Do NOT form `&mut ProxyTunnel` (see ALIASING NOTE).
     let _guard = ProxyTunnel::ref_scope(proxy_nn);
-    this.state.response_stage = HTTPStage::ProxyHeaders;
-    this.state.request_stage = HTTPStage::ProxyHeaders;
-    this.state.request_sent_len = 0;
+    // on_handshake fires once per completed handshake, including TLS 1.2
+    // renegotiations. Only the first dispatch may rewind the stages and
+    // re-send the request (same first-call gate as HTTPContext::first_call).
+    if this.state.request_stage == HTTPStage::ProxyHandshake {
+        this.state.response_stage = HTTPStage::ProxyHeaders;
+        this.state.request_stage = HTTPStage::ProxyHeaders;
+        this.state.request_sent_len = 0;
+    }
     let handshake_error = HTTPCertError::from_verify_error(ssl_error);
     if handshake_success {
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake success");

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -354,13 +354,16 @@ fn on_handshake(
     // Do NOT form `&mut ProxyTunnel` (see ALIASING NOTE).
     let _guard = ProxyTunnel::ref_scope(proxy_nn);
     // on_handshake fires once per completed handshake, including TLS 1.2
-    // renegotiations. Only the first dispatch may rewind the stages and
-    // re-send the request (same first-call gate as HTTPContext::first_call).
-    if this.state.request_stage == HTTPStage::ProxyHandshake {
-        this.state.response_stage = HTTPStage::ProxyHeaders;
-        this.state.request_stage = HTTPStage::ProxyHeaders;
-        this.state.request_sent_len = 0;
+    // renegotiations. Everything below is first-dispatch work: the stage
+    // rewind, the identity check (whose JS checkServerIdentity path parks
+    // the request), and the write kick. A repeat-dispatch failure is handled
+    // by the wrapper's close callback.
+    if this.state.request_stage != HTTPStage::ProxyHandshake {
+        return;
     }
+    this.state.response_stage = HTTPStage::ProxyHeaders;
+    this.state.request_stage = HTTPStage::ProxyHeaders;
+    this.state.request_sent_len = 0;
     let handshake_error = HTTPCertError::from_verify_error(ssl_error);
     if handshake_success {
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake success");

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -135,6 +135,9 @@ pub struct WebSocketProxyTunnel {
     sni_hostname: Option<Box<[u8]>>,
     /// Whether to reject unauthorized certificates
     reject_unauthorized: bool,
+    /// The TLS-complete notification fired; a TLS 1.2 renegotiation
+    /// re-dispatches on_handshake and the upgrade-request kick is single-shot.
+    handshake_reported: bool,
 }
 
 use bun_uws::MaybeAnySocket as SocketUnion;
@@ -175,6 +178,7 @@ impl WebSocketProxyTunnel {
             ssl: None,
             sni_hostname: Some(Box::<[u8]>::from(sni_hostname)),
             reject_unauthorized,
+            handshake_reported: false,
         });
         // ref_count initialized to 1; caller owns the Box allocation via the
         // returned raw pointer (paired with `heap::take` in `deref()`).
@@ -342,12 +346,25 @@ impl WebSocketProxyTunnel {
         // re-enter `tunnel.detach_upgrade_client()` / `tunnel.write()`, so no borrow of
         // `*this` may span the dispatch.
         // SAFETY: ScopedRef guard holds a ref; `this` is live. Reads of `Copy` fields.
-        let (upgrade_client, reject_unauthorized) =
-            unsafe { ((*this).upgrade_client, (*this).reject_unauthorized) };
+        let (upgrade_client, reject_unauthorized, handshake_reported) = unsafe {
+            (
+                (*this).upgrade_client,
+                (*this).reject_unauthorized,
+                (*this).handshake_reported,
+            )
+        };
 
         if upgrade_client.is_none() {
             return;
         }
+        if handshake_reported {
+            // TLS 1.2 renegotiation repeat dispatch; a failed renegotiation is
+            // handled by the wrapper's close callback.
+            return;
+        }
+        // SAFETY: ScopedRef guard holds a ref; plain field write, no
+        // whole-struct borrow is formed.
+        unsafe { (*this).handshake_reported = true };
 
         if !success {
             upgrade_client.terminate(ErrorCode::TlsHandshakeFailed);

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -647,11 +647,23 @@ pub mod ssl_wrapper {
                 }
                 self.flags.set_received_ssl_shutdown(true);
                 // Reset pending handshake because we are closed for sure now
-                if self.flags.handshake_state() != HandshakeState::HandshakeCompleted {
-                    self.flags
-                        .set_handshake_state(HandshakeState::HandshakeCompleted);
-                    let verify = self.get_verify_error();
-                    self.trigger_handshake_callback(false, verify);
+                match self.flags.handshake_state() {
+                    HandshakeState::HandshakeCompleted => {}
+                    HandshakeState::HandshakeRenegotiationPending => {
+                        // The initial handshake completed long ago: this
+                        // teardown must not be reported as a handshake
+                        // failure. A renegotiation that already finished
+                        // still reports its success.
+                        self.handle_end_of_renegotiation();
+                        self.flags
+                            .set_handshake_state(HandshakeState::HandshakeCompleted);
+                    }
+                    HandshakeState::HandshakePending => {
+                        self.flags
+                            .set_handshake_state(HandshakeState::HandshakeCompleted);
+                        let verify = self.get_verify_error();
+                        self.trigger_handshake_callback(false, verify);
+                    }
                 }
 
                 // we need to trigger close because we are not receiving a SSL_shutdown
@@ -1059,6 +1071,12 @@ pub mod ssl_wrapper {
                         return false;
                     } else {
                         log!("wanna read/write just break");
+                        // A renegotiation can finish inside this SSL_read with
+                        // no app data to deliver (the peer's Finished arrived
+                        // alone); unlatch and fire on_handshake like the
+                        // app-data path below, or the state stays
+                        // HandshakeRenegotiationPending forever.
+                        self.handle_end_of_renegotiation();
                         // we wanna read/write just break
                         break;
                     }

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1001,6 +1001,22 @@ pub mod ssl_wrapper {
                         && err != boring_sys::SSL_ERROR_WANT_WRITE
                     {
                         if err == boring_sys::SSL_ERROR_WANT_RENEGOTIATE {
+                            // The initial handshake can complete inside this
+                            // same SSL_read with the HelloRequest coalesced
+                            // right behind the peer's Finished; report it
+                            // before the renegotiation state overwrites it.
+                            if self.flags.handshake_state() == HandshakeState::HandshakePending
+                                // SAFETY: ssl is still valid.
+                                && unsafe { boring_sys::SSL_is_init_finished(ssl.as_ptr()) } != 0
+                            {
+                                self.flags
+                                    .set_handshake_state(HandshakeState::HandshakeCompleted);
+                                let verify = self.get_verify_error();
+                                self.trigger_handshake_callback(true, verify);
+                                if self.ssl.get().is_none() || self.flags.closed_notified() {
+                                    return false;
+                                }
+                            }
                             self.flags
                                 .set_handshake_state(HandshakeState::HandshakeRenegotiationPending);
                             // An over-limit renegotiation request is treated

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -650,10 +650,8 @@ pub mod ssl_wrapper {
                 match self.flags.handshake_state() {
                     HandshakeState::HandshakeCompleted => {}
                     HandshakeState::HandshakeRenegotiationPending => {
-                        // The initial handshake completed long ago: this
-                        // teardown must not be reported as a handshake
-                        // failure. A renegotiation that already finished
-                        // still reports its success.
+                        // The initial handshake completed; a finished
+                        // renegotiation reports success, never a failure.
                         self.handle_end_of_renegotiation();
                         self.flags
                             .set_handshake_state(HandshakeState::HandshakeCompleted);
@@ -1071,11 +1069,8 @@ pub mod ssl_wrapper {
                         return false;
                     } else {
                         log!("wanna read/write just break");
-                        // A renegotiation can finish inside this SSL_read with
-                        // no app data to deliver (the peer's Finished arrived
-                        // alone); unlatch and fire on_handshake like the
-                        // app-data path below, or the state stays
-                        // HandshakeRenegotiationPending forever.
+                        // A renegotiation can finish inside SSL_read with no
+                        // app data to deliver; unlatch like the paths below.
                         self.handle_end_of_renegotiation();
                         // we wanna read/write just break
                         break;

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -200,6 +200,109 @@ if (handshakes < 2) {
 console.log("ok");
 `;
 
+// TLS 1.2 server that renegotiates right after the handshake and ends the
+// socket once the renegotiation completes, WITHOUT sending any application
+// data. The client's SSL_read finishes the renegotiated handshake with
+// nothing to deliver, which is the path that used to leave the socket stuck
+// in RENEGOTIATION_PENDING (no second handshake dispatch, and the close was
+// misreported as a pre-handshake ECONNRESET).
+function spawnQuietRenegotiationServer() {
+  return Bun.spawn({
+    cmd: [
+      "node",
+      "-e",
+      `
+        const tls = require("tls");
+        const server = tls.createServer(
+          {
+            cert: process.env.SERVER_CERT,
+            key: process.env.SERVER_KEY,
+            minVersion: "TLSv1.2",
+            maxVersion: "TLSv1.2",
+          },
+          socket => {
+            socket.on("error", () => {});
+            socket.renegotiate({ requestCert: true, rejectUnauthorized: false }, err => {
+              if (err) process.exit(1);
+              socket.end();
+            });
+          },
+        );
+        server.listen(0, () => console.log(server.address().port));
+      `,
+    ],
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+    env: { ...bunEnv, SERVER_CERT: tls.cert, SERVER_KEY: tls.key },
+  });
+}
+
+async function readPort(proc: Subprocess<"ignore", "pipe", "ignore">) {
+  const { value } = await proc.stdout.getReader().read();
+  return Number(new TextDecoder().decode(value).trim());
+}
+
+it("should dispatch handshake success, not ECONNRESET, when renegotiation completes without app data", async () => {
+  await using server = spawnQuietRenegotiationServer();
+  const port = await readPort(server);
+
+  const events: unknown[] = [];
+  const { promise: closed, resolve } = Promise.withResolvers<void>();
+  await Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    tls: { rejectUnauthorized: false },
+    socket: {
+      open() {},
+      data() {},
+      handshake(_socket, success, authorizationError) {
+        events.push({ success, code: (authorizationError as any)?.code ?? null });
+      },
+      error(_socket, err) {
+        events.push({ error: (err as any)?.code ?? String(err) });
+      },
+      close() {
+        resolve();
+      },
+    },
+  });
+  await closed;
+
+  // One dispatch per completed handshake (initial + renegotiation), both with
+  // the certificate verdict. The renegotiated session completed, so no
+  // "disconnected before secure TLS connection was established" ECONNRESET.
+  expect(events).toEqual([
+    { success: true, code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+    { success: true, code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+  ]);
+});
+
+it("should re-emit secure/secureConnect after server-initiated renegotiation like node", async () => {
+  await using server = spawnQuietRenegotiationServer();
+  const port = await readPort(server);
+
+  // Node (verified against v26.3.0) emits 'secure' and 'secureConnect' once
+  // per completed handshake, including the renegotiated one, and closes
+  // cleanly with no error.
+  const { promise, resolve } = Promise.withResolvers<{
+    secure: number;
+    secureConnect: number;
+    errors: string[];
+    hadError: boolean;
+  }>();
+  let secure = 0;
+  let secureConnect = 0;
+  const errors: string[] = [];
+  const socket = require("tls").connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+  socket.on("secure", () => secure++);
+  socket.on("secureConnect", () => secureConnect++);
+  socket.on("error", (e: any) => errors.push(e.code ?? e.message));
+  socket.on("close", (hadError: boolean) => resolve({ secure, secureConnect, errors, hadError }));
+
+  expect(await promise).toEqual({ secure: 2, secureConnect: 2, errors: [], hadError: false });
+});
+
 it("should terminate the connection when the peer exceeds the renegotiation limit over a duplex socket", async () => {
   // tls.connect({ socket: <Duplex> }) is encrypted by the SSLWrapper path
   // (UpgradedDuplex) rather than the uSockets C path. It must apply the same

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -2,6 +2,9 @@ import type { Subprocess } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { bunEnv, bunExe, tls } from "harness";
 import type { IncomingMessage } from "http";
+import { connect as netConnect } from "node:net";
+import { Duplex } from "node:stream";
+import { connect as tlsConnect } from "node:tls";
 import { join } from "path";
 let url: URL;
 let process: Subprocess<"ignore", "pipe", "ignore"> | null = null;
@@ -200,52 +203,86 @@ if (handshakes < 2) {
 console.log("ok");
 `;
 
-// TLS 1.2 server that renegotiates right after the handshake and ends the
-// socket once the renegotiation completes, WITHOUT sending any application
-// data. The client's SSL_read finishes the renegotiated handshake with
+// TLS 1.2 server that renegotiates right after the handshake WITHOUT sending
+// any application data. The client finishes the renegotiated handshake with
 // nothing to deliver, which is the path that used to leave the socket stuck
-// in RENEGOTIATION_PENDING (no second handshake dispatch, and the close was
-// misreported as a pre-handshake ECONNRESET).
-function spawnQuietRenegotiationServer() {
+// in RENEGOTIATION_PENDING (no second handshake dispatch, no writable
+// dispatch, and the close was misreported as a pre-handshake ECONNRESET). In
+// "end" mode the server ends the socket once the renegotiation completes; in
+// "pause" mode it stops reading, prints "reneg-done", and resumes when
+// anything arrives on stdin.
+const QUIET_RENEG_SERVER_JS = /* js */ `
+  const tls = require("tls");
+  const server = tls.createServer(
+    {
+      cert: process.env.SERVER_CERT,
+      key: process.env.SERVER_KEY,
+      minVersion: "TLSv1.2",
+      maxVersion: "TLSv1.2",
+    },
+    socket => {
+      socket.on("error", () => {});
+      socket.on("data", () => {});
+      socket.renegotiate({ requestCert: true, rejectUnauthorized: false }, err => {
+        if (err) process.exit(1);
+        if (process.env.RENEG_MODE === "pause") {
+          socket.pause();
+          console.log("reneg-done");
+          process.stdin.on("data", () => socket.resume());
+        } else {
+          socket.end();
+        }
+      });
+    },
+  );
+  server.listen(0, () => console.log(server.address().port));
+`;
+
+function spawnQuietRenegotiationServer(mode: "end" | "pause") {
   return Bun.spawn({
-    cmd: [
-      "node",
-      "-e",
-      `
-        const tls = require("tls");
-        const server = tls.createServer(
-          {
-            cert: process.env.SERVER_CERT,
-            key: process.env.SERVER_KEY,
-            minVersion: "TLSv1.2",
-            maxVersion: "TLSv1.2",
-          },
-          socket => {
-            socket.on("error", () => {});
-            socket.renegotiate({ requestCert: true, rejectUnauthorized: false }, err => {
-              if (err) process.exit(1);
-              socket.end();
-            });
-          },
-        );
-        server.listen(0, () => console.log(server.address().port));
-      `,
-    ],
+    cmd: ["node", "-e", QUIET_RENEG_SERVER_JS],
     stdout: "pipe",
     stderr: "inherit",
-    stdin: "ignore",
-    env: { ...bunEnv, SERVER_CERT: tls.cert, SERVER_KEY: tls.key },
+    stdin: "pipe",
+    env: { ...bunEnv, SERVER_CERT: tls.cert, SERVER_KEY: tls.key, RENEG_MODE: mode },
   });
 }
 
-async function readPort(proc: Subprocess<"ignore", "pipe", "ignore">) {
-  const { value } = await proc.stdout.getReader().read();
-  return Number(new TextDecoder().decode(value).trim());
+type RenegServer = ReturnType<typeof spawnQuietRenegotiationServer>;
+
+// stdout arrives in arbitrary chunks; accumulate until a full line is
+// available.
+function lineReader(proc: RenegServer) {
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  return async function nextLine(): Promise<string> {
+    for (;;) {
+      const newline = buffered.indexOf("\n");
+      if (newline !== -1) {
+        const line = buffered.slice(0, newline).trim();
+        buffered = buffered.slice(newline + 1);
+        return line;
+      }
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`server exited before printing a full line; buffered: ${JSON.stringify(buffered)}`);
+      buffered += decoder.decode(value);
+    }
+  };
 }
 
-it("should dispatch handshake success, not ECONNRESET, when renegotiation completes without app data", async () => {
-  await using server = spawnQuietRenegotiationServer();
-  const port = await readPort(server);
+async function readPort(nextLine: () => Promise<string>) {
+  const line = await nextLine();
+  const port = Number(line);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`server printed an invalid port: ${JSON.stringify(line)}`);
+  }
+  return port;
+}
+
+it.concurrent("should dispatch handshake success, not ECONNRESET, when renegotiation completes without app data", async () => {
+  await using server = spawnQuietRenegotiationServer("end");
+  const port = await readPort(lineReader(server));
 
   const events: unknown[] = [];
   const { promise: closed, resolve } = Promise.withResolvers<void>();
@@ -278,9 +315,9 @@ it("should dispatch handshake success, not ECONNRESET, when renegotiation comple
   ]);
 });
 
-it("should re-emit secure/secureConnect after server-initiated renegotiation like node", async () => {
-  await using server = spawnQuietRenegotiationServer();
-  const port = await readPort(server);
+it.concurrent("should re-emit secure/secureConnect after server-initiated renegotiation like node", async () => {
+  await using server = spawnQuietRenegotiationServer("end");
+  const port = await readPort(lineReader(server));
 
   // Node (verified against v26.3.0) emits 'secure' and 'secureConnect' once
   // per completed handshake, including the renegotiated one, and closes
@@ -294,13 +331,167 @@ it("should re-emit secure/secureConnect after server-initiated renegotiation lik
   let secure = 0;
   let secureConnect = 0;
   const errors: string[] = [];
-  const socket = require("tls").connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+  const socket = tlsConnect({ port, host: "127.0.0.1", rejectUnauthorized: false });
   socket.on("secure", () => secure++);
   socket.on("secureConnect", () => secureConnect++);
   socket.on("error", (e: any) => errors.push(e.code ?? e.message));
   socket.on("close", (hadError: boolean) => resolve({ secure, secureConnect, errors, hadError }));
 
   expect(await promise).toEqual({ secure: 2, secureConnect: 2, errors: [], hadError: false });
+});
+
+// While the handshake state was latched in RENEGOTIATION_PENDING, the
+// writable path suppressed every drain dispatch, so a backpressured write's
+// completion was lost until the peer happened to send data. Flood the paused
+// server until the kernel buffers fill, then resume it and require the drain
+// callback. Runs in a subprocess with a kill timeout so a regression (drain
+// never delivered) cannot wedge the test runner.
+const drainAfterRenegotiationFixture = /* js */ `
+const server = Bun.spawn({
+  cmd: ["node", "-e", process.env.SERVER_JS],
+  stdout: "pipe",
+  stderr: "inherit",
+  stdin: "pipe",
+  env: process.env,
+});
+const reader = server.stdout.getReader();
+const decoder = new TextDecoder();
+let buffered = "";
+async function nextLine() {
+  for (;;) {
+    const newline = buffered.indexOf("\\n");
+    if (newline !== -1) {
+      const line = buffered.slice(0, newline).trim();
+      buffered = buffered.slice(newline + 1);
+      return line;
+    }
+    const { value, done } = await reader.read();
+    if (done) throw new Error("server exited early; buffered: " + JSON.stringify(buffered));
+    buffered += decoder.decode(value);
+  }
+}
+const port = Number(await nextLine());
+
+// Drain also fires for earlier writable events (connect, handshake
+// completion); only the one that completes the backpressured flood counts.
+let awaitingDrain = false;
+const { promise: drained, resolve: resolveDrained } = Promise.withResolvers();
+// The renegotiation's own completion must dispatch the second handshake
+// event: the server never sends app data and never closes, so nothing else
+// can deliver it.
+let handshakes = 0;
+const { promise: renegotiated, resolve: resolveRenegotiated } = Promise.withResolvers();
+const socket = await Bun.connect({
+  hostname: "127.0.0.1",
+  port,
+  tls: { rejectUnauthorized: false },
+  socket: {
+    open() {},
+    data() {},
+    handshake() {
+      if (++handshakes === 2) resolveRenegotiated();
+    },
+    drain() {
+      if (awaitingDrain) resolveDrained();
+    },
+    error() {},
+    close() {},
+  },
+});
+
+// The server has completed the renegotiation and stopped reading.
+const line = await nextLine();
+if (line !== "reneg-done") throw new Error("expected reneg-done, got " + JSON.stringify(line));
+
+// Write until the kernel send/receive buffers fill and the write is only
+// partially accepted (or parked by a renegotiation still finishing on our
+// side, which also reports a short write).
+const chunk = Buffer.alloc(1 << 20, 120);
+let backpressured = false;
+for (let i = 0; i < 256; i++) {
+  if (socket.write(chunk) < chunk.length) {
+    backpressured = true;
+    break;
+  }
+}
+if (!backpressured) throw new Error("never hit backpressure");
+awaitingDrain = true;
+
+// Resuming the server drains the flood; the socket must report drain.
+server.stdin.write("resume\\n");
+await drained;
+await renegotiated;
+socket.terminate();
+server.kill();
+console.log("drained-ok");
+`;
+
+it.concurrent(
+  "should dispatch drain for a backpressured write after a quiet renegotiation",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", drainAfterRenegotiationFixture],
+      env: {
+        ...bunEnv,
+        SERVER_JS: QUIET_RENEG_SERVER_JS,
+        SERVER_CERT: tls.cert,
+        SERVER_KEY: tls.key,
+        RENEG_MODE: "pause",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "drained-ok", exitCode: 0 });
+  },
+  30_000,
+);
+
+it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWrapper path)", async () => {
+  // tls.connect({ socket: <Duplex> }) is encrypted by the SSLWrapper path
+  // (UpgradedDuplex) rather than the uSockets C path. Its renegotiation state
+  // machine had the same latch: a renegotiation finishing with no app data in
+  // the same read pass never dispatched the second handshake event, so
+  // 'secure' was not re-emitted until the peer sent something.
+  await using server = spawnQuietRenegotiationServer("pause");
+  const nextLine = lineReader(server);
+  const port = await readPort(nextLine);
+
+  const raw = netConnect(port, "127.0.0.1");
+  const duplex = new Duplex({
+    read() {},
+    write(chunk, encoding, callback) {
+      raw.write(chunk, encoding, callback);
+    },
+    final(callback) {
+      raw.end();
+      callback();
+    },
+  });
+  raw.on("data", (chunk: Buffer) => duplex.push(chunk));
+  raw.on("end", () => duplex.push(null));
+  raw.on("close", () => duplex.destroy());
+
+  const { promise: renegotiated, resolve } = Promise.withResolvers<void>();
+  let secure = 0;
+  const errors: string[] = [];
+  const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
+  socket.on("secure", () => {
+    secure++;
+    // One per completed handshake: initial + the quiet renegotiation. The
+    // server sends no app data and no close, so only the renegotiation's own
+    // completion can deliver the second event.
+    if (secure === 2) resolve();
+  });
+  socket.on("error", (e: any) => errors.push(e.code ?? e.message));
+
+  await renegotiated;
+  expect(errors).toEqual([]);
+  socket.destroy();
+  raw.destroy();
 });
 
 it("should terminate the connection when the peer exceeds the renegotiation limit over a duplex socket", async () => {

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -373,7 +373,11 @@ async function nextLine() {
     buffered += decoder.decode(value);
   }
 }
-const port = Number(await nextLine());
+const portLine = await nextLine();
+const port = Number(portLine);
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  throw new Error("server printed an invalid port: " + JSON.stringify(portLine));
+}
 
 // Drain also fires for earlier writable events (connect, handshake
 // completion); only the one that completes the backpressured flood counts.
@@ -384,6 +388,11 @@ const { promise: drained, resolve: resolveDrained } = Promise.withResolvers();
 // can deliver it.
 let handshakes = 0;
 const { promise: renegotiated, resolve: resolveRenegotiated } = Promise.withResolvers();
+// Rejected on socket failure so the awaits below fail fast instead of riding
+// out the kill timeout; no-op once the scenario completed.
+let finished = false;
+const { promise: failed, reject: rejectFailed } = Promise.withResolvers();
+failed.catch(() => {});
 const socket = await Bun.connect({
   hostname: "127.0.0.1",
   port,
@@ -397,8 +406,12 @@ const socket = await Bun.connect({
     drain() {
       if (awaitingDrain) resolveDrained();
     },
-    error() {},
-    close() {},
+    error(s, err) {
+      if (!finished) rejectFailed(new Error("socket error before completion: " + (err?.code ?? err)));
+    },
+    close() {
+      if (!finished) rejectFailed(new Error("socket closed before drain/renegotiation completed"));
+    },
   },
 });
 
@@ -422,8 +435,9 @@ awaitingDrain = true;
 
 // Resuming the server drains the flood; the socket must report drain.
 server.stdin.write("resume\\n");
-await drained;
-await renegotiated;
+await Promise.race([drained, failed]);
+await Promise.race([renegotiated, failed]);
+finished = true;
 socket.terminate();
 server.kill();
 console.log("drained-ok");
@@ -455,7 +469,6 @@ it.concurrent(
       stderr: expect.any(String),
     });
   },
-  30_000,
 );
 
 it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWrapper path)", async () => {

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -525,66 +525,69 @@ it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWr
   }
 });
 
-it.concurrent("should not re-dispatch the handshake when teardown cuts a renegotiation mid-flight (SSLWrapper path)", async () => {
-  // On a quiet connection the first client-to-server write after the first
-  // 'secure' can only be the renegotiation ClientHello (the client answers
-  // the server's HelloRequest; it has no app data to send). Dropping it and
-  // destroying the raw socket guarantees teardown runs while the wrapper is
-  // mid-renegotiation, which used to re-dispatch a bogus handshake event.
-  await using server = spawnQuietRenegotiationServer("pause");
-  const nextLine = lineReader(server);
-  const port = await readPort(nextLine);
+it.concurrent(
+  "should not re-dispatch the handshake when teardown cuts a renegotiation mid-flight (SSLWrapper path)",
+  async () => {
+    // On a quiet connection the first client-to-server write after the first
+    // 'secure' can only be the renegotiation ClientHello (the client answers
+    // the server's HelloRequest; it has no app data to send). Dropping it and
+    // destroying the raw socket guarantees teardown runs while the wrapper is
+    // mid-renegotiation, which used to re-dispatch a bogus handshake event.
+    await using server = spawnQuietRenegotiationServer("pause");
+    const nextLine = lineReader(server);
+    const port = await readPort(nextLine);
 
-  const events: string[] = [];
-  let secure = 0;
-  let cut = false;
-  const raw = netConnect(port, "127.0.0.1");
-  const duplex = new Duplex({
-    read() {},
-    write(chunk, encoding, callback) {
-      if (secure >= 1 && !cut) {
-        cut = true;
-        queueMicrotask(() => raw.destroy());
+    const events: string[] = [];
+    let secure = 0;
+    let cut = false;
+    const raw = netConnect(port, "127.0.0.1");
+    const duplex = new Duplex({
+      read() {},
+      write(chunk, encoding, callback) {
+        if (secure >= 1 && !cut) {
+          cut = true;
+          queueMicrotask(() => raw.destroy());
+          callback();
+          return;
+        }
+        if (cut) {
+          callback();
+          return;
+        }
+        raw.write(chunk, encoding, callback);
+      },
+      final(callback) {
+        raw.end();
         callback();
-        return;
-      }
-      if (cut) {
-        callback();
-        return;
-      }
-      raw.write(chunk, encoding, callback);
-    },
-    final(callback) {
-      raw.end();
-      callback();
-    },
-  });
-  raw.on("data", (chunk: Buffer) => {
-    if (!cut) duplex.push(chunk);
-  });
-  // Deliberately no raw 'end' -> push(null) forwarding: teardown must arrive
-  // via the duplex 'close' thunk alone so the wrapper's fast shutdown runs
-  // mid-renegotiation with the TLS socket's handlers still attached.
-  raw.on("close", () => duplex.destroy());
+      },
+    });
+    raw.on("data", (chunk: Buffer) => {
+      if (!cut) duplex.push(chunk);
+    });
+    // Deliberately no raw 'end' -> push(null) forwarding: teardown must arrive
+    // via the duplex 'close' thunk alone so the wrapper's fast shutdown runs
+    // mid-renegotiation with the TLS socket's handlers still attached.
+    raw.on("close", () => duplex.destroy());
 
-  const { promise: closed, resolve } = Promise.withResolvers<void>();
-  const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
-  socket.on("secure", () => {
-    secure++;
-    events.push(`secure#${secure}`);
-  });
-  socket.on("secureConnect", () => events.push("secureConnect"));
-  socket.on("error", (e: any) => events.push(`error:${e.code ?? e.message}`));
-  socket.on("close", (hadError: boolean) => {
-    events.push(`close(hadError=${hadError})`);
-    resolve();
-  });
-  await closed;
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
+    socket.on("secure", () => {
+      secure++;
+      events.push(`secure#${secure}`);
+    });
+    socket.on("secureConnect", () => events.push("secureConnect"));
+    socket.on("error", (e: any) => events.push(`error:${e.code ?? e.message}`));
+    socket.on("close", (hadError: boolean) => {
+      events.push(`close(hadError=${hadError})`);
+      resolve();
+    });
+    await closed;
 
-  // Exactly one dispatch for the initial handshake; a renegotiation cut
-  // mid-flight must not produce a duplicate secureConnect/secure.
-  expect(events).toEqual(["secureConnect", "secure#1", "close(hadError=false)"]);
-});
+    // Exactly one dispatch for the initial handshake; a renegotiation cut
+    // mid-flight must not produce a duplicate secureConnect/secure.
+    expect(events).toEqual(["secureConnect", "secure#1", "close(hadError=false)"]);
+  },
+);
 
 it("should terminate the connection when the peer exceeds the renegotiation limit over a duplex socket", async () => {
   // tls.connect({ socket: <Duplex> }) is encrypted by the SSLWrapper path

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -487,7 +487,11 @@ it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWr
   let secure = 0;
   const errors: string[] = [];
   raw.on("error", (e: any) =>
-    reject(new Error(`raw socket failed before the second 'secure' (secure=${secure}, error=${e.code ?? e.message})`)),
+    reject(
+      new Error(`raw socket failed before the second 'secure' (secure=${secure}, error=${e.code ?? e.message})`, {
+        cause: e,
+      }),
+    ),
   );
   const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
   socket.on("secure", () => {

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -525,6 +525,67 @@ it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWr
   }
 });
 
+it.concurrent("should not re-dispatch the handshake when teardown cuts a renegotiation mid-flight (SSLWrapper path)", async () => {
+  // On a quiet connection the first client-to-server write after the first
+  // 'secure' can only be the renegotiation ClientHello (the client answers
+  // the server's HelloRequest; it has no app data to send). Dropping it and
+  // destroying the raw socket guarantees teardown runs while the wrapper is
+  // mid-renegotiation, which used to re-dispatch a bogus handshake event.
+  await using server = spawnQuietRenegotiationServer("pause");
+  const nextLine = lineReader(server);
+  const port = await readPort(nextLine);
+
+  const events: string[] = [];
+  let secure = 0;
+  let cut = false;
+  const raw = netConnect(port, "127.0.0.1");
+  const duplex = new Duplex({
+    read() {},
+    write(chunk, encoding, callback) {
+      if (secure >= 1 && !cut) {
+        cut = true;
+        queueMicrotask(() => raw.destroy());
+        callback();
+        return;
+      }
+      if (cut) {
+        callback();
+        return;
+      }
+      raw.write(chunk, encoding, callback);
+    },
+    final(callback) {
+      raw.end();
+      callback();
+    },
+  });
+  raw.on("data", (chunk: Buffer) => {
+    if (!cut) duplex.push(chunk);
+  });
+  // Deliberately no raw 'end' -> push(null) forwarding: teardown must arrive
+  // via the duplex 'close' thunk alone so the wrapper's fast shutdown runs
+  // mid-renegotiation with the TLS socket's handlers still attached.
+  raw.on("close", () => duplex.destroy());
+
+  const { promise: closed, resolve } = Promise.withResolvers<void>();
+  const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
+  socket.on("secure", () => {
+    secure++;
+    events.push(`secure#${secure}`);
+  });
+  socket.on("secureConnect", () => events.push("secureConnect"));
+  socket.on("error", (e: any) => events.push(`error:${e.code ?? e.message}`));
+  socket.on("close", (hadError: boolean) => {
+    events.push(`close(hadError=${hadError})`);
+    resolve();
+  });
+  await closed;
+
+  // Exactly one dispatch for the initial handshake; a renegotiation cut
+  // mid-flight must not produce a duplicate secureConnect/secure.
+  expect(events).toEqual(["secureConnect", "secure#1", "close(hadError=false)"]);
+});
+
 it("should terminate the connection when the peer exceeds the renegotiation limit over a duplex socket", async () => {
   // tls.connect({ socket: <Duplex> }) is encrypted by the SSLWrapper path
   // (UpgradedDuplex) rather than the uSockets C path. It must apply the same

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -448,7 +448,12 @@ it.concurrent(
       killSignal: "SIGKILL",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "drained-ok", exitCode: 0 });
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode, stderr }).toEqual({
+      stdout: "drained-ok",
+      exitCode: 0,
+      signalCode: null,
+      stderr: expect.any(String),
+    });
   },
   30_000,
 );
@@ -478,7 +483,7 @@ it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWr
   raw.on("end", () => duplex.push(null));
   raw.on("close", () => duplex.destroy());
 
-  const { promise: renegotiated, resolve } = Promise.withResolvers<void>();
+  const { promise: renegotiated, resolve, reject } = Promise.withResolvers<void>();
   let secure = 0;
   const errors: string[] = [];
   const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
@@ -490,11 +495,17 @@ it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWr
     if (secure === 2) resolve();
   });
   socket.on("error", (e: any) => errors.push(e.code ?? e.message));
+  socket.on("close", () =>
+    reject(new Error(`closed before the second 'secure' (secure=${secure}, errors=${JSON.stringify(errors)})`)),
+  );
 
-  await renegotiated;
-  expect(errors).toEqual([]);
-  socket.destroy();
-  raw.destroy();
+  try {
+    await renegotiated;
+    expect(errors).toEqual([]);
+  } finally {
+    socket.destroy();
+    raw.destroy();
+  }
 });
 
 it("should terminate the connection when the peer exceeds the renegotiation limit over a duplex socket", async () => {

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -407,7 +407,7 @@ const socket = await Bun.connect({
       if (awaitingDrain) resolveDrained();
     },
     error(s, err) {
-      if (!finished) rejectFailed(new Error("socket error before completion: " + (err?.code ?? err)));
+      if (!finished) rejectFailed(new Error("socket error before completion", { cause: err }));
     },
     close() {
       if (!finished) rejectFailed(new Error("socket closed before drain/renegotiation completed"));

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -486,6 +486,9 @@ it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWr
   const { promise: renegotiated, resolve, reject } = Promise.withResolvers<void>();
   let secure = 0;
   const errors: string[] = [];
+  raw.on("error", (e: any) =>
+    reject(new Error(`raw socket failed before the second 'secure' (secure=${secure}, error=${e.code ?? e.message})`)),
+  );
   const socket = tlsConnect({ socket: duplex, rejectUnauthorized: false });
   socket.on("secure", () => {
     secure++;

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -443,33 +443,30 @@ server.kill();
 console.log("drained-ok");
 `;
 
-it.concurrent(
-  "should dispatch drain for a backpressured write after a quiet renegotiation",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", drainAfterRenegotiationFixture],
-      env: {
-        ...bunEnv,
-        SERVER_JS: QUIET_RENEG_SERVER_JS,
-        SERVER_CERT: tls.cert,
-        SERVER_KEY: tls.key,
-        RENEG_MODE: "pause",
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-      timeout: 20_000,
-      killSignal: "SIGKILL",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode, stderr }).toEqual({
-      stdout: "drained-ok",
-      exitCode: 0,
-      signalCode: null,
-      stderr: expect.any(String),
-    });
-  },
-);
+it.concurrent("should dispatch drain for a backpressured write after a quiet renegotiation", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", drainAfterRenegotiationFixture],
+    env: {
+      ...bunEnv,
+      SERVER_JS: QUIET_RENEG_SERVER_JS,
+      SERVER_CERT: tls.cert,
+      SERVER_KEY: tls.key,
+      RENEG_MODE: "pause",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode, stderr }).toEqual({
+    stdout: "drained-ok",
+    exitCode: 0,
+    signalCode: null,
+    stderr: expect.any(String),
+  });
+});
 
 it.concurrent("should complete a quiet renegotiation over a duplex socket (SSLWrapper path)", async () => {
   // tls.connect({ socket: <Duplex> }) is encrypted by the SSLWrapper path

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -280,40 +280,43 @@ async function readPort(nextLine: () => Promise<string>) {
   return port;
 }
 
-it.concurrent("should dispatch handshake success, not ECONNRESET, when renegotiation completes without app data", async () => {
-  await using server = spawnQuietRenegotiationServer("end");
-  const port = await readPort(lineReader(server));
+it.concurrent(
+  "should dispatch handshake success, not ECONNRESET, when renegotiation completes without app data",
+  async () => {
+    await using server = spawnQuietRenegotiationServer("end");
+    const port = await readPort(lineReader(server));
 
-  const events: unknown[] = [];
-  const { promise: closed, resolve } = Promise.withResolvers<void>();
-  await Bun.connect({
-    hostname: "127.0.0.1",
-    port,
-    tls: { rejectUnauthorized: false },
-    socket: {
-      open() {},
-      data() {},
-      handshake(_socket, success, authorizationError) {
-        events.push({ success, code: (authorizationError as any)?.code ?? null });
+    const events: unknown[] = [];
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      tls: { rejectUnauthorized: false },
+      socket: {
+        open() {},
+        data() {},
+        handshake(_socket, success, authorizationError) {
+          events.push({ success, code: (authorizationError as any)?.code ?? null });
+        },
+        error(_socket, err) {
+          events.push({ error: (err as any)?.code ?? String(err) });
+        },
+        close() {
+          resolve();
+        },
       },
-      error(_socket, err) {
-        events.push({ error: (err as any)?.code ?? String(err) });
-      },
-      close() {
-        resolve();
-      },
-    },
-  });
-  await closed;
+    });
+    await closed;
 
-  // One dispatch per completed handshake (initial + renegotiation), both with
-  // the certificate verdict. The renegotiated session completed, so no
-  // "disconnected before secure TLS connection was established" ECONNRESET.
-  expect(events).toEqual([
-    { success: true, code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
-    { success: true, code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
-  ]);
-});
+    // One dispatch per completed handshake (initial + renegotiation), both with
+    // the certificate verdict. The renegotiated session completed, so no
+    // "disconnected before secure TLS connection was established" ECONNRESET.
+    expect(events).toEqual([
+      { success: true, code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+      { success: true, code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+    ]);
+  },
+);
 
 it.concurrent("should re-emit secure/secureConnect after server-initiated renegotiation like node", async () => {
   await using server = spawnQuietRenegotiationServer("end");


### PR DESCRIPTION
### What

Fixes the TLS renegotiation handshake state machine in both TLS client paths: the usockets C path (`Bun.connect`, `node:tls`, fetch) and the Rust `SSLWrapper` path (`tls.connect({ socket: <Duplex> })`, proxy tunnels), which share the same three-state design and the same bug.

When a TLS 1.2 server sends a HelloRequest (the classic IIS/Apache "request a client certificate mid-connection" pattern), the client socket entered `HANDSHAKE_RENEGOTIATION_PENDING`, but the completion check in the `SSL_read` loop only matched `HANDSHAKE_PENDING`. A renegotiation that completed without application data in the same read left the state latched forever, with three symptoms:

- The renegotiation's handshake dispatch only fired when the peer happened to send data later (via the app-data branch), not when the handshake actually finished.
- `on_writable` suppressed every drain dispatch while latched, so a backpressured write lost its write-completion callback until the peer sent something.
- Closing the socket fired `on_handshake(0)` with `ECONNRESET` / "Client network socket disconnected before secure TLS connection was established" for a session whose initial handshake completed long ago.
- A fourth bug in the same class surfaced while hunting a Windows CI flake of the new tests: when the server's Finished and its HelloRequest coalesce into one read batch (node sends them back to back; any loaded client can receive them together), `SSL_read` completes the initial handshake internally and returns `SSL_ERROR_WANT_RENEGOTIATE` without crossing any completion check, and entering the renegotiation overwrote `HANDSHAKE_PENDING`. The initial handshake's dispatch was lost for good: two completed handshakes produced a single `on_handshake`. The timing is platform-independent; Windows test concurrency just made it likely.

### Repro

Against a node TLS 1.2 server that calls `socket.renegotiate({...}, () => socket.end())` with no application data:

```js
const socket = await Bun.connect({
  hostname, port,
  tls: { rejectUnauthorized: false },
  socket: {
    handshake(s, success, authorizationError) {
      console.log(success, authorizationError?.code);
    },
    // ...
  },
});
```

Before (bun 1.4.0): handshake #1 `DEPTH_ZERO_SELF_SIGNED_CERT`, handshake #2 `ECONNRESET` at close. With a `node:tls` client, the second `secure`/`secureConnect` never fires (count 1, node emits 2).

### Fix

Three gates in `packages/bun-usockets/src/crypto/openssl.c`:

- The `SSL_read` quiet-completion check now fires for `RENEGOTIATION_PENDING` too (`state != HANDSHAKE_COMPLETED` instead of `== HANDSHAKE_PENDING`), so a renegotiation that finishes with no app data dispatches at the right time and the state returns to `HANDSHAKE_COMPLETED`.
- The close path only reports the pre-handshake ECONNRESET when the initial handshake never completed (`== HANDSHAKE_PENDING`). A renegotiation that finished inside the same read as the peer's close_notify still gets its success dispatch (the same init-finished rule the initial handshake uses); one genuinely cut short surfaces a parked protocol reason if `SSL_read` recorded one, and otherwise stays silent like any other post-handshake failure.
- Drain dispatch is suppressed only while the initial handshake is pending (`!= HANDSHAKE_PENDING` instead of `== HANDSHAKE_COMPLETED`). The drain a mid-renegotiation writable event carries belongs to bytes SSL accepted before the renegotiation began, and the event is consumed on dispatch, so suppressing it loses that drain until the peer happens to send. Mid-window writes themselves park on `WANT_READ` (BoringSSL rejects app data for the whole renegotiation window) and resume via the parked-write retry at completion, which is what makes dispatching during the window safe as well as necessary.
- The `WANT_RENEGOTIATE` branch dispatches a still-pending initial handshake (state `PENDING` with `SSL_is_init_finished`) before entering the renegotiation, with the same BIO save/restore the app-data dispatch uses.

And the same class in `src/uws/lib.rs` (`SSLWrapper`, raised in review):

- `handle_reading`'s WANT_READ/WANT_WRITE exit now calls `handle_end_of_renegotiation()` (it is gated on the renegotiation state and `SSL_is_init_finished`, so it is a no-op everywhere else), matching the app-data and ZERO_RETURN exits.
- `shutdown(fast_shutdown)` only reports a handshake failure when the initial handshake never completed; a pending renegotiation either reports its finished success or is silently reset.

The dispatch consumers also needed single-shot guards (raised in review, fixed across three sites):

- `ProxyTunnel::on_handshake` rewound the stages and `request_sent_len` on every dispatch (request re-sent into the tunnel, response parser rewound), and even with the rewind gated its repeat dispatch re-ran `check_server_identity`, whose JS `checkServerIdentity` path re-parks the request mid-response. The whole body is now first-dispatch-only (stage still `ProxyHandshake`).
- `HTTPContext::on_handshake` (direct fetch) had the same `check_server_identity` re-park on repeat dispatches; its verification block now runs only while the request stage is pre-first-call (`first_call` itself was already stage-gated).
- `WebSocketProxyTunnel::on_handshake` called `on_proxy_tls_handshake_complete()` on every dispatch; the second call takes an already-emptied upgrade-request buffer and tears the proxied `wss://` upgrade down with `FailedToWrite`. A `handshake_reported` flag makes it single-shot.

All three were reachable on main whenever a (proxied) TLS 1.2 origin renegotiated and then responded; the symptoms depend on how the response interleaves with the renegotiation, which is why they have no deterministic regression tests here (the proxy and websocket suites cover the guarded paths' normal flow).

### Why this shape

Dispatching `on_handshake` once per completed handshake (initial + each renegotiation) matches node: verified against node v26.3.0 that a client receiving a server-initiated renegotiation emits `secure`/`secureConnect` once per handshake and closes cleanly (`hadError=false`, no error). It is also the existing contract here: the fixture from #29757 asserts the second dispatch, and the dispatch consumers guard against repeats (`HTTPContext::first_call`'s stage gate, `onOpen`'s clear-after-first-call; `ProxyTunnel` was the missing one and gets its guard in this PR). BoringSSL keeps the peer certificate (and verify result) pinned across renegotiations, so the repeated dispatch carries the same verdict as the initial one.

For connections that never renegotiate the diff is behavior-neutral: every changed gate is equivalent whenever the state never reaches `RENEGOTIATION_PENDING`, and server sockets never do (server-side renegotiation is `ssl_renegotiate_never`).

### Verification

Four new tests in `test/js/node/tls/renegotiation.test.ts` against a node TLS 1.2 server that renegotiates without sending data:

- `Bun.connect`: exactly two handshake dispatches, both with the certificate verdict, no ECONNRESET (server ends after the renegotiation).
- `node:tls`: `{ secure: 2, secureConnect: 2, errors: [], hadError: false }`, matching node v26.3.0.
- Drain: the server stops reading after the renegotiation; the client floods until backpressure, the server resumes, and the drain callback plus the renegotiation's own handshake dispatch must both arrive. Runs as a subprocess with a kill timeout so a regression cannot wedge the runner.
- Duplex (`SSLWrapper`): `tls.connect({ socket: duplex })` must re-emit `secure` from the renegotiation's own completion, with no close and no app data to deliver it late.
- Mid-flight teardown (`SSLWrapper`): dropping the client's renegotiation ClientHello (the first client-to-server write after `secure` on a quiet connection) and destroying the raw transport makes the fast shutdown run while the renegotiation is pending; the previous shutdown gate re-dispatched a bogus duplicate handshake event there, and the test requires exactly one `secureConnect`/`secure` and a clean close.

Each fails on the unfixed build (second dispatch arrives as ECONNRESET, never arrives, or drain is suppressed) and passes with the fix. The coalesced-HelloRequest case is covered by the same tests: it reproduced as a 4-in-12 failure rate of this file on Windows under test concurrency, and 20 consecutive runs pass with the fix. All 8 pre-existing renegotiation tests, the rest of `test/js/node/tls/` (237 pass), the http2 client suite (347 tests), and the proxy tunnel tests pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/renegotiation.test.ts
bun test v1.4.0 (ecaf72eb2)

test/js/node/tls/renegotiation.test.ts:
 HTTP/1.1 GET https://localhost:39355/
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:39355
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Type: text/plain
< Date: Fri, 07 Aug 2026 08:37:47 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked

(pass) allow renegotiation in fetch [90.25ms]
(pass) should fail if renegotiation fails using fetch [12.37ms]
(pass) allow renegotiation in https module [1557.53ms]
(pass) should fail if renegotiation fails using https [106.12ms]
(pass) allow renegotiation in tls module [52.49ms]
(pass) should not crash when socket is closed inside the renegotiation handshake callback [372.18ms]
309 |     await closed;
310 | 
311 |     // One dispatch per completed handshake (initial + renegotiation), both with
312 |     // the certificate verdict. The renegotiated session completed, so no
313 |     // "disconnected before secure TLS connection was esta
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (0ffabf64d)

test/js/node/tls/renegotiation.test.ts:
 HTTP/1.1 GET https://localhost:46367/
 User-Agent: Bun/1.4.0
 Accept: */*
 Host: localhost:46367
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Type: text/plain
< Date: Fri, 07 Aug 2026 08:37:57 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked

(pass) allow renegotiation in fetch [18.31ms]
(pass) should fail if renegotiation fails using fetch [2.24ms]
(pass) allow renegotiation in https module [27.94ms]
(pass) should fail if renegotiation fails using https [3.08ms]
(pass) allow renegotiation in tls module [3.42ms]
(pass) should not crash when socket is closed inside the renegotiation handshake callback [20.72ms]
583 |     });
584 |     await closed;
585 | 
586 |     // Exactly one dispatch for the initial handshake; a renegotiation cut
587 |     // mid-flight must not produce a duplicate secureConnect/secure.
588 |     expect(events).toEqual(["secureConnect", "secure#1", "close(hadError=false)"]);
                         ^
error: expect(received).toEqual(expected)

  [
    "secureConnect",
    "secure#1",
+   "secureConnect",
+   "secure#2",
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/renegotiation.test.ts
bun test v1.4.0 (ecaf72eb2)

test/js/node/tls/renegotiation.test.ts:
 HTTP/1.1 GET https://localhost:43705/
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:43705
 Accept-Encoding: gzip, deflate, br, zstd
< 200 OK
< Content-Type: text/plain
< Date: Fri, 07 Aug 2026 08:38:54 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked

(pass) allow renegotiation in fetch [91.35ms]
(pass) should fail if renegotiation fails using fetch [13.95ms]
(pass) allow renegotiation in https module [1582.22ms]
(pass) should fail if renegotiation fails using https [109.28ms]
(pass) allow renegotiation in tls module [54.19ms]
(pass) should not crash when socket is closed inside the renegotiation handshake callback [383.39ms]
(pass) should dispatch handshake success, not ECONNRESET, when renegotiation completes without app data [322.50ms]
(pass) should re-emit secure/secureConnect after server-initiated renegotiation like node [323.48ms]
(pass) should complete a quiet renegotiation o
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ecaf72eb2b
  features     baseline

22 deps, 105 codegen, 1175 objects in 718ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1237] install /workspace/bun
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 107 installs across 153 packages (no changes) [11.00ms]
[2/1237] gen ErrorCode+*.h
[3/1237] gen bindgenv2
[4/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 1 install across 2 packages (no changes) [5.00ms]
[5/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[7/1237] fetch picohttpparser
[picohttpparser] up to date
[8/1237] fetch tinycc
[tinycc] up to date
[9/1236] gen .bind.ts → GeneratedBindings.cpp
[10/1236] fetch zlib
[zlib] up to date
[11/1236] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c         |  54 ++-
 src/http/HTTPContext.rs                            |  11 +-
 src/http/ProxyTunnel.rs                            |   8 +
 .../websocket_client/WebSocketProxyTunnel.rs       |  21 +-
 src/uws/lib.rs                                     |  39 ++-
 test/js/node/tls/renegotiation.test.ts             | 389 +++++++++++++++++++++
 6 files changed, 510 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c                13      8      0
src/http/HTTPContext.rs                                    2      1      0
src/http/ProxyTunnel.rs                                    1      2      0
src/http_jsc/websocket_client/WebSocketProxyTunnel.rs      2      1      0
src/uws/lib.rs                                             3      4      0
test/js/node/tls/renegotiation.test.ts                     9     18      0
```

</details>

<!-- robobun:evidence:end -->