### PR TITLE
install: don't copy the project's node_modules into a file: dependency on an ancestor directory

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -108,6 +108,25 @@ impl Method {
 
 type BackendSupport = enum_map::EnumMap<Method, bool>;
 
+// `bun.OSPathLiteral("node_modules")` — u8 on posix / u16 on windows.
+#[cfg(windows)]
+const NODE_MODULES_LIT: &OSPathSlice = &[
+    b'n' as u16,
+    b'o' as u16,
+    b'd' as u16,
+    b'e' as u16,
+    b'_' as u16,
+    b'm' as u16,
+    b'o' as u16,
+    b'd' as u16,
+    b'u' as u16,
+    b'l' as u16,
+    b'e' as u16,
+    b's' as u16,
+];
+#[cfg(not(windows))]
+const NODE_MODULES_LIT: &OSPathSlice = b"node_modules";
+
 bun_core::comptime_string_map! {
     pub(crate) static METHOD_MAP: Method = {
         b"clonefile" => Method::Clonefile,
@@ -1025,6 +1044,36 @@ impl<'a> PackageInstall<'a> {
             == self.package_name.slice(&self.lockfile.buffers.string_bytes)
     }
 
+    /// Whether the install source is a `file:` folder containing the destination
+    /// `node_modules` directory (e.g. `"pkg": "file:../"` installed into
+    /// `<cwd>/node_modules/pkg`). Copying such a folder must not descend into
+    /// `node_modules` directories: the walk would race the asynchronous deletion
+    /// of the renamed previous install (`uninstall_before_install`) and re-copy
+    /// already-installed packages into the destination itself.
+    fn source_folder_contains_destination(&self) -> bool {
+        if self.cache_dir != Fd::cwd() {
+            // Only `file:` folder sources are resolved relative to the cwd; other
+            // resolutions copy from a cache directory outside the project.
+            return false;
+        }
+        let top_level_dir = bun_fs::FileSystem::instance().top_level_dir();
+        let mut source_buf = bun_paths::path_buffer_pool::get();
+        let source = path::resolve_path::join_abs_string_buf::<path::platform::Auto>(
+            top_level_dir,
+            source_buf.as_mut_slice(),
+            &[self.cache_dir_subpath.as_bytes()],
+        );
+        let node_modules_dir = path::resolve_path::join_abs_string::<path::platform::Auto>(
+            top_level_dir,
+            &[self.node_modules.path.as_slice()],
+        );
+        node_modules_dir.len() >= source.len()
+            && node_modules_dir[..source.len()] == *source
+            && (node_modules_dir.len() == source.len()
+                || source[source.len() - 1] == SEP
+                || node_modules_dir[source.len()] == SEP)
+    }
+
     // ───────────────────────────── install backends ─────────────────────────────
 
     #[cfg(target_os = "macos")]
@@ -1036,10 +1085,15 @@ impl<'a> PackageInstall<'a> {
             Ok(d) => d,
             Err(err) => return Ok(InstallResult::fail(err, Step::OpeningCacheDir, None)),
         };
+        let skip_dirs: &[&OSPathSlice] = if self.source_folder_contains_destination() {
+            &[NODE_MODULES_LIT]
+        } else {
+            &[]
+        };
         let mut walker_ = match walker_skippable::walk(
             cached_package_dir.fd(),
             &[] as &[&OSPathSlice],
-            &[] as &[&OSPathSlice],
+            skip_dirs,
         ) {
             Ok(w) => w,
             Err(err) => return Ok(InstallResult::fail(err.into(), Step::OpeningCacheDir, None)),
@@ -1114,6 +1168,12 @@ impl<'a> PackageInstall<'a> {
     // https://www.unix.com/man-page/mojave/2/fclonefileat/
     #[cfg(target_os = "macos")]
     fn install_with_clonefile(&mut self, destination_dir: &Dir) -> crate::Result<InstallResult> {
+        if self.source_folder_contains_destination() {
+            // A whole-directory clone would snapshot the destination tree into
+            // itself; the per-directory walk skips `node_modules` instead.
+            return self.install_with_clonefile_each_dir(destination_dir);
+        }
+
         if self.destination_dir_subpath.as_bytes()[0] == b'@' {
             if let Some(slash) = strings::index_of_char_z(self.destination_dir_subpath, SEP) {
                 let slash = slash as usize;
@@ -1179,27 +1239,10 @@ impl<'a> PackageInstall<'a> {
             Err(err) => return InstallResult::fail(err, Step::OpeningCacheDir, None),
         };
 
-        // `bun.OSPathLiteral("node_modules")` — u8 on posix / u16 on windows.
-        #[cfg(windows)]
-        const NODE_MODULES_LIT: &OSPathSlice = &[
-            b'n' as u16,
-            b'o' as u16,
-            b'd' as u16,
-            b'e' as u16,
-            b'_' as u16,
-            b'm' as u16,
-            b'o' as u16,
-            b'd' as u16,
-            b'u' as u16,
-            b'l' as u16,
-            b'e' as u16,
-            b's' as u16,
-        ];
-        #[cfg(not(windows))]
-        const NODE_MODULES_LIT: &OSPathSlice = b"node_modules";
-        let skip_dirs: &[&OSPathSlice] = if method == Method::Symlink
+        let skip_dirs: &[&OSPathSlice] = if (method == Method::Symlink
             && self.cache_dir_subpath.len() == 1
-            && self.cache_dir_subpath.as_bytes()[0] == b'.'
+            && self.cache_dir_subpath.as_bytes()[0] == b'.')
+            || self.source_folder_contains_destination()
         {
             &[NODE_MODULES_LIT]
         } else {

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1159,6 +1159,10 @@ impl<'a> PackageInstall<'a> {
         };
         self.file_count = match copy(&subdir, &mut walker_) {
             Ok(n) => n,
+            // `install()` only falls back to copyfile on `Err(NotSupported)`;
+            // wrapping it in an `InstallResult` would report the install failed
+            // on filesystems without clonefile support.
+            Err(crate::Error::NotSupported) => return Err(crate::Error::NotSupported),
             Err(err) => return Ok(InstallResult::fail(err, Step::CopyingFiles, None)),
         };
 

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1064,11 +1064,8 @@ impl<'a> PackageInstall<'a> {
             top_level_dir,
             &[self.node_modules.path.as_slice()],
         );
-        node_modules_dir.len() >= source.len()
-            && node_modules_dir[..source.len()] == *source
-            && (node_modules_dir.len() == source.len()
-                || source[source.len() - 1] == SEP
-                || node_modules_dir[source.len()] == SEP)
+        path::resolve_path::is_parent_or_equal(source, node_modules_dir)
+            != path::resolve_path::ParentEqual::Unrelated
     }
 
     // ───────────────────────────── install backends ─────────────────────────────

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -108,25 +108,6 @@ impl Method {
 
 type BackendSupport = enum_map::EnumMap<Method, bool>;
 
-// `bun.OSPathLiteral("node_modules")` — u8 on posix / u16 on windows.
-#[cfg(windows)]
-const NODE_MODULES_LIT: &OSPathSlice = &[
-    b'n' as u16,
-    b'o' as u16,
-    b'd' as u16,
-    b'e' as u16,
-    b'_' as u16,
-    b'm' as u16,
-    b'o' as u16,
-    b'd' as u16,
-    b'u' as u16,
-    b'l' as u16,
-    b'e' as u16,
-    b's' as u16,
-];
-#[cfg(not(windows))]
-const NODE_MODULES_LIT: &OSPathSlice = b"node_modules";
-
 bun_core::comptime_string_map! {
     pub(crate) static METHOD_MAP: Method = {
         b"clonefile" => Method::Clonefile,
@@ -1048,22 +1029,24 @@ impl<'a> PackageInstall<'a> {
     /// `node_modules` (e.g. `"pkg": "file:../"`). Walking such a source must
     /// skip `node_modules`: it would mirror installed packages into the
     /// destination and race the async deletion of the renamed previous install.
-    fn source_folder_contains_destination(&self) -> bool {
+    fn source_folder_contains_destination(&self, destination_dir: &Dir) -> bool {
         // Only `file:` folder sources resolve relative to the cwd.
         if self.cache_dir != Fd::cwd() {
             return false;
         }
-        let top_level_dir = bun_fs::FileSystem::instance().top_level_dir();
+        // Compare fd-derived paths: the destination can sit behind a workspace
+        // symlink (node_modules/a -> packages/a), which lexical paths miss.
+        let Ok(source_dir) = open_dir(self.cache_dir, self.cache_dir_subpath) else {
+            return false;
+        };
         let mut source_buf = bun_paths::path_buffer_pool::get();
-        let source = path::resolve_path::join_abs_string_buf::<path::platform::Auto>(
-            top_level_dir,
-            source_buf.as_mut_slice(),
-            &[self.cache_dir_subpath.as_bytes()],
-        );
-        let node_modules_dir = path::resolve_path::join_abs_string::<path::platform::Auto>(
-            top_level_dir,
-            &[self.node_modules.path.as_slice()],
-        );
+        let mut dest_buf = bun_paths::path_buffer_pool::get();
+        let (Ok(source), Ok(node_modules_dir)) = (
+            source_dir.get_fd_path(&mut source_buf),
+            destination_dir.get_fd_path(&mut dest_buf),
+        ) else {
+            return false;
+        };
         path::resolve_path::is_parent_or_equal(source, node_modules_dir)
             != path::resolve_path::ParentEqual::Unrelated
     }
@@ -1079,8 +1062,9 @@ impl<'a> PackageInstall<'a> {
             Ok(d) => d,
             Err(err) => return Ok(InstallResult::fail(err, Step::OpeningCacheDir, None)),
         };
-        let skip_dirs: &[&OSPathSlice] = if self.source_folder_contains_destination() {
-            &[NODE_MODULES_LIT]
+        let skip_dirs: &[&OSPathSlice] = if self.source_folder_contains_destination(destination_dir)
+        {
+            &[bun_paths::os_path_literal!("node_modules")]
         } else {
             &[]
         };
@@ -1164,7 +1148,7 @@ impl<'a> PackageInstall<'a> {
     // https://www.unix.com/man-page/mojave/2/fclonefileat/
     #[cfg(target_os = "macos")]
     fn install_with_clonefile(&mut self, destination_dir: &Dir) -> crate::Result<InstallResult> {
-        if self.source_folder_contains_destination() {
+        if self.source_folder_contains_destination(destination_dir) {
             // A whole-directory clone cannot skip `node_modules`; the
             // per-directory walk can.
             return self.install_with_clonefile_each_dir(destination_dir);
@@ -1238,9 +1222,9 @@ impl<'a> PackageInstall<'a> {
         let skip_dirs: &[&OSPathSlice] = if (method == Method::Symlink
             && self.cache_dir_subpath.len() == 1
             && self.cache_dir_subpath.as_bytes()[0] == b'.')
-            || self.source_folder_contains_destination()
+            || self.source_folder_contains_destination(destination_dir)
         {
-            &[NODE_MODULES_LIT]
+            &[bun_paths::os_path_literal!("node_modules")]
         } else {
             &[]
         };

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1044,16 +1044,13 @@ impl<'a> PackageInstall<'a> {
             == self.package_name.slice(&self.lockfile.buffers.string_bytes)
     }
 
-    /// Whether the install source is a `file:` folder containing the destination
-    /// `node_modules` directory (e.g. `"pkg": "file:../"` installed into
-    /// `<cwd>/node_modules/pkg`). Copying such a folder must not descend into
-    /// `node_modules` directories: the walk would race the asynchronous deletion
-    /// of the renamed previous install (`uninstall_before_install`) and re-copy
-    /// already-installed packages into the destination itself.
+    /// Whether the source is a `file:` folder that contains the destination
+    /// `node_modules` (e.g. `"pkg": "file:../"`). Walking such a source must
+    /// skip `node_modules`: it would mirror installed packages into the
+    /// destination and race the async deletion of the renamed previous install.
     fn source_folder_contains_destination(&self) -> bool {
+        // Only `file:` folder sources resolve relative to the cwd.
         if self.cache_dir != Fd::cwd() {
-            // Only `file:` folder sources are resolved relative to the cwd; other
-            // resolutions copy from a cache directory outside the project.
             return false;
         }
         let top_level_dir = bun_fs::FileSystem::instance().top_level_dir();
@@ -1159,9 +1156,7 @@ impl<'a> PackageInstall<'a> {
         };
         self.file_count = match copy(&subdir, &mut walker_) {
             Ok(n) => n,
-            // `install()` only falls back to copyfile on `Err(NotSupported)`;
-            // wrapping it in an `InstallResult` would report the install failed
-            // on filesystems without clonefile support.
+            // `install()` falls back to copyfile only on `Err(NotSupported)`.
             Err(crate::Error::NotSupported) => return Err(crate::Error::NotSupported),
             Err(err) => return Ok(InstallResult::fail(err, Step::CopyingFiles, None)),
         };
@@ -1173,8 +1168,8 @@ impl<'a> PackageInstall<'a> {
     #[cfg(target_os = "macos")]
     fn install_with_clonefile(&mut self, destination_dir: &Dir) -> crate::Result<InstallResult> {
         if self.source_folder_contains_destination() {
-            // A whole-directory clone would snapshot the destination tree into
-            // itself; the per-directory walk skips `node_modules` instead.
+            // A whole-directory clone cannot skip `node_modules`; the
+            // per-directory walk can.
             return self.install_with_clonefile_each_dir(destination_dir);
         }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9489,6 +9489,59 @@ it("does not install transitive file: dependencies with overlong folder targets"
   expect(exitCode).toBe(1);
 });
 
+it("reinstalls a file: dependency pointing at an ancestor directory", async () => {
+  // "sample" depends on its own parent package via `file:../`, so the copy
+  // source contains the destination node_modules. The walk must skip
+  // node_modules directories: descending into them copied every installed
+  // package into node_modules/poto itself, and on reinstall raced the
+  // asynchronous deletion of the renamed previous install (ENOENT).
+  using dir = tempDir("file-dep-ancestor", {
+    "package.json": JSON.stringify({ name: "poto", version: "1.0.0" }),
+    "index.js": "module.exports = 'poto';",
+    "sample/package.json": JSON.stringify({
+      name: "sample",
+      version: "1.0.0",
+      dependencies: { poto: "file:../" },
+    }),
+  });
+  const projectDir = join(String(dir), "sample");
+
+  for (let i = 0; i < 3; i++) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("ENOENT");
+    expect(err).not.toContain("Failed to install");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    // The copy contains the package's files but never a snapshot of the
+    // project's own node_modules.
+    expect(await exists(join(projectDir, "node_modules", "poto", "package.json"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "index.js"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "sample", "node_modules"))).toBe(false);
+  }
+
+  // The installed copy resolves at runtime.
+  await using runProc = spawn({
+    cmd: [bunExe(), "-e", "console.log(require('poto'))"],
+    cwd: projectDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, runExit] = await Promise.all([runProc.stdout.text(), runProc.exited]);
+  expect(runOut).toBe("poto\n");
+  expect(runExit).toBe(0);
+});
+
 for (const field of ["resolutions", "overrides"]) {
   it(`installs a file: dependency pointing outside the project when it came from root package.json "${field}"`, async () => {
     // `overrides` / `resolutions` can only be declared in the root package.json,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9711,11 +9711,7 @@ it("preserves a vendored node_modules inside a file: folder dependency", async (
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [runOut, runErr, runExit] = await Promise.all([
-    runProc.stdout.text(),
-    runProc.stderr.text(),
-    runProc.exited,
-  ]);
+  const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
   expect(runErr).toBe("");
   expect(runOut).toBe("vendored\n");
   expect(runExit).toBe(0);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9537,11 +9537,7 @@ it("reinstalls a file: dependency pointing at an ancestor directory", async () =
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [runOut, runErr, runExit] = await Promise.all([
-    runProc.stdout.text(),
-    runProc.stderr.text(),
-    runProc.exited,
-  ]);
+  const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
   expect(runErr).toBe("");
   expect(runOut).toBe("poto\n");
   expect(runExit).toBe(0);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9600,6 +9600,127 @@ it("reinstalls a file: dependency on an ancestor directory resolved to an absolu
   }
 });
 
+for (const backend of [null, "hardlink", "copyfile"]) {
+  it(`installs a workspace member's file: dependency on an ancestor behind the workspace symlink${backend ? ` (--backend ${backend})` : ""}`, async () => {
+    // packages/ is itself a package ("x") and member packages/a depends on it
+    // via `file:../`, while the root depends on a different "x", so the
+    // member's copy cannot hoist and installs at node_modules/a/node_modules/x.
+    // node_modules/a is a symlink to packages/a, so the destination physically
+    // lives inside the copy source; containment must be detected through the
+    // symlink or the install self-copies and fails.
+    using dir = tempDir("file-dep-ws-ancestor", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+        dependencies: { x: "file:./other-x" },
+      }),
+      "other-x/package.json": JSON.stringify({ name: "x", version: "2.0.0" }),
+      "other-x/index.js": "module.exports = 'other-x';",
+      "packages/package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      "packages/index.js": "module.exports = 'packages-x';",
+      "packages/a/package.json": JSON.stringify({
+        name: "a",
+        version: "1.0.0",
+        dependencies: { x: "file:../" },
+      }),
+    });
+
+    for (let i = 0; i < 2; i++) {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--linker", "hoisted", ...(backend ? ["--backend", backend] : [])],
+        cwd: String(dir),
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+      expect(err).not.toContain("ENOENT");
+      expect(err).not.toContain("Failed to install");
+      expect(out).toContain("installed");
+      expect(exitCode).toBe(0);
+
+      const nested = join(String(dir), "node_modules", "a", "node_modules", "x");
+      expect(await Bun.file(join(nested, "package.json")).json()).toMatchObject({ name: "x", version: "1.0.0" });
+      // Never a self-copy of the member's own node_modules.
+      expect(await exists(join(nested, "a", "node_modules"))).toBe(false);
+    }
+  });
+}
+
+it("preserves a vendored node_modules inside a file: folder dependency", async () => {
+  // The node_modules skip only engages when the source contains the
+  // destination: an ordinary folder dependency that ships its own
+  // node_modules keeps it, through the copy walk (absolute lockfile path).
+  using dir = tempDir("file-dep-vendored", {
+    "sibling/package.json": JSON.stringify({ name: "sibling", version: "1.0.0" }),
+    "sibling/index.js": "module.exports = require('vendored-pkg');",
+    "sibling/node_modules/vendored-pkg/package.json": JSON.stringify({
+      name: "vendored-pkg",
+      version: "1.0.0",
+    }),
+    "sibling/node_modules/vendored-pkg/index.js": "module.exports = 'vendored';",
+    "app/package.json": "",
+  });
+  const sibAbs = String(dir).replaceAll("\\", "/") + "/sibling";
+  const projectDir = join(String(dir), "app");
+  await write(
+    join(projectDir, "package.json"),
+    JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { sibling: "file:" + sibAbs },
+    }),
+  );
+  await write(
+    join(projectDir, "bun.lock"),
+    JSON.stringify({
+      lockfileVersion: 2,
+      configVersion: 1,
+      workspaces: { "": { name: "app", dependencies: { sibling: "file:" + sibAbs } } },
+      packages: { sibling: ["sibling@file:" + sibAbs, {}] },
+    }),
+  );
+
+  for (let i = 0; i < 2; i++) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("Failed to install");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    expect(
+      await exists(join(projectDir, "node_modules", "sibling", "node_modules", "vendored-pkg", "package.json")),
+    ).toBe(true);
+  }
+
+  await using runProc = spawn({
+    cmd: [bunExe(), "-e", "console.log(require('sibling'))"],
+    cwd: projectDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, runErr, runExit] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.stderr.text(),
+    runProc.exited,
+  ]);
+  expect(runErr).toBe("");
+  expect(runOut).toBe("vendored\n");
+  expect(runExit).toBe(0);
+});
+
 for (const field of ["resolutions", "overrides"]) {
   it(`installs a file: dependency pointing outside the project when it came from root package.json "${field}"`, async () => {
     // `overrides` / `resolutions` can only be declared in the root package.json,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6,6 +6,7 @@ import {
   bunEnv,
   bunExe,
   bunEnv as env,
+  isMacOS,
   isWindows,
   joinP,
   readdirSorted,
@@ -9554,7 +9555,10 @@ it("reinstalls a file: dependency on an ancestor directory resolved to an absolu
     "index.js": "module.exports = 'poto';",
     "sample/package.json": "",
   });
-  const root = String(dir).replaceAll("\\", "/");
+  // On case-insensitive filesystems, containment must be detected even when
+  // the lockfile spells the ancestor path with different casing.
+  const realRoot = String(dir).replaceAll("\\", "/");
+  const root = isWindows || isMacOS ? realRoot.toUpperCase() : realRoot;
   const projectDir = join(String(dir), "sample");
   await write(
     join(projectDir, "package.json"),

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6,7 +6,6 @@ import {
   bunEnv,
   bunExe,
   bunEnv as env,
-  isMacOS,
   isWindows,
   joinP,
   readdirSorted,
@@ -9556,9 +9555,13 @@ it("reinstalls a file: dependency on an ancestor directory resolved to an absolu
     "sample/package.json": "",
   });
   // On case-insensitive filesystems, containment must be detected even when
-  // the lockfile spells the ancestor path with different casing.
+  // the lockfile spells the ancestor path with different casing. Flip only the
+  // ASCII basename and keep the real spelling where the flipped path does not
+  // resolve (case-sensitive filesystems).
   const realRoot = String(dir).replaceAll("\\", "/");
-  const root = isWindows || isMacOS ? realRoot.toUpperCase() : realRoot;
+  const basenameStart = realRoot.lastIndexOf("/") + 1;
+  const flipped = realRoot.slice(0, basenameStart) + realRoot.slice(basenameStart).toUpperCase();
+  const root = (await exists(flipped)) ? flipped : realRoot;
   const projectDir = join(String(dir), "sample");
   await write(
     join(projectDir, "package.json"),

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9537,9 +9537,67 @@ it("reinstalls a file: dependency pointing at an ancestor directory", async () =
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [runOut, runExit] = await Promise.all([runProc.stdout.text(), runProc.exited]);
+  const [runOut, runErr, runExit] = await Promise.all([
+    runProc.stdout.text(),
+    runProc.stderr.text(),
+    runProc.exited,
+  ]);
+  expect(runErr).toBe("");
   expect(runOut).toBe("poto\n");
   expect(runExit).toBe(0);
+});
+
+it("reinstalls a file: dependency on an ancestor directory resolved to an absolute path", async () => {
+  // Folder paths parsed from package.json are normalized relative to the
+  // project (`file:../` becomes `..`, installed as symlinks), but resolutions
+  // parsed from a lockfile are verbatim: an absolute path routes the install
+  // through the hardlink/copyfile walk instead. That walk must also skip the
+  // project's node_modules when the source contains the destination.
+  using dir = tempDir("file-dep-ancestor-abs", {
+    "package.json": JSON.stringify({ name: "poto", version: "1.0.0" }),
+    "index.js": "module.exports = 'poto';",
+    "sample/package.json": "",
+  });
+  const root = String(dir).replaceAll("\\", "/");
+  const projectDir = join(String(dir), "sample");
+  await write(
+    join(projectDir, "package.json"),
+    JSON.stringify({
+      name: "sample",
+      version: "1.0.0",
+      dependencies: { poto: "file:" + root },
+    }),
+  );
+  await write(
+    join(projectDir, "bun.lock"),
+    JSON.stringify({
+      lockfileVersion: 2,
+      configVersion: 1,
+      workspaces: { "": { name: "sample", dependencies: { poto: "file:" + root } } },
+      packages: { poto: ["poto@file:" + root, {}] },
+    }),
+  );
+
+  for (let i = 0; i < 3; i++) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("ENOENT");
+    expect(err).not.toContain("Failed to install");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+
+    expect(await exists(join(projectDir, "node_modules", "poto", "package.json"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "index.js"))).toBe(true);
+    expect(await exists(join(projectDir, "node_modules", "poto", "sample", "node_modules"))).toBe(false);
+  }
 });
 
 for (const field of ["resolutions", "overrides"]) {


### PR DESCRIPTION
## Repro

```console
$ mkdir -p poto/sample && cd poto
$ echo '{"name":"poto","version":"1.0.0"}' > package.json
$ cd sample
$ echo '{"name":"sample","version":"1.0.0","dependencies":{"poto":"file:../"}}' > package.json
$ bun install
1 package installed
$ bun install
ENOENT: failed copying files from cache to destination for package poto
Failed to install 1 package
```

The reinstall usually fails with the ENOENT above (it loses a race against a background deletion, see below), and every install mirrors the project's own `node_modules` into `node_modules/poto`: the first install of this repro writes about 500 entries instead of 3, nesting `node_modules/poto/sample/node_modules/...` one level deeper per run. This is what remains of #23453: the unbounded growth is gone, but the self-copy is not.

The same failure reaches the non-symlink copy backends through other spellings of the layout: a lockfile that stores the folder resolution as an absolute path (yarn/pnpm migration, hand-committed lockfile), and a workspace member depending on an ancestor directory (`packages/a` with `"x": "file:../"` where `packages/` is itself a package), which self-copies through the member symlink and reports `Failed to install` even on the first install.

## Cause

A `file:` folder dependency installs by walking the source folder and mirroring it into `node_modules/<name>` (per-file symlinks for `..`-style paths, hardlinks/clones/copies for other folder paths). When the source folder contains the destination:

1. The walk descends into the destination's `node_modules` and mirrors previously installed packages, including the previous copy of the package itself, into the new destination.
2. On reinstall, `uninstall_before_install` renames the old destination to `node_modules/.old-<rand>` and deletes it on a worker thread. The walk descends into `.old-<rand>` while it is being deleted; a directory that vanishes between `readdir` and `openat` (or a file unlinked before `linkat`) surfaces ENOENT and the install is reported failed (exit code 1).

## Fix

`PackageInstall` already skips directories named `node_modules` when walking the source of a transitive `file:.` self-dependency, and the isolated linker skips them unconditionally for folder sources (`Installer.rs`). This extends the same treatment to the hoisted installer: when the source folder contains the destination's `node_modules` directory, the walker skips `node_modules` directories in the hardlink, copyfile, and symlink paths.

Containment is decided from fd-derived on-disk paths (`get_fd_path` on the opened source dir and the destination `node_modules` dir), not lexical paths: the destination can sit behind a workspace symlink (`node_modules/a -> packages/a`), where the lexical tree path `node_modules/a/node_modules` never matches the source prefix, and fd paths also make the comparison immune to path-casing differences on case-insensitive filesystems. Only `file:` folder sources resolve relative to the cwd, so cache-based installs are unaffected.

On macOS, a whole-directory `clonefileat` of a self-containing source would snapshot the destination into itself, so it is routed to the per-directory clone path, which applies the same skip; that path now also propagates `NotSupported` as an error so `install()` still falls back to copyfile on filesystems without clonefile support (previously the error was wrapped into a failed install result, which also left the fallback dead for the explicit `clonefile_each_dir` backend and the EEXIST path).

Folder sources that do not contain the destination are unaffected: a vendored `node_modules` inside an ordinary `file:` folder dependency is still mirrored.

## Verification

New tests in `test/cli/install/bun-install.test.ts`:

- `reinstalls a file: dependency pointing at an ancestor directory`: the package.json spelling (`file:../`), which installs through the symlink walk. Three consecutive installs must succeed, the installed tree must never contain a snapshot of the project's `node_modules`, and the installed package must resolve at runtime.
- `reinstalls a file: dependency on an ancestor directory resolved to an absolute path`: the same layout driven by a lockfile that stores the folder resolution as an absolute path, which installs through the hardlink walk on Linux/Windows and clonefile on macOS. The path is spelled in a different case on Windows/macOS to cover case-insensitive filesystems.
- `installs a workspace member's file: dependency on an ancestor behind the workspace symlink` (default, `--backend hardlink`, `--backend copyfile`): the workspace scenario above, where containment is only visible through the member symlink.
- `preserves a vendored node_modules inside a file: folder dependency`: pins the non-self-referential behavior so the skip can never silently engage for ordinary folder deps.

The three ancestor tests fail on main (self-copied `node_modules` present, reinstalls usually ENOENT, the workspace variant fails on the first install); with the fix, repeated installs converge on a stable tree. All were also verified on Windows (fail on the baked canary, pass with the fix built from this branch).

`test/cli/install/bun-install.test.ts`, `bun-add.test.ts`, `bun-patch.test.ts`, `bun-install-patch.test.ts`, and `isolated-install.test.ts` pass with the fix (except pre-existing failures in tests that need public network access). `cargo check` passes for all platform targets; the clonefile paths are macOS-only.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->