### PR TITLE
sql(mysql): bind JSON parameters as MYSQL_TYPE_STRING so MariaDB accepts them

### DIFF
--- a/src/sql/mysql/MySQLTypes.rs
+++ b/src/sql/mysql/MySQLTypes.rs
@@ -89,12 +89,10 @@ impl FieldType {
     }
 
     /// Type code declared in the COM_STMT_EXECUTE parameter-type block.
-    /// `MYSQL_TYPE_JSON` is a result-set-only code there: MariaDB's
-    /// `parameter_type_sanity_check` rejects it with ER_WRONG_ARGUMENTS
-    /// ("Incorrect arguments to mysqld_stmt_execute"), while MySQL reads a
-    /// JSON parameter through the same `set_str` path as VARCHAR/VAR_STRING/
-    /// STRING. Declaring the serialized JSON text as `MYSQL_TYPE_STRING`
-    /// keeps both servers happy without changing the value bytes.
+    /// MariaDB rejects `MYSQL_TYPE_JSON` as an input parameter type (error
+    /// 1210, "Incorrect arguments to mysqld_stmt_execute"); MySQL reads a
+    /// JSON parameter exactly like a string one, so the serialized JSON
+    /// text is declared as `MYSQL_TYPE_STRING`.
     pub(crate) fn to_param_bind_type(self) -> Self {
         match self {
             FieldType::MYSQL_TYPE_JSON => FieldType::MYSQL_TYPE_STRING,

--- a/src/sql/mysql/MySQLTypes.rs
+++ b/src/sql/mysql/MySQLTypes.rs
@@ -89,10 +89,9 @@ impl FieldType {
     }
 
     /// Type code declared in the COM_STMT_EXECUTE parameter-type block.
-    /// MariaDB rejects `MYSQL_TYPE_JSON` as an input parameter type (error
-    /// 1210, "Incorrect arguments to mysqld_stmt_execute"); MySQL reads a
-    /// JSON parameter exactly like a string one, so the serialized JSON
-    /// text is declared as `MYSQL_TYPE_STRING`.
+    /// MariaDB rejects `MYSQL_TYPE_JSON` there (error 1210, "Incorrect
+    /// arguments to mysqld_stmt_execute"); MySQL reads a JSON parameter
+    /// exactly like a string one.
     pub(crate) fn to_param_bind_type(self) -> Self {
         match self {
             FieldType::MYSQL_TYPE_JSON => FieldType::MYSQL_TYPE_STRING,

--- a/src/sql/mysql/MySQLTypes.rs
+++ b/src/sql/mysql/MySQLTypes.rs
@@ -88,6 +88,20 @@ impl FieldType {
         })
     }
 
+    /// Type code declared in the COM_STMT_EXECUTE parameter-type block.
+    /// `MYSQL_TYPE_JSON` is a result-set-only code there: MariaDB's
+    /// `parameter_type_sanity_check` rejects it with ER_WRONG_ARGUMENTS
+    /// ("Incorrect arguments to mysqld_stmt_execute"), while MySQL reads a
+    /// JSON parameter through the same `set_str` path as VARCHAR/VAR_STRING/
+    /// STRING. Declaring the serialized JSON text as `MYSQL_TYPE_STRING`
+    /// keeps both servers happy without changing the value bytes.
+    pub(crate) fn to_param_bind_type(self) -> Self {
+        match self {
+            FieldType::MYSQL_TYPE_JSON => FieldType::MYSQL_TYPE_STRING,
+            other => other,
+        }
+    }
+
     pub(crate) fn is_binary_format_supported(self) -> bool {
         matches!(
             self,

--- a/src/sql/mysql/protocol/PreparedStatement.rs
+++ b/src/sql/mysql/protocol/PreparedStatement.rs
@@ -89,7 +89,7 @@ impl<'a> Execute<'a> {
                         <&'static str>::from(param_type.r#type),
                         unsigned
                     );
-                    writer.int1(param_type.r#type as u8)?;
+                    writer.int1(param_type.r#type.to_param_bind_type() as u8)?;
                     writer.int1(if unsigned { 0x80 } else { 0 })?;
                 }
             }

--- a/test/js/sql/sql-mysql-json-param-type.test.ts
+++ b/test/js/sql/sql-mysql-json-param-type.test.ts
@@ -1,0 +1,119 @@
+// Object/array parameters are serialized to JSON text and were declared as
+// MYSQL_TYPE_JSON (0xf5) in the COM_STMT_EXECUTE parameter-type block.
+// MariaDB rejects that type code outright (parameter_type_sanity_check ->
+// error 1210 "Incorrect arguments to mysqld_stmt_execute"); MySQL reads a
+// JSON parameter through the same string path as MYSQL_TYPE_STRING. The
+// client must therefore declare JSON parameters as MYSQL_TYPE_STRING.
+//
+// This asserts on the bytes the client emits, which only a mock server can
+// observe: CI's real-server suites run MySQL, which accepts either type code,
+// so a container test cannot catch a regression here. The MariaDB-visible
+// behavior (binding an object succeeds) is covered by the "JSON" test in
+// sql-mysql.test.ts when the mysql service is backed by MariaDB.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import {
+  listeningServer,
+  mysqlColumnDefinition,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadLenencInt,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+} from "./wire-frames";
+
+const COM_QUIT = 0x01;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+const MYSQL_TYPE_STRING = 0xfe;
+
+test("MySQL: object and array parameters are declared as MYSQL_TYPE_STRING, not MYSQL_TYPE_JSON", async () => {
+  const executePayloads: Buffer[] = [];
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        switch (payload[0]) {
+          case COM_STMT_PREPARE:
+            // INSERT INTO t (a, b) VALUES (?, ?) -> two params, no result columns.
+            socket.write(
+              Buffer.concat([
+                mysqlStmtPrepareOk(1, 1, 0, 2),
+                mysqlColumnDefinition(2, { name: "?", type: MYSQL_TYPE_VAR_STRING }),
+                mysqlColumnDefinition(3, { name: "?", type: MYSQL_TYPE_VAR_STRING }),
+              ]),
+            );
+            break;
+          case COM_STMT_EXECUTE:
+            executePayloads.push(Buffer.from(payload));
+            socket.write(mysqlOkPacket(seq + 1));
+            break;
+          case COM_QUIT:
+            socket.end();
+            break;
+          default:
+            socket.write(mysqlOkPacket(seq + 1));
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    {
+      await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+      await sql`INSERT INTO t (a, b) VALUES (${{ b: 2 }}, ${[1, "x"]})`;
+    }
+
+    expect(executePayloads).toHaveLength(1);
+    const payload = executePayloads[0];
+    // COM_STMT_EXECUTE: Int<1>(0x17) Int<4>(statement_id) Int<1>(flags)
+    // Int<4>(iteration_count) null_bitmap<(params+7)/8> Int<1>(new_params_bind_flag)
+    // then per param Int<1>(type) Int<1>(0x80 if unsigned) and the values.
+    const statementId = payload.readUInt32LE(1);
+    const nullBitmap = payload[10];
+    const newParamsBindFlag = payload[11];
+    const paramTypes = [payload[12], payload[14]];
+    const paramFlags = [payload[13], payload[15]];
+    const values: string[] = [];
+    let offset = 16;
+    for (let i = 0; i < 2; i++) {
+      const { value: len, width } = mysqlReadLenencInt(payload, offset);
+      offset += width;
+      values.push(payload.subarray(offset, offset + len).toString("utf-8"));
+      offset += len;
+    }
+    // Before the fix the two type bytes were 0xf5 (MYSQL_TYPE_JSON), which
+    // MariaDB servers reject at execute time.
+    expect({
+      statementId,
+      nullBitmap,
+      newParamsBindFlag,
+      paramTypes,
+      paramFlags,
+      values,
+      trailing: payload.length - offset,
+    }).toEqual({
+      statementId: 1,
+      nullBitmap: 0,
+      newParamsBindFlag: 1,
+      paramTypes: [MYSQL_TYPE_STRING, MYSQL_TYPE_STRING],
+      paramFlags: [0, 0],
+      values: ['{"b":2}', '[1,"x"]'],
+      trailing: 0,
+    });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/sql-mysql-json-param-type.test.ts
+++ b/test/js/sql/sql-mysql-json-param-type.test.ts
@@ -7,9 +7,9 @@
 //
 // This asserts on the bytes the client emits, which only a mock server can
 // observe: CI's real-server suites run MySQL, which accepts either type code,
-// so a container test cannot catch a regression here. The MariaDB-visible
-// behavior (binding an object succeeds) is covered by the "JSON" test in
-// sql-mysql.test.ts when the mysql service is backed by MariaDB.
+// so a container test cannot catch a regression here. (The "JSON" test in
+// sql-mysql.test.ts is MySQL-only: CAST(? AS JSON) is a 1064 syntax error on
+// MariaDB, whose json columns are LONGTEXT and read back as strings.)
 // All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
 // Buffer.alloc frame construction here.
 


### PR DESCRIPTION
### Problem

Binding a JS object (or array) parameter with Bun's MySQL client fails against any MariaDB server:

```js
const sql = new SQL({ url: "mysql://root@127.0.0.1:3306/bun_sql_test", max: 1 });
await sql`CREATE TEMPORARY TABLE t (a json)`;
await sql`INSERT INTO t (a) VALUES (${JSON.stringify({ b: 1 })})`; // OK: string param
await sql`INSERT INTO t (a) VALUES (${{ b: 2 }})`;                 // MySQLError: Incorrect arguments to mysqld_stmt_execute (errno 1210)
```

Bun.SQL documents a `mariadb` adapter (alias of `mysql`), and object parameters are the documented convenience for json columns, so this combination is expected to work.

### Cause

Object and array parameters are serialized to JSON text, but the COM_STMT_EXECUTE parameter-type block declared them as `MYSQL_TYPE_JSON` (0xf5). That type code is result-set-only for MariaDB: `parameter_type_sanity_check` in its `sql/sql_prepare.cc` whitelists the permitted input parameter type codes and 0xf5 is not among them, so the server rejects the execute with `ER_WRONG_ARGUMENTS` ("Incorrect arguments to mysqld_stmt_execute"). MySQL 8 happens to accept it, reading a JSON parameter through the same `set_str` path as `MYSQL_TYPE_STRING` / `VAR_STRING` / `VARCHAR`.

### Fix

Declare JSON parameters as `MYSQL_TYPE_STRING` in the parameter-type block. Since MySQL treats JSON and string input parameters identically, this is behavior-preserving on MySQL and fixes MariaDB. The internal `MYSQL_TYPE_JSON` marker still drives JSON serialization and statement-cache naming; only the type byte on the wire changes (the value was already sent as a length-encoded string).

### Verification

- New mock-server test asserts the client declares object/array parameters as `MYSQL_TYPE_STRING` (0xfe), not `MYSQL_TYPE_JSON` (0xf5), and still sends the JSON text as the value. It fails on the unfixed build (type byte 245) and passes with the fix. A mock is used because the rejection is MariaDB-specific and CI's real-server suites run MySQL, which accepts either code; the bytes the client emits are the observable contract.
- Verified manually against MariaDB 11.8.6: the repro above fails before and succeeds after, including `JSON_VALID(?)` returning 1 for an object parameter, array parameters, bulk inserts via `sql(values)`, and re-execution of a cached prepared statement (the types-not-resent path).
- The existing docker-gated `JSON` test in `sql-mysql.test.ts` covers the MySQL path and is unchanged. It cannot run against MariaDB (`CAST(? AS JSON)` is a 1064 syntax error there), so the mock test is the CI regression guard for this byte.

### Scope

This fixes parameter binding (the write half). On MariaDB, json columns still read back as strings rather than parsed objects: MariaDB reports them as LONGTEXT over the wire unless the client negotiates `MARIADB_CLIENT_EXTENDED_TYPE_INFO`, which Bun does not do today. That read-side gap exists with or without this change and is tracked separately.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-json-param-type.test.ts
bun test v1.4.0 (51f646e66)

test/js/sql/sql-mysql-json-param-type.test.ts:
102 |       newParamsBindFlag,
103 |       paramTypes,
104 |       paramFlags,
105 |       values,
106 |       trailing: payload.length - offset,
107 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
    "newParamsBindFlag": 1,
    "nullBitmap": 0,
    "paramFlags": [
      0,
      0,
    ],
    "paramTypes": [
-     254,
-     254,
+     245,
+     245,
    ],
    "statementId": 1,
    "trailing": 0,
    "values": [
      "{"b":2}",
      "[1,"x"]",
    ],
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-json-param-type.test.ts:107:8)
(fail) MySQL: object and array parameters are declared as MYSQL_TYPE_STRING, not MYSQL_TYPE_JSON [613.25ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [3.04s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0ffabf64d)

test/js/sql/sql-mysql-json-param-type.test.ts:
102 |       newParamsBindFlag,
103 |       paramTypes,
104 |       paramFlags,
105 |       values,
106 |       trailing: payload.length - offset,
107 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
    "newParamsBindFlag": 1,
    "nullBitmap": 0,
    "paramFlags": [
      0,
      0,
    ],
    "paramTypes": [
-     254,
-     254,
+     245,
+     245,
    ],
    "statementId": 1,
    "trailing": 0,
    "values": [
      "{"b":2}",
      "[1,"x"]",
    ],
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/sql-mysql-json-param-type.test.ts:107:8)
(fail) MySQL: object and array parameters are declared as MYSQL_TYPE_STRING, not MYSQL_TYPE_JSON [11.45ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [195.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mysql-json-param-type.test.ts
bun test v1.4.0 (51f646e66)

test/js/sql/sql-mysql-json-param-type.test.ts:
(pass) MySQL: object and array parameters are declared as MYSQL_TYPE_STRING, not MYSQL_TYPE_JSON [605.23ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.02s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 674ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/143] cc obj/vendor/mimalloc/src/static.c.o
[2/143] gen JS modules (bundle-modules)
Preprocess modules (9064ms)
Bundle modules (652ms)
Postprocesss modules (850ms)
Bundle Functions (848ms)
Generate Code (40ms)

[11.48s] Bundled "src/js" for production
  2578 kb
  193 internal modules
  13 native modules
  89 internal functions across 17 files
[2/143] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_opaque v0.0.0 (/workspace/bun/src/opaque)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_windows_sy
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/mysql/MySQLTypes.rs                   |  11 +++
 src/sql/mysql/protocol/PreparedStatement.rs   |   2 +-
 test/js/sql/sql-mysql-json-param-type.test.ts | 119 ++++++++++++++++++++++++++
 3 files changed, 131 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/sql/mysql/MySQLTypes.rs                        1      3      0
src/sql/mysql/protocol/PreparedStatement.rs        1      1      0
test/js/sql/sql-mysql-json-param-type.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->