### PR TITLE
usockets(win): free the poll when us_poll_free runs after the uv close callback

### DIFF
--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -19,8 +19,16 @@
 #include "internal/fault_inject.h"
 #include "libusockets.h"
 #include <stdlib.h>
+#include <stdatomic.h>
 
 #ifdef LIBUS_USE_LIBUV
+
+/* Live us_poll_t count: incremented on create/resize, decremented wherever
+ * one is freed. Read by leak tests (bun:internal-for-testing
+ * uvPollLiveCount) to assert this backend frees every poll it allocates. */
+static _Atomic long uv_poll_live = 0;
+
+long us_internal_uv_poll_live_count(void) { return atomic_load(&uv_poll_live); }
 
 /* The shared dispatch follows socket adoption (a tunneled/upgraded socket
  * moves; the old allocation stays readable with flags.adopted set and prev
@@ -171,6 +179,7 @@ static void close_cb_free_poll(uv_handle_t *h) {
   /* It is only in case we called us_poll_stop then quickly us_poll_free that we
    * enter this. Most of the time, actual freeing is done by us_poll_free. */
   if (h->data) {
+    atomic_fetch_sub(&uv_poll_live, 1);
     us_free(h->data);
     us_free(h);
   } else {
@@ -205,6 +214,7 @@ void us_poll_init(struct us_poll_t *p, LIBUS_SOCKET_DESCRIPTOR fd,
 void us_poll_free(struct us_poll_t *p, struct us_loop_t *loop) {
   // poll was resized and dont own uv_poll_t anymore
   if(!p->uv_p) {
+    atomic_fetch_sub(&uv_poll_live, 1);
     us_free(p);
     return;
   }
@@ -220,12 +230,14 @@ void us_poll_free(struct us_poll_t *p, struct us_loop_t *loop) {
        * close_cb_free_poll already ran (marking the handle; see above) and
        * will never run again, so deferring to it would leak both blocks.
        * libuv is done with the handle; free them here. */
+      atomic_fetch_sub(&uv_poll_live, 1);
       us_free(p->uv_p);
       us_free(p);
     } else {
       p->uv_p->data = p;
     }
   } else {
+    atomic_fetch_sub(&uv_poll_live, 1);
     us_free(p->uv_p);
     us_free(p);
   }
@@ -421,6 +433,7 @@ struct us_poll_t *us_create_poll(struct us_loop_t *loop, int fallthrough,
                                  unsigned int ext_size) {
   struct us_poll_t *p =
       (struct us_poll_t *)us_malloc(sizeof(struct us_poll_t) + ext_size);
+  atomic_fetch_add(&uv_poll_live, 1);
   p->uv_p = us_malloc(sizeof(uv_poll_t));
   p->uv_p->data = p;
   return p;
@@ -439,6 +452,7 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop,
   if(new_size <= old_size) return p;
 
   struct us_poll_t *new_p = us_calloc(1, new_size);
+  atomic_fetch_add(&uv_poll_live, 1);
   memcpy(new_p, p, old_size);
 
   new_p->uv_p->data = new_p;

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -173,6 +173,14 @@ static void close_cb_free_poll(uv_handle_t *h) {
   if (h->data) {
     us_free(h->data);
     us_free(h);
+  } else {
+    /* us_poll_stop ran but us_poll_free has not yet. This callback never runs
+     * again, and uv_is_closing() cannot tell a CLOSED handle from a CLOSING
+     * one, so mark the handle: a later us_poll_free must free both blocks
+     * itself instead of deferring to us. The mark cannot collide with a live
+     * poll, whose data is either 0 or the us_poll_t (a different
+     * allocation). */
+    h->data = h;
   }
 }
 
@@ -207,7 +215,16 @@ void us_poll_free(struct us_poll_t *p, struct us_loop_t *loop) {
    * simply change back the data to point to our structure so that we actually
    * do free it like we should. */
   if (uv_is_closing((uv_handle_t *)p->uv_p)) {
-    p->uv_p->data = p;
+    if (p->uv_p->data == (void *)p->uv_p) {
+      /* uv_is_closing() is also true for a handle that finished closing.
+       * close_cb_free_poll already ran (marking the handle; see above) and
+       * will never run again, so deferring to it would leak both blocks.
+       * libuv is done with the handle; free them here. */
+      us_free(p->uv_p);
+      us_free(p);
+    } else {
+      p->uv_p->data = p;
+    }
   } else {
     us_free(p->uv_p);
     us_free(p);

--- a/packages/bun-usockets/src/internal/eventing/libuv.h
+++ b/packages/bun-usockets/src/internal/eventing/libuv.h
@@ -27,6 +27,10 @@
 /* Defined in eventing/libuv.c; used by the sweep escalation in loop.c. */
 int us_internal_libuv_peer_reset_probe(LIBUS_SOCKET_DESCRIPTOR fd);
 
+/* Defined in eventing/libuv.c; number of live us_poll_t allocations on this
+ * backend. Read by leak tests via bun:internal-for-testing. */
+long us_internal_uv_poll_live_count(void);
+
 struct us_loop_t {
   alignas(LIBUS_EXT_ALIGNMENT) struct us_internal_loop_data_t data;
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -212,6 +212,9 @@ export const createSocketPair: () => [number, number] = $newRustFunction(
   0,
 );
 
+/** Live us_poll_t count on the libuv (Windows) eventing backend; -1 elsewhere. */
+export const uvPollLiveCount: () => number = $newRustFunction("runtime/socket/socket.rs", "jsUvPollLiveCount", 0);
+
 export const isModuleResolveFilenameSlowPathEnabled: () => boolean = $newCppFunction(
   "NodeModuleModule.cpp",
   "jsFunctionIsModuleResolveFilenameSlowPathEnabled",

--- a/src/runtime/socket/mod.rs
+++ b/src/runtime/socket/mod.rs
@@ -114,7 +114,8 @@ pub use udp_socket::UDPSocket;
 pub mod socket {
     pub use super::socket_body::{
         js_create_socket_pair, js_get_buffered_amount, js_is_named_pipe_socket,
-        js_set_socket_options, js_upgrade_duplex_to_tls, js_upgrade_tls_deferred, testing_ap_is,
+        js_set_socket_options, js_upgrade_duplex_to_tls, js_upgrade_tls_deferred,
+        js_uv_poll_live_count, testing_ap_is,
     };
 }
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4923,16 +4923,14 @@ pub fn js_get_buffered_amount(global: &JSGlobalObject, callframe: &CallFrame) ->
     Ok(JSValue::js_number(0.0))
 }
 
-/// Exposed via `bun:internal-for-testing` so Windows leak tests can assert
-/// the libuv eventing backend frees every `us_poll_t` it allocates. -1 on
-/// platforms without that backend.
+/// `bun:internal-for-testing` poll-leak probe; -1 on platforms without the
+/// libuv eventing backend.
 #[bun_jsc::host_fn]
 pub fn js_uv_poll_live_count(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     jsc::mark_binding!();
 
     #[cfg(windows)]
     {
-        // Declared `safe fn` (reads a process-global atomic counter).
         Ok(JSValue::js_number(
             bun_uws_sys::socket_context::c::us_internal_uv_poll_live_count() as f64,
         ))

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4923,6 +4923,26 @@ pub fn js_get_buffered_amount(global: &JSGlobalObject, callframe: &CallFrame) ->
     Ok(JSValue::js_number(0.0))
 }
 
+/// Exposed via `bun:internal-for-testing` so Windows leak tests can assert
+/// the libuv eventing backend frees every `us_poll_t` it allocates. -1 on
+/// platforms without that backend.
+#[bun_jsc::host_fn]
+pub fn js_uv_poll_live_count(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    jsc::mark_binding!();
+
+    #[cfg(windows)]
+    {
+        // Declared `safe fn` (reads a process-global atomic counter).
+        Ok(JSValue::js_number(
+            bun_uws_sys::socket_context::c::us_internal_uv_poll_live_count() as f64,
+        ))
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(JSValue::js_number(-1.0))
+    }
+}
+
 #[bun_jsc::host_fn]
 pub fn js_create_socket_pair(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     jsc::mark_binding!();

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -328,9 +328,8 @@ pub mod c {
         ) -> *mut SSL_CTX;
         // safe: no args; reads a process-global counter — no preconditions.
         pub safe fn us_ssl_ctx_live_count() -> c_long;
-        /// Live `us_poll_t` count on the libuv backend (`eventing/libuv.c`);
-        /// the symbol only exists on Windows.
         // safe: no args; reads a process-global counter — no preconditions.
+        // The symbol (eventing/libuv.c) only exists on Windows.
         #[cfg(windows)]
         pub safe fn us_internal_uv_poll_live_count() -> c_long;
         /// Appends the certificates in the NUL-terminated PEM `content` to

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -328,6 +328,11 @@ pub mod c {
         ) -> *mut SSL_CTX;
         // safe: no args; reads a process-global counter — no preconditions.
         pub safe fn us_ssl_ctx_live_count() -> c_long;
+        /// Live `us_poll_t` count on the libuv backend (`eventing/libuv.c`);
+        /// the symbol only exists on Windows.
+        // safe: no args; reads a process-global counter — no preconditions.
+        #[cfg(windows)]
+        pub safe fn us_internal_uv_poll_live_count() -> c_long;
         /// Appends the certificates in the NUL-terminated PEM `content` to
         /// `ctx`'s trust store; returns 0 when nothing could be added.
         pub fn us_ssl_ctx_add_ca_cert(

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -9,6 +9,7 @@ import {
   bunRun,
   expectMaxObjectTypeCount,
   getMaxFD,
+  isDebug,
   isLinux,
   isWindows,
   libcPathForDlopen,
@@ -3667,3 +3668,102 @@ describe.concurrent("connect() failure promise settlement", () => {
     ).rejects.toBe(boom);
   });
 });
+
+// On the libuv backend (Windows), us_poll_free defers freeing a stopped poll
+// to the uv close callback while the handle is closing. uv_is_closing() is
+// also true once the handle has *finished* closing, when that callback
+// already ran (freeing nothing, since us_poll_stop nulled handle->data) and
+// will never run again: us_poll_free re-pointed handle->data and returned,
+// leaking both the us_socket_t and the uv_poll_t allocations.
+//
+// Reachable from JS: terminate() dispatches the close handler synchronously
+// before the socket is linked to the closed-sockets sweep list, so a
+// synchronous event-loop re-entry inside the close handler (expect().resolves
+// blocks on waitForPromise) lets libuv finish closing the poll handle; the
+// sweep then calls us_poll_free on a CLOSED handle. Unfixed this leaks
+// ~4.8KB per connection; fixed it stays at allocator noise (~0.5KB/round).
+it.skipIf(!isWindows)(
+  "socket terminated around a nested event-loop tick does not leak its poll",
+  async () => {
+    const rounds = isDebug ? 1000 : 3000;
+    using dir = tempDir("uv-poll-free-leak", {
+      "poll-free-leak.test.ts": `
+        import { test, expect } from "bun:test";
+
+        const ROUNDS = parseInt(process.env.LEAK_ROUNDS!, 10);
+        const WARMUP = 300;
+
+        test(
+          "probe",
+          async () => {
+            let roundDone: (() => void) | null = null;
+
+            using server = Bun.listen({
+              hostname: "127.0.0.1",
+              port: 0,
+              socket: {
+                open(s) {
+                  s.terminate();
+                },
+                data() {},
+                error() {},
+                close() {
+                  // Synchronous event-loop re-entry from inside the close
+                  // dispatch: .resolves blocks on waitForPromise.
+                  expect(new Promise<void>(r => setImmediate(r))).resolves.toBeUndefined();
+                  roundDone?.();
+                  roundDone = null;
+                },
+              },
+            });
+
+            async function round() {
+              const { promise, resolve } = Promise.withResolvers<void>();
+              roundDone = resolve;
+              try {
+                await Bun.connect({
+                  hostname: "127.0.0.1",
+                  port: server.port,
+                  socket: { data() {}, error() {}, close() {} },
+                });
+              } catch {
+                // The server terminates on open; connect may observe the
+                // reset before the client-side open handler runs.
+              }
+              await promise;
+            }
+
+            for (let i = 0; i < WARMUP; i++) await round();
+            Bun.gc(true);
+            const rss0 = process.memoryUsage.rss();
+
+            for (let i = 0; i < ROUNDS; i++) await round();
+            Bun.gc(true);
+            const rss1 = process.memoryUsage.rss();
+
+            console.log(JSON.stringify({ perRound: Math.round((rss1 - rss0) / ROUNDS) }));
+          },
+          110_000,
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "poll-free-leak.test.ts"],
+      env: { ...bunEnv, LEAK_ROUNDS: String(rounds) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const line = stdout.split("\n").find(l => l.includes("perRound"));
+    expect(line, `probe produced no measurement.\nstdout: ${stdout}\nstderr: ${stderr}`).toBeDefined();
+    const { perRound } = JSON.parse(line!);
+    // Unfixed, every round leaks the socket + uv_poll_t blocks (~4.8KB
+    // measured). Allocator/GC noise stays well under 2KB/round.
+    expect(perRound).toBeLessThan(2048);
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3679,113 +3679,122 @@ describe.concurrent("connect() failure promise settlement", () => {
 // before the socket is linked to the closed-sockets sweep list, so a
 // synchronous event-loop re-entry inside the close handler (expect().resolves
 // blocks on waitForPromise) lets libuv finish closing the poll handle; the
-// sweep then frees a CLOSED handle. The probe chains K terminates through
-// close handlers (none of the K sockets is on the sweep list until its
-// handler returns) with one re-entry at the bottom, leaking K pairs (568
-// bytes each) per round when broken: 120 rounds x 25 = ~1.7MB of leak plus
-// allocator overhead (measured 3.4-6.7MB RSS growth unfixed, <= 1.9MB fixed).
-it.skipIf(!isWindows)(
-  "socket terminated around a nested event-loop tick does not leak its poll",
-  async () => {
-    using dir = tempDir("uv-poll-free-leak", {
-      "poll-free-leak.test.ts": `
+// sweep then frees a CLOSED handle. The probe chains terminates through close
+// handlers (none of the chained sockets is on the sweep list until its
+// handler returns) with one re-entry at the bottom, so every chained socket's
+// handle is CLOSED by the time the sweep frees it. uvPollLiveCount (a counter
+// of live us_poll_t allocations in eventing/libuv.c) must return to its
+// pre-churn baseline; unfixed, it grows by ROUNDS x DEPTH.
+it.skipIf(!isWindows)("socket terminated around a nested event-loop tick does not leak its poll", async () => {
+  using dir = tempDir("uv-poll-free-leak", {
+    "poll-free-leak.test.ts": `
         import { test, expect } from "bun:test";
+        import { uvPollLiveCount } from "bun:internal-for-testing";
 
-        const ROUNDS = 120;
-        const DEPTH = 25;
-        const WARMUP = 20;
+        const ROUNDS = 10;
+        const DEPTH = 8;
+        const WARMUP = 3;
 
-        test(
-          "probe",
-          async () => {
-            let pile: any[] = [];
-            let closedCount = 0;
-            let allClosed: (() => void) | null = null;
+        test("probe", async () => {
+          let pile: any[] = [];
+          let closedCount = 0;
+          let allClosed: (() => void) | null = null;
 
-            using server = Bun.listen({
-              hostname: "127.0.0.1",
-              port: 0,
-              socket: {
-                open(s) {
-                  pile.push(s);
-                },
-                data() {},
-                error() {},
-                close() {
-                  const next = pile.pop();
-                  if (next) {
-                    next.terminate();
-                  } else {
-                    // Bottom of the chain: DEPTH sockets are mid-close-
-                    // dispatch, none on the sweep list yet. Synchronous
-                    // event-loop re-entry (.resolves blocks on
-                    // waitForPromise) lets libuv finish closing their poll
-                    // handles before the sweep frees them.
-                    expect(new Promise<void>(r => setImmediate(r))).resolves.toBeUndefined();
-                  }
-                  closedCount++;
-                  if (closedCount === DEPTH && allClosed) allClosed();
-                },
+          using server = Bun.listen({
+            hostname: "127.0.0.1",
+            port: 0,
+            socket: {
+              open(s) {
+                pile.push(s);
               },
-            });
+              data() {},
+              error() {},
+              close() {
+                const next = pile.pop();
+                if (next) {
+                  next.terminate();
+                } else {
+                  // Bottom of the chain: DEPTH sockets are mid-close-
+                  // dispatch, none on the sweep list yet. Synchronous
+                  // event-loop re-entry (.resolves blocks on waitForPromise)
+                  // lets libuv finish closing their poll handles before the
+                  // sweep frees them.
+                  expect(new Promise<void>(r => setImmediate(r))).resolves.toBeUndefined();
+                }
+                closedCount++;
+                if (closedCount === DEPTH && allClosed) allClosed();
+              },
+            },
+          });
 
-            async function round() {
-              pile = [];
-              closedCount = 0;
-              const { promise, resolve } = Promise.withResolvers<void>();
-              allClosed = resolve;
+          async function round() {
+            pile = [];
+            closedCount = 0;
+            const { promise, resolve } = Promise.withResolvers<void>();
+            allClosed = resolve;
 
-              const clients = await Promise.all(
-                Array.from({ length: DEPTH }, () =>
-                  Bun.connect({
-                    hostname: "127.0.0.1",
-                    port: server.port,
-                    socket: { data() {}, error() {}, close() {} },
-                  }),
-                ),
-              );
-              while (pile.length < DEPTH) {
-                await new Promise(r => setImmediate(r));
-              }
-
-              pile.pop()!.terminate();
-              await promise;
-              allClosed = null;
-
-              for (const c of clients) c.terminate();
+            const clients = await Promise.all(
+              Array.from({ length: DEPTH }, () =>
+                Bun.connect({
+                  hostname: "127.0.0.1",
+                  port: server.port,
+                  socket: { data() {}, error() {}, close() {} },
+                }),
+              ),
+            );
+            while (pile.length < DEPTH) {
+              await new Promise(r => setImmediate(r));
             }
 
-            for (let i = 0; i < WARMUP; i++) await round();
-            Bun.gc(true);
-            const rss0 = process.memoryUsage.rss();
-            for (let i = 0; i < ROUNDS; i++) await round();
-            Bun.gc(true);
-            const rss1 = process.memoryUsage.rss();
+            pile.pop()!.terminate();
+            await promise;
+            allClosed = null;
 
-            console.log(JSON.stringify({ deltaBytes: rss1 - rss0 }));
-          },
-          110_000,
-        );
+            for (const c of clients) c.terminate();
+          }
+
+          // Pending frees flush asynchronously (a CLOSING handle is freed by
+          // its uv close callback a tick later), so settle before reading.
+          async function stableCount(): Promise<number> {
+            let prev = uvPollLiveCount();
+            for (let stable = 0; stable < 10; ) {
+              await new Promise(r => setImmediate(r));
+              const cur = uvPollLiveCount();
+              if (cur === prev) stable++;
+              else [stable, prev] = [0, cur];
+            }
+            return prev;
+          }
+
+          for (let i = 0; i < WARMUP; i++) await round();
+          const baseline = await stableCount();
+          expect(baseline).toBeGreaterThan(0); // the listen poll, at least
+
+          for (let i = 0; i < ROUNDS; i++) await round();
+          let after = uvPollLiveCount();
+          for (let i = 0; i < 200 && after !== baseline; i++) {
+            await new Promise(r => setImmediate(r));
+            after = uvPollLiveCount();
+          }
+
+          console.log(JSON.stringify({ baseline, after, leaked: after - baseline }));
+          expect(after - baseline).toBe(0);
+        });
       `,
-    });
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "poll-free-leak.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "poll-free-leak.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const line = stdout.split("\n").find(l => l.includes("deltaBytes"));
-    expect(line, `probe produced no measurement.\nstdout: ${stdout}\nstderr: ${stderr}`).toBeDefined();
-    const { deltaBytes } = JSON.parse(line!);
-    // Unfixed leaks 120 x 25 x 568B = 1.7MB plus allocator overhead: measured
-    // >= 3.4MB on debug, ~6.7MB on release. Fixed stays at churn noise:
-    // <= 1.9MB on debug, less on release.
-    expect(deltaBytes).toBeLessThan(2_600_000);
-    expect(exitCode).toBe(0);
-  },
-  120_000,
-);
+  const line = stdout.split("\n").find(l => l.includes("leaked"));
+  expect(line, `probe produced no measurement.\nstdout: ${stdout}\nstderr: ${stderr}`).toBeDefined();
+  const { leaked } = JSON.parse(line!);
+  expect(leaked).toBe(0);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -9,7 +9,6 @@ import {
   bunRun,
   expectMaxObjectTypeCount,
   getMaxFD,
-  isDebug,
   isLinux,
   isWindows,
   libcPathForDlopen,
@@ -3680,68 +3679,90 @@ describe.concurrent("connect() failure promise settlement", () => {
 // before the socket is linked to the closed-sockets sweep list, so a
 // synchronous event-loop re-entry inside the close handler (expect().resolves
 // blocks on waitForPromise) lets libuv finish closing the poll handle; the
-// sweep then calls us_poll_free on a CLOSED handle. Unfixed this leaks
-// ~4.8KB per connection; fixed it stays at allocator noise (~0.5KB/round).
+// sweep then frees a CLOSED handle. The probe chains K terminates through
+// close handlers (none of the K sockets is on the sweep list until its
+// handler returns) with one re-entry at the bottom, leaking K pairs (568
+// bytes each) per round when broken: 120 rounds x 25 = ~1.7MB of leak plus
+// allocator overhead (measured 3.4-6.7MB RSS growth unfixed, <= 1.9MB fixed).
 it.skipIf(!isWindows)(
   "socket terminated around a nested event-loop tick does not leak its poll",
   async () => {
-    const rounds = isDebug ? 1000 : 3000;
     using dir = tempDir("uv-poll-free-leak", {
       "poll-free-leak.test.ts": `
         import { test, expect } from "bun:test";
 
-        const ROUNDS = parseInt(process.env.LEAK_ROUNDS!, 10);
-        const WARMUP = 300;
+        const ROUNDS = 120;
+        const DEPTH = 25;
+        const WARMUP = 20;
 
         test(
           "probe",
           async () => {
-            let roundDone: (() => void) | null = null;
+            let pile: any[] = [];
+            let closedCount = 0;
+            let allClosed: (() => void) | null = null;
 
             using server = Bun.listen({
               hostname: "127.0.0.1",
               port: 0,
               socket: {
                 open(s) {
-                  s.terminate();
+                  pile.push(s);
                 },
                 data() {},
                 error() {},
                 close() {
-                  // Synchronous event-loop re-entry from inside the close
-                  // dispatch: .resolves blocks on waitForPromise.
-                  expect(new Promise<void>(r => setImmediate(r))).resolves.toBeUndefined();
-                  roundDone?.();
-                  roundDone = null;
+                  const next = pile.pop();
+                  if (next) {
+                    next.terminate();
+                  } else {
+                    // Bottom of the chain: DEPTH sockets are mid-close-
+                    // dispatch, none on the sweep list yet. Synchronous
+                    // event-loop re-entry (.resolves blocks on
+                    // waitForPromise) lets libuv finish closing their poll
+                    // handles before the sweep frees them.
+                    expect(new Promise<void>(r => setImmediate(r))).resolves.toBeUndefined();
+                  }
+                  closedCount++;
+                  if (closedCount === DEPTH && allClosed) allClosed();
                 },
               },
             });
 
             async function round() {
+              pile = [];
+              closedCount = 0;
               const { promise, resolve } = Promise.withResolvers<void>();
-              roundDone = resolve;
-              try {
-                await Bun.connect({
-                  hostname: "127.0.0.1",
-                  port: server.port,
-                  socket: { data() {}, error() {}, close() {} },
-                });
-              } catch {
-                // The server terminates on open; connect may observe the
-                // reset before the client-side open handler runs.
+              allClosed = resolve;
+
+              const clients = await Promise.all(
+                Array.from({ length: DEPTH }, () =>
+                  Bun.connect({
+                    hostname: "127.0.0.1",
+                    port: server.port,
+                    socket: { data() {}, error() {}, close() {} },
+                  }),
+                ),
+              );
+              while (pile.length < DEPTH) {
+                await new Promise(r => setImmediate(r));
               }
+
+              pile.pop()!.terminate();
               await promise;
+              allClosed = null;
+
+              for (const c of clients) c.terminate();
             }
 
             for (let i = 0; i < WARMUP; i++) await round();
             Bun.gc(true);
             const rss0 = process.memoryUsage.rss();
-
             for (let i = 0; i < ROUNDS; i++) await round();
             Bun.gc(true);
             const rss1 = process.memoryUsage.rss();
 
-            console.log(JSON.stringify({ perRound: Math.round((rss1 - rss0) / ROUNDS) }));
+            console.log(JSON.stringify({ deltaBytes: rss1 - rss0 }));
           },
           110_000,
         );
@@ -3750,19 +3771,20 @@ it.skipIf(!isWindows)(
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "poll-free-leak.test.ts"],
-      env: { ...bunEnv, LEAK_ROUNDS: String(rounds) },
+      env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const line = stdout.split("\n").find(l => l.includes("perRound"));
+    const line = stdout.split("\n").find(l => l.includes("deltaBytes"));
     expect(line, `probe produced no measurement.\nstdout: ${stdout}\nstderr: ${stderr}`).toBeDefined();
-    const { perRound } = JSON.parse(line!);
-    // Unfixed, every round leaks the socket + uv_poll_t blocks (~4.8KB
-    // measured). Allocator/GC noise stays well under 2KB/round.
-    expect(perRound).toBeLessThan(2048);
+    const { deltaBytes } = JSON.parse(line!);
+    // Unfixed leaks 120 x 25 x 568B = 1.7MB plus allocator overhead: measured
+    // >= 3.4MB on debug, ~6.7MB on release. Fixed stays at churn noise:
+    // <= 1.9MB on debug, less on release.
+    expect(deltaBytes).toBeLessThan(2_600_000);
     expect(exitCode).toBe(0);
   },
   120_000,


### PR DESCRIPTION
### Symptom

On Windows (libuv backend), `us_poll_free` leaks both the `us_socket_t` block and the `uv_poll_t` block whenever it runs after libuv has already finished closing the poll handle. Each leaked pair is 568 bytes (24 `us_poll_t` + 128 ext + 416 `uv_poll_t`); a server churning sockets through this path grows RSS without bound (measured ~6.7MB per 3000 sockets on release builds).

### Cause

The stop/free handshake in `packages/bun-usockets/src/eventing/libuv.c`:

- `us_poll_stop` nulls `uv_p->data` and calls `uv_close(handle, close_cb_free_poll)`.
- `close_cb_free_poll` frees both blocks only when `data != 0`.
- `us_poll_free` checks `uv_is_closing()`: if true, it re-points `data` at the poll so the close callback frees it later; otherwise it frees both blocks directly.

`uv_is_closing()` returns true for a handle that is CLOSING (close requested, callback pending) **and** for one that is CLOSED (callback already ran). In the CLOSED case the callback ran with `data == 0`, freed nothing, and will never run again, so `us_poll_free`'s deferral branch drops both allocations on the floor. The epoll/kqueue backend's `us_poll_free` always frees; callers (the closed-socket sweep in `loop.c`) rely on that contract.

This is reachable from plain JS. `terminate()` dispatches the JS `close` handler synchronously from `us_internal_socket_close_raw`, *before* the socket is linked to the sweep list. A synchronous event-loop re-entry inside that handler (anything that blocks on `waitForPromise`, e.g. `expect().resolves` in `bun:test`) lets libuv process the poll's cancellation completion and run its endgames phase: the handle reaches CLOSED while the socket is still waiting for the sweep. The sweep then calls `us_poll_free` on a CLOSED handle and leaks. Native addons driving uv callbacks can hit the same window.

### Fix

`close_cb_free_poll` now marks the handle (`h->data = h`) when it runs with `data == 0`, recording that it ran and freed nothing. When `us_poll_free` sees the mark on a closing handle it frees both blocks itself instead of deferring to a callback that will never fire. The mark cannot collide with a live poll: `data` is otherwise `0` or the `us_poll_t`, which is a different live allocation than the handle, and handle reuse (`us_poll_start_rc`) memsets the `uv_poll_t` first.

For the test, the libuv backend now keeps an atomic count of live `us_poll_t` allocations, exposed as `uvPollLiveCount` via `bun:internal-for-testing` (same shape as the existing `sslCtxLiveCount`); it returns -1 on platforms without that backend. An RSS-based assertion was tried first and dropped: the probe's churn noise varies by machine (1.7MB locally, 2.9MB on the CI runners), while the count is exact.

Related: #33018 (nested-tick heap corruption) needs this same handshake repair once the closed-socket sweep is deferred on Windows; fixing the leak separately keeps that PR to its own bug.

### Verification

The test chains 8 `terminate()` calls through close handlers (none of the chained sockets reaches the sweep list until its handler returns) with one loop re-entry at the bottom, so every chained socket's handle is CLOSED by the time the sweep frees it, 10 rounds. `uvPollLiveCount` must return to its pre-churn baseline. Measured on debug builds of this branch on both Windows architectures:

- fix present: `leaked: 0`, test passes (windows-x64 and windows-aarch64)
- fix disabled (same build with the rescue branch in `us_poll_free` neutered): `leaked: 80`, exactly rounds x depth, test fails (windows-x64 and windows-aarch64) - so the rescue branch is load-bearing and the probe drives every chained handle to CLOSED on both arches, not just the machine the fix was written on
- release binary without the fix (system Bun 1.4.0-canary.1): the counter export does not exist yet, so the probe fails at import; an RSS variant of the same probe run on that binary leaks 568 bytes per pair (6.7MB over 3000 pairs), which is the user-visible form of the bug

With counters temporarily added to every branch of the handshake (an instrumented 1500-pair RSS run during development), the close callback ran with `data == 0` once per chained terminate (`cb_sentinel`) and the rescue branch freed those handles 1:1 (`rescue`), with no change to the normal paths:

```
[pollfree] cb_defer=1500 cb_sentinel=1501 direct=0 closing=1501 rescue=1500
```

The off-by-one on `cb_sentinel`/`closing` is the process-exit boundary: the listen socket (and one client) closed during teardown after the final sweep, a pre-existing exit path this PR does not change.

The test is Windows-only (`it.skipIf(!isWindows)`); the buggy code is compiled only under `LIBUS_USE_LIBUV`, so there is no Linux/macOS path to exercise, and the fail-before half of the proof can only run on a Windows build. On Linux `uvPollLiveCount()` returns -1 (verified on a debug build).

`bun bd test test/js/bun/net/socket.test.ts` on Windows: 74 pass, 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->