### PR TITLE
test: merge the zlib estimatedSize GC fixtures into one process and strengthen assertions

### DIFF
--- a/test/js/node/zlib/zlib-estimated-size-gc.test.ts
+++ b/test/js/node/zlib/zlib-estimated-size-gc.test.ts
@@ -56,62 +56,46 @@ test("zstd decompress: estimated size stays tied to construction mode across clo
 // ASAN under `bun bd`).
 //
 // The guarded race is marking-thread vs work-pool timing, not compression
-// effort, so quality/level are set low and both classes share one process:
-// spawn + module load dominate the fixture's cost, which matters on slow
-// contended CI runners (this file used to time out in parallel batches on
-// Windows).
+// effort, so quality/level are set low and both classes share one child
+// process: spawn + module load dominate the fixture's cost, which matters on
+// slow contended CI runners. A failed group names itself, either in the
+// stderr of its rejection or as the missing "<group> OK" line.
 const gcFixture = /* js */ `
   const zlib = require("zlib");
   const compressible = Buffer.alloc(128 * 1024, "abcdefgh");
   const random = require("crypto").randomBytes(128 * 1024);
-  function drive(z, buf, bucket) {
+  function drive(z, buf, name, bucket) {
     bucket.push(new Promise((resolve, reject) => {
+      const fail = why => reject(new Error(name + ": " + why));
       let out = 0;
       let sampled = false;
-      z.on("error", reject);
+      z.on("error", e => fail(e.message || e));
       z.on("data", c => {
         out += c.length;
         if (!sampled) { sampled = true; Bun.gc(true); }
       });
-      z.on("end", () => (out > 0 ? resolve() : reject(new Error("stream produced no output"))));
+      z.on("end", () => (out > 0 ? resolve() : fail("stream produced no output")));
       z.write(buf, () => z.end());
       Bun.gc(true);
     }));
   }
   const brotli = [], zstd = [];
   for (let i = 0; i < 8; i++) {
-    drive(zlib.createBrotliCompress({ chunkSize: 32 * 1024, params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 2 } }), compressible, brotli);
-    drive(zlib.createZstdCompress({ chunkSize: 32 * 1024, params: { [zlib.constants.ZSTD_c_compressionLevel]: 1 } }), random, zstd);
+    drive(zlib.createBrotliCompress({ chunkSize: 32 * 1024, params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 2 } }), compressible, "brotli", brotli);
+    drive(zlib.createZstdCompress({ chunkSize: 32 * 1024, params: { [zlib.constants.ZSTD_c_compressionLevel]: 1 } }), random, "zstd", zstd);
   }
   Promise.all(brotli).then(() => { Bun.gc(true); console.log("brotli OK"); });
   Promise.all(zstd).then(() => { Bun.gc(true); console.log("zstd OK"); });
 `;
 
-// Both fixture tests share one child process; a failed group is identified by
-// its missing "<group> OK" line in the assertion diff.
-let gcRunPromise: Promise<{ stdout: string; stderr: string; exitCode: number }> | undefined;
-function gcRun() {
-  return (gcRunPromise ??= (async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", gcFixture],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
-  })());
-}
-
-test.concurrent("brotli: estimatedSize during GC while a stream is live exits cleanly", async () => {
-  const { stdout, stderr, exitCode } = await gcRun();
-  expect(stderr).toBe("");
-  expect(stdout.split("\n").filter(Boolean).toSorted()).toEqual(["brotli OK", "zstd OK"]);
-  expect(exitCode).toBe(0);
-});
-
-test.concurrent("zstd: estimatedSize during GC while a stream is live exits cleanly", async () => {
-  const { stdout, stderr, exitCode } = await gcRun();
+test.concurrent("brotli+zstd: estimatedSize during GC while streams are live exits cleanly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", gcFixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout.split("\n").filter(Boolean).toSorted()).toEqual(["brotli OK", "zstd OK"]);
   expect(exitCode).toBe(0);

--- a/test/js/node/zlib/zlib-estimated-size-gc.test.ts
+++ b/test/js/node/zlib/zlib-estimated-size-gc.test.ts
@@ -12,93 +12,107 @@ import zlib from "node:zlib";
 
 // estimateShallowMemoryUsageOf(cell) == sizeof(cell) + estimated_size(). `min`
 // is a floor below the per-mode footprint the constructor caches (brotli encode
-// 5143, brotli decode 855, zstd compress 5272, zstd decompress 95968).
-function checkFootprintStableAcrossClose(create: () => any, min: number) {
+// 5143, brotli decode 855, zstd compress 5272, zstd decompress 95968); `max`
+// has enough headroom to survive dependency bumps while still catching a
+// garbage estimate from an uninitialized or racing read.
+function checkFootprintStableAcrossClose(create: () => any, className: string, min: number, max: number) {
   const engine = create();
   engine.on("error", () => {});
   engine.on("data", () => {});
   const handle = engine._handle;
+  expect(handle.constructor.name).toBe(className);
   const before = estimateShallowMemoryUsageOf(handle);
+  expect(estimateShallowMemoryUsageOf(handle)).toBe(before); // stable while live
   engine.destroy(); // closes the handle once and nulls engine._handle
+  expect(engine._handle).toBeNull();
   const after = estimateShallowMemoryUsageOf(handle);
   expect(before).toBeGreaterThan(min);
+  expect(before).toBeLessThan(max);
   expect(after).toBe(before);
 }
 
 test("brotli compress: estimated size stays tied to construction mode across close", () => {
-  checkFootprintStableAcrossClose(() => zlib.createBrotliCompress(), 5000);
+  checkFootprintStableAcrossClose(() => zlib.createBrotliCompress(), "NativeBrotli", 5000, 60_000);
 });
 
 test("brotli decompress: estimated size stays tied to construction mode across close", () => {
-  checkFootprintStableAcrossClose(() => zlib.createBrotliDecompress(), 855);
+  checkFootprintStableAcrossClose(() => zlib.createBrotliDecompress(), "NativeBrotli", 855, 60_000);
 });
 
 test("zstd compress: estimated size stays tied to construction mode across close", () => {
-  checkFootprintStableAcrossClose(() => zlib.createZstdCompress(), 5000);
+  checkFootprintStableAcrossClose(() => zlib.createZstdCompress(), "NativeZstd", 5000, 60_000);
 });
 
 test("zstd decompress: estimated size stays tied to construction mode across close", () => {
-  checkFootprintStableAcrossClose(() => zlib.createZstdDecompress(), 90000);
+  checkFootprintStableAcrossClose(() => zlib.createZstdDecompress(), "NativeZstd", 90_000, 1_000_000);
 });
 
-// GC-safety guard: drive a write so the JS thread enters with_mut, then force
-// GC so estimatedSize/visitChildren fires on the marking thread against a live
-// stream. Asserts the stream still works and the process exits cleanly (this
-// build has ASAN under `bun bd`).
-const brotliGcFixture = /* js */ `
+// GC-safety guard: one spawned process interleaves 8 brotli and 8 zstd
+// compression streams, forcing a full GC right after each write is queued on
+// the work pool and again on the first data event (mid drive loop), so
+// estimatedSize/visitChildren fires on the marking thread against live
+// streams; each group's final GC marks the already-closed handles. Asserts
+// every stream produced output and the process exits cleanly (this build has
+// ASAN under `bun bd`).
+//
+// The guarded race is marking-thread vs work-pool timing, not compression
+// effort, so quality/level are set low and both classes share one process:
+// spawn + module load dominate the fixture's cost, which matters on slow
+// contended CI runners (this file used to time out in parallel batches on
+// Windows).
+const gcFixture = /* js */ `
   const zlib = require("zlib");
-  const buf = Buffer.alloc(256 * 1024, "abcdefgh");
-  let remaining = 0;
-  for (let i = 0; i < 8; i++) {
-    remaining++;
-    const z = zlib.createBrotliCompress({ chunkSize: 64 * 1024 });
-    z.on("error", e => { throw e; });
-    z.on("data", () => {});
-    z.write(buf, () => { z.end(); if (--remaining === 0) console.log("OK"); });
-    Bun.gc(true);
-    Bun.gc(true);
+  const compressible = Buffer.alloc(128 * 1024, "abcdefgh");
+  const random = require("crypto").randomBytes(128 * 1024);
+  function drive(z, buf, bucket) {
+    bucket.push(new Promise((resolve, reject) => {
+      let out = 0;
+      let sampled = false;
+      z.on("error", reject);
+      z.on("data", c => {
+        out += c.length;
+        if (!sampled) { sampled = true; Bun.gc(true); }
+      });
+      z.on("end", () => (out > 0 ? resolve() : reject(new Error("stream produced no output"))));
+      z.write(buf, () => z.end());
+      Bun.gc(true);
+    }));
   }
-  Bun.gc(true);
+  const brotli = [], zstd = [];
+  for (let i = 0; i < 8; i++) {
+    drive(zlib.createBrotliCompress({ chunkSize: 32 * 1024, params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 2 } }), compressible, brotli);
+    drive(zlib.createZstdCompress({ chunkSize: 32 * 1024, params: { [zlib.constants.ZSTD_c_compressionLevel]: 1 } }), random, zstd);
+  }
+  Promise.all(brotli).then(() => { Bun.gc(true); console.log("brotli OK"); });
+  Promise.all(zstd).then(() => { Bun.gc(true); console.log("zstd OK"); });
 `;
 
-const zstdGcFixture = /* js */ `
-  const zlib = require("zlib");
-  const crypto = require("crypto");
-  const buf = crypto.randomBytes(256 * 1024);
-  let remaining = 0;
-  for (let i = 0; i < 8; i++) {
-    remaining++;
-    const z = zlib.createZstdCompress({ chunkSize: 64 * 1024 });
-    z.on("error", e => { throw e; });
-    z.on("data", () => {});
-    z.write(buf, () => { z.end(); if (--remaining === 0) console.log("OK"); });
-    Bun.gc(true);
-    Bun.gc(true);
-  }
-  Bun.gc(true);
-`;
-
-async function runGc(fixture: string) {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+// Both fixture tests share one child process; a failed group is identified by
+// its missing "<group> OK" line in the assertion diff.
+let gcRunPromise: Promise<{ stdout: string; stderr: string; exitCode: number }> | undefined;
+function gcRun() {
+  return (gcRunPromise ??= (async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", gcFixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  })());
 }
 
 test.concurrent("brotli: estimatedSize during GC while a stream is live exits cleanly", async () => {
-  const { stdout, stderr, exitCode } = await runGc(brotliGcFixture);
+  const { stdout, stderr, exitCode } = await gcRun();
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
+  expect(stdout.split("\n").filter(Boolean).toSorted()).toEqual(["brotli OK", "zstd OK"]);
   expect(exitCode).toBe(0);
 });
 
 test.concurrent("zstd: estimatedSize during GC while a stream is live exits cleanly", async () => {
-  const { stdout, stderr, exitCode } = await runGc(zstdGcFixture);
+  const { stdout, stderr, exitCode } = await gcRun();
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
+  expect(stdout.split("\n").filter(Boolean).toSorted()).toEqual(["brotli OK", "zstd OK"]);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Problem

In build 89973, `test/js/node/zlib/zlib-estimated-size-gc.test.ts` (the guard for #31865, added in #31867) failed its parallel batch on both Windows lanes and passed when retried alone. The job logs show the batch failure was the worker process dying while on this file (`worker crashed: exit code 9`, the u8-truncated form of NTSTATUS 0xC0000409), with the solo retry passing 6/6 in about 200ms; there are no test timeouts in those logs. A test-only PR cannot fix a native worker crash, and parallel workers run many files before the one they die on, so the crash is not even proven to be this file's doing.

What a test-only PR can do is shrink the file's footprint in contended parallel batches, where it was flagged as expensive, and strengthen what it asserts. Measured under the debug+ASAN build on Linux: child startup 0.38s, `require("zlib")` about 0.6s, the 17 full GCs about 0.3s, while compression volume is nearly irrelevant (the repetitive buffer compresses in about the same time at brotli quality 11 as at quality 2, and shrinking it 4x did not move the numbers). The dominant fixed cost was paid twice because each codec's fixture spawned its own child.

## Change

- One spawned child replaces the two per-codec fixture children. It interleaves 8 brotli and 8 zstd compression streams; the GC sample count is preserved exactly (2 full GCs per stream plus finals = 34, the same as the old two processes combined) and every GC now marks both native classes, since both are live in one heap.
- Samples are better timed than before. The old fixture fired both GCs back to back right after `write()`; now one fires with the write queued on the work pool and one on the stream's first `data` event, i.e. mid drive loop, and each group's final GC marks the already-closed handles (the after-close `estimatedSize` path on the marking thread).
- Compression effort is lowered: brotli quality 2, zstd level 1, 128KB buffers, `chunkSize` 32KB keeping 4 native chunk rounds per write as before. The guarded race is marking-thread vs work-pool timing, not compression effort, so the work only needs to be in flight when the GC fires, which is unchanged.
- The two per-codec fixture tests are collapsed into one. Review correctly flagged that the pair had become byte-identical assertions over one shared child and could never diverge, while nothing in CI keys on test names (annotations and retries are per file). The merged name still matches `-t brotli` and `-t zstd`, and a failing group identifies itself either in stderr (fixture errors are prefixed with their group name) or as the missing `"<group> OK"` line in the exact stdout assertion.

Strengthened assertions:

- in-process tests: native class name (`NativeBrotli`/`NativeZstd`), footprint stable across two live reads, `engine._handle` nulled by `destroy()`, and a generous ceiling that catches a garbage estimate, on top of the existing floor and the `after === before` contract;
- fixture: every stream must produce output and reach `end` (full lifecycle, not just the write callback) before its group prints OK, stdout is asserted exactly (sorted `["brotli OK", "zstd OK"]`), stderr must be empty, exit code 0.

Test count goes from 6 to 5: the four per-mode value tests are untouched, no coverage is removed, and every remaining assertion is strictly stronger than before.

## Verification

- `bun bd test test/js/node/zlib/zlib-estimated-size-gc.test.ts` (debug+ASAN, Linux): 7.66s before; 5.9 to 7.9s across repeated runs after, all pass.
- Windows 11 aarch64, release, idle: file 164ms before, 197ms after. A single idle run is slightly slower because one child serializes what two did in parallel; idle single runs were never the problem.
- Windows 11 aarch64, parallel-batch simulation (32 concurrent runs of the file): total wall 1.18s before vs 0.74s after, slowest single fixture test 619ms before vs 302ms after, all 32 green. Per-test wall under batch contention is what trips on the Windows lanes, and halving the spawned processes also halves this file's contribution to the rest of the batch's contention.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/zlib/zlib-estimated-size-gc.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/zlib/zlib-estimated-size-gc.test.ts
bun test v1.4.0 (d7df118db)

test/js/node/zlib/zlib-estimated-size-gc.test.ts:
(pass) brotli compress: estimated size stays tied to construction mode across close [136.48ms]
(pass) brotli decompress: estimated size stays tied to construction mode across close [14.44ms]
(pass) zstd compress: estimated size stays tied to construction mode across close [19.69ms]
(pass) zstd decompress: estimated size stays tied to construction mode across close [10.61ms]
(pass) brotli+zstd: estimatedSize during GC while streams are live exits cleanly [3501.03ms]

 5 pass
 0 fail
 27 expect() calls
Ran 5 tests across 1 file. [6.67s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/zlib/zlib-estimated-size-gc.test.ts | 102 +++++++++++------------
 1 file changed, 50 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
test/js/node/zlib/zlib-estimated-size-gc.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->