### PR TITLE
Keep the addon name in the temp file an embedded native library extracts to

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -200,6 +200,20 @@ pub mod fs {
             buf: &'b mut [u8],
             hash: u64,
         ) -> crate::CrateResult<&'b mut ZStr> {
+            Self::tmpname_with_stem(b"", extname, buf, hash)
+        }
+
+        /// [`Self::tmpname`], but keeps a caller-supplied stem in the
+        /// generated name: `.{stem}.{hex}-{N}.{ext}` instead of
+        /// `.{hex}-{N}.{ext}`. Embedded native libraries extracted for
+        /// dlopen use this so a crash report naming the faulting module
+        /// names the addon rather than a random hash.
+        pub fn tmpname_with_stem<'b>(
+            stem: &[u8],
+            extname: &[u8],
+            buf: &'b mut [u8],
+            hash: u64,
+        ) -> crate::CrateResult<&'b mut ZStr> {
             // bun_core has no `time` module yet; use std directly.
             let nanos: u128 = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -209,13 +223,25 @@ pub mod fs {
 
             let len = buf.len();
             let mut cursor = &mut buf[..];
-            write!(
-                &mut cursor,
-                ".{:x}-{:X}.{}",
-                hex_value,
-                TMPNAME_ID_NUMBER.fetch_add(1, Ordering::Relaxed),
-                bstr::BStr::new(extname),
-            )
+            let id = TMPNAME_ID_NUMBER.fetch_add(1, Ordering::Relaxed);
+            if stem.is_empty() {
+                write!(
+                    &mut cursor,
+                    ".{:x}-{:X}.{}",
+                    hex_value,
+                    id,
+                    bstr::BStr::new(extname),
+                )
+            } else {
+                write!(
+                    &mut cursor,
+                    ".{}.{:x}-{:X}.{}",
+                    bstr::BStr::new(stem),
+                    hex_value,
+                    id,
+                    bstr::BStr::new(extname),
+                )
+            }
             .map_err(|_| crate::Error::Sys(bun_errno::SystemErrno::ENOSPC))?;
             let written = len - cursor.len();
             if written >= len {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4700,6 +4700,41 @@ unsafe fn transpile_virtual_module(
     }
 }
 
+/// Stem kept in the temp filename an embedded native library is extracted to
+/// (`.{stem}.{hex}-{N}.{ext}`), so a crash report that names the faulting
+/// module names the addon instead of a random hash. Conservative charset:
+/// bytes outside `[A-Za-z0-9._-]` become `_`; leading dots are dropped (the
+/// generated name supplies the single leading dot) and so are trailing ones;
+/// may be empty, in which case the name degrades to the hash-only form.
+fn embedded_library_stem<'a>(virtual_path: &[u8], buf: &'a mut [u8; 64]) -> &'a [u8] {
+    let base = bun_paths::resolve_path::basename(virtual_path);
+    // Drop the extension; the temp name appends the canonical one.
+    let stem = match bun_core::strings::last_index_of_char(base, b'.') {
+        Some(0) | None => base,
+        Some(i) => &base[..i],
+    };
+    let mut n = 0;
+    for &c in stem {
+        if n == buf.len() {
+            break;
+        }
+        let mapped = if c.is_ascii_alphanumeric() || matches!(c, b'-' | b'_' | b'.') {
+            c
+        } else {
+            b'_'
+        };
+        if n == 0 && mapped == b'.' {
+            continue;
+        }
+        buf[n] = mapped;
+        n += 1;
+    }
+    while n > 0 && buf[n - 1] == b'.' {
+        n -= 1;
+    }
+    &buf[..n]
+}
+
 /// Core of `ModuleLoader.resolveEmbeddedFile`:
 /// finds an embedded file in the standalone module graph, materializes it to
 /// a real on-disk temp file with `extname`, and writes the resulting absolute
@@ -4735,9 +4770,16 @@ pub(crate) fn resolve_embedded_file_to_buf(
     let file_name: &[u8] = file.name;
     let file_contents: &[u8] = file.contents.as_bytes();
 
+    let mut stem_buf = [0u8; 64];
+    let stem = embedded_library_stem(file_name, &mut stem_buf);
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
-    let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
+    let tmpfilename = Fs::FileSystem::tmpname_with_stem(
+        stem,
+        extname,
+        &mut tmpname_buf[..],
+        bun_wyhash::hash(file_name),
+    )
+    .ok()?;
 
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -77,6 +77,52 @@ describe("bundler", () => {
     },
     run: { exitCode: 0 },
   });
+  // An embedded .node addon is extracted to a temp file before dlopen. The
+  // temp name must keep the addon's basename (`.my_native_addon.{hex}-{N}.node`)
+  // so crash reports attribute a fault inside the addon to the addon instead
+  // of a random hash. dlerror() echoes the path, which makes the name
+  // observable through the load-failure message. Windows formats LoadLibrary
+  // errors from GetLastError() without the path, so this is POSIX-only.
+  test.skipIf(isWindows)("compile/EmbeddedNodeAddonTempNameKeepsAddonName", async () => {
+    using dir = tempDir("compile-addon-temp-name", {
+      "entry.ts": `
+        try {
+          require("./my_native_addon.node");
+          console.log("unexpectedly loaded");
+        } catch (e) {
+          console.log(e.message);
+        }
+      `,
+      "my_native_addon.node": "not actually a shared library",
+    });
+    const outfile = join(String(dir), "out");
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "./entry.ts", "--outfile", outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+    await using proc = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // dlopen failed on the extracted temp file; the message carries its path,
+    // which must embed the addon name (plus the bundler's content-hash asset
+    // suffix) ahead of the per-run random part.
+    expect(stdout).toMatch(/\.my_native_addon[-\w]*\.[0-9a-f]+-[0-9A-F]+\.node/);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
   itBundled("compile/HelloWorldWithProcessVersionsBunAPI", {
     compile: true,
     backend: "api",


### PR DESCRIPTION
## Problem

A compiled standalone executable (`bun build --compile`) extracts an embedded `.node` addon (or a `bun:ffi` shared library imported `with { type: "file" }`) to a temp file before dlopen, since dlopen cannot read the virtual bunfs. The temp name is `.{hex}-{N}.node`, derived from a hash and a per-process counter.

When such an addon crashes, the crash report's module column shows that random name. Sentry group [BUN-2PFR](https://bun-p9.sentry.io/issues/7375454270/) (~30 events/day) is a segfault inside `.dafb37e78ed77f3f-0.node`: there is no way to tell which addon that is, and the name is different in every process, so crashes in the same addon do not even group together. dlopen failure messages have the same problem: `/tmp/.c7a034accf905e76-0.node: file too short` names nothing.

## Fix

`resolve_embedded_file_to_buf` now keeps the embedded file's own basename as a stem in the generated temp name:

```
before  /tmp/.c7a034accf905e76-0.node
after   /tmp/.my_native_addon-msn58fw9.c7a034da05c78833-0.node
```

(the `-msn58fw9` token is the bundler's content-hash asset suffix, part of the embedded file's name in the module graph.)

The stem is sanitized to `[A-Za-z0-9._-]` (other bytes become `_`), leading/trailing dots are dropped, and it is capped at 64 bytes; if nothing survives, the name degrades to the old hash-only form. Implemented as `tmpname_with_stem` next to the existing `tmpname` in `bun_resolver::fs`, sharing the same entropy and counter; `tmpname` delegates with an empty stem. Both the `process.dlopen` path and the `bun:ffi` path go through the same helper.

The crash-report side (bun.report) recognizes this name shape and titles/groups such crashes by the addon: oven-sh/bun.report#30.

## Verification

New test `compile/EmbeddedNodeAddonTempNameKeepsAddonName` in `test/bundler/bundler_compile.test.ts` compiles an app requiring a garbage `.node` file and asserts the dlopen error path contains the addon stem (dlerror echoes the temp path on POSIX; Windows formats LoadLibrary errors without the path, so the test is POSIX-only).

- fails on bun without this change: message shows `/tmp/.c7a034accf905e76-0.node`
- passes with it: `/tmp/.my_native_addon-msn58fw9.{hex}-0.node`

`bun bd test test/bundler/bundler_compile.test.ts`: 61 pass, 1 pre-existing debug-only failure (`compile/HelloWorldWithProcessVersionsBun` compares version strings against the `-debug` suffix; fails identically on a clean tree).