### PR TITLE
undici: export ping() and publish undici:websocket:ping/pong diagnostics channels

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -384,11 +384,6 @@ class WebSocket extends BunWebSocket {
   }
 }
 
-/**
- * Sends a ping frame on an established WebSocket connection.
- * @param {WebSocket} ws
- * @param {Buffer|undefined} payload
- */
 function ping(ws, payload) {
   if (!(ws instanceof BunWebSocket)) {
     throw new TypeError("Expected a WebSocket instance");

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -368,17 +368,25 @@ const util = {
 const pingChannel = diagnosticsChannel.channel("undici:websocket:ping");
 const pongChannel = diagnosticsChannel.channel("undici:websocket:pong");
 
+// undici publishes a Buffer regardless of the socket's binaryType
+function controlFramePayload(data) {
+  if (Buffer.isBuffer(data)) return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  return data;
+}
+
 class WebSocket extends BunWebSocket {
   constructor(...args) {
     super(...args);
     this.addEventListener("ping", ({ data }) => {
       if (pingChannel.hasSubscribers) {
-        pingChannel.publish({ payload: data, websocket: this });
+        pingChannel.publish({ payload: controlFramePayload(data), websocket: this });
       }
     });
     this.addEventListener("pong", ({ data }) => {
       if (pongChannel.hasSubscribers) {
-        pongChannel.publish({ payload: data, websocket: this });
+        pongChannel.publish({ payload: controlFramePayload(data), websocket: this });
       }
     });
   }

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -1,4 +1,5 @@
 const EventEmitter = require("node:events");
+const diagnosticsChannel = require("node:diagnostics_channel");
 const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapters");
 
 const ObjectCreate = Object.create;
@@ -14,7 +15,7 @@ const File = bindings[4];
 const URL = bindings[5];
 const AbortSignal = bindings[6];
 const URLSearchParams = bindings[7];
-const WebSocket = bindings[8];
+const BunWebSocket = bindings[8];
 const CloseEvent = bindings[9];
 const ErrorEvent = bindings[10];
 const MessageEvent = bindings[11];
@@ -364,6 +365,49 @@ const util = {
   },
 };
 
+const pingChannel = diagnosticsChannel.channel("undici:websocket:ping");
+const pongChannel = diagnosticsChannel.channel("undici:websocket:pong");
+
+class WebSocket extends BunWebSocket {
+  constructor(...args) {
+    super(...args);
+    this.addEventListener("ping", ({ data }) => {
+      if (pingChannel.hasSubscribers) {
+        pingChannel.publish({ payload: data, websocket: this });
+      }
+    });
+    this.addEventListener("pong", ({ data }) => {
+      if (pongChannel.hasSubscribers) {
+        pongChannel.publish({ payload: data, websocket: this });
+      }
+    });
+  }
+}
+
+/**
+ * Sends a ping frame on an established WebSocket connection.
+ * @param {WebSocket} ws
+ * @param {Buffer|undefined} payload
+ */
+function ping(ws, payload) {
+  if (!(ws instanceof BunWebSocket)) {
+    throw new TypeError("Expected a WebSocket instance");
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    if (payload.length > 125) {
+      throw new TypeError("A PING frame cannot have a body larger than 125 bytes.");
+    }
+  } else if (payload !== undefined) {
+    throw new TypeError("Expected buffer payload");
+  }
+
+  if (ws.readyState === BunWebSocket.OPEN) {
+    if (payload === undefined) ws.ping();
+    else ws.ping(payload);
+  }
+}
+
 class EventSource extends EventTarget {
   static CONNECTING = 0;
   static OPEN = 1;
@@ -474,6 +518,7 @@ const moduleExports = {
   mockErrors,
   MockPool,
   parseMIMEType,
+  ping,
   pipeline,
   Pool,
   ProxyAgent,

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -4,6 +4,7 @@ const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapt
 
 const ObjectCreate = Object.create;
 const kEmptyObject = ObjectCreate(null);
+const NativeArrayBuffer = ArrayBuffer;
 
 var fetch = Bun.fetch;
 const bindings = $cpp("Undici.cpp", "createUndiciInternalBinding");
@@ -371,8 +372,8 @@ const pongChannel = diagnosticsChannel.channel("undici:websocket:pong");
 // undici publishes a Buffer regardless of the socket's binaryType
 function controlFramePayload(data) {
   if (Buffer.isBuffer(data)) return data;
-  if (data instanceof ArrayBuffer) return Buffer.from(data);
-  if (ArrayBuffer.isView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  if (data instanceof NativeArrayBuffer) return Buffer.from(data);
+  if ($isTypedArrayView(data)) return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
   return data;
 }
 

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -269,7 +269,7 @@ describe("undici.request maxRedirections", () => {
   });
 });
 
-describe("undici WebSocket ping", () => {
+describe.concurrent("undici WebSocket ping", () => {
   function serveWebSocket(handlers: Partial<Bun.WebSocketHandler> = {}) {
     return Bun.serve({
       port: 0,
@@ -296,12 +296,14 @@ describe("undici WebSocket ping", () => {
       },
     });
 
+    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
     const pongMessage = Promise.withResolvers<{ payload: Buffer; websocket: unknown }>();
     const pongChannel = diagnosticsChannel.channel("undici:websocket:pong");
-    const onPong = (message: any) => pongMessage.resolve(message);
+    // the channel is process-global, so only accept messages for this socket
+    const onPong = (message: any) => {
+      if (message.websocket === ws) pongMessage.resolve(message);
+    };
     pongChannel.subscribe(onPong);
-
-    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
     try {
       const opened = Promise.withResolvers<void>();
       ws.addEventListener("open", () => opened.resolve());
@@ -330,13 +332,19 @@ describe("undici WebSocket ping", () => {
       },
     });
 
+    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
     const pingMessage = Promise.withResolvers<{ payload: Buffer; websocket: unknown }>();
     const pingChannel = diagnosticsChannel.channel("undici:websocket:ping");
-    const onPing = (message: any) => pingMessage.resolve(message);
+    // the channel is process-global, so only accept messages for this socket
+    const onPing = (message: any) => {
+      if (message.websocket === ws) pingMessage.resolve(message);
+    };
     pingChannel.subscribe(onPing);
-
-    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
     try {
+      ws.addEventListener("error", (e: any) => pingMessage.reject(e.error ?? new Error(e.message)));
+      ws.addEventListener("close", (e: any) =>
+        pingMessage.reject(new Error(`socket closed before ping: ${e.code} ${e.reason}`)),
+      );
       const message = await pingMessage.promise;
       expect(Buffer.isBuffer(message.payload)).toBe(true);
       expect(message.payload.toString()).toBe("from server");
@@ -351,10 +359,16 @@ describe("undici WebSocket ping", () => {
     await using server = serveWebSocket();
     const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
     try {
+      expect(() => ping(undefined as any)).toThrow(TypeError);
+      expect(() => ping(null as any)).toThrow(TypeError);
       expect(() => ping({} as any)).toThrow(TypeError);
       expect(() => ping(ws, "not a buffer" as any)).toThrow("Expected buffer payload");
+      expect(() => ping(ws, null as any)).toThrow("Expected buffer payload");
+      expect(() => ping(ws, new Uint8Array(4) as any)).toThrow("Expected buffer payload");
       expect(() => ping(ws, Buffer.alloc(126))).toThrow("A PING frame cannot have a body larger than 125 bytes.");
       // a ping on a socket that is not open is a no-op, not an error
+      // (matches undici 7.x: ping() only sends while OPEN and never throws on state)
+      expect(ws.readyState).toBe(UndiciWebSocket.CONNECTING);
       expect(() => ping(ws, Buffer.alloc(125))).not.toThrow();
       expect(() => ping(ws)).not.toThrow();
     } finally {

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import diagnosticsChannel from "node:diagnostics_channel";
 import { Readable } from "node:stream";
-import { request, fetch as undiciFetch } from "undici";
+import { ping, request, fetch as undiciFetch, WebSocket as UndiciWebSocket } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -264,6 +265,100 @@ describe("undici.request maxRedirections", () => {
       );
     } finally {
       server.stop(true);
+    }
+  });
+});
+
+describe("undici WebSocket ping", () => {
+  function serveWebSocket(handlers: Partial<Bun.WebSocketHandler> = {}) {
+    return Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response(null, { status: 400 });
+      },
+      websocket: {
+        message() {},
+        ...handlers,
+      },
+    });
+  }
+
+  it("exports ping as a function", () => {
+    expect(typeof ping).toBe("function");
+  });
+
+  it("ping() sends a ping frame and undici:websocket:pong fires on the reply", async () => {
+    const serverReceived = Promise.withResolvers<Buffer>();
+    await using server = serveWebSocket({
+      ping(_ws, data) {
+        serverReceived.resolve(data);
+      },
+    });
+
+    const pongMessage = Promise.withResolvers<{ payload: Buffer; websocket: unknown }>();
+    const pongChannel = diagnosticsChannel.channel("undici:websocket:pong");
+    const onPong = (message: any) => pongMessage.resolve(message);
+    pongChannel.subscribe(onPong);
+
+    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
+    try {
+      const opened = Promise.withResolvers<void>();
+      ws.addEventListener("open", () => opened.resolve());
+      ws.addEventListener("error", (e: any) => opened.reject(e.error ?? new Error(e.message)));
+      await opened.promise;
+
+      ping(ws, Buffer.from("hello slack"));
+
+      expect((await serverReceived.promise).toString()).toBe("hello slack");
+
+      // the server answers the ping with a pong echoing the payload
+      const message = await pongMessage.promise;
+      expect(Buffer.isBuffer(message.payload)).toBe(true);
+      expect(message.payload.toString()).toBe("hello slack");
+      expect(message.websocket).toBe(ws);
+    } finally {
+      pongChannel.unsubscribe(onPong);
+      ws.close();
+    }
+  });
+
+  it("undici:websocket:ping fires when the server sends a ping", async () => {
+    await using server = serveWebSocket({
+      open(ws) {
+        ws.ping(Buffer.from("from server"));
+      },
+    });
+
+    const pingMessage = Promise.withResolvers<{ payload: Buffer; websocket: unknown }>();
+    const pingChannel = diagnosticsChannel.channel("undici:websocket:ping");
+    const onPing = (message: any) => pingMessage.resolve(message);
+    pingChannel.subscribe(onPing);
+
+    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
+    try {
+      const message = await pingMessage.promise;
+      expect(Buffer.isBuffer(message.payload)).toBe(true);
+      expect(message.payload.toString()).toBe("from server");
+      expect(message.websocket).toBe(ws);
+    } finally {
+      pingChannel.unsubscribe(onPing);
+      ws.close();
+    }
+  });
+
+  it("ping() validates its arguments like undici", async () => {
+    await using server = serveWebSocket();
+    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
+    try {
+      expect(() => ping({} as any)).toThrow(TypeError);
+      expect(() => ping(ws, "not a buffer" as any)).toThrow("Expected buffer payload");
+      expect(() => ping(ws, Buffer.alloc(126))).toThrow("A PING frame cannot have a body larger than 125 bytes.");
+      // a ping on a socket that is not open is a no-op, not an error
+      expect(() => ping(ws, Buffer.alloc(125))).not.toThrow();
+      expect(() => ping(ws)).not.toThrow();
+    } finally {
+      ws.close();
     }
   });
 });

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -355,6 +355,35 @@ describe.concurrent("undici WebSocket ping", () => {
     }
   });
 
+  it("publishes a Buffer payload even when binaryType is 'arraybuffer'", async () => {
+    await using server = serveWebSocket({
+      open(ws) {
+        ws.ping(Buffer.from("typed"));
+      },
+    });
+
+    const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);
+    ws.binaryType = "arraybuffer";
+    const pingMessage = Promise.withResolvers<{ payload: Buffer; websocket: unknown }>();
+    const pingChannel = diagnosticsChannel.channel("undici:websocket:ping");
+    const onPing = (message: any) => {
+      if (message.websocket === ws) pingMessage.resolve(message);
+    };
+    pingChannel.subscribe(onPing);
+    try {
+      ws.addEventListener("error", (e: any) => pingMessage.reject(e.error ?? new Error(e.message)));
+      ws.addEventListener("close", (e: any) =>
+        pingMessage.reject(new Error(`socket closed before ping: ${e.code} ${e.reason}`)),
+      );
+      const message = await pingMessage.promise;
+      expect(Buffer.isBuffer(message.payload)).toBe(true);
+      expect(message.payload.toString()).toBe("typed");
+    } finally {
+      pingChannel.unsubscribe(onPing);
+      ws.close();
+    }
+  });
+
   it("ping() validates its arguments like undici", async () => {
     await using server = serveWebSocket();
     const ws = new UndiciWebSocket(`ws://localhost:${server.port}/`);


### PR DESCRIPTION
Fixes #37110.

### What does this PR do?

Bun aliases the bare `undici` specifier to its builtin shim, and the shim covered neither the module-level `ping()` export nor the `undici:websocket:ping`/`undici:websocket:pong` diagnostics channels that undici v7 publishes. `@slack/socket-mode@3.x` (the transport under Bolt's SocketModeReceiver) uses both, so every connection died on its first heartbeat with `TypeError: ping is not a function` and the client reconnected forever; even with that swallowed, its health monitor would count 3 missed pongs (the pong channel never fires) and disconnect anyway.

```js
// with undici@7.29.0 installed in node_modules
import * as undici from "undici";
console.log(typeof undici.ping);
// before: "undefined"   after (and on node): "function"
```

### How

Shim-level changes in `src/js/thirdparty/undici.js`, no native changes:

- `ping(ws, payload)` mirrors undici's semantics: payload must be a `Buffer` or `undefined` and at most 125 bytes (`TypeError` otherwise, with undici's messages), and the frame is only sent while the socket is open (no-op otherwise). It delegates to the native `WebSocket`'s nonstandard `ping()` method, the same one the `ws` shim already relies on.
- The shim's exported `WebSocket` is now a subclass of the native class that listens for the native `ping`/`pong` events and publishes `{ payload, websocket }` (payload is a `Buffer`) to the `undici:websocket:ping`/`undici:websocket:pong` channels when they have subscribers, matching undici's message shape. `@slack/socket-mode` constructs its socket via `new (require("undici").WebSocket)(...)` and identity-checks `message.websocket`, so the subclass covers it.

Related: #36102 would resolve bare `undici` to the installed package when present (which also fixes this scenario when the real package is installed), and #34635 publishes the websocket channels natively for all WebSocket instances. This PR keeps the shim itself correct for this surface and stands alone; if #34635 lands, its native publish supersedes the subclass listeners here.

### Verification

New tests in `test/js/first_party/undici/undici.test.ts`:

- `ping` is exported as a function (fails on current bun with `SyntaxError: Export named 'ping' not found in module 'undici'`)
- `ping(ws, payload)` delivers a ping frame to a `Bun.serve` websocket server, and the server's pong reply publishes on `undici:websocket:pong` with the echoed `Buffer` payload and the originating websocket
- a server-initiated ping publishes on `undici:websocket:ping`
- argument validation: non-WebSocket receiver and non-Buffer payload throw `TypeError`, payloads over 125 bytes throw, and pinging a not-yet-open socket is a no-op

`bun bd test test/js/first_party/undici/undici.test.ts`: 14 pass, 0 fail. The pre-existing `undici-primordials.test.ts` also passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'ping' not found in module 'undici'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [2.77s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (6e906e468)

test/js/first_party/undici/undici.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'ping' not found in module 'undici'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [174.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [74.98ms]
(pass) undici > request > should error when body has already been consumed [18.13ms]
(pass) undici > request > should make a POST request when provided a body and POST method [17.54ms]
(pass) undici > request > should stream a node:stream Readable body [252.30ms]
(pass) undici > request > should accept a URL class object [11.14ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [12.35ms]
(pass) undici > request > a 204 has no body [55.50ms]
(pass) undici > request > the response to a HEAD request has no body [22.66ms]
(pass) undici > request > should allow a query string to be passed [20.83ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [19.09ms]
(pass) undici > request > should allow us to abort the request with a signal [533.38ms]
(pass) undici > req
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     139022da2b
  features     baseline

23 deps, 129 codegen, 1172 objects in 684ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] gen bindgenv2
[6/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/undici.js               |  51 ++++++++++-
 test/js/first_party/undici/undici.test.ts | 140 +++++++++++++++++++++++++++++-
 2 files changed, 189 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/thirdparty/undici.js                    7     13      0
test/js/first_party/undici/undici.test.ts      5     10      0
```

</details>

<!-- robobun:evidence:end -->