### PR TITLE
bake: speed up ssg-pages-router dev tests by sharing dev servers

### DIFF
--- a/test/bake/dev/ssg-pages-router.test.ts
+++ b/test/bake/dev/ssg-pages-router.test.ts
@@ -155,6 +155,9 @@ devTest("SSG pages router - static, dynamic, nested, and async pages with hot re
     expect(await fetchHtml(dev, "/blog/2")).toContain("<h1>Blog Post <!-- -->2</h1>");
     expect(await fetchHtml(dev, "/blog/categories/tech")).toContain("<h1>Category: <!-- -->tech</h1>");
     expect(await fetchHtml(dev, "/blog/categories/lifestyle")).toContain("<h1>Category: <!-- -->lifestyle</h1>");
+    // The categories/ directory has no index page, so /blog/categories falls
+    // back to the [id] sibling (Next.js parity)
+    expect(await fetchHtml(dev, "/blog/categories")).toContain("<h1>Blog Post <!-- -->categories</h1>");
 
     // Async page components can await data before rendering
     {
@@ -244,7 +247,16 @@ devTest("SSG pages router - Bun.file data loading and named import edge case", {
       console.log(md);
 
       export default function IndexPage() {
-        return <h1>Welcome to SSG</h1>;
+        const bindings =
+          typeof Markdoc === "function" && md.default === Markdoc && typeof Markdoc().parse === "function"
+            ? "bindings agree"
+            : "bindings broken";
+        return (
+          <div>
+            <h1>Welcome to SSG</h1>
+            <p id="bindings">{bindings}</p>
+          </div>
+        );
       }
     `,
     "src/ooga.ts": `var Markdoc = function () {
@@ -289,10 +301,12 @@ export { Markdoc as default };`,
     "posts/second-post.txt": "This is the second post content",
   },
   async test(dev) {
-    // Mixed default + namespace import of the same module must not error
+    // Mixed default + namespace import of the same module: both bindings must
+    // resolve to the same working function
     {
       await using c = await dev.client("/");
       expect(await c.elemText("h1")).toBe("Welcome to SSG");
+      expect(await c.elemText("#bindings")).toBe("bindings agree");
     }
 
     // Page content loaded from disk with Bun.file during render

--- a/test/bake/dev/ssg-pages-router.test.ts
+++ b/test/bake/dev/ssg-pages-router.test.ts
@@ -1,35 +1,26 @@
 // Test SSG pages router functionality
+//
+// Each devTest boots a dev server (bundler + react framework install), which
+// dominates wall time, so related routes share one server. Route variations
+// are asserted on the server-rendered HTML via fetch; hydration is still
+// covered by a happy-dom client per distinct page shape.
 import { expect } from "bun:test";
-import { devTest } from "../bake-harness";
+import { devTest, type Dev } from "../bake-harness";
 
-devTest("SSG pages router - multiple static pages", {
+async function fetchHtml(dev: Dev, url: string): Promise<string> {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(200);
+  return await res.text();
+}
+
+devTest("SSG pages router - static, dynamic, nested, and async pages with hot reload", {
   framework: "react",
   files: {
-    "pages/about.tsx": `
-      export default function AboutPage() {
-        return <h1>About Page</h1>;
+    "pages/index.tsx": `
+      export default function IndexPage() {
+        return <h1>Welcome to SSG</h1>;
       }
     `,
-    "pages/contact.tsx": `
-      export default function ContactPage() {
-        return <h1>Contact Page</h1>;
-      }
-    `,
-  },
-  async test(dev) {
-    // Test about page
-    await using c2 = await dev.client("/about");
-    expect(await c2.elemText("h1")).toBe("About Page");
-
-    // Test contact page
-    await using c3 = await dev.client("/contact");
-    expect(await c3.elemText("h1")).toBe("Contact Page");
-  },
-});
-
-devTest("SSG pages router - dynamic routes with [slug]", {
-  framework: "react",
-  files: {
     "pages/[slug].tsx": `
       type Props = Bun.SSGProps;
 
@@ -54,24 +45,41 @@ devTest("SSG pages router - dynamic routes with [slug]", {
         };
       };
     `,
-  },
-  async test(dev) {
-    // Test dynamic routes
-    await using c1 = await dev.client("/first-post");
-    expect(await c1.elemText("h1")).toBe("Dynamic Page: <!-- -->first-post");
-    expect(await c1.elemText("p")).toBe("Slug value: <!-- -->first-post");
+    "pages/about.tsx": `
+      export default function AboutPage() {
+        return <h1>About Page</h1>;
+      }
+    `,
+    "pages/contact.tsx": `
+      export default function ContactPage() {
+        return <h1>Contact Page</h1>;
+      }
+    `,
+    "pages/data.tsx": `
+      async function fetchData() {
+        // Simulate API call
+        return new Promise(resolve => {
+          setTimeout(() => {
+            resolve({ message: "Data from API", items: ["Item 1", "Item 2", "Item 3"] });
+          }, 10);
+        });
+      }
 
-    await using c2 = await dev.client("/second-post");
-    expect(await c2.elemText("h1")).toBe("Dynamic Page: <!-- -->second-post");
+      export default async function DataPage() {
+        const data = await fetchData();
 
-    await using c3 = await dev.client("/third-post");
-    expect(await c3.elemText("h1")).toBe("Dynamic Page: <!-- -->third-post");
-  },
-});
-
-devTest("SSG pages router - nested routes", {
-  framework: "react",
-  files: {
+        return (
+          <div>
+            <h1>{data.message}</h1>
+            <ul>
+              {data.items.map((item, index) => (
+                <li key={index}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+    `,
     "pages/blog/index.tsx": `
       export default function BlogIndex() {
         return <h1>Blog Index</h1>;
@@ -111,40 +119,55 @@ devTest("SSG pages router - nested routes", {
     `,
   },
   async test(dev) {
-    // Test blog index
-    await using c1 = await dev.client("/blog");
-    expect(await c1.elemText("h1")).toBe("Blog Index");
+    // This client stays open so the hot reload step at the end can observe
+    // the update; every other client is scoped to its own block.
+    await using indexClient = await dev.client("/");
+    expect(await indexClient.elemText("h1")).toBe("Welcome to SSG");
 
-    // Test blog posts
-    await using c2 = await dev.client("/blog/1");
-    expect(await c2.elemText("h1")).toBe("Blog Post <!-- -->1");
+    // Multiple static pages, server-rendered. These also assert that static
+    // routes win over the sibling [slug] pattern.
+    expect(await fetchHtml(dev, "/about")).toContain("<h1>About Page</h1>");
+    expect(await fetchHtml(dev, "/contact")).toContain("<h1>Contact Page</h1>");
 
-    await using c3 = await dev.client("/blog/2");
-    expect(await c3.elemText("h1")).toBe("Blog Post <!-- -->2");
+    // Dynamic [slug] route with params
+    {
+      await using c = await dev.client("/first-post");
+      expect(await c.elemText("h1")).toBe("Dynamic Page: <!-- -->first-post");
+      expect(await c.elemText("p")).toBe("Slug value: <!-- -->first-post");
+    }
+    expect(await fetchHtml(dev, "/second-post")).toContain("<h1>Dynamic Page: <!-- -->second-post</h1>");
+    const third = await fetchHtml(dev, "/third-post");
+    expect(third).toContain("<h1>Dynamic Page: <!-- -->third-post</h1>");
+    expect(third).toContain("<p>Slug value: <!-- -->third-post</p>");
 
-    // Test categories
-    await using c4 = await dev.client("/blog/categories/tech");
-    expect(await c4.elemText("h1")).toBe("Category: <!-- -->tech");
+    // In dev, getStaticPaths does not restrict rendering: params that are not
+    // in the returned list still render on demand.
+    expect(await fetchHtml(dev, "/not-in-static-paths")).toContain(
+      "<h1>Dynamic Page: <!-- -->not-in-static-paths</h1>",
+    );
 
-    await using c5 = await dev.client("/blog/categories/lifestyle");
-    expect(await c5.elemText("h1")).toBe("Category: <!-- -->lifestyle");
-  },
-});
+    // Nested routes: static index + dynamic siblings
+    {
+      await using c = await dev.client("/blog/1");
+      expect(await c.elemText("h1")).toBe("Blog Post <!-- -->1");
+    }
+    expect(await fetchHtml(dev, "/blog")).toContain("<h1>Blog Index</h1>");
+    expect(await fetchHtml(dev, "/blog/2")).toContain("<h1>Blog Post <!-- -->2</h1>");
+    expect(await fetchHtml(dev, "/blog/categories/tech")).toContain("<h1>Category: <!-- -->tech</h1>");
+    expect(await fetchHtml(dev, "/blog/categories/lifestyle")).toContain("<h1>Category: <!-- -->lifestyle</h1>");
 
-devTest("SSG pages router - hot reload on page changes", {
-  framework: "react",
-  files: {
-    "pages/index.tsx": `
-      export default function IndexPage() {
-        return <h1>Welcome to SSG</h1>;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    expect(await c.elemText("h1")).toBe("Welcome to SSG");
+    // Async page components can await data before rendering
+    {
+      await using c = await dev.client("/data");
+      expect(await c.elemText("h1")).toBe("Data from API");
+      expect(await c.elemsText("li")).toEqual(["Item 1", "Item 2", "Item 3"]);
+    }
 
-    // Update the page
+    // Paths that match no route return 404
+    await dev.fetch("/two/segments").expect404();
+    await dev.fetch("/blog/categories/tech/extra").expect404();
+
+    // Hot reload: update the index page while its client is connected
     await dev.write(
       "pages/index.tsx",
       `
@@ -156,49 +179,15 @@ devTest("SSG pages router - hot reload on page changes", {
     );
 
     // this %c%s%c is a react devtools thing and I don't know how to turn it off
-    await c.expectMessage("%c%s%c updated load");
-    expect(await c.elemText("h1")).toBe("Updated Content");
+    await indexClient.expectMessage("%c%s%c updated load");
+    expect(await indexClient.elemText("h1")).toBe("Updated Content");
   },
 });
 
-devTest("SSG pages router - data fetching with async components", {
-  framework: "react",
-  files: {
-    "pages/data.tsx": `
-      async function fetchData() {
-        // Simulate API call
-        return new Promise(resolve => {
-          setTimeout(() => {
-            resolve({ message: "Data from API", items: ["Item 1", "Item 2", "Item 3"] });
-          }, 10);
-        });
-      }
-
-      export default async function DataPage() {
-        const data = await fetchData();
-
-        return (
-          <div>
-            <h1>{data.message}</h1>
-            <ul>
-              {data.items.map((item, index) => (
-                <li key={index}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        );
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/data");
-    expect(await c.elemText("h1")).toBe("Data from API");
-
-    const items = await c.elemsText("li");
-    expect(items).toEqual(["Item 1", "Item 2", "Item 3"]);
-  },
-});
-
+// [category]/[year]/[slug] and [...slug] stay in separate dev servers (and
+// apart from the [slug] tree above): overlapping dynamic patterns at the same
+// level resolve by insertion order, so sharing a tree would change what each
+// test matches.
 devTest("SSG pages router - multiple dynamic segments", {
   framework: "react",
   files: {
@@ -227,27 +216,45 @@ devTest("SSG pages router - multiple dynamic segments", {
     `,
   },
   async test(dev) {
-    // Test first path
-    await using c1 = await dev.client("/tech/2024/bun-release");
-    expect(await c1.elemText("h1")).toBe("bun-release");
-    expect(await c1.elemsText("p")).toEqual(["Category: <!-- -->tech", "Year: <!-- -->2024"]);
+    {
+      await using c = await dev.client("/tech/2024/bun-release");
+      expect(await c.elemText("h1")).toBe("bun-release");
+      expect(await c.elemsText("p")).toEqual(["Category: <!-- -->tech", "Year: <!-- -->2024"]);
+    }
+    const news = await fetchHtml(dev, "/news/2024/breaking-story");
+    expect(news).toContain("<h1>breaking-story</h1>");
+    expect(news).toContain("<p>Category: <!-- -->news</p>");
+    expect(news).toContain("<p>Year: <!-- -->2024</p>");
+    const review = await fetchHtml(dev, "/tech/2023/year-review");
+    expect(review).toContain("<h1>year-review</h1>");
+    expect(review).toContain("<p>Category: <!-- -->tech</p>");
+    expect(review).toContain("<p>Year: <!-- -->2023</p>");
 
-    // Test second path
-    await using c2 = await dev.client("/news/2024/breaking-story");
-    expect(await c2.elemText("h1")).toBe("breaking-story");
-    expect(await c2.elemsText("p")).toEqual(["Category: <!-- -->news", "Year: <!-- -->2024"]);
-
-    // Test third path
-    await using c3 = await dev.client("/tech/2023/year-review");
-    expect(await c3.elemText("h1")).toBe("year-review");
-    expect(await c3.elemsText("p")).toEqual(["Category: <!-- -->tech", "Year: <!-- -->2023"]);
+    // Four segments do not match the three-segment pattern
+    await dev.fetch("/a/b/c/d").expect404();
   },
 });
 
-devTest("SSG pages router - file loading with Bun.file", {
+devTest("SSG pages router - Bun.file data loading and named import edge case", {
   framework: "react",
-  fixture: "ssg-pages-router",
   files: {
+    "pages/index.tsx": `
+      import Markdoc, * as md from '../src/ooga'
+
+      console.log(md);
+
+      export default function IndexPage() {
+        return <h1>Welcome to SSG</h1>;
+      }
+    `,
+    "src/ooga.ts": `var Markdoc = function () {
+  return {
+    parse: () => {},
+    transform: () => {},
+  };
+};
+
+export { Markdoc as default };`,
     "pages/[slug].tsx": `
       import { join } from "path";
 
@@ -282,46 +289,21 @@ devTest("SSG pages router - file loading with Bun.file", {
     "posts/second-post.txt": "This is the second post content",
   },
   async test(dev) {
-    // Test first post
-    await using c1 = await dev.client("/hello-world");
-    expect(await c1.elemText("h1")).toBe("hello-world");
-    expect(await c1.elemText("div div")).toBe("This is the content of hello world post");
+    // Mixed default + namespace import of the same module must not error
+    {
+      await using c = await dev.client("/");
+      expect(await c.elemText("h1")).toBe("Welcome to SSG");
+    }
 
-    // Test second post
-    await using c2 = await dev.client("/second-post");
-    expect(await c2.elemText("h1")).toBe("second-post");
-    expect(await c2.elemText("div div")).toBe("This is the second post content");
-  },
-});
-
-devTest("SSG pages router - named import edge case", {
-  framework: "react",
-  fixture: "ssg-pages-router",
-  files: {
-    "pages/index.tsx": `
-      import Markdoc, * as md from '../src/ooga'
-
-      console.log(md);
-
-      export default function IndexPage() {
-        return <h1>Welcome to SSG</h1>;
-      }
-    `,
-    "src/ooga.ts": `var Markdoc = function () {
-  return {
-    parse: () => {},
-    transform: () => {},
-  };
-};
-
-export { Markdoc as default };`,
-    "posts/hello-world.txt": "This is the content of hello world post",
-    "posts/second-post.txt": "This is the second post content",
-  },
-  async test(dev) {
-    // Should not error
-    await using c1 = await dev.client("/");
-    expect(await c1.elemText("h1")).toBe("Welcome to SSG");
+    // Page content loaded from disk with Bun.file during render
+    {
+      await using c = await dev.client("/hello-world");
+      expect(await c.elemText("h1")).toBe("hello-world");
+      expect(await c.elemText("div div")).toBe("This is the content of hello world post");
+    }
+    const second = await fetchHtml(dev, "/second-post");
+    expect(second).toContain("<h1>second-post</h1>");
+    expect(second).toContain("<div>This is the second post content</div>");
   },
 });
 
@@ -362,28 +344,28 @@ devTest("SSG pages router - catch-all routes [...slug]", {
     `,
   },
   async test(dev) {
-    // Test single segment
-    await using c1 = await dev.client("/docs");
-    expect(await c1.elemText("h1")).toBe("Catch-all Route");
-    expect(await c1.elemText("#params")).toBe('{"slug":"docs"}');
-    expect(await c1.elemsText("li")).toEqual(["No slug array"]);
+    // Two segments arrive as an array
+    {
+      await using c = await dev.client("/docs/getting-started");
+      expect(await c.elemText("h1")).toBe("Catch-all Route");
+      expect(await c.elemText("#params")).toBe('{"slug":["docs","getting-started"]}');
+      expect(await c.elemsText("li")).toEqual(["docs", "getting-started"]);
+    }
 
-    // Test two segments
-    await using c2 = await dev.client("/docs/getting-started");
-    expect(await c2.elemText("h1")).toBe("Catch-all Route");
-    expect(await c2.elemText("#params")).toBe('{"slug":["docs","getting-started"]}');
-    expect(await c2.elemsText("li")).toEqual(["docs", "getting-started"]);
+    // A single segment is passed as a string, not a one-element array
+    const single = await fetchHtml(dev, "/docs");
+    expect(single).toContain("<h1>Catch-all Route</h1>");
+    expect(single).toContain("{&quot;slug&quot;:&quot;docs&quot;}");
+    expect(single).toContain("<ul><li>No slug array</li></ul>");
 
-    // Test three segments
-    await using c3 = await dev.client("/docs/api/reference");
-    expect(await c3.elemText("h1")).toBe("Catch-all Route");
-    expect(await c3.elemText("#params")).toBe('{"slug":["docs","api","reference"]}');
-    expect(await c3.elemsText("li")).toEqual(["docs", "api", "reference"]);
+    const three = await fetchHtml(dev, "/docs/api/reference");
+    expect(three).toContain("{&quot;slug&quot;:[&quot;docs&quot;,&quot;api&quot;,&quot;reference&quot;]}");
+    expect(three).toContain("<ul><li>docs</li><li>api</li><li>reference</li></ul>");
 
-    // Test four segments
-    await using c4 = await dev.client("/blog/2024/january/new-features");
-    expect(await c4.elemText("h1")).toBe("Catch-all Route");
-    expect(await c4.elemText("#params")).toBe('{"slug":["blog","2024","january","new-features"]}');
-    expect(await c4.elemsText("li")).toEqual(["blog", "2024", "january", "new-features"]);
+    const four = await fetchHtml(dev, "/blog/2024/january/new-features");
+    expect(four).toContain(
+      "{&quot;slug&quot;:[&quot;blog&quot;,&quot;2024&quot;,&quot;january&quot;,&quot;new-features&quot;]}",
+    );
+    expect(four).toContain("<ul><li>blog</li><li>2024</li><li>january</li><li>new-features</li></ul>");
   },
 });

--- a/test/expected-durations.json
+++ b/test/expected-durations.json
@@ -130,10 +130,10 @@
     "windows": 3551
   },
   "bake/dev/ssg-pages-router.test.ts": {
-    "default": 35620,
-    "asan": 37048,
-    "musl": 34888,
-    "windows": 40356
+    "default": 14000,
+    "asan": 18000,
+    "musl": 14000,
+    "windows": 18000
   },
   "bake/dev/stress.test.ts": {
     "default": 7079,


### PR DESCRIPTION
### What

`test/bake/dev/ssg-pages-router.test.ts` took ~50s of wall time on the Windows 11 aarch64 CI lane (and was proportionally slow everywhere). Each of its nine `devTest` cases boots a dev server (react node_modules install plus framework bundle), and every route assertion paid for a fresh happy-dom client subprocess: 9 boots and 22 client processes for what is mostly "does this route render this markup".

### Change

- Group page trees that do not overlap in route matching into **4 dev servers instead of 9**. Trees with overlapping dynamic patterns at the same level (`[slug]` vs `[category]/[year]/[slug]` vs `[...slug]`) are deliberately kept in separate servers, since overlapping patterns resolve by insertion order and sharing a tree would change what each case matches.
- Assert route variations on the server-rendered HTML via `dev.fetch` instead of booting a happy-dom client per route. One client per distinct page component remains (8 instead of 22), so hydration, the error overlay check, and the HMR handshake are still exercised for every component kind.
- Every behavior previously asserted is still asserted: all routes from the original nine cases, the hot reload sequence (console replay message plus updated DOM), the async data page, `Bun.file` loading inside `getStaticPaths` pages, the mixed default+namespace import edge case, and the string-vs-array catch-all params.

### Stronger assertions

- Response status is checked on every fetched page (200) and on unmatched paths (404: `/two/segments`, `/blog/categories/tech/extra`, `/a/b/c/d`).
- Dev mode renders params on demand even when they are not in the `getStaticPaths` list (new assertion documenting that `getStaticPaths` only constrains production builds).
- Static routes win over a sibling `[slug]` pattern (previously untested: no tree mixed static and dynamic files at the same level).
- Full rendered markup is asserted for fetched pages (exact `<h1>`/`<p>` fragments including SSR text separators), and catch-all segment lists are asserted as the complete `<ul>` so extra items would fail.

### Timing (same machine, before vs after)

| build | before | after |
|---|---|---|
| debug + ASAN (`bun bd test`) | 96.1s (9 tests) | 45.0s (4 tests) |
| release (`USE_SYSTEM_BUN=1`) | 37.7s | 13.9s |

expect() calls went from 40 to 60.

### Review follow-ups (second commit)

- The named import case now renders and asserts that the default binding, `namespace.default`, and a call through the imported function all work, instead of only proving the page does not error.
- Pinned `/blog/categories` (a directory with no index page) falling back to the `[id]` sibling with `id="categories"`, matching Next.js; this precedence edge is created by the merged tree and was previously unasserted anywhere.
- Reseeded this file's entry in `test/expected-durations.json` (35.6s/37.0s/34.9s/40.4s to 14s/18s/14s/18s) so shard packing reflects the new duration.

expect() calls are now 63.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bake/dev/ssg-pages-router.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bake/dev/ssg-pages-router.test.ts
bun test v1.4.0 (c531f07f1)

test/bake/dev/ssg-pages-router.test.ts:
Dev server testing directory: /tmp/bun-dev-test-Ux9gC1
bun add v1.4.0 (c531f07f1)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [321.00ms]
bun install v1.4.0 (c531f07f1)

Checked 6 installs across 7 packages (no changes) [99.00ms]
[0;30mdev|[0m Started development server: http://localhost:33535
[0;30mdev|[0m [32mBundled page in 2085ms[0m[2m:[0m pages/index.tsx [2m+ 2 more[0m
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mBundled page in 38ms[0m[2m:[0m pages/about.tsx
[0;30mdev|[0m [32mBundled page in 34ms[0m[2m:[0m pages/contact.tsx
[0;30mdev|[0m [32mBundled page in 52ms[0m[2m:[0m pages/[slug].tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mBundled page in 33ms[0m[2m:[0m pages/blog/[id].tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mBundled page in 32ms[0m[2m:[0m pages/blog/index.tsx
[0;30mdev|[0m [32mBundled page in 72ms[0m[2m:[0m pages/blog/categories/[category].tsx
[0;30mdev|[0m [32mBundled page in 52ms[0m[2m:[0m pages/data.tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bake/dev/ssg-pages-router.test.ts | 382 ++++++++++++++++-----------------
 test/expected-durations.json           |   8 +-
 2 files changed, 193 insertions(+), 197 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
test/bake/dev/ssg-pages-router.test.ts      3     12      0
test/expected-durations.json                1      1      0
```

</details>

<!-- robobun:evidence:end -->