### PR TITLE
usockets: stop the sweep timer when the last socket closes on Windows

### DIFF
--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -475,23 +475,6 @@ void us_timer_set(struct us_timer_t *t, void (*cb)(struct us_timer_t *t),
   struct us_internal_callback_t *internal_cb =
       (struct us_internal_callback_t *)t;
 
-  // Match the epoll_kqueue backend: re-arming is allowed (uv_timer_start
-  // restarts an already-running timer). The one-shot guard only applies to
-  // the sweep timer: re-arming it with the same args would skew the 4s tick.
-  // Disabling it (ms == 0, us_internal_disable_sweep_timer) must fall through
-  // to uv_timer_stop below, clearing the guard so the next enable re-arms;
-  // early-returning here instead left the timer firing every 4s for the rest
-  // of the process after the last socket closed.
-  if (internal_cb->loop->data.sweep_timer == t) {
-    if (!ms) {
-      internal_cb->has_added_timer_to_event_loop = 0;
-    } else if (internal_cb->has_added_timer_to_event_loop) {
-      return;
-    } else {
-      internal_cb->has_added_timer_to_event_loop = 1;
-    }
-  }
-
   internal_cb->cb = (void (*)(struct us_internal_callback_t *))cb;
 
   uv_timer_t *uv_timer = (uv_timer_t *)(internal_cb + 1);

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -477,13 +477,19 @@ void us_timer_set(struct us_timer_t *t, void (*cb)(struct us_timer_t *t),
 
   // Match the epoll_kqueue backend: re-arming is allowed (uv_timer_start
   // restarts an already-running timer). The one-shot guard only applies to
-  // the sweep timer, which is set with the same args from every new socket
-  // context — restarting it would skew the 4s tick.
+  // the sweep timer: re-arming it with the same args would skew the 4s tick.
+  // Disabling it (ms == 0, us_internal_disable_sweep_timer) must fall through
+  // to uv_timer_stop below, clearing the guard so the next enable re-arms;
+  // early-returning here instead left the timer firing every 4s for the rest
+  // of the process after the last socket closed.
   if (internal_cb->loop->data.sweep_timer == t) {
-    if (internal_cb->has_added_timer_to_event_loop) {
+    if (!ms) {
+      internal_cb->has_added_timer_to_event_loop = 0;
+    } else if (internal_cb->has_added_timer_to_event_loop) {
       return;
+    } else {
+      internal_cb->has_added_timer_to_event_loop = 1;
     }
-    internal_cb->has_added_timer_to_event_loop = 1;
   }
 
   internal_cb->cb = (void (*)(struct us_internal_callback_t *))cb;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -404,9 +404,6 @@ struct us_internal_callback_t {
   int cb_expects_the_loop;
   int leave_poll_ready;
   void (*cb)(struct us_internal_callback_t *cb);
-#ifdef LIBUS_USE_LIBUV
-  unsigned has_added_timer_to_event_loop;
-#endif
 };
 
 #endif

--- a/test/napi/uv-sweep-timer.test.ts
+++ b/test/napi/uv-sweep-timer.test.ts
@@ -134,7 +134,10 @@ describe.if(isWindows && canBuildNodeAddons())("usockets sweep timer (libuv back
 
     // --ignore-scripts skips the implicit `node-gyp rebuild` bun install runs
     // for a root binding.gyp package; build:napi below is the single build.
-    for (const cmd of [[bunExe(), "install", "--ignore-scripts"], [bunExe(), "run", "build:napi"]]) {
+    for (const cmd of [
+      [bunExe(), "install", "--ignore-scripts"],
+      [bunExe(), "run", "build:napi"],
+    ]) {
       const proc = spawnSync({ cmd, cwd: dir, env: bunEnv, stdout: "inherit", stderr: "inherit" });
       if (!proc.success) throw new Error(`${cmd.join(" ")} failed`);
     }

--- a/test/napi/uv-sweep-timer.test.ts
+++ b/test/napi/uv-sweep-timer.test.ts
@@ -17,47 +17,71 @@ const ADDON_C = /* c */ `
 #include <node_api.h>
 #include <uv.h>
 
+#define NODE_API_CALL(env, call)                                               \\
+  do {                                                                         \\
+    if ((call) != napi_ok) {                                                   \\
+      napi_throw_error((env), NULL, #call " failed");                          \\
+      return NULL;                                                             \\
+    }                                                                          \\
+  } while (0)
+
 typedef struct {
   napi_env env;
   napi_value arr;
   uint32_t idx;
+  napi_status status;
+  const char *failed_call;
 } walk_state;
+
+// uv_walk has no way to abort mid-walk, so record the first failure and make
+// the remaining visits no-ops; Timers() turns it into a thrown error.
+#define WALK_CALL(st, call)                                                    \\
+  do {                                                                         \\
+    if ((st)->status == napi_ok) {                                             \\
+      (st)->status = (call);                                                   \\
+      if ((st)->status != napi_ok) (st)->failed_call = #call " failed";        \\
+    }                                                                          \\
+  } while (0)
 
 static void walk_cb(uv_handle_t *handle, void *arg) {
   walk_state *st = (walk_state *)arg;
+  if (st->status != napi_ok) return;
   if (uv_handle_get_type(handle) != UV_TIMER) return;
   uv_timer_t *timer = (uv_timer_t *)handle;
   int active = uv_is_active(handle);
   napi_value obj, v;
-  napi_create_object(st->env, &obj);
-  napi_get_boolean(st->env, active != 0, &v);
-  napi_set_named_property(st->env, obj, "active", v);
-  napi_create_double(st->env, active ? (double)uv_timer_get_due_in(timer) : -1.0, &v);
-  napi_set_named_property(st->env, obj, "dueIn", v);
-  napi_create_double(st->env, (double)uv_timer_get_repeat(timer), &v);
-  napi_set_named_property(st->env, obj, "repeat", v);
-  napi_set_element(st->env, st->arr, st->idx++, obj);
+  WALK_CALL(st, napi_create_object(st->env, &obj));
+  WALK_CALL(st, napi_get_boolean(st->env, active != 0, &v));
+  WALK_CALL(st, napi_set_named_property(st->env, obj, "active", v));
+  WALK_CALL(st, napi_create_double(st->env, active ? (double)uv_timer_get_due_in(timer) : -1.0, &v));
+  WALK_CALL(st, napi_set_named_property(st->env, obj, "dueIn", v));
+  WALK_CALL(st, napi_create_double(st->env, (double)uv_timer_get_repeat(timer), &v));
+  WALK_CALL(st, napi_set_named_property(st->env, obj, "repeat", v));
+  WALK_CALL(st, napi_set_element(st->env, st->arr, st->idx, obj));
+  st->idx++;
 }
 
 static napi_value Timers(napi_env env, napi_callback_info info) {
   uv_loop_t *loop = NULL;
-  napi_status status = napi_get_uv_event_loop(env, &loop);
-  if (status != napi_ok || loop == NULL) {
-    napi_throw_error(env, NULL, "napi_get_uv_event_loop failed");
+  NODE_API_CALL(env, napi_get_uv_event_loop(env, &loop));
+  if (loop == NULL) {
+    napi_throw_error(env, NULL, "napi_get_uv_event_loop returned NULL");
     return NULL;
   }
-  walk_state st;
-  st.env = env;
-  st.idx = 0;
-  napi_create_array(env, &st.arr);
+  walk_state st = {env, NULL, 0, napi_ok, NULL};
+  NODE_API_CALL(env, napi_create_array(env, &st.arr));
   uv_walk(loop, walk_cb, &st);
+  if (st.status != napi_ok) {
+    napi_throw_error(env, NULL, st.failed_call);
+    return NULL;
+  }
   return st.arr;
 }
 
 NAPI_MODULE_INIT() {
   napi_value fn;
-  napi_create_function(env, "timers", NAPI_AUTO_LENGTH, Timers, NULL, &fn);
-  napi_set_named_property(env, exports, "timers", fn);
+  NODE_API_CALL(env, napi_create_function(env, "timers", NAPI_AUTO_LENGTH, Timers, NULL, &fn));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "timers", fn));
   return exports;
 }
 `;

--- a/test/napi/uv-sweep-timer.test.ts
+++ b/test/napi/uv-sweep-timer.test.ts
@@ -1,0 +1,161 @@
+import { spawnSync } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, canBuildNodeAddons, isWindows, tempDirWithFiles } from "harness";
+import path from "node:path";
+
+// On Windows (the libuv usockets backend), the socket-timeout sweep is a
+// repeating 4s uv_timer. It must be armed only while sockets exist: once the
+// last socket closes, us_internal_disable_sweep_timer stops it so an idle
+// process blocks in the poll instead of waking every 4s forever, and a later
+// socket must arm it again so socket.timeout() keeps firing.
+//
+// The fixture observes the real uv timer through a node-gyp addon using
+// public embedder API (napi_get_uv_event_loop + uv_walk), identifying the
+// sweep timer by its repeat interval (LIBUS_TIMEOUT_GRANULARITY = 4s; no
+// other uv timer in Bun repeats at 4000ms).
+const ADDON_C = /* c */ `
+#include <node_api.h>
+#include <uv.h>
+
+typedef struct {
+  napi_env env;
+  napi_value arr;
+  uint32_t idx;
+} walk_state;
+
+static void walk_cb(uv_handle_t *handle, void *arg) {
+  walk_state *st = (walk_state *)arg;
+  if (uv_handle_get_type(handle) != UV_TIMER) return;
+  uv_timer_t *timer = (uv_timer_t *)handle;
+  int active = uv_is_active(handle);
+  napi_value obj, v;
+  napi_create_object(st->env, &obj);
+  napi_get_boolean(st->env, active != 0, &v);
+  napi_set_named_property(st->env, obj, "active", v);
+  napi_create_double(st->env, active ? (double)uv_timer_get_due_in(timer) : -1.0, &v);
+  napi_set_named_property(st->env, obj, "dueIn", v);
+  napi_create_double(st->env, (double)uv_timer_get_repeat(timer), &v);
+  napi_set_named_property(st->env, obj, "repeat", v);
+  napi_set_element(st->env, st->arr, st->idx++, obj);
+}
+
+static napi_value Timers(napi_env env, napi_callback_info info) {
+  uv_loop_t *loop = NULL;
+  napi_status status = napi_get_uv_event_loop(env, &loop);
+  if (status != napi_ok || loop == NULL) {
+    napi_throw_error(env, NULL, "napi_get_uv_event_loop failed");
+    return NULL;
+  }
+  walk_state st;
+  st.env = env;
+  st.idx = 0;
+  napi_create_array(env, &st.arr);
+  uv_walk(loop, walk_cb, &st);
+  return st.arr;
+}
+
+NAPI_MODULE_INIT() {
+  napi_value fn;
+  napi_create_function(env, "timers", NAPI_AUTO_LENGTH, Timers, NULL, &fn);
+  napi_set_named_property(env, exports, "timers", fn);
+  return exports;
+}
+`;
+
+const FIXTURE_JS = /* js */ `
+const addon = require("./build/Release/sweep_introspect.node");
+
+// LIBUS_TIMEOUT_GRANULARITY * 1000
+const SWEEP_REPEAT_MS = 4000;
+
+function sweepTimers() {
+  return addon.timers().filter(t => t.repeat === SWEEP_REPEAT_MS);
+}
+
+function dump(label) {
+  console.error(label, JSON.stringify(addon.timers()));
+}
+
+async function pollUntil(cond, deadlineMs) {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    if (cond()) return true;
+    await Bun.sleep(50);
+  }
+  return cond();
+}
+
+const noop = { data() {}, open() {}, close() {} };
+const result = {};
+
+dump("before any socket");
+result.inactiveBeforeSockets = sweepTimers().every(t => !t.active);
+
+const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: noop });
+const sock = await Bun.connect({ hostname: "127.0.0.1", port: server.port, socket: noop });
+dump("sockets open");
+result.armedWhileSocketsOpen = sweepTimers().some(t => t.active);
+
+sock.end();
+server.stop(true);
+result.stoppedAfterLastClose = await pollUntil(() => sweepTimers().every(t => !t.active), 10_000);
+dump("after close");
+
+const server2 = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: noop });
+const sock2 = await Bun.connect({ hostname: "127.0.0.1", port: server2.port, socket: noop });
+result.rearmedForNewSocket = await pollUntil(() => sweepTimers().some(t => t.active), 10_000);
+dump("reopened");
+
+sock2.end();
+server2.stop(true);
+result.stoppedAfterSecondClose = await pollUntil(() => sweepTimers().every(t => !t.active), 10_000);
+dump("after second close");
+
+console.log(JSON.stringify(result));
+`;
+
+describe.if(isWindows && canBuildNodeAddons())("usockets sweep timer (libuv backend)", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = tempDirWithFiles("uv-sweep-timer", {
+      "addon.c": ADDON_C,
+      "fixture.js": FIXTURE_JS,
+      "binding.gyp": JSON.stringify({
+        targets: [{ target_name: "sweep_introspect", sources: ["addon.c"] }],
+      }),
+      "package.json": JSON.stringify({
+        name: "sweep-introspect",
+        version: "1.0.0",
+        scripts: { "build:napi": "node-gyp configure && node-gyp build" },
+        dependencies: { "node-gyp": "10.2.0" },
+      }),
+    });
+
+    // --ignore-scripts skips the implicit `node-gyp rebuild` bun install runs
+    // for a root binding.gyp package; build:napi below is the single build.
+    for (const cmd of [[bunExe(), "install", "--ignore-scripts"], [bunExe(), "run", "build:napi"]]) {
+      const proc = spawnSync({ cmd, cwd: dir, env: bunEnv, stdout: "inherit", stderr: "inherit" });
+      if (!proc.success) throw new Error(`${cmd.join(" ")} failed`);
+    }
+  }, 300_000);
+
+  test("stops when the last socket closes and re-arms for new sockets", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(dir, "fixture.js")],
+      cwd: dir,
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error(stderr);
+    expect(JSON.parse(stdout)).toEqual({
+      inactiveBeforeSockets: true,
+      armedWhileSocketsOpen: true,
+      stoppedAfterLastClose: true,
+      rearmedForNewSocket: true,
+      stoppedAfterSecondClose: true,
+    });
+    expect(exitCode).toBe(0);
+  }, 90_000);
+});

--- a/test/napi/uv-sweep-timer.test.ts
+++ b/test/napi/uv-sweep-timer.test.ts
@@ -151,8 +151,12 @@ describe.if(isWindows && canBuildNodeAddons())("usockets sweep timer (libuv back
       "package.json": JSON.stringify({
         name: "sweep-introspect",
         version: "1.0.0",
-        scripts: { "build:napi": "node-gyp configure && node-gyp build" },
-        dependencies: { "node-gyp": "10.2.0" },
+        // `bun --bun` like napi-app: under node >= 26, node-gyp inherits
+        // clang=1 from the runner's process.config and generates vcxprojs
+        // for the ClangCL toolset, which CI's VS install does not have.
+        // Bun reports clang=0, selecting the stock MSVC toolset.
+        scripts: { "build:napi": "bun --bun node-gyp rebuild" },
+        dependencies: { "node-gyp": "^11.2.0" },
       }),
     });
 

--- a/test/napi/uv-sweep-timer.test.ts
+++ b/test/napi/uv-sweep-timer.test.ts
@@ -126,9 +126,25 @@ result.stoppedAfterLastClose = await pollUntil(() => sweepTimers().every(t => !t
 dump("after close");
 
 const server2 = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: noop });
-const sock2 = await Bun.connect({ hostname: "127.0.0.1", port: server2.port, socket: noop });
+let sawTimeout = false;
+const sock2 = await Bun.connect({
+  hostname: "127.0.0.1",
+  port: server2.port,
+  socket: {
+    ...noop,
+    timeout() {
+      sawTimeout = true;
+    },
+  },
+});
 result.rearmedForNewSocket = await pollUntil(() => sweepTimers().some(t => t.active), 10_000);
 dump("reopened");
+
+// Armed is not enough: disabling installs a noop callback, so prove the
+// re-enabled timer dispatches to the real sweep by waiting for a socket
+// timeout to fire (notify-only; one ~4s granularity tick).
+sock2.timeout(1);
+result.timeoutFiredAfterRearm = await pollUntil(() => sawTimeout, 30_000);
 
 sock2.end();
 server2.stop(true);
@@ -185,6 +201,7 @@ describe.if(isWindows && canBuildNodeAddons())("usockets sweep timer (libuv back
       armedWhileSocketsOpen: true,
       stoppedAfterLastClose: true,
       rearmedForNewSocket: true,
+      timeoutFiredAfterRearm: true,
       stoppedAfterSecondClose: true,
     });
     expect(exitCode).toBe(0);


### PR DESCRIPTION
### Symptom

Windows only (the libuv usockets backend). Once a process creates any socket (one `fetch`, one `Bun.listen`), the usockets timeout-sweep timer, a repeating 4s `uv_timer`, keeps firing until loop teardown even after every socket has closed. An otherwise idle process wakes every 4 seconds for its whole lifetime: each expiry runs the sweep walk plus the prepare/check hooks, and `uv__next_timeout` bounds the poll timeout to <= 4000ms whenever anything else keeps the loop alive (the timer handle is unref'd, but libuv's next-timeout scan takes the min of the full timer heap with no ref check). The POSIX backends already park the sweep on disable (`sweep_next_tick_ns = -1` in `loop.c`), so this is a parity bug with power/perf impact, not a correctness bug.

### Cause

`us_internal_disable_sweep_timer` stops the sweep by calling `us_timer_set(loop->data.sweep_timer, sweep_timer_noop, 0, 0)`. On the libuv backend, `us_timer_set` had a one-shot guard for the sweep timer:

```c
if (internal_cb->loop->data.sweep_timer == t) {
  if (internal_cb->has_added_timer_to_event_loop) {
    return;
  }
  internal_cb->has_added_timer_to_event_loop = 1;
}
```

Once the first socket armed the timer, every later call, including the disable call, early-returned before the `if (!ms) uv_timer_stop(...)` below, so the timer could never be stopped.

### Fix

Delete the guard and the `has_added_timer_to_event_loop` field. The guard predates the `sweep_timer_count` gating in `us_internal_enable_sweep_timer` / `us_internal_disable_sweep_timer`: that counter already guarantees the sweep timer is armed only on the 0 -> 1 transition and stopped only on 1 -> 0 (those are the only two `us_timer_set` calls on the sweep timer in the tree), so an arm-while-armed call the guard was protecting against cannot happen, and the flag had become a write-only duplicate of loop-level state. `us_timer_set` is now a plain `ms == 0 ? uv_timer_stop : uv_timer_start` passthrough, the same for every timer. The field has no Rust mirror, so the removal is contained to the two C files.

### Test

`test/napi/uv-sweep-timer.test.ts` (Windows-only): a small node-gyp addon observes the real event loop through public embedder API (`napi_get_uv_event_loop` + `uv_walk`), identifying the sweep timer by its 4000ms repeat interval (no other uv timer in Bun repeats at 4000ms). The fixture asserts, in one process:

1. no active sweep timer before any socket,
2. armed while sockets are open,
3. stopped once the last socket closes,
4. re-armed when a new socket appears,
5. a `socket.timeout(1)` on the new socket actually fires (disable installs a noop callback, so an armed timer alone would not prove the re-enabled timer dispatches to the real sweep),
6. stopped again after the second close.

All waits poll with deadlines rather than fixed sleeps. On unmodified bun (1.4.0 canary, win32 x64) the test fails exactly on the two stop assertions, and the dispatch assertion passes because the stuck timer never stopped sweeping:

```
-   "stoppedAfterLastClose": true,
-   "stoppedAfterSecondClose": true,
+   "stoppedAfterLastClose": false,
+   "stoppedAfterSecondClose": false,
```

With this change the whole fixture passes (~4s, one sweep granularity tick for the timeout dispatch), and `bun bd test test/js/bun/net/socket.test.ts -t timeout` still passes on Windows.

The changed code only compiles under `LIBUS_USE_LIBUV`, so the test skips on POSIX; behavior there is unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/uv-sweep-timer.test.ts

<!-- robobun:evidence:end -->