### PR TITLE
test: speed up ws-syscall-fault.test.ts and make its assertions exact

### DIFF
--- a/test/js/first_party/ws/ws-syscall-fault.test.ts
+++ b/test/js/first_party/ws/ws-syscall-fault.test.ts
@@ -1,109 +1,169 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
+import { WebSocketServer } from "ws";
 
 const skip = !fault.available() || isWindows;
 
 // The 'ws' module in Bun is a thirdparty shim over the native WebSocket
 // client/server. These tests verify the shim's event surface (on('message'),
 // on('error'), on('close')) under transport faults.
+//
+// Fixtures print one JSON line per completed scenario ({ scenario, ...result })
+// so a crash mid-fixture still attributes to the scenario that was running.
 
 async function runWsFixture(body: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", body],
-    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+    env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { ...JSON.parse(stdout.trim() || "{}"), stderr, exitCode, signal: proc.signalCode };
+  const scenarios: Record<string, unknown> = {};
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const { scenario, ...result } = JSON.parse(line);
+      scenarios[scenario] = result;
+    } catch {
+      // A half-written line means the fixture died mid-print; the stderr,
+      // exitCode and signal assertions report what happened.
+    }
+  }
+  return { scenarios, stderr, exitCode, signal: proc.signalCode };
 }
 
-describe.skipIf(skip)("ws (thirdparty) under injected syscall faults", () => {
-  test("recv → short reads (1 byte) deliver complete echoed message", async () => {
-    const r = await runWsFixture(/* js */ `
-      const { WebSocketServer, WebSocket } = require("ws");
-      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
-      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-      wss.on("connection", ws => ws.on("message", m => ws.send(m)));
-      wss.on("listening", () => {
-        fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
-        const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
-        c.on("open", () => c.send("hello-ws"));
-        c.on("message", m => {
-          console.log(JSON.stringify({ ok: true, data: m.toString() }));
-          c.close();
-        });
-        c.on("close", () => { fault.clear(); wss.close(() => process.exit(0)); });
-        c.on("error", () => console.log(JSON.stringify({ ok: false })));
+// Process startup dominates each subprocess (~2s in a debug build, vs ~100ms
+// for a faulted round trip), so both short-I/O scenarios run sequentially in
+// ONE subprocess: fault rules are process-global, armed after the scenario's
+// server is listening (so the handshake is faulted too) and cleared before the
+// next scenario. Lazily started so the describe-level skip spawns nothing.
+let shortIoResult: ReturnType<typeof runWsFixture> | undefined;
+const shortIoFixture = () =>
+  (shortIoResult ??= runWsFixture(/* js */ `
+    const { WebSocketServer, WebSocket } = require("ws");
+    const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+
+    function listen(onConnection) {
+      return new Promise(resolve => {
+        const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+        wss.on("connection", onConnection);
+        wss.on("listening", () => resolve(wss));
       });
-    `);
-    expect(r).toMatchObject({ ok: true, data: "hello-ws", signal: null, exitCode: 0 });
+    }
+
+    async function scenario(name, rule, onConnection, drive) {
+      const wss = await listen(onConnection);
+      fault.set(rule);
+      try {
+        const result = await drive("ws://127.0.0.1:" + wss.address().port);
+        console.log(JSON.stringify({ scenario: name, ...result }));
+      } finally {
+        fault.clear();
+        await new Promise(resolve => wss.close(resolve));
+      }
+    }
+
+    await scenario(
+      "recv-short",
+      { syscall: "recv", action: "short", bytes: 1, repeat: -1 },
+      ws => ws.on("message", m => ws.send(m)),
+      url =>
+        new Promise(resolve => {
+          const c = new WebSocket(url);
+          let data = null;
+          c.on("open", () => c.send("hello-ws"));
+          c.on("message", m => { data = m.toString(); c.close(); });
+          c.on("close", (code, reason, wasClean) => resolve({ data, code, wasClean }));
+          c.on("error", e => resolve({ error: e.message }));
+        }),
+    );
+
+    await scenario(
+      "send-short",
+      { syscall: "send", action: "short", bytes: 1, repeat: -1 },
+      ws => {
+        ws.on("message", m => ws.send(m));
+        ws.on("ping", () => {});
+      },
+      url =>
+        new Promise(resolve => {
+          const c = new WebSocket(url);
+          // Close only once BOTH the echo and the pong have arrived: 'pong' is
+          // a separate event with no ordering guarantee relative to 'message'.
+          let pong = false, echoed = null;
+          const maybeClose = () => { if (pong && echoed) c.close(); };
+          // 1024 > 125 forces the 2-byte extended-length frame header, so the
+          // length bytes themselves are also split across 1-byte writes.
+          c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
+          c.on("pong", () => { pong = true; maybeClose(); });
+          c.on("message", m => { echoed = m; maybeClose(); });
+          c.on("close", (code, reason, wasClean) =>
+            resolve({
+              pong,
+              len: echoed ? echoed.length : -1,
+              intact: !!echoed && echoed.every(b => b === 0x77),
+              code,
+              wasClean,
+            }),
+          );
+          c.on("error", e => resolve({ error: e.message }));
+        }),
+    );
+
+    process.exit(0);
+  `));
+
+describe.concurrent.skipIf(skip)("ws (thirdparty) under injected syscall faults", () => {
+  test("recv → short reads (1 byte) deliver complete echoed message", async () => {
+    const { scenarios, ...outcome } = await shortIoFixture();
+    expect(outcome).toEqual({ stderr: "", exitCode: 0, signal: null });
+    expect(scenarios["recv-short"]).toEqual({ data: "hello-ws", code: 1000, wasClean: true });
   });
 
   test("send → short writes (1 byte) deliver complete message and ping/pong round-trips", async () => {
-    const r = await runWsFixture(/* js */ `
-      const { WebSocketServer, WebSocket } = require("ws");
-      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
-      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-      wss.on("connection", ws => {
-        ws.on("message", m => ws.send(m));
-        ws.on("ping", () => {});
-      });
-      wss.on("listening", () => {
-        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
-        const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
-        // Report only once BOTH the echo and the pong have arrived: 'pong' is
-        // a separate event with no ordering guarantee relative to 'message'.
-        let pong = false, echoed = null;
-        const report = () => {
-          if (!pong || !echoed) return;
-          console.log(JSON.stringify({ ok: true, len: echoed.length, pong }));
-          c.close();
-        };
-        c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
-        c.on("pong", () => { pong = true; report(); });
-        c.on("message", m => { echoed = m; report(); });
-        c.on("close", () => { fault.clear(); wss.close(() => process.exit(0)); });
-        c.on("error", () => console.log(JSON.stringify({ ok: false })));
-      });
-    `);
-    expect(r).toMatchObject({ ok: true, len: 1024, pong: true, signal: null, exitCode: 0 });
+    const { scenarios, ...outcome } = await shortIoFixture();
+    expect(outcome).toEqual({ stderr: "", exitCode: 0, signal: null });
+    expect(scenarios["send-short"]).toEqual({ pong: true, len: 1024, intact: true, code: 1000, wasClean: true });
   });
 
-  test("recv → ECONNRESET fires 'close' with abnormal code (split-process)", async () => {
+  test("recv → ECONNRESET fires 'error' then 'close' with abnormal code (split-process)", async () => {
     // Server runs in this process (no fault); client runs in a subprocess so
     // the process-global recv rule only affects the client side.
-    const { WebSocketServer } = require("ws");
     const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-    wss.on("connection", (ws: import("ws").WebSocket) => {
+    wss.on("connection", ws => {
       ws.on("error", () => {});
       ws.send("x");
     });
     await new Promise<void>(r => wss.on("listening", () => r()));
     const port = (wss.address() as import("node:net").AddressInfo).port;
     try {
-      const r = await runWsFixture(/* js */ `
+      const { scenarios, ...outcome } = await runWsFixture(/* js */ `
         const { WebSocket } = require("ws");
         const { socketFaultInjection: fault } = require("bun:internal-for-testing");
-        // Arm before connecting so the upgrade-response recv fails — that
-        // exercises the same close(1006) path without depending on the
-        // server to send a frame after 'open' (which races the arm).
+        // Arm before connecting so the upgrade-response recv fails: that
+        // exercises the close(1006) path without depending on the server to
+        // send a frame after 'open' (which would race the arm).
         fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
         const c = new WebSocket("ws://127.0.0.1:${port}");
-        let errored = false;
+        let errorMessage = null;
         c.on("open", () => {});
-        c.on("error", () => { errored = true; });
-        c.on("close", code => {
-          console.log(JSON.stringify({ ok: true, errored, code }));
+        c.on("error", e => { errorMessage = e.message; });
+        c.on("close", (code, reason, wasClean) => {
+          // errorMessage being set here proves 'error' fired before 'close'.
+          console.log(JSON.stringify({ scenario: "recv-econnreset", errorMessage, code, reason, wasClean }));
           fault.clear();
           process.exit(0);
         });
       `);
-      expect(r.signal).toBeNull();
-      expect(r.ok).toBe(true);
-      expect(r.code).toBe(1006);
-      expect(r.errored).toBe(true);
+      expect(outcome).toEqual({ stderr: "", exitCode: 0, signal: null });
+      expect(scenarios["recv-econnreset"]).toEqual({
+        errorMessage: `WebSocket connection to 'ws://127.0.0.1:${port}/' failed: Connection ended`,
+        code: 1006,
+        reason: "Connection ended",
+        wasClean: false,
+      });
     } finally {
       await new Promise<void>(r => wss.close(() => r()));
     }

--- a/test/js/first_party/ws/ws-syscall-fault.test.ts
+++ b/test/js/first_party/ws/ws-syscall-fault.test.ts
@@ -9,8 +9,12 @@ const skip = !fault.available() || isWindows;
 // client/server. These tests verify the shim's event surface (on('message'),
 // on('error'), on('close')) under transport faults.
 //
-// Fixtures print one JSON line per completed scenario ({ scenario, ...result })
-// so a crash mid-fixture still attributes to the scenario that was running.
+// One subprocess per test, because fault rules are process-global. Each
+// fixture reports exactly once via report(): the scenario result, the first
+// 'error' event, or a 30s watchdog carrying the partial state the scenario
+// wedged at. The watchdog only fires when the test has already failed; it
+// exists so a wedged faulted socket produces an attributable toEqual diff and
+// a dead subprocess instead of a bare test timeout and an orphaned process.
 
 async function runWsFixture(body: string) {
   await using proc = Bun.spawn({
@@ -20,112 +24,86 @@ async function runWsFixture(body: string) {
     stdout: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const scenarios: Record<string, unknown> = {};
-  for (const line of stdout.split("\n")) {
-    if (!line.trim()) continue;
-    try {
-      const { scenario, ...result } = JSON.parse(line);
-      scenarios[scenario] = result;
-    } catch {
-      // A half-written line means the fixture died mid-print; the stderr,
-      // exitCode and signal assertions report what happened.
-    }
+  let result: Record<string, unknown>;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    // Missing or half-written result line: put the raw stdout in the diff
+    // next to stderr/exitCode/signal.
+    result = { stdout };
   }
-  return { scenarios, stderr, exitCode, signal: proc.signalCode };
+  return { ...result, stderr, exitCode, signal: proc.signalCode };
 }
-
-// Process startup dominates each subprocess (~2s in a debug build, vs ~100ms
-// for a faulted round trip), so both short-I/O scenarios run sequentially in
-// ONE subprocess: fault rules are process-global, armed after the scenario's
-// server is listening (so the handshake is faulted too) and cleared before the
-// next scenario. Lazily started so the describe-level skip spawns nothing.
-let shortIoResult: ReturnType<typeof runWsFixture> | undefined;
-const shortIoFixture = () =>
-  (shortIoResult ??= runWsFixture(/* js */ `
-    const { WebSocketServer, WebSocket } = require("ws");
-    const { socketFaultInjection: fault } = require("bun:internal-for-testing");
-
-    function listen(onConnection) {
-      return new Promise(resolve => {
-        const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
-        wss.on("connection", onConnection);
-        wss.on("listening", () => resolve(wss));
-      });
-    }
-
-    async function scenario(name, rule, onConnection, drive) {
-      const wss = await listen(onConnection);
-      fault.set(rule);
-      try {
-        const result = await drive("ws://127.0.0.1:" + wss.address().port);
-        console.log(JSON.stringify({ scenario: name, ...result }));
-      } finally {
-        fault.clear();
-        await new Promise(resolve => wss.close(resolve));
-      }
-    }
-
-    await scenario(
-      "recv-short",
-      { syscall: "recv", action: "short", bytes: 1, repeat: -1 },
-      ws => ws.on("message", m => ws.send(m)),
-      url =>
-        new Promise(resolve => {
-          const c = new WebSocket(url);
-          let data = null;
-          c.on("open", () => c.send("hello-ws"));
-          c.on("message", m => { data = m.toString(); c.close(); });
-          c.on("close", (code, reason, wasClean) => resolve({ data, code, wasClean }));
-          c.on("error", e => resolve({ error: e.message }));
-        }),
-    );
-
-    await scenario(
-      "send-short",
-      { syscall: "send", action: "short", bytes: 1, repeat: -1 },
-      ws => {
-        ws.on("message", m => ws.send(m));
-        ws.on("ping", () => {});
-      },
-      url =>
-        new Promise(resolve => {
-          const c = new WebSocket(url);
-          // Close only once BOTH the echo and the pong have arrived: 'pong' is
-          // a separate event with no ordering guarantee relative to 'message'.
-          let pong = false, echoed = null;
-          const maybeClose = () => { if (pong && echoed) c.close(); };
-          // 1024 > 125 forces the 2-byte extended-length frame header, so the
-          // length bytes themselves are also split across 1-byte writes.
-          c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
-          c.on("pong", () => { pong = true; maybeClose(); });
-          c.on("message", m => { echoed = m; maybeClose(); });
-          c.on("close", (code, reason, wasClean) =>
-            resolve({
-              pong,
-              len: echoed ? echoed.length : -1,
-              intact: !!echoed && echoed.every(b => b === 0x77),
-              code,
-              wasClean,
-            }),
-          );
-          c.on("error", e => resolve({ error: e.message }));
-        }),
-    );
-
-    process.exit(0);
-  `));
 
 describe.concurrent.skipIf(skip)("ws (thirdparty) under injected syscall faults", () => {
   test("recv → short reads (1 byte) deliver complete echoed message", async () => {
-    const { scenarios, ...outcome } = await shortIoFixture();
-    expect(outcome).toEqual({ stderr: "", exitCode: 0, signal: null });
-    expect(scenarios["recv-short"]).toEqual({ data: "hello-ws", code: 1000, wasClean: true });
+    const r = await runWsFixture(/* js */ `
+      const { WebSocketServer, WebSocket } = require("ws");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const report = r => { console.log(JSON.stringify(r)); process.exit(0); };
+      let opened = false, data = null;
+      setTimeout(() => report({ error: "timed out", opened, data }), 30_000);
+      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      wss.on("connection", ws => ws.on("message", m => ws.send(m)));
+      wss.on("listening", () => {
+        // Armed before the client connects, so the upgrade handshake is also
+        // read 1 byte at a time.
+        fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+        const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
+        c.on("open", () => { opened = true; c.send("hello-ws"); });
+        c.on("message", m => { data = m.toString(); c.close(); });
+        c.on("close", (code, reason, wasClean) => report({ data, code, wasClean }));
+        c.on("error", e => report({ error: e.message }));
+      });
+    `);
+    expect(r).toEqual({ data: "hello-ws", code: 1000, wasClean: true, stderr: "", exitCode: 0, signal: null });
   });
 
   test("send → short writes (1 byte) deliver complete message and ping/pong round-trips", async () => {
-    const { scenarios, ...outcome } = await shortIoFixture();
-    expect(outcome).toEqual({ stderr: "", exitCode: 0, signal: null });
-    expect(scenarios["send-short"]).toEqual({ pong: true, len: 1024, intact: true, code: 1000, wasClean: true });
+    const r = await runWsFixture(/* js */ `
+      const { WebSocketServer, WebSocket } = require("ws");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const report = r => { console.log(JSON.stringify(r)); process.exit(0); };
+      let pong = false, echoed = null;
+      setTimeout(() => report({ error: "timed out", pong, echoedBytes: echoed ? echoed.length : null }), 30_000);
+      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      wss.on("connection", ws => {
+        ws.on("message", m => ws.send(m));
+        ws.on("ping", () => {});
+      });
+      wss.on("listening", () => {
+        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+        const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
+        // Close only once BOTH the echo and the pong have arrived: 'pong' is
+        // a separate event with no ordering guarantee relative to 'message'.
+        const maybeClose = () => { if (pong && echoed) c.close(); };
+        // 1024 > 125 forces the 2-byte extended-length frame header, so the
+        // length bytes themselves are also split across 1-byte writes.
+        c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
+        c.on("pong", () => { pong = true; maybeClose(); });
+        c.on("message", m => { echoed = m; maybeClose(); });
+        c.on("close", (code, reason, wasClean) =>
+          report({
+            pong,
+            len: echoed ? echoed.length : -1,
+            intact: !!echoed && echoed.every(b => b === 0x77),
+            code,
+            wasClean,
+          }),
+        );
+        c.on("error", e => report({ error: e.message }));
+      });
+    `);
+    expect(r).toEqual({
+      pong: true,
+      len: 1024,
+      intact: true,
+      code: 1000,
+      wasClean: true,
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
   });
 
   test("recv → ECONNRESET fires 'error' then 'close' with abnormal code (split-process)", async () => {
@@ -139,30 +117,31 @@ describe.concurrent.skipIf(skip)("ws (thirdparty) under injected syscall faults"
     await new Promise<void>(r => wss.on("listening", () => r()));
     const port = (wss.address() as import("node:net").AddressInfo).port;
     try {
-      const { scenarios, ...outcome } = await runWsFixture(/* js */ `
+      const r = await runWsFixture(/* js */ `
         const { WebSocket } = require("ws");
         const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const report = r => { console.log(JSON.stringify(r)); process.exit(0); };
+        let errorMessage = null;
+        setTimeout(() => report({ error: "timed out", errorMessage }), 30_000);
         // Arm before connecting so the upgrade-response recv fails: that
         // exercises the close(1006) path without depending on the server to
         // send a frame after 'open' (which would race the arm).
         fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
         const c = new WebSocket("ws://127.0.0.1:${port}");
-        let errorMessage = null;
         c.on("open", () => {});
         c.on("error", e => { errorMessage = e.message; });
-        c.on("close", (code, reason, wasClean) => {
-          // errorMessage being set here proves 'error' fired before 'close'.
-          console.log(JSON.stringify({ scenario: "recv-econnreset", errorMessage, code, reason, wasClean }));
-          fault.clear();
-          process.exit(0);
-        });
+        // errorMessage being set by the time 'close' fires proves 'error'
+        // fired before 'close'.
+        c.on("close", (code, reason, wasClean) => report({ errorMessage, code, reason, wasClean }));
       `);
-      expect(outcome).toEqual({ stderr: "", exitCode: 0, signal: null });
-      expect(scenarios["recv-econnreset"]).toEqual({
+      expect(r).toEqual({
         errorMessage: `WebSocket connection to 'ws://127.0.0.1:${port}/' failed: Connection ended`,
         code: 1006,
         reason: "Connection ended",
         wasClean: false,
+        stderr: "",
+        exitCode: 0,
+        signal: null,
       });
     } finally {
       await new Promise<void>(r => wss.close(() => r()));


### PR DESCRIPTION
### What

`test/js/first_party/ws/ws-syscall-fault.test.ts` took 17s wall time on the debian 13 x64-asan CI lane. Profiling the fixtures shows each spawned subprocess is dominated by process startup and loading the ws shim (~1.9s under a debug build), while the faulted round trip itself is 20-250ms. The file also asserted less than it captured: `toMatchObject` ignored unexpected fields, stderr was captured but never checked, and the error path only asserted booleans.

### Changes

Speed (11.2s -> 6.1s with a local debug+ASAN build):

- The three tests run concurrently (`describe.concurrent`), which is where the whole wall-time win comes from: wall time becomes the max of the subprocess durations instead of their sum. The structure stays one subprocess per test, matching `test/js/web/websocket/websocket-syscall-fault.test.ts`. (An earlier revision of this PR merged the two short-I/O scenarios into one subprocess; measurement showed that saves CPU but zero wall time, while coupling two tests to one process hurt failure attribution, so it was dropped.)
- The parent-side `ws` import moved to module scope (previously paid inside the ECONNRESET test body via `require`).

Assertions and failure attribution:

- Each test asserts its full result with a single exact `toEqual`: the scenario fields plus `stderr: ""`, `exitCode: 0`, `signal: null`. Any failure renders everything in one diff (a crash shows the stderr and signal next to the missing scenario fields). Unparseable fixture stdout is surfaced raw in the same diff instead of throwing in the helper.
- The short-read test now also proves the close handshake completes cleanly under 1-byte reads (code 1000, `wasClean: true`).
- The short-write test now asserts the echoed 1024-byte payload is byte-for-byte intact, not just its length. The 1024-byte size stays: it costs ~90ms and payloads over 125 bytes force the 2-byte extended-length frame header, so the length bytes themselves are split across 1-byte writes.
- The ECONNRESET test asserts the exact surfaced error message (`WebSocket connection to 'ws://127.0.0.1:<port>/' failed: Connection ended`), close code 1006, reason `"Connection ended"`, `wasClean: false`, and that `'error'` fired before `'close'`. "Connection ended" is the deterministic reason for this path (`WebSocketErrorCode::ended` in src/jsc/bindings/webcore/WebSocket.cpp).
- Each fixture carries a 30s watchdog that reports the partial state it wedged at and exits. A hung faulted socket previously meant a bare test timeout (90s, or 270s on ASAN lanes, in CI) plus a subprocess that can outlive the runner for concurrent tests; now it fails fast as a structured diff naming what was reached (e.g. `{ error: "timed out", opened: true, data: null }`). The watchdog only fires when the test has already failed; success never waits on it.

No scenario was removed: all three tests and their fault configurations survive.

### Verification

With a local debug+ASAN build (`bun bd test test/js/first_party/ws/ws-syscall-fault.test.ts`):

- before: `Ran 3 tests across 1 file. [11.22s]`
- after: `Ran 3 tests across 1 file. [6.12s]`

5 consecutive runs green. The watchdog path was exercised by hand (a server that never echoes) and reports `{"error":"timed out","opened":true,"data":null}` with a clean exit. `USE_SYSTEM_BUN=1 bun test` skips all 3 as before (fault injection is compiled out of release builds).

Note: #33704 also flips this file to `describe.concurrent` as part of a broad sweep; this PR subsumes that one-line change for this file.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->