### PR TITLE
sql: support named parameters in SQLite unsafe() queries

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -437,6 +437,12 @@ const result = await sql.unsafe(`
 const result = await sql.unsafe("SELECT " + dangerous + " FROM users WHERE id = $1", [id]);
 ```
 
+With the SQLite adapter, parameters can also be an object of named parameters using `:name`, `$name`, or `@name` placeholders:
+
+```ts
+const result = await sql.unsafe("SELECT * FROM users WHERE id = :id", { id: 1 });
+```
+
 ### Execute and Cancelling Queries
 
 Queries are lazy: they only start executing when awaited or run with `.execute()`.

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -422,6 +422,8 @@ Simple queries cannot use parameters (`${value}`). If you need parameters, split
 const result = await sql.file("query.sql", [1, 2, 3]);
 ```
 
+With the SQLite adapter, parameters can also be an object of named parameters (`:name`, `$name`, or `@name` placeholders), the same form `sql.unsafe` accepts below.
+
 ### Unsafe Queries
 
 `sql.unsafe` executes raw SQL strings. Use it with caution: it does not escape user input. Without parameters, the string can contain more than one command.

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -437,9 +437,10 @@ const result = await sql.unsafe(`
 const result = await sql.unsafe("SELECT " + dangerous + " FROM users WHERE id = $1", [id]);
 ```
 
-With the SQLite adapter, parameters can also be an object of named parameters using `:name`, `$name`, or `@name` placeholders:
+With the SQLite adapter, parameters can also be an object of named parameters using `:name`, `$name`, or `@name` placeholders. Object keys keep the prefix (`{ ":id": 1 }`) unless the connection sets `strict: true`, which allows bare keys:
 
 ```ts
+const sql = new SQL({ adapter: "sqlite", filename: "myapp.db", strict: true });
 const result = await sql.unsafe("SELECT * FROM users WHERE id = :id", { id: 1 });
 ```
 

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -937,11 +937,12 @@ declare module "bun" {
      * when only part of the query is unsafe.
      *
      * With the SQLite adapter, `values` may also be an object of named
-     * parameters (`:name`, `$name`, or `@name` placeholders).
+     * parameters (`:name`, `$name`, or `@name` placeholders). Object keys
+     * keep the prefix unless the connection sets `strict: true`.
      * @example
      * ```ts
      * const result = await sql.unsafe(`select ${danger} from users where id = ${dragons}`)
-     * const row = await sql.unsafe("select * from users where id = :id", { id: 1 })
+     * const row = await sql.unsafe("select * from users where id = :id", { ":id": 1 })
      * ```
      */
     unsafe<T = any>(string: string, values?: any[] | Record<string, any>): SQL.Query<T>;
@@ -950,7 +951,8 @@ declare module "bun" {
      * Reads a file and runs its contents as a query.
      * Pass `values` if the file uses positional parameters (`$1`, `$2`, ...).
      * With the SQLite adapter, `values` may also be an object of named
-     * parameters (`:name`, `$name`, or `@name` placeholders).
+     * parameters (`:name`, `$name`, or `@name` placeholders); keys keep the
+     * prefix unless the connection sets `strict: true`.
      * @example
      * ```ts
      * const result = await sql.file("query.sql", [1, 2, 3]);

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -935,22 +935,28 @@ declare module "bun" {
      *
      * `sql.unsafe` can be nested inside a safe `sql` expression, for example
      * when only part of the query is unsafe.
+     *
+     * With the SQLite adapter, `values` may also be an object of named
+     * parameters (`:name`, `$name`, or `@name` placeholders).
      * @example
      * ```ts
      * const result = await sql.unsafe(`select ${danger} from users where id = ${dragons}`)
+     * const row = await sql.unsafe("select * from users where id = :id", { id: 1 })
      * ```
      */
-    unsafe<T = any>(string: string, values?: any[]): SQL.Query<T>;
+    unsafe<T = any>(string: string, values?: any[] | Record<string, any>): SQL.Query<T>;
 
     /**
      * Reads a file and runs its contents as a query.
-     * Pass `values` if the file uses positional parameters (`$1`, `$2`, ...)
+     * Pass `values` if the file uses positional parameters (`$1`, `$2`, ...).
+     * With the SQLite adapter, `values` may also be an object of named
+     * parameters (`:name`, `$name`, or `@name` placeholders).
      * @example
      * ```ts
      * const result = await sql.file("query.sql", [1, 2, 3]);
      * ```
      */
-    file<T = any>(filename: string, values?: any[]): SQL.Query<T>;
+    file<T = any>(filename: string, values?: any[] | Record<string, any>): SQL.Query<T>;
   }
 
   /**

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -245,8 +245,7 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
         const stmt = db.prepare(sql);
         let result: unknown[] | undefined;
 
-        // Arrays are positional parameters and spread into arguments; a plain
-        // object is a single named-parameters binding (:name, $name, @name).
+        // Named-parameter objects need $call: $apply would treat them as an empty array-like.
         if (mode === SQLQueryResultMode.values) {
           result = $isArray(values) ? stmt.values.$apply(stmt, values) : stmt.values.$call(stmt, values);
         } else if (mode === SQLQueryResultMode.raw) {

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -245,13 +245,17 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
         const stmt = db.prepare(sql);
         let result: unknown[] | undefined;
 
-        // Named-parameter objects need $call: $apply would treat them as an empty array-like.
-        if (mode === SQLQueryResultMode.values) {
-          result = $isArray(values) ? stmt.values.$apply(stmt, values) : stmt.values.$call(stmt, values);
-        } else if (mode === SQLQueryResultMode.raw) {
-          result = $isArray(values) ? stmt.raw.$apply(stmt, values) : stmt.raw.$call(stmt, values);
-        } else {
-          result = $isArray(values) ? stmt.all.$apply(stmt, values) : stmt.all.$call(stmt, values);
+        try {
+          // Named-parameter objects need $call: $apply would treat them as an empty array-like.
+          if (mode === SQLQueryResultMode.values) {
+            result = $isArray(values) ? stmt.values.$apply(stmt, values) : stmt.values.$call(stmt, values);
+          } else if (mode === SQLQueryResultMode.raw) {
+            result = $isArray(values) ? stmt.raw.$apply(stmt, values) : stmt.raw.$call(stmt, values);
+          } else {
+            result = $isArray(values) ? stmt.all.$apply(stmt, values) : stmt.all.$call(stmt, values);
+          }
+        } finally {
+          stmt.finalize();
         }
 
         const sqlResult = $isArray(result) ? new SQLResultArray(result) : new SQLResultArray([result]);
@@ -259,7 +263,6 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
         sqlResult.command = commandToString(command, parsedInfo.lastToken);
         sqlResult.count = $isArray(result) ? result.length : 1;
 
-        stmt.finalize();
         query.resolve(sqlResult);
       } else {
         // For INSERT/UPDATE/DELETE/CREATE etc., use db.run() which handles multiple statements natively

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -213,10 +213,10 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
   private mode = SQLQueryResultMode.objects;
 
   private readonly sql: string;
-  private readonly values: unknown[];
+  private readonly values: unknown[] | Record<string, unknown>;
   private readonly parsedInfo: SQLParsedInfo;
 
-  public constructor(sql: string, values: unknown[]) {
+  public constructor(sql: string, values: unknown[] | Record<string, unknown>) {
     this.sql = sql;
     this.values = values;
     // Parse the SQL query once when creating the handle
@@ -245,12 +245,14 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
         const stmt = db.prepare(sql);
         let result: unknown[] | undefined;
 
+        // Arrays are positional parameters and spread into arguments; a plain
+        // object is a single named-parameters binding (:name, $name, @name).
         if (mode === SQLQueryResultMode.values) {
-          result = stmt.values.$apply(stmt, values);
+          result = $isArray(values) ? stmt.values.$apply(stmt, values) : stmt.values.$call(stmt, values);
         } else if (mode === SQLQueryResultMode.raw) {
-          result = stmt.raw.$apply(stmt, values);
+          result = $isArray(values) ? stmt.raw.$apply(stmt, values) : stmt.raw.$call(stmt, values);
         } else {
-          result = stmt.all.$apply(stmt, values);
+          result = $isArray(values) ? stmt.all.$apply(stmt, values) : stmt.all.$call(stmt, values);
         }
 
         const sqlResult = $isArray(result) ? new SQLResultArray(result) : new SQLResultArray([result]);
@@ -262,7 +264,7 @@ class SQLiteQueryHandle implements BaseQueryHandle<BunSQLiteModule.Database> {
         query.resolve(sqlResult);
       } else {
         // For INSERT/UPDATE/DELETE/CREATE etc., use db.run() which handles multiple statements natively
-        const changes = db.run.$apply(db, [sql].concat(values));
+        const changes = $isArray(values) ? db.run.$apply(db, [sql].concat(values)) : db.run.$call(db, sql, values);
         const sqlResult = new SQLResultArray();
 
         sqlResult.command = commandToString(command, parsedInfo.lastToken);
@@ -350,7 +352,10 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
     }
   }
 
-  createQueryHandle(sql: string, values: unknown[] | undefined | null = []): SQLiteQueryHandle {
+  createQueryHandle(
+    sql: string,
+    values: unknown[] | Record<string, unknown> | undefined | null = [],
+  ): SQLiteQueryHandle {
     return new SQLiteQueryHandle(sql, values ?? []);
   }
   escapeIdentifier(str: string) {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1605,16 +1605,24 @@ describe("SQL helpers", () => {
   });
 
   test("file with named parameters", async () => {
-    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
-    await strictSql`CREATE TABLE file_named_test (id INTEGER, name TEXT)`;
-    await strictSql.unsafe("INSERT INTO file_named_test VALUES (:id, :name)", { id: 1, name: "Alice" });
-
     await using dir = tempDir("sql-file-named", {
       "query.sql": `SELECT * FROM file_named_test WHERE name = :name`,
     });
 
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE file_named_test (id INTEGER, name TEXT)`;
+    await strictSql.unsafe("INSERT INTO file_named_test VALUES (:id, :name)", { id: 1, name: "Alice" });
+
     const result = await strictSql.file(path.join(dir, "query.sql"), { name: "Alice" });
     expect(result).toEqual([{ id: 1, name: "Alice" }]);
+
+    // Non-strict connections use the same file with prefixed keys.
+    await using defaultSql = new SQL({ adapter: "sqlite", filename: ":memory:" });
+    await defaultSql`CREATE TABLE file_named_test (id INTEGER, name TEXT)`;
+    await defaultSql.unsafe("INSERT INTO file_named_test VALUES (:id, :name)", { ":id": 2, ":name": "Bob" });
+
+    const defaultResult = await defaultSql.file(path.join(dir, "query.sql"), { ":name": "Bob" });
+    expect(defaultResult).toEqual([{ id: 2, name: "Bob" }]);
   });
 });
 

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1421,6 +1421,24 @@ describe("SQL helpers", () => {
     const raw = await strictSql.unsafe("SELECT id FROM named_modes_test WHERE id = :id", { id: 7 }).raw();
     expect(raw).toHaveLength(1);
     expect(raw[0]).toHaveLength(1);
+    const idBuf = raw[0][0] as Uint8Array;
+    expect(idBuf).toBeInstanceOf(Uint8Array);
+    expect(new DataView(idBuf.buffer, idBuf.byteOffset, idBuf.byteLength).getBigInt64(0, true)).toBe(7n);
+  });
+
+  test("unsafe with named parameters rejects on missing bindings in strict mode", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE missing_binding_test (id INTEGER, name TEXT)`;
+    await strictSql.unsafe("INSERT INTO missing_binding_test VALUES (:id, :name)", { id: 1, name: "Alice" });
+
+    await expect(
+      async () =>
+        await strictSql.unsafe("SELECT * FROM missing_binding_test WHERE id = :id AND name = :name", { id: 1 }),
+    ).toThrow('Missing parameter "name"');
+
+    // The statement from the failed query is finalized and the connection stays usable.
+    const rows = await strictSql.unsafe("SELECT * FROM missing_binding_test WHERE id = :id", { id: 1 });
+    expect(rows).toEqual([{ id: 1, name: "Alice" }]);
   });
 
   test("unsafe with named parameters for UPDATE and DELETE", async () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, SQL } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { tempDir } from "harness";
+import { isDebug, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { rm, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -2111,9 +2111,9 @@ describe("Memory and resource management", () => {
 
     await sql`CREATE TABLE stmt_test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    // Small enough that the serial awaited inserts stay under the default
-    // timeout on a debug + ASAN build.
-    const iterations = 1000;
+    // Debug builds run the serial awaited inserts 10-100x slower, so use a
+    // smaller workload there to stay under the default timeout.
+    const iterations = isDebug ? 1000 : 10000;
 
     for (let i = 0; i < iterations; i++) {
       await sql`INSERT INTO stmt_test (id, value) VALUES (${i}, ${"test" + i})`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1591,6 +1591,19 @@ describe("SQL helpers", () => {
     expect(result[0].param1).toBe("value1");
     expect(result[0].param2).toBe("value2");
   });
+
+  test("file with named parameters", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE file_named_test (id INTEGER, name TEXT)`;
+    await strictSql.unsafe("INSERT INTO file_named_test VALUES (:id, :name)", { id: 1, name: "Alice" });
+
+    await using dir = tempDir("sql-file-named", {
+      "query.sql": `SELECT * FROM file_named_test WHERE name = :name`,
+    });
+
+    const result = await strictSql.file(path.join(dir, "query.sql"), { name: "Alice" });
+    expect(result).toEqual([{ id: 1, name: "Alice" }]);
+  });
 });
 
 describe("Helper argument validation", () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2111,7 +2111,9 @@ describe("Memory and resource management", () => {
 
     await sql`CREATE TABLE stmt_test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    const iterations = 10000;
+    // Small enough that the serial awaited inserts stay under the default
+    // timeout on a debug + ASAN build.
+    const iterations = 1000;
 
     for (let i = 0; i < iterations; i++) {
       await sql`INSERT INTO stmt_test (id, value) VALUES (${i}, ${"test" + i})`;
@@ -2132,8 +2134,7 @@ describe("Memory and resource management", () => {
     expect(finalCount[0].count).toBe(iterations - 300);
 
     await sql.close();
-    // 10k awaited inserts need more than the 5s default under debug + ASAN
-  }, 60_000);
+  });
 
   test("handles many concurrent prepared statements", async () => {
     const sql = new SQL("sqlite://:memory:");

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1356,6 +1356,90 @@ describe("SQL helpers", () => {
     expect(results[0].value).toBe("test");
   });
 
+  test("unsafe with named parameters (strict mode)", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE named_test (id INTEGER, name TEXT, age INTEGER)`;
+
+    const insert = await strictSql.unsafe("INSERT INTO named_test VALUES (:id, :name, :age)", {
+      id: 1,
+      name: "Alice",
+      age: 30,
+    });
+    expect(insert.count).toBe(1);
+
+    const results = await strictSql.unsafe("SELECT * FROM named_test WHERE name = :name", { name: "Alice" });
+    expect(results).toEqual([{ id: 1, name: "Alice", age: 30 }]);
+  });
+
+  test("unsafe with named parameters using different prefixes", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE prefix_test (col TEXT)`;
+
+    await strictSql.unsafe("INSERT INTO prefix_test VALUES (:value)", { value: "colon" });
+    await strictSql.unsafe("INSERT INTO prefix_test VALUES ($value)", { value: "dollar" });
+    await strictSql.unsafe("INSERT INTO prefix_test VALUES (@value)", { value: "at" });
+
+    const results = await strictSql.unsafe("SELECT * FROM prefix_test WHERE col = :wanted", { wanted: "dollar" });
+    expect(results).toEqual([{ col: "dollar" }]);
+
+    const all = await strictSql.unsafe("SELECT * FROM prefix_test");
+    expect(all.map(r => r.col).sort()).toEqual(["at", "colon", "dollar"]);
+  });
+
+  test("unsafe with named parameters without strict mode (requires prefix in keys)", async () => {
+    await using defaultSql = new SQL({ adapter: "sqlite", filename: ":memory:" });
+    await defaultSql`CREATE TABLE default_named_test (id INTEGER, name TEXT)`;
+
+    await defaultSql.unsafe("INSERT INTO default_named_test VALUES (:id, :name)", { ":id": 1, ":name": "Bob" });
+
+    const results = await defaultSql.unsafe("SELECT * FROM default_named_test WHERE id = :id_param", {
+      ":id_param": 1,
+    });
+    expect(results).toEqual([{ id: 1, name: "Bob" }]);
+  });
+
+  test("unsafe with named parameters supports values() and raw() modes", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE named_modes_test (id INTEGER, name TEXT)`;
+    await strictSql.unsafe("INSERT INTO named_modes_test VALUES (:id, :name)", { id: 7, name: "Carol" });
+
+    const values = await strictSql.unsafe("SELECT id, name FROM named_modes_test WHERE id = :id", { id: 7 }).values();
+    expect(values).toEqual([[7, "Carol"]]);
+
+    const raw = await strictSql.unsafe("SELECT id FROM named_modes_test WHERE id = :id", { id: 7 }).raw();
+    expect(raw).toHaveLength(1);
+    expect(raw[0]).toHaveLength(1);
+  });
+
+  test("unsafe with named parameters for UPDATE and DELETE", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE named_update_test (id INTEGER, name TEXT)`;
+    await strictSql.unsafe("INSERT INTO named_update_test VALUES (:id, :name)", { id: 1, name: "before" });
+
+    const update = await strictSql.unsafe("UPDATE named_update_test SET name = :name WHERE id = :id", {
+      id: 1,
+      name: "after",
+    });
+    expect(update.count).toBe(1);
+
+    const results = await strictSql.unsafe("SELECT name FROM named_update_test WHERE id = :id", { id: 1 });
+    expect(results).toEqual([{ name: "after" }]);
+
+    const del = await strictSql.unsafe("DELETE FROM named_update_test WHERE id = :id", { id: 1 });
+    expect(del.count).toBe(1);
+  });
+
+  test("unsafe with named parameters inside a transaction", async () => {
+    await using strictSql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
+    await strictSql`CREATE TABLE named_tx_test (id INTEGER, name TEXT)`;
+
+    const rows = await strictSql.begin(async tx => {
+      await tx.unsafe("INSERT INTO named_tx_test VALUES (:id, :name)", { id: 1, name: "tx" });
+      return await tx.unsafe("SELECT * FROM named_tx_test WHERE id = :id", { id: 1 });
+    });
+    expect(rows).toEqual([{ id: 1, name: "tx" }]);
+  });
+
   test("insert into with select helper using where IN", async () => {
     const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
     await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text, age int)`;

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1436,7 +1436,7 @@ describe("SQL helpers", () => {
         await strictSql.unsafe("SELECT * FROM missing_binding_test WHERE id = :id AND name = :name", { id: 1 }),
     ).toThrow('Missing parameter "name"');
 
-    // The statement from the failed query is finalized and the connection stays usable.
+    // The connection stays usable after a rejected bind.
     const rows = await strictSql.unsafe("SELECT * FROM missing_binding_test WHERE id = :id", { id: 1 });
     expect(rows).toEqual([{ id: 1, name: "Alice" }]);
   });

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -1391,11 +1391,23 @@ describe("SQL helpers", () => {
     await defaultSql`CREATE TABLE default_named_test (id INTEGER, name TEXT)`;
 
     await defaultSql.unsafe("INSERT INTO default_named_test VALUES (:id, :name)", { ":id": 1, ":name": "Bob" });
+    await defaultSql.unsafe("INSERT INTO default_named_test VALUES ($id, $name)", { $id: 2, $name: "Dan" });
+    await defaultSql.unsafe("INSERT INTO default_named_test VALUES (@id, @name)", { "@id": 3, "@name": "Eve" });
 
-    const results = await defaultSql.unsafe("SELECT * FROM default_named_test WHERE id = :id_param", {
+    const byColon = await defaultSql.unsafe("SELECT * FROM default_named_test WHERE id = :id_param", {
       ":id_param": 1,
     });
-    expect(results).toEqual([{ id: 1, name: "Bob" }]);
+    expect(byColon).toEqual([{ id: 1, name: "Bob" }]);
+
+    const byDollar = await defaultSql.unsafe("SELECT name FROM default_named_test WHERE id = $wanted", {
+      $wanted: 2,
+    });
+    expect(byDollar).toEqual([{ name: "Dan" }]);
+
+    const byAt = await defaultSql.unsafe("SELECT name FROM default_named_test WHERE id = @wanted", {
+      "@wanted": 3,
+    });
+    expect(byAt).toEqual([{ name: "Eve" }]);
   });
 
   test("unsafe with named parameters supports values() and raw() modes", async () => {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2119,7 +2119,8 @@ describe("Memory and resource management", () => {
     expect(finalCount[0].count).toBe(iterations - 300);
 
     await sql.close();
-  });
+    // 10k awaited inserts need more than the 5s default under debug + ASAN
+  }, 60_000);
 
   test("handles many concurrent prepared statements", async () => {
     const sql = new SQL("sqlite://:memory:");


### PR DESCRIPTION
Redo of #23375 by @savannahar68 against current main, as requested there. Fixes #22799.

## Problem

`Bun.SQL`'s `unsafe()` only bound array values. Passing an object of named parameters to a SELECT silently returned no rows:

```ts
const sql = new SQL({ adapter: "sqlite", filename: ":memory:", strict: true });
await sql`CREATE TABLE tbl (id INTEGER, name TEXT)`;
await sql.unsafe("INSERT INTO tbl VALUES (:id, :name)", { id: 1, name: "Alice" });
await sql.unsafe("SELECT * FROM tbl WHERE name = :name", { name: "Alice" });
// before: []  (no error)
// after:  [{ id: 1, name: "Alice" }]
```

## Cause

`SQLiteQueryHandle.run` spread values with `$apply`. A plain object is an array-like of length 0 to `apply`, so `stmt.all()` ran with nothing bound and SQLite treated the named placeholders as NULL, returning empty results instead of erroring.

## Fix

In `src/js/internal/sql/sqlite.ts`, detect object bindings and pass them as a single argument to the underlying `bun:sqlite` methods (`stmt.all`/`stmt.values`/`stmt.raw`/`db.run`), which already support `:name`, `$name`, and `@name` placeholders. Arrays keep spreading into positional arguments. Statement execution is now wrapped in try/finally so a failed bind (for example a missing named parameter in strict mode) still finalizes the prepared statement. The `unsafe`/`file` type signatures are widened and the docs note that this is SQLite only and that object keys keep their prefix unless the connection sets `strict: true`.

Named parameters stay SQLite only: Postgres and MySQL already reject non-array values natively (`src/sql_jsc/shared/QueryCtorArgs.rs`), and those adapters are unchanged.

## Verification

Eight new tests in `test/js/sql/sqlite-sql.test.ts`: strict mode, all three placeholder prefixes, non-strict mode with prefixed keys for all three prefixes, `values()`/`raw()` result modes (raw bytes checked), the missing-binding error path, UPDATE/DELETE change counts, `unsafe()` inside a transaction, and `sql.file()` on both strict and default connections. All eight fail on main (empty results) and pass with this change; the rest of the file and the bun-types integration test pass. The pre-existing 10k-insert finalization test uses 1000 iterations on debug builds only, so the file fits the default timeout under ASAN.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sqlite-sql.test.ts
bun test v1.4.0 (fa34508cc)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [113.02ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [12.32ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [38.31ms]
(pass) Connection & Initialization > should handle connection with options object [101.41ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [16.96ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [26.93ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [42.28ms]
(pass) Connection & Initialization > should work with relative paths [33.10ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [44.04ms]
(pass) Connection & Initialization 
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [2.16ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [0.80ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [1.14ms]
(pass) Connection & Initialization > should handle connection with options object [8.09ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [0.43ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [4.12ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [26.99ms]
(pass) Connection & Initialization > should work with relative paths [19.61ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [14.91ms]
(pass) Connection & Initialization > Environment Variable Handling > should handle DATABASE_URL with :memory: [0.73ms]
(pass) Connection & Initialization > Environment Variable Handling > should han
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sqlite-sql.test.ts
bun test v1.4.0 (fa34508cc)

test/js/sql/sqlite-sql.test.ts:
(pass) Connection & Initialization > common default connection strings > should parse common connection strings [118.63ms]
(pass) Connection & Initialization > should connect to in-memory SQLite database [13.44ms]
(pass) Connection & Initialization > should connect to file-based SQLite database [53.40ms]
(pass) Connection & Initialization > should handle connection with options object [106.23ms]
(pass) Connection & Initialization > onconnect and onclose callbacks are invoked for SQLite [17.97ms]
(pass) Connection & Initialization > onconnect receives Error when open fails (readonly non-existent) [27.97ms]
(pass) Connection & Initialization > should create database file if it doesn't exist [47.47ms]
(pass) Connection & Initialization > should work with relative paths [113.79ms]
(pass) Connection & Initialization > Environment Variable Handling > should use DATABASE_URL for SQLite when it's a SQLite URL [67.37ms]
(pass) Connection & Initialization
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fa34508ccd
  features     baseline

22 deps, 107 codegen, 1176 objects in 736ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1194] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/1194] cc obj/vendor/zlib/adler32.c.o
[3/1194] cc obj/vendor/zlib/compress.c.o
[4/1194] cc obj/vendor/zlib/crc32.c.o
[5/1194] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/1194] fetch cares
[cares] up to date
[7/1194] cc obj/vendor/zlib/crc32_braid_comb.c.o
[8/1194] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[9/1194] cc obj/vendor/zlib/deflate_huff.c.o
[10/1194] cc obj/vendor/zlib/deflate_quick.c.o
[11/1194] cc obj/vendor/zlib/deflate_medium.c.o
[12/1194] cc obj/vendor/zlib/deflate_slow.c.o
[13/1194] cc obj/vendor/zlib/deflate_rle.c.o
[14/1194] cc obj/vendor/zli
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx           |   9 +++
 packages/bun-types/sql.d.ts    |  14 +++-
 src/js/internal/sql/sqlite.ts  |  29 +++++----
 test/js/sql/sqlite-sql.test.ts | 141 ++++++++++++++++++++++++++++++++++++++++-
 4 files changed, 177 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 4 passed · 3 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
docs/runtime/sql.mdx                2      4      0
packages/bun-types/sql.d.ts         2      3      0
src/js/internal/sql/sqlite.ts       5      5      0
test/js/sql/sqlite-sql.test.ts     12     12      0
```

</details>

<!-- robobun:evidence:end -->
