### PR TITLE
bake: don't match framework routes with missing or empty URL segments

### DIFF
--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -320,7 +320,11 @@ impl EncodedPattern {
                     if !strings::eql(&path[i..i + expect.len()], expect) {
                         return false;
                     }
-                    i += 1 + expect.len();
+                    i += expect.len();
+                    if i < path.len() {
+                        // Consume the separator unless the text ends the path.
+                        i += 1;
+                    }
                 }
                 Part::Param(name) => {
                     if i >= path.len() {

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -377,8 +377,7 @@ impl EncodedPattern {
                     }
                     // A required catch-all ([...name]) must capture at least
                     // one segment; only [[...name]] matches zero segments.
-                    return matches!(part, Part::CatchAllOptional(_))
-                        || param_num > params_before;
+                    return matches!(part, Part::CatchAllOptional(_)) || param_num > params_before;
                 }
                 Part::Group(_) => continue,
             }

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -360,8 +360,7 @@ impl EncodedPattern {
                         while segment_start < path.len() {
                             let segment_end = strings::index_of_char_pos(path, b'/', segment_start)
                                 .unwrap_or(path.len());
-                            // An empty segment (double slash) never matches,
-                            // same as the Param arm.
+                            // An empty segment (double slash) never matches.
                             if segment_start == segment_end {
                                 return false;
                             }
@@ -1871,11 +1870,10 @@ impl JSFrameworkRouter {
     pub fn r#match(&self, global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let path_value = callframe.arguments_as_array::<1>()[0];
         let path = path_value.to_slice(global)?;
-        // match_slow requires an origin-form path; see the same guard in
-        // DevServer's server-side route lookup.
+        // match_slow requires an origin-form path.
         if path.slice().is_empty() || path.slice()[0] != b'/' {
             return Err(global.throw(format_args!(
-                "Invalid path \"{}\" it should be non-empty and start with a slash",
+                "Invalid path \"{}\": it should be non-empty and start with a slash",
                 bstr::BStr::new(path.slice())
             )));
         }

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -321,10 +321,14 @@ impl EncodedPattern {
                     i += 1 + expect.len();
                 }
                 Part::Param(name) => {
-                    if i > path.len() {
+                    if i >= path.len() {
                         return false;
                     }
                     let end = strings::index_of_char_pos(path, b'/', i).unwrap_or(path.len());
+                    // A parameter matches exactly one non-empty segment.
+                    if end == i {
+                        return false;
+                    }
                     // Check if we're about to exceed the maximum number of parameters
                     if param_num >= MatchedParams::MAX_COUNT {
                         // TODO: ideally we should throw a nice user message
@@ -343,6 +347,7 @@ impl EncodedPattern {
                     i = if end == path.len() { end } else { end + 1 };
                 }
                 Part::CatchAllOptional(name) | Part::CatchAll(name) => {
+                    let params_before = param_num;
                     // Capture remaining path segments as individual parameters
                     if i < path.len() {
                         let mut segment_start = i;
@@ -370,7 +375,10 @@ impl EncodedPattern {
                             };
                         }
                     }
-                    return true;
+                    // A required catch-all ([...name]) must capture at least
+                    // one segment; only [[...name]] matches zero segments.
+                    return matches!(part, Part::CatchAllOptional(_))
+                        || param_num > params_before;
                 }
                 Part::Group(_) => continue,
             }
@@ -1864,22 +1872,9 @@ impl JSFrameworkRouter {
         };
         if let Some(index) = self.router.match_slow(path.slice(), &mut params_out) {
             let obj = JSValue::create_empty_object(global, 2);
-            obj.put(
-                global,
-                b"params",
-                if params_out.params.len() > 0 {
-                    let params_obj =
-                        JSValue::create_empty_object(global, params_out.params.len() as usize);
-                    for param in params_out.params.slice() {
-                        // key/value borrow from `path`/pattern, both live here (RawSlice invariant)
-                        let value_str = bun_core::String::clone_utf8(param.value.slice());
-                        params_obj.put(global, param.key.slice(), value_str.to_js(global)?);
-                    }
-                    params_obj
-                } else {
-                    JSValue::NULL
-                },
-            );
+            // Use the same conversion as the dev server so repeated catch-all
+            // keys aggregate into arrays instead of overwriting each other.
+            obj.put(global, b"params", params_out.to_js(global));
             obj.put(global, b"route", self.route_to_json_inverse(global, index)?);
             return Ok(obj);
         }

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -304,6 +304,8 @@ impl EncodedPattern {
     }
 
     fn matches(&self, path: &[u8], params: &mut MatchedParams) -> bool {
+        // Discard captures left by a previous candidate that failed partway.
+        params.params.clear();
         let mut param_num: usize = 0;
         let mut it = self.iterate();
         let mut i: usize = 1;
@@ -375,8 +377,7 @@ impl EncodedPattern {
                             };
                         }
                     }
-                    // A required catch-all ([...name]) must capture at least
-                    // one segment; only [[...name]] matches zero segments.
+                    // Only the optional form may match zero segments.
                     return matches!(part, Part::CatchAllOptional(_)) || param_num > params_before;
                 }
                 Part::Group(_) => continue,
@@ -1871,8 +1872,6 @@ impl JSFrameworkRouter {
         };
         if let Some(index) = self.router.match_slow(path.slice(), &mut params_out) {
             let obj = JSValue::create_empty_object(global, 2);
-            // Use the same conversion as the dev server so repeated catch-all
-            // keys aggregate into arrays instead of overwriting each other.
             obj.put(global, b"params", params_out.to_js(global));
             obj.put(global, b"route", self.route_to_json_inverse(global, index)?);
             return Ok(obj);

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -360,20 +360,21 @@ impl EncodedPattern {
                         while segment_start < path.len() {
                             let segment_end = strings::index_of_char_pos(path, b'/', segment_start)
                                 .unwrap_or(path.len());
-                            if segment_start < segment_end {
-                                // Check if we're about to exceed the maximum number of parameters
-                                if param_num >= MatchedParams::MAX_COUNT {
-                                    return false;
-                                }
-                                params.params.resize(param_num + 1).unwrap();
-                                params.params.slice()[param_num] = MatchedParamEntry {
-                                    key: bun_ptr::RawSlice::new(name),
-                                    value: bun_ptr::RawSlice::new(
-                                        &path[segment_start..segment_end],
-                                    ),
-                                };
-                                param_num += 1;
+                            // An empty segment (double slash) never matches,
+                            // same as the Param arm.
+                            if segment_start == segment_end {
+                                return false;
                             }
+                            // Check if we're about to exceed the maximum number of parameters
+                            if param_num >= MatchedParams::MAX_COUNT {
+                                return false;
+                            }
+                            params.params.resize(param_num + 1).unwrap();
+                            params.params.slice()[param_num] = MatchedParamEntry {
+                                key: bun_ptr::RawSlice::new(name),
+                                value: bun_ptr::RawSlice::new(&path[segment_start..segment_end]),
+                            };
+                            param_num += 1;
                             segment_start = if segment_end == path.len() {
                                 segment_end
                             } else {
@@ -1870,6 +1871,14 @@ impl JSFrameworkRouter {
     pub fn r#match(&self, global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let path_value = callframe.arguments_as_array::<1>()[0];
         let path = path_value.to_slice(global)?;
+        // match_slow requires an origin-form path; see the same guard in
+        // DevServer's server-side route lookup.
+        if path.slice().is_empty() || path.slice()[0] != b'/' {
+            return Err(global.throw(format_args!(
+                "Invalid path \"{}\" it should be non-empty and start with a slash",
+                bstr::BStr::new(path.slice())
+            )));
+        }
 
         let mut params_out = MatchedParams {
             params: BoundedArray::default(),

--- a/test/bake/dev/import-meta-inline.test.ts
+++ b/test/bake/dev/import-meta-inline.test.ts
@@ -208,13 +208,9 @@ export default function BlogPost(req, meta) {
     expect(json2.meta.file).toBe("[...slug].ts");
     expect(json2.meta.path).toContain(platformPath("routes/blog/[...slug].ts"));
 
-    // Test empty slug (just /blog/)
-    const post3 = await dev.fetch("/blog/");
-    const json3 = await post3.json();
-
-    expect(json3.slug).toEqual([]);
-    expect(json3.title).toBe("");
-    expect(json3.content).toBe("This is a blog post at: ");
+    // A required catch-all does not match zero segments
+    await dev.fetch("/blog").expect404();
+    await dev.fetch("/blog/").expect404();
   },
 });
 

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -141,6 +141,7 @@ describe("url matching", () => {
     const dir = tempDir("fsr-match", Object.fromEntries(files.map(file => [file, "1"])));
     const router = new FrameworkRouter({ root: String(dir), style: "nextjs-pages" });
     return {
+      router,
       match(url: string): { file: string; params: Record<string, string | string[]> | null } | null {
         const result = router.match(url);
         if (result === null) return null;
@@ -148,6 +149,10 @@ describe("url matching", () => {
           file: path.relative(String(dir), result.route.page).replaceAll("\\", "/"),
           params: result.params,
         };
+      },
+      /** Top-level route parts in scan order (= dynamic candidate order). */
+      rootParts(): string[] {
+        return router.toJSON().children.map((child: { part: string }) => child.part);
       },
       [Symbol.dispose]() {
         dir[Symbol.dispose]();
@@ -199,6 +204,30 @@ describe("url matching", () => {
       file: "docs/[...slug].tsx",
       params: { slug: ["a", "b"] },
     });
+    // Empty segments never match, same as params.
+    expect(r.match("/docs//")).toBe(null);
+    expect(r.match("/docs//a")).toBe(null);
+    expect(r.match("/docs/a//b")).toBe(null);
+  });
+
+  test("params capture before a required catch-all", () => {
+    using r = makeMatcher("docs/[section]/[...rest].tsx");
+    expect(r.match("/docs/x")).toBe(null);
+    expect(r.match("/docs/x/")).toBe(null);
+    expect(r.match("/docs/x/y")).toEqual({
+      file: "docs/[section]/[...rest].tsx",
+      params: { section: "x", rest: "y" },
+    });
+    expect(r.match("/docs/x/y/z")).toEqual({
+      file: "docs/[section]/[...rest].tsx",
+      params: { section: "x", rest: ["y", "z"] },
+    });
+  });
+
+  test("param followed by an optional catch-all with zero segments", () => {
+    using r = makeMatcher("[a]/[[...opt]].tsx");
+    expect(r.match("/v")).toEqual({ file: "[a]/[[...opt]].tsx", params: { a: "v" } });
+    expect(r.match("/v/w")).toEqual({ file: "[a]/[[...opt]].tsx", params: { a: "v", opt: "w" } });
   });
 
   test("required catch-all at the root does not match /", () => {
@@ -220,12 +249,19 @@ describe("url matching", () => {
   });
 
   test("a failed candidate's captures don't leak into a later zero-segment match", () => {
-    // The [category] directory is scanned before blog/ (deterministic hash
-    // order), so the three-param pattern runs first, captures
-    // category="blog", then fails on [year]. The optional catch-all then
-    // matches /blog with zero segments and must not report that capture.
     using r = makeMatcher("[category]/[year]/[slug].tsx", "blog/[[...slug]].tsx");
+    // Premise: candidates run in scan order, so the three-param pattern must
+    // come first for this test to exercise the leak (it captures
+    // category="blog", fails on [year], then the catch-all matches with zero
+    // segments). If this assert breaks, reorder or rename the routes.
+    expect(r.rootParts()).toEqual(["/:category", "/blog"]);
     expect(r.match("/blog")).toEqual({ file: "blog/[[...slug]].tsx", params: null });
+  });
+
+  test("match rejects a path that is empty or does not start with a slash", () => {
+    using r = makeMatcher("docs/[...slug].tsx");
+    expect(() => r.router.match("")).toThrow("should be non-empty and start with a slash");
+    expect(() => r.router.match("docs/a")).toThrow("should be non-empty and start with a slash");
   });
 
   test("optional catch-all matches zero segments", () => {
@@ -240,5 +276,7 @@ describe("url matching", () => {
       file: "blog/[[...slug]].tsx",
       params: { slug: ["a", "b"] },
     });
+    // One trailing slash is tolerated, an empty segment is not.
+    expect(r.match("/blog//")).toBe(null);
   });
 });

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -133,3 +133,93 @@ test("discovers from filesystem paths", () => {
     ],
   });
 });
+
+describe("url matching", () => {
+  // Builds a router over `files` and returns match(url) normalized to
+  // { file: <relative page path>, params } or null for no match.
+  const makeMatcher = (...files: string[]) => {
+    const dir = tempDir("fsr-match", Object.fromEntries(files.map(file => [file, "1"])));
+    const router = new FrameworkRouter({ root: String(dir), style: "nextjs-pages" });
+    return {
+      match(url: string): { file: string; params: Record<string, string | string[]> | null } | null {
+        const result = router.match(url);
+        if (result === null) return null;
+        return {
+          file: path.relative(String(dir), result.route.page).replaceAll("\\", "/"),
+          params: result.params,
+        };
+      },
+      [Symbol.dispose]() {
+        dir[Symbol.dispose]();
+      },
+    };
+  };
+
+  test("every dynamic segment must be present in the url", () => {
+    using r = makeMatcher("[category]/[year]/[slug].tsx");
+    expect(r.match("/a/b/c")).toEqual({
+      file: "[category]/[year]/[slug].tsx",
+      params: { category: "a", year: "b", slug: "c" },
+    });
+    // Missing segments must not match as empty params.
+    expect(r.match("/first-post")).toBe(null);
+    expect(r.match("/a/b")).toBe(null);
+    expect(r.match("/a/b/c/d")).toBe(null);
+  });
+
+  test("a url with fewer segments matches the shorter pattern, not a longer one with empty params", () => {
+    using r = makeMatcher("[slug].tsx", "[category]/[year]/[slug].tsx");
+    expect(r.match("/first-post")).toEqual({
+      file: "[slug].tsx",
+      params: { slug: "first-post" },
+    });
+    expect(r.match("/a/b/c")).toEqual({
+      file: "[category]/[year]/[slug].tsx",
+      params: { category: "a", year: "b", slug: "c" },
+    });
+  });
+
+  test("params never match an empty segment", () => {
+    using r = makeMatcher("[slug].tsx", "a/[b].tsx");
+    expect(r.match("/")).toBe(null);
+    expect(r.match("//")).toBe(null);
+    expect(r.match("/a//")).toBe(null);
+    expect(r.match("/a/b")).toEqual({ file: "a/[b].tsx", params: { b: "b" } });
+  });
+
+  test("required catch-all needs at least one segment", () => {
+    using r = makeMatcher("docs/[...slug].tsx");
+    expect(r.match("/docs")).toBe(null);
+    expect(r.match("/docs/")).toBe(null);
+    expect(r.match("/docs/a")).toEqual({
+      file: "docs/[...slug].tsx",
+      params: { slug: "a" },
+    });
+    expect(r.match("/docs/a/b")).toEqual({
+      file: "docs/[...slug].tsx",
+      params: { slug: ["a", "b"] },
+    });
+  });
+
+  test("required catch-all at the root does not match /", () => {
+    using r = makeMatcher("[...slug].tsx");
+    expect(r.match("/")).toBe(null);
+    expect(r.match("/a/b")).toEqual({
+      file: "[...slug].tsx",
+      params: { slug: ["a", "b"] },
+    });
+  });
+
+  test("optional catch-all matches zero segments", () => {
+    using r = makeMatcher("blog/[[...slug]].tsx");
+    expect(r.match("/blog")).toEqual({ file: "blog/[[...slug]].tsx", params: null });
+    expect(r.match("/blog/a")).toEqual({
+      file: "blog/[[...slug]].tsx",
+      params: { slug: "a" },
+    });
+    expect(r.match("/blog/a/b")).toEqual({
+      file: "blog/[[...slug]].tsx",
+      params: { slug: ["a", "b"] },
+    });
+  });
+});

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -210,9 +210,19 @@ describe("url matching", () => {
     });
   });
 
+  test("a failed candidate's captures don't leak into a later zero-segment match", () => {
+    // The [category] directory is scanned before blog/ (deterministic hash
+    // order), so the three-param pattern runs first, captures
+    // category="blog", then fails on [year]. The optional catch-all then
+    // matches /blog with zero segments and must not report that capture.
+    using r = makeMatcher("[category]/[year]/[slug].tsx", "blog/[[...slug]].tsx");
+    expect(r.match("/blog")).toEqual({ file: "blog/[[...slug]].tsx", params: null });
+  });
+
   test("optional catch-all matches zero segments", () => {
     using r = makeMatcher("blog/[[...slug]].tsx");
     expect(r.match("/blog")).toEqual({ file: "blog/[[...slug]].tsx", params: null });
+    expect(r.match("/blog/")).toEqual({ file: "blog/[[...slug]].tsx", params: null });
     expect(r.match("/blog/a")).toEqual({
       file: "blog/[[...slug]].tsx",
       params: { slug: "a" },

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -210,6 +210,15 @@ describe("url matching", () => {
     });
   });
 
+  test("dynamic pattern ending in a static segment matches without a trailing slash", () => {
+    using r = makeMatcher("[user]/posts.tsx");
+    expect(r.match("/joe/posts")).toEqual({ file: "[user]/posts.tsx", params: { user: "joe" } });
+    expect(r.match("/joe/posts/")).toEqual({ file: "[user]/posts.tsx", params: { user: "joe" } });
+    expect(r.match("/joe")).toBe(null);
+    expect(r.match("/joe/other")).toBe(null);
+    expect(r.match("/joe/posts/extra")).toBe(null);
+  });
+
   test("a failed candidate's captures don't leak into a later zero-segment match", () => {
     // The [category] directory is scanned before blog/ (deterministic hash
     // order), so the three-param pattern runs first, captures


### PR DESCRIPTION
### Problem

`FrameworkRouter`'s URL matcher (used by the bake dev server for `nextjs-pages` style routes) gets several segment boundaries wrong:

1. A `[param]` segment matches even when the URL has run out of segments, capturing an empty string. With `pages/[category]/[year]/[slug].tsx`, `GET /first-post` returns 200 and renders that page with `params = { category: "first-post", year: "", slug: "" }` instead of 404. In a project that also has `pages/[slug].tsx`, `/first-post` can be routed to the three-segment page (whichever dynamic pattern is iterated first wins) and renders with empty params. An empty segment from a double slash (`/a//`) is captured the same way.

2. A required catch-all (`[...slug]`) matches zero segments, so `pages/[...slug].tsx` matches `GET /`. The framework then receives `params = null`, and a typical page doing `params.slug` throws (`TypeError: null is not an object (evaluating 'params.slug')`, 500 response). Next.js semantics: required `[...slug]` does not match the parent path; only the optional form `[[...slug]]` matches zero segments. The pattern parser already distinguishes the two forms; `matches()` collapsed them.

3. A dynamic pattern ending in a static segment never matches without a trailing slash: `[user]/posts.tsx` matches `/joe/posts/` but not `/joe/posts` (found in review).

4. A candidate pattern that captured a param and then failed left its captures behind, and a later pattern matching with zero captures (an optional catch-all at its base path) reported them: with `[a]/[b].tsx` and `foo/[[...slug]].tsx`, `GET /foo` could render with `params = { a: "foo" }` instead of `null` (found in review).

5. Catch-alls silently skipped empty segments while params now reject them: `/docs//a` matched `docs/[...slug].tsx`. Bake does not normalize repeated slashes before routing (Next.js redirects them), so the matcher does see such paths (found in review).

Repro with the internal test router (same matcher the dev server uses):

```ts
import { frameworkRouterInternals } from "bun:internal-for-testing";
const { FrameworkRouter } = frameworkRouterInternals;
// root contains [category]/[year]/[slug].tsx and docs/[...slug].tsx
const router = new FrameworkRouter({ root, style: "nextjs-pages" });
router.match("/first-post"); // matched, params { category: "first-post", year: "", slug: "" }
router.match("/docs");       // matched, params null
```

### Cause

In `EncodedPattern::matches` (src/runtime/bake/FrameworkRouter.rs):

- The `Part::Param` arm guarded with `i > path.len()`. After the last real segment is consumed, `i == path.len()`, so the guard passed and the param captured `path[i..i]`, the empty string. Nothing rejected an empty capture when the next byte was `/` either.
- The `Part::CatchAll` and `Part::CatchAllOptional` arms shared one body that returns `true` regardless of whether any segment was captured, erasing the required/optional distinction, and skipped empty segments instead of failing on them.
- The `Part::Text` arm always advanced past an assumed trailing separator (`i += 1 + expect.len()`), overshooting the path length by one when the text ends the path, so the final `i == path.len()` check failed.
- `matches()` appends captures into the `MatchedParams` that `match_slow` reuses across candidates, and only resizes it when it writes; the one success path that writes nothing (zero-segment optional catch-all) exposed whatever a previously failed candidate left there.

### Fix

- `Part::Param` requires a remaining, non-empty segment: the guard is now `i >= path.len()`, and a capture where `end == i` (empty segment) fails the match. This matches Next.js, where `[param]` compiles to `[^/]+`.
- The catch-all arm records how many params it captured; a required catch-all only matches if it captured at least one segment, while `[[...name]]` keeps matching zero. An empty segment fails the match, same as the Param arm; a single trailing slash is still tolerated.
- The `Part::Text` arm consumes the separator only when the text does not end the path, mirroring the `Part::Param` arm.
- `matches()` clears the params array on entry, so its output always reflects the matched pattern only.
- `JSFrameworkRouter.match` (the `bun:internal-for-testing` binding) validates its input like the dev server's route lookup (non-empty, leading `/`) instead of feeding arbitrary JS strings into `match_slow`, where `match("")` hit an index panic and a slash-less path aborted debug builds via the `path[0] == b'/'` assert. It also now converts params with `MatchedParams::to_js`, the same conversion the dev server uses, instead of a duplicated loop that `put` each key and silently dropped all but the last segment of a catch-all.

Not changed here:

- `match_slow` still tries dynamic patterns in insertion order rather than sorting by specificity as Next.js does. With missing segments no longer matching, patterns with different segment counts can no longer collide, which was the harmful case.
- The dev server's `on_request` matches routes against the raw request target (query string included) while the later params computation matches the stripped pathname, so the two can disagree on query-bearing URLs like `/a/?x=1` (the `?x=1` tail parses as a phantom segment during selection). That divergence predates this PR; the lenient matcher just made both sides agree more often on such URLs, rendering with empty params. #33232 fixes it at the right layer by routing `on_request` on `extract_pathname_from_url(req.url())`, after which selection and params agree and these URLs resolve by their pathname. Matching `?` specially inside the matcher here would paper over the caller's contract violation instead.

### Verification

`test/bake/framework-router.test.ts` gains a "url matching" block covering: all params required (`/a/b` and `/first-post` no longer match a three-param route, `/a/b/c` still does), shorter pattern preferred when the longer one cannot fill its segments, empty segments rejected for params and catch-alls (`/`, `//`, `/a//`, `/docs//`, `/docs//a`, `/docs/a//b`, `/blog//`), required catch-all needing one segment (`/docs`, `/docs/` are 404; `/docs/a`, `/docs/a/b` match), params capturing before a catch-all (`docs/[section]/[...rest].tsx`, `[a]/[[...opt]].tsx`), required catch-all at the root not matching `/`, trailing-slash-less matching for patterns ending in static text, no capture leakage from a failed candidate into a zero-segment match (with the candidate-order premise asserted), optional catch-all matching zero segments (including `/blog/`), and the binding rejecting empty or slash-less input. Ten tests fail on the unfixed build and pass with the fix.

`test/bake/dev/import-meta-inline.test.ts` asserted the old behavior (`/blog/` matching `routes/blog/[...slug].ts` with an empty slug); it now expects 404 for `/blog` and `/blog/`.

Also ran the bake suites that exercise dynamic routes (`ssg-pages-router`, `production`, `react-response`, `sourcemap`, `server-sourcemap`) with the fix; no regressions.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/import-meta-inline.test.ts

<!-- robobun:evidence:end -->