### PR TITLE
install: fix bun patch --commit cache path for git, github, and tarball dependencies

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -921,12 +921,9 @@ pub struct CacheDirAndSubpath<'a> {
 /// this is copy pasted from `installPackageWithNameAndResolution()`
 /// it's not great to do this
 ///
-/// `resolution_string_bytes` is the string buffer that `resolution`'s strings
-/// index into, for callers whose resolution was read from a lockfile other
-/// than `manager.lockfile` (`bun patch --commit` loads its own copy before the
-/// install populates the manager's). `None` means `resolution` belongs to
-/// `manager.lockfile`. Strings longer than 7 bytes are offsets into that
-/// buffer, so slicing them with the wrong one yields empty or garbage paths.
+/// `resolution_string_bytes`: the string buffer `resolution`'s strings index
+/// into when it came from a lockfile other than `manager.lockfile` (`bun
+/// patch --commit` loads its own copy); `None` means `manager.lockfile`.
 pub fn compute_cache_dir_and_subpath<'a>(
     manager: &mut PackageManager,
     pkg_name: &[u8],

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -920,10 +920,18 @@ pub struct CacheDirAndSubpath<'a> {
 
 /// this is copy pasted from `installPackageWithNameAndResolution()`
 /// it's not great to do this
+///
+/// `resolution_string_bytes` is the string buffer that `resolution`'s strings
+/// index into, for callers whose resolution was read from a lockfile other
+/// than `manager.lockfile` (`bun patch --commit` loads its own copy before the
+/// install populates the manager's). `None` means `resolution` belongs to
+/// `manager.lockfile`. Strings longer than 7 bytes are offsets into that
+/// buffer, so slicing them with the wrong one yields empty or garbage paths.
 pub fn compute_cache_dir_and_subpath<'a>(
     manager: &mut PackageManager,
     pkg_name: &[u8],
     resolution: &Resolution,
+    resolution_string_bytes: Option<&[u8]>,
     folder_path_buf: &'a mut PathBuffer,
     patch_hash: Option<u64>,
 ) -> CacheDirAndSubpath<'a> {
@@ -939,16 +947,35 @@ pub fn compute_cache_dir_and_subpath<'a>(
         }
         ResolutionTag::Git => {
             let git = resolution.git();
-            cache_dir_subpath = cached_git_folder_name(manager, git, patch_hash);
+            let resolved = match resolution_string_bytes {
+                Some(buf) => git.resolved.slice(buf),
+                None => manager.lockfile.str(&git.resolved),
+            };
+            cache_dir_subpath = cached_git_folder_name_print(
+                cached_package_folder_name_buf(),
+                resolved,
+                patch_hash,
+            );
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Github => {
             let github = resolution.github();
-            cache_dir_subpath = cached_github_folder_name(manager, github, patch_hash);
+            let resolved = match resolution_string_bytes {
+                Some(buf) => github.resolved.slice(buf),
+                None => manager.lockfile.str(&github.resolved),
+            };
+            cache_dir_subpath = cached_github_folder_name_print(
+                cached_package_folder_name_buf(),
+                resolved,
+                patch_hash,
+            );
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Folder => {
-            let buf = manager.lockfile.buffers.string_bytes.as_slice();
+            let buf = match resolution_string_bytes {
+                Some(buf) => buf,
+                None => manager.lockfile.buffers.string_bytes.as_slice(),
+            };
             let folder = resolution.folder().slice(buf);
             // Handle when a package depends on itself via file:
             // example:
@@ -963,17 +990,30 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = Fd::cwd();
         }
         ResolutionTag::LocalTarball => {
-            let tarball = *resolution.local_tarball();
-            cache_dir_subpath = cached_tarball_folder_name(manager, tarball, patch_hash);
+            let tarball = resolution.local_tarball();
+            let url = match resolution_string_bytes {
+                Some(buf) => tarball.slice(buf),
+                None => manager.lockfile.str(tarball),
+            };
+            cache_dir_subpath =
+                cached_tarball_folder_name_print(cached_package_folder_name_buf(), url, patch_hash);
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::RemoteTarball => {
-            let tarball = *resolution.remote_tarball();
-            cache_dir_subpath = cached_tarball_folder_name(manager, tarball, patch_hash);
+            let tarball = resolution.remote_tarball();
+            let url = match resolution_string_bytes {
+                Some(buf) => tarball.slice(buf),
+                None => manager.lockfile.str(tarball),
+            };
+            cache_dir_subpath =
+                cached_tarball_folder_name_print(cached_package_folder_name_buf(), url, patch_hash);
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Workspace => {
-            let buf = manager.lockfile.buffers.string_bytes.as_slice();
+            let buf = match resolution_string_bytes {
+                Some(buf) => buf,
+                None => manager.lockfile.buffers.string_bytes.as_slice(),
+            };
             let folder = resolution.workspace().slice(buf);
             // Handle when a package depends on itself
             if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
@@ -991,10 +1031,13 @@ pub fn compute_cache_dir_and_subpath<'a>(
             // borrowck — `global_link_dir_path` below reborrows
             // `manager` mutably, so copy the symlink target out of the lockfile
             // string buffer first instead of holding a slice across that call.
-            let folder = resolution
-                .symlink()
-                .slice(manager.lockfile.buffers.string_bytes.as_slice())
-                .to_vec();
+            let folder = {
+                let buf = match resolution_string_bytes {
+                    Some(buf) => buf,
+                    None => manager.lockfile.buffers.string_bytes.as_slice(),
+                };
+                resolution.symlink().slice(buf).to_vec()
+            };
 
             if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                 cache_dir_subpath = z_static(b".\0");

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -918,6 +918,16 @@ pub struct CacheDirAndSubpath<'a> {
     pub(crate) cache_dir_subpath: &'a ZStr,
 }
 
+/// Slice one of a `Resolution`'s strings with the buffer it actually indexes
+/// into: `resolution_string_bytes` when given, else `lockfile`'s own.
+fn resolution_str<'a, T: Semver::Slicable>(
+    lockfile: &'a Lockfile,
+    resolution_string_bytes: Option<&'a [u8]>,
+    s: &'a T,
+) -> &'a [u8] {
+    s.slice(resolution_string_bytes.unwrap_or_else(|| lockfile.buffers.string_bytes.as_slice()))
+}
+
 /// this is copy pasted from `installPackageWithNameAndResolution()`
 /// it's not great to do this
 ///
@@ -943,11 +953,11 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Git => {
-            let git = resolution.git();
-            let resolved = match resolution_string_bytes {
-                Some(buf) => git.resolved.slice(buf),
-                None => manager.lockfile.str(&git.resolved),
-            };
+            let resolved = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                &resolution.git().resolved,
+            );
             cache_dir_subpath = cached_git_folder_name_print(
                 cached_package_folder_name_buf(),
                 resolved,
@@ -956,11 +966,11 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Github => {
-            let github = resolution.github();
-            let resolved = match resolution_string_bytes {
-                Some(buf) => github.resolved.slice(buf),
-                None => manager.lockfile.str(&github.resolved),
-            };
+            let resolved = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                &resolution.github().resolved,
+            );
             cache_dir_subpath = cached_github_folder_name_print(
                 cached_package_folder_name_buf(),
                 resolved,
@@ -969,11 +979,11 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Folder => {
-            let buf = match resolution_string_bytes {
-                Some(buf) => buf,
-                None => manager.lockfile.buffers.string_bytes.as_slice(),
-            };
-            let folder = resolution.folder().slice(buf);
+            let folder = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                resolution.folder(),
+            );
             // Handle when a package depends on itself via file:
             // example:
             //   "mineflayer": "file:."
@@ -987,31 +997,31 @@ pub fn compute_cache_dir_and_subpath<'a>(
             cache_dir = Fd::cwd();
         }
         ResolutionTag::LocalTarball => {
-            let tarball = resolution.local_tarball();
-            let url = match resolution_string_bytes {
-                Some(buf) => tarball.slice(buf),
-                None => manager.lockfile.str(tarball),
-            };
+            let url = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                resolution.local_tarball(),
+            );
             cache_dir_subpath =
                 cached_tarball_folder_name_print(cached_package_folder_name_buf(), url, patch_hash);
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::RemoteTarball => {
-            let tarball = resolution.remote_tarball();
-            let url = match resolution_string_bytes {
-                Some(buf) => tarball.slice(buf),
-                None => manager.lockfile.str(tarball),
-            };
+            let url = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                resolution.remote_tarball(),
+            );
             cache_dir_subpath =
                 cached_tarball_folder_name_print(cached_package_folder_name_buf(), url, patch_hash);
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Workspace => {
-            let buf = match resolution_string_bytes {
-                Some(buf) => buf,
-                None => manager.lockfile.buffers.string_bytes.as_slice(),
-            };
-            let folder = resolution.workspace().slice(buf);
+            let folder = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                resolution.workspace(),
+            );
             // Handle when a package depends on itself
             if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                 cache_dir_subpath = z_static(b".\0");
@@ -1028,13 +1038,12 @@ pub fn compute_cache_dir_and_subpath<'a>(
             // borrowck — `global_link_dir_path` below reborrows
             // `manager` mutably, so copy the symlink target out of the lockfile
             // string buffer first instead of holding a slice across that call.
-            let folder = {
-                let buf = match resolution_string_bytes {
-                    Some(buf) => buf,
-                    None => manager.lockfile.buffers.string_bytes.as_slice(),
-                };
-                resolution.symlink().slice(buf).to_vec()
-            };
+            let folder = resolution_str(
+                &manager.lockfile,
+                resolution_string_bytes,
+                resolution.symlink(),
+            )
+            .to_vec();
 
             if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
                 cache_dir_subpath = z_static(b".\0");

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -252,6 +252,7 @@ pub fn do_patch_commit(
                     manager,
                     &name,
                     &resolution_clone,
+                    Some(lockfile.buffers.string_bytes.as_slice()),
                     &mut folder_path_buf,
                     None,
                 );
@@ -289,6 +290,7 @@ pub fn do_patch_commit(
                     manager,
                     &pkg_name_slice,
                     &resolution_clone,
+                    Some(lockfile.buffers.string_bytes.as_slice()),
                     &mut folder_path_buf,
                     None,
                 );
@@ -889,6 +891,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     manager,
                     &name,
                     &actual_package.resolution,
+                    None,
                     &mut folder_path_buf,
                     existing_patchfile_hash,
                 );
@@ -949,6 +952,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     manager,
                     &pkg_name,
                     &pkg_resolution,
+                    None,
                     &mut folder_path_buf,
                     existing_patchfile_hash,
                 );

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -667,11 +667,8 @@ fn escape_patch_filename(name: &[u8]) -> Option<Box<[u8]>> {
         Newline,
         CarriageReturn,
         Tab,
-        // Reserved in Windows filenames. Git and github resolution labels put
-        // `:` in the patch filename (`pkg@github:owner/repo#sha.patch`), and
-        // an unescaped name both fails the rename into patches/ on NTFS and
-        // makes a patches/ dir committed from another OS uncheckoutable on
-        // Windows.
+        // Reserved in Windows filenames; escaped on every OS so a committed
+        // patches/ dir stays checkoutable on Windows.
         Colon,
         Question,
         Asterisk,

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -667,6 +667,18 @@ fn escape_patch_filename(name: &[u8]) -> Option<Box<[u8]>> {
         Newline,
         CarriageReturn,
         Tab,
+        // Reserved in Windows filenames. Git and github resolution labels put
+        // `:` in the patch filename (`pkg@github:owner/repo#sha.patch`), and
+        // an unescaped name both fails the rename into patches/ on NTFS and
+        // makes a patches/ dir committed from another OS uncheckoutable on
+        // Windows.
+        Colon,
+        Question,
+        Asterisk,
+        Quote,
+        LessThan,
+        GreaterThan,
+        Pipe,
         // Dot,
         Other,
     }
@@ -680,6 +692,13 @@ fn escape_patch_filename(name: &[u8]) -> Option<Box<[u8]>> {
                 EscapeVal::Newline => Some(b"%0A"),
                 EscapeVal::CarriageReturn => Some(b"%0D"),
                 EscapeVal::Tab => Some(b"%09"),
+                EscapeVal::Colon => Some(b"%3A"),
+                EscapeVal::Question => Some(b"%3F"),
+                EscapeVal::Asterisk => Some(b"%2A"),
+                EscapeVal::Quote => Some(b"%22"),
+                EscapeVal::LessThan => Some(b"%3C"),
+                EscapeVal::GreaterThan => Some(b"%3E"),
+                EscapeVal::Pipe => Some(b"%7C"),
                 // EscapeVal::Dot => Some(b"%2E"),
                 EscapeVal::Other => None,
             }
@@ -695,6 +714,13 @@ fn escape_patch_filename(name: &[u8]) -> Option<Box<[u8]>> {
         table[b'\n' as usize] = EscapeVal::Newline;
         table[b'\r' as usize] = EscapeVal::CarriageReturn;
         table[b'\t' as usize] = EscapeVal::Tab;
+        table[b':' as usize] = EscapeVal::Colon;
+        table[b'?' as usize] = EscapeVal::Question;
+        table[b'*' as usize] = EscapeVal::Asterisk;
+        table[b'"' as usize] = EscapeVal::Quote;
+        table[b'<' as usize] = EscapeVal::LessThan;
+        table[b'>' as usize] = EscapeVal::GreaterThan;
+        table[b'|' as usize] = EscapeVal::Pipe;
         table
     };
     let mut count: usize = 0;

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -793,6 +793,7 @@ impl PatchTask {
             pkg_manager,
             &pkg_name_slice,
             &resolution_clone,
+            None,
             &mut folder_path_buf,
             Some(patch_hash),
         );

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -968,13 +968,11 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
   async function expectPatchFlowWorks(dir: string, env: Record<string, string | undefined>, commitArg: string) {
     {
       const { stderr, exitCode } = await runBun(dir, env, "install");
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expect(exitCode, `bun install failed: ${stderr}`).toBe(0);
     }
     {
       const { stderr, exitCode } = await runBun(dir, env, "patch", "pkg-to-patch");
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expect(exitCode, `bun patch failed: ${stderr}`).toBe(0);
     }
 
     await Bun.write(join(dir, "node_modules", "pkg-to-patch", "index.js"), `module.exports = "patched";\n`);
@@ -982,14 +980,15 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
     {
       const { stderr, exitCode } = await runBun(dir, env, "patch", "--commit", commitArg);
       expect(stderr).not.toContain("Could not access");
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expect(exitCode, `bun patch --commit failed: ${stderr}`).toBe(0);
     }
 
     const pkg = await Bun.file(join(dir, "package.json")).json();
     const entries = Object.entries(pkg.patchedDependencies ?? {}) as [string, string][];
     expect(entries).toHaveLength(1);
     const [patchKey, patchPath] = entries[0];
+    // the filename must stay valid on Windows (no NTFS-reserved characters)
+    expect(patchPath).not.toMatch(/[:?*"<>|]/);
     const patchContents = await Bun.file(join(dir, patchPath)).text();
     expect(patchContents).toContain('-module.exports = "original";');
     expect(patchContents).toContain('+module.exports = "patched";');
@@ -1057,6 +1056,8 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
     });
     const repo = join(String(dir), "gitrepo");
 
+    // keep git away from the machine's global/system config (autocrlf, gpgsign)
+    const gitEnv = { ...bunEnv, GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: join(String(dir), "no-gitconfig") };
     for (const args of [
       ["init", "-q"],
       ["config", "core.autocrlf", "false"],
@@ -1065,10 +1066,9 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
       // serve the repo over git's dumb HTTP protocol (plain file fetches)
       ["update-server-info"],
     ]) {
-      await using proc = Bun.spawn({ cmd: ["git", ...args], cwd: repo, env: bunEnv, stderr: "pipe" });
+      await using proc = Bun.spawn({ cmd: ["git", ...args], cwd: repo, env: gitEnv, stderr: "pipe" });
       const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(stderr, `git ${args.join(" ")} failed: ${stderr}`).not.toContain("fatal:");
-      expect(exitCode).toBe(0);
+      expect(exitCode, `git ${args.join(" ")} failed: ${stderr}`).toBe(0);
     }
 
     await using server = Bun.serve({

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -946,3 +946,179 @@ module.exports = function isOdd() {
     }
   });
 });
+
+// `bun patch --commit` derives the pristine copy's cache folder from the
+// package's resolution. For non-registry resolutions (git, github, tarball)
+// the resolution strings live in the lockfile's string buffer; resolving them
+// against the wrong buffer produced paths like "@GH@@@@1" and the diff step
+// failed with "Could not access".
+describe.concurrent("bun patch --commit for non-registry dependencies", () => {
+  async function runBun(cwd: string, env: Record<string, string | undefined>, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  async function expectPatchFlowWorks(dir: string, env: Record<string, string | undefined>, commitArg: string) {
+    {
+      const { stderr, exitCode } = await runBun(dir, env, "install");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+    {
+      const { stderr, exitCode } = await runBun(dir, env, "patch", "pkg-to-patch");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    await Bun.write(join(dir, "node_modules", "pkg-to-patch", "index.js"), `module.exports = "patched";\n`);
+
+    {
+      const { stderr, exitCode } = await runBun(dir, env, "patch", "--commit", commitArg);
+      expect(stderr).not.toContain("Could not access");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    const pkg = await Bun.file(join(dir, "package.json")).json();
+    const entries = Object.entries(pkg.patchedDependencies ?? {}) as [string, string][];
+    expect(entries).toHaveLength(1);
+    const [patchKey, patchPath] = entries[0];
+    const patchContents = await Bun.file(join(dir, patchPath)).text();
+    expect(patchContents).toContain('-module.exports = "original";');
+    expect(patchContents).toContain('+module.exports = "patched";');
+    // the commit flow reinstalls with the patch applied
+    expect(await Bun.file(join(dir, "node_modules", "pkg-to-patch", "index.js")).text()).toBe(
+      `module.exports = "patched";\n`,
+    );
+    return patchKey;
+  }
+
+  test("github dependency", async () => {
+    await using dir = tempDir("patch-commit-github", {
+      "package.json": JSON.stringify({
+        name: "test-patch-github",
+        dependencies: { "pkg-to-patch": "github:testowner/testrepo#aaaaaaa" },
+      }),
+      // GitHub API tarballs have an `<owner>-<repo>-<committish>` root folder;
+      // that folder name becomes the `resolved` part of the cache folder name.
+      "tarball-src": {
+        "testowner-testrepo-aaaaaaa": {
+          "package.json": JSON.stringify({ name: "pkg-to-patch", version: "1.0.0" }),
+          "index.js": `module.exports = "original";\n`,
+        },
+      },
+    });
+
+    await using tarProc = Bun.spawn({
+      cmd: [
+        "tar",
+        "-czf",
+        join(String(dir), "gh.tgz"),
+        "-C",
+        join(String(dir), "tarball-src"),
+        "testowner-testrepo-aaaaaaa",
+      ],
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(await tarProc.exited).toBe(0);
+    const tgz = await Bun.file(join(String(dir), "gh.tgz")).bytes();
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(tgz, { headers: { "content-type": "application/gzip" } }),
+    });
+
+    const env = {
+      ...bunEnv,
+      GITHUB_API_URL: `http://localhost:${server.port}`,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    };
+
+    const patchKey = await expectPatchFlowWorks(String(dir), env, "node_modules/pkg-to-patch");
+    expect(patchKey).toBe("pkg-to-patch@github:testowner/testrepo#aaaaaaa");
+  });
+
+  test("git dependency", async () => {
+    await using dir = tempDir("patch-commit-git", {
+      "gitrepo": {
+        "package.json": JSON.stringify({ name: "pkg-to-patch", version: "1.0.0" }),
+        "index.js": `module.exports = "original";\n`,
+      },
+      "project": {},
+    });
+    const repo = join(String(dir), "gitrepo");
+
+    for (const args of [
+      ["init", "-q"],
+      ["add", "-A"],
+      ["-c", "user.email=test@test.test", "-c", "user.name=test", "commit", "-q", "-m", "init"],
+      // serve the repo over git's dumb HTTP protocol (plain file fetches)
+      ["update-server-info"],
+    ]) {
+      await using proc = Bun.spawn({ cmd: ["git", ...args], cwd: repo, env: bunEnv, stderr: "pipe" });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const pathname = new URL(req.url).pathname;
+        if (!pathname.startsWith("/repo.git/")) return new Response("not found", { status: 404 });
+        const file = Bun.file(join(repo, ".git", ...pathname.slice("/repo.git/".length).split("/")));
+        return (await file.exists()) ? new Response(file) : new Response("not found", { status: 404 });
+      },
+    });
+
+    const project = join(String(dir), "project");
+    const depUrl = `git+http://localhost:${server.port}/repo.git`;
+    await Bun.write(
+      join(project, "package.json"),
+      JSON.stringify({ name: "test-patch-git", dependencies: { "pkg-to-patch": depUrl } }),
+    );
+
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") };
+
+    const patchKey = await expectPatchFlowWorks(project, env, "node_modules/pkg-to-patch");
+    expect(patchKey).toStartWith(`pkg-to-patch@${depUrl}#`);
+  });
+
+  test("local tarball dependency", async () => {
+    await using dir = tempDir("patch-commit-tarball", {
+      "package.json": JSON.stringify({
+        name: "test-patch-tarball",
+        dependencies: { "pkg-to-patch": "file:./dep.tgz" },
+      }),
+      "tarball-src": {
+        "package": {
+          "package.json": JSON.stringify({ name: "pkg-to-patch", version: "1.0.0" }),
+          "index.js": `module.exports = "original";\n`,
+        },
+      },
+    });
+
+    await using tarProc = Bun.spawn({
+      cmd: ["tar", "-czf", join(String(dir), "dep.tgz"), "-C", join(String(dir), "tarball-src"), "package"],
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(await tarProc.exited).toBe(0);
+
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") };
+
+    // name-only argument exercises the name-and-version lookup path
+    const patchKey = await expectPatchFlowWorks(String(dir), env, "pkg-to-patch");
+    expect(patchKey).toBe("pkg-to-patch@./dep.tgz");
+  });
+});

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1059,6 +1059,7 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
 
     for (const args of [
       ["init", "-q"],
+      ["config", "core.autocrlf", "false"],
       ["add", "-A"],
       ["-c", "user.email=test@test.test", "-c", "user.name=test", "commit", "-q", "-m", "init"],
       // serve the repo over git's dumb HTTP protocol (plain file fetches)
@@ -1066,7 +1067,7 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
     ]) {
       await using proc = Bun.spawn({ cmd: ["git", ...args], cwd: repo, env: bunEnv, stderr: "pipe" });
       const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
+      expect(stderr, `git ${args.join(" ")} failed: ${stderr}`).not.toContain("fatal:");
       expect(exitCode).toBe(0);
     }
 


### PR DESCRIPTION
### Repro

```sh
printf '{"name":"r","dependencies":{"@types/betterdiscord":"github:zerthox/betterdiscord-types"}}' > package.json
bun install
bun patch @types/betterdiscord
echo '// x' >> node_modules/@types/betterdiscord/index.d.ts
bun patch --commit 'node_modules/@types/betterdiscord'
```

```
error: failed to make diff error: Could not access '/root/.bun/install/cache/@GH@@@@1'
```

exit code 2 and no patch is written. The pristine copy actually lives at `@GH@Zerthox-betterdiscord-types-7ee79af@@@1`. The same failure hits git dependencies (`Could not access '.../@G@'`) and tarball dependencies (`Could not access '.../@T@0000000000000000@@@1'`). npm registry dependencies patch fine.

### Cause

`do_patch_commit` loads its own copy of the lockfile (it runs before the install flow populates `manager.lockfile`), then hands the package's `Resolution` to `compute_cache_dir_and_subpath`, which resolved the resolution's strings against `manager.lockfile`'s string buffer. That buffer is empty at this point. Lockfile strings longer than 7 bytes are stored as offsets into their lockfile's string buffer, so `repository.resolved` / tarball URLs sliced against the wrong buffer come back empty, and the computed cache folder name collapses to just its prefix and cache-version suffix (`@GH@` + `` + `@@@1`). npm resolutions were unaffected because the version is stored inline in the `Resolution` value.

This mismatch predates the Rust port: the same flow segfaulted in v1.1.42 (#18792), where `manager.lockfile` was an undefined pointer rather than an empty lockfile.

### Fix

`compute_cache_dir_and_subpath` now takes the string buffer that owns the resolution's strings (`resolution_string_bytes: Option<&[u8]>`). The two `bun patch --commit` call sites pass the locally loaded lockfile's buffer; `bun patch` and the patch-apply task keep resolving against `manager.lockfile` (their resolutions come from it). All non-npm arms (git, github, local/remote tarball, folder, workspace, symlink) go through the new parameter.

### Windows: patch filename escaping

With the cache path fixed, the same flow on Windows hit a second failure: the patch filename is `{name}@{resolution}.patch`, and git/github resolution labels contain `:` (`pkg@github:owner/repo#sha.patch`), which NTFS rejects in filenames (`STATUS_OBJECT_NAME_INVALID` when renaming the patch into `patches/`). `escape_patch_filename` now escapes the NTFS-reserved printable characters (`: ? * " < > |`) the same way it already escapes `/`. This applies on every OS so a `patches/` directory committed from macOS or Linux stays checkoutable on Windows.

### Known limitation: workspaces with the isolated linker

In a workspace using the isolated linker (the default for new projects), the reinstall that `bun patch --commit` runs after writing the patch hangs. That hang is a pre-existing `bun install` bug, reproducible on released bun with no patch commands involved: a workspace with an existing `patchedDependencies` entry for a github: dependency hangs the same way on a plain `bun install` (it completes with `--linker hoisted`). With this fix, `bun patch --commit --linker hoisted` completes end to end in workspaces; the isolated-linker install hang is tracked separately.

### Verification

Three new tests in `test/cli/install/bun-patch.test.ts` run the full install, `bun patch`, edit, `bun patch --commit` flow offline and assert the patch file contents, the `patchedDependencies` key, and the reinstalled patched package:

- `github:` dependency served by a local tarball server via `GITHUB_API_URL`
- git dependency cloned from a local server over git's dumb HTTP protocol
- local `file:` tarball, committed by package name to also cover the name-based lookup path

All three fail on bun 1.4.0-canary.1 with the `Could not access` errors above and pass with this change, on Linux and Windows. The rest of `bun-patch.test.ts` (34 tests) and `bun-install-patch.test.ts` (18 tests) pass.

Fixes #18792
Fixes #17945

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-patch.test.ts

<!-- robobun:evidence:end -->