### PR TITLE
usockets(win): deliver UV_DISCONNECT on libuv's slow poll path

### DIFF
--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,6 +1,6 @@
 --- a/src/win/poll.c
 +++ b/src/win/poll.c
-@@ -269,58 +269,122 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
+@@ -269,58 +269,125 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
    int r;
    uv_single_fd_set_t rfds, wfds, efds;
    struct timeval timeout;
@@ -123,13 +123,16 @@
 +           * from the kernel instead). WSAEWOULDBLOCK: the loop thread
 +           * consumed the data between select() and here. WSAENOTCONN: a
 +           * listening socket, readable on a pending accept with no peer
-+           * to lose. Anything else means the connection is gone. */
++           * to lose. WSAEMSGSIZE: a datagram wider than the 1-byte peek,
++           * which a stream socket can never produce. Anything else means
++           * the connection is gone. */
 +          peeked = recv(handle->socket, &byte, 1, MSG_PEEK);
 +          if (peeked == 0) {
 +            reported_events |= UV_DISCONNECT;
 +          } else if (peeked == SOCKET_ERROR) {
 +            peek_error = WSAGetLastError();
-+            if (peek_error != WSAEWOULDBLOCK && peek_error != WSAENOTCONN)
++            if (peek_error != WSAEWOULDBLOCK && peek_error != WSAENOTCONN &&
++                peek_error != WSAEMSGSIZE)
 +              reported_events |= UV_DISCONNECT;
 +          }
 +        }
@@ -164,7 +167,7 @@
    }
  
    SET_REQ_SUCCESS(req);
-@@ -403,6 +467,25 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+@@ -403,6 +470,25 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
  }
  
  
@@ -190,7 +193,7 @@
  int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
  }
-@@ -457,7 +540,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+@@ -457,7 +543,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
    /* Get the peer socket that is needed to enable fast poll. If the returned
     * value is NULL, the protocol is not implemented by MSAFD and we'll have to
     * use slow mode. */

--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,14 +1,14 @@
 --- a/src/win/poll.c
 +++ b/src/win/poll.c
-@@ -300,58 +300,156 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
+@@ -269,57 +269,150 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
    int r;
    uv_single_fd_set_t rfds, wfds, efds;
    struct timeval timeout;
 +  int events;
 +  int suppress_rfds;
 +  ULONGLONG deadline;
-+  ULONGLONG wake;
 +  ULONGLONG now;
++  ULONGLONG wait;
  
    assert(handle->type == UV_POLL);
    assert(req->type == UV_POLL_REQ);
@@ -19,27 +19,18 @@
 -  } else {
 -    rfds.fd_count = 0;
 -  }
--
--  if (handle->events & UV_WRITABLE) {
--    wfds.fd_count = 1;
--    wfds.fd_array[0] = handle->socket;
--    efds.fd_count = 1;
--    efds.fd_array[0] = handle->socket;
--  } else {
--    wfds.fd_count = 0;
--    efds.fd_count = 0;
--  }
-+  /* Give up after 3 minutes (the original select() timeout): a zero-event
-+   * completion is posted and the processing step submits a fresh request
-+   * if the watcher is still active. */
++  /* Complete with no events after 3 minutes (the original select()
++   * timeout): the processing step submits a fresh request if the watcher
++   * is still active. */
 +  deadline = GetTickCount64() + 3 * 60 * 1000;
 +  suppress_rfds = 0;
 +
 +  for (;;) {
-+    /* Refreshed every lap. uv_poll_start/uv_poll_stop on the loop thread
-+     * change this mid-flight; new events are covered by the second request
-+     * (see uv__poll_set), so this unsynchronized read only lets a stale
-+     * request retire itself early. */
++    /* Refreshed every lap, and each select() below waits at most one
++     * second: uv_poll_start/uv_poll_stop on the loop thread change the
++     * subscription mid-flight, and when both requests are checked out
++     * (see uv__slow_poll_submit_poll_req) this lap refresh is the only
++     * thing that converges a parked request onto the new subscription. */
 +    events = handle->events;
 +
 +    /* Watch readability for UV_DISCONNECT too: winsock select() has no
@@ -49,10 +40,10 @@
 +     * watcher that wants only UV_DISCONNECT: with all three sets empty,
 +     * select() fails WSAEINVAL immediately, which stopped the watcher
 +     * and reported a bogus error for every poll parked in that state.
-+     * suppress_rfds (set at the bottom of the loop) skips the read set
-+     * for one lap when pending data the watcher does not want would
++     * suppress_rfds (set at the bottom of the loop, one lap only) skips
++     * the read set when pending data the watcher does not want would
 +     * otherwise make select() return instantly instead of blocking on
-+     * writability. */
++     * writability; the UV_WRITABLE guard keeps the sets non-empty. */
 +    if ((events & (UV_READABLE | UV_DISCONNECT)) &&
 +        !(suppress_rfds && (events & UV_WRITABLE))) {
 +      rfds.fd_count = 1;
@@ -60,11 +51,17 @@
 +    } else {
 +      rfds.fd_count = 0;
 +    }
++    suppress_rfds = 0;
  
--  /* Make the select() time out after 3 minutes. If select() hangs because the
--   * user closed the socket, we will at least not hang indefinitely. */
--  timeout.tv_sec = 3 * 60;
--  timeout.tv_usec = 0;
+-  if (handle->events & UV_WRITABLE) {
+-    wfds.fd_count = 1;
+-    wfds.fd_array[0] = handle->socket;
+-    efds.fd_count = 1;
+-    efds.fd_array[0] = handle->socket;
+-  } else {
+-    wfds.fd_count = 0;
+-    efds.fd_count = 0;
+-  }
 +    if (events & UV_WRITABLE) {
 +      wfds.fd_count = 1;
 +      wfds.fd_array[0] = handle->socket;
@@ -75,6 +72,16 @@
 +      efds.fd_count = 0;
 +    }
  
+-  /* Make the select() time out after 3 minutes. If select() hangs because the
+-   * user closed the socket, we will at least not hang indefinitely. */
+-  timeout.tv_sec = 3 * 60;
+-  timeout.tv_usec = 0;
++    now = GetTickCount64();
++    if (events == 0 || now >= deadline) {
++      reported_events = 0;
++      break;
++    }
+ 
 -  r = select(1, (fd_set*) &rfds, (fd_set*) &wfds, (fd_set*) &efds, &timeout);
 -  if (r == SOCKET_ERROR) {
 -    /* Queue this req, reporting an error. */
@@ -82,22 +89,11 @@
 -    POST_COMPLETION_FOR_REQ(handle->loop, req);
 -    return 0;
 -  }
-+    now = GetTickCount64();
-+    if (events == 0 || now >= deadline) {
-+      reported_events = 0;
-+      break;
-+    }
- 
--  reported_events = 0;
-+    /* With the read set suppressed, wake within a second anyway so the
-+     * disconnect peek keeps running behind the pending data. */
-+    wake = deadline;
-+    if (suppress_rfds && rfds.fd_count == 0 && now + 1000 < wake)
-+      wake = now + 1000;
-+    suppress_rfds = 0;
-+
-+    timeout.tv_sec = (long) ((wake - now) / 1000);
-+    timeout.tv_usec = (long) (((wake - now) % 1000) * 1000);
++    wait = deadline - now;
++    if (wait > 1000)
++      wait = 1000;
++    timeout.tv_sec = (long) (wait / 1000);
++    timeout.tv_usec = (long) ((wait % 1000) * 1000);
 +
 +    r = select(1, (fd_set*) &rfds, (fd_set*) &wfds, (fd_set*) &efds, &timeout);
 +    if (r == SOCKET_ERROR) {
@@ -107,11 +103,7 @@
 +      return 0;
 +    }
  
--  if (r > 0) {
--    if (rfds.fd_count > 0) {
--      assert(rfds.fd_count == 1);
--      assert(rfds.fd_array[0] == handle->socket);
--      reported_events |= UV_READABLE;
+-  reported_events = 0;
 +    reported_events = 0;
 +
 +    if (r > 0) {
@@ -144,7 +136,12 @@
 +          }
 +        }
 +      }
-+
+ 
+-  if (r > 0) {
+-    if (rfds.fd_count > 0) {
+-      assert(rfds.fd_count == 1);
+-      assert(rfds.fd_array[0] == handle->socket);
+-      reported_events |= UV_READABLE;
 +      if (wfds.fd_count > 0) {
 +        assert(wfds.fd_count == 1);
 +        assert(wfds.fd_array[0] == handle->socket);
@@ -164,67 +161,87 @@
 -      assert(efds.fd_count == 1);
 -      assert(efds.fd_array[0] == handle->socket);
 -      reported_events |= UV_WRITABLE;
-+    /* A suppressed-rfds select() that hit its one-second cap is a re-peek
-+     * tick, not the real deadline: loop so the next lap re-arms the read
-+     * set and runs the peek again. */
-+    if (r == 0 && wake < deadline)
-+      continue;
-+
-+    /* A timeout or anything the watcher subscribed to completes the
-+     * request (the processing step masks and resubmits as needed). What
-+     * remains is data pending on a poll that does not want UV_READABLE
-+     * (a receive-paused socket): completing now would be masked to
-+     * nothing and resubmitted straight back into an instantly-readable
-+     * select(), a hot spin. Park instead and keep re-peeking, so a
-+     * connection that dies behind the pending data is still discovered:
-+     * an RST discards the receive queue and turns the peek into an error
-+     * within a second. A FIN behind data stays invisible to the peek
-+     * until the data is consumed (select() cannot see it; AFD would have
-+     * reported it), so its delivery keeps riding the readable path once
-+     * reads resume. How to park depends on whether the watcher also
-+     * wants UV_WRITABLE: if so, re-select() with the read set suppressed
-+     * so the send-buffer drain still wakes it instantly (sleeping here
-+     * would throttle a backpressured writer to one wake a second); if
-+     * not, there is nothing else to wait on, so just sleep. */
-+    if (r == 0 || (reported_events & events) != 0)
++    /* Anything the watcher subscribed to completes the request (the
++     * processing step masks and resubmits as needed). */
++    if ((reported_events & events) != 0)
 +      break;
 +
-+    if (events & UV_WRITABLE) {
-+      suppress_rfds = 1;
-+      continue;
++    /* r == 0: a quiet tick; lap to pick up subscription changes. r > 0
++     * with nothing deliverable: data pending on a poll that does not
++     * want UV_READABLE (a receive-paused socket). Completing now would
++     * be masked to nothing and resubmitted straight back into an
++     * instantly-readable select(), a hot spin; park instead and keep
++     * re-peeking, so a connection that dies behind the pending data is
++     * still discovered (an RST discards the receive queue and turns the
++     * peek into an error within a tick). A FIN behind data stays
++     * invisible to the peek until the data is consumed (select() cannot
++     * see it; AFD would have reported it), so its delivery keeps riding
++     * the readable path once reads resume. How to park depends on
++     * whether the watcher also wants UV_WRITABLE: if so, re-select()
++     * with the read set suppressed so the send-buffer drain still wakes
++     * it instantly (sleeping here would throttle a backpressured writer
++     * to one wake a second); if not, there is nothing else to wait on,
++     * so just sleep a tick. */
++    if (r > 0) {
++      if (events & UV_WRITABLE) {
++        suppress_rfds = 1;
++        continue;
++      }
++      Sleep(1000);
      }
-+
-+    Sleep(1000);
    }
  
-   SET_REQ_SUCCESS(req);
-@@ -434,6 +532,25 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+@@ -346,7 +439,15 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
+     handle->mask_events_1 = handle->events;
+     handle->mask_events_2 = 0;
+   } else {
+-    assert(0);
++    /* Both requests are checked out. The AFD fast path forces one to
++     * return (Exclusive), but a slow request can legitimately be parked
++     * in its select()/peek loop. That loop re-reads handle->events every
++     * lap (at most one second), so the live requests converge on the new
++     * subscription, and the processing step resubmits with correct
++     * accounting when one completes. This used to assert(0): it was
++     * unreachable while a DISCONNECT-only subscription made select()
++     * fail WSAEINVAL instantly, but such polls now genuinely park, so a
++     * third subscription change (e.g. pause, resume, pause) lands here. */
+     return;
+   }
+ 
+@@ -403,6 +504,32 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
  }
  
  
-+static int uv__slow_poll_forced(void) {
-+  /* Test hook: UV_FORCE_SLOW_POLL=1 routes every poll through the slow
-+   * (select-based) path, which is normally reachable only on machines
-+   * where a layered service provider owns the socket, so the path can be
-+   * exercised without installing an LSP. Read once: polls created before
-+   * and after a change would otherwise disagree for the process
-+   * lifetime. */
-+  static int forced = -1;
++static uv_once_t uv__slow_poll_forced_guard_ = UV_ONCE_INIT;
++static int uv__slow_poll_forced_;
++
++static void uv__slow_poll_forced_init(void) {
++  /* Test hook: BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL=1 routes every poll
++   * through the slow (select-based) path, which is normally reachable
++   * only on machines where a layered service provider owns the socket,
++   * so the path can be exercised without installing an LSP. Read once
++   * under uv_once: uv_poll_init_socket runs on every loop's own thread,
++   * and polls created before and after an env change must agree for the
++   * process lifetime. */
 +  char value[2];
 +
-+  if (forced == -1)
-+    forced = GetEnvironmentVariableA("UV_FORCE_SLOW_POLL",
-+                                     value,
-+                                     sizeof(value)) == 1 &&
-+             value[0] == '1';
-+  return forced;
++  uv__slow_poll_forced_ =
++      GetEnvironmentVariableA("BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL",
++                              value,
++                              sizeof(value)) == 1 &&
++      value[0] == '1';
++}
++
++static int uv__slow_poll_forced(void) {
++  uv_once(&uv__slow_poll_forced_guard_, uv__slow_poll_forced_init);
++  return uv__slow_poll_forced_;
 +}
 +
 +
  int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
  }
-@@ -488,7 +605,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+@@ -457,7 +584,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
    /* Get the peer socket that is needed to enable fast poll. If the returned
     * value is NULL, the protocol is not implemented by MSAFD and we'll have to
     * use slow mode. */

--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,0 +1,206 @@
+diff --git a/src/win/poll.c b/src/win/poll.c
+index a20867a..01b7c6c 100644
+--- a/src/win/poll.c
++++ b/src/win/poll.c
+@@ -269,58 +269,122 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
+   int r;
+   uv_single_fd_set_t rfds, wfds, efds;
+   struct timeval timeout;
++  int events;
++  ULONGLONG deadline;
++  ULONGLONG now;
+ 
+   assert(handle->type == UV_POLL);
+   assert(req->type == UV_POLL_REQ);
+ 
+-  if (handle->events & UV_READABLE) {
+-    rfds.fd_count = 1;
+-    rfds.fd_array[0] = handle->socket;
+-  } else {
+-    rfds.fd_count = 0;
+-  }
+-
+-  if (handle->events & UV_WRITABLE) {
+-    wfds.fd_count = 1;
+-    wfds.fd_array[0] = handle->socket;
+-    efds.fd_count = 1;
+-    efds.fd_array[0] = handle->socket;
+-  } else {
+-    wfds.fd_count = 0;
+-    efds.fd_count = 0;
+-  }
++  /* Give up after 3 minutes (the original select() timeout): a zero-event
++   * completion is posted and the processing step submits a fresh request
++   * if the watcher is still active. */
++  deadline = GetTickCount64() + 3 * 60 * 1000;
++
++  for (;;) {
++    /* Refreshed every lap. uv_poll_start/uv_poll_stop on the loop thread
++     * change this mid-flight; new events are covered by the second request
++     * (see uv__poll_set), so this unsynchronized read only lets a stale
++     * request retire itself early. */
++    events = handle->events;
++
++    /* Watch readability for UV_DISCONNECT too: winsock select() has no
++     * disconnect event, but a peer FIN or RST makes the socket readable
++     * and the MSG_PEEK below tells those apart from data without
++     * consuming anything. This also keeps the fd sets non-empty for a
++     * watcher that wants only UV_DISCONNECT: with all three sets empty,
++     * select() fails WSAEINVAL immediately, which stopped the watcher
++     * and reported a bogus error for every poll parked in that state. */
++    if (events & (UV_READABLE | UV_DISCONNECT)) {
++      rfds.fd_count = 1;
++      rfds.fd_array[0] = handle->socket;
++    } else {
++      rfds.fd_count = 0;
++    }
+ 
+-  /* Make the select() time out after 3 minutes. If select() hangs because the
+-   * user closed the socket, we will at least not hang indefinitely. */
+-  timeout.tv_sec = 3 * 60;
+-  timeout.tv_usec = 0;
++    if (events & UV_WRITABLE) {
++      wfds.fd_count = 1;
++      wfds.fd_array[0] = handle->socket;
++      efds.fd_count = 1;
++      efds.fd_array[0] = handle->socket;
++    } else {
++      wfds.fd_count = 0;
++      efds.fd_count = 0;
++    }
+ 
+-  r = select(1, (fd_set*) &rfds, (fd_set*) &wfds, (fd_set*) &efds, &timeout);
+-  if (r == SOCKET_ERROR) {
+-    /* Queue this req, reporting an error. */
+-    SET_REQ_ERROR(&handle->poll_req_1, WSAGetLastError());
+-    POST_COMPLETION_FOR_REQ(handle->loop, req);
+-    return 0;
+-  }
++    now = GetTickCount64();
++    if (events == 0 || now >= deadline) {
++      reported_events = 0;
++      break;
++    }
+ 
+-  reported_events = 0;
++    timeout.tv_sec = (long) ((deadline - now) / 1000);
++    timeout.tv_usec = (long) (((deadline - now) % 1000) * 1000);
+ 
+-  if (r > 0) {
+-    if (rfds.fd_count > 0) {
+-      assert(rfds.fd_count == 1);
+-      assert(rfds.fd_array[0] == handle->socket);
+-      reported_events |= UV_READABLE;
++    r = select(1, (fd_set*) &rfds, (fd_set*) &wfds, (fd_set*) &efds, &timeout);
++    if (r == SOCKET_ERROR) {
++      /* Queue this req, reporting an error. */
++      SET_REQ_ERROR(req, WSAGetLastError());
++      POST_COMPLETION_FOR_REQ(handle->loop, req);
++      return 0;
+     }
+ 
+-    if (wfds.fd_count > 0) {
+-      assert(wfds.fd_count == 1);
+-      assert(wfds.fd_array[0] == handle->socket);
+-      reported_events |= UV_WRITABLE;
+-    } else if (efds.fd_count > 0) {
+-      assert(efds.fd_count == 1);
+-      assert(efds.fd_array[0] == handle->socket);
+-      reported_events |= UV_WRITABLE;
++    reported_events = 0;
++
++    if (r > 0) {
++      if (rfds.fd_count > 0) {
++        assert(rfds.fd_count == 1);
++        assert(rfds.fd_array[0] == handle->socket);
++        reported_events |= UV_READABLE;
++
++        if (events & UV_DISCONNECT) {
++          char byte;
++          int peeked;
++          int peek_error;
++
++          /* Readable means data, FIN or RST; only a peek can tell which
++           * (the AFD fast path gets AFD_POLL_DISCONNECT / AFD_POLL_ABORT
++           * from the kernel instead). WSAEWOULDBLOCK: the loop thread
++           * consumed the data between select() and here. WSAENOTCONN: a
++           * listening socket, readable on a pending accept with no peer
++           * to lose. Anything else means the connection is gone. */
++          peeked = recv(handle->socket, &byte, 1, MSG_PEEK);
++          if (peeked == 0) {
++            reported_events |= UV_DISCONNECT;
++          } else if (peeked == SOCKET_ERROR) {
++            peek_error = WSAGetLastError();
++            if (peek_error != WSAEWOULDBLOCK && peek_error != WSAENOTCONN)
++              reported_events |= UV_DISCONNECT;
++          }
++        }
++      }
++
++      if (wfds.fd_count > 0) {
++        assert(wfds.fd_count == 1);
++        assert(wfds.fd_array[0] == handle->socket);
++        reported_events |= UV_WRITABLE;
++      } else if (efds.fd_count > 0) {
++        assert(efds.fd_count == 1);
++        assert(efds.fd_array[0] == handle->socket);
++        reported_events |= UV_WRITABLE;
++      }
+     }
++
++    /* A timeout or anything the watcher subscribed to completes the
++     * request (the processing step masks and resubmits as needed). What
++     * remains is data pending on a poll that wants only UV_DISCONNECT (a
++     * receive-paused socket): completing now would be masked to nothing
++     * and resubmitted straight back into an instantly-readable select(),
++     * a hot spin. Park instead and re-peek, so a connection that dies
++     * behind the pending data is still discovered: an RST discards the
++     * receive queue and turns the peek into an error within one sleep.
++     * A FIN behind data stays invisible to the peek until the data is
++     * consumed (select() cannot see it; AFD would have reported it), so
++     * its delivery keeps riding the readable path once reads resume. */
++    if (r == 0 || (reported_events & events) != 0)
++      break;
++
++    Sleep(1000);
+   }
+ 
+   SET_REQ_SUCCESS(req);
+@@ -403,6 +467,25 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+ }
+ 
+ 
++static int uv__slow_poll_forced(void) {
++  /* Test hook: UV_FORCE_SLOW_POLL=1 routes every poll through the slow
++   * (select-based) path, which is normally reachable only on machines
++   * where a layered service provider owns the socket, so the path can be
++   * exercised without installing an LSP. Read once: polls created before
++   * and after a change would otherwise disagree for the process
++   * lifetime. */
++  static int forced = -1;
++  char value[2];
++
++  if (forced == -1)
++    forced = GetEnvironmentVariableA("UV_FORCE_SLOW_POLL",
++                                     value,
++                                     sizeof(value)) == 1 &&
++             value[0] == '1';
++  return forced;
++}
++
++
+ int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
+   return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
+ }
+@@ -457,7 +540,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+   /* Get the peer socket that is needed to enable fast poll. If the returned
+    * value is NULL, the protocol is not implemented by MSAFD and we'll have to
+    * use slow mode. */
+-  peer_socket = uv__fast_poll_get_peer_socket(loop, &protocol_info);
++  if (uv__slow_poll_forced())
++    peer_socket = INVALID_SOCKET;
++  else
++    peer_socket = uv__fast_poll_get_peer_socket(loop, &protocol_info);
+ 
+   if (peer_socket != INVALID_SOCKET) {
+     /* Initialize fast poll specific fields. */

--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,11 +1,13 @@
 --- a/src/win/poll.c
 +++ b/src/win/poll.c
-@@ -269,58 +269,125 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
+@@ -300,58 +300,156 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
    int r;
    uv_single_fd_set_t rfds, wfds, efds;
    struct timeval timeout;
 +  int events;
++  int suppress_rfds;
 +  ULONGLONG deadline;
++  ULONGLONG wake;
 +  ULONGLONG now;
  
    assert(handle->type == UV_POLL);
@@ -31,6 +33,7 @@
 +   * completion is posted and the processing step submits a fresh request
 +   * if the watcher is still active. */
 +  deadline = GetTickCount64() + 3 * 60 * 1000;
++  suppress_rfds = 0;
 +
 +  for (;;) {
 +    /* Refreshed every lap. uv_poll_start/uv_poll_stop on the loop thread
@@ -45,8 +48,13 @@
 +     * consuming anything. This also keeps the fd sets non-empty for a
 +     * watcher that wants only UV_DISCONNECT: with all three sets empty,
 +     * select() fails WSAEINVAL immediately, which stopped the watcher
-+     * and reported a bogus error for every poll parked in that state. */
-+    if (events & (UV_READABLE | UV_DISCONNECT)) {
++     * and reported a bogus error for every poll parked in that state.
++     * suppress_rfds (set at the bottom of the loop) skips the read set
++     * for one lap when pending data the watcher does not want would
++     * otherwise make select() return instantly instead of blocking on
++     * writability. */
++    if ((events & (UV_READABLE | UV_DISCONNECT)) &&
++        !(suppress_rfds && (events & UV_WRITABLE))) {
 +      rfds.fd_count = 1;
 +      rfds.fd_array[0] = handle->socket;
 +    } else {
@@ -81,30 +89,29 @@
 +    }
  
 -  reported_events = 0;
-+    timeout.tv_sec = (long) ((deadline - now) / 1000);
-+    timeout.tv_usec = (long) (((deadline - now) % 1000) * 1000);
- 
--  if (r > 0) {
--    if (rfds.fd_count > 0) {
--      assert(rfds.fd_count == 1);
--      assert(rfds.fd_array[0] == handle->socket);
--      reported_events |= UV_READABLE;
++    /* With the read set suppressed, wake within a second anyway so the
++     * disconnect peek keeps running behind the pending data. */
++    wake = deadline;
++    if (suppress_rfds && rfds.fd_count == 0 && now + 1000 < wake)
++      wake = now + 1000;
++    suppress_rfds = 0;
++
++    timeout.tv_sec = (long) ((wake - now) / 1000);
++    timeout.tv_usec = (long) (((wake - now) % 1000) * 1000);
++
 +    r = select(1, (fd_set*) &rfds, (fd_set*) &wfds, (fd_set*) &efds, &timeout);
 +    if (r == SOCKET_ERROR) {
 +      /* Queue this req, reporting an error. */
 +      SET_REQ_ERROR(req, WSAGetLastError());
 +      POST_COMPLETION_FOR_REQ(handle->loop, req);
 +      return 0;
-     }
++    }
  
--    if (wfds.fd_count > 0) {
--      assert(wfds.fd_count == 1);
--      assert(wfds.fd_array[0] == handle->socket);
--      reported_events |= UV_WRITABLE;
--    } else if (efds.fd_count > 0) {
--      assert(efds.fd_count == 1);
--      assert(efds.fd_array[0] == handle->socket);
--      reported_events |= UV_WRITABLE;
+-  if (r > 0) {
+-    if (rfds.fd_count > 0) {
+-      assert(rfds.fd_count == 1);
+-      assert(rfds.fd_array[0] == handle->socket);
+-      reported_events |= UV_READABLE;
 +    reported_events = 0;
 +
 +    if (r > 0) {
@@ -148,26 +155,50 @@
 +        reported_events |= UV_WRITABLE;
 +      }
      }
+ 
+-    if (wfds.fd_count > 0) {
+-      assert(wfds.fd_count == 1);
+-      assert(wfds.fd_array[0] == handle->socket);
+-      reported_events |= UV_WRITABLE;
+-    } else if (efds.fd_count > 0) {
+-      assert(efds.fd_count == 1);
+-      assert(efds.fd_array[0] == handle->socket);
+-      reported_events |= UV_WRITABLE;
++    /* A suppressed-rfds select() that hit its one-second cap is a re-peek
++     * tick, not the real deadline: loop so the next lap re-arms the read
++     * set and runs the peek again. */
++    if (r == 0 && wake < deadline)
++      continue;
 +
 +    /* A timeout or anything the watcher subscribed to completes the
 +     * request (the processing step masks and resubmits as needed). What
-+     * remains is data pending on a poll that wants only UV_DISCONNECT (a
-+     * receive-paused socket): completing now would be masked to nothing
-+     * and resubmitted straight back into an instantly-readable select(),
-+     * a hot spin. Park instead and re-peek, so a connection that dies
-+     * behind the pending data is still discovered: an RST discards the
-+     * receive queue and turns the peek into an error within one sleep.
-+     * A FIN behind data stays invisible to the peek until the data is
-+     * consumed (select() cannot see it; AFD would have reported it), so
-+     * its delivery keeps riding the readable path once reads resume. */
++     * remains is data pending on a poll that does not want UV_READABLE
++     * (a receive-paused socket): completing now would be masked to
++     * nothing and resubmitted straight back into an instantly-readable
++     * select(), a hot spin. Park instead and keep re-peeking, so a
++     * connection that dies behind the pending data is still discovered:
++     * an RST discards the receive queue and turns the peek into an error
++     * within a second. A FIN behind data stays invisible to the peek
++     * until the data is consumed (select() cannot see it; AFD would have
++     * reported it), so its delivery keeps riding the readable path once
++     * reads resume. How to park depends on whether the watcher also
++     * wants UV_WRITABLE: if so, re-select() with the read set suppressed
++     * so the send-buffer drain still wakes it instantly (sleeping here
++     * would throttle a backpressured writer to one wake a second); if
++     * not, there is nothing else to wait on, so just sleep. */
 +    if (r == 0 || (reported_events & events) != 0)
 +      break;
++
++    if (events & UV_WRITABLE) {
++      suppress_rfds = 1;
++      continue;
+     }
 +
 +    Sleep(1000);
    }
  
    SET_REQ_SUCCESS(req);
-@@ -403,6 +470,25 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+@@ -434,6 +532,25 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
  }
  
  
@@ -193,7 +224,7 @@
  int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
  }
-@@ -457,7 +543,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+@@ -488,7 +605,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
    /* Get the peer socket that is needed to enable fast poll. If the returned
     * value is NULL, the protocol is not implemented by MSAFD and we'll have to
     * use slow mode. */

--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,6 +1,6 @@
 --- a/src/win/poll.c
 +++ b/src/win/poll.c
-@@ -269,57 +269,150 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
+@@ -269,57 +269,152 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
    int r;
    uv_single_fd_set_t rfds, wfds, efds;
    struct timeval timeout;
@@ -30,8 +30,10 @@
 +     * second: uv_poll_start/uv_poll_stop on the loop thread change the
 +     * subscription mid-flight, and when both requests are checked out
 +     * (see uv__slow_poll_submit_poll_req) this lap refresh is the only
-+     * thing that converges a parked request onto the new subscription. */
-+    events = handle->events;
++     * thing that converges a parked request onto the new subscription.
++     * volatile: the loop thread writes this field while we are parked,
++     * and this cross-thread re-read is what the convergence rests on. */
++    events = *(volatile unsigned char*) &handle->events;
 +
 +    /* Watch readability for UV_DISCONNECT too: winsock select() has no
 +     * disconnect event, but a peer FIN or RST makes the socket readable
@@ -191,7 +193,7 @@
      }
    }
  
-@@ -346,7 +439,15 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
+@@ -346,7 +441,15 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
      handle->mask_events_1 = handle->events;
      handle->mask_events_2 = 0;
    } else {
@@ -208,7 +210,7 @@
      return;
    }
  
-@@ -403,6 +504,32 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+@@ -403,6 +506,32 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
  }
  
  
@@ -241,7 +243,7 @@
  int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
  }
-@@ -457,7 +584,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+@@ -457,7 +586,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
    /* Get the peer socket that is needed to enable fast poll. If the returned
     * value is NULL, the protocol is not implemented by MSAFD and we'll have to
     * use slow mode. */

--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,6 +1,6 @@
 --- a/src/win/poll.c
 +++ b/src/win/poll.c
-@@ -269,57 +269,152 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
+@@ -269,57 +269,161 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {
    int r;
    uv_single_fd_set_t rfds, wfds, efds;
    struct timeval timeout;
@@ -42,11 +42,14 @@
 +     * watcher that wants only UV_DISCONNECT: with all three sets empty,
 +     * select() fails WSAEINVAL immediately, which stopped the watcher
 +     * and reported a bogus error for every poll parked in that state.
++     * UV_PRIORITIZED gets the same treatment: it is the abort-only watch
++     * a half-open socket parks with after its EOF was consumed, and an
++     * abort turns the peek into an error just like any other death.
 +     * suppress_rfds (set at the bottom of the loop, one lap only) skips
 +     * the read set when pending data the watcher does not want would
 +     * otherwise make select() return instantly instead of blocking on
 +     * writability; the UV_WRITABLE guard keeps the sets non-empty. */
-+    if ((events & (UV_READABLE | UV_DISCONNECT)) &&
++    if ((events & (UV_READABLE | UV_DISCONNECT | UV_PRIORITIZED)) &&
 +        !(suppress_rfds && (events & UV_WRITABLE))) {
 +      rfds.fd_count = 1;
 +      rfds.fd_array[0] = handle->socket;
@@ -114,7 +117,7 @@
 +        assert(rfds.fd_array[0] == handle->socket);
 +        reported_events |= UV_READABLE;
 +
-+        if (events & UV_DISCONNECT) {
++        if (events & (UV_DISCONNECT | UV_PRIORITIZED)) {
 +          char byte;
 +          int peeked;
 +          int peek_error;
@@ -129,12 +132,16 @@
 +           * the connection is gone. */
 +          peeked = recv(handle->socket, &byte, 1, MSG_PEEK);
 +          if (peeked == 0) {
++            /* FIN: a disconnect, not an abort. A watcher that wants only
++             * UV_PRIORITIZED already consumed this FIN (the socket stays
++             * select()-readable forever after it); reporting nothing
++             * sends it to the park below until a real abort. */
 +            reported_events |= UV_DISCONNECT;
 +          } else if (peeked == SOCKET_ERROR) {
 +            peek_error = WSAGetLastError();
 +            if (peek_error != WSAEWOULDBLOCK && peek_error != WSAENOTCONN &&
 +                peek_error != WSAEMSGSIZE)
-+              reported_events |= UV_DISCONNECT;
++              reported_events |= UV_DISCONNECT | UV_PRIORITIZED;
 +          }
 +        }
 +      }
@@ -170,7 +177,9 @@
 +
 +    /* r == 0: a quiet tick; lap to pick up subscription changes. r > 0
 +     * with nothing deliverable: data pending on a poll that does not
-+     * want UV_READABLE (a receive-paused socket). Completing now would
++     * want UV_READABLE (a receive-paused socket), or the permanent
++     * post-FIN readability of a poll that wants only UV_PRIORITIZED.
++     * Completing now would
 +     * be masked to nothing and resubmitted straight back into an
 +     * instantly-readable select(), a hot spin; park instead and keep
 +     * re-peeking, so a connection that dies behind the pending data is
@@ -193,7 +202,7 @@
      }
    }
  
-@@ -346,7 +441,15 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
+@@ -346,7 +450,15 @@ static void uv__slow_poll_submit_poll_req(uv_loop_t* loop, uv_poll_t* handle) {
      handle->mask_events_1 = handle->events;
      handle->mask_events_2 = 0;
    } else {
@@ -210,7 +219,7 @@
      return;
    }
  
-@@ -403,6 +506,32 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+@@ -403,6 +515,32 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
  }
  
  
@@ -243,7 +252,7 @@
  int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd) {
    return uv_poll_init_socket(loop, handle, (SOCKET) uv__get_osfhandle(fd));
  }
-@@ -457,7 +586,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
+@@ -457,7 +595,10 @@ int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle,
    /* Get the peer socket that is needed to enable fast poll. If the returned
     * value is NULL, the protocol is not implemented by MSAFD and we'll have to
     * use slow mode. */

--- a/patches/libuv/win-slow-poll-disconnect.patch
+++ b/patches/libuv/win-slow-poll-disconnect.patch
@@ -1,5 +1,3 @@
-diff --git a/src/win/poll.c b/src/win/poll.c
-index a20867a..01b7c6c 100644
 --- a/src/win/poll.c
 +++ b/src/win/poll.c
 @@ -269,58 +269,122 @@ static DWORD WINAPI uv__slow_poll_thread_proc(void* arg) {

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -64,9 +64,10 @@ export const libuv: Dependency = {
   // win-slow-poll-disconnect: the select()-based slow poll path (taken when
   // a winsock LSP with a non-IFS protocol chain owns the socket) never
   // reported UV_DISCONNECT, and a poll subscribed to only UV_DISCONNECT
-  // handed select() three empty fd sets, which fails WSAEINVAL and killed
-  // the watcher with a bogus error. usockets arms UV_DISCONNECT on every
-  // poll and parks paused/half-closed sockets in exactly that state.
+  // (or only UV_PRIORITIZED, the abort watch) handed select() three empty
+  // fd sets, which fails WSAEINVAL and killed the watcher with a bogus
+  // error. usockets arms UV_DISCONNECT on every poll and parks
+  // paused/half-closed sockets in exactly those states.
   // Synthesize UV_DISCONNECT from select() readability + MSG_PEEK, and add
   // the BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL=1 hook so tests reach the path without an LSP.
   // Upstreamable to libuv/libuv (minus the hook).

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -60,7 +60,21 @@ export const libuv: Dependency = {
   // an in-process loopback fetch().abort() can fall into. To upstream:
   // send to libuv/libuv with the wepoll/ReactOS references in the patch
   // comment as the rationale.
-  patches: ["patches/libuv/win-poll-rearm-before-callback.patch", "patches/libuv/win-poll-abort-with-disconnect.patch"],
+  //
+  // win-slow-poll-disconnect: the select()-based slow poll path (taken when
+  // a winsock LSP with a non-IFS protocol chain owns the socket) never
+  // reported UV_DISCONNECT, and a poll subscribed to only UV_DISCONNECT
+  // handed select() three empty fd sets, which fails WSAEINVAL and killed
+  // the watcher with a bogus error. usockets arms UV_DISCONNECT on every
+  // poll and parks paused/half-closed sockets in exactly that state.
+  // Synthesize UV_DISCONNECT from select() readability + MSG_PEEK, and add
+  // the UV_FORCE_SLOW_POLL=1 hook so tests reach the path without an LSP.
+  // Upstreamable to libuv/libuv (minus the hook).
+  patches: [
+    "patches/libuv/win-poll-rearm-before-callback.patch",
+    "patches/libuv/win-poll-abort-with-disconnect.patch",
+    "patches/libuv/win-slow-poll-disconnect.patch",
+  ],
 
   build: () => ({
     kind: "direct",

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -70,6 +70,11 @@ export const libuv: Dependency = {
   // Synthesize UV_DISCONNECT from select() readability + MSG_PEEK, and add
   // the UV_FORCE_SLOW_POLL=1 hook so tests reach the path without an LSP.
   // Upstreamable to libuv/libuv (minus the hook).
+  //
+  // Patch files here must use traditional `--- a/` / `+++ b/` headers, not
+  // `diff --git` ones: fetch-cli's `git apply` runs from vendor/<dep> inside
+  // this repo, and git resolves git-style paths against the enclosing repo
+  // root, silently skipping them with exit 0.
   patches: [
     "patches/libuv/win-poll-rearm-before-callback.patch",
     "patches/libuv/win-poll-abort-with-disconnect.patch",

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -68,7 +68,7 @@ export const libuv: Dependency = {
   // the watcher with a bogus error. usockets arms UV_DISCONNECT on every
   // poll and parks paused/half-closed sockets in exactly that state.
   // Synthesize UV_DISCONNECT from select() readability + MSG_PEEK, and add
-  // the UV_FORCE_SLOW_POLL=1 hook so tests reach the path without an LSP.
+  // the BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL=1 hook so tests reach the path without an LSP.
   // Upstreamable to libuv/libuv (minus the hook).
   //
   // Patch files here must use traditional `--- a/` / `+++ b/` headers, not

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4735,6 +4735,7 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
   it("a paused socket with buffered data survives quiescence and resumes", async () => {
     const { stdout, stderr, exitCode } = await runChild(`
         let sawError = null;
+        let closeError = null;
         let closed = false;
         const opened = Promise.withResolvers();
         const gotData = Promise.withResolvers();
@@ -4754,7 +4755,8 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
             error(s, e) {
               sawError = e?.code || String(e);
             },
-            close() {
+            close(s, e) {
+              closeError = e?.code || (e ? String(e) : null);
               closed = true;
             },
           },
@@ -4779,7 +4781,7 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
         // "poll parked N times", so hold the state across a fixed window.
         await Bun.sleep(1500);
         if (sawError || closed) {
-          console.log("FAIL early-death error=" + sawError + " closed=" + closed);
+          console.log("FAIL early-death error=" + (sawError || closeError) + " closed=" + closed);
           process.exit(1);
         }
         paused.resume();
@@ -4798,6 +4800,7 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
   it("a half-closed paused socket sees the peer FIN and closes cleanly", async () => {
     const { stdout, stderr, exitCode } = await runChild(`
         let sawError = null;
+        let closeError = null;
         const serverClosed = Promise.withResolvers();
         using server = Bun.listen({
           hostname: "127.0.0.1",
@@ -4814,7 +4817,8 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
             error(s, e) {
               sawError = e?.code || String(e);
             },
-            close() {
+            close(s, e) {
+              closeError = e?.code || (e ? String(e) : null);
               serverClosed.resolve();
             },
           },
@@ -4822,9 +4826,16 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
         await Bun.connect({
           hostname: "127.0.0.1",
           port: server.port,
+          // Half-open so receiving the server FIN does not auto-answer with
+          // ours: the delayed reply first holds the server socket parked in
+          // the DISCONNECT-only state across loop iterations (the broken path
+          // error-closes it within one), then delivers the FIN it must not
+          // miss.
+          allowHalfOpen: true,
           socket: {
             data() {},
-            end(s) {
+            async end(s) {
+              await Bun.sleep(700);
               s.end();
             },
             error() {},
@@ -4832,8 +4843,9 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
           },
         });
         await serverClosed.promise;
-        console.log(sawError ? "FAIL " + sawError : "OK clean close");
-        process.exit(sawError ? 1 : 0);
+        const bad = sawError || closeError;
+        console.log(bad ? "FAIL " + bad : "OK clean close");
+        process.exit(bad ? 1 : 0);
       `);
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("OK clean close");
@@ -4843,6 +4855,7 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
   it("a paused socket with buffered data learns of a peer reset", async () => {
     const { stdout, stderr, exitCode } = await runChild(`
         let sawError = null;
+        let closeError = null;
         let closed = false;
         const opened = Promise.withResolvers();
         const gone = Promise.withResolvers();
@@ -4859,7 +4872,8 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
               sawError = e?.code || String(e);
               gone.resolve("error");
             },
-            close() {
+            close(s, e) {
+              closeError = e?.code || (e ? String(e) : null);
               closed = true;
               gone.resolve("close");
             },
@@ -4877,7 +4891,7 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
         // instant error-close would satisfy the later assertion by accident.
         await Bun.sleep(1200);
         if (sawError || closed) {
-          console.log("FAIL early-death error=" + sawError + " closed=" + closed);
+          console.log("FAIL early-death error=" + (sawError || closeError) + " closed=" + closed);
           process.exit(1);
         }
         // Abortive close: the RST discards the queued byte, so the periodic

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4797,21 +4797,24 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
     expect(exitCode).toBe(0);
   }, 15_000);
 
-  it("a half-closed paused socket sees the peer FIN and closes cleanly", async () => {
+  it("a half-closed paused socket defers the peer FIN and closes cleanly on resume", async () => {
     const { stdout, stderr, exitCode } = await runChild(`
         let sawError = null;
         let closeError = null;
+        let closed = false;
+        let paused;
         const serverClosed = Promise.withResolvers();
         using server = Bun.listen({
           hostname: "127.0.0.1",
           port: 0,
           socket: {
             open(s) {
-              // Half-close (FIN) with reads parked: the poll ends up
-              // subscribed to UV_DISCONNECT only, so the peer's answering FIN
-              // is exactly the event the slow path used to never deliver
-              // (hanging teardown). end() would flush-and-close outright;
-              // shutdown() keeps the socket waiting for that FIN.
+              // Half-close (FIN) with reads parked: the poll parks
+              // subscribed to UV_DISCONNECT only, the state the broken slow
+              // path error-closed with WSAEINVAL within one loop iteration.
+              // end() would flush-and-close outright; shutdown() keeps the
+              // socket waiting for the peer's answering FIN.
+              paused = s;
               s.pause();
               s.shutdown();
             },
@@ -4821,6 +4824,7 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             },
             close(s, e) {
               closeError = e?.code || (e ? String(e) : null);
+              closed = true;
               serverClosed.resolve();
             },
           },
@@ -4829,10 +4833,9 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
           hostname: "127.0.0.1",
           port: server.port,
           // Half-open so receiving the server FIN does not auto-answer with
-          // ours: the delayed reply first holds the server socket parked in
-          // the DISCONNECT-only state across loop iterations (the broken path
-          // error-closes it within one), then delivers the FIN it must not
-          // miss.
+          // ours: the delayed reply holds the server socket parked in the
+          // DISCONNECT-only state across loop iterations before the FIN
+          // arrives.
           allowHalfOpen: true,
           socket: {
             data() {},
@@ -4844,13 +4847,25 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             close() {},
           },
         });
+        // The FIN lands at ~700ms. The paused-EOF deferral means it must
+        // NOT close the socket while reads are parked (the tail of the
+        // stream may not have been read yet); the broken slow path instead
+        // error-closed the healthy socket within one iteration. Hold the
+        // state across both.
+        await Bun.sleep(1500);
+        if (sawError || closed) {
+          console.log("FAIL early-death error=" + (sawError || closeError) + " closed=" + closed);
+          process.exit(1);
+        }
+        // Resuming reads delivers the deferred EOF and closes cleanly.
+        paused.resume();
         await serverClosed.promise;
         const bad = sawError || closeError;
-        console.log(bad ? "FAIL " + bad : "OK clean close");
+        console.log(bad ? "FAIL " + bad : "OK clean close on resume");
         process.exit(bad ? 1 : 0);
       `);
     expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK clean close");
+    expect(stdout.trim()).toBe("OK clean close on resume");
     expect(exitCode).toBe(0);
   }, 15_000);
 

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4992,15 +4992,31 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
     // request slots (sleeping between peeks); resume's request, cycled back
     // to a blocked readable wait, holds the other. A backpressured write
     // then re-arms WRITABLE, a subscription bit neither checked-out request
-    // carries, and libuv's slow submit used to assert(0) on that third
-    // generation (debug abort; in release WRITABLE stayed unarmed until a
-    // request completed). The parked request must instead converge onto
-    // the new subscription within a lap.
+    // carries, and libuv's slow submit hits its both-slots-busy branch:
+    // historically assert(0), and without the graceful-return + one-second
+    // lap cap the new subscription stayed unarmed until a request
+    // completed, stalling the writer. The full payload must still drain.
     const { stdout, stderr, exitCode } = await runChild(`
+        const TOTAL = 4 * 1024 * 1024;
+        const CHUNK = 64 * 1024;
+        const payload = Buffer.alloc(CHUNK, "b");
+        let sent = 0;
         let sawError = null;
         const opened = Promise.withResolvers();
         const gotData = Promise.withResolvers();
-        const clientGotSome = Promise.withResolvers();
+        const drained = Promise.withResolvers();
+        function pump(s) {
+          while (sent < TOTAL) {
+            const want = Math.min(CHUNK, TOTAL - sent);
+            const n = s.write(payload.subarray(0, want));
+            if (n < 0) {
+              console.log("FAIL write returned " + n + " after " + sent + " bytes");
+              process.exit(1);
+            }
+            sent += n;
+            if (n < want) return; // backpressure: drain() resumes the pump
+          }
+        }
         let paused;
         using server = Bun.listen({
           hostname: "127.0.0.1",
@@ -5014,24 +5030,27 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             data(s, buf) {
               gotData.resolve(buf.toString());
             },
+            drain(s) {
+              pump(s);
+            },
             error(s, e) {
               sawError = e?.code || String(e);
             },
             close() {},
           },
         });
+        let received = 0;
         const client = await Bun.connect({
           hostname: "127.0.0.1",
           port: server.port,
           socket: {
             open(s) {
-              // Never reads until resumed, so the server's big write below
-              // cannot be absorbed by the kernel buffers and must leave
-              // WRITABLE armed.
+              // Not reading yet: the server's flood below must backpressure.
               s.pause();
             },
             data(s, buf) {
-              clientGotSome.resolve(buf.length);
+              received += buf.length;
+              if (received >= TOTAL) drained.resolve();
             },
             error() {},
             close() {},
@@ -5043,27 +5062,25 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
         // checked out, sleeping between peeks).
         await Bun.sleep(400);
         paused.resume();
-        const first = await gotData.promise;
+        await gotData.promise;
         // One settled loop turn so resume's request cycles back to a
         // parked readable wait (slot 2 checked out too).
         await Bun.sleep(80);
-        // 8MB against ~128KB of loopback buffering: the raw send is
-        // necessarily partial, which re-arms WRITABLE; this is the
-        // submission that used to abort the process.
-        const big = Buffer.alloc(8 * 1024 * 1024, 65).toString();
-        paused.write(big);
-        await Bun.sleep(300);
+        // The first partial write re-arms WRITABLE with both slots held:
+        // the submission that used to have no slot to land in.
+        pump(paused);
+        await Bun.sleep(200);
         if (sawError) {
           console.log("FAIL " + sawError);
           process.exit(1);
         }
         client.resume();
-        const got = await clientGotSome.promise;
-        console.log("OK " + first + " " + (got > 0));
+        await drained.promise;
+        console.log("OK drained " + received);
         process.exit(0);
       `);
     expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK x true");
+    expect(stdout.trim()).toBe("OK drained " + 4 * 1024 * 1024);
     expect(exitCode).toBe(0);
   }, 15_000);
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4924,7 +4924,6 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
         const CHUNK = 64 * 1024;
         const payload = Buffer.alloc(CHUNK, "a");
         let sent = 0;
-        let sawError = null;
         const opened = Promise.withResolvers();
         const drained = Promise.withResolvers();
         function pump(s) {
@@ -4940,6 +4939,13 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             if (n < want) return; // backpressure: drain() resumes the pump
           }
         }
+        // Any socket death mid-transfer is a failure: exit with the cause
+        // right away instead of hanging the child until the parent timeout
+        // with nothing on stdout.
+        function die(what) {
+          console.log("FAIL " + what);
+          process.exit(1);
+        }
         using server = Bun.listen({
           hostname: "127.0.0.1",
           port: 0,
@@ -4953,9 +4959,11 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
               pump(s);
             },
             error(s, e) {
-              sawError = e?.code || String(e);
+              die("server error " + (e?.code || e));
             },
-            close() {},
+            close(s, e) {
+              die("server closed err=" + (e?.code || e));
+            },
           },
         });
         let received = 0;
@@ -4967,18 +4975,18 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
               received += buf.length;
               if (received >= TOTAL) drained.resolve();
             },
-            error() {},
-            close() {},
+            error(s, e) {
+              die("client error " + (e?.code || e));
+            },
+            close(s, e) {
+              die("client closed err=" + (e?.code || e));
+            },
           },
         });
         const serverSock = await opened.promise;
         client.write("x");
         pump(serverSock);
         await drained.promise;
-        if (sawError) {
-          console.log("FAIL " + sawError);
-          process.exit(1);
-        }
         console.log("OK drained");
         process.exit(0);
       `);
@@ -5001,7 +5009,6 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
         const CHUNK = 64 * 1024;
         const payload = Buffer.alloc(CHUNK, "b");
         let sent = 0;
-        let sawError = null;
         const opened = Promise.withResolvers();
         const gotData = Promise.withResolvers();
         const drained = Promise.withResolvers();
@@ -5016,6 +5023,13 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             sent += n;
             if (n < want) return; // backpressure: drain() resumes the pump
           }
+        }
+        // Any socket death is a failure (the broken path error-closes the
+        // parked socket): exit with the cause right away instead of hanging
+        // the child until the parent timeout with nothing on stdout.
+        function die(what) {
+          console.log("FAIL " + what);
+          process.exit(1);
         }
         let paused;
         using server = Bun.listen({
@@ -5034,9 +5048,11 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
               pump(s);
             },
             error(s, e) {
-              sawError = e?.code || String(e);
+              die("server error " + (e?.code || e));
             },
-            close() {},
+            close(s, e) {
+              die("server closed err=" + (e?.code || e));
+            },
           },
         });
         let received = 0;
@@ -5052,8 +5068,12 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
               received += buf.length;
               if (received >= TOTAL) drained.resolve();
             },
-            error() {},
-            close() {},
+            error(s, e) {
+              die("client error " + (e?.code || e));
+            },
+            close(s, e) {
+              die("client closed err=" + (e?.code || e));
+            },
           },
         });
         await opened.promise;
@@ -5069,11 +5089,6 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
         // The first partial write re-arms WRITABLE with both slots held:
         // the submission that used to have no slot to land in.
         pump(paused);
-        await Bun.sleep(200);
-        if (sawError) {
-          console.log("FAIL " + sawError);
-          process.exit(1);
-        }
         client.resume();
         await drained.promise;
         console.log("OK drained " + received);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -5079,16 +5079,24 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
         await opened.promise;
         client.write("x");
         // Let the paused server poll park with the byte pending (slot 1
-        // checked out, sleeping between peeks).
+        // checked out, sleeping between peeks). Nothing JS-observable marks
+        // "the slow-poll worker has parked", so a fixed window is the only
+        // way to reach that state.
         await Bun.sleep(400);
         paused.resume();
         await gotData.promise;
         // One settled loop turn so resume's request cycles back to a
         // parked readable wait (slot 2 checked out too).
-        await Bun.sleep(80);
+        await Bun.sleep(0);
         // The first partial write re-arms WRITABLE with both slots held:
         // the submission that used to have no slot to land in.
         pump(paused);
+        // The flood must actually have hit backpressure, or nothing was
+        // re-armed and the both-slots branch went unexercised.
+        if (sent >= TOTAL) {
+          console.log("FAIL no backpressure: " + sent + " bytes accepted outright");
+          process.exit(1);
+        }
         client.resume();
         await drained.promise;
         console.log("OK drained " + received);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4807,11 +4807,13 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
           port: 0,
           socket: {
             open(s) {
-              // Send our FIN with reads parked: the poll ends up subscribed to
-              // UV_DISCONNECT only, so the peer's answering FIN is exactly the
-              // event the slow path used to never deliver (hanging teardown).
+              // Half-close (FIN) with reads parked: the poll ends up
+              // subscribed to UV_DISCONNECT only, so the peer's answering FIN
+              // is exactly the event the slow path used to never deliver
+              // (hanging teardown). end() would flush-and-close outright;
+              // shutdown() keeps the socket waiting for that FIN.
               s.pause();
-              s.end();
+              s.shutdown();
             },
             data() {},
             error(s, e) {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4715,11 +4715,11 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
 // paused or half-closed socket parks on Windows) handed select() three empty
 // fd sets, which fails WSAEINVAL instantly and error-closed the healthy
 // connection. Our libuv patch synthesizes UV_DISCONNECT on the slow path from
-// select() readability plus MSG_PEEK, and adds the UV_FORCE_SLOW_POLL=1 hook
+// select() readability plus MSG_PEEK, and adds the BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL=1 hook
 // so these scenarios can run without installing an LSP. The hook is read once
 // per process at the first poll creation, so every scenario runs in a child.
-describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORCE_SLOW_POLL)", () => {
-  const slowPollEnv = { ...bunEnv, UV_FORCE_SLOW_POLL: "1" };
+describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL)", () => {
+  const slowPollEnv = { ...bunEnv, BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL: "1" };
 
   async function runChild(script: string) {
     await using proc = Bun.spawn({
@@ -4986,4 +4986,84 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
     expect(stdout.trim()).toBe("OK drained");
     expect(exitCode).toBe(0);
   }, 20_000);
+
+  it("a backpressured write lands while both poll requests are checked out", async () => {
+    // A parked DISCONNECT-only request holds one of the handle's two poll
+    // request slots (sleeping between peeks); resume's request, cycled back
+    // to a blocked readable wait, holds the other. A backpressured write
+    // then re-arms WRITABLE, a subscription bit neither checked-out request
+    // carries, and libuv's slow submit used to assert(0) on that third
+    // generation (debug abort; in release WRITABLE stayed unarmed until a
+    // request completed). The parked request must instead converge onto
+    // the new subscription within a lap.
+    const { stdout, stderr, exitCode } = await runChild(`
+        let sawError = null;
+        const opened = Promise.withResolvers();
+        const gotData = Promise.withResolvers();
+        const clientGotSome = Promise.withResolvers();
+        let paused;
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(s) {
+              paused = s;
+              s.pause();
+              opened.resolve();
+            },
+            data(s, buf) {
+              gotData.resolve(buf.toString());
+            },
+            error(s, e) {
+              sawError = e?.code || String(e);
+            },
+            close() {},
+          },
+        });
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            open(s) {
+              // Never reads until resumed, so the server's big write below
+              // cannot be absorbed by the kernel buffers and must leave
+              // WRITABLE armed.
+              s.pause();
+            },
+            data(s, buf) {
+              clientGotSome.resolve(buf.length);
+            },
+            error() {},
+            close() {},
+          },
+        });
+        await opened.promise;
+        client.write("x");
+        // Let the paused server poll park with the byte pending (slot 1
+        // checked out, sleeping between peeks).
+        await Bun.sleep(400);
+        paused.resume();
+        const first = await gotData.promise;
+        // One settled loop turn so resume's request cycles back to a
+        // parked readable wait (slot 2 checked out too).
+        await Bun.sleep(80);
+        // 8MB against ~128KB of loopback buffering: the raw send is
+        // necessarily partial, which re-arms WRITABLE; this is the
+        // submission that used to abort the process.
+        const big = Buffer.alloc(8 * 1024 * 1024, 65).toString();
+        paused.write(big);
+        await Bun.sleep(300);
+        if (sawError) {
+          console.log("FAIL " + sawError);
+          process.exit(1);
+        }
+        client.resume();
+        const got = await clientGotSome.promise;
+        console.log("OK " + first + " " + (got > 0));
+        process.exit(0);
+      `);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK x true");
+    expect(exitCode).toBe(0);
+  }, 15_000);
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4706,3 +4706,190 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
 
   await Promise.all([serverClosed.promise, clientClosed.promise]);
 });
+
+// When a winsock LSP (layered service provider) with a non-IFS protocol chain
+// owns a socket, libuv cannot AFD-poll it and falls back to its slow poll path:
+// a select() on a worker thread. That path historically computed only
+// readable/writable, so the UV_DISCONNECT subscription usockets arms on every
+// poll did nothing there, and a poll subscribed to ONLY UV_DISCONNECT (how a
+// paused or half-closed socket parks on Windows) handed select() three empty
+// fd sets, which fails WSAEINVAL instantly and error-closed the healthy
+// connection. Our libuv patch synthesizes UV_DISCONNECT on the slow path from
+// select() readability plus MSG_PEEK, and adds the UV_FORCE_SLOW_POLL=1 hook
+// so these scenarios can run without installing an LSP. The hook is read once
+// per process at the first poll creation, so every scenario runs in a child.
+describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORCE_SLOW_POLL)", () => {
+  const slowPollEnv = { ...bunEnv, UV_FORCE_SLOW_POLL: "1" };
+
+  async function runChild(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: slowPollEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("a paused socket with buffered data survives quiescence and resumes", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+        let sawError = null;
+        let closed = false;
+        const opened = Promise.withResolvers();
+        const gotData = Promise.withResolvers();
+        let paused;
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(s) {
+              paused = s;
+              s.pause();
+              opened.resolve();
+            },
+            data(s, buf) {
+              gotData.resolve(buf.toString());
+            },
+            error(s, e) {
+              sawError = e?.code || String(e);
+            },
+            close() {
+              closed = true;
+            },
+          },
+        });
+        const clientData = Promise.withResolvers();
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            data(s, buf) {
+              clientData.resolve(buf.toString());
+            },
+            error() {},
+            close() {},
+          },
+        });
+        await opened.promise;
+        client.write("ping");
+        // The paused socket's poll is subscribed to UV_DISCONNECT only, with
+        // the unread byte pending: the state the broken slow path error-closed
+        // with WSAEINVAL within one loop iteration. Nothing observable marks
+        // "poll parked N times", so hold the state across a fixed window.
+        await Bun.sleep(1500);
+        if (sawError || closed) {
+          console.log("FAIL early-death error=" + sawError + " closed=" + closed);
+          process.exit(1);
+        }
+        paused.resume();
+        const got = await gotData.promise;
+        paused.write("pong");
+        const echoed = await clientData.promise;
+        client.end();
+        console.log("OK " + got + " " + echoed);
+        process.exit(0);
+      `);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK ping pong");
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
+  it("a half-closed paused socket sees the peer FIN and closes cleanly", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+        let sawError = null;
+        const serverClosed = Promise.withResolvers();
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(s) {
+              // Send our FIN with reads parked: the poll ends up subscribed to
+              // UV_DISCONNECT only, so the peer's answering FIN is exactly the
+              // event the slow path used to never deliver (hanging teardown).
+              s.pause();
+              s.end();
+            },
+            data() {},
+            error(s, e) {
+              sawError = e?.code || String(e);
+            },
+            close() {
+              serverClosed.resolve();
+            },
+          },
+        });
+        await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            data() {},
+            end(s) {
+              s.end();
+            },
+            error() {},
+            close() {},
+          },
+        });
+        await serverClosed.promise;
+        console.log(sawError ? "FAIL " + sawError : "OK clean close");
+        process.exit(sawError ? 1 : 0);
+      `);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK clean close");
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
+  it("a paused socket with buffered data learns of a peer reset", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+        let sawError = null;
+        let closed = false;
+        const opened = Promise.withResolvers();
+        const gone = Promise.withResolvers();
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(s) {
+              s.pause();
+              opened.resolve();
+            },
+            data() {},
+            error(s, e) {
+              sawError = e?.code || String(e);
+              gone.resolve("error");
+            },
+            close() {
+              closed = true;
+              gone.resolve("close");
+            },
+          },
+        });
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: { data() {}, error() {}, close() {} },
+        });
+        await opened.promise;
+        client.write("x");
+        // Same fixed window as above: the paused socket must survive parked
+        // with data pending before the connection dies, or a broken build's
+        // instant error-close would satisfy the later assertion by accident.
+        await Bun.sleep(1200);
+        if (sawError || closed) {
+          console.log("FAIL early-death error=" + sawError + " closed=" + closed);
+          process.exit(1);
+        }
+        // Abortive close: the RST discards the queued byte, so the periodic
+        // slow-path re-peek is the only thing that can discover the death
+        // (AFD would have reported AFD_POLL_ABORT; select() alone cannot).
+        client.terminate();
+        await gone.promise;
+        console.log("OK dead connection surfaced");
+        process.exit(0);
+      `);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK dead connection surfaced");
+    expect(exitCode).toBe(0);
+  }, 15_000);
+});

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -5121,4 +5121,89 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
     expect(stdout.trim()).toBe("OK drained " + 4 * 1024 * 1024);
     expect(exitCode).toBe(0);
   }, 15_000);
+
+  it("a half-open socket that consumed the peer FIN survives its abort watch and stays usable", async () => {
+    // After a half-open socket reads the peer's FIN to EOF, usockets parks
+    // its poll subscribed to only UV_PRIORITIZED: the abort-only watch that
+    // lets a later reset still close the socket. That mask armed no fd set
+    // on the slow path, so select() failed WSAEINVAL and error-closed the
+    // healthy socket, same class as the DISCONNECT-only bug. (A reset that
+    // arrives after the FIN was consumed is invisible to the socket API
+    // itself, per probing: peek stays 0, SO_ERROR stays 0, so only the AFD
+    // fast path can deliver that one; the slow path's job is to survive
+    // the park and deliver what a peek can see.)
+    const { stdout, stderr, exitCode } = await runChild(`
+        let sawError = null;
+        let closeError = null;
+        let closed = false;
+        let victim;
+        const opened = Promise.withResolvers();
+        const clientGotReply = Promise.withResolvers();
+        const gone = Promise.withResolvers();
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          allowHalfOpen: true,
+          socket: {
+            open(s) {
+              victim = s;
+              opened.resolve();
+            },
+            data() {},
+            end() {},
+            error(s, e) {
+              sawError = e?.code || String(e);
+              gone.resolve("error");
+            },
+            close(s, e) {
+              closeError = e?.code || (e ? String(e) : null);
+              closed = true;
+              gone.resolve("close");
+            },
+          },
+        });
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          allowHalfOpen: true,
+          socket: {
+            data(s, buf) {
+              clientGotReply.resolve(buf.toString());
+            },
+            end() {},
+            error() {},
+            close() {},
+          },
+        });
+        await opened.promise;
+        client.write("x");
+        // FIN with the byte consumed on the server side: the server reads
+        // to EOF, drops READABLE, and parks on the abort-only watch. The
+        // broken path error-closes it within a loop iteration; hold the
+        // state across a fixed window (nothing JS-observable marks the
+        // park itself).
+        client.shutdown();
+        await Bun.sleep(1500);
+        if (sawError || closed) {
+          console.log("FAIL early-death error=" + (sawError || closeError) + " closed=" + closed);
+          process.exit(1);
+        }
+        // Still usable for writes after surviving parked.
+        victim.write("reply");
+        const got = await clientGotReply.promise;
+        if (got !== "reply") {
+          console.log("FAIL reply corrupted: " + got);
+          process.exit(1);
+        }
+        // Answer the FIN: both directions done, clean teardown.
+        victim.end();
+        await gone.promise;
+        const bad = sawError || closeError;
+        console.log(bad ? "FAIL " + bad : "OK survived the abort watch");
+        process.exit(bad ? 1 : 0);
+      `);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK survived the abort watch");
+    expect(exitCode).toBe(0);
+  }, 15_000);
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4901,11 +4901,84 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
         // (AFD would have reported AFD_POLL_ABORT; select() alone cannot).
         client.terminate();
         await gone.promise;
-        console.log("OK dead connection surfaced");
+        // The RST must surface as a dirty close (the re-peek sees
+        // WSAECONNRESET), not be mistaken for a clean FIN.
+        const dirty = sawError || closeError;
+        console.log(dirty ? "OK dead connection surfaced dirty" : "FAIL clean close on RST");
+        process.exit(dirty ? 0 : 1);
+      `);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK dead connection surfaced dirty");
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
+  it("a backpressured writer parked with unread data drains at full speed", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+        // Receive-paused socket with a write backlog: the poll parks
+        // subscribed to UV_WRITABLE | UV_DISCONNECT while the client's
+        // unread byte keeps the socket readable. The slow path must block
+        // on writability here; a version that parked this state with a
+        // 1-second sleep throttles the transfer to one send-buffer per
+        // second and cannot finish 8MB inside the test timeout.
+        const TOTAL = 8 * 1024 * 1024;
+        const CHUNK = 64 * 1024;
+        const payload = Buffer.alloc(CHUNK, "a");
+        let sent = 0;
+        let sawError = null;
+        const opened = Promise.withResolvers();
+        const drained = Promise.withResolvers();
+        function pump(s) {
+          while (sent < TOTAL) {
+            const want = Math.min(CHUNK, TOTAL - sent);
+            const n = s.write(payload.subarray(0, want));
+            sent += n;
+            if (n < want) return; // backpressure: drain() resumes the pump
+          }
+        }
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(s) {
+              s.pause();
+              opened.resolve(s);
+            },
+            data() {},
+            drain(s) {
+              pump(s);
+            },
+            error(s, e) {
+              sawError = e?.code || String(e);
+            },
+            close() {},
+          },
+        });
+        let received = 0;
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            data(s, buf) {
+              received += buf.length;
+              if (received >= TOTAL) drained.resolve();
+            },
+            error() {},
+            close() {},
+          },
+        });
+        const serverSock = await opened.promise;
+        client.write("x");
+        pump(serverSock);
+        await drained.promise;
+        if (sawError) {
+          console.log("FAIL " + sawError);
+          process.exit(1);
+        }
+        console.log("OK drained");
         process.exit(0);
       `);
     expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK dead connection surfaced");
+    expect(stdout.trim()).toBe("OK drained");
     expect(exitCode).toBe(0);
-  }, 15_000);
+  }, 20_000);
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4762,6 +4762,9 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
           },
         });
         const clientData = Promise.withResolvers();
+        // Set before the final end(): from then on the client closing is
+        // expected, not a failure (end() can dispatch close synchronously).
+        let finishing = false;
         const client = await Bun.connect({
           hostname: "127.0.0.1",
           port: server.port,
@@ -4769,8 +4772,18 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             data(s, buf) {
               clientData.resolve(buf.toString());
             },
-            error() {},
-            close() {},
+            // A dying client would leave clientData pending until the
+            // parent timeout with the cause unprinted: fail fast instead.
+            error(s, e) {
+              console.log("FAIL client error " + (e?.code || e));
+              process.exit(1);
+            },
+            close() {
+              if (!finishing) {
+                console.log("FAIL client closed early");
+                process.exit(1);
+              }
+            },
           },
         });
         await opened.promise;
@@ -4786,8 +4799,13 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
         }
         paused.resume();
         const got = await gotData.promise;
-        paused.write("pong");
+        const wrote = paused.write("pong");
+        if (wrote < 0) {
+          console.log("FAIL write returned " + wrote);
+          process.exit(1);
+        }
         const echoed = await clientData.promise;
+        finishing = true;
         client.end();
         console.log("OK " + got + " " + echoed);
         process.exit(0);
@@ -5162,6 +5180,9 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
             },
           },
         });
+        // Set when the clean teardown starts: from then on the client
+        // closing is expected, not a failure.
+        let finishing = false;
         const client = await Bun.connect({
           hostname: "127.0.0.1",
           port: server.port,
@@ -5171,8 +5192,18 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
               clientGotReply.resolve(buf.toString());
             },
             end() {},
-            error() {},
-            close() {},
+            // A dying client would leave clientGotReply pending until the
+            // parent timeout with the cause unprinted: fail fast instead.
+            error(s, e) {
+              console.log("FAIL client error " + (e?.code || e));
+              process.exit(1);
+            },
+            close() {
+              if (!finishing) {
+                console.log("FAIL client closed early");
+                process.exit(1);
+              }
+            },
           },
         });
         await opened.promise;
@@ -5189,13 +5220,18 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via BUN_FEA
           process.exit(1);
         }
         // Still usable for writes after surviving parked.
-        victim.write("reply");
+        const wrote = victim.write("reply");
+        if (wrote < 0) {
+          console.log("FAIL write returned " + wrote);
+          process.exit(1);
+        }
         const got = await clientGotReply.promise;
         if (got !== "reply") {
           console.log("FAIL reply corrupted: " + got);
           process.exit(1);
         }
         // Answer the FIN: both directions done, clean teardown.
+        finishing = true;
         victim.end();
         await gone.promise;
         const bad = sawError || closeError;

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4931,6 +4931,11 @@ describe.concurrent.skipIf(!isWindows)("libuv slow poll path (forced via UV_FORC
           while (sent < TOTAL) {
             const want = Math.min(CHUNK, TOTAL - sent);
             const n = s.write(payload.subarray(0, want));
+            if (n < 0) {
+              // Dead socket: fail now instead of waiting out the timeout.
+              console.log("FAIL write returned " + n + " after " + sent + " bytes");
+              process.exit(1);
+            }
             sent += n;
             if (n < want) return; // backpressure: drain() resumes the pump
           }


### PR DESCRIPTION
### Problem

On Windows, when a winsock LSP (layered service provider) with a non-IFS protocol chain owns a socket (some antivirus/firewall/VPN products install these), libuv cannot AFD-poll it and falls back to its slow poll path: a `select()` on a worker thread (`uv__slow_poll_thread_proc` in `src/win/poll.c`). That path had two defects for the way usockets uses `uv_poll`:

1. It never reported `UV_DISCONNECT`. usockets arms `UV_DISCONNECT` on every poll and depends on it for connection teardown: it is how a half-closed socket that stopped reading learns of the peer's FIN, and how a paused socket discriminates FIN from abort (`poll_cb` in `packages/bun-usockets/src/eventing/libuv.c`). On LSP machines all of that silently degraded: hung teardown (e.g. `server.close()` waiting forever on a half-closed connection), paused sockets never learning their peer died.

2. Worse: a poll subscribed to only `UV_DISCONNECT`, which is the normal parked state for a paused or half-closed socket (pause drops READABLE, the writable dispatch drops WRITABLE once flushed), handed `select()` three empty fd sets. Winsock `select()` fails that with `WSAEINVAL` immediately, which stopped the watcher and reported a bogus error, so usockets error-closed the healthy connection. On an LSP machine, every paused socket dies within one loop iteration.

Winsock semantics verified with a raw C probe on Windows Server 2019:

<details>
<summary>probe output</summary>

```
1. select with all three sets empty (non-null ptrs, fd_count=0), 300ms timeout:
  select r=-1 err=10022 revents=--- elapsed=0ms        (WSAEINVAL, instant)
2. idle healthy socket, rfds armed: r=0 after timeout  (normal)
3. peer FIN, empty rx buffer: select readable; MSG_PEEK r=0 (repeatably)
4. peer RST, empty rx buffer: select readable; MSG_PEEK err=10054
5. peer sends 3 bytes then FIN: MSG_PEEK r=1           (FIN invisible behind data)
6. peer sends 3 bytes then RST: MSG_PEEK err=10054     (RST discards the queue)
7. closesocket from another thread wakes a blocked select immediately
8. RST wakes a blocked select immediately
9. zero-byte send on a half-open socket: r=0           (healthy)
```

</details>

### Fix

`patches/libuv/win-slow-poll-disconnect.patch`, touching only the slow path (the AFD fast path, which reports `AFD_POLL_DISCONNECT` natively, is untouched):

- Arm the read fd set when `UV_DISCONNECT` or `UV_PRIORITIZED` is requested, so the fd sets are never empty and a FIN or RST (which make the socket select()-readable) wakes the poll. `UV_PRIORITIZED` is the abort-only watch usockets parks a half-open socket on after its EOF was consumed; an abortive peek error reports it alongside `UV_DISCONNECT`. (A reset that lands after the FIN was already consumed is invisible to the socket API itself, probed: peek stays 0, SO_ERROR stays 0, so only the AFD fast path can carry that one.)
- On a readable wake with `UV_DISCONNECT` requested, discriminate with `recv(MSG_PEEK)`: 0 means FIN, an error other than `WSAEWOULDBLOCK`/`WSAENOTCONN`/`WSAEMSGSIZE` means the connection is gone; both report `UV_DISCONNECT`. `WSAENOTCONN` exempts listening sockets (readable on a pending accept, no peer to lose); `WSAEMSGSIZE` exempts datagrams wider than the 1-byte peek, which a stream socket can never produce. The peek cannot block: `uv_poll_init_socket` puts every poll socket in non-blocking mode (`FIONBIO`, poll.c:419) before a request can exist, and the peek only runs after select() reported readability.
- The one undeliverable state (data pending on a poll that does not want READABLE: a receive-paused socket) parks and re-peeks once a second instead of hot-spinning the instantly-readable select(). An RST behind the data discards the receive queue and turns the peek into an error within a tick. If the watcher also wants WRITABLE (a backpressured writer), the park re-selects with the read set suppressed for the lap instead of sleeping, so the send-buffer drain still wakes it instantly; without that, the drain test below throttles to one send-buffer per second.
- Every `select()` lap is capped at one second and re-reads `handle->events`, and `uv__slow_poll_submit_poll_req`'s both-slots-busy branch becomes a graceful return (mirroring the fast path's) instead of `assert(0)`. Slow requests are now long-lived by design (a parked DISCONNECT-only request can hold a slot for minutes), so a third subscription generation, e.g. a backpressured write while a parked request holds one slot and a resumed request holds the other, must land somewhere: the live requests converge onto the new subscription within a lap and the processing step resubmits with correct accounting. Previously that sequence hit the assert (or, with asserts compiled out, left the new subscription unarmed until a request completed, up to the full select() timeout).
- Fixes a pre-existing slot bug where a select() error was recorded on `poll_req_1` even when the failing request was `poll_req_2`.
- Adds a `BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL=1` hook (read once per process under `uv_once`, the file's idiom, since `uv_poll_init_socket` runs on every loop's thread) that routes `uv_poll_init_socket` to the slow path, so the path can be exercised without installing an LSP. The hook only selects between two production paths; the slow path is otherwise unreachable from any CI environment, and this is patched vendored C, out of reach of `bun:internal-for-testing`. The name follows the `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD` precedent for release-live env hooks that force a slower production path.

When no `UV_DISCONNECT` is subscribed, the rewritten thread proc behaves like upstream (same fd set arming, same masking at the processing step, same 3-minute completion cadence; the select just wakes to re-check its subscription once a second), so non-LSP machines see zero behavior change. Upstreamable to libuv/libuv minus the hook.

The patch file deliberately uses traditional `--- a/` / `+++ b/` headers: the dep fetcher runs `git apply` from `vendor/libuv` inside this repo, and git resolves `diff --git`-style paths against the enclosing repo root and silently skips them with exit 0 (tracked separately; the sibling abort patch is affected by that today).

### Tests

Six Windows-only tests in `test/js/bun/net/socket.test.ts`, each spawning a child with `BUN_FEATURE_FLAG_UV_FORCE_SLOW_POLL=1`:

- a paused socket with buffered data survives quiescence across loop iterations and resumes (catches the `WSAEINVAL` insta-close),
- a half-closed (`shutdown()`) paused socket survives the peer's answering FIN while parked (the paused-EOF deferral must hold, not error-close) and closes cleanly once reads resume,
- a paused socket with buffered data learns of a later RST, surfaced as a dirty close (catches the missing abort delivery and exercises the re-peek),
- a receive-paused backpressured writer with unread data pending drains 8MB at full speed (catches a park that sleeps instead of blocking on writability),
- a backpressured write landing while both poll request slots are checked out still drains fully (covers the graceful both-slots path and lap convergence).
- a half-open socket that consumed the peer FIN survives its parked abort-only watch (the broken path error-closes it within two loop iterations), still serves a write, and tears down cleanly.

Verification on Windows Server 2019 x64, debug build:

- full patch: the 5 tests pass; the whole `socket.test.ts` file (85 tests) passes both with and without the hook in the environment, and `node-http-connect.test.ts`, `udp_socket.test.ts` (207 tests) and `dgram.test.ts` pass with it forced (general traffic at parity on the slow path: TLS, backpressure, CONNECT tunnels, UDP);
- hook-only build (hook applied, behavioral hunks removed): the paused-socket tests fail with the instant dirty close (`FAIL early-death error=ESHUTDOWN closed=true`), the half-close test fails with a dirty close instead of a clean FIN-answered teardown, and the both-slots test fails with `FAIL write returned -10054 after 131072 bytes`.

POSIX backends are unaffected: they do not use libuv, and kqueue/epoll deliver EOF/HUP natively. There is no way to reproduce the LSP condition itself in CI, which is what the force hook is for; the two-build matrix above stands in for the fail-before the gate cannot run on a Windows-only test.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->
