### PR TITLE
test(sql): drop redundant isDockerEnabled() gates that block BUN_TEST_SERVICE overrides

### DIFF
--- a/test/js/sql/sql-mysql-bigint-out-of-range.test.ts
+++ b/test/js/sql/sql-mysql-bigint-out-of-range.test.ts
@@ -1,6 +1,6 @@
 import { SQL } from "bun";
-import { describe, expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
 
 async function assertOutOfRangeBigIntRejected(url: string) {
   await using sql = new SQL(url);
@@ -9,18 +9,9 @@ async function assertOutOfRangeBigIntRejected(url: string) {
   expect(await sql`select ${-1n} as v`).toEqual([{ v: -1 }]);
 }
 
-if (isDockerEnabled()) {
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test("an out-of-range BigInt bind parameter is rejected, not truncated", async () => {
-      await container.ready;
-      await assertOutOfRangeBigIntRejected(`mysql://root@${container.host}:${container.port}/bun_sql_test`);
-    });
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test("an out-of-range BigInt bind parameter is rejected, not truncated", async () => {
+    await container.ready;
+    await assertOutOfRangeBigIntRejected(`mysql://root@${container.host}:${container.port}/bun_sql_test`);
   });
-} else {
-  const url = process.env.MYSQL_URL;
-  describe("mysql (local)", () => {
-    test.skipIf(!url)("an out-of-range BigInt bind parameter is rejected, not truncated", async () => {
-      await assertOutOfRangeBigIntRejected(url!);
-    });
-  });
-}
+});

--- a/test/js/sql/sql-mysql-bind-blob-borrow.test.ts
+++ b/test/js/sql/sql-mysql-bind-blob-borrow.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer } from "harness";
 import path from "path";
 
 // Regression: Value.fromJS for MySQL BLOB parameters borrowed the
@@ -67,45 +67,15 @@ function assertFixtureOutput(stdout: string, stderr: string, exitCode: number) {
 // default on a cold cache under ASAN.
 const TEST_TIMEOUT = 30_000;
 
-if (isDockerEnabled()) {
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test(
-      "BLOB param backing store is pinned across the bind loop",
-      async () => {
-        await container.ready;
-        const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
-        const { stdout, stderr, exitCode } = await runFixture(url);
-        assertFixtureOutput(stdout, stderr, exitCode);
-      },
-      TEST_TIMEOUT,
-    );
-  });
-} else {
-  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server
-  // is reachable at MYSQL_URL or the conventional local address, exercise
-  // the fixture there so the regression is still covered.
-  const url = process.env.MYSQL_URL || "mysql://bun@127.0.0.1:3306/bun_sql_test";
-
-  describe("mysql (local)", () => {
-    test(
-      "BLOB param backing store is pinned across the bind loop",
-      async () => {
-        const { stdout, stderr, exitCode } = await runFixture(url);
-        // The fixture prints "CONNECTED" after the priming query succeeds. If
-        // it never got that far, there's no MySQL to talk to in this
-        // environment; the docker-gated branch above provides the CI coverage.
-        if (!stdout.startsWith("CONNECTED")) {
-          if (process.env.MYSQL_URL) {
-            throw new Error(
-              `sql-mysql-bind-blob-borrow: MYSQL_URL was provided but fixture never reached CONNECTED\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-            );
-          }
-          console.warn("sql-mysql-bind-blob-borrow: no MySQL reachable at " + url + "; skipping assertions");
-          return;
-        }
-        assertFixtureOutput(stdout, stderr, exitCode);
-      },
-      TEST_TIMEOUT,
-    );
-  });
-}
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test(
+    "BLOB param backing store is pinned across the bind loop",
+    async () => {
+      await container.ready;
+      const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+      const { stdout, stderr, exitCode } = await runFixture(url);
+      assertFixtureOutput(stdout, stderr, exitCode);
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/test/js/sql/sql-mysql-bind-oob.test.ts
+++ b/test/js/sql/sql-mysql-bind-oob.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer } from "harness";
 import path from "path";
 
 // Regression: MySQLQuery.bind() allocates `params` sized to the prepared
@@ -43,40 +43,11 @@ function assertFixtureOutput(stdout: string, stderr: string, exitCode: number) {
   expect(exitCode).toBe(0);
 }
 
-if (isDockerEnabled()) {
-  // CI: run against the docker-compose MySQL service.
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test("bind() does not OOB when the params array grows during binding", async () => {
-      await container.ready;
-      const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
-      const { stdout, stderr, exitCode } = await runFixture(url);
-      assertFixtureOutput(stdout, stderr, exitCode);
-    });
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test("bind() does not OOB when the params array grows during binding", async () => {
+    await container.ready;
+    const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+    const { stdout, stderr, exitCode } = await runFixture(url);
+    assertFixtureOutput(stdout, stderr, exitCode);
   });
-} else {
-  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server
-  // is reachable at MYSQL_URL or the conventional local address, exercise the
-  // fixture there so the regression is still covered.
-  const url = process.env.MYSQL_URL || "mysql://bun@127.0.0.1:3306/bun_sql_test";
-
-  describe("mysql (local)", () => {
-    test("bind() does not OOB when the params array grows during binding", async () => {
-      const { stdout, stderr, exitCode } = await runFixture(url);
-      // The fixture prints "CONNECTED" after the priming query succeeds. If
-      // it never got that far, there's no MySQL to talk to in this
-      // environment; the docker-gated branch above provides the CI coverage.
-      if (!stdout.startsWith("CONNECTED")) {
-        if (process.env.MYSQL_URL) {
-          // MYSQL_URL was explicitly provided; failing to connect is a real
-          // error, not an environment without MySQL.
-          throw new Error(
-            `sql-mysql-bind-oob: MYSQL_URL was provided but fixture never reached CONNECTED\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-          );
-        }
-        console.warn("sql-mysql-bind-oob: no MySQL reachable at " + url + "; skipping assertions");
-        return;
-      }
-      assertFixtureOutput(stdout, stderr, exitCode);
-    });
-  });
-}
+});

--- a/test/js/sql/sql-mysql-cached-error.test.ts
+++ b/test/js/sql/sql-mysql-cached-error.test.ts
@@ -6,68 +6,66 @@
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { describeWithContainer } from "harness";
 
-if (isDockerEnabled()) {
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test("MySQL: cached failed prepared statement error_message is not a dangling slice", async () => {
-      await container.ready;
-      await using sql = new SQL({
-        url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
-        max: 1,
-      });
-
-      // Long bogus identifiers so the server's echoed error_message exceeds the 15-byte
-      // inline-string threshold and is heap-backed, and so the two messages differ at
-      // bytes the second packet would overwrite in the read buffer. MySQL truncates the
-      // "near '...'" clause to ~80 chars, so keep these short enough to appear in full.
-      const longA = Buffer.alloc(50, "A").toString();
-      const longZ = Buffer.alloc(50, "Z").toString();
-
-      // First failing query → statement cached as .failed with error_message.
-      const err1 = await sql`wat ${1} ${sql.unsafe(longA)}`.catch((x: any) => x);
-      expect(err1).toBeInstanceOf(Error);
-      expect(err1.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
-      expect(err1.errno).toBe(1064);
-      expect(err1.message).toContain(longA);
-
-      // Different failing query → server sends a different ERROR packet that overwrites
-      // the connection read buffer where err1's message slice used to point.
-      const errOverwrite = await sql`other ${1} ${sql.unsafe(longZ)}`.catch((x: any) => x);
-      expect(errOverwrite).toBeInstanceOf(Error);
-      expect(errOverwrite.message).toContain(longZ);
-      expect(errOverwrite.message).not.toBe(err1.message);
-
-      // Same as the first failing query → hits the cached .failed statement and calls
-      // stmt.error_response.toJS(). Before the fix this read the overwritten buffer and
-      // returned bytes from errOverwrite's packet; after the fix it returns the original.
-      // Com_stmt_prepare (read via .simple() so the status query itself does not prepare)
-      // must not increment across this call — proving the third query was served from
-      // Bun's failed-statement cache, not re-prepared on the server. A fresh prepare
-      // would return an identical error for identical SQL and silently satisfy every
-      // assertion below without exercising the cached-slice path.
-      const [{ Value: preparesBefore }] = await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple();
-      // err1 and errOverwrite each reached COM_STMT_PREPARE, so the counter is
-      // already non-zero here; if it were 0 the "no increment" check below would
-      // be vacuous because the prepared path was never taken.
-      expect(Number(preparesBefore)).toBeGreaterThan(0);
-      const err2 = await sql`wat ${1} ${sql.unsafe(longA)}`.catch((x: any) => x);
-      const [{ Value: preparesAfter }] = await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple();
-      expect({
-        code: err2.code,
-        errno: err2.errno,
-        sqlState: err2.sqlState,
-        message: err2.message,
-        preparesAfter: Number(preparesAfter),
-      }).toEqual({
-        code: err1.code,
-        errno: err1.errno,
-        sqlState: err1.sqlState,
-        message: err1.message,
-        preparesAfter: Number(preparesBefore),
-      });
-      expect(err2.message).toContain(longA);
-      expect(err2.message).not.toContain(longZ);
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test("MySQL: cached failed prepared statement error_message is not a dangling slice", async () => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
     });
+
+    // Long bogus identifiers so the server's echoed error_message exceeds the 15-byte
+    // inline-string threshold and is heap-backed, and so the two messages differ at
+    // bytes the second packet would overwrite in the read buffer. MySQL truncates the
+    // "near '...'" clause to ~80 chars, so keep these short enough to appear in full.
+    const longA = Buffer.alloc(50, "A").toString();
+    const longZ = Buffer.alloc(50, "Z").toString();
+
+    // First failing query → statement cached as .failed with error_message.
+    const err1 = await sql`wat ${1} ${sql.unsafe(longA)}`.catch((x: any) => x);
+    expect(err1).toBeInstanceOf(Error);
+    expect(err1.code).toBe("ERR_MYSQL_SYNTAX_ERROR");
+    expect(err1.errno).toBe(1064);
+    expect(err1.message).toContain(longA);
+
+    // Different failing query → server sends a different ERROR packet that overwrites
+    // the connection read buffer where err1's message slice used to point.
+    const errOverwrite = await sql`other ${1} ${sql.unsafe(longZ)}`.catch((x: any) => x);
+    expect(errOverwrite).toBeInstanceOf(Error);
+    expect(errOverwrite.message).toContain(longZ);
+    expect(errOverwrite.message).not.toBe(err1.message);
+
+    // Same as the first failing query → hits the cached .failed statement and calls
+    // stmt.error_response.toJS(). Before the fix this read the overwritten buffer and
+    // returned bytes from errOverwrite's packet; after the fix it returns the original.
+    // Com_stmt_prepare (read via .simple() so the status query itself does not prepare)
+    // must not increment across this call — proving the third query was served from
+    // Bun's failed-statement cache, not re-prepared on the server. A fresh prepare
+    // would return an identical error for identical SQL and silently satisfy every
+    // assertion below without exercising the cached-slice path.
+    const [{ Value: preparesBefore }] = await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple();
+    // err1 and errOverwrite each reached COM_STMT_PREPARE, so the counter is
+    // already non-zero here; if it were 0 the "no increment" check below would
+    // be vacuous because the prepared path was never taken.
+    expect(Number(preparesBefore)).toBeGreaterThan(0);
+    const err2 = await sql`wat ${1} ${sql.unsafe(longA)}`.catch((x: any) => x);
+    const [{ Value: preparesAfter }] = await sql.unsafe("SHOW SESSION STATUS LIKE 'Com_stmt_prepare'").simple();
+    expect({
+      code: err2.code,
+      errno: err2.errno,
+      sqlState: err2.sqlState,
+      message: err2.message,
+      preparesAfter: Number(preparesAfter),
+    }).toEqual({
+      code: err1.code,
+      errno: err1.errno,
+      sqlState: err1.sqlState,
+      message: err1.message,
+      preparesAfter: Number(preparesBefore),
+    });
+    expect(err2.message).toContain(longA);
+    expect(err2.message).not.toContain(longZ);
   });
-}
+});

--- a/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
+++ b/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import { bunEnv, bunExe, describeWithContainer } from "harness";
 import path from "path";
 
 // A JS Date bound to a MySQL DATETIME/TIMESTAMP and read back must be the same
@@ -9,8 +9,9 @@ import path from "path";
 // silently shifts by the machine's UTC offset.
 //
 // The fixture runs against a real MySQL server (docker-compose in CI, or a
-// MYSQL_URL/local instance otherwise) and prints "OK TZ=<tz> offsetMin=<n>"
-// only when every Date round-trips to the same instant.
+// BUN_TEST_SERVICE_mysql_plain override otherwise) and prints
+// "OK TZ=<tz> offsetMin=<n>" only when every Date round-trips to the same
+// instant.
 
 const TIMEZONES = ["Etc/UTC", "America/New_York", "Asia/Tokyo"];
 const fixture = path.join(import.meta.dir, "sql-mysql-datetime-tz-fixture.ts");
@@ -38,45 +39,16 @@ function assertRoundTrip(stdout: string, stderr: string, TZ: string) {
   expect(stdout).toMatch(TZ === "Etc/UTC" ? /offsetMin=0\b/ : /offsetMin=-?[1-9]/);
 }
 
-if (isDockerEnabled()) {
-  // CI: run against the docker-compose MySQL service.
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    describe.each(TIMEZONES)("TZ=%s", TZ => {
-      test("DATETIME Date round-trip is the identity", async () => {
-        await container.ready;
-        const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
-        const { stdout, stderr, exitCode } = runFixture(url, TZ);
-        const out = String(stdout);
-        expect(out).toContain("CONNECTED");
-        assertRoundTrip(out, String(stderr), TZ);
-        expect(exitCode).toBe(0);
-      });
-    });
-  });
-} else {
-  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server is
-  // reachable at MYSQL_URL or the conventional local address, exercise the
-  // fixture there so the round-trip is still covered without a mock.
-  const url = process.env.MYSQL_URL || "mysql://bun@127.0.0.1:3306/bun_sql_test";
-
-  describe.each(TIMEZONES)("mysql (local) TZ=%s", TZ => {
-    test("DATETIME Date round-trip is the identity", () => {
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  describe.each(TIMEZONES)("TZ=%s", TZ => {
+    test("DATETIME Date round-trip is the identity", async () => {
+      await container.ready;
+      const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
       const { stdout, stderr, exitCode } = runFixture(url, TZ);
       const out = String(stdout);
-      // The fixture prints "CONNECTED" once it reaches the server. If it never
-      // got that far, there's no MySQL to talk to here; the docker-gated branch
-      // above provides the CI coverage.
-      if (!out.includes("CONNECTED")) {
-        if (process.env.MYSQL_URL) {
-          throw new Error(
-            `sql-mysql-datetime-roundtrip: MYSQL_URL was provided but fixture never reached CONNECTED\nstdout:\n${out}\nstderr:\n${String(stderr)}`,
-          );
-        }
-        console.warn("sql-mysql-datetime-roundtrip: no MySQL reachable at " + url + "; skipping assertions");
-        return;
-      }
+      expect(out).toContain("CONNECTED");
       assertRoundTrip(out, String(stderr), TZ);
       expect(exitCode).toBe(0);
     });
   });
-}
+});

--- a/test/js/sql/sql-mysql-mediumint.test.ts
+++ b/test/js/sql/sql-mysql-mediumint.test.ts
@@ -5,17 +5,16 @@
 
 import { SQL, randomUUIDv7 } from "bun";
 import { expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { describeWithContainer } from "harness";
 
-if (isDockerEnabled()) {
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test("MEDIUMINT before other columns is read as 4 bytes (binary protocol)", async () => {
-      await container.ready;
-      await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test("MEDIUMINT before other columns is read as 4 bytes (binary protocol)", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
 
-      const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
-      try {
-        await sql`
+    const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+    try {
+      await sql`
         CREATE TEMPORARY TABLE ${sql(table)} (
           id      INT,
           uviews  MEDIUMINT UNSIGNED,
@@ -25,22 +24,21 @@ if (isDockerEnabled()) {
           name    VARCHAR(255)
         )
       `.simple();
-        await sql`INSERT INTO ${sql(table)} (id, uviews, sviews, balance, ratio, name) VALUES (1, 100, -50, 5000, 3.5, 'alice')`.simple();
+      await sql`INSERT INTO ${sql(table)} (id, uviews, sviews, balance, ratio, name) VALUES (1, 100, -50, 5000, 3.5, 'alice')`.simple();
 
-        // Prepared → binary protocol. If the decoder consumes only 3 of the 4
-        // INT24 bytes the cursor desyncs into balance/ratio/name and this row
-        // either hangs on the VARCHAR length prefix or returns garbage.
-        const [row] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(table)}`;
-        expect(row).toEqual({ id: 1, uviews: 100, sviews: -50, balance: 5000, ratio: 3.5, name: "alice" });
+      // Prepared → binary protocol. If the decoder consumes only 3 of the 4
+      // INT24 bytes the cursor desyncs into balance/ratio/name and this row
+      // either hangs on the VARCHAR length prefix or returns garbage.
+      const [row] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(table)}`;
+      expect(row).toEqual({ id: 1, uviews: 100, sviews: -50, balance: 5000, ratio: 3.5, name: "alice" });
 
-        const [rawRow] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(table)}`.raw();
-        expect(rawRow).toHaveLength(6);
-        expect(rawRow[1]).toEqual(new Uint8Array([0x64, 0x00, 0x00])); // 100
-        expect(rawRow[2]).toEqual(new Uint8Array([0xce, 0xff, 0xff])); // -50 as i24 LE
-        expect(Buffer.from(rawRow[5]).toString("utf-8")).toBe("alice");
-      } finally {
-        await sql`DROP TABLE IF EXISTS ${sql(table)}`.simple();
-      }
-    });
+      const [rawRow] = await sql`SELECT id, uviews, sviews, balance, ratio, name FROM ${sql(table)}`.raw();
+      expect(rawRow).toHaveLength(6);
+      expect(rawRow[1]).toEqual(new Uint8Array([0x64, 0x00, 0x00])); // 100
+      expect(rawRow[2]).toEqual(new Uint8Array([0xce, 0xff, 0xff])); // -50 as i24 LE
+      expect(Buffer.from(rawRow[5]).toString("utf-8")).toBe("alice");
+    } finally {
+      await sql`DROP TABLE IF EXISTS ${sql(table)}`.simple();
+    }
   });
-}
+});

--- a/test/js/sql/sql-mysql-query-string-leak.test.ts
+++ b/test/js/sql/sql-mysql-query-string-leak.test.ts
@@ -9,86 +9,84 @@
 // retain the query-string bytes.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isASAN, isDockerEnabled, tempDir } from "harness";
+import { bunEnv, bunExe, describeWithContainer, isASAN, tempDir } from "harness";
 
-if (isDockerEnabled()) {
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    test("MySQL: query string is not leaked across query lifecycle", async () => {
-      await container.ready;
-      const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  test("MySQL: query string is not leaked across query lifecycle", async () => {
+    await container.ready;
+    const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
 
-      using dir = tempDir("mysql-query-string-leak", {
-        "fixture.js": /* js */ `
-        const { SQL } = require("bun");
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    using dir = tempDir("mysql-query-string-leak", {
+      "fixture.js": /* js */ `
+      const { SQL } = require("bun");
+      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
 
-        const sql = new SQL({ url: process.env.MYSQL_URL, max: 1 });
+      const sql = new SQL({ url: process.env.MYSQL_URL, max: 1 });
 
-        // Warm up: first query allocates connection buffers, JIT, etc.
-        await sql.unsafe("select 1").simple();
+      // Warm up: first query allocates connection buffers, JIT, etc.
+      await sql.unsafe("select 1").simple();
 
-        // Each query string is ~512 KiB and unique (so JSC can't dedupe/intern
-        // them) and goes through the full create -> run -> finalize lifecycle.
-        // 200 iterations x 512 KiB = ~100 MiB of string payload.
-        const ITERATIONS = 200;
-        const CHUNK = 512 * 1024;
+      // Each query string is ~512 KiB and unique (so JSC can't dedupe/intern
+      // them) and goes through the full create -> run -> finalize lifecycle.
+      // 200 iterations x 512 KiB = ~100 MiB of string payload.
+      const ITERATIONS = 200;
+      const CHUNK = 512 * 1024;
 
-        Bun.gc(true);
-        const rssBefore = rss();
+      Bun.gc(true);
+      const rssBefore = rss();
 
-        for (let i = 0; i < ITERATIONS; i++) {
-          const pad = Buffer.alloc(CHUNK, 0x61 + (i % 26)).toString("latin1");
-          // Embed the bulk as a comment so the server's reply is a trivial OK
-          // regardless of content; suffix makes every string unique.
-          const q = "select 1 /* " + pad + " " + i + " */";
-          await sql.unsafe(q).simple();
-          if ((i & 15) === 15) Bun.gc(true);
-        }
-
-        await sql.close({ timeout: 0 }).catch(() => {});
-
-        // Give the MySQLQuery wrappers a chance to be finalized so cleanup()
-        // runs and drops its (single) ref on each query string.
-        for (let i = 0; i < 8; i++) {
-          await new Promise(r => setImmediate(r));
-          Bun.gc(true);
-        }
-
-        const rssAfter = rss();
-        const deltaMiB = (rssAfter - rssBefore) / 1024 / 1024;
-        console.log(JSON.stringify({ rssBefore, rssAfter, deltaMiB }));
-      `,
-      });
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "fixture.js"],
-        env: { ...bunEnv, MYSQL_URL: url },
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        timeout: 120_000,
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      let parsed: { deltaMiB: number };
-      try {
-        parsed = JSON.parse(stdout.trim());
-      } catch {
-        throw new Error(`fixture did not emit JSON\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+      for (let i = 0; i < ITERATIONS; i++) {
+        const pad = Buffer.alloc(CHUNK, 0x61 + (i % 26)).toString("latin1");
+        // Embed the bulk as a comment so the server's reply is a trivial OK
+        // regardless of content; suffix makes every string unique.
+        const q = "select 1 /* " + pad + " " + i + " */";
+        await sql.unsafe(q).simple();
+        if ((i & 15) === 15) Bun.gc(true);
       }
-      // With the leak, every one of the ~200 x 512 KiB query strings is retained
-      // (plus per-string overhead), so RSS grows by >= ~100 MiB. With the fix the
-      // strings are freed as each MySQLQuery is finalized and growth stays small.
-      // ASAN's quarantine retains freed allocations (default 256 MB) and a real
-      // server adds wire-buffer + encode churn on top of the string churn, so the
-      // delta runs higher under bun-asan even with the fix; widen the threshold
-      // there. The non-ASAN bound is the discriminating check.
-      expect(parsed.deltaMiB).toBeLessThan(isASAN ? 384 : 50);
-      expect(exitCode).toBe(0);
-      // 200 × 512 KiB round-trips to a real MySQL server plus ~20 Bun.gc(true)
-      // calls in an ASAN debug subprocess can take tens of seconds; the 5s
-      // default is too tight.
-    }, 120_000);
-  });
-}
+
+      await sql.close({ timeout: 0 }).catch(() => {});
+
+      // Give the MySQLQuery wrappers a chance to be finalized so cleanup()
+      // runs and drops its (single) ref on each query string.
+      for (let i = 0; i < 8; i++) {
+        await new Promise(r => setImmediate(r));
+        Bun.gc(true);
+      }
+
+      const rssAfter = rss();
+      const deltaMiB = (rssAfter - rssBefore) / 1024 / 1024;
+      console.log(JSON.stringify({ rssBefore, rssAfter, deltaMiB }));
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: { ...bunEnv, MYSQL_URL: url },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 120_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let parsed: { deltaMiB: number };
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`fixture did not emit JSON\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    }
+    // With the leak, every one of the ~200 x 512 KiB query strings is retained
+    // (plus per-string overhead), so RSS grows by >= ~100 MiB. With the fix the
+    // strings are freed as each MySQLQuery is finalized and growth stays small.
+    // ASAN's quarantine retains freed allocations (default 256 MB) and a real
+    // server adds wire-buffer + encode churn on top of the string churn, so the
+    // delta runs higher under bun-asan even with the fix; widen the threshold
+    // there. The non-ASAN bound is the discriminating check.
+    expect(parsed.deltaMiB).toBeLessThan(isASAN ? 384 : 50);
+    expect(exitCode).toBe(0);
+    // 200 × 512 KiB round-trips to a real MySQL server plus ~20 Bun.gc(true)
+    // calls in an ASAN debug subprocess can take tens of seconds; the 5s
+    // default is too tight.
+  }, 120_000);
+});

--- a/test/js/sql/sql-mysql-raw-length-prefix.test.ts
+++ b/test/js/sql/sql-mysql-raw-length-prefix.test.ts
@@ -8,7 +8,7 @@
 
 import { SQL, randomUUIDv7 } from "bun";
 import { expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { describeWithContainer } from "harness";
 
 // >251-byte JSON payload — encodes on the wire with the 3-byte length prefix
 // (0xfc NN NN). The 8-byte VARCHAR exercises the 1-byte form. Both shapes
@@ -26,176 +26,174 @@ const shortText = "testname";
 const bio251 = "\x05admin" + Buffer.alloc(251 - 6, "x").toString();
 const realRole = "user";
 
-if (isDockerEnabled()) {
-  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
-    function url() {
-      return `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+  function url() {
+    return `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+  }
+
+  // --- .raw() length-prefix stripping (#30039) -----------------------------
+
+  function assertRawRow(name: unknown, post: unknown, blob: unknown) {
+    expect(name).toBeInstanceOf(Uint8Array);
+    expect(post).toBeInstanceOf(Uint8Array);
+    expect(blob).toBeInstanceOf(Uint8Array);
+
+    // Defining assertion: first byte is the payload's first byte
+    // ('t' = 0x74 for the VARCHAR, '{' = 0x7b for the JSON/BLOB), NOT the
+    // MySQL length-encoded-integer prefix (0x08 for the 8-byte VARCHAR,
+    // 0xfc for the >251-byte JSON/BLOB).
+    expect((name as Uint8Array)[0]).toBe(0x74); // 't'
+    expect((post as Uint8Array)[0]).toBe(0x7b); // '{'
+    expect((blob as Uint8Array)[0]).toBe(0x7b); // '{'
+
+    // VARCHAR / BLOB round-trip byte-exact.
+    expect(Buffer.from(name as Uint8Array).toString("utf-8")).toBe(shortText);
+    expect((name as Uint8Array).length).toBe(shortText.length);
+    expect(Buffer.from(blob as Uint8Array).toString("utf-8")).toBe(jsonText);
+    expect((blob as Uint8Array).length).toBe(jsonText.length);
+
+    // MySQL normalizes stored JSON (adds spaces after ':' and ','), so
+    // compare parsed values. With the prefix bug present the leading 0xfc
+    // byte makes JSON.parse throw, so this still discriminates.
+    const postText = Buffer.from(post as Uint8Array).toString("utf-8");
+    expect(JSON.parse(postText)).toEqual(jsonPayload);
+    // Normalized JSON is at least as long as the compact form, so the wire
+    // encoding still uses the 3-byte (0xfc) length prefix.
+    expect((post as Uint8Array).length).toBeGreaterThanOrEqual(jsonText.length);
+  }
+
+  test(".raw() strips length-prefix bytes (#30039) — text protocol", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+    const table = "t_rawlen_" + randomUUIDv7("hex").replaceAll("-", "");
+    try {
+      await sql`CREATE TEMPORARY TABLE ${sql(table)} (name VARCHAR(64), post JSON, blob_data BLOB)`;
+      await sql`INSERT INTO ${sql(table)} (name, post, blob_data) VALUES (${shortText}, ${jsonText}, ${Buffer.from(jsonText)})`;
+
+      // `.simple().raw()` exercises the ResultSet text-protocol raw branch
+      // that used to call rawEncodeLenData.
+      const rows = (await sql`SELECT name, post, blob_data FROM ${sql(table)}`.simple().raw()) as unknown as [
+        Uint8Array,
+        Uint8Array,
+        Uint8Array,
+      ][];
+      expect(rows).toHaveLength(1);
+      const [name, post, blob] = rows[0];
+      assertRawRow(name, post, blob);
+    } finally {
+      await sql`DROP TABLE IF EXISTS ${sql(table)}`;
     }
+  });
 
-    // --- .raw() length-prefix stripping (#30039) -----------------------------
+  test(".raw() strips length-prefix bytes (#30039) — binary protocol", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+    const table = "t_rawlen_" + randomUUIDv7("hex").replaceAll("-", "");
+    try {
+      await sql`CREATE TEMPORARY TABLE ${sql(table)} (name VARCHAR(64), post JSON, blob_data BLOB)`;
+      await sql`INSERT INTO ${sql(table)} (name, post, blob_data) VALUES (${shortText}, ${jsonText}, ${Buffer.from(jsonText)})`;
 
-    function assertRawRow(name: unknown, post: unknown, blob: unknown) {
-      expect(name).toBeInstanceOf(Uint8Array);
-      expect(post).toBeInstanceOf(Uint8Array);
-      expect(blob).toBeInstanceOf(Uint8Array);
-
-      // Defining assertion: first byte is the payload's first byte
-      // ('t' = 0x74 for the VARCHAR, '{' = 0x7b for the JSON/BLOB), NOT the
-      // MySQL length-encoded-integer prefix (0x08 for the 8-byte VARCHAR,
-      // 0xfc for the >251-byte JSON/BLOB).
-      expect((name as Uint8Array)[0]).toBe(0x74); // 't'
-      expect((post as Uint8Array)[0]).toBe(0x7b); // '{'
-      expect((blob as Uint8Array)[0]).toBe(0x7b); // '{'
-
-      // VARCHAR / BLOB round-trip byte-exact.
-      expect(Buffer.from(name as Uint8Array).toString("utf-8")).toBe(shortText);
-      expect((name as Uint8Array).length).toBe(shortText.length);
-      expect(Buffer.from(blob as Uint8Array).toString("utf-8")).toBe(jsonText);
-      expect((blob as Uint8Array).length).toBe(jsonText.length);
-
-      // MySQL normalizes stored JSON (adds spaces after ':' and ','), so
-      // compare parsed values. With the prefix bug present the leading 0xfc
-      // byte makes JSON.parse throw, so this still discriminates.
-      const postText = Buffer.from(post as Uint8Array).toString("utf-8");
-      expect(JSON.parse(postText)).toEqual(jsonPayload);
-      // Normalized JSON is at least as long as the compact form, so the wire
-      // encoding still uses the 3-byte (0xfc) length prefix.
-      expect((post as Uint8Array).length).toBeGreaterThanOrEqual(jsonText.length);
+      // Without `.simple()`, the client uses a prepared statement and the
+      // binary-protocol row decoder — exercising the DecodeBinaryValue raw
+      // branches that used to call rawEncodeLenData for VAR_STRING / JSON /
+      // BLOB.
+      const rows = (await sql`SELECT name, post, blob_data FROM ${sql(table)}`.raw()) as unknown as [
+        Uint8Array,
+        Uint8Array,
+        Uint8Array,
+      ][];
+      expect(rows).toHaveLength(1);
+      const [name, post, blob] = rows[0];
+      assertRawRow(name, post, blob);
+    } finally {
+      await sql`DROP TABLE IF EXISTS ${sql(table)}`;
     }
+  });
 
-    test(".raw() strips length-prefix bytes (#30039) — text protocol", async () => {
-      await container.ready;
-      await using sql = new SQL({ url: url(), max: 1 });
-      const table = "t_rawlen_" + randomUUIDv7("hex").replaceAll("-", "");
-      try {
-        await sql`CREATE TEMPORARY TABLE ${sql(table)} (name VARCHAR(64), post JSON, blob_data BLOB)`;
-        await sql`INSERT INTO ${sql(table)} (name, post, blob_data) VALUES (${shortText}, ${jsonText}, ${Buffer.from(jsonText)})`;
+  // --- oversized COM_QUERY rollback ----------------------------------------
+  //
+  // A COM_QUERY whose payload exceeds the 24-bit packet length limit cannot
+  // be framed as a single MySQL packet. It must be rejected client-side AND
+  // rolled back out of the connection's write buffer: leaving the partially-
+  // serialized packet behind desynchronizes the protocol stream, and the next
+  // query gets appended after the garbage and reparsed by the server as
+  // bogus packets.
+  test("oversized COM_QUERY is rejected and rolled back out of the write buffer", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
 
-        // `.simple().raw()` exercises the ResultSet text-protocol raw branch
-        // that used to call rawEncodeLenData.
-        const rows = (await sql`SELECT name, post, blob_data FROM ${sql(table)}`.simple().raw()) as unknown as [
-          Uint8Array,
-          Uint8Array,
-          Uint8Array,
-        ][];
-        expect(rows).toHaveLength(1);
-        const [name, post, blob] = rows[0];
-        assertRawRow(name, post, blob);
-      } finally {
-        await sql`DROP TABLE IF EXISTS ${sql(table)}`;
-      }
-    });
+    // Ensure the single pooled connection is established before the oversized
+    // attempt so both queries share it, and capture its server-side
+    // CONNECTION_ID() so we can prove the follow-up runs on the SAME session.
+    // A regression that flushed partial bytes (or closed on overflow) would
+    // let the pool transparently reconnect and `select 1 as ok` would succeed
+    // on a new session without the write-buffer rollback having worked.
+    const [{ cid: cidBefore }] = await sql`SELECT CONNECTION_ID() as cid`;
 
-    test(".raw() strips length-prefix bytes (#30039) — binary protocol", async () => {
-      await container.ready;
-      await using sql = new SQL({ url: url(), max: 1 });
-      const table = "t_rawlen_" + randomUUIDv7("hex").replaceAll("-", "");
-      try {
-        await sql`CREATE TEMPORARY TABLE ${sql(table)} (name VARCHAR(64), post JSON, blob_data BLOB)`;
-        await sql`INSERT INTO ${sql(table)} (name, post, blob_data) VALUES (${shortText}, ${jsonText}, ${Buffer.from(jsonText)})`;
+    // 1 command byte + 0xffffff bytes of query text = 0x1000000 — one past
+    // the largest payload a single MySQL packet can frame.
+    const oversized = Buffer.alloc(0xffffff, "-").toString();
+    const first = await sql.unsafe(oversized).then(
+      () => "resolved",
+      e => e?.code ?? String(e),
+    );
 
-        // Without `.simple()`, the client uses a prepared statement and the
-        // binary-protocol row decoder — exercising the DecodeBinaryValue raw
-        // branches that used to call rawEncodeLenData for VAR_STRING / JSON /
-        // BLOB.
-        const rows = (await sql`SELECT name, post, blob_data FROM ${sql(table)}`.raw()) as unknown as [
-          Uint8Array,
-          Uint8Array,
-          Uint8Array,
-        ][];
-        expect(rows).toHaveLength(1);
-        const [name, post, blob] = rows[0];
-        assertRawRow(name, post, blob);
-      } finally {
-        await sql`DROP TABLE IF EXISTS ${sql(table)}`;
-      }
-    });
+    // The same connection must still be usable: the rejected packet must not
+    // leave any bytes behind in the write buffer. If it did, the server would
+    // see garbage instead of `select 1` and this query would not resolve to
+    // the expected row.
+    const second = await sql.unsafe("select 1 as ok");
+    const [{ cid: cidAfter }] = await sql`SELECT CONNECTION_ID() as cid`;
 
-    // --- oversized COM_QUERY rollback ----------------------------------------
-    //
-    // A COM_QUERY whose payload exceeds the 24-bit packet length limit cannot
-    // be framed as a single MySQL packet. It must be rejected client-side AND
-    // rolled back out of the connection's write buffer: leaving the partially-
-    // serialized packet behind desynchronizes the protocol stream, and the next
-    // query gets appended after the garbage and reparsed by the server as
-    // bogus packets.
-    test("oversized COM_QUERY is rejected and rolled back out of the write buffer", async () => {
-      await container.ready;
-      await using sql = new SQL({ url: url(), max: 1 });
-
-      // Ensure the single pooled connection is established before the oversized
-      // attempt so both queries share it, and capture its server-side
-      // CONNECTION_ID() so we can prove the follow-up runs on the SAME session.
-      // A regression that flushed partial bytes (or closed on overflow) would
-      // let the pool transparently reconnect and `select 1 as ok` would succeed
-      // on a new session without the write-buffer rollback having worked.
-      const [{ cid: cidBefore }] = await sql`SELECT CONNECTION_ID() as cid`;
-
-      // 1 command byte + 0xffffff bytes of query text = 0x1000000 — one past
-      // the largest payload a single MySQL packet can frame.
-      const oversized = Buffer.alloc(0xffffff, "-").toString();
-      const first = await sql.unsafe(oversized).then(
-        () => "resolved",
-        e => e?.code ?? String(e),
-      );
-
-      // The same connection must still be usable: the rejected packet must not
-      // leave any bytes behind in the write buffer. If it did, the server would
-      // see garbage instead of `select 1` and this query would not resolve to
-      // the expected row.
-      const second = await sql.unsafe("select 1 as ok");
-      const [{ cid: cidAfter }] = await sql`SELECT CONNECTION_ID() as cid`;
-
-      expect({ first, second, cidAfter }).toEqual({
-        first: "ERR_MYSQL_OVERFLOW",
-        second: [{ ok: 1 }],
-        // Same MySQL session ⇒ rollback worked, no reconnect masked the failure.
-        cidAfter: cidBefore,
-      });
-    });
-
-    // --- 251-byte length-encoded values vs. the NULL marker ------------------
-    //
-    // The text-protocol NULL marker is the single literal byte 0xfb. A column
-    // value that is exactly 251 bytes long is length-encoded as
-    // `0xfc 0xfb 0x00` followed by 251 payload bytes — and the decoded
-    // *length* is also 251 (0xfb). The decoder must distinguish the two by
-    // encoding width: if it only compares the decoded value, the column is
-    // misread as NULL, only the 3 length bytes are consumed, and the 251
-    // payload bytes are re-parsed as the lengths/contents of the following
-    // columns. Whoever controls the first column then controls what the
-    // application sees in the rest of the row.
-    test("text protocol decodes a 251-byte column value as data, not as NULL", async () => {
-      // Sanity: the payload is exactly 251 bytes — the length whose lenenc
-      // encoding is `0xfc 0xfb 0x00` and whose decoded value collides with the
-      // text-protocol NULL marker byte (0xfb).
-      expect(Buffer.byteLength(bio251, "utf-8")).toBe(251);
-
-      await container.ready;
-      await using sql = new SQL({ url: url(), max: 1 });
-      const table = "t_null251_" + randomUUIDv7("hex").replaceAll("-", "");
-      try {
-        await sql`CREATE TEMPORARY TABLE ${sql(table)} (id INT PRIMARY KEY, bio VARCHAR(300), role VARCHAR(32))`;
-        await sql`INSERT INTO ${sql(table)} (id, bio, role) VALUES (1, ${bio251}, ${realRole}), (2, NULL, ${"editor"})`;
-
-        // `.simple()` forces the text protocol → ResultSet decode_text, where
-        // the NULL-marker check lives.
-        const rows = (await sql`SELECT bio, role FROM ${sql(table)} ORDER BY id`.simple()) as unknown as {
-          bio: string | null;
-          role: string;
-        }[];
-        expect(rows).toHaveLength(2);
-        // The 251-byte value must come back intact — not as NULL with the
-        // following column re-read out of the 251 payload bytes (which would
-        // make role === "admin").
-        expect(rows[0].role).toBe(realRole);
-        expect(rows[0].bio).toBe(bio251);
-        // A genuine NULL still decodes as NULL and the row stays aligned.
-        expect(rows[1].bio).toBeNull();
-        expect(rows[1].role).toBe("editor");
-      } finally {
-        await sql`DROP TABLE IF EXISTS ${sql(table)}`;
-      }
+    expect({ first, second, cidAfter }).toEqual({
+      first: "ERR_MYSQL_OVERFLOW",
+      second: [{ ok: 1 }],
+      // Same MySQL session ⇒ rollback worked, no reconnect masked the failure.
+      cidAfter: cidBefore,
     });
   });
-}
+
+  // --- 251-byte length-encoded values vs. the NULL marker ------------------
+  //
+  // The text-protocol NULL marker is the single literal byte 0xfb. A column
+  // value that is exactly 251 bytes long is length-encoded as
+  // `0xfc 0xfb 0x00` followed by 251 payload bytes — and the decoded
+  // *length* is also 251 (0xfb). The decoder must distinguish the two by
+  // encoding width: if it only compares the decoded value, the column is
+  // misread as NULL, only the 3 length bytes are consumed, and the 251
+  // payload bytes are re-parsed as the lengths/contents of the following
+  // columns. Whoever controls the first column then controls what the
+  // application sees in the rest of the row.
+  test("text protocol decodes a 251-byte column value as data, not as NULL", async () => {
+    // Sanity: the payload is exactly 251 bytes — the length whose lenenc
+    // encoding is `0xfc 0xfb 0x00` and whose decoded value collides with the
+    // text-protocol NULL marker byte (0xfb).
+    expect(Buffer.byteLength(bio251, "utf-8")).toBe(251);
+
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+    const table = "t_null251_" + randomUUIDv7("hex").replaceAll("-", "");
+    try {
+      await sql`CREATE TEMPORARY TABLE ${sql(table)} (id INT PRIMARY KEY, bio VARCHAR(300), role VARCHAR(32))`;
+      await sql`INSERT INTO ${sql(table)} (id, bio, role) VALUES (1, ${bio251}, ${realRole}), (2, NULL, ${"editor"})`;
+
+      // `.simple()` forces the text protocol → ResultSet decode_text, where
+      // the NULL-marker check lives.
+      const rows = (await sql`SELECT bio, role FROM ${sql(table)} ORDER BY id`.simple()) as unknown as {
+        bio: string | null;
+        role: string;
+      }[];
+      expect(rows).toHaveLength(2);
+      // The 251-byte value must come back intact — not as NULL with the
+      // following column re-read out of the 251 payload bytes (which would
+      // make role === "admin").
+      expect(rows[0].role).toBe(realRole);
+      expect(rows[0].bio).toBe(bio251);
+      // A genuine NULL still decodes as NULL and the row stays aligned.
+      expect(rows[1].bio).toBeNull();
+      expect(rows[1].role).toBe("editor");
+    } finally {
+      await sql`DROP TABLE IF EXISTS ${sql(table)}`;
+    }
+  });
+});

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -64,6 +64,11 @@ async function assertComputedDecimalsAreStrings(sql: SQL) {
   const [rawRow] = await sql`SELECT SUM(balance) AS total FROM ${sql(t)}`.raw();
   expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from("350.75")));
 }
+// Deliberately still gated while the rest of test/js/sql calls describeWithContainer
+// ungated: a few tests here are MySQL-specific (CAST(... AS JSON), MYSQL_TYPE_JSON
+// binds, FROM_UNIXTIME(0)) or dial example.com expecting the connect to hang, and
+// would fail against a MariaDB-backed BUN_TEST_SERVICE_mysql_plain override.
+// Ungate once those tests are server-agnostic.
 if (isDockerEnabled()) {
   // Ordered so the suites whose containers become healthy quickly (mysql_plain,
   // mysql:9) run first; the slow-to-start mysql_tls container warms up in the

--- a/test/js/sql/sql-postgres-datetime-roundtrip.test.ts
+++ b/test/js/sql/sql-postgres-datetime-roundtrip.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import { bunEnv, bunExe, describeWithContainer } from "harness";
 import path from "path";
 
 // A Postgres `timestamp` (WITHOUT TIME ZONE) carries no offset, so the binary
@@ -9,8 +9,9 @@ import path from "path";
 // must keep decoding correctly.
 //
 // The fixture runs against a real Postgres server (docker-compose in CI, or a
-// DATABASE_URL/local instance otherwise) and prints "OK TZ=<tz> offsetMin=<n>"
-// only when binary and text decode to the same instant for every column.
+// BUN_TEST_SERVICE_postgres_plain override otherwise) and prints
+// "OK TZ=<tz> offsetMin=<n>" only when binary and text decode to the same
+// instant for every column.
 
 const TIMEZONES = ["Etc/UTC", "America/New_York", "Asia/Tokyo"];
 const fixture = path.join(import.meta.dir, "sql-postgres-datetime-tz-fixture.ts");
@@ -47,43 +48,15 @@ function assertRoundTrip(stdout: string, stderr: string, TZ: string) {
   expect(stdout).toMatch(TZ === "Etc/UTC" ? /offsetMin=0\b/ : /offsetMin=-?[1-9]/);
 }
 
-if (isDockerEnabled()) {
-  // CI: run against the docker-compose Postgres service.
-  describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-    describe.each(TIMEZONES)("TZ=%s", TZ => {
-      test.concurrent("TIMESTAMP decode is UTC on both protocols", async () => {
-        await container.ready;
-        const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
-        const { stdout, stderr, exitCode } = await runFixture(url, TZ);
-        expect(stdout).toContain("CONNECTED");
-        assertRoundTrip(stdout, stderr, TZ);
-        expect(exitCode).toBe(0);
-      });
-    });
-  });
-} else {
-  // No docker daemon (e.g. local/sandboxed environments). If a Postgres server
-  // is reachable at DATABASE_URL or the conventional local address, exercise
-  // the fixture there so the round-trip is still covered.
-  const url = process.env.DATABASE_URL || "postgres://bun_sql_test@127.0.0.1:5432/bun_sql_test";
-
-  describe.each(TIMEZONES)("postgres (local) TZ=%s", TZ => {
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  describe.each(TIMEZONES)("TZ=%s", TZ => {
     test.concurrent("TIMESTAMP decode is UTC on both protocols", async () => {
+      await container.ready;
+      const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
       const { stdout, stderr, exitCode } = await runFixture(url, TZ);
-      // The fixture prints "CONNECTED" once it reaches the server. If it never
-      // got that far, there's no Postgres to talk to here; the docker-gated
-      // branch above provides the CI coverage.
-      if (!stdout.includes("CONNECTED")) {
-        if (process.env.DATABASE_URL) {
-          throw new Error(
-            `sql-postgres-datetime-roundtrip: DATABASE_URL was provided but fixture never reached CONNECTED\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-          );
-        }
-        console.warn("sql-postgres-datetime-roundtrip: no Postgres reachable at " + url + "; skipping assertions");
-        return;
-      }
+      expect(stdout).toContain("CONNECTED");
       assertRoundTrip(stdout, stderr, TZ);
       expect(exitCode).toBe(0);
     });
   });
-}
+});

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -17,6 +17,10 @@ import * as dockerCompose from "../../docker/index.ts";
 import { UnixDomainSocketProxy } from "../../unix-domain-socket-proxy.ts";
 import { neverAnsweringServer } from "./wire-frames";
 
+// Load-bearing gate, do not delete: the describe body below runs a top-level
+// `await dockerCompose.ensure()`, which throws where docker is unavailable. To
+// support BUN_TEST_SERVICE overrides here, widen this to the
+// override || coordinator || docker condition from harness.ts instead.
 if (isDockerEnabled()) {
   describe("PostgreSQL tests", async () => {
     let container: { port: number; host: string };

--- a/test/js/sql/tls-sql.test.ts
+++ b/test/js/sql/tls-sql.test.ts
@@ -4,6 +4,9 @@ import { describeWithContainer, isDockerEnabled } from "harness";
 import path from "node:path";
 import { listeningServer, pgAuthenticationCleartextPassword, pgSSLRequest, pgSSLResponse } from "./wire-frames";
 
+// Inverted gate kept for the visible skip message. Tradeoff: with no docker,
+// this branch wins before describeWithContainer can honor a
+// BUN_TEST_SERVICE_postgres_tls override (no current environment sets one).
 if (!isDockerEnabled()) {
   test.skip("skipping TLS SQL tests - Docker is not available", () => {});
 } else {

--- a/test/regression/issue/28632.test.ts
+++ b/test/regression/issue/28632.test.ts
@@ -1,87 +1,87 @@
 // https://github.com/oven-sh/bun/issues/28632
 import { SQL } from "bun";
 import { beforeAll, expect, test } from "bun:test";
-import { describeWithContainer, isASAN, isDebug, isDockerEnabled, rss } from "harness";
+import { describeWithContainer, isASAN, isDebug, rss } from "harness";
 
-if (isDockerEnabled()) {
-  describeWithContainer(
-    "issue #28632: MySQL adapter should not leak memory on repeated queries",
-    {
-      image: "mysql_plain",
-      concurrent: true,
-    },
-    container => {
-      let sql: SQL;
+describeWithContainer(
+  "issue #28632: MySQL adapter should not leak memory on repeated queries",
+  {
+    image: "mysql_plain",
+    concurrent: true,
+  },
+  container => {
+    let sql: SQL;
 
-      beforeAll(async () => {
-        await container.ready;
-        sql = new SQL({
-          url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
-          max: 1,
-        });
+    beforeAll(async () => {
+      await container.ready;
+      sql = new SQL({
+        url: `mysql://root@${container.host}:${container.port}/bun_sql_test`,
+        max: 1,
       });
+    });
 
-      test("prepared statement re-execution should not leak name_or_index", async () => {
-        // Create a wide table to amplify the per-column leak signal
-        await sql`DROP TABLE IF EXISTS leak_test_28632`;
-        await sql`CREATE TABLE leak_test_28632 (
-          primary_id VARCHAR(255) PRIMARY KEY,
-          column_alpha_bravo TEXT, column_charlie_delta TEXT, column_echo_foxtrot TEXT,
-          column_golf_hotel TEXT, column_india_juliet TEXT, column_kilo_lima TEXT,
-          column_mike_november TEXT, column_oscar_papa TEXT, column_quebec_romeo TEXT,
-          column_sierra_tango TEXT, column_uniform_victor TEXT, column_whiskey_xray TEXT,
-          column_yankee_zulu TEXT, column_one_two_three TEXT, column_four_five_six TEXT,
-          column_seven_eight TEXT, column_nine_ten TEXT, column_eleven_twelve TEXT,
-          column_thirteen_fourtn TEXT, column_fifteen_sixtn TEXT, column_seventeen TEXT,
-          column_eighteen TEXT, column_nineteen TEXT, column_twenty_extra TEXT,
-          column_twentyone TEXT, column_twentytwo TEXT, column_twentythree TEXT,
-          column_twentyfour TEXT, column_twentyfive TEXT, column_twentysix TEXT,
-          column_twentyseven TEXT, column_twentyeight TEXT, column_twentynine TEXT,
-          column_thirty_extra TEXT, column_thirtyone TEXT, column_thirtytwo TEXT,
-          column_thirtythree TEXT, column_thirtyfour TEXT, column_thirtyfive TEXT,
-          column_thirtysix TEXT, column_thirtyseven TEXT, column_thirtyeight TEXT,
-          column_thirtynine TEXT, column_forty_extra TEXT, column_fortyone TEXT,
-          column_fortytwo TEXT, column_fortythree TEXT, column_fortyfour TEXT,
-          column_fortyfive TEXT
-        )`;
-        await sql`INSERT INTO leak_test_28632 (primary_id) VALUES ('123')`;
+    test("prepared statement re-execution should not leak name_or_index", async () => {
+      // Create a wide table to amplify the per-column leak signal
+      await sql`DROP TABLE IF EXISTS leak_test_28632`;
+      await sql`CREATE TABLE leak_test_28632 (
+        primary_id VARCHAR(255) PRIMARY KEY,
+        column_alpha_bravo TEXT, column_charlie_delta TEXT, column_echo_foxtrot TEXT,
+        column_golf_hotel TEXT, column_india_juliet TEXT, column_kilo_lima TEXT,
+        column_mike_november TEXT, column_oscar_papa TEXT, column_quebec_romeo TEXT,
+        column_sierra_tango TEXT, column_uniform_victor TEXT, column_whiskey_xray TEXT,
+        column_yankee_zulu TEXT, column_one_two_three TEXT, column_four_five_six TEXT,
+        column_seven_eight TEXT, column_nine_ten TEXT, column_eleven_twelve TEXT,
+        column_thirteen_fourtn TEXT, column_fifteen_sixtn TEXT, column_seventeen TEXT,
+        column_eighteen TEXT, column_nineteen TEXT, column_twenty_extra TEXT,
+        column_twentyone TEXT, column_twentytwo TEXT, column_twentythree TEXT,
+        column_twentyfour TEXT, column_twentyfive TEXT, column_twentysix TEXT,
+        column_twentyseven TEXT, column_twentyeight TEXT, column_twentynine TEXT,
+        column_thirty_extra TEXT, column_thirtyone TEXT, column_thirtytwo TEXT,
+        column_thirtythree TEXT, column_thirtyfour TEXT, column_thirtyfive TEXT,
+        column_thirtysix TEXT, column_thirtyseven TEXT, column_thirtyeight TEXT,
+        column_thirtynine TEXT, column_forty_extra TEXT, column_fortyone TEXT,
+        column_fortytwo TEXT, column_fortythree TEXT, column_fortyfour TEXT,
+        column_fortyfive TEXT
+      )`;
+      await sql`INSERT INTO leak_test_28632 (primary_id) VALUES ('123')`;
 
-        // Warm up to stabilize RSS
-        for (let i = 0; i < 500; i++) {
-          await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-        }
-        Bun.gc(true);
-        await Bun.sleep(50);
-        const rssAfterWarmup = rss();
+      // Warm up to stabilize RSS
+      for (let i = 0; i < 500; i++) {
+        await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+      }
+      Bun.gc(true);
+      await Bun.sleep(50);
+      const rssAfterWarmup = rss();
 
-        // Run queries — each re-decodes 50 column definitions. Collect every 500
-        // so the RSS delta reflects the name_or_index leak rather than the
-        // controller's opportunistic-GC cadence (which no longer fires at this
-        // allocation volume): without this, peak uncollected garbage between
-        // opportunistic passes commits extra MarkedBlock pages that Bun.gc(true)
-        // at the end does not synchronously decommit.
-        for (let i = 0; i < 5000; i++) {
-          await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
-          if (i % 500 === 499) Bun.gc(true);
-        }
-        Bun.gc(true);
-        await Bun.sleep(50);
-        const rssAfterQueries = rss();
+      // Run queries — each re-decodes 50 column definitions. Collect every 500
+      // so the RSS delta reflects the name_or_index leak rather than the
+      // controller's opportunistic-GC cadence (which no longer fires at this
+      // allocation volume): without this, peak uncollected garbage between
+      // opportunistic passes commits extra MarkedBlock pages that Bun.gc(true)
+      // at the end does not synchronously decommit.
+      for (let i = 0; i < 5000; i++) {
+        await sql`SELECT * FROM leak_test_28632 WHERE primary_id = ${"123"} LIMIT 1`;
+        if (i % 500 === 499) Bun.gc(true);
+      }
+      Bun.gc(true);
+      await Bun.sleep(50);
+      const rssAfterQueries = rss();
 
-        const growthMB = (rssAfterQueries - rssAfterWarmup) / 1024 / 1024;
+      const growthMB = (rssAfterQueries - rssAfterWarmup) / 1024 / 1024;
 
-        // Without the fix, ~17MB growth (50 leaked name_or_index allocs × 5000 queries).
-        // With the fix, ~7MB (allocator noise + ASAN shadow memory). Under ASAN the
-        // Rust global allocator routes every alloc through the interceptor, so the
-        // per-query free/alloc churn (row cells, etc.) lands in ASAN's 256 MB
-        // quarantine and shows up as RSS even though nothing leaks — give it 3×
-        // headroom there. Debug builds enable ASAN by default on Linux/macOS, so
-        // treat them the same. The non-ASAN bound is what guards the actual
-        // regression.
-        expect(growthMB).toBeLessThan(isASAN || isDebug ? 36 : 12);
+      // Without the fix, ~17MB growth (50 leaked name_or_index allocs × 5000 queries).
+      // With the fix, ~7MB (allocator noise + ASAN shadow memory). Under ASAN the
+      // Rust global allocator routes every alloc through the interceptor, so the
+      // per-query free/alloc churn (row cells, etc.) lands in ASAN's 256 MB
+      // quarantine and shows up as RSS even though nothing leaks — give it 3×
+      // headroom there. Debug builds enable ASAN by default on Linux/macOS, so
+      // treat them the same. The non-ASAN bound is what guards the actual
+      // regression.
+      expect(growthMB).toBeLessThan(isASAN || isDebug ? 36 : 12);
 
-        await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
-      });
-    },
-  );
-}
+      await sql`DROP TABLE IF EXISTS leak_test_28632`.catch(() => {});
+      // 5500 sequential queries plus periodic Bun.gc(true) take ~14s under a
+      // debug+ASAN build on capped-CPU hosts; the 5s default is too tight.
+    }, 60_000);
+  },
+);


### PR DESCRIPTION
Companion to #37114 (open), which removes the same gate from `sql-onconnect-onclose-throw.test.ts` as part of a larger rework of that file and listed the remaining files; the two PRs touch disjoint files and can land in either order. If #37114 does not land, that file still needs the same ungating in a follow-up.

### Problem

Ten test files (nine in `test/js/sql/`, one in `test/regression/issue/`) wrapped their `describeWithContainer` blocks in a file-level `if (isDockerEnabled())`. The gate is redundant and harmful:

- Redundant: `describeWithContainer` already self-skips via `describe.todo` when neither docker, a coordinator socket, nor a `BUN_TEST_SERVICE_<service>` override is present. The check at test/harness.ts:1208 deliberately tests the env override and `BUN_DOCKER_COORDINATOR` before calling `isDockerEnabled()` (which can throw on CI linux without docker).
- Harmful: on a machine where `BUN_TEST_SERVICE_mysql_plain` / `BUN_TEST_SERVICE_postgres_plain` point at reachable services but no docker daemon exists, the file-level gate evaluates false and silently skips every container scenario the override mechanism was built to run.

Five of the sql files also carried an `else` branch that reimplemented no-docker coverage by dialing `MYSQL_URL`/`DATABASE_URL` or a conventional local address, warning and passing when nothing answered. That is the same job the override now does through the real `describeWithContainer` path with full assertions, so the fallback branches are dropped rather than left to produce vacuous passes on agents with neither docker nor services. The roughly 30 other sql test files already call `describeWithContainer` ungated; this brings the stragglers in line.

`test/regression/issue/28632.test.ts` (MySQL RSS-leak regression) gets the same ungating, plus an explicit 60s test timeout: its 5500 sequential queries take ~14s under a debug+ASAN build on capped-CPU hosts, past the 5s default that only ever applied where docker was present.

Behavior per environment:

- docker or coordinator present (CI linux): unchanged, gate was true there anyway.
- `BUN_TEST_SERVICE_*` set, no docker: container scenarios now run (previously 0 of them ran).
- nothing set, no docker (e.g. darwin shards today): `describe.todo` instead of silent omission or a warn-and-pass fallback.

### Gates kept, with the rationale now recorded in-file

The three kept gates all looked identical to the nine deleted ones, so each now carries a short comment saying why it stays:

- `sql.test.ts`: load-bearing (guards a top-level `await dockerCompose.ensure(...)`, which throws where docker is unavailable). Supporting overrides there means widening the condition, not deleting it; left for a follow-up.
- `tls-sql.test.ts`: inverted gate kept for its visible skip message. The comment also records the tradeoff: with no docker it wins before `describeWithContainer` could honor a `BUN_TEST_SERVICE_postgres_tls` override, though no current environment sets one.
- `sql-mysql.test.ts`: its gate also only wraps `describeWithContainer` code, but 4 of its 104 tests fail against anything other than MySQL proper on an unrestricted network: `CAST(... AS JSON)` and `MYSQL_TYPE_JSON` bind params do not exist on MariaDB, `FROM_UNIXTIME(0)` is NULL on MariaDB, the "only allows one statement" assertion matches the exact "MySQL server version" error string, and "Connection timeout works" dials `example.com:3306` expecting the connect to hang. Ungating it would turn MariaDB-backed override environments red, so it keeps its gate until those tests are made server-agnostic.

Also not included: `test/regression/issue/26063.test.ts` carries the same redundant gate, but open PR #36948 already removes it as part of consolidating that file, so it is left to that PR to avoid conflicting.

Non-gate checks on the remaining `isDockerEnabled()` callers in `test/`: the rest are load-bearing top-level docker usage (`s3.test.ts`, `bun-install-proxy.test.ts`), inverted visible-skip gates (`autobahn.test.ts`, `websocket-proxy.test.ts`), or docker-build tests.

### Verification

On a host with `BUN_TEST_SERVICE_mysql_plain`/`BUN_TEST_SERVICE_postgres_plain` set, local mysql-compatible/postgres services running, and no docker daemon:

| | before (parent commit) | after |
|---|---|---|
| container scenarios defined | 0 of 17 | 17, all pass (release and `bun bd test` debug+ASAN) |
| fallback/else tests | 9 defined: 3 real passes (postgres local), 5 vacuous warn-and-passes (mysql fallback URL unreachable), 1 skip | removed |
| overrides unset, no docker | silent omission or warn-and-pass | 0 ran, clean `describe.todo` |

The diff is whitespace-dominated (dedent after removing the wrapper); `git diff -w` shows only the gate/else/import removals and the one added test timeout.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->