### PR TITLE
webcrypto: generate RSA keys on the work pool instead of the JS thread

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -32,6 +32,8 @@
 #include "CryptoKeyPair.h"
 #include "CryptoKeyRSAComponents.h"
 #include "OpenSSLUtilities.h"
+#include "PhonyWorkQueue.h"
+#include "ScriptExecutionContext.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <openssl/x509.h>
 #include <openssl/evp.h>
@@ -189,7 +191,35 @@ static std::optional<uint32_t> exponentVectorToUInt32(const Vector<uint8_t>& exp
     return result;
 }
 
-void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgorithmIdentifier hash, bool hasHash, unsigned modulusLength, const Vector<uint8_t>& publicExponent, bool extractable, CryptoKeyUsageBitmap usages, KeyPairCallback&& callback, VoidCallback&& failureCallback, ScriptExecutionContext*)
+struct PlatformRSAKeyPair {
+    EvpPKeyPtr publicKey;
+    EvpPKeyPtr privateKey;
+};
+
+// Returns null keys on failure.
+static PlatformRSAKeyPair generatePlatformKeyPair(unsigned modulusLength, const Vector<uint8_t>& publicExponent)
+{
+    auto exponent = convertToBigNumber(publicExponent);
+    auto privateRSA = RSAPtr(RSA_new());
+    if (!exponent || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0)
+        return {};
+
+    auto publicRSA = RSAPtr(RSAPublicKey_dup(privateRSA.get()));
+    if (!publicRSA)
+        return {};
+
+    auto privatePKey = EvpPKeyPtr(EVP_PKEY_new());
+    if (EVP_PKEY_set1_RSA(privatePKey.get(), privateRSA.get()) <= 0)
+        return {};
+
+    auto publicPKey = EvpPKeyPtr(EVP_PKEY_new());
+    if (EVP_PKEY_set1_RSA(publicPKey.get(), publicRSA.get()) <= 0)
+        return {};
+
+    return { WTF::move(publicPKey), WTF::move(privatePKey) };
+}
+
+void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgorithmIdentifier hash, bool hasHash, unsigned modulusLength, const Vector<uint8_t>& publicExponent, bool extractable, CryptoKeyUsageBitmap usages, KeyPairCallback&& callback, VoidCallback&& failureCallback, ScriptExecutionContext* context)
 {
     // OpenSSL doesn't report an error if the exponent is smaller than three or even.
     auto e = exponentVectorToUInt32(publicExponent);
@@ -198,34 +228,22 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
         return;
     }
 
-    auto exponent = convertToBigNumber(publicExponent);
-    auto privateRSA = RSAPtr(RSA_new());
-    if (!exponent || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0) {
-        failureCallback();
-        return;
-    }
-
-    auto publicRSA = RSAPtr(RSAPublicKey_dup(privateRSA.get()));
-    if (!publicRSA) {
-        failureCallback();
-        return;
-    }
-
-    auto privatePKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_RSA(privatePKey.get(), privateRSA.get()) <= 0) {
-        failureCallback();
-        return;
-    }
-
-    auto publicPKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_RSA(publicPKey.get(), publicRSA.get()) <= 0) {
-        failureCallback();
-        return;
-    }
-
-    auto publicKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Public, WTF::move(publicPKey), true, usages);
-    auto privateKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Private, WTF::move(privatePKey), extractable, usages);
-    callback(CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) });
+    // RSA key generation takes tens to hundreds of milliseconds, so run it in the work
+    // pool and post the platform keys back, like the CommonCrypto port's dispatch to a
+    // background queue. The CryptoKey wrappers are created on the context's thread.
+    auto workQueue = Bun::PhonyWorkQueue::create("RSA key generation"_s);
+    workQueue->dispatch(context->globalObject(), [algorithm, hash, hasHash, modulusLength, publicExponent = publicExponent, extractable, usages, callback = WTF::move(callback), failureCallback = WTF::move(failureCallback), contextIdentifier = context->identifier()]() mutable {
+        auto platformKeys = generatePlatformKeyPair(modulusLength, publicExponent);
+        ScriptExecutionContext::postTaskTo(contextIdentifier, [algorithm, hash, hasHash, extractable, usages, publicPKey = WTF::move(platformKeys.publicKey), privatePKey = WTF::move(platformKeys.privateKey), callback = WTF::move(callback), failureCallback = WTF::move(failureCallback)](auto&) mutable {
+            if (!publicPKey || !privatePKey) {
+                failureCallback();
+                return;
+            }
+            auto publicKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Public, WTF::move(publicPKey), true, usages);
+            auto privateKey = CryptoKeyRSA::create(algorithm, hash, hasHash, CryptoKeyType::Private, WTF::move(privatePKey), extractable, usages);
+            callback(CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) });
+        });
+    });
 }
 
 RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifier, std::optional<CryptoAlgorithmIdentifier> hash, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, bool* keyTypeMismatch)

--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -228,8 +228,7 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
         return;
     }
 
-    // Like the CommonCrypto port, generate the platform keys off-thread; the
-    // CryptoKey wrappers must be created on the context's thread.
+    // The CryptoKey wrappers must be created on the context's thread.
     auto workQueue = Bun::PhonyWorkQueue::create("RSA key generation"_s);
     workQueue->dispatch(context->globalObject(), [algorithm, hash, hasHash, modulusLength, publicExponent = publicExponent, extractable, usages, callback = WTF::move(callback), failureCallback = WTF::move(failureCallback), contextIdentifier = context->identifier()]() mutable {
         auto platformKeys = generatePlatformKeyPair(modulusLength, publicExponent);

--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -228,9 +228,8 @@ void CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier algorithm, CryptoAlgor
         return;
     }
 
-    // RSA key generation takes tens to hundreds of milliseconds, so run it in the work
-    // pool and post the platform keys back, like the CommonCrypto port's dispatch to a
-    // background queue. The CryptoKey wrappers are created on the context's thread.
+    // Like the CommonCrypto port, generate the platform keys off-thread; the
+    // CryptoKey wrappers must be created on the context's thread.
     auto workQueue = Bun::PhonyWorkQueue::create("RSA key generation"_s);
     workQueue->dispatch(context->globalObject(), [algorithm, hash, hasHash, modulusLength, publicExponent = publicExponent, extractable, usages, callback = WTF::move(callback), failureCallback = WTF::move(failureCallback), contextIdentifier = context->identifier()]() mutable {
         auto platformKeys = generatePlatformKeyPair(modulusLength, publicExponent);

--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -201,7 +201,7 @@ static PlatformRSAKeyPair generatePlatformKeyPair(unsigned modulusLength, const 
 {
     auto exponent = convertToBigNumber(publicExponent);
     auto privateRSA = RSAPtr(RSA_new());
-    if (!exponent || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0)
+    if (!exponent || !privateRSA || RSA_generate_key_ex(privateRSA.get(), modulusLength, exponent.get(), nullptr) <= 0)
         return {};
 
     auto publicRSA = RSAPtr(RSAPublicKey_dup(privateRSA.get()));
@@ -209,11 +209,11 @@ static PlatformRSAKeyPair generatePlatformKeyPair(unsigned modulusLength, const 
         return {};
 
     auto privatePKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_RSA(privatePKey.get(), privateRSA.get()) <= 0)
+    if (!privatePKey || EVP_PKEY_set1_RSA(privatePKey.get(), privateRSA.get()) <= 0)
         return {};
 
     auto publicPKey = EvpPKeyPtr(EVP_PKEY_new());
-    if (EVP_PKEY_set1_RSA(publicPKey.get(), publicRSA.get()) <= 0)
+    if (!publicPKey || EVP_PKEY_set1_RSA(publicPKey.get(), publicRSA.get()) <= 0)
         return {};
 
     return { WTF::move(publicPKey), WTF::move(privatePKey) };

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1281,10 +1281,12 @@ describe("RSA generateKey", () => {
   };
 
   it("resolves asynchronously instead of inside the generateKey call", async () => {
+    const order: string[] = [];
     const pending = crypto.subtle.generateKey(rsaParams, true, ["sign", "verify"]);
     let settled = false;
     pending.then(() => {
       settled = true;
+      order.push("keygen");
     });
     // With synchronous keygen the promise is already fulfilled when the call
     // returns, so its reaction runs at this microtask checkpoint. Off-thread
@@ -1293,7 +1295,19 @@ describe("RSA generateKey", () => {
     await Promise.resolve();
     expect(settled).toBe(false);
 
+    // A 0ms timer armed right after the call must fire before the keygen
+    // resolves. A synchronous keygen that merely posted its resolution as a
+    // task would have enqueued the completion before this timer existed and
+    // would flip the order.
+    await new Promise<void>(resolve =>
+      setTimeout(() => {
+        order.push("timer");
+        resolve();
+      }, 0),
+    );
     const { publicKey, privateKey } = (await pending) as CryptoKeyPair;
+    expect(order).toEqual(["timer", "keygen"]);
+
     const data = new Uint8Array([1, 2, 3]);
     const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", privateKey, data);
     expect(await crypto.subtle.verify("RSASSA-PKCS1-v1_5", publicKey, signature, data)).toBe(true);
@@ -1313,6 +1327,26 @@ describe("RSA generateKey", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("public private\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("keeps the process alive for a floating generateKey promise", async () => {
+    // No top-level await: the process lifetime rides entirely on the work-pool
+    // task's event-loop ref. If that ref were lost, the process would exit
+    // silently before the keygen completes.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `crypto.subtle.generateKey({ name: "RSA-PSS", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) }, true, ["sign", "verify"]).then(pair => console.log(pair.publicKey.type));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("public\n");
     expect(exitCode).toBe(0);
   });
 
@@ -1343,32 +1377,33 @@ describe("RSA generateKey", () => {
   });
 
   it("generates keys inside a Worker", async () => {
-    const worker = new Worker(
-      URL.createObjectURL(
-        new Blob(
-          [
-            `(async () => {
-              const pair = await crypto.subtle.generateKey(
-                { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
-                true,
-                ["sign", "verify"],
-              );
-              const data = new Uint8Array([1, 2, 3]);
-              const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", pair.privateKey, data);
-              postMessage({ verified: await crypto.subtle.verify("RSASSA-PKCS1-v1_5", pair.publicKey, signature, data) });
-            })().catch(e => postMessage({ error: String(e) }));`,
-          ],
-          { type: "application/javascript" },
-        ),
+    const workerUrl = URL.createObjectURL(
+      new Blob(
+        [
+          `(async () => {
+            const pair = await crypto.subtle.generateKey(
+              { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+              true,
+              ["sign", "verify"],
+            );
+            const data = new Uint8Array([1, 2, 3]);
+            const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", pair.privateKey, data);
+            postMessage({ verified: await crypto.subtle.verify("RSASSA-PKCS1-v1_5", pair.publicKey, signature, data) });
+          })().catch(e => postMessage({ error: String(e) }));`,
+        ],
+        { type: "application/javascript" },
       ),
     );
+    let worker: Worker | undefined;
     try {
+      worker = new Worker(workerUrl);
       const { promise, resolve, reject } = Promise.withResolvers<any>();
       worker.onmessage = e => resolve(e.data);
       worker.onerror = e => reject(new Error(e.message));
       expect(await promise).toEqual({ verified: true });
     } finally {
-      worker.terminate();
+      worker?.terminate();
+      URL.revokeObjectURL(workerUrl);
     }
   });
 });

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1268,6 +1268,111 @@ describe("crypto.getRandomValues argument types", () => {
   }
 });
 
+// RSA key generation runs in the work pool instead of synchronously on the JS
+// thread. Before, generateKey returned an already-resolved promise: the keygen
+// (tens to hundreds of ms for 2048 bits) blocked the event loop and serialized
+// concurrent calls.
+describe("RSA generateKey", () => {
+  const rsaParams: RsaHashedKeyGenParams = {
+    name: "RSASSA-PKCS1-v1_5",
+    hash: "SHA-256",
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1]),
+  };
+
+  it("resolves asynchronously instead of inside the generateKey call", async () => {
+    const pending = crypto.subtle.generateKey(rsaParams, true, ["sign", "verify"]);
+    let settled = false;
+    pending.then(() => {
+      settled = true;
+    });
+    // With synchronous keygen the promise is already fulfilled when the call
+    // returns, so its reaction runs at this microtask checkpoint. Off-thread
+    // keygen cannot resolve during a microtask drain; it needs a full
+    // event-loop turn to deliver the result.
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    const { publicKey, privateKey } = (await pending) as CryptoKeyPair;
+    const data = new Uint8Array([1, 2, 3]);
+    const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", privateKey, data);
+    expect(await crypto.subtle.verify("RSASSA-PKCS1-v1_5", publicKey, signature, data)).toBe(true);
+  });
+
+  it("keeps the process alive until pending key generation resolves", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const pair = await crypto.subtle.generateKey({ name: "RSA-OAEP", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) }, true, ["encrypt", "decrypt"]); console.log(pair.publicKey.type, pair.privateKey.type);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("public private\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("still rejects empty usages after generating the pair", async () => {
+    const result = await crypto.subtle.generateKey(rsaParams, true, []).then(
+      () => "resolved",
+      e => `${e.name}: ${e.message}`,
+    );
+    expect(result).toBe("SyntaxError: Usages cannot be empty when creating a key.");
+  });
+
+  it("rejects invalid generation parameters with OperationError", async () => {
+    const probe = (params: RsaHashedKeyGenParams) =>
+      crypto.subtle.generateKey(params, true, ["encrypt", "decrypt"]).then(
+        () => "resolved",
+        e => e.name,
+      );
+    expect({
+      // Rejected synchronously before any keygen is dispatched.
+      evenExponent: await probe({ ...rsaParams, name: "RSA-OAEP", publicExponent: new Uint8Array([4]) }),
+      // Makes RSA_generate_key_ex itself fail, on the failure path of the
+      // dispatched keygen.
+      tinyModulus: await probe({ ...rsaParams, name: "RSA-OAEP", modulusLength: 8 }),
+    }).toEqual({
+      evenExponent: "OperationError",
+      tinyModulus: "OperationError",
+    });
+  });
+
+  it("generates keys inside a Worker", async () => {
+    const worker = new Worker(
+      URL.createObjectURL(
+        new Blob(
+          [
+            `(async () => {
+              const pair = await crypto.subtle.generateKey(
+                { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+                true,
+                ["sign", "verify"],
+              );
+              const data = new Uint8Array([1, 2, 3]);
+              const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", pair.privateKey, data);
+              postMessage({ verified: await crypto.subtle.verify("RSASSA-PKCS1-v1_5", pair.publicKey, signature, data) });
+            })().catch(e => postMessage({ error: String(e) }));`,
+          ],
+          { type: "application/javascript" },
+        ),
+      ),
+    );
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<any>();
+      worker.onmessage = e => resolve(e.data);
+      worker.onerror = e => reject(new Error(e.message));
+      expect(await promise).toEqual({ verified: true });
+    } finally {
+      worker.terminate();
+    }
+  });
+});
+
 describe("exception scope discipline", () => {
   // BUN_JSC_validateExceptionChecks=1 aborts on the first unchecked throw scope, so the
   // fixture (every SubtleCrypto op, success and normalize-failure) only produces the full


### PR DESCRIPTION
### What

`crypto.subtle.generateKey` for the RSA algorithms (RSASSA-PKCS1-v1_5, RSA-OAEP, RSA-PSS) ran `RSA_generate_key_ex` synchronously on the JS thread and resolved the promise before `generateKey` even returned. A 2048-bit generation stalls the event loop for ~50-150ms (more at 4096), and concurrent calls were fully serialized. (RSAES-PKCS1-v1_5 shares the same `generatePair`, but its `generateKey` is rejected at algorithm normalization as deprecated, so that path is unreachable.)

```js
const p = { name: "RSA-OAEP", hash: "SHA-256", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) };
const pending = crypto.subtle.generateKey(p, true, ["encrypt", "decrypt"]);
setTimeout(() => console.log("timer"), 0);
pending.then(() => console.log("keygen"));
// before: "keygen" then "timer" (promise already resolved inside the call)
// after:  "timer" then "keygen"
```

The spec says the generateKey operation runs in parallel, and the WebKit comment above the call site ("we perform it as an async task only for RSA keys") describes exactly that behavior in the CommonCrypto port, which dispatches RSA generation to a background queue. Bun's OpenSSL port ignored its `ScriptExecutionContext*` parameter and did everything inline, so the comment did not hold here.

### Fix

`CryptoKeyRSA::generatePair` now validates the public exponent synchronously (unchanged), then dispatches the OpenSSL key generation to the work pool through the same queue mechanism the other SubtleCrypto operations use, and posts the resulting `EVP_PKEY`s back to the context's thread via `ScriptExecutionContext::postTaskTo`. The `CryptoKey` wrappers are created and the callbacks run on the context's thread, as before. Failure of the generation itself (e.g. a modulus OpenSSL rejects) still surfaces as the same `OperationError`, and the extracted helper now also null-checks the `RSA_new`/`EVP_PKEY_new` allocations, consistent with `CryptoKeyRSA::create` in the same file.

This mirrors the structure of the CommonCrypto port's `generatePair` (background generation, platform keys posted back, wrappers created on the owning thread) and keeps the `CryptoAlgorithm::generateKey` signature untouched, so AES/HMAC/EC/OKP generation stays synchronous, matching WebKit's deliberate choice for the cheap algorithms.

Measured with 8x RSA-2048 generateKey (release-built BoringSSL, debug bun): serial 1791ms vs `Promise.all` 473ms (3.79x) after the change; before, concurrent was 0.69x serial, i.e. no overlap at all.

### Tests

`test/js/web/crypto/web-crypto.test.ts`:
- the promise is not already resolved at the first microtask checkpoint after the call (fails on the old implementation, which resolved inside the call), and a 0ms timer armed right after the call fires before the keygen resolves (fails if generation runs on the JS thread even with resolution deferred to a task); the generated pair then signs/verifies
- a process top-level-awaiting `generateKey` stays alive until it resolves, and so does a process whose only pending work is a floating (non-awaited) `generateKey` promise, whose lifetime rides on the work-pool task's event-loop ref
- empty usages still reject with `SyntaxError: Usages cannot be empty when creating a key.` (this rejection now happens after the off-thread generation)
- invalid parameters: even exponent (synchronous pre-validation) and 8-bit modulus (failure on the pool thread) both reject with `OperationError`
- generation inside a `Worker` works (posts back to the worker's context)

Also ran: the WPT generateKey suite (`test/js/bun/crypto/wpt-webcrypto.generateKey.test.ts`, 10226 pass), the node webcrypto RSA tests (`test-webcrypto-encrypt-decrypt-rsa`, `test-webcrypto-export-import-rsa`, `test-webcrypto-sign-verify`, `test-webcrypto-wrap-unwrap`, `test-webcrypto-methods-not-async`, `test-webcrypto-cryptokey-workers`), and the full `web-crypto.test.ts` under `BUN_JSC_validateExceptionChecks=1`.

### Interaction with `worker.terminate()`

While probing this change under ASAN I hit a heap-use-after-free when `worker.terminate()` lands while a work-pool crypto task is still in flight: the pool thread's completion path reads the worker's already-freed `VirtualMachine` (`ConcurrentCppTask::run_owned` -> `VirtualMachine::event_loop_shared`, freed by `WebWorker::shutdown`). This race is pre-existing: it reproduces identically with PBKDF2 `deriveBits` (untouched by this PR), and it is the class #34154 addresses, though that PR's producer coverage does not yet include `ConcurrentCppTask`. This PR does widen the window for hitting it via `generateKey` in a worker (RSA generation holds a pool task for ~50-150ms instead of microseconds), so that coverage gap is worth closing; it is tracked separately. The worker test added here terminates only after the operation completes, so it does not race.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.0 (72548d956)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [5.44ms]
(pass) Web Crypto > keeps event loop alive [341.37ms]
(pass) Web Crypto > has globals [3.45ms]
(pass) Web Crypto > should encrypt and decrypt [14.02ms]
(pass) Web Crypto > should verify and sign [38.80ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [16.17ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.91ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.60ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2564.68ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [344.48ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [7.04ms]
(pass) ChaCha20-Pol
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0ffabf64d)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
(pass) Web Crypto > keeps event loop alive [9.09ms]
(pass) Web Crypto > has globals [0.05ms]
(pass) Web Crypto > should encrypt and decrypt [0.36ms]
(pass) Web Crypto > should verify and sign [0.69ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.26ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.19ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.16ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [27.75ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [8.77ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.17ms]
(pass) ChaCha20-Poly1305 and AKP review fixes > raw-public import of an RSA key reports Node's aliased-format message [0.23ms]
(pass) ChaCha20-Poly1305 and AKP review fixes > wrapKey rejects a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.0 (72548d956)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [5.27ms]
(pass) Web Crypto > keeps event loop alive [330.95ms]
(pass) Web Crypto > has globals [3.23ms]
(pass) Web Crypto > should encrypt and decrypt [12.82ms]
(pass) Web Crypto > should verify and sign [37.78ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.89ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.28ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.75ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2522.27ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [348.62ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [7.19ms]
(pass) ChaCha20-Pol
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/113] gen cpp.rs (cppbind)
[1/113] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp |  64 ++++++----
 test/js/web/crypto/web-crypto.test.ts              | 140 +++++++++++++++++++++
 2 files changed, 180 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp      2      6      0
test/js/web/crypto/web-crypto.test.ts                   2      5      0
```

</details>

<!-- robobun:evidence:end -->