### PR TITLE
HTMLRewriter: fix use-after-free when GC sweeps an abandoned transform before its stream sink controller

### DIFF
--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -45,6 +45,8 @@ public:
         HTTPSServerH3RequestContext,
         DebugHTTPSServerH3RequestContext,
         HTMLRewriterSuspension,
+        // Task-only tag on the Rust side; never stored in a context cell.
+        HTMLRewriterPipeFree,
     };
 
     // `held` is visited, so the reaction keeps it alive for as long as the

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -57,10 +57,14 @@ pub enum Tag {
     HTTPSServerH3RequestContext,
     DebugHTTPSServerH3RequestContext,
     HTMLRewriterSuspension,
+    /// Task-only tag (never a context cell): frees a `RewriterPipe` whose
+    /// last claim was released from a GC destructor; see
+    /// `RewriterPipe::release_pump_claim`.
+    HTMLRewriterPipeFree,
 }
 
 impl Tag {
-    pub const COUNT: usize = 7;
+    pub const COUNT: usize = 8;
 
     #[inline]
     const fn from_raw(n: u8) -> Tag {
@@ -72,6 +76,7 @@ impl Tag {
             4 => Tag::HTTPSServerH3RequestContext,
             5 => Tag::DebugHTTPSServerH3RequestContext,
             6 => Tag::HTMLRewriterSuspension,
+            7 => Tag::HTMLRewriterPipeFree,
             _ => unreachable!(),
         }
     }
@@ -184,7 +189,7 @@ impl Taskable for DeferredDerefTask {
 impl DeferredDerefTask {
     const TAG_MASK: usize = 0b111;
 
-    fn schedule(ctx: *mut c_void, tag: Tag) {
+    pub(crate) fn schedule(ctx: *mut c_void, tag: Tag) {
         // SAFETY: called from the JS thread (GC sweep → C++ destructor); the
         // thread-local VM is alive for the duration of this call.
         let vm = VirtualMachine::get();
@@ -235,9 +240,10 @@ impl DeferredDerefTask {
                     let back = bun_ptr::BackRef::from(NonNull::new_unchecked(
                         ctx.cast::<html_rewriter::RewriterPipe>(),
                     ));
-                    if html_rewriter::RewriterPipe::abandon_suspension(back) {
-                        drop(Box::from_raw(ctx.cast::<html_rewriter::RewriterPipe>()));
-                    }
+                    html_rewriter::RewriterPipe::abandon_suspension(back);
+                }
+                Tag::HTMLRewriterPipeFree => {
+                    bun_core::heap::destroy(ctx.cast::<html_rewriter::RewriterPipe>());
                 }
             }
         }

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -216,8 +216,13 @@ impl DeferredDerefTask {
     pub(crate) fn run_from_js_thread(packed_ptr: usize) {
         let tag = Tag::from_raw((packed_ptr & Self::TAG_MASK) as u8);
         let ctx = (packed_ptr & !Self::TAG_MASK) as *mut c_void;
-        // SAFETY: ctx was packed in `schedule` from a live intrusive-refcounted
-        // pointer of the type indicated by `tag`; we are on the JS thread.
+        // SAFETY: ctx was packed in `schedule` from a live pointer of the
+        // type indicated by `tag`. The request-context tags hold an intrusive
+        // refcount released here. The HTMLRewriter tags point at a
+        // claim-counted `RewriterPipe`: the suspension task owns the claim
+        // taken in `begin_suspension`, and `HTMLRewriterPipeFree` is
+        // scheduled only by the release of the last claim, so this task is
+        // the sole owner of the allocation it frees. We are on the JS thread.
         unsafe {
             match tag {
                 Tag::HTTPServerRequestContext => (*ctx.cast::<HTTPServerRequestContext>()).deref(),

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -755,51 +755,90 @@ pub struct RewriterPipe {
     /// Shared pending drain promise for the JS-pump `write()`/`flush(true)`.
     pending: JsCell<WritablePending>,
     done: Cell<bool>,
+
+    // ── allocation lifetime ──────────────────────────────────────────────
+    /// Owners that may still dispatch into this allocation: the Transform
+    /// cell (until [`Self::finalize`]), the JS-pump controller's raw
+    /// `m_sinkPtr` (until `__controllerDetached`), and a parked suspension's
+    /// reaction/abandon task (until the promise settles or
+    /// [`Self::abandon_suspension`] runs). GC sweeps cells in unspecified
+    /// order within one cycle, so the Box is freed by whichever owner
+    /// releases last, never by cell-destructor position.
+    claims: Cell<u8>,
+    /// `claims` includes a JS-pump controller entry; consumed exactly once by
+    /// [`Self::release_pump_claim`].
+    pump_controller_attached: Cell<bool>,
 }
 
 impl RewriterPipe {
-    /// `JSHTMLRewriterTransform` finalizer: the cell was collected, so
-    /// nothing that could dispatch into the pipe is left alive — a wired
-    /// native input source roots the cell through its `sinkOwner` slot, the
-    /// pipe's own output source through its `owner` slot, the output
-    /// ByteStream through the Response's `transform` slot, and a pending
-    /// handler promise through its reaction — so there is nothing to detach
-    /// and nothing here may touch other GC cells (sweep order across cells in
-    /// the same cycle is unspecified).
-    ///
-    /// If the pipe is still suspended, the handler promise was collected
-    /// without settling, and that promise's `NativePromiseContext` destructor
-    /// has already queued [`Self::abandon_suspension`] (promise dead implies
-    /// context cell dead: the promise's reaction was its only root). Hand the
-    /// Box to that task instead of dropping, signalled by the zeroed `cell`.
+    /// `JSHTMLRewriterTransform` finalizer: release the cell's claim on the
+    /// pipe. Runs during GC sweep, so nothing here may touch other GC cells
+    /// — and for the same reason the pipe must outlive the JS-pump
+    /// controller cell (whose destructor calls `__controllerDetached` /
+    /// `__finalize` on its raw `m_sinkPtr`) and a parked suspension (whose
+    /// `NativePromiseContext` destructor queues
+    /// [`Self::abandon_suspension`]). Those owners hold `claims`; leak the
+    /// Box here and the last of them frees it.
     pub fn finalize(this: Box<Self>) {
         this.cell.set(JSValue::ZERO);
-        if this.is_suspended() && !VirtualMachine::get().is_shutting_down() {
+        if !VirtualMachine::get().is_shutting_down() && this.release_claim() {
             let _ = Box::into_raw(this);
             return;
         }
         drop(this);
     }
 
+    #[inline]
+    fn acquire_claim(&self) {
+        self.claims.set(self.claims.get() + 1);
+    }
+
+    /// Releases one claim; `true` while other owners remain (the caller must
+    /// not free the pipe).
+    #[inline]
+    fn release_claim(&self) -> bool {
+        let n = self
+            .claims
+            .get()
+            .checked_sub(1)
+            .expect("RewriterPipe claims underflow");
+        self.claims.set(n);
+        n > 0
+    }
+
+    /// The JS-pump controller detached — stream close/end, explicit
+    /// detach, or its GC destructor — and can never dispatch into the pipe
+    /// again: release its claim. A last-owner free is deferred to the event
+    /// loop instead of happening inline because the C++ caller keeps using
+    /// the allocation within the same frame (the destructor calls
+    /// `__finalize` next; the close/end host fns call `__close` /
+    /// `__endWithSink` on the saved pointer).
+    fn release_pump_claim(&self) {
+        if !self.pump_controller_attached.replace(false) {
+            return;
+        }
+        if self.release_claim() {
+            return;
+        }
+        native_promise_context::DeferredDerefTask::schedule(
+            core::ptr::from_ref(self).cast_mut().cast(),
+            native_promise_context::Tag::HTMLRewriterPipeFree,
+        );
+    }
+
     /// Queued by the `NativePromiseContext` destructor (via
     /// `DeferredDerefTask`) when the handler's promise was collected without
     /// settling: it will never resume this pipe. Runs on the JS thread,
-    /// outside GC sweep.
+    /// outside GC sweep; the suspension's claim keeps `pipe` live until here.
     ///
-    /// Two states are possible. If the Transform cell is still alive (its
-    /// `cell` backref is set) — a reader or the output Response keeps the
-    /// rewrite reachable — fail the body normally, which errors the live
-    /// output stream and clears the `owner`/`sinkOwner` edges so the cell becomes
-    /// ordinary garbage. If the cell was swept with the promise (`cell` is
-    /// zeroed), `finalize` relinquished the Box to this task: every source
-    /// that could have held a backref died with the cell, so clear the
-    /// handles raw, fail the body through the Response native `+1`, and free.
-    ///
-    /// `pipe` is live either way: the context cell's held Transform rooted it
-    /// until the destructor ran, and `finalize` defers the free to this task.
-    /// Returns `true` when the cell was already swept (`finalize` handed the
-    /// Box to this task) and the caller must `Box::from_raw`-drop it.
-    pub(crate) fn abandon_suspension(pipe: bun_ptr::BackRef<Self>) -> bool {
+    /// If the Transform cell is still alive (its `cell` backref is set) —
+    /// a reader or the output Response keeps the rewrite reachable — fail
+    /// the body normally, which errors the live output stream and clears the
+    /// `owner`/`sinkOwner` edges so the cell becomes ordinary garbage. If the
+    /// cell was swept with the promise (`cell` is zeroed), every source that
+    /// could have held a backref died with the cell, so clear the handles
+    /// raw and fail the body through the Response native `+1`.
+    pub(crate) fn abandon_suspension(pipe: bun_ptr::BackRef<Self>) {
         let this = &*pipe;
         let cell_alive = this.cell.get().is_cell();
         this.release_suspended_wrapper();
@@ -810,7 +849,11 @@ impl RewriterPipe {
         this.fail(webcore::body::ValueError::Message(BunString::static_(
             "HTMLRewriter content handler returned a Promise that will never settle",
         )));
-        !cell_alive
+        if !this.release_claim() {
+            // SAFETY: last owner; no cell, controller, or task points at the
+            // allocation any more.
+            unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
+        }
     }
 
     /// Record a handler's exception for the enclosing lol-html call to pick
@@ -927,6 +970,8 @@ impl RewriterPipe {
             driving: Cell::new(false),
             pending: JsCell::new(WritablePending::default()),
             done: Cell::new(false),
+            claims: Cell::new(1),
+            pump_controller_attached: Cell::new(false),
         });
         // Every field is `Cell`/`JsCell`, so a shared `&RewriterPipe` via
         // `BackRef` is sound across the re-entrant lol-html calls below.
@@ -1126,7 +1171,12 @@ impl RewriterPipe {
         }
 
         // JS-pump fallback: `assign_to_stream` installs a JS sink wrapper that
-        // forwards to `JsSinkType for RewriterPipe`.
+        // forwards to `JsSinkType for RewriterPipe`. The controller cell it
+        // creates holds `pipe` raw as `m_sinkPtr` and dispatches
+        // `__controllerDetached` from wherever it detaches — including its
+        // GC destructor — so it owns a claim until `release_pump_claim`.
+        this.pump_controller_attached.set(true);
+        this.acquire_claim();
         let assignment_result =
             JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
         assignment_result.ensure_still_alive();
@@ -1517,6 +1567,10 @@ impl RewriterPipe {
             .expect("suspension promise slot empty");
         let pipe = core::ptr::from_ref(self).cast_mut();
         let context = native_promise_context::create(&self.global, pipe, cell);
+        // The context destructor (promise GC'd unsettled) queues
+        // `abandon_suspension`; this claim keeps the pipe alive until that
+        // task or the settle reaction releases it.
+        self.acquire_claim();
         promise.then_with_value(
             &self.global,
             context,
@@ -1633,7 +1687,13 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
     fn memory_cost(&self) -> usize {
         self.pending_input.get().capacity() + self.output_buffer.get().capacity()
     }
+    // Unlike other sinks, the controller does not own the pipe: its claim is
+    // released by `controller_detached` below, and the free happens wherever
+    // the last claim drops.
     fn finalize(&mut self) {}
+    fn controller_detached(&mut self) {
+        RewriterPipe::release_pump_claim(self);
+    }
     fn write_bytes(&mut self, data: &StreamResult) -> Writable {
         RewriterPipe::write(self, data)
     }
@@ -1724,9 +1784,15 @@ fn on_handler_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
         return Ok(JSValue::UNDEFINED);
     };
     let pipe = BackRef::from(pipe);
-    let pipe = &*pipe;
     pipe.release_suspended_wrapper();
     pipe.resume_rewrite();
+    // Balances the `acquire_claim` in `begin_suspension`. Never the last
+    // claim in practice: the context cell roots the Transform cell, so the
+    // cell's own claim is still held while this reaction runs.
+    if !pipe.release_claim() {
+        // SAFETY: last owner (see above; defensive).
+        unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
+    }
     Ok(JSValue::UNDEFINED)
 }
 
@@ -1737,11 +1803,16 @@ fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSV
         return Ok(JSValue::UNDEFINED);
     };
     let pipe = BackRef::from(pipe);
-    let pipe = &*pipe;
     pipe.release_suspended_wrapper();
     pipe.fail(webcore::body::ValueError::JSValue(
         jsc::strong::Optional::create(reason, global),
     ));
+    // Balances the `acquire_claim` in `begin_suspension` (see
+    // `on_handler_resolve`).
+    if !pipe.release_claim() {
+        // SAFETY: last owner (defensive; the context cell roots the Transform cell).
+        unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
+    }
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -758,12 +758,10 @@ pub struct RewriterPipe {
 
     // ── allocation lifetime ──────────────────────────────────────────────
     /// Owners that may still dispatch into this allocation: the Transform
-    /// cell (until [`Self::finalize`]), the JS-pump controller's raw
-    /// `m_sinkPtr` (until `__controllerDetached`), and a parked suspension's
-    /// reaction/abandon task (until the promise settles or
-    /// [`Self::abandon_suspension`] runs). GC sweeps cells in unspecified
-    /// order within one cycle, so the Box is freed by whichever owner
-    /// releases last, never by cell-destructor position.
+    /// cell (releases in [`Self::finalize`]), the JS-pump controller's raw
+    /// `m_sinkPtr` (releases via `__controllerDetached`), and a parked
+    /// suspension's reaction/abandon task. GC sweeps cells in unspecified
+    /// order within a cycle, so whichever owner releases last frees the Box.
     claims: Cell<u8>,
     /// `claims` includes a JS-pump controller entry; consumed exactly once by
     /// [`Self::release_pump_claim`].
@@ -771,17 +769,12 @@ pub struct RewriterPipe {
 }
 
 impl RewriterPipe {
-    /// `JSHTMLRewriterTransform` finalizer: release the cell's claim on the
-    /// pipe. Runs during GC sweep, so nothing here may touch other GC cells
-    /// — and for the same reason the pipe must outlive the JS-pump
-    /// controller cell (whose destructor calls `__controllerDetached` /
-    /// `__finalize` on its raw `m_sinkPtr`) and a parked suspension (whose
-    /// `NativePromiseContext` destructor queues
-    /// [`Self::abandon_suspension`]). Those owners hold `claims`; leak the
-    /// Box here and the last of them frees it. At VM shutdown the other
-    /// owners' deferred releases never run, so a still-claimed pipe leaks —
-    /// the safe side of that teardown race, since their destructors can still
-    /// dispatch into the allocation.
+    /// `JSHTMLRewriterTransform` finalizer. Runs during GC sweep: nothing
+    /// here may touch other GC cells, and the other `claims` holders may
+    /// still dispatch into the pipe after this cell is swept. So only
+    /// release the cell's claim; the last holder frees the Box. At VM
+    /// shutdown deferred releases never run, so a still-claimed pipe leaks
+    /// instead of being freed under a live claim.
     pub fn finalize(this: Box<Self>) {
         this.cell.set(JSValue::ZERO);
         if this.release_claim() {
@@ -809,13 +802,11 @@ impl RewriterPipe {
         n > 0
     }
 
-    /// The JS-pump controller detached — stream close/end, explicit
-    /// detach, or its GC destructor — and can never dispatch into the pipe
+    /// The JS-pump controller detached and can never dispatch into the pipe
     /// again: release its claim. A last-owner free is deferred to the event
-    /// loop instead of happening inline because the C++ caller keeps using
-    /// the allocation within the same frame (the destructor calls
-    /// `__finalize` next; the close/end host fns call `__close` /
-    /// `__endWithSink` on the saved pointer).
+    /// loop because the C++ caller keeps using the allocation in the same
+    /// frame (the destructor's trailing `__finalize`, the close/end host
+    /// fns' `__close`/`__endWithSink` on the saved pointer).
     fn release_pump_claim(&self) {
         if !self.pump_controller_attached.replace(false) {
             return;

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -778,10 +778,13 @@ impl RewriterPipe {
     /// `__finalize` on its raw `m_sinkPtr`) and a parked suspension (whose
     /// `NativePromiseContext` destructor queues
     /// [`Self::abandon_suspension`]). Those owners hold `claims`; leak the
-    /// Box here and the last of them frees it.
+    /// Box here and the last of them frees it. At VM shutdown the other
+    /// owners' deferred releases never run, so a still-claimed pipe leaks —
+    /// the safe side of that teardown race, since their destructors can still
+    /// dispatch into the allocation.
     pub fn finalize(this: Box<Self>) {
         this.cell.set(JSValue::ZERO);
-        if !VirtualMachine::get().is_shutting_down() && this.release_claim() {
+        if this.release_claim() {
             let _ = Box::into_raw(this);
             return;
         }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -293,17 +293,13 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn source(&mut self) -> Option<&mut SourceHandle> {
         None
     }
-    /// Called from `js_controller_detached` after the source handle is
-    /// cleared, i.e. once per JS-pump controller on every path that detaches
-    /// it (explicit `close()`/`end()`/`detach()` or its GC destructor). A sink
-    /// whose allocation is co-owned by another GC cell releases the
-    /// controller's claim here (the two cells are swept in unspecified order
-    /// within one GC cycle, so neither destructor alone may free it).
-    /// Implementations must not free the sink allocation inline: the caller
-    /// holds `&mut Self`, and the C++ dispatcher keeps using `m_sinkPtr` in
-    /// the same frame after this returns (the destructor's trailing
-    /// `__finalize`, the close path's `__close`). Defer a last-owner free to
-    /// the event loop.
+    /// Called from `js_controller_detached`: once per JS-pump controller, on
+    /// every detach path including its GC destructor. A sink co-owned by
+    /// another GC cell releases the controller's claim here (sweep order
+    /// between the two cells is unspecified, so neither destructor alone may
+    /// free it). Never free the allocation inline: the caller holds
+    /// `&mut Self` and the C++ dispatcher keeps using `m_sinkPtr` in the
+    /// same frame; defer a last-owner free to the event loop.
     fn controller_detached(&mut self) {}
     fn done(&self) -> bool {
         false

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -299,6 +299,11 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     /// whose allocation is co-owned by another GC cell releases the
     /// controller's claim here (the two cells are swept in unspecified order
     /// within one GC cycle, so neither destructor alone may free it).
+    /// Implementations must not free the sink allocation inline: the caller
+    /// holds `&mut Self`, and the C++ dispatcher keeps using `m_sinkPtr` in
+    /// the same frame after this returns (the destructor's trailing
+    /// `__finalize`, the close path's `__close`). Defer a last-owner free to
+    /// the event loop.
     fn controller_detached(&mut self) {}
     fn done(&self) -> bool {
         false

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -293,6 +293,13 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     fn source(&mut self) -> Option<&mut SourceHandle> {
         None
     }
+    /// Called from `js_controller_detached` after the source handle is
+    /// cleared, i.e. once per JS-pump controller on every path that detaches
+    /// it (explicit `close()`/`end()`/`detach()` or its GC destructor). A sink
+    /// whose allocation is co-owned by another GC cell releases the
+    /// controller's claim here (the two cells are swept in unspecified order
+    /// within one GC cycle, so neither destructor alone may free it).
+    fn controller_detached(&mut self) {}
     fn done(&self) -> bool {
         false
     }
@@ -579,6 +586,7 @@ impl<T: JsSinkType> JSSink<T> {
                 }
             }
         }
+        this.controller_detached();
     }
 
     /// `${abi_name}__close` body — called from

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -1,6 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 
 // `wire_input`'s materialized-body path transfers the body's `+1` (a
 // `WTFStringImpl` for an all-ASCII `new Response("...")`) into an `AnyBlob`
@@ -622,6 +622,54 @@ test("never-settling handler promises with a realized body release their parked 
   expect(results.every(m => m.includes("will never settle"))).toBe(true);
   expect(after - before).toBeLessThan(N / 3);
 });
+
+// Abandoning a transform whose JS-pump input stream never closes makes the
+// Transform cell and the pump's sink controller garbage in the same GC cycle.
+// The controller's destructor dispatches `__controllerDetached`/`__finalize`
+// into the shared RewriterPipe, and cells sweep in unspecified order, so the
+// pipe must survive whichever cell dies first (unfixed: ASAN
+// heap-use-after-free in `js_controller_detached`, Sink.rs). Only ASAN builds
+// observe the stale read, so release lanes skip it.
+test.skipIf(!isASAN)(
+  "abandoned transforms over a never-closing JS stream survive GC sweep order",
+  async () => {
+    const code = /* js */ `
+      function once() {
+        const rs = new ReadableStream({
+          pull(c) {
+            c.enqueue(new TextEncoder().encode("<p>x</p>"));
+            return new Promise(() => {});
+          },
+        });
+        new HTMLRewriter().on("p", { element() {} }).transform(new Response(rs));
+      }
+      for (let round = 0; round < 10; round++) {
+        for (let i = 0; i < 150; i++) once();
+        await Bun.sleep(0);
+        Bun.gc(true);
+      }
+      console.log("done");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(
+      stderr
+        .split("\n")
+        .filter(l => !l.startsWith("WARNING: ASAN"))
+        .join("\n")
+        .trim(),
+    ).toBe("");
+    expect(stdout.trim()).toBe("done");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
 
 // Input-side sibling of the realized-body case: a `type: 'direct'` pull
 // parked on `await controller.flush(true)` holds a pending-flush promise


### PR DESCRIPTION
Fixes an ASAN heap-use-after-free found by fuzzing on current main (new in the window that added the HTMLRewriter SinkHandle/SourceHandle streaming path, #36733; older builds throw `ERR_STREAM_CANNOT_PIPE` before reaching it).

### Repro

```js
function once() {
  const rs = new ReadableStream({
    pull(c) { c.enqueue(new TextEncoder().encode("<p>x</p>")); return new Promise(() => {}); },
  });
  new HTMLRewriter().on("p", { element(e) {} }).transform(new Response(rs));
}
for (let round = 0; round < 20; round++) {
  for (let i = 0; i < 200; i++) once();
  await Bun.sleep(0);
  Bun.gc(true);
}
console.log("done");
```

On an ASAN build this aborts within the first few GC rounds:

```
SUMMARY: AddressSanitizer: heap-use-after-free src/runtime/webcore/Sink.rs:575:55 in JSSink<RewriterPipe>::js_controller_detached
```

ACCESS is `HTMLRewriterSink__controllerDetached` called from `~JSReadableHTMLRewriterSinkController`; FREE is `drop<Box<RewriterPipe>>` in the `JSHTMLRewriterTransform` cell finalizer.

### Cause

`transform()` over a plain JS `ReadableStream` takes the JS-pump fallback: `assignToStream` creates a `JSReadableHTMLRewriterSinkController` whose `m_sinkPtr` points at the `RewriterPipe` raw, and the controller destructor dispatches `__controllerDetached` and `__finalize` into that pointer unless something nulled it first. The pipe itself is owned by the `JSHTMLRewriterTransform` cell, whose finalizer frees the Box.

When the rewrite is abandoned mid-stream (input never closes, output dropped), the Transform cell, the input stream, the pump, and the controller all become garbage in the same GC cycle, and JSC sweeps those cells in unspecified order. Transform cell first means the controller destructor then reads (and on the matching path writes) the freed pipe.

The suspension hand-off had the same shape: a suspended transform abandoned with a JS-pump input could have the deferred `abandon_suspension` task free the pipe while the controller destructor still held the raw pointer, in either order.

### Fix

`RewriterPipe` now tracks its owners in a small claim count: the Transform cell (from `init` until its finalizer), the JS-pump controller (from `assign_to_stream` until `__controllerDetached`, which fires exactly once on every detach path including the destructor), and a parked suspension's reaction or abandon task. Whoever releases the last claim frees the Box.

A controller-origin release never frees inline because the releasing C++ frame keeps calling into the allocation after it returns (the destructor calls `__finalize` next; the close/end host fns call `__close`/`__endWithSink` on the saved pointer), so that case defers the free to an event-loop task, reusing the existing `DeferredDerefTask` used by the abandon path.

`JsSinkType` gains a default no-op `controller_detached` hook so the generic `js_controller_detached` can notify the sink; behavior for every other sink type is unchanged.

### Verification

- Unfixed debug ASAN build: repro aborts with the stack above, 3/3 runs; the new test fails the same way.
- Fixed build: repro prints `done`, 5/5 runs; new test passes.
- `test/js/workerd/html-rewriter-leak.test.ts` (includes the suspension/abandon lifetime tests), `html-rewriter.test.js`, `html-rewriter-end-error.test.ts`, `html-rewriter-doctype.test.ts`, `htmlrewriter-additional-bugs.test.ts`: all pass (154 tests).
- `test/js/web/fetch/body-stream.test.ts` (9086) and `test/js/bun/util/filesink.test.ts` (57) pass, covering the shared sink-controller machinery.

The new test is `skipIf(!isASAN)`: the stale read is only observable under ASAN.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/workerd/html-rewriter-leak.test.ts

<!-- robobun:evidence:end -->