### PR TITLE
udp: bound one readable dispatch at 32 datagrams to prevent event-loop starvation

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -946,6 +946,15 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
 #endif
             if (run_recv && !u->closed) {
 
+                /* Bound one readable dispatch: a peer sending at or above our
+                 * drain rate otherwise keeps recvmmsg returning data forever
+                 * and this loop never exits - timers, every other socket and
+                 * the pre/post callbacks starve. libuv caps a UDP dispatch at
+                 * 32 datagrams ("Prevent loop starvation", unix/udp.c); 4
+                 * batches of LIBUS_UDP_RECV_COUNT(8) matches that. Leftover
+                 * data redelivers on the next tick (level-triggered/persistent
+                 * readable on all three backends). */
+                int recv_batches = 4;
                 do {
                     struct udp_recvbuf recvbuf;
                     bsd_udp_setup_recvbuf(&recvbuf, u->loop->data.recv_buf, LIBUS_RECV_BUFFER_LENGTH);
@@ -997,7 +1006,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
 
                         break;
                     }
-                } while (!u->closed);
+                } while (!u->closed && --recv_batches);
             }
 
             if (events & LIBUS_SOCKET_WRITABLE && !u->closed) {

--- a/test/js/bun/udp/udp-flood-starvation-fixture.ts
+++ b/test/js/bun/udp/udp-flood-starvation-fixture.ts
@@ -1,0 +1,82 @@
+// A UDP peer sending at or above our drain rate must not starve the event
+// loop: the recv dispatch used to loop until EAGAIN, so while the kernel
+// queue stayed non-empty no timer or other socket ever ran. libuv bounds a
+// dispatch at 32 datagrams; usockets now does the same (4 batches of 8).
+//
+// The receiver burns ~2ms per datagram so a child-process flooder easily
+// outpaces it; a 20ms interval then measures whether the loop still breathes.
+import { bunEnv, bunExe } from "harness";
+
+const firstPacket = Promise.withResolvers<void>();
+let got = 0;
+// Under total starvation not even Bun.sleep's timer fires, so the data
+// handler itself is the watchdog: it is the one callback starvation keeps
+// feeding. 0 until the measurement starts.
+let watchdogDeadline = 0;
+
+const receiver = await Bun.udpSocket({
+  hostname: "127.0.0.1",
+  port: 0,
+  socket: {
+    data() {
+      if (++got === 1) firstPacket.resolve();
+      if (watchdogDeadline && Bun.nanoseconds() > watchdogDeadline) {
+        fail(`STARVED: data handler still monopolizing the loop after 6s (received ${got})`);
+      }
+      const end = Bun.nanoseconds() + 2_000_000; // ~2ms of work per datagram
+      while (Bun.nanoseconds() < end) {}
+    },
+    error() {},
+  },
+});
+
+// The flooder self-expires after 15s so no exit path of ours can leak it, and
+// swallows the ICMP unreachable errors it gets once our socket closes.
+const flooder = Bun.spawn({
+  cmd: [
+    bunExe(),
+    "-e",
+    `
+      const s = await Bun.udpSocket({ socket: { data() {}, error() {} } });
+      const buf = new Uint8Array(64);
+      const deadline = Date.now() + 15_000;
+      function burst() {
+        if (Date.now() > deadline) process.exit(0);
+        for (let i = 0; i < 500; i++) {
+          try { s.send(buf, ${receiver.port}, "127.0.0.1"); } catch {}
+        }
+        setTimeout(burst, 0);
+      }
+      burst();
+    `,
+  ],
+  env: bunEnv,
+  stdout: "ignore",
+  stderr: "ignore",
+});
+
+function fail(message: string): never {
+  console.error(message);
+  flooder.kill();
+  process.exit(1);
+}
+
+await firstPacket.promise;
+watchdogDeadline = Bun.nanoseconds() + 6_000_000_000;
+
+let ticks = 0;
+const interval = setInterval(() => {
+  ticks++;
+}, 20);
+
+await Bun.sleep(2000);
+clearInterval(interval);
+flooder.kill();
+receiver.close();
+
+console.log(`interval fired ${ticks} times during 2s of flood (received ${got} datagrams)`);
+if (ticks < 5) {
+  console.error(`STARVED: interval fired only ${ticks} times in 2s under UDP flood`);
+  process.exit(1);
+}
+process.exit(0);

--- a/test/js/bun/udp/udp-flood-starvation-fixture.ts
+++ b/test/js/bun/udp/udp-flood-starvation-fixture.ts
@@ -52,7 +52,7 @@ const flooder = Bun.spawn({
   ],
   env: bunEnv,
   stdout: "ignore",
-  stderr: "ignore",
+  stderr: "pipe",
 });
 
 function fail(message: string): never {
@@ -61,7 +61,14 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-await firstPacket.promise;
+// A flooder that dies before its first datagram would leave firstPacket
+// pending forever; surface its exit (and stderr) instead of an opaque hang.
+await Promise.race([
+  firstPacket.promise,
+  flooder.exited.then(async code => {
+    throw new Error(`flooder exited (${code}) before the first packet: ${await flooder.stderr.text()}`);
+  }),
+]);
 watchdogDeadline = Bun.nanoseconds() + 6_000_000_000;
 
 let ticks = 0;

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -643,3 +643,19 @@ test("sendMany() sends every packet of a larger-than-one-batch call", async () =
     server.close();
   }
 });
+
+// The recv dispatch used to loop until EAGAIN, so a peer sending at or above
+// our drain rate kept the kernel queue non-empty and starved the entire event
+// loop (no timers, no other sockets). It is now bounded per dispatch like
+// libuv (32 datagrams); leftover data redelivers on the next tick.
+test("sustained inbound flood must not starve the event loop", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "udp-flood-starvation-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stdout, stderr);
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -655,7 +655,12 @@ test("sustained inbound flood must not starve the event loop", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  if (exitCode !== 0) console.error(stdout, stderr);
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderr = rawStderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/interval fired \d+ times during 2s of flood/);
   expect(exitCode).toBe(0);
 }, 30_000);


### PR DESCRIPTION
### What

One `node:dgram` / `Bun.udpSocket` receiver under sustained inbound traffic starves the entire event loop: timers, every other socket, the timeout sweep, and the pre/post callbacks all stop until the sender slows down. The condition is remotely inducible against any exposed UDP port, since per-packet JS handling is far slower than kernel enqueue at line rate.

### Why

The UDP readable dispatch loops `recvmmsg` until EAGAIN/error/close. A peer sending at or above the drain rate keeps the kernel receive queue non-empty, so the loop never exits. libuv bounds one dispatch at 32 datagrams for exactly this reason (`uv__udp_recvmsg`: "Prevent loop starvation when the data comes in as fast as (or faster than) we can read it").

### Fix

Bound the dispatch at 4 batches of `LIBUS_UDP_RECV_COUNT` (8), i.e. the same 32 datagrams as libuv. Readable interest is level-triggered (epoll), persistent (kqueue), or re-armed (the libuv backend), so leftover data redelivers on the next tick; nothing is lost, the loop just breathes between rounds.

### Verification

New fixture `test/js/bun/udp/udp-flood-starvation-fixture.ts` + test in `udp_socket.test.ts`: the receiver burns ~2ms per datagram while a child process floods it, and a 20ms interval measures liveness. On current bun the interval fires 0 times in 2 seconds (the run is terminated by a watchdog inside the data handler, because even `Bun.sleep`'s timer starves); with this change it fires 30 times, across repeated runs. The flooder self-expires and all exit paths kill it, so nothing leaks on failure.

`udp_socket.test.ts` (208), `dgram.test.ts` (61), and `udp_socket_recv_flags.test.ts` pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/udp/udp_socket.test.ts

<!-- robobun:evidence:end -->