### PR TITLE
usockets(kqueue): deliver a peer reset to sockets polling for no events

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -367,15 +367,25 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
              * the EV_CLEAR write knote kqueue_change keeps as a
              * connection-death detector (a half-open socket past on_end whose
              * writes drained, or a paused socket). EV_EOF there means
-             * SS_CANTSENDMORE: for a socket we did not shut down, the
-             * connection is dead (peer reset) - deliver it as the poll error
-             * epoll reports via its implicit EPOLLERR, not as eof, which
-             * would re-run on_end on a half-open socket. After our own
-             * shutdown EV_EOF merely echoes that shutdown; only a pending
-             * socket error (fflags) marks a dead peer. */
+             * SS_CANTSENDMORE, which is not a read EOF: never surface it as
+             * eof (that would re-run on_end on a half-open socket, or
+             * clean-close a shut-down one on its own shutdown echo). It is
+             * the connection dying - route it to the error path the way epoll
+             * reports its implicit EPOLLERR - when the kernel holds an error
+             * (fflags, a TCP reset), or when a socket we neither shut down
+             * nor paused loses its write side (a unix peer's close sets
+             * SS_CANTSENDMORE with no so_error). A paused socket without a
+             * pending error stays quiet instead: a graceful unix disconnect
+             * may still have readable data queued, and us_socket_resume
+             * re-arms EVFILT_READ, which then drains it and delivers the
+             * proper end-of-stream (epoll's EPOLLHUP takes the same deferred
+             * route through the is_paused guard in loop.c). */
             const int kind = us_internal_poll_type(poll);
-            if (kind == POLL_TYPE_SOCKET || (kind == POLL_TYPE_SOCKET_SHUT_DOWN && bits.send_eof_err)) {
-                error = 1;
+            if (kind == POLL_TYPE_SOCKET || kind == POLL_TYPE_SOCKET_SHUT_DOWN) {
+                const struct us_socket_t *s = (const struct us_socket_t *) poll;
+                if (bits.send_eof_err || (kind == POLL_TYPE_SOCKET && !s->flags.is_paused)) {
+                    error = 1;
+                }
                 eof = bits.eof;
             }
         }

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -366,24 +366,24 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
             /* This poll asked for no events, so its only kernel presence is
              * the EV_CLEAR write knote kqueue_change keeps as a
              * connection-death detector (a half-open socket past on_end whose
-             * writes drained, or a paused socket). EV_EOF there means
-             * SS_CANTSENDMORE, which is not a read EOF: never surface it as
-             * eof (that would re-run on_end on a half-open socket, or
-             * clean-close a shut-down one on its own shutdown echo). It is
-             * the connection dying - route it to the error path the way epoll
-             * reports its implicit EPOLLERR - when the kernel holds an error
-             * (fflags, a TCP reset), or when a socket we neither shut down
-             * nor paused loses its write side (a unix peer's close sets
-             * SS_CANTSENDMORE with no so_error). A paused socket without a
-             * pending error stays quiet instead: a graceful unix disconnect
-             * may still have readable data queued, and us_socket_resume
-             * re-arms EVFILT_READ, which then drains it and delivers the
-             * proper end-of-stream (epoll's EPOLLHUP takes the same deferred
-             * route through the is_paused guard in loop.c). */
+             * writes drained, or a paused socket). EV_EOF there is
+             * SS_CANTSENDMORE, never a read EOF: keep it away from the eof
+             * path, which would re-run on_end on a half-open socket or
+             * clean-close a shut-down one on its own shutdown echo. With a
+             * socket error in fflags (a TCP reset) it is the poll error,
+             * routed exactly like epoll's implicit EPOLLERR. Without one it
+             * stays silent - our own shutdown's echo, a unix peer's graceful
+             * close (SS_CANTSENDMORE with so_error 0), the peer's FIN after
+             * our shutdown - because tearing down an allowHalfOpen or paused
+             * socket here would fabricate ECONNRESET for a graceful
+             * disconnect that epoll reports as a mere EPOLLHUP. Such a
+             * socket stays reachable through us_socket_resume, a write's
+             * EPIPE, or a later reset; epoll reports some of these promptly
+             * where kqueue now waits for the app, which is the deliberate
+             * cost of not guessing. */
             const int kind = us_internal_poll_type(poll);
             if (kind == POLL_TYPE_SOCKET || kind == POLL_TYPE_SOCKET_SHUT_DOWN) {
-                const struct us_socket_t *s = (const struct us_socket_t *) poll;
-                if (bits.send_eof_err || (kind == POLL_TYPE_SOCKET && !s->flags.is_paused)) {
+                if (bits.send_eof_err) {
                     error = 1;
                 }
                 eof = bits.eof;

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -280,8 +280,10 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
         uint8_t writable : 1;
         uint8_t error    : 1;
         uint8_t eof      : 1;
+        uint8_t send_eof : 1;
+        uint8_t send_eof_err : 1;
         uint8_t skip     : 1;
-        uint8_t _pad     : 3;
+        uint8_t _pad     : 1;
     };
 
     _Static_assert(sizeof(struct kevent_flags) == 1, "kevent_flags must be 1 byte");
@@ -305,7 +307,15 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
 #endif
             .writable = (filter == EVFILT_WRITE),
             .error = !!(flags & EV_ERROR),
-            .eof = !!(flags & EV_EOF),
+            /* eof tracks the read side only; the write filter's EV_EOF
+             * (SS_CANTSENDMORE) is kept separate so the zero-event detector
+             * below can route it to the error path without fabricating a
+             * second read EOF. Dispatch still ORs them, preserving behavior
+             * for polls with events armed. */
+            .eof = (flags & EV_EOF) && filter != EVFILT_WRITE,
+            .send_eof = (filter == EVFILT_WRITE) && (flags & EV_EOF),
+            /* kevent(2): with EV_EOF set, fflags carries the socket error. */
+            .send_eof_err = (filter == EVFILT_WRITE) && (flags & EV_EOF) && loop->ready_polls[i].fflags != 0,
         };
 
         /* Look backward for a prior entry with the same poll to coalesce into.
@@ -317,6 +327,8 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
                 coalesced[j].writable |= bits.writable;
                 coalesced[j].error |= bits.error;
                 coalesced[j].eof |= bits.eof;
+                coalesced[j].send_eof |= bits.send_eof;
+                coalesced[j].send_eof_err |= bits.send_eof_err;
                 coalesced[i] = (struct kevent_flags){ .skip = 1 };
                 merged = 1;
                 break;
@@ -344,9 +356,32 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
         int events = (bits.readable ? LIBUS_SOCKET_READABLE : 0)
                    | (bits.writable ? LIBUS_SOCKET_WRITABLE : 0);
 
-        events &= us_poll_events(poll);
-        if (events || bits.error || bits.eof) {
-            us_internal_dispatch_ready_poll(poll, bits.error, bits.eof, events);
+        int error = bits.error;
+        int eof = bits.eof | bits.send_eof;
+
+        const int wanted = us_poll_events(poll);
+        events &= wanted;
+
+        if (bits.send_eof && wanted == 0) {
+            /* This poll asked for no events, so its only kernel presence is
+             * the EV_CLEAR write knote kqueue_change keeps as a
+             * connection-death detector (a half-open socket past on_end whose
+             * writes drained, or a paused socket). EV_EOF there means
+             * SS_CANTSENDMORE: for a socket we did not shut down, the
+             * connection is dead (peer reset) - deliver it as the poll error
+             * epoll reports via its implicit EPOLLERR, not as eof, which
+             * would re-run on_end on a half-open socket. After our own
+             * shutdown EV_EOF merely echoes that shutdown; only a pending
+             * socket error (fflags) marks a dead peer. */
+            const int kind = us_internal_poll_type(poll);
+            if (kind == POLL_TYPE_SOCKET || (kind == POLL_TYPE_SOCKET_SHUT_DOWN && bits.send_eof_err)) {
+                error = 1;
+                eof = bits.eof;
+            }
+        }
+
+        if (events || error || eof) {
+            us_internal_dispatch_ready_poll(poll, error, eof, events);
         }
     }
 #endif
@@ -543,10 +578,18 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
     }
 
     if(!is_readable && !is_writable) {
-        if(!(old_events & LIBUS_SOCKET_WRITABLE)) {
-            // if we are not reading or writing, we need to add writable to receive FIN
-            EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0, (uint64_t)(void*)user_data, 0, 0);
-        }
+        /* Polling neither direction must still see the connection die, the way a
+         * zero-event epoll registration still reports EPOLLHUP/EPOLLERR (see
+         * us_poll_start_rc). Keep an EV_CLEAR write knote armed: it fires once on
+         * arming (the socket is trivially writable; the dispatcher masks it out)
+         * and then only on write-side state changes, so an idle half-open or
+         * paused socket does not wake the loop, while a peer reset reports
+         * EV_EOF/fflags through it. EV_ONESHOT here got consumed by that first
+         * masked wakeup, leaving the fd with no knote at all: the reset was never
+         * seen and the socket leaked until process exit. Unconditional because
+         * EV_ADD must also convert a still-armed oneshot from prior WRITABLE
+         * interest. */
+        EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, EV_ADD | EV_CLEAR, 0, 0, (uint64_t)(void*)user_data, 0, 0);
     } else if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
         /* Do they differ in writable? */
         EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD | EV_ONESHOT : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
@@ -660,6 +703,19 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
         /* Set all removed events to null-polls in pending ready poll list */
         us_internal_loop_update_pending_ready_polls(loop, p, p, old_events, events);
     }
+#ifdef LIBUS_USE_KQUEUE
+    else if (events == 0) {
+        /* 0 -> 0 is not a no-op on kqueue for a socket: a writable dispatch
+         * consumed the EV_ONESHOT write knote (loop.c clears
+         * POLL_TYPE_POLLING_OUT to mirror that), so the fd may hold no knote
+         * at all. Re-register the EV_CLEAR detector (see kqueue_change) so a
+         * peer reset can still wake the socket. */
+        const int kind = us_internal_poll_type(p);
+        if (kind == POLL_TYPE_SOCKET || kind == POLL_TYPE_SOCKET_SHUT_DOWN) {
+            kqueue_change(loop->fd, p->state.fd, 0, 0, p);
+        }
+    }
+#endif
 }
 
 void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {
@@ -672,9 +728,20 @@ void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {
          rc = epoll_ctl(loop->fd, EPOLL_CTL_DEL, p->state.fd, &event);
     } while (IS_EINTR(rc));
 #else
-    if (old_events) {
-        kqueue_change(loop->fd, p->state.fd, old_events, new_events, NULL);
-    }
+    /* Delete both filters explicitly, whatever the tracked events say: a poll
+     * at 0 events still holds the EV_CLEAR detector knote (see kqueue_change),
+     * and kqueue_change's diff cannot express "delete everything" (its 0 -> 0
+     * transition arms the detector instead). This matters for detach paths
+     * (us_socket_detach) that stop the poll but keep the fd open: a leftover
+     * knote would keep the freed poll as udata. Deleting an absent filter just
+     * reports ENOENT through KEVENT_FLAG_ERROR_EVENTS, which we ignore. */
+    struct kevent64_s change_list[2];
+    EV_SET64(&change_list[0], p->state.fd, EVFILT_READ, EV_DELETE, 0, 0, 0, 0, 0);
+    EV_SET64(&change_list[1], p->state.fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0, 0, 0);
+    int rc;
+    do {
+        rc = kevent64(loop->fd, change_list, 2, change_list, 2, KEVENT_FLAG_ERROR_EVENTS, NULL);
+    } while (IS_EINTR(rc));
 #endif
 
     /* Disable any instance of us in the pending ready poll list */

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -362,31 +362,44 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
         const int wanted = us_poll_events(poll);
         events &= wanted;
 
-        if (bits.send_eof && wanted == 0) {
-            /* This poll asked for no events, so its only kernel presence is
-             * the EV_CLEAR write knote kqueue_change keeps as a
-             * connection-death detector (a half-open socket past on_end whose
-             * writes drained, or a paused socket). EV_EOF there is
-             * SS_CANTSENDMORE, never a read EOF: keep it away from the eof
-             * path, which would re-run on_end on a half-open socket or
-             * clean-close a shut-down one on its own shutdown echo. With a
-             * socket error in fflags (a TCP reset) it is the poll error,
-             * routed exactly like epoll's implicit EPOLLERR. Without one it
-             * stays silent - our own shutdown's echo, a unix peer's graceful
-             * close (SS_CANTSENDMORE with so_error 0), the peer's FIN after
-             * our shutdown - because tearing down an allowHalfOpen or paused
-             * socket here would fabricate ECONNRESET for a graceful
-             * disconnect that epoll reports as a mere EPOLLHUP. Such a
-             * socket stays reachable through us_socket_resume, a write's
-             * EPIPE, or a later reset; epoll reports some of these promptly
-             * where kqueue now waits for the app, which is the deliberate
-             * cost of not guessing. */
+        /* The EV_CLEAR write knote kqueue_change keeps as a connection-death
+         * detector exists whenever WRITABLE is not armed: it is the only
+         * kernel presence of a poll at zero events (a half-open socket past
+         * on_end whose writes drained, or a paused socket), and it survives a
+         * later 0 -> READABLE transition, whose diff has no reason to touch
+         * the write filter. EV_EOF from it is SS_CANTSENDMORE, and what that
+         * means depends on what we know. */
+        if (bits.send_eof && !(wanted & LIBUS_SOCKET_WRITABLE)) {
             const int kind = us_internal_poll_type(poll);
             if (kind == POLL_TYPE_SOCKET || kind == POLL_TYPE_SOCKET_SHUT_DOWN) {
+                const struct us_socket_t *s = (const struct us_socket_t *) poll;
                 if (bits.send_eof_err) {
+                    /* A pending socket error (a TCP reset) is the poll error,
+                     * routed exactly like epoll's implicit EPOLLERR. */
                     error = 1;
+                    eof = bits.eof;
+                } else if (kind == POLL_TYPE_SOCKET_SHUT_DOWN && !s->flags.is_paused && wanted == 0) {
+                    /* Both directions are done: the only route to zero events
+                     * without pause consumed the peer's FIN already (and
+                     * deleted the read knote with it), and our own shutdown
+                     * answered it, so this echo is the close signal. eof
+                     * stays set (bits.eof | bits.send_eof) and the shut-down
+                     * branch in loop.c clean-closes, exactly like epoll's
+                     * EPOLLHUP for the same both-directions-shut state. */
+                } else {
+                    /* Stay silent. A paused socket's disconnect may have
+                     * readable data queued ahead of it, which resume()'s
+                     * re-armed EVFILT_READ drains before the real
+                     * end-of-stream. A resumed reader (wanted == READABLE)
+                     * hears the peer through the read filter, so a stale
+                     * shutdown echo must not clean-close it first. And on a
+                     * not-shut-down socket, a unix peer's graceful close
+                     * (SS_CANTSENDMORE with so_error 0) must not fabricate
+                     * the ECONNRESET the error path would clamp to, nor
+                     * re-run on_end via eof, for a disconnect epoll reports
+                     * as a mere EPOLLHUP. */
+                    eof = bits.eof;
                 }
-                eof = bits.eof;
             }
         }
 

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -372,32 +372,33 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
         if (bits.send_eof && !(wanted & LIBUS_SOCKET_WRITABLE)) {
             const int kind = us_internal_poll_type(poll);
             if (kind == POLL_TYPE_SOCKET || kind == POLL_TYPE_SOCKET_SHUT_DOWN) {
-                const struct us_socket_t *s = (const struct us_socket_t *) poll;
                 if (bits.send_eof_err) {
                     /* A pending socket error (a TCP reset) is the poll error,
                      * routed exactly like epoll's implicit EPOLLERR. */
                     error = 1;
                     eof = bits.eof;
-                } else if (kind == POLL_TYPE_SOCKET_SHUT_DOWN && !s->flags.is_paused && wanted == 0) {
-                    /* Both directions are done: the only route to zero events
-                     * without pause consumed the peer's FIN already (and
-                     * deleted the read knote with it), and our own shutdown
-                     * answered it, so this echo is the close signal. eof
-                     * stays set (bits.eof | bits.send_eof) and the shut-down
-                     * branch in loop.c clean-closes, exactly like epoll's
-                     * EPOLLHUP for the same both-directions-shut state. */
+                } else if (kind == POLL_TYPE_SOCKET_SHUT_DOWN && wanted == 0) {
+                    /* A shut-down socket with no read knote has no other way
+                     * to learn the connection is over: eof stays set
+                     * (bits.eof | bits.send_eof) and the shut-down branch in
+                     * loop.c clean-closes. For the half-open path that is
+                     * exact epoll parity (the peer's FIN was consumed before
+                     * the read knote was deleted, and EPOLLHUP would fire for
+                     * the same both-directions-shut state). For a paused
+                     * socket it means closing on our own shutdown's echo,
+                     * which node:http's half-close-with-unread-body depends
+                     * on (nothing ever resumes that socket), where epoll
+                     * waits for the peer's FIN to complete SHUTDOWN_MASK. */
                 } else {
-                    /* Stay silent. A paused socket's disconnect may have
-                     * readable data queued ahead of it, which resume()'s
-                     * re-armed EVFILT_READ drains before the real
-                     * end-of-stream. A resumed reader (wanted == READABLE)
+                    /* Stay silent. A resumed reader (wanted == READABLE)
                      * hears the peer through the read filter, so a stale
                      * shutdown echo must not clean-close it first. And on a
                      * not-shut-down socket, a unix peer's graceful close
                      * (SS_CANTSENDMORE with so_error 0) must not fabricate
                      * the ECONNRESET the error path would clamp to, nor
                      * re-run on_end via eof, for a disconnect epoll reports
-                     * as a mere EPOLLHUP. */
+                     * as a mere EPOLLHUP; a paused one keeps its queued data
+                     * readable for resume(). */
                     eof = bits.eof;
                 }
             }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -832,6 +832,115 @@ describe.concurrent("socket", () => {
     }
   });
 
+  // Replying to the peer's FIN with our own shutdown (what node:net's end()
+  // does) leaves the socket shut down at zero poll events, and the write-side
+  // shutdown echo is then its only close signal (the read knote went away
+  // with the consumed FIN). It must be delivered as the clean close, the way
+  // epoll's EPOLLHUP closes the same both-directions-shut state.
+  it.skipIf(isWindows)("allowHalfOpen socket closes cleanly after both sides shut down", async () => {
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<string>();
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      allowHalfOpen: true,
+      socket: {
+        open() {},
+        data() {},
+        end(socket) {
+          // The canonical reply to the peer's FIN: finish our side too.
+          // shutdown() half-closes natively; end() would close outright at
+          // the JS layer and never depend on the kernel's close signal.
+          socket.shutdown();
+        },
+        close() {
+          onClosed("close");
+        },
+        error() {
+          onClosed("error");
+        },
+      },
+    });
+
+    const client = net.connect({ port: server.port, host: "127.0.0.1", allowHalfOpen: true });
+    client.on("error", () => {});
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once("connect", resolve);
+        client.once("error", reject);
+      });
+      client.end();
+
+      // Hangs forever if the shutdown echo is suppressed at zero events.
+      expect(await closed).toBe("close");
+    } finally {
+      client.destroy();
+    }
+  });
+
+  // The reverse ordering: half-close while paused, then resume reading. The
+  // detector knote survives the 0 -> READABLE transition, so the stale
+  // shutdown echo is delivered while the socket legitimately reads; it must
+  // not clean-close the socket before the peer's reply and FIN arrive.
+  it.skipIf(isWindows)("half-closed paused socket still hears the peer after resume", async () => {
+    const { promise: opened, resolve: onOpen } = Promise.withResolvers<Socket<undefined>>();
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<string>();
+    let received = "";
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      allowHalfOpen: true,
+      socket: {
+        open(socket) {
+          socket.pause();
+          onOpen(socket);
+        },
+        data(_socket, buffer) {
+          received += buffer.toString();
+        },
+        end() {},
+        close() {
+          onClosed("close");
+        },
+        error() {
+          onClosed("error");
+        },
+      },
+    });
+
+    // A raw half-open client: it must keep writing after the server's FIN
+    // arrives (node:net's client tears its stream down there).
+    const client = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      allowHalfOpen: true,
+      socket: { open() {}, data() {}, end() {}, close() {}, error() {} },
+    });
+    try {
+      const socket = await opened;
+      // Let the pause's writable dispatch drop the poll to zero events and
+      // arm the detector.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      socket.shutdown(); // half-close while paused; the shutdown echo is now queued
+      socket.resume(); // re-arms reading; the detector knote survives
+
+      // The peer answers in two chunks. A stale echo closing the socket
+      // early loses part or all of the reply.
+      client.write("part1");
+      await new Promise(resolve => setImmediate(resolve));
+      client.write("part2");
+      client.end();
+
+      expect(await closed).toBe("close");
+      expect(received).toBe("part1part2");
+    } finally {
+      client.terminate();
+    }
+  });
+
   it("upgradeTLS handles errors", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -720,7 +720,7 @@ describe.concurrent("socket", () => {
   // end-of-stream, instead of being torn down with a fabricated ECONNRESET.
   it.skipIf(isWindows)("paused unix socket keeps data from a peer that closed gracefully", async () => {
     const { promise: opened, resolve: onOpen } = Promise.withResolvers<Socket<undefined>>();
-    const { promise: gotData, resolve: onData } = Promise.withResolvers<string>();
+    const { promise: gotData, resolve: onData, reject: onDataLost } = Promise.withResolvers<string>();
     const { promise: closed, resolve: onClosed } = Promise.withResolvers<string>();
     let teardown: string | null = null;
 
@@ -740,10 +740,14 @@ describe.concurrent("socket", () => {
         end() {},
         close() {
           teardown ??= "close";
+          // No-op on the expected path (data already resolved); an early
+          // teardown fails the data await with the cause instead of hanging.
+          onDataLost(new Error("server socket closed before the queued data was delivered"));
           onClosed(teardown);
         },
         error() {
           teardown ??= "error";
+          onDataLost(new Error("server socket errored before the queued data was delivered"));
           onClosed(teardown);
         },
       },

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -686,21 +686,29 @@ describe.concurrent("socket", () => {
     });
 
     const client = net.connect({ port: server.port, host: "127.0.0.1", allowHalfOpen: true });
+    // Post-connect teardown errors must not become uncaught exceptions.
     client.on("error", () => {});
-    await new Promise<void>(resolve => client.once("connect", resolve));
-    client.end(); // FIN; the server side stays half-open
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once("connect", resolve);
+        client.once("error", reject);
+      });
+      client.end(); // FIN; the server side stays half-open
 
-    await ended;
-    // Let the server's post-end writable dispatch run so its poll drops to zero
-    // requested events (the state that used to lose the last kqueue filter)
-    // before the reset arrives.
-    await new Promise(resolve => setImmediate(resolve));
-    await new Promise(resolve => setImmediate(resolve));
+      await ended;
+      // Let the server's post-end writable dispatch run so its poll drops to zero
+      // requested events (the state that used to lose the last kqueue filter)
+      // before the reset arrives.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
 
-    client.resetAndDestroy();
+      client.resetAndDestroy();
 
-    // Hangs forever on a deaf socket; the test timeout is the failure signal.
-    expect(await closed).toBeOneOf(["close", "error"]);
+      // Hangs forever on a deaf socket; the test timeout is the failure signal.
+      expect(await closed).toBeOneOf(["close", "error"]);
+    } finally {
+      client.destroy();
+    }
   });
 
   it("upgradeTLS handles errors", async () => {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -761,9 +761,7 @@ describe.concurrent("socket", () => {
       await new Promise(resolve => setImmediate(resolve));
       await new Promise(resolve => setImmediate(resolve));
 
-      await new Promise<void>((resolve, reject) =>
-        client.write("hello", err => (err ? reject(err) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => client.write("hello", err => (err ? reject(err) : resolve())));
       client.destroy(); // graceful full close; unix sockets have no RST
 
       // Give a misrouted detector event plenty of turns to close the socket.

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -655,6 +655,54 @@ describe.concurrent("socket", () => {
     }
   });
 
+  // An allowHalfOpen socket that consumed the peer's FIN and drained its writes
+  // polls for no events at all. On Linux the fd stays registered in epoll, which
+  // reports EPOLLERR/EPOLLHUP even at zero interest, so a later RST still closes
+  // the socket. On macOS the kqueue write oneshot used to be consumed by the
+  // first writable wakeup, leaving the fd with no filter: the peer's reset was
+  // never delivered and the socket leaked until process exit (this test timed
+  // out). Windows (libuv) tracks this state separately and is skipped here.
+  it.skipIf(isWindows)("allowHalfOpen socket sees the peer reset after end + drain", async () => {
+    const { promise: ended, resolve: onEnd } = Promise.withResolvers<void>();
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<string>();
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      allowHalfOpen: true,
+      socket: {
+        open() {},
+        data() {},
+        end() {
+          onEnd();
+        },
+        close() {
+          onClosed("close");
+        },
+        error() {
+          onClosed("error");
+        },
+      },
+    });
+
+    const client = net.connect({ port: server.port, host: "127.0.0.1", allowHalfOpen: true });
+    client.on("error", () => {});
+    await new Promise<void>(resolve => client.once("connect", resolve));
+    client.end(); // FIN; the server side stays half-open
+
+    await ended;
+    // Let the server's post-end writable dispatch run so its poll drops to zero
+    // requested events (the state that used to lose the last kqueue filter)
+    // before the reset arrives.
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    client.resetAndDestroy();
+
+    // Hangs forever on a deaf socket; the test timeout is the failure signal.
+    expect(await closed).toBeOneOf(["close", "error"]);
+  });
+
   it("upgradeTLS handles errors", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -711,6 +711,125 @@ describe.concurrent("socket", () => {
     }
   });
 
+  // The zero-event state must distinguish a dead connection from a graceful
+  // unix-domain disconnect: a unix peer's close() makes our write side
+  // unusable with no socket error, which epoll reports as a mere EPOLLHUP
+  // (and not at all at zero interest before both directions are shut). A
+  // paused unix socket with data still queued in the kernel must stay open
+  // through that disconnect so resume() can deliver the data and the real
+  // end-of-stream, instead of being torn down with a fabricated ECONNRESET.
+  it.skipIf(isWindows)("paused unix socket keeps data from a peer that closed gracefully", async () => {
+    const { promise: opened, resolve: onOpen } = Promise.withResolvers<Socket<undefined>>();
+    const { promise: gotData, resolve: onData } = Promise.withResolvers<string>();
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<string>();
+    let teardown: string | null = null;
+
+    using dir = tempDir("unix-paused-close", {});
+    const sock = join(String(dir), "s.sock");
+
+    using server = Bun.listen({
+      unix: sock,
+      socket: {
+        open(socket) {
+          socket.pause();
+          onOpen(socket);
+        },
+        data(_socket, buffer) {
+          onData(buffer.toString());
+        },
+        end() {},
+        close() {
+          teardown ??= "close";
+          onClosed(teardown);
+        },
+        error() {
+          teardown ??= "error";
+          onClosed(teardown);
+        },
+      },
+    });
+
+    const client = net.connect({ path: sock });
+    client.on("error", () => {});
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once("connect", resolve);
+        client.once("error", reject);
+      });
+      const socket = await opened;
+      // Let the pause's writable dispatch drop the poll to zero events.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      await new Promise<void>((resolve, reject) =>
+        client.write("hello", err => (err ? reject(err) : resolve())),
+      );
+      client.destroy(); // graceful full close; unix sockets have no RST
+
+      // Give a misrouted detector event plenty of turns to close the socket.
+      for (let i = 0; i < 10; i++) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      expect(teardown).toBeNull();
+
+      // resume() re-arms reading: the buffered bytes arrive, then the
+      // end-of-stream closes the (not half-open) socket cleanly.
+      socket.resume();
+      expect(await gotData).toBe("hello");
+      expect(await closed).toBe("close");
+    } finally {
+      client.destroy();
+    }
+  });
+
+  // A paused socket reaches the same zero-event state (pause arms WRITABLE,
+  // whose dispatch drops the poll to no events). A peer reset must still
+  // close it: Linux delivers EPOLLERR at zero interest; kqueue needs the
+  // detector knote and its fflags error routing.
+  it.skipIf(isWindows)("paused socket sees the peer reset", async () => {
+    const { promise: opened, resolve: onOpen } = Promise.withResolvers<Socket<undefined>>();
+    const { promise: closed, resolve: onClosed } = Promise.withResolvers<string>();
+
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.pause();
+          onOpen(socket);
+        },
+        data() {},
+        end() {},
+        close() {
+          onClosed("close");
+        },
+        error() {
+          onClosed("error");
+        },
+      },
+    });
+
+    const client = net.connect({ port: server.port, host: "127.0.0.1" });
+    client.on("error", () => {});
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once("connect", resolve);
+        client.once("error", reject);
+      });
+      await opened;
+      // Let the pause's writable dispatch drop the poll to zero events.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      client.resetAndDestroy();
+
+      // Hangs forever on a deaf socket; the test timeout is the failure signal.
+      expect(await closed).toBeOneOf(["close", "error"]);
+    } finally {
+      client.destroy();
+    }
+  });
+
   it("upgradeTLS handles errors", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### What

On macOS, an `allowHalfOpen` socket that consumed the peer's FIN and drained its writes became permanently deaf: a later RST from the peer was never delivered, `close`/`error` never fired, and the socket leaked until process exit (raw `Bun.listen`/`Bun.connect` sockets have no default timeout). Linux is unaffected.

Repro shape (macOS):

```js
const server = Bun.listen({
  hostname: "127.0.0.1", port: 0, allowHalfOpen: true,
  socket: { data() {}, end() {}, close() { console.log("closed"); }, error() {} },
});
const client = net.connect({ port: server.port, allowHalfOpen: true });
client.once("connect", () => client.end()); // FIN; server side stays half-open
// two turns later:
client.resetAndDestroy(); // RST
// server's close/error never fires on macOS; on Linux it fires with ECONNRESET
```

### Why

A half-open socket past `on_end` whose writes drained polls for no events at all. The two backends treat that state differently:

- epoll keeps the fd registered with zero interest, and the kernel reports `EPOLLHUP`/`EPOLLERR` regardless, so the RST closes the socket through the error path (`us_poll_start_rc` documents this).
- kqueue has no implicit reporting, only filters. `kqueue_change` armed an `EV_ONESHOT` `EVFILT_WRITE` as the detector for this state, but a connected socket is immediately writable, so the very next kevent wakeup consumed the oneshot. The dispatch then cleared `POLL_TYPE_POLLING_OUT` (loop.c) and the post-dispatch `us_poll_change(0)` was an old == new no-op. Net result: zero filters on the fd, and nothing can ever wake that socket again.

### Fix

All in `packages/bun-usockets/src/eventing/epoll_kqueue.c`:

- `kqueue_change`: arm the zero-event detector as `EV_ADD | EV_CLEAR` instead of `EV_ONESHOT`, and unconditionally, so a WRITABLE -> 0 transition converts a still-armed oneshot. `EV_CLEAR` fires once on arming (the dispatcher masks it out) and then only on write-side state changes, so an idle half-open or paused socket does not wake the loop, while a dead connection re-activates the knote.
- `us_poll_change`: a 0 -> 0 change on a socket poll re-arms the detector instead of no-opping, because the writable dispatch just consumed the oneshot behind the tracked state.
- dispatcher: `EV_EOF` on the detector (any write-filter event while WRITABLE is not armed, since the knote also survives a later 0 -> READABLE transition) means `SS_CANTSENDMORE`, and its routing depends on what that proves:
  - fflags carries a pending socket error (a TCP reset always does): the poll error, routed exactly like epoll's implicit `EPOLLERR`, closing with `SO_ERROR`.
  - a shut-down socket at zero events: the read knote is gone, so the echo is its only close signal; it dispatches as eof and the shut-down branch in loop.c clean-closes. For the half-open path (peer's FIN consumed, then we shut down) that is exact epoll parity with `EPOLLHUP`. For a paused socket it closes on our own shutdown's echo, which is what kqueue did before this PR and what node:http's mid-upload half-close depends on (the socket with the unread request body is never resumed); epoll instead waits for the peer's FIN to complete `SHUTDOWN_MASK`, a pre-existing platform difference this PR keeps rather than widens.
  - otherwise silent: a resumed reader hears the peer through the read filter (a stale echo must not clean-close it early), and a unix peer's graceful `close()` (`SS_CANTSENDMORE` with `so_error` 0) on a not-shut-down socket must not be torn down with a fabricated `ECONNRESET` for what epoll reports as a mere `EPOLLHUP`; a paused not-shut-down socket keeps its queued data readable for `resume()`.

  Polls with WRITABLE armed dispatch exactly as before.
- `us_poll_stop`: delete both filters explicitly. The detector knote is invisible to the event diff, and detach paths (`us_socket_detach`) stop the poll while keeping the fd open; a leftover knote would keep the freed poll as udata.

The same gap was noted in the test comment of #37098 ("kqueue keeps no kernel filter on such a socket, so the reset goes unseen there"). It is distinct from #37077, which handles `EV_EOF` arriving on a still-armed write filter behind pending writes; here the problem is that no filter exists to deliver anything. The two are compatible.

### Tests

`test/js/bun/net/socket.test.ts`, all running on Linux and macOS (skipped on Windows, whose libuv backend tracks this state separately):

- "allowHalfOpen socket sees the peer reset after end + drain": FIN, wait for `on_end` plus the drain dispatch, then RST, require `close`/`error` to fire. Times out on an unfixed macOS build; on Linux it passes before and after (locking in the epoll behavior the fix mirrors).
- "paused socket sees the peer reset": `pause()` reaches the same zero-event state, and a peer reset must still close the socket (Linux already does via `EPOLLERR`). Also times out on an unfixed macOS build.
- "paused unix socket keeps data from a peer that closed gracefully": the guard for the fflags gate. A graceful unix disconnect must not close the paused socket or discard its queued bytes; `resume()` delivers the data and then the clean end-of-stream.
- "allowHalfOpen socket closes cleanly after both sides shut down": the end handler replies with `socket.shutdown()` (the native half-close node:net's `end()` maps to; the raw JS `end()` closes the socket itself after flushing), and the shutdown echo must deliver the clean close.
- "half-closed paused socket still hears the peer after resume": `shutdown()` while paused then `resume()`; the surviving detector's stale echo must not clean-close the socket ahead of the peer's two-chunk reply and FIN.

This machine is Linux, where the bug does not reproduce, so the failing-before runs are CI's to show on the macOS lanes; locally `bun bd test test/js/bun/net/socket.test.ts` passes with the only failures being the file's pre-existing ones (identical list on main, network-restricted environment).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->