### PR TITLE
install: clone git dependencies from file:// URLs

### DIFF
--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -467,13 +467,10 @@ impl<'a> Task<'a> {
                                     // without a repository, keeping an earlier
                                     // https error if one was set.
                                     if this.status != Status::Fail {
-                                        this.err =
-                                            Some(crate::Error::RepositoryNotFound);
+                                        this.err = Some(crate::Error::RepositoryNotFound);
                                         this.status = Status::Fail;
                                         this.data = Data {
-                                            git_clone: ManuallyDrop::new(
-                                                Fd::invalid(),
-                                            ),
+                                            git_clone: ManuallyDrop::new(Fd::invalid()),
                                         };
                                     }
                                     break 'body;

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -450,30 +450,22 @@ impl<'a> Task<'a> {
                         None => {
                             let fallback = match Repository::try_ssh(url) {
                                 Some(ssh) => ssh,
-                                // URL-shaped specifiers neither rewrite
-                                // recognizes (file://, git://) are ones git
-                                // clones as written. Bare strings must not
-                                // reach git: it would resolve them as
-                                // filesystem paths relative to the current
-                                // directory. `attempt > 1` means an https
-                                // clone of the verbatim URL already failed
-                                // (`try_https` returns http(s) URLs
-                                // unchanged); don't repeat it.
+                                // git clones file:// and git:// URLs as
+                                // written. Bare strings are excluded (git
+                                // treats them as cwd-relative paths), as are
+                                // http(s) URLs whose verbatim clone already
+                                // failed (attempt > 1).
                                 None if attempt == 1
                                     && bun_core::strings::contains(url, b"://") =>
                                 {
-                                    // Sole attempt for this URL: mark it final
-                                    // so `download` logs a clone failure
-                                    // (attempt 1 stays quiet expecting a
-                                    // fallback retry).
+                                    // Final attempt: have `download` log it.
                                     attempt = 2;
                                     url
                                 }
                                 None => {
-                                    // No clone candidate: fail the task instead
-                                    // of completing without a repository. A
-                                    // failed https attempt already set its own
-                                    // error; keep it.
+                                    // No candidate: fail rather than complete
+                                    // without a repository, keeping an earlier
+                                    // https error if one was set.
                                     if this.status != Status::Fail {
                                         this.err =
                                             Some(crate::Error::RepositoryNotFound);

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -448,17 +448,44 @@ impl<'a> Task<'a> {
                     let dir = match dir {
                         Some(d) => d,
                         None => {
-                            // URLs neither `try_https` nor `try_ssh` recognize
-                            // (file://, git://) are ones git clones as written,
-                            // so fall back to the URL itself instead of
-                            // completing without a clone. `attempt > 1` means an
-                            // https clone of the verbatim URL already failed
-                            // (`try_https` returns http(s) URLs unchanged);
-                            // repeating it would be redundant, keep the failure.
                             let fallback = match Repository::try_ssh(url) {
                                 Some(ssh) => ssh,
-                                None if attempt == 1 => url,
-                                None => break 'body,
+                                // URL-shaped specifiers neither rewrite
+                                // recognizes (file://, git://) are ones git
+                                // clones as written. Bare strings must not
+                                // reach git: it would resolve them as
+                                // filesystem paths relative to the current
+                                // directory. `attempt > 1` means an https
+                                // clone of the verbatim URL already failed
+                                // (`try_https` returns http(s) URLs
+                                // unchanged); don't repeat it.
+                                None if attempt == 1
+                                    && bun_core::strings::contains(url, b"://") =>
+                                {
+                                    // Sole attempt for this URL: mark it final
+                                    // so `download` logs a clone failure
+                                    // (attempt 1 stays quiet expecting a
+                                    // fallback retry).
+                                    attempt = 2;
+                                    url
+                                }
+                                None => {
+                                    // No clone candidate: fail the task instead
+                                    // of completing without a repository. A
+                                    // failed https attempt already set its own
+                                    // error; keep it.
+                                    if this.status != Status::Fail {
+                                        this.err =
+                                            Some(crate::Error::RepositoryNotFound);
+                                        this.status = Status::Fail;
+                                        this.data = Data {
+                                            git_clone: ManuallyDrop::new(
+                                                Fd::invalid(),
+                                            ),
+                                        };
+                                    }
+                                    break 'body;
+                                }
                             };
                             match Repository::download(
                                 req.env,

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -448,29 +448,37 @@ impl<'a> Task<'a> {
                     let dir = match dir {
                         Some(d) => d,
                         None => {
-                            if let Some(ssh) = Repository::try_ssh(url) {
-                                match Repository::download(
-                                    req.env,
-                                    &mut this.log,
-                                    // SAFETY: see `manager` decl — short-lived `&mut` at call boundary.
-                                    unsafe { &mut *manager }.get_cache_directory(),
-                                    this.id,
-                                    name,
-                                    ssh,
-                                    attempt,
-                                ) {
-                                    Ok(d) => d,
-                                    Err(err) => {
-                                        this.err = Some(err);
-                                        this.status = Status::Fail;
-                                        this.data = Data {
-                                            git_clone: ManuallyDrop::new(Fd::invalid()),
-                                        };
-                                        break 'body;
-                                    }
+                            // URLs neither `try_https` nor `try_ssh` recognize
+                            // (file://, git://) are ones git clones as written,
+                            // so fall back to the URL itself instead of
+                            // completing without a clone. `attempt > 1` means an
+                            // https clone of the verbatim URL already failed
+                            // (`try_https` returns http(s) URLs unchanged);
+                            // repeating it would be redundant, keep the failure.
+                            let fallback = match Repository::try_ssh(url) {
+                                Some(ssh) => ssh,
+                                None if attempt == 1 => url,
+                                None => break 'body,
+                            };
+                            match Repository::download(
+                                req.env,
+                                &mut this.log,
+                                // SAFETY: see `manager` decl — short-lived `&mut` at call boundary.
+                                unsafe { &mut *manager }.get_cache_directory(),
+                                this.id,
+                                name,
+                                fallback,
+                                attempt,
+                            ) {
+                                Ok(d) => d,
+                                Err(err) => {
+                                    this.err = Some(err);
+                                    this.status = Status::Fail;
+                                    this.data = Data {
+                                        git_clone: ManuallyDrop::new(Fd::invalid()),
+                                    };
+                                    break 'body;
                                 }
-                            } else {
-                                break 'body;
                             }
                         }
                     };

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -845,63 +845,153 @@ describe.concurrent("bun-install", () => {
     expect(exitCode).toBe(1);
   });
 
+  // Shared by the git file:// tests below. Isolates git from the machine's
+  // config (a developer gitconfig can carry url rewrites, signing, autocrlf);
+  // `base` must contain an "empty.gitconfig" file.
+  const gitFixtureEnv = (base: string) => ({
+    ...env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: join(base, "empty.gitconfig"),
+    GIT_AUTHOR_NAME: "bun-test",
+    GIT_AUTHOR_EMAIL: "bun@example.com",
+    GIT_COMMITTER_NAME: "bun-test",
+    GIT_COMMITTER_EMAIL: "bun@example.com",
+  });
+  const runGit = async (cwd: string, gitEnv: NodeJS.Dict<string>, ...args: string[]) => {
+    await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+  };
+
   it.each([
     ["", "2.0.0"],
     ["#v1", "1.0.0"],
   ])("installs a git dependency from a file:// URL (committish %j)", async (committish, expectedVersion) => {
-    using repoDir = tempDir("git-file-repo", {
-      "package.json": JSON.stringify({ name: "git-file-dep", version: "1.0.0" }),
+    using dir = tempDir("git-file-dep-test", {
+      "empty.gitconfig": "",
+      "repo/package.json": JSON.stringify({ name: "git-file-dep", version: "1.0.0" }),
     });
-    const git = async (...args: string[]) => {
-      await using proc = spawn({
-        cmd: ["git", "-c", "user.email=bun@example.com", "-c", "user.name=bun", "-c", "commit.gpgsign=false", ...args],
-        cwd: String(repoDir),
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-      if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
-    };
-    await git("init", "-q");
-    await git("add", "-A");
-    await git("commit", "-q", "-m", "1.0.0");
-    await git("tag", "v1");
-    await write(join(String(repoDir), "package.json"), JSON.stringify({ name: "git-file-dep", version: "2.0.0" }));
-    await git("commit", "-q", "-a", "-m", "2.0.0");
+    const gitEnv = gitFixtureEnv(String(dir));
+    const repoDir = join(String(dir), "repo");
+    const projDir = join(String(dir), "proj");
+    await runGit(repoDir, gitEnv, "init", "-q");
+    await runGit(repoDir, gitEnv, "add", "-A");
+    await runGit(repoDir, gitEnv, "commit", "-q", "-m", "1.0.0");
+    await runGit(repoDir, gitEnv, "tag", "v1");
+    await write(join(repoDir, "package.json"), JSON.stringify({ name: "git-file-dep", version: "2.0.0" }));
+    await runGit(repoDir, gitEnv, "commit", "-q", "-a", "-m", "2.0.0");
 
-    using dir = tempDir("git-file-proj", {
-      "package.json": JSON.stringify({
+    await write(
+      join(projDir, "package.json"),
+      JSON.stringify({
         name: "app",
         version: "1.0.0",
-        dependencies: { "git-file-dep": `git+${pathToFileURL(String(repoDir)).href}${committish}` },
+        dependencies: { "git-file-dep": `git+${pathToFileURL(repoDir).href}${committish}` },
       }),
-    });
+    );
 
-    // First run clones the file:// URL; second run hits the cached bare repo
-    // and fetches from the file:// origin.
-    for (let run = 0; run < 2; run++) {
-      if (run === 1) {
-        await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
-        await rm(join(String(dir), "bun.lock"), { force: true });
+    const lockfilePath = join(projDir, "bun.lock");
+    const installEnv = { ...gitEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") };
+    let savedLockfile = "";
+    // "cold" clones the file:// URL from scratch; "lockfile-cold-cache"
+    // re-clones to install the lockfile-pinned commit; "resolve-warm-cache"
+    // re-resolves against the cached bare repo (the `git fetch` path).
+    for (const mode of ["cold", "lockfile-cold-cache", "resolve-warm-cache"] as const) {
+      if (mode === "lockfile-cold-cache") {
+        savedLockfile = await file(lockfilePath).text();
+        await rm(join(projDir, "node_modules"), { recursive: true, force: true });
+        await rm(join(String(dir), ".cache"), { recursive: true, force: true });
+      } else if (mode === "resolve-warm-cache") {
+        await rm(join(projDir, "node_modules"), { recursive: true, force: true });
+        await rm(lockfilePath, { force: true });
       }
       await using proc = spawn({
         cmd: [bunExe(), "install"],
-        cwd: String(dir),
-        env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+        cwd: projDir,
+        env: installEnv,
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain("Saved lockfile");
       expect(stderr).not.toContain("error:");
+      if (mode === "lockfile-cold-cache") {
+        // An install driven by the lockfile must keep the pinned commit.
+        expect(await file(lockfilePath).text()).toBe(savedLockfile);
+      } else {
+        expect(stderr).toContain("Saved lockfile");
+      }
       expect(stdout).toContain("1 package installed");
       expect(exitCode).toBe(0);
-      expect(await file(join(String(dir), "node_modules", "git-file-dep", "package.json")).json()).toMatchObject({
+      expect(await file(join(projDir, "node_modules", "git-file-dep", "package.json")).json()).toMatchObject({
         name: "git-file-dep",
         version: expectedVersion,
       });
     }
+  });
+
+  it("does not treat a bare git specifier as a project-relative path", async () => {
+    // "sshlatest" is classified as a git dependency. It must fail to
+    // resolve; handing it to git verbatim would clone the ./sshlatest
+    // directory (git resolves bare strings as local paths) and poison the
+    // shared cache with cwd-dependent content.
+    using dir = tempDir("git-bare-word", {
+      "empty.gitconfig": "",
+      "proj/package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "bare-word-dep": "sshlatest" },
+      }),
+      "proj/sshlatest/package.json": JSON.stringify({ name: "bare-word-dep", version: "9.9.9" }),
+    });
+    const gitEnv = gitFixtureEnv(String(dir));
+    const projDir = join(String(dir), "proj");
+    const decoyRepo = join(projDir, "sshlatest");
+    await runGit(decoyRepo, gitEnv, "init", "-q");
+    await runGit(decoyRepo, gitEnv, "add", "-A");
+    await runGit(decoyRepo, gitEnv, "commit", "-q", "-m", "init");
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projDir,
+      env: { ...gitEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("cloning repository for");
+    expect(stderr).not.toContain("no commit matching");
+    expect(await exists(join(projDir, "node_modules", "bare-word-dep"))).toBe(false);
+    expect(stdout).toContain("bun install v1.");
+    expect(exitCode).toBe(1);
+  });
+
+  it("fails cleanly for a git file:// dependency that is not a repository", async () => {
+    using dir = tempDir("git-file-bad", { "empty.gitconfig": "" });
+    const projDir = join(String(dir), "proj");
+    await write(
+      join(projDir, "package.json"),
+      JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "bad-git-dep": `git+${pathToFileURL(join(String(dir), "missing-repo")).href}` },
+      }),
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projDir,
+      env: { ...gitFixtureEnv(String(dir)), BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain('"git clone" for "bad-git-dep" failed');
+    expect(stderr).toContain("cloning repository for");
+    expect(stderr).not.toContain("no commit matching");
+    expect(stdout).toContain("bun install v1.");
+    expect(exitCode).toBe(1);
   });
 
   it("should handle empty string in dependencies", async () => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -17,6 +17,7 @@ import {
   toHaveBins,
 } from "harness";
 import { join, resolve, sep } from "path";
+import { pathToFileURL } from "url";
 import {
   createTestContext,
   destroyTestContext,
@@ -842,6 +843,65 @@ describe.concurrent("bun-install", () => {
     expect(stderr).toContain("long-git-dep");
     expect(stdout).toContain("bun install v1.");
     expect(exitCode).toBe(1);
+  });
+
+  it.each([
+    ["", "2.0.0"],
+    ["#v1", "1.0.0"],
+  ])("installs a git dependency from a file:// URL (committish %j)", async (committish, expectedVersion) => {
+    using repoDir = tempDir("git-file-repo", {
+      "package.json": JSON.stringify({ name: "git-file-dep", version: "1.0.0" }),
+    });
+    const git = async (...args: string[]) => {
+      await using proc = spawn({
+        cmd: ["git", "-c", "user.email=bun@example.com", "-c", "user.name=bun", "-c", "commit.gpgsign=false", ...args],
+        cwd: String(repoDir),
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+    };
+    await git("init", "-q");
+    await git("add", "-A");
+    await git("commit", "-q", "-m", "1.0.0");
+    await git("tag", "v1");
+    await write(join(String(repoDir), "package.json"), JSON.stringify({ name: "git-file-dep", version: "2.0.0" }));
+    await git("commit", "-q", "-a", "-m", "2.0.0");
+
+    using dir = tempDir("git-file-proj", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "git-file-dep": `git+${pathToFileURL(String(repoDir)).href}${committish}` },
+      }),
+    });
+
+    // First run clones the file:// URL; second run hits the cached bare repo
+    // and fetches from the file:// origin.
+    for (let run = 0; run < 2; run++) {
+      if (run === 1) {
+        await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+        await rm(join(String(dir), "bun.lock"), { force: true });
+      }
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Saved lockfile");
+      expect(stderr).not.toContain("error:");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+      expect(await file(join(String(dir), "node_modules", "git-file-dep", "package.json")).json()).toMatchObject({
+        name: "git-file-dep",
+        version: expectedVersion,
+      });
+    }
   });
 
   it("should handle empty string in dependencies", async () => {


### PR DESCRIPTION
### Problem

`bun install` cannot install a dependency written as `git+file:///abs/path/to/repo` (npm installs it fine):

```
mkdir /tmp/gitrepo && cd /tmp/gitrepo && git init -q && printf '{"name":"git-dep","version":"1.0.0"}' > package.json && git add -A && git -c user.email=t@t -c user.name=t commit -qm init
mkdir /tmp/proj && cd /tmp/proj && printf '{"name":"p","dependencies":{"git-dep":"git+file:///tmp/gitrepo"}}' > package.json
bun install
```

```
Resolving dependencies
fatal: cannot change to '/root/.bun/install/cache/84a919e074b3d875.git': No such file or directory
error: git failed with exit code 128
error: no commit matching "" found for "git-dep" (but repository exists)
```

### Cause

The dependency parser explicitly classifies `git+file:` (and `git://`) specifiers as git dependencies, but the `GitClone` task only attempted a clone when `Repository::try_https` or `Repository::try_ssh` produced a candidate URL. Neither recognizes `file://` or `git://` remotes, so the task hit the no-candidate `else` branch, which exited without cloning and without setting a failure status. Resolution then proceeded to `find_commit`, which ran `git log` against a cache directory that was never created, producing the errors above.

### Fix

When neither rewrite recognizes the URL and the specifier is URL-shaped (contains `://`), clone it as written: git handles `file://` and `git://` natively. The attempt is marked final so a failure logs the usual `"git clone" for "<name>" failed` entry.

The URL-shape check matters: some bare strings also parse as git dependencies (for example `"dep": "sshlatest"`, which npm would treat as a dist-tag), and git resolves a bare string as a filesystem path relative to the current directory. Cloning those verbatim would silently install a same-named directory from the project root and store it in the shared cache under a key derived only from the string, poisoning later installs in other projects. Bare specifiers therefore fail the task with `RepositoryNotFound` instead of completing without a repository, which also removes the old silent fall-through for every shape.

A clone failure on any of these paths now surfaces git's stderr and fails resolution cleanly instead of producing the misleading "no commit matching" error. The one case that exits without a new attempt is an http(s) URL whose clone already failed, since `try_https` passes http(s) URLs through unchanged and retrying the identical URL would be redundant (failure status is already set on that path).

### Verification

New tests in `test/cli/install/bun-install.test.ts`, all failing on the released build and passing with this change:

- installs from a `git+file://` URL, with and without a `#committish`, each across three installs: cold clone, lockfile-driven reinstall with a cold cache (pinned commit, lockfile byte-identical afterwards), and re-resolve against the cached bare repo (the `git fetch` path)
- a `git+file://` URL pointing at a nonexistent path fails with `"git clone" for "<name>" failed` instead of "no commit matching"
- a bare specifier (`"sshlatest"`) with a same-named git repository in the project directory fails to resolve and does not install the directory

The git fixtures run with `GIT_CONFIG_NOSYSTEM`/`GIT_CONFIG_GLOBAL` isolation so machine gitconfig cannot affect them. Also verified manually: `bun add git+file:///path` resolves and pins a commit. The full `bun-install.test.ts` suite shows no new failures (remaining failures are pre-existing network-dependent bitbucket/gitlab tests that fail identically without this change).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->