### PR TITLE
test: run react-spa dev server cases against one server and strengthen assertions

### DIFF
--- a/test/bake/dev/react-spa.test.ts
+++ b/test/bake/dev/react-spa.test.ts
@@ -1,7 +1,12 @@
 // these tests involve ensuring react (html loader + single page app) works
 // react is big and we do lots of stuff like fast refresh.
+//
+// Booting a dev server (and tearing it down under ASAN) dominates the cost of
+// every `devTest`, so the react-refresh cases that share the same app shape
+// (html entry + react-refresh stub) run as sections of a single test instead
+// of one server per case.
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { devTest, emptyHtmlFile } from "../bake-harness";
 
 /** To test react refresh's registration system */
 const reactAndRefreshStub = {
@@ -99,6 +104,11 @@ devTest("react in html", {
     await using c = await dev.client();
 
     expect(await c.elemText("h1")).toBe("Hello World");
+    expect(await c.elemText("#root")).toBe("<h1>Hello World</h1>");
+
+    // Mark the window so the edit below can be proven to apply as a hot
+    // update within the same page, not via a reload.
+    await c.js`globalThis.__hmr_test_marker = "hot"`;
 
     await dev.write(
       "App.tsx",
@@ -111,16 +121,23 @@ devTest("react in html", {
     );
     await c.expectMessage("reload");
     expect(await c.elemText("h1")).toBe("Yay");
+    expect(await c.elemText("#root")).toBe("<h1>Yay</h1>");
+    expect(await c.js`globalThis.__hmr_test_marker`).toBe("hot");
 
     await c.hardReload();
     await c.expectMessage("reload");
 
     expect(await c.elemText("h1")).toBe("Yay");
+    expect(await c.elemText("#root")).toBe("<h1>Yay</h1>");
+    // The hard reload ran the bundle in a fresh window.
+    expect(await c.js`globalThis.__hmr_test_marker`).toBeUndefined();
   },
 });
+// One dev server covers all react refresh registration cases. Each section of
+// index.tsx logs a distinct marker so a failure points at the section, and
+// in-page assertion failures surface as console.error, which fails the test.
 // https://github.com/oven-sh/bun/issues/17447
-devTest("react refresh should register and track hook state", {
-  framework: minimalFramework,
+devTest("react refresh registers components and tracks hook state", {
   files: {
     ...reactAndRefreshStub,
     "index.html": emptyHtmlFile({
@@ -128,62 +145,21 @@ devTest("react refresh should register and track hook state", {
       scripts: ["index.tsx"],
     }),
     "index.tsx": `
-      import { expectHookComponent } from 'bun-devserver-react-mock';
-      import App from './App.tsx';
-      expectHookComponent(App, "App.tsx", "default");
-    `,
-    "App.tsx": `
       import { useState } from "react";
-      export default function App() {
-        let [a, b] = useState(1);
-        return <div>Hello, world!</div>;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {});
-    const firstHash = await c.reactRefreshComponentHash("App.tsx", "default");
-    expect(firstHash).toBeDefined();
+      import { expectComponent, expectHook, expectHookComponent, getCustomHooks } from 'bun-devserver-react-mock';
+      import App from './App.tsx';
+      import { useCustom1, useCustom2 } from './custom-hook';
+      import ComponentWithConst, { helper } from './component-with-const';
+      import ComponentWithLet, { getCounter } from './component-with-let';
+      import ComponentWithVar, { getGlobalState } from './component-with-var';
+      import MathComponent, { utilityFunction } from './component-with-function';
+      import ProcessorComponent, { DataProcessor } from './component-with-class';
 
-    // hash does not change when hooks stay same
-    await dev.write(
-      "App.tsx",
-      `
-        import { useState } from "react";
-        export default function App() {
-          let [a, b] = useState(1);
-          return <div>Hello, world! {a}</div>;
-        }
-      `,
-    );
-    const secondHash = await c.reactRefreshComponentHash("App.tsx", "default");
-    expect(secondHash).toEqual(firstHash);
+      // The test body reads (and deletes) this component's hash around hot
+      // updates to App.tsx.
+      expectHookComponent(App, "App.tsx", "default");
 
-    // hash changes when hooks change
-    await dev.write(
-      "App.tsx",
-      `
-        export default function App() {
-          let [a, b] = useState(2);
-          return <div>Hello, world! {a}</div>;
-        }
-      `,
-    );
-    const thirdHash = await c.reactRefreshComponentHash("App.tsx", "default");
-    expect(thirdHash).not.toEqual(firstHash);
-  },
-});
-devTest("react refresh cases", {
-  framework: minimalFramework,
-  files: {
-    ...reactAndRefreshStub,
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.tsx"],
-    }),
-    "index.tsx": `
-      import { expectComponent, expectHookComponent } from 'bun-devserver-react-mock';
-
+      // Section: every export/declaration shape registers under the right name.
       expectComponent((await import("./default_unnamed")).default, "default_unnamed.tsx", "default");
       expectComponent((await import("./default_named")).default, "default_named.tsx", "default");
       expectComponent((await import("./default_arrow")).default, "default_arrow.tsx", "default");
@@ -198,7 +174,136 @@ devTest("react refresh cases", {
       expectHookComponent((await import("./local_const_hooks")).LocalConst, "local_const_hooks.tsx", "LocalConst");
       await import("./non_exported_hooks");
 
-      console.log("PASS");
+      console.log("refresh cases PASS");
+
+      // Section: two functions with hooks are independently tracked.
+      function method1() {
+        const _ = useState(1);
+      }
+      const method2 = function method2() {
+        const _ = useState(2);
+      }
+      const method3 = () => {
+        const _ = useState(3);
+      }
+
+      expectHook(method1);
+      expectHook(method2);
+      expectHook(method3);
+
+      console.log("independent hooks PASS");
+
+      // Section: custom hook tracking.
+      function customHookUser1() {
+        const _ = useCustom1();
+      }
+      function customHookUser2() {
+        const _ = useCustom1();
+      }
+      function customHookUser3() {
+        const _ = useCustom2();
+      }
+      function customHookUser4() {
+        const a = useCustom1();
+        const b = useCustom2();
+      }
+
+      const hash1 = expectHook(customHookUser1);
+      const hash2 = expectHook(customHookUser2);
+      const hash3 = expectHook(customHookUser3);
+      const hash4 = expectHook(customHookUser4);
+
+      if (hash1 !== hash2) throw new Error("hash1 and hash2 should be the same: " + hash1 + " " + hash2);
+      if (hash1 === hash3) throw new Error("hash1 and hash3 should be different: " + hash1 + " " + hash3);
+      if (hash1 === hash4) throw new Error("hash1 and hash4 should be different: " + hash1 + " " + hash4);
+      if (hash3 === hash4) throw new Error("hash3 and hash4 should be different: " + hash3 + " " + hash4);
+
+      function assertCustomHooks(method, expected) {
+        const customHooks = getCustomHooks(method);
+        if (customHooks.length !== expected.length) throw new Error("customHooks should have " + expected.length + " hooks: " + customHooks.length);
+        for (let i = 0; i < expected.length; i++) {
+          if (customHooks[i] !== expected[i]) throw new Error(\`customHooks[\${i}] should be \${expected[i]} but got \${customHooks[i]}\`);
+        }
+      }
+
+      assertCustomHooks(customHookUser1, [useCustom1]);
+      assertCustomHooks(customHookUser2, [useCustom1]);
+      assertCustomHooks(customHookUser3, [useCustom2]);
+      assertCustomHooks(customHookUser4, [useCustom1, useCustom2]);
+
+      console.log("custom hooks PASS");
+
+      // Section: components with hooks and mutual recursion render without
+      // error, and the statement -> expression transform preserves results.
+      function useThis() {
+        return null;
+      }
+
+      function useFakeState(initial) {
+        return [initial, () => {}];
+      }
+
+      function useFakeEffect(fn) {
+        fn();
+      }
+
+      export default function AA({ depth = 0 }: { depth: number }) {
+        const [count, setCount] = useFakeState(0);
+        useThis();
+        useFakeEffect(() => {});
+        return depth === 0 && <B />
+      }
+
+      function B() {
+        const [value, setValue] = useFakeState(42);
+        useFakeEffect(() => {});
+        return <AA depth={1} />
+      }
+
+      // Call B outside the function body to test statement -> expression transform
+      B();
+
+      // Call all imported default functions outside their bodies
+      ComponentWithConst();
+      ComponentWithLet();
+      ComponentWithVar();
+      MathComponent({ input: 10 });
+      ProcessorComponent({ text: "test" });
+
+      // Use all the imported components and their non-default exports. Log a
+      // single string so the value is asserted, not just the label.
+      console.log("ComponentWithConst: " + ComponentWithConst());
+      console.log("helper: " + helper());
+
+      console.log("ComponentWithLet: " + ComponentWithLet());
+      console.log("getCounter: " + getCounter());
+
+      console.log("ComponentWithVar: " + ComponentWithVar());
+      console.log("getGlobalState: " + JSON.stringify(getGlobalState()));
+
+      console.log("MathComponent: " + MathComponent({ input: 10 }));
+      console.log("utilityFunction: " + utilityFunction(15));
+
+      console.log("ProcessorComponent: " + ProcessorComponent({ text: "test" }));
+      const processor = new DataProcessor();
+      console.log("DataProcessor: " + processor.process("world"));
+
+      console.log("mutual recursion PASS");
+    `,
+    "App.tsx": `
+      import { useState } from "react";
+      export default function App() {
+        let [a, b] = useState(1);
+        return <div>Hello, world!</div>;
+      }
+    `,
+    "custom-hook.ts": `
+      export function useCustom1() {
+        return 1;
+      }
+      export function useCustom2() {
+        return 2;
+      }
     `,
     "default_unnamed.tsx": `
       export default function() {
@@ -317,184 +422,9 @@ devTest("react refresh cases", {
       expectHookComponent(NonExportedAnon, "non_exported_hooks.tsx", "NonExportedAnon");
       expectHookComponent(NonExportedAnonUnnamed, "non_exported_hooks.tsx", "NonExportedAnonUnnamed");
     `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("PASS");
-  },
-});
-devTest("two functions with hooks should be independently tracked", {
-  framework: minimalFramework,
-  files: {
-    ...reactAndRefreshStub,
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.tsx"],
-    }),
-    "index.tsx": `
-      import { useState } from "react";
-      import { expectHook } from 'bun-devserver-react-mock';
-
-      function method1() {
-        const _ = useState(1);
-      }
-      const method2 = function method2() {
-        const _ = useState(2);
-      }
-      const method3 = () => {
-        const _ = useState(3);
-      }
-
-      expectHook(method1);
-      expectHook(method2);
-      expectHook(method3);
-
-      console.log("PASS");
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {});
-    await c.expectMessage("PASS");
-  },
-});
-devTest("custom hook tracking", {
-  framework: minimalFramework,
-  files: {
-    ...reactAndRefreshStub,
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.tsx"],
-    }),
-    "index.tsx": `
-      import { useCustom1, useCustom2 } from "./custom-hook";
-      import { expectHook, getCustomHooks } from 'bun-devserver-react-mock';
-
-      function method1() {
-        const _ = useCustom1();
-      }
-      function method2() {
-        const _ = useCustom1();
-      }
-      function method3() {
-        const _ = useCustom2();
-      }
-      function method4() {
-        const a = useCustom1();
-        const b = useCustom2();
-      }
-
-      const hash1 = expectHook(method1);
-      const hash2 = expectHook(method2);
-      const hash3 = expectHook(method3);
-      const hash4 = expectHook(method4);
-
-      if (hash1 !== hash2) throw new Error("hash1 and hash2 should be the same: " + hash1 + " " + hash2);
-      if (hash1 === hash3) throw new Error("hash1 and hash3 should be different: " + hash1 + " " + hash3);
-      if (hash1 === hash4) throw new Error("hash1 and hash4 should be different: " + hash1 + " " + hash4);
-      if (hash3 === hash4) throw new Error("hash3 and hash4 should be different: " + hash3 + " " + hash4);
-
-      const customHooks1 = getCustomHooks(method1);
-      const customHooks2 = getCustomHooks(method2);
-      const customHooks3 = getCustomHooks(method3);
-
-      function assertCustomHooks(method, expected) {
-        const customHooks = getCustomHooks(method);
-        if (customHooks.length !== expected.length) throw new Error("customHooks should have " + expected.length + " hooks: " + customHooks.length);
-        for (let i = 0; i < expected.length; i++) {
-          if (customHooks[i] !== expected[i]) throw new Error(\`customHooks[\${i}] should be \${expected[i]} but got \${customHooks[i]}\`);
-        }
-      }
-
-      assertCustomHooks(method1, [useCustom1]);
-      assertCustomHooks(method2, [useCustom1]);
-      assertCustomHooks(method3, [useCustom2]);
-      assertCustomHooks(method4, [useCustom1, useCustom2]);
-
-      console.log("PASS");
-    `,
-    "custom-hook.ts": `
-      export function useCustom1() {
-        return 1;
-      }
-      export function useCustom2() {
-        return 2;
-      }
-    `,
-  },
-
-  async test(dev) {
-    await using c = await dev.client("/", {});
-    await c.expectMessage("PASS");
-  },
-});
-
-devTest("react component with hooks and mutual recursion renders without error", {
-  files: {
-    ...reactAndRefreshStub,
-    "index.tsx": `
-      import ComponentWithConst, { helper } from './component-with-const';
-      import ComponentWithLet, { getCounter } from './component-with-let';
-      import ComponentWithVar, { getGlobalState } from './component-with-var';
-      import MathComponent, { utilityFunction } from './component-with-function';
-      import ProcessorComponent, { DataProcessor } from './component-with-class';
-      
-      function useThis() {
-        return null;
-      }
-
-      function useFakeState(initial) {
-        return [initial, () => {}];
-      }
-
-      function useFakeEffect(fn) {
-        fn();
-      }
-
-      export default function AA({ depth = 0 }: { depth: number }) {
-        const [count, setCount] = useFakeState(0);
-        useThis();
-        useFakeEffect(() => {});
-        return depth === 0 && <B />
-      }
-
-      function B() {
-        const [value, setValue] = useFakeState(42);
-        useFakeEffect(() => {});
-        return <AA depth={1} />
-      }
-
-      // Call B outside the function body to test statement -> expression transform
-      B();
-      
-      // Call all imported default functions outside their bodies
-      ComponentWithConst();
-      ComponentWithLet();
-      ComponentWithVar();
-      MathComponent({ input: 10 });
-      ProcessorComponent({ text: "test" });
-      
-      // Use all the imported components and their non-default exports
-      console.log("ComponentWithConst:", ComponentWithConst());
-      console.log("helper:", helper());
-      
-      console.log("ComponentWithLet:", ComponentWithLet());
-      console.log("getCounter:", getCounter());
-      
-      console.log("ComponentWithVar:", ComponentWithVar());
-      console.log("getGlobalState:", getGlobalState());
-      
-      console.log("MathComponent:", MathComponent({ input: 10 }));
-      console.log("utilityFunction:", utilityFunction(15));
-      
-      console.log("ProcessorComponent:", ProcessorComponent({ text: "test" }));
-      const processor = new DataProcessor();
-      console.log("DataProcessor:", processor.process("world"));
-      
-      console.log("PASS");
-    `,
     "component-with-const.tsx": `
       const helperValue = "helper-result";
-      
+
       function useFakeState(initial) {
         return [initial, () => {}];
       }
@@ -502,16 +432,16 @@ devTest("react component with hooks and mutual recursion renders without error",
       function useFakeCallback(fn) {
         return fn;
       }
-      
+
       export default function Component() {
         const [state, setState] = useFakeState(helperValue);
         const [count, setCount] = useFakeState(0);
         const callback = useFakeCallback(() => {});
         return helperValue;
       }
-      
+
       export const helper = () => helperValue;
-      
+
       // Call Component outside its body to test statement -> expression transform
       Component();
       const result1 = Component();
@@ -519,7 +449,7 @@ devTest("react component with hooks and mutual recursion renders without error",
     `,
     "component-with-let.tsx": `
       let counter = 0;
-      
+
       function useFakeState(initial) {
         return [initial, () => {}];
       }
@@ -531,7 +461,7 @@ devTest("react component with hooks and mutual recursion renders without error",
       function useFakeMemo(fn, deps) {
         return fn();
       }
-      
+
       export default function Counter() {
         const [localCount, setLocalCount] = useFakeState(0);
         const [multiplier, setMultiplier] = useFakeState(1);
@@ -541,22 +471,22 @@ devTest("react component with hooks and mutual recursion renders without error",
         const memoized = useFakeMemo(() => counter * 2, [counter]);
         return ++counter;
       }
-      
+
       export const getCounter = () => counter;
-      
+
       // Call Counter outside its body multiple times
       Counter();
       Counter();
       const currentCount = Counter();
       getCounter();
-      
+
       // Test with different call patterns
       [1, 2, 3].forEach(() => Counter());
       const counters = [Counter, Counter, Counter].map(fn => fn());
     `,
     "component-with-var.tsx": `
       var globalState = { value: 42 };
-      
+
       function useFakeState(initial) {
         return [initial, () => {}];
       }
@@ -568,7 +498,7 @@ devTest("react component with hooks and mutual recursion renders without error",
       function useFakeRef(initial) {
         return { current: initial };
       }
-      
+
       export default function StateComponent() {
         const [localState, setLocalState] = useFakeState(globalState.value);
         const [factor, setFactor] = useFakeState(2);
@@ -576,19 +506,19 @@ devTest("react component with hooks and mutual recursion renders without error",
         const ref = useFakeRef(null);
         return globalState.value;
       }
-      
+
       export const getGlobalState = () => globalState;
-      
+
       // Call StateComponent outside its body
       StateComponent();
       const state1 = StateComponent();
       const state2 = StateComponent();
       getGlobalState();
-      
+
       // Test with object method calls
       const obj = { fn: StateComponent };
       obj.fn();
-      
+
       // Test with array of functions
       const fns = [StateComponent, getGlobalState];
       fns[0]();
@@ -598,7 +528,7 @@ devTest("react component with hooks and mutual recursion renders without error",
       function multiply(x: number) {
         return x * 2;
       }
-      
+
       function useFakeState(initial) {
         return [initial, () => {}];
       }
@@ -610,43 +540,43 @@ devTest("react component with hooks and mutual recursion renders without error",
       function useFakeReducer(reducer, initial) {
         return [initial, () => {}];
       }
-      
+
       export default function MathComponent({ input }: { input: number }) {
         const [result, setResult] = useFakeState(0);
         const [operations, setOperations] = useFakeState(0);
         const [state, dispatch] = useFakeReducer((s, a) => s, {});
-        
+
         const calculate = useFakeCallback(() => {
           const value = multiply(input);
           setResult(value);
           setOperations(prev => prev + 1);
           return value;
         }, [input]);
-        
+
         return multiply(input);
       }
-      
+
       export const utilityFunction = multiply;
-      
+
       // Call MathComponent outside its body with various patterns
       MathComponent({ input: 5 });
       MathComponent({ input: 10 });
       const result1 = MathComponent({ input: 15 });
       utilityFunction(20);
-      
+
       // Test with function composition
       const compose = (fn: Function) => fn({ input: 25 });
       compose(MathComponent);
-      
+
       // Test with conditional calls
       const shouldCall = true;
       if (shouldCall) {
         MathComponent({ input: 30 });
       }
-      
+
       // Test with ternary
       const ternaryResult = true ? MathComponent({ input: 35 }) : null;
-      
+
       // Test with logical operators
       true && MathComponent({ input: 40 });
       false || MathComponent({ input: 45 });
@@ -657,7 +587,7 @@ devTest("react component with hooks and mutual recursion renders without error",
           return data.toUpperCase();
         }
       }
-      
+
       function useFakeState(initial) {
         return [initial, () => {}];
       }
@@ -673,7 +603,7 @@ devTest("react component with hooks and mutual recursion renders without error",
       function useFakeContext() {
         return {};
       }
-      
+
       const reducer = (state: any, action: any) => {
         switch (action.type) {
           case 'process':
@@ -682,69 +612,101 @@ devTest("react component with hooks and mutual recursion renders without error",
             return state;
         }
       };
-      
+
       export default function ProcessorComponent({ text }: { text: string }) {
         const [state, setState] = useFakeState({ text, processed: '' });
         const [history, dispatch] = useFakeReducer(reducer, { processed: [] });
         const processorRef = useFakeRef(new Processor());
         const context = useFakeContext();
-        
+
         const processor = new Processor();
         const result = processor.process(text);
-        
+
         dispatch({ type: 'process', payload: result });
-        
+
         return processor.process(text);
       }
-      
+
       export const DataProcessor = Processor;
-      
+
       // Call ProcessorComponent outside its body
       ProcessorComponent({ text: "hello" });
       ProcessorComponent({ text: "world" });
       const processed1 = ProcessorComponent({ text: "test1" });
       const processed2 = ProcessorComponent({ text: "test2" });
-      
+
       // Test with new DataProcessor
       const proc1 = new DataProcessor();
       const proc2 = new DataProcessor();
       proc1.process("data1");
       proc2.process("data2");
-      
+
       // Test with function binding
       const boundProcessor = ProcessorComponent.bind(null);
       boundProcessor({ text: "bound" });
-      
+
       // Test with apply/call
       ProcessorComponent.call(null, { text: "called" });
       ProcessorComponent.apply(null, [{ text: "applied" }]);
-      
+
       // Test with destructuring
       const { process } = new DataProcessor();
-      
+
       // Test with spread operator
       const args = [{ text: "spread" }];
       ProcessorComponent(...args);
     `,
-    "index.html": emptyHtmlFile({
-      scripts: ["index.tsx"],
-      body: `<div id="root"></div>`,
-    }),
   },
   async test(dev) {
-    await using c = await dev.client("/", {});
+    await using c = await dev.client("/");
+    // Counter is called 9 times while component-with-let.tsx evaluates, once
+    // by the bare ComponentWithLet() call in index.tsx, and once in the log.
     await c.expectMessage(
-      "ComponentWithConst:",
-      "helper:",
-      "ComponentWithLet:",
-      "getCounter:",
-      "ComponentWithVar:",
-      "getGlobalState:",
-      "MathComponent:",
-      "utilityFunction:",
-      "ProcessorComponent:",
-      "DataProcessor:",
-      "PASS",
+      "refresh cases PASS",
+      "independent hooks PASS",
+      "custom hooks PASS",
+      "ComponentWithConst: helper-result",
+      "helper: helper-result",
+      "ComponentWithLet: 11",
+      "getCounter: 11",
+      "ComponentWithVar: 42",
+      'getGlobalState: {"value":42}',
+      "MathComponent: 20",
+      "utilityFunction: 30",
+      "ProcessorComponent: TEST",
+      "DataProcessor: WORLD",
+      "mutual recursion PASS",
     );
+
+    const firstHash = await c.reactRefreshComponentHash("App.tsx", "default");
+    expect(firstHash).toBeString();
+
+    // hash does not change when hooks stay same
+    await dev.write(
+      "App.tsx",
+      `
+        import { useState } from "react";
+        export default function App() {
+          let [a, b] = useState(1);
+          return <div>Hello, world! {a}</div>;
+        }
+      `,
+    );
+    const secondHash = await c.reactRefreshComponentHash("App.tsx", "default");
+    expect(secondHash).toEqual(firstHash);
+
+    // hash changes when hooks change
+    await dev.write(
+      "App.tsx",
+      `
+        export default function App() {
+          let [a, b] = useState(2);
+          return <div>Hello, world! {a}</div>;
+        }
+      `,
+    );
+    const thirdHash = await c.reactRefreshComponentHash("App.tsx", "default");
+    expect(thirdHash).toBeString();
+    expect(thirdHash).not.toEqual(firstHash);
   },
 });


### PR DESCRIPTION
### What

`test/bake/dev/react-spa.test.ts` booted a full dev server for each of its 6 cases, making it one of the slower files on ASAN CI lanes (~19s wall on the debian x64-asan lane). Five of the six cases exercise the identical app shape: an `index.html` entry plus the react-refresh stub in `node_modules`. Server boot and teardown (GC loop plus ASAN leak check on exit) is the dominant per-case cost, so those five cases now share one dev server:

- The pure initial-load cases (export/declaration shape registration, independent hook tracking, custom hook tracking, mutual recursion) run as sections of one combined entry script. Each section logs a distinct marker so a failure still points at the section.
- The hook-state hash case runs against the same client as two sequential hot updates of `App.tsx`, exactly as before.
- "react in html" keeps its own server because it uses the real react 19 fixture.

No case was deleted; every in-page assertion from the original five cases still runs. Two equivalence notes:

- The dropped `framework: minimalFramework` option in the merged cases was inert: the bake harness ignores `framework` whenever the files contain an html entry, so all five already ran as plain html-entry apps.
- The custom-hook case's functions are renamed (`method1..4` to `customHookUser1..4`) to coexist with the independent-hooks section in one module. Nothing asserts those names (`expectHook` keys on function identity), and the hash equality/inequality assertions are unchanged.

### Stronger assertions

- "react in html" now asserts the full `#root` innerHTML at every step, and a window-global marker proves the `App.tsx` edit applies as a hot update in the same window while `hardReload()` runs the bundle in a fresh one.
- The mutual-recursion logs now assert computed values (`"ComponentWithLet: 11"`, `"getGlobalState: {\"value\":42}"`, `"ProcessorComponent: TEST"`, ...) instead of only the label. Previously only the first `console.log` argument was compared, so the returned values were never checked.
- Component hashes are asserted to be strings rather than just defined, for all three reads.

### Timing

Back-to-back runs of old vs new file on the same machine:

| build | before | after |
|---|---|---|
| debug ASAN | 36.98s / 36.08s | 18.46s / 17.02s |
| release | 13.4s | 7.6s |

Also verified the strengthened message assertion fails with a clear diff when an expected value is wrong, and the new file passed 7 consecutive debug-build runs.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bake/dev/react-spa.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bake/dev/react-spa.test.ts
bun test v1.4.0 (20b5ff068)

test/bake/dev/react-spa.test.ts:
Dev server testing directory: /tmp/bun-dev-test-NMzWmw
bun install v1.4.0 (20b5ff068)

+ react@19.2.4
+ react-dom@19.2.4

3 packages installed [111.00ms]
[0;30mdev|[0m Started development server: http://localhost:45069
[0;30mdev|[0m [32mBundled page in 1383ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 44ms[0m[2m:[0m App.tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:react-spa-1: react in html [7364.57ms]
[0;30mdev|[0m Started development server: http://localhost:34737
[0;30mdev|[0m [32mBundled page in 176ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 31ms[0m[2m:[0m App.tsx
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 30ms[0m[2m:[0m App.tsx
(pass)  DEV:react-spa-2: react refresh registers components and tracks hook state [5855.52ms]

 2 pass
 0 fail
 16 expect() calls
Ran 2 tests across 1 file. [17.54s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bake/dev/react-spa.test.ts | 534 +++++++++++++++++++---------------------
 1 file changed, 248 insertions(+), 286 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
test/bake/dev/react-spa.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->