### PR TITLE
sql(mysql): negotiate MariaDB extended type info so JSON columns parse into objects

### DIFF
--- a/src/sql/mysql/Capabilities.rs
+++ b/src/sql/mysql/Capabilities.rs
@@ -7,25 +7,32 @@
 use core::fmt;
 
 macro_rules! capabilities {
-    ($($name:ident = $bit:literal),* $(,)?) => {
+    ($struct_name:ident { $($name:ident = $bit:literal),* $(,)? }) => {
         #[derive(Default, Clone, Copy, PartialEq, Eq)]
-        pub struct Capabilities {
+        pub struct $struct_name {
             $(pub $name: bool,)*
         }
 
-        impl Capabilities {
+        impl $struct_name {
             pub fn to_int(self) -> u32 {
                 0 $(| ((self.$name as u32) << $bit))*
             }
 
-            pub fn from_int(flags: u32) -> Capabilities {
-                Capabilities {
+            pub fn from_int(flags: u32) -> $struct_name {
+                $struct_name {
                     $($name: (flags & (1u32 << $bit)) != 0,)*
                 }
             }
+
+            /// Returns the intersection of two capability sets (AND).
+            /// Per MySQL protocol, the client should only request capabilities
+            /// that the server also advertises.
+            pub fn intersect(self, other: $struct_name) -> $struct_name {
+                Self::from_int(self.to_int() & other.to_int())
+            }
         }
 
-        impl fmt::Display for Capabilities {
+        impl fmt::Display for $struct_name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 let mut first = true;
                 $(
@@ -45,7 +52,7 @@ macro_rules! capabilities {
 }
 
 // Bit positions from the MySQL protocol.
-capabilities! {
+capabilities! { Capabilities {
     CLIENT_LONG_PASSWORD                   = 0,
     CLIENT_FOUND_ROWS                      = 1,
     CLIENT_LONG_FLAG                       = 2,
@@ -78,6 +85,32 @@ capabilities! {
     CLIENT_CAPABILITY_EXTENSION            = 29,
     CLIENT_SSL_VERIFY_SERVER_CERT          = 30,
     CLIENT_REMEMBER_OPTIONS                = 31,
+} }
+
+// MariaDB extended capability flags (MariaDB 10.2+). Conceptually bits 32..63
+// of the combined capability value; the handshake carries them in a separate
+// 4-byte field (the tail of the reserved/filler bytes), so bit positions here
+// are relative to that field.
+capabilities! { MariaDBCapabilities {
+    MARIADB_CLIENT_PROGRESS                = 0,
+    MARIADB_CLIENT_COM_MULTI               = 1,
+    MARIADB_CLIENT_STMT_BULK_OPERATIONS    = 2,
+    MARIADB_CLIENT_EXTENDED_TYPE_INFO      = 3,
+    MARIADB_CLIENT_CACHE_METADATA          = 4,
+    MARIADB_CLIENT_BULK_UNIT_RESULTS       = 5,
+} }
+
+impl MariaDBCapabilities {
+    pub fn get_default_capabilities() -> MariaDBCapabilities {
+        MariaDBCapabilities {
+            // Without this, MariaDB has no way to distinguish a JSON column
+            // from the LONGTEXT it is stored as: it reports both as
+            // MYSQL_TYPE_BLOB with a text charset. The extended column
+            // metadata this negotiates carries the "format=json" marker.
+            MARIADB_CLIENT_EXTENDED_TYPE_INFO: true,
+            ..Default::default()
+        }
+    }
 }
 
 impl Capabilities {
@@ -95,13 +128,6 @@ impl Capabilities {
         self.CLIENT_LOCAL_FILES = false;
         self.CLIENT_OPTIONAL_RESULTSET_METADATA = false;
         self.CLIENT_QUERY_ATTRIBUTES = false;
-    }
-
-    /// Returns the intersection of two capability sets (AND).
-    /// Per MySQL protocol, the client should only request capabilities
-    /// that the server also advertises.
-    pub fn intersect(self, other: Capabilities) -> Capabilities {
-        Self::from_int(self.to_int() & other.to_int())
     }
 
     pub fn get_default_capabilities(ssl: bool, has_db_name: bool) -> Capabilities {

--- a/src/sql/mysql/Capabilities.rs
+++ b/src/sql/mysql/Capabilities.rs
@@ -87,10 +87,9 @@ capabilities! { Capabilities {
     CLIENT_REMEMBER_OPTIONS                = 31,
 } }
 
-// MariaDB extended capability flags (MariaDB 10.2+). Conceptually bits 32..63
-// of the combined capability value; the handshake carries them in a separate
-// 4-byte field (the tail of the reserved/filler bytes), so bit positions here
-// are relative to that field.
+// MariaDB extended capability flags (MariaDB 10.2+): bits 32..63 of the
+// combined capability value, carried as their own 4-byte handshake field, so
+// bit positions here are relative to that field.
 capabilities! { MariaDBCapabilities {
     MARIADB_CLIENT_PROGRESS                = 0,
     MARIADB_CLIENT_COM_MULTI               = 1,
@@ -103,10 +102,8 @@ capabilities! { MariaDBCapabilities {
 impl MariaDBCapabilities {
     pub fn get_default_capabilities() -> MariaDBCapabilities {
         MariaDBCapabilities {
-            // Without this, MariaDB has no way to distinguish a JSON column
-            // from the LONGTEXT it is stored as: it reports both as
-            // MYSQL_TYPE_BLOB with a text charset. The extended column
-            // metadata this negotiates carries the "format=json" marker.
+            // MariaDB serves JSON columns as plain LONGTEXT/BLOB; the extended
+            // column metadata this negotiates carries their format=json marker.
             MARIADB_CLIENT_EXTENDED_TYPE_INFO: true,
             ..Default::default()
         }

--- a/src/sql/mysql/protocol/ColumnDefinition41.rs
+++ b/src/sql/mysql/protocol/ColumnDefinition41.rs
@@ -75,11 +75,9 @@ impl ColumnFlags {
 /// ("uuid", "inet4", ...), 1 carries a storage format name ("json").
 const EXTENDED_METADATA_FORMAT: u8 = 1;
 
-/// Walks a MariaDB extended-metadata blob, a sequence of (int<1> kind,
-/// string<lenenc> value) pairs, and reports whether it marks the column as
-/// format=json.
-/// Unrecognized kinds and values are skipped; MariaDB stores those columns
-/// as plain strings, which is how the rest of the decoder already treats them.
+/// Walks a MariaDB extended-metadata blob ((int<1> kind, string<lenenc> value)
+/// pairs) and reports whether it marks the column as format=json. Other kinds
+/// and values ("uuid", "inet4", ...) keep their string decoding; skip them.
 fn extended_metadata_is_json(mut bytes: &[u8]) -> Result<bool, AnyMySQLError> {
     let mut is_json = false;
     while let Some((&kind, rest)) = bytes.split_first() {
@@ -144,9 +142,9 @@ impl ColumnDefinition41 {
             BStr::new(self.org_name.slice())
         );
 
-        // With MARIADB_CLIENT_EXTENDED_TYPE_INFO negotiated, MariaDB inserts a
-        // lenenc blob of extended metadata between org_name and the
-        // fixed-length fields: https://mariadb.com/kb/en/result-set-packets/
+        // With MARIADB_CLIENT_EXTENDED_TYPE_INFO negotiated, a lenenc blob of
+        // extended metadata sits between org_name and the fixed-length
+        // fields: https://mariadb.com/kb/en/result-set-packets/
         let mut json_format = false;
         if extended_type_info {
             let extended = reader.encode_len_string()?;
@@ -163,11 +161,11 @@ impl ColumnDefinition41 {
         let type_byte = reader.int::<u8>()?;
         self.column_type =
             FieldType::from_raw(type_byte).ok_or(AnyMySQLError::UnsupportedColumnType)?;
-        // MariaDB has no MYSQL_TYPE_JSON; JSON columns (and JSON function
-        // results) arrive as TEXT/BLOB types marked format=json. Remap them so
-        // both row decoders parse the value like MySQL's native JSON type. The
-        // type gate keeps the remap to types whose wire values are
-        // length-encoded strings, the same shape MYSQL_TYPE_JSON decodes.
+        // MariaDB has no MYSQL_TYPE_JSON: JSON columns and JSON function
+        // results arrive as TEXT/BLOB marked format=json, so remap them onto
+        // the MySQL JSON decode path. Only types whose wire values are
+        // length-encoded strings (the shape MYSQL_TYPE_JSON decodes) remap,
+        // keeping the row reader aligned.
         if json_format
             && matches!(
                 self.column_type,

--- a/src/sql/mysql/protocol/ColumnDefinition41.rs
+++ b/src/sql/mysql/protocol/ColumnDefinition41.rs
@@ -1,5 +1,6 @@
 use crate::mysql::mysql_types::FieldType;
 use crate::mysql::protocol::any_mysql_error::Error as AnyMySQLError;
+use crate::mysql::protocol::encode_int::decode_length_int;
 use crate::mysql::protocol::new_reader::{NewReader, ReaderContext};
 use crate::shared::column_identifier::ColumnIdentifier;
 use crate::shared::data::Data;
@@ -70,10 +71,39 @@ impl ColumnFlags {
     }
 }
 
+/// Chunk kind in MariaDB's extended column metadata: 0 carries a type name
+/// ("uuid", "inet4", ...), 1 carries a storage format name ("json").
+const EXTENDED_METADATA_FORMAT: u8 = 1;
+
+/// Walks a MariaDB extended-metadata blob, a sequence of (int<1> kind,
+/// string<lenenc> value) pairs, and reports whether it marks the column as
+/// format=json.
+/// Unrecognized kinds and values are skipped; MariaDB stores those columns
+/// as plain strings, which is how the rest of the decoder already treats them.
+fn extended_metadata_is_json(mut bytes: &[u8]) -> Result<bool, AnyMySQLError> {
+    let mut is_json = false;
+    while let Some((&kind, rest)) = bytes.split_first() {
+        let decoded = decode_length_int(rest).ok_or(AnyMySQLError::InvalidEncodedInteger)?;
+        let len =
+            usize::try_from(decoded.value).map_err(|_| AnyMySQLError::InvalidEncodedLength)?;
+        let value_end = decoded
+            .bytes_read
+            .checked_add(len)
+            .filter(|end| *end <= rest.len())
+            .ok_or(AnyMySQLError::InvalidEncodedLength)?;
+        if kind == EXTENDED_METADATA_FORMAT && rest[decoded.bytes_read..value_end] == *b"json" {
+            is_json = true;
+        }
+        bytes = &rest[value_end..];
+    }
+    Ok(is_json)
+}
+
 impl ColumnDefinition41 {
     pub(crate) fn decode_internal<Context: ReaderContext>(
         &mut self,
         reader: &mut NewReader<Context>,
+        extended_type_info: bool,
     ) -> Result<bool, AnyMySQLError> {
         // Length encoded strings
         self.catalog = reader.encode_len_string()?;
@@ -114,6 +144,15 @@ impl ColumnDefinition41 {
             BStr::new(self.org_name.slice())
         );
 
+        // With MARIADB_CLIENT_EXTENDED_TYPE_INFO negotiated, MariaDB inserts a
+        // lenenc blob of extended metadata between org_name and the
+        // fixed-length fields: https://mariadb.com/kb/en/result-set-packets/
+        let mut json_format = false;
+        if extended_type_info {
+            let extended = reader.encode_len_string()?;
+            json_format = extended_metadata_is_json(extended.slice())?;
+        }
+
         self.fixed_length_fields_length = reader.encoded_len_int()?;
         self.character_set = reader.int::<u16>()?;
         self.column_length = reader.int::<u32>()?;
@@ -124,6 +163,25 @@ impl ColumnDefinition41 {
         let type_byte = reader.int::<u8>()?;
         self.column_type =
             FieldType::from_raw(type_byte).ok_or(AnyMySQLError::UnsupportedColumnType)?;
+        // MariaDB has no MYSQL_TYPE_JSON; JSON columns (and JSON function
+        // results) arrive as TEXT/BLOB types marked format=json. Remap them so
+        // both row decoders parse the value like MySQL's native JSON type. The
+        // type gate keeps the remap to types whose wire values are
+        // length-encoded strings, the same shape MYSQL_TYPE_JSON decodes.
+        if json_format
+            && matches!(
+                self.column_type,
+                FieldType::MYSQL_TYPE_BLOB
+                    | FieldType::MYSQL_TYPE_TINY_BLOB
+                    | FieldType::MYSQL_TYPE_MEDIUM_BLOB
+                    | FieldType::MYSQL_TYPE_LONG_BLOB
+                    | FieldType::MYSQL_TYPE_STRING
+                    | FieldType::MYSQL_TYPE_VAR_STRING
+                    | FieldType::MYSQL_TYPE_VARCHAR
+            )
+        {
+            self.column_type = FieldType::MYSQL_TYPE_JSON;
+        }
         self.flags = ColumnFlags::from_int(reader.int::<u16>()?);
         self.decimals = reader.int::<u8>()?;
 
@@ -161,7 +219,8 @@ impl ColumnDefinition41 {
     pub fn decode<Context: ReaderContext>(
         &mut self,
         reader: &mut NewReader<Context>,
+        extended_type_info: bool,
     ) -> Result<bool, AnyMySQLError> {
-        self.decode_internal(reader)
+        self.decode_internal(reader, extended_type_info)
     }
 }

--- a/src/sql/mysql/protocol/HandshakeResponse41.rs
+++ b/src/sql/mysql/protocol/HandshakeResponse41.rs
@@ -4,7 +4,7 @@ use super::any_mysql_error::Error as AnyMySQLError;
 use super::character_set::CharacterSet;
 use super::encode_int::encode_length_int;
 use super::new_writer::NewWriter;
-use crate::mysql::capabilities::Capabilities;
+use crate::mysql::capabilities::{Capabilities, MariaDBCapabilities};
 use crate::shared::data::Data;
 use bun_collections::StringHashMap;
 
@@ -12,6 +12,7 @@ bun_core::declare_scope!(MySQLConnection, hidden);
 
 pub struct HandshakeResponse41 {
     pub capability_flags: Capabilities,
+    pub mariadb_capability_flags: MariaDBCapabilities,
     pub max_packet_size: u32,        // default: 0xFFFFFF (16MB)
     pub character_set: CharacterSet, // default: CharacterSet::default()
     pub username: Data,
@@ -48,8 +49,12 @@ impl HandshakeResponse41 {
         // Write character set (1 byte)
         writer.int1(self.character_set.to_int())?;
 
-        // Write 23 bytes of padding
-        writer.write(&[0u8; 23])?;
+        // 23 bytes of padding: 19 reserved, then 4 that carry the extended
+        // client capabilities when talking to a MariaDB 10.2+ server (all
+        // zero otherwise, matching MySQL's filler).
+        // https://mariadb.com/kb/en/connection/#handshake-response-packet
+        writer.write(&[0u8; 19])?;
+        writer.int4(self.mariadb_capability_flags.to_int())?;
 
         // Write username (null terminated)
         writer.write_z(self.username.slice())?;

--- a/src/sql/mysql/protocol/HandshakeResponse41.rs
+++ b/src/sql/mysql/protocol/HandshakeResponse41.rs
@@ -49,9 +49,8 @@ impl HandshakeResponse41 {
         // Write character set (1 byte)
         writer.int1(self.character_set.to_int())?;
 
-        // 23 bytes of padding: 19 reserved, then 4 that carry the extended
-        // client capabilities when talking to a MariaDB 10.2+ server (all
-        // zero otherwise, matching MySQL's filler).
+        // 23 bytes of padding; the last 4 carry the MariaDB extended client
+        // capabilities (zero for MySQL servers, identical to plain filler).
         // https://mariadb.com/kb/en/connection/#handshake-response-packet
         writer.write(&[0u8; 19])?;
         writer.int4(self.mariadb_capability_flags.to_int())?;

--- a/src/sql/mysql/protocol/HandshakeV10.rs
+++ b/src/sql/mysql/protocol/HandshakeV10.rs
@@ -81,10 +81,9 @@ impl HandshakeV10 {
         // Length of auth plugin data
         let auth_plugin_data_len = reader.int::<u8>()?.max(21);
 
-        // Reserved bytes: 6 bytes of filler, then 4 bytes a MariaDB 10.2+
-        // server uses for its extended capability flags. MariaDB identifies
-        // itself by leaving CLIENT_LONG_PASSWORD (CLIENT_MYSQL in MariaDB's
-        // dialect) unset; MySQL sets that bit and zero-fills all 10 bytes.
+        // Reserved bytes: 6 filler, then 4 a MariaDB 10.2+ server uses for
+        // its extended capability flags. MariaDB marks itself by leaving
+        // CLIENT_LONG_PASSWORD (its CLIENT_MYSQL) unset; MySQL zero-fills all 10.
         // https://mariadb.com/kb/en/connection/#initial-handshake-packet
         reader.skip(6);
         let mariadb_flags = reader.int::<u32>()?;

--- a/src/sql/mysql/protocol/HandshakeV10.rs
+++ b/src/sql/mysql/protocol/HandshakeV10.rs
@@ -2,6 +2,7 @@
 
 use crate::mysql::Capabilities;
 use crate::mysql::StatusFlags;
+use crate::mysql::capabilities::MariaDBCapabilities;
 use crate::mysql::protocol::CharacterSet;
 use crate::mysql::protocol::any_mysql_error::Error as AnyMySQLError;
 use crate::mysql::protocol::new_reader::{NewReader, ReaderContext};
@@ -14,6 +15,7 @@ pub struct HandshakeV10 {
     pub auth_plugin_data_part_1: [u8; 8],
     pub auth_plugin_data_part_2: Box<[u8]>,
     pub capability_flags: Capabilities,
+    pub mariadb_capability_flags: MariaDBCapabilities,
     pub(crate) character_set: CharacterSet,
     pub status_flags: StatusFlags,
     pub auth_plugin_name: Data,
@@ -28,6 +30,7 @@ impl Default for HandshakeV10 {
             auth_plugin_data_part_1: [0u8; 8],
             auth_plugin_data_part_2: Box::default(),
             capability_flags: Capabilities::default(),
+            mariadb_capability_flags: MariaDBCapabilities::default(),
             character_set: CharacterSet::default(),
             status_flags: StatusFlags::default(),
             auth_plugin_name: Data::empty(),
@@ -78,8 +81,18 @@ impl HandshakeV10 {
         // Length of auth plugin data
         let auth_plugin_data_len = reader.int::<u8>()?.max(21);
 
-        // Skip reserved bytes
-        reader.skip(10);
+        // Reserved bytes: 6 bytes of filler, then 4 bytes a MariaDB 10.2+
+        // server uses for its extended capability flags. MariaDB identifies
+        // itself by leaving CLIENT_LONG_PASSWORD (CLIENT_MYSQL in MariaDB's
+        // dialect) unset; MySQL sets that bit and zero-fills all 10 bytes.
+        // https://mariadb.com/kb/en/connection/#initial-handshake-packet
+        reader.skip(6);
+        let mariadb_flags = reader.int::<u32>()?;
+        self.mariadb_capability_flags = if self.capability_flags.CLIENT_LONG_PASSWORD {
+            MariaDBCapabilities::default()
+        } else {
+            MariaDBCapabilities::from_int(mariadb_flags)
+        };
 
         // Auth plugin data part 2
         let remaining_auth_len = auth_plugin_data_len - 8;

--- a/src/sql/mysql/protocol/SSLRequest.rs
+++ b/src/sql/mysql/protocol/SSLRequest.rs
@@ -55,9 +55,8 @@ impl SSLRequest {
         // Write character set (1 byte)
         writer.int1(self.character_set.to_int())?;
 
-        // 23 bytes of padding: 19 reserved, then 4 for the MariaDB extended
-        // client capabilities, mirroring HandshakeResponse41 (the SSLRequest
-        // is that packet's prefix and the server parses it the same way).
+        // Same padding layout as HandshakeResponse41: the SSLRequest is that
+        // packet's prefix and the server reads its capability bytes the same way.
         writer.write(&[0u8; 19])?;
         writer.int4(self.mariadb_capability_flags.to_int())?;
 

--- a/src/sql/mysql/protocol/SSLRequest.rs
+++ b/src/sql/mysql/protocol/SSLRequest.rs
@@ -2,6 +2,7 @@
 // SSLRequest
 
 use crate::mysql::Capabilities;
+use crate::mysql::capabilities::MariaDBCapabilities;
 use crate::mysql::protocol::any_mysql_error::Error as AnyMySQLError;
 use crate::mysql::protocol::character_set::CharacterSet;
 use crate::mysql::protocol::new_writer::NewWriter;
@@ -10,6 +11,7 @@ bun_core::declare_scope!(MySQLConnection, hidden);
 
 pub struct SSLRequest {
     pub capability_flags: Capabilities,
+    pub mariadb_capability_flags: MariaDBCapabilities,
     /// 16MB default
     pub max_packet_size: u32,
     pub character_set: CharacterSet,
@@ -20,6 +22,7 @@ impl Default for SSLRequest {
     fn default() -> Self {
         Self {
             capability_flags: Capabilities::default(),
+            mariadb_capability_flags: MariaDBCapabilities::default(),
             max_packet_size: 0xFFFFFF, // 16MB default
             character_set: CharacterSet::default(),
             has_connection_attributes: false,
@@ -52,8 +55,11 @@ impl SSLRequest {
         // Write character set (1 byte)
         writer.int1(self.character_set.to_int())?;
 
-        // Write 23 bytes of padding
-        writer.write(&[0u8; 23])?;
+        // 23 bytes of padding: 19 reserved, then 4 for the MariaDB extended
+        // client capabilities, mirroring HandshakeResponse41 (the SSLRequest
+        // is that packet's prefix and the server parses it the same way).
+        writer.write(&[0u8; 19])?;
+        writer.int4(self.mariadb_capability_flags.to_int())?;
 
         packet.end()?;
         Ok(())

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -5,6 +5,7 @@ use bun_uws::{self as uws, AnySocket as Socket, SslCtx};
 use bun_sql::mysql::Capabilities;
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::auth_method::AuthMethod;
+use bun_sql::mysql::capabilities::MariaDBCapabilities;
 use bun_sql::mysql::connection_state::ConnectionState;
 use bun_sql::mysql::mysql_types::FieldType;
 use bun_sql::mysql::protocol::any_mysql_error::{self as any_mysql_error, Error as AnyMySQLError};
@@ -65,6 +66,7 @@ pub struct MySQLConnection {
     server_version: Vec<u8>,
     connection_id: u32,
     capabilities: Capabilities,
+    mariadb_capabilities: MariaDBCapabilities,
     character_set: CharacterSet,
     status_flags: StatusFlags,
 
@@ -105,6 +107,7 @@ impl Default for MySQLConnection {
             server_version: Vec::<u8>::default(),
             connection_id: 0,
             capabilities: Capabilities::default(),
+            mariadb_capabilities: MariaDBCapabilities::default(),
             character_set: CharacterSet::default(),
             status_flags: StatusFlags::default(),
             auth_plugin: None,
@@ -647,6 +650,10 @@ impl MySQLConnection {
             !self.database.is_empty(),
         )
         .intersect(handshake.capability_flags);
+        // MariaDB servers advertise extended capabilities of their own
+        // (HandshakeV10 leaves them zeroed for MySQL), negotiated the same way.
+        self.mariadb_capabilities = MariaDBCapabilities::get_default_capabilities()
+            .intersect(handshake.mariadb_capability_flags);
 
         // Override with utf8mb4 instead of using server's default
         self.character_set = CharacterSet::default();
@@ -693,6 +700,7 @@ impl MySQLConnection {
         if self.capabilities.CLIENT_SSL {
             let mut response = SSLRequest {
                 capability_flags: self.capabilities,
+                mariadb_capability_flags: self.mariadb_capabilities,
                 max_packet_size: 0, // 16777216,
                 character_set: CharacterSet::default(),
                 // bun always send connection attributes
@@ -1035,6 +1043,7 @@ impl MySQLConnection {
 
         let mut response = HandshakeResponse41 {
             capability_flags: self.capabilities,
+            mariadb_capability_flags: self.mariadb_capabilities,
             max_packet_size: 0, // 16777216,
             character_set: CharacterSet::default(),
             username: Data::Temporary(bun_ptr::RawSlice::new(&self.user)),
@@ -1188,16 +1197,18 @@ impl MySQLConnection {
                 self.check_if_prepared_statement_is_done(statement);
                 return Ok(());
             }
+            let extended_type_info = self.mariadb_capabilities.MARIADB_CLIENT_EXTENDED_TYPE_INFO;
             if (statement.params_received as usize) < statement.params.len() {
                 let mut column = ColumnDefinition41::default();
-                column.decode(&mut reader)?;
+                column.decode(&mut reader, extended_type_info)?;
                 statement.params[statement.params_received as usize] = Param {
                     r#type: column.column_type,
                     flags: column.flags,
                 };
                 statement.params_received += 1;
             } else if (statement.columns_received as usize) < statement.columns.len() {
-                statement.columns[statement.columns_received as usize].decode(&mut reader)?;
+                statement.columns[statement.columns_received as usize]
+                    .decode(&mut reader, extended_type_info)?;
                 statement.columns_received += 1;
             }
             // In CLIENT_DEPRECATE_EOF mode, there are no trailing EOF packets, so
@@ -1483,8 +1494,10 @@ impl MySQLConnection {
                         .insert(mysql_statement::ExecutionFlags::HEADER_RECEIVED);
                     return Ok(());
                 } else if (statement.columns_received as usize) < statement.columns.len() {
-                    let changed = statement.columns[statement.columns_received as usize]
-                        .decode(&mut reader)?;
+                    let changed = statement.columns[statement.columns_received as usize].decode(
+                        &mut reader,
+                        self.mariadb_capabilities.MARIADB_CLIENT_EXTENDED_TYPE_INFO,
+                    )?;
                     if changed {
                         statement.cached_structure = Default::default();
                         statement.fields_flags = Default::default();

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -650,8 +650,6 @@ impl MySQLConnection {
             !self.database.is_empty(),
         )
         .intersect(handshake.capability_flags);
-        // MariaDB servers advertise extended capabilities of their own
-        // (HandshakeV10 leaves them zeroed for MySQL), negotiated the same way.
         self.mariadb_capabilities = MariaDBCapabilities::get_default_capabilities()
             .intersect(handshake.mariadb_capability_flags);
 

--- a/test/docker/Dockerfile.mariadb-plain
+++ b/test/docker/Dockerfile.mariadb-plain
@@ -1,0 +1,22 @@
+FROM mariadb:11.8
+
+# Same baked-datadir trick as Dockerfile.mysql-plain: initialize the data
+# directory at build time into a sibling path (the base image declares
+# `VOLUME /var/lib/mysql`, which discards build-time writes there) so cold
+# container start skips first-boot init and is just `exec mariadbd`. The
+# MARIADB_* env vars below are build inputs only; at runtime the entrypoint
+# sees `$DATADIR/mysql` exists and execs straight away.
+ENV MARIADB_ALLOW_EMPTY_ROOT_PASSWORD=yes \
+    MARIADB_DATABASE=bun_sql_test
+
+RUN set -e; \
+    docker-entrypoint.sh mariadbd --datadir=/var/lib/mysql-init & pid=$!; \
+    for i in $(seq 180); do \
+        mariadb -h127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1 && break; \
+        sleep 1; \
+    done; \
+    mariadb -h127.0.0.1 -uroot -e 'SELECT 1'; \
+    mariadb-admin -h127.0.0.1 -uroot shutdown; \
+    wait "$pid"
+
+CMD ["mariadbd", "--datadir=/var/lib/mysql-init"]

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -135,6 +135,23 @@ services:
       start_period: 60s
       start_interval: 1s
 
+  mariadb_plain:
+    build:
+      context: .
+      dockerfile: Dockerfile.mariadb-plain
+    image: bun-mariadb-plain:local
+    ports:
+      - target: 3306
+        published: 0
+        protocol: tcp
+    healthcheck:
+      test: ["CMD", "mariadb", "-h", "127.0.0.1", "-uroot", "-e", "SELECT 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+      start_interval: 1s
+
   # Redis/Valkey Services
   redis_plain:
     image: redis:7-alpine

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -13,6 +13,7 @@ export type ServiceName =
   | "mysql_plain"
   | "mysql_native_password"
   | "mysql_tls"
+  | "mariadb_plain"
   | "redis_plain"
   | "redis_unified"
   | "minio"
@@ -50,6 +51,7 @@ const serviceMeta: Record<ServiceName, { ports: number[]; tls?: ServiceInfo["tls
   },
   mysql_plain: { ports: [3306] },
   mysql_native_password: { ports: [3306] },
+  mariadb_plain: { ports: [3306] },
   mysql_tls: {
     ports: [3306],
     tls: {

--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -11,6 +11,7 @@
 // starts on first request instead of at launch (correct, just slower).
 export const prestartMap = {
   "js/sql/sql-mysql": ["mysql_plain", "mysql_native_password", "mysql_tls"],
+  "js/sql/sql-mariadb": ["mariadb_plain"],
   "js/sql/tls-sql": ["postgres_tls"],
   "js/sql/local-sql": ["postgres_tls"],
   "js/sql/sql.test": ["postgres_plain"],

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1171,6 +1171,7 @@ export async function describeWithContainer(
     "mysql_plain": 3306,
     "mysql_native_password": 3306,
     "mysql_tls": 3306,
+    "mariadb_plain": 3306,
     "mysql:8": 3306, // Map mysql:8 to mysql_plain
     "mysql:9": 3306, // Map mysql:9 to mysql_native_password
     "redis_plain": 6379,

--- a/test/js/sql/sql-mariadb-json.test.ts
+++ b/test/js/sql/sql-mariadb-json.test.ts
@@ -14,11 +14,16 @@
 // MariaDB follows at the bottom.
 
 import { SQL, randomUUIDv7 } from "bun";
-import { expect, test } from "bun:test";
-import { describeWithContainer } from "harness";
+import { describe, expect, test } from "bun:test";
+import { describeWithContainer, isCI, isDockerEnabled } from "harness";
+import { readFileSync } from "node:fs";
+import type net from "node:net";
+import { join } from "node:path";
+import tls from "node:tls";
 import {
   MARIADB_CLIENT_EXTENDED_TYPE_INFO,
   MYSQL_CLIENT_LONG_PASSWORD,
+  MYSQL_CLIENT_SSL,
   MYSQL_DEFAULT_CAPABILITIES,
   listeningServer,
   mysqlColumnDefinition,
@@ -45,9 +50,18 @@ const jsonValue = { answer: 42, list: [1, 2, 3] };
 // single LONGTEXT-backed JSON column. Like the real server, it advertises
 // `extendedCaps` in the handshake's reserved tail and attaches the
 // format=json extended metadata only when the client negotiated
-// MARIADB_CLIENT_EXTENDED_TYPE_INFO in its response.
-async function mariadbMockServer(opts: { serverCapabilities?: number; extendedCaps: number }) {
-  const state = { clientExtendedCaps: -1 };
+// MARIADB_CLIENT_EXTENDED_TYPE_INFO in its response. With `ssl` it requires
+// the SSLRequest-then-TLS upgrade flow and records the SSLRequest's bytes,
+// which are the ones a real MariaDB server reads the extended capabilities
+// from on TLS connections. `extendedBlob` replaces the well-formed extended
+// metadata contents for fault injection.
+async function mariadbMockServer(opts: {
+  serverCapabilities?: number;
+  extendedCaps: number;
+  ssl?: boolean;
+  extendedBlob?: Buffer;
+}) {
+  const state = { clientExtendedCaps: -1, sslRequestPayloadLength: -1, sslRequestExtendedCaps: -1 };
   const columnDefinition = (seq: number, negotiated: boolean) =>
     mysqlColumnDefinition(seq, {
       name: "j",
@@ -58,65 +72,101 @@ async function mariadbMockServer(opts: { serverCapabilities?: number; extendedCa
       // kind 0 entries carry type names ("uuid", "inet4", ...); include one to
       // prove unrelated entries are skipped without desyncing the decoder.
       extendedTypeInfo: negotiated
-        ? [
+        ? (opts.extendedBlob ?? [
             { kind: 0, value: "ignored" },
             { kind: 1, value: "json" },
-          ]
+          ])
         : undefined,
     });
 
-  const { server, port } = await listeningServer(socket => {
+  const { server, port } = await listeningServer(rawSocket => {
     let buffered = Buffer.alloc(0);
     let authed = false;
-    socket.write(
+    let socket: net.Socket | tls.TLSSocket = rawSocket;
+    rawSocket.write(
       mysqlHandshakeV10({
         serverVersion: "11.8.0-MariaDB",
-        capabilities: opts.serverCapabilities ?? MYSQL_DEFAULT_CAPABILITIES,
+        capabilities: opts.serverCapabilities ?? MYSQL_DEFAULT_CAPABILITIES | (opts.ssl ? MYSQL_CLIENT_SSL : 0),
         mariadbExtendedCapabilities: opts.extendedCaps,
       }),
     );
-    socket.on("data", chunk => {
-      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
-        if (!authed) {
-          authed = true;
-          state.clientExtendedCaps = mysqlParseHandshakeResponseExtendedCaps(payload);
-          socket.write(mysqlOkPacket(seq + 1));
-          return;
-        }
-        const negotiated = (state.clientExtendedCaps & MARIADB_CLIENT_EXTENDED_TYPE_INFO) !== 0;
-        switch (payload[0]) {
-          case COM_STMT_PREPARE:
-            socket.write(Buffer.concat([mysqlStmtPrepareOk(1, 1, 1, 0), columnDefinition(2, negotiated)]));
-            break;
-          case COM_STMT_EXECUTE:
-            socket.write(
-              Buffer.concat([
-                mysqlRawPacket(1, Buffer.from([0x01])), // result set header: 1 column
-                columnDefinition(2, negotiated),
-                // binary row: header byte, null bitmap, then the lenenc value
-                mysqlRawPacket(3, Buffer.concat([Buffer.from([0x00, 0x00]), mysqlLenencStr(jsonText)])),
-                mysqlOkPacket(4, 0xfe),
-              ]),
-            );
-            break;
-          case COM_QUERY:
-            socket.write(
-              Buffer.concat([
-                mysqlRawPacket(1, Buffer.from([0x01])), // result set header: 1 column
-                columnDefinition(2, negotiated),
-                mysqlRawPacket(3, mysqlLenencStr(jsonText)), // text row
-                mysqlOkPacket(4, 0xfe),
-              ]),
-            );
-            break;
-          case COM_STMT_CLOSE:
-            break; // no response
-          default:
-            socket.end();
-        }
-      });
-    });
-    socket.on("error", () => {});
+
+    const onPacket = (seq: number, payload: Buffer) => {
+      if (!authed) {
+        authed = true;
+        state.clientExtendedCaps = mysqlParseHandshakeResponseExtendedCaps(payload);
+        socket.write(mysqlOkPacket(seq + 1));
+        return;
+      }
+      const negotiated = (state.clientExtendedCaps & MARIADB_CLIENT_EXTENDED_TYPE_INFO) !== 0;
+      switch (payload[0]) {
+        case COM_STMT_PREPARE:
+          socket.write(Buffer.concat([mysqlStmtPrepareOk(1, 1, 1, 0), columnDefinition(2, negotiated)]));
+          break;
+        case COM_STMT_EXECUTE:
+          socket.write(
+            Buffer.concat([
+              mysqlRawPacket(1, Buffer.from([0x01])), // result set header: 1 column
+              columnDefinition(2, negotiated),
+              // binary row: header byte, null bitmap, then the lenenc value
+              mysqlRawPacket(3, Buffer.concat([Buffer.from([0x00, 0x00]), mysqlLenencStr(jsonText)])),
+              mysqlOkPacket(4, 0xfe),
+            ]),
+          );
+          break;
+        case COM_QUERY:
+          socket.write(
+            Buffer.concat([
+              mysqlRawPacket(1, Buffer.from([0x01])), // result set header: 1 column
+              columnDefinition(2, negotiated),
+              mysqlRawPacket(3, mysqlLenencStr(jsonText)), // text row
+              mysqlOkPacket(4, 0xfe),
+            ]),
+          );
+          break;
+        case COM_STMT_CLOSE:
+          break; // no response
+        default:
+          socket.end();
+      }
+    };
+    const onData = (chunk: Buffer) => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), onPacket);
+    };
+
+    if (opts.ssl) {
+      // Plaintext phase: exactly one packet (the SSLRequest) arrives before
+      // the TLS handshake. The client starts its ClientHello immediately
+      // after, so any bytes past the packet boundary are TLS records: unshift
+      // them for the TLSSocket wrap (which replays the socket's readable
+      // buffer into the TLS engine) instead of parsing them here.
+      const onPlainData = (chunk: Buffer) => {
+        buffered = Buffer.concat([buffered, chunk]);
+        if (buffered.length < 4) return;
+        const length = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + length) return;
+        const payload = buffered.subarray(4, 4 + length);
+        state.sslRequestPayloadLength = payload.length;
+        state.sslRequestExtendedCaps = mysqlParseHandshakeResponseExtendedCaps(payload);
+        const leftover = buffered.subarray(4 + length);
+        buffered = Buffer.alloc(0);
+        rawSocket.removeListener("data", onPlainData);
+        rawSocket.pause();
+        if (leftover.length) rawSocket.unshift(leftover);
+        const tlsSocket = new tls.TLSSocket(rawSocket, {
+          isServer: true,
+          key: readFileSync(join(import.meta.dir, "mysql-tls/ssl/server-key.pem")),
+          cert: readFileSync(join(import.meta.dir, "mysql-tls/ssl/server-cert.pem")),
+        });
+        socket = tlsSocket;
+        tlsSocket.on("data", onData);
+        tlsSocket.on("error", () => {});
+      };
+      rawSocket.on("data", onPlainData);
+    } else {
+      rawSocket.on("data", onData);
+    }
+    rawSocket.on("error", () => {});
   });
   return { server, port, state };
 }
@@ -179,55 +229,132 @@ test.concurrent("MySQL-style servers get an all-zero filler even with garbage in
   }
 });
 
+test.concurrent("over TLS, the SSLRequest carries the extended capabilities", async () => {
+  // On TLS connections MariaDB reads the extended client capabilities from
+  // the SSLRequest (the pre-TLS prefix of the handshake response), so this is
+  // the packet that must carry the bit for extended metadata to flow at all.
+  const { server, port, state } = await mariadbMockServer({ extendedCaps: 0x3d, ssl: true });
+  try {
+    await using sql = new SQL({
+      url: `mysql://root@127.0.0.1:${port}/db`,
+      max: 1,
+      tls: { rejectUnauthorized: false },
+    });
+    const rows = await sql`SELECT j`;
+    // 4 capability bytes + 4 max-packet + 1 charset + 19 reserved + 4
+    // extended capability bytes; same length as before, different tail.
+    expect(state.sslRequestPayloadLength).toBe(32);
+    expect(state.sslRequestExtendedCaps).toBe(MARIADB_CLIENT_EXTENDED_TYPE_INFO);
+    // The post-TLS handshake response repeats the same capabilities.
+    expect(state.clientExtendedCaps).toBe(MARIADB_CLIENT_EXTENDED_TYPE_INFO);
+    expect(rows).toEqual([{ j: jsonValue }]);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test.concurrent("a truncated length in the extended metadata rejects the query", async () => {
+  // kind byte, then a 0xfc lenenc prefix that promises 2 length bytes but
+  // delivers 1: the value length itself cannot be decoded.
+  const { server, port } = await mariadbMockServer({
+    extendedCaps: 0x3d,
+    extendedBlob: Buffer.from([0x01, 0xfc, 0x01]),
+  });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    const err = await sql`SELECT j`.then(
+      () => ({ code: "UNEXPECTED_SUCCESS" }),
+      e => ({ code: e?.code ?? String(e) }),
+    );
+    expect(err).toEqual({ code: "ERR_MYSQL_INVALID_ENCODED_INTEGER" });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test.concurrent("an extended metadata length past the blob's end rejects the query", async () => {
+  // kind byte, then a value length of 5 with a single byte following.
+  const { server, port } = await mariadbMockServer({
+    extendedCaps: 0x3d,
+    extendedBlob: Buffer.from([0x01, 0x05, 0x61]),
+  });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    // Text protocol; the truncated-length case above covers the prepared
+    // path, and both share the decoder.
+    const err = await sql`SELECT j`.simple().then(
+      () => ({ code: "UNEXPECTED_SUCCESS" }),
+      e => ({ code: e?.code ?? String(e) }),
+    );
+    expect(err).toEqual({ code: "ERR_MYSQL_INVALID_ENCODED_LENGTH" });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
 // Real-server coverage. MariaDB negotiates extended metadata on every column
 // definition once the capability is agreed on, so these also verify decode
 // alignment for columns with empty / non-json extended metadata.
-describeWithContainer("mariadb", { image: "mariadb_plain" }, container => {
-  test("JSON columns and JSON function results parse into objects", async () => {
-    await container.ready;
-    await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+//
+// Only attempt the container when something can actually provide it: an
+// explicit BUN_TEST_SERVICE_mariadb_plain override (point it at any MariaDB
+// 10.5+, e.g. 127.0.0.1:3306), the CI docker coordinator, or CI docker. A
+// bare isDockerEnabled() is deliberately not enough to auto-start outside CI:
+// a daemon that answers `docker info` but cannot pull or build images (seen
+// on partially provisioned machines) would fail the suite instead of
+// skipping it.
+const mariadbProvided =
+  !!process.env.BUN_TEST_SERVICE_mariadb_plain || !!process.env.BUN_DOCKER_COORDINATOR || (isCI && isDockerEnabled());
+if (!mariadbProvided) {
+  describe.todo("mariadb");
+} else {
+  describeWithContainer("mariadb", { image: "mariadb_plain" }, container => {
+    test("JSON columns and JSON function results parse into objects", async () => {
+      await container.ready;
+      await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
 
-    const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
-    await sql`CREATE TEMPORARY TABLE ${sql(table)} (id INT, doc JSON, name VARCHAR(32))`;
-    await sql`INSERT INTO ${sql(table)} VALUES (1, ${JSON.stringify(jsonValue)}, 'alice'), (2, ${JSON.stringify([false, null, "x"])}, 'bob'), (3, NULL, 'carol')`;
+      const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      await sql`CREATE TEMPORARY TABLE ${sql(table)} (id INT, doc JSON, name VARCHAR(32))`;
+      await sql`INSERT INTO ${sql(table)} VALUES (1, ${JSON.stringify(jsonValue)}, 'alice'), (2, ${JSON.stringify([false, null, "x"])}, 'bob'), (3, NULL, 'carol')`;
 
-    const expected = [
-      { id: 1, doc: jsonValue, name: "alice" },
-      { id: 2, doc: [false, null, "x"], name: "bob" },
-      { id: 3, doc: null, name: "carol" },
-    ];
-    // Prepared → binary protocol; the surrounding columns prove the extended
-    // metadata block is consumed without desyncing the row decoder.
-    expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`).toEqual(expected);
-    // Re-running the same prepared statement re-decodes the column
-    // definitions (the server resends them on every execute).
-    expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`).toEqual(expected);
-    // `.simple()` → text protocol.
-    expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`.simple()).toEqual(expected);
+      const expected = [
+        { id: 1, doc: jsonValue, name: "alice" },
+        { id: 2, doc: [false, null, "x"], name: "bob" },
+        { id: 3, doc: null, name: "carol" },
+      ];
+      // Prepared → binary protocol; the surrounding columns prove the extended
+      // metadata block is consumed without desyncing the row decoder.
+      expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`).toEqual(expected);
+      // Re-running the same prepared statement re-decodes the column
+      // definitions (the server resends them on every execute).
+      expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`).toEqual(expected);
+      // `.simple()` → text protocol.
+      expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`.simple()).toEqual(expected);
 
-    // JSON functions return LONGTEXT marked format=json, like MySQL's native
-    // JSON results.
-    expect(await sql`SELECT JSON_OBJECT('x', 1) AS j, JSON_EXTRACT(${jsonText}, '$.answer') AS n`).toEqual([
-      { j: { x: 1 }, n: 42 },
-    ]);
+      // JSON functions return LONGTEXT marked format=json, like MySQL's native
+      // JSON results.
+      expect(await sql`SELECT JSON_OBJECT('x', 1) AS j, JSON_EXTRACT(${jsonText}, '$.answer') AS n`).toEqual([
+        { j: { x: 1 }, n: 42 },
+      ]);
 
-    // `.raw()` still returns the bytes, not parsed values.
-    const [rawRow] = await sql`SELECT doc FROM ${sql(table)} WHERE id = 1`.raw();
-    expect(JSON.parse(Buffer.from(rawRow[0] as Uint8Array).toString("utf-8"))).toEqual(jsonValue);
+      // `.raw()` still returns the bytes, not parsed values.
+      const [rawRow] = await sql`SELECT doc FROM ${sql(table)} WHERE id = 1`.raw();
+      expect(JSON.parse(Buffer.from(rawRow[0] as Uint8Array).toString("utf-8"))).toEqual(jsonValue);
+    });
+
+    test("extended type info for non-JSON MariaDB types is skipped, values stay strings", async () => {
+      await container.ready;
+      await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+
+      const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+      // UUID and INET6 columns carry a kind-0 ("type") extended metadata entry;
+      // they must keep decoding as plain strings.
+      await sql`CREATE TEMPORARY TABLE ${sql(table)} (u UUID, addr INET6, note TEXT)`;
+      await sql`INSERT INTO ${sql(table)} VALUES ('5f8b6b9c-6b6f-11ee-8c99-0242ac120002', '::1', 'hi')`;
+
+      const expected = [{ u: "5f8b6b9c-6b6f-11ee-8c99-0242ac120002", addr: "::1", note: "hi" }];
+      expect(await sql`SELECT u, addr, note FROM ${sql(table)}`).toEqual(expected);
+      expect(await sql`SELECT u, addr, note FROM ${sql(table)}`.simple()).toEqual(expected);
+    });
   });
-
-  test("extended type info for non-JSON MariaDB types is skipped, values stay strings", async () => {
-    await container.ready;
-    await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
-
-    const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
-    // UUID and INET6 columns carry a kind-0 ("type") extended metadata entry;
-    // they must keep decoding as plain strings.
-    await sql`CREATE TEMPORARY TABLE ${sql(table)} (u UUID, addr INET6, note TEXT)`;
-    await sql`INSERT INTO ${sql(table)} VALUES ('5f8b6b9c-6b6f-11ee-8c99-0242ac120002', '::1', 'hi')`;
-
-    const expected = [{ u: "5f8b6b9c-6b6f-11ee-8c99-0242ac120002", addr: "::1", note: "hi" }];
-    expect(await sql`SELECT u, addr, note FROM ${sql(table)}`).toEqual(expected);
-    expect(await sql`SELECT u, addr, note FROM ${sql(table)}`.simple()).toEqual(expected);
-  });
-});
+}

--- a/test/js/sql/sql-mariadb-json.test.ts
+++ b/test/js/sql/sql-mariadb-json.test.ts
@@ -1,0 +1,233 @@
+// MariaDB has no server-side JSON type: JSON columns are LONGTEXT and reach
+// the client as MYSQL_TYPE_BLOB with a text charset, so the MYSQL_TYPE_JSON
+// decode path (which parses the value into objects/arrays, like on MySQL)
+// never fired and `SELECT` returned raw JSON text as a string. The way a
+// MariaDB server distinguishes them is the MARIADB_CLIENT_EXTENDED_TYPE_INFO
+// capability: once negotiated, every column definition carries extended
+// metadata and JSON columns are marked "format=json".
+//
+// The mock-server tests below byte-assert the negotiation itself (which bits
+// of the handshake's reserved tail the client writes); that part cannot be
+// asserted against a real server. The mocks behave like a real MariaDB 11.x: extended metadata is only
+// sent when the client actually requested the capability, so an un-negotiated
+// connection keeps returning plain strings. A docker-backed suite against real
+// MariaDB follows at the bottom.
+
+import { SQL, randomUUIDv7 } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+import {
+  MARIADB_CLIENT_EXTENDED_TYPE_INFO,
+  MYSQL_CLIENT_LONG_PASSWORD,
+  MYSQL_DEFAULT_CAPABILITIES,
+  listeningServer,
+  mysqlColumnDefinition,
+  mysqlHandshakeV10,
+  mysqlLenencStr,
+  mysqlOkPacket,
+  mysqlParseHandshakeResponseExtendedCaps,
+  mysqlRawPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+} from "./wire-frames";
+
+const COM_QUERY = 0x03;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
+const COM_STMT_CLOSE = 0x19;
+const MYSQL_TYPE_BLOB = 0xfc;
+const BLOB_FLAG = 0x10;
+
+const jsonText = '{"answer":42,"list":[1,2,3]}';
+const jsonValue = { answer: 42, list: [1, 2, 3] };
+
+// A mock MariaDB server that answers `SELECT j` over both protocols with a
+// single LONGTEXT-backed JSON column. Like the real server, it advertises
+// `extendedCaps` in the handshake's reserved tail and attaches the
+// format=json extended metadata only when the client negotiated
+// MARIADB_CLIENT_EXTENDED_TYPE_INFO in its response.
+async function mariadbMockServer(opts: { serverCapabilities?: number; extendedCaps: number }) {
+  const state = { clientExtendedCaps: -1 };
+  const columnDefinition = (seq: number, negotiated: boolean) =>
+    mysqlColumnDefinition(seq, {
+      name: "j",
+      type: MYSQL_TYPE_BLOB,
+      charset: 224, // utf8mb4_unicode_ci, a text charset (not the binary pseudo-charset)
+      flags: BLOB_FLAG,
+      columnLength: 0xffffffff,
+      // kind 0 entries carry type names ("uuid", "inet4", ...); include one to
+      // prove unrelated entries are skipped without desyncing the decoder.
+      extendedTypeInfo: negotiated
+        ? [
+            { kind: 0, value: "ignored" },
+            { kind: 1, value: "json" },
+          ]
+        : undefined,
+    });
+
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(
+      mysqlHandshakeV10({
+        serverVersion: "11.8.0-MariaDB",
+        capabilities: opts.serverCapabilities ?? MYSQL_DEFAULT_CAPABILITIES,
+        mariadbExtendedCapabilities: opts.extendedCaps,
+      }),
+    );
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          state.clientExtendedCaps = mysqlParseHandshakeResponseExtendedCaps(payload);
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        const negotiated = (state.clientExtendedCaps & MARIADB_CLIENT_EXTENDED_TYPE_INFO) !== 0;
+        switch (payload[0]) {
+          case COM_STMT_PREPARE:
+            socket.write(Buffer.concat([mysqlStmtPrepareOk(1, 1, 1, 0), columnDefinition(2, negotiated)]));
+            break;
+          case COM_STMT_EXECUTE:
+            socket.write(
+              Buffer.concat([
+                mysqlRawPacket(1, Buffer.from([0x01])), // result set header: 1 column
+                columnDefinition(2, negotiated),
+                // binary row: header byte, null bitmap, then the lenenc value
+                mysqlRawPacket(3, Buffer.concat([Buffer.from([0x00, 0x00]), mysqlLenencStr(jsonText)])),
+                mysqlOkPacket(4, 0xfe),
+              ]),
+            );
+            break;
+          case COM_QUERY:
+            socket.write(
+              Buffer.concat([
+                mysqlRawPacket(1, Buffer.from([0x01])), // result set header: 1 column
+                columnDefinition(2, negotiated),
+                mysqlRawPacket(3, mysqlLenencStr(jsonText)), // text row
+                mysqlOkPacket(4, 0xfe),
+              ]),
+            );
+            break;
+          case COM_STMT_CLOSE:
+            break; // no response
+          default:
+            socket.end();
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+  return { server, port, state };
+}
+
+test.concurrent("MariaDB marks JSON columns via extended type info: binary protocol parses them", async () => {
+  // 0x3d is what MariaDB 11.8 advertises (progress, bulk ops, extended type
+  // info, metadata caching, bulk unit results).
+  const { server, port, state } = await mariadbMockServer({ extendedCaps: 0x3d });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    const rows = await sql`SELECT j`;
+    // Of the advertised bits, the client must request exactly the one it
+    // implements, in the last 4 of the 23 filler bytes.
+    expect(state.clientExtendedCaps).toBe(MARIADB_CLIENT_EXTENDED_TYPE_INFO);
+    expect(rows).toEqual([{ j: jsonValue }]);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test.concurrent("MariaDB marks JSON columns via extended type info: text protocol parses them", async () => {
+  const { server, port, state } = await mariadbMockServer({ extendedCaps: 0x3d });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    const rows = await sql`SELECT j`.simple();
+    expect(state.clientExtendedCaps).toBe(MARIADB_CLIENT_EXTENDED_TYPE_INFO);
+    expect(rows).toEqual([{ j: jsonValue }]);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test.concurrent("MariaDB without extended type info keeps returning JSON text as strings", async () => {
+  const { server, port, state } = await mariadbMockServer({ extendedCaps: 0 });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    const rows = await sql`SELECT j`;
+    // The server advertised nothing, so the client must request nothing.
+    expect(state.clientExtendedCaps).toBe(0);
+    expect(rows).toEqual([{ j: jsonText }]);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+test.concurrent("MySQL-style servers get an all-zero filler even with garbage in the reserved bytes", async () => {
+  // CLIENT_LONG_PASSWORD set = not a MariaDB 10.2+ server; the reserved tail
+  // is then plain filler and must be ignored no matter its content.
+  const { server, port, state } = await mariadbMockServer({
+    serverCapabilities: MYSQL_DEFAULT_CAPABILITIES | MYSQL_CLIENT_LONG_PASSWORD,
+    extendedCaps: 0xdeadbeef,
+  });
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    const rows = await sql`SELECT j`;
+    expect(state.clientExtendedCaps).toBe(0);
+    expect(rows).toEqual([{ j: jsonText }]);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+// Real-server coverage. MariaDB negotiates extended metadata on every column
+// definition once the capability is agreed on, so these also verify decode
+// alignment for columns with empty / non-json extended metadata.
+describeWithContainer("mariadb", { image: "mariadb_plain" }, container => {
+  test("JSON columns and JSON function results parse into objects", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+
+    const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+    await sql`CREATE TEMPORARY TABLE ${sql(table)} (id INT, doc JSON, name VARCHAR(32))`;
+    await sql`INSERT INTO ${sql(table)} VALUES (1, ${JSON.stringify(jsonValue)}, 'alice'), (2, ${JSON.stringify([false, null, "x"])}, 'bob'), (3, NULL, 'carol')`;
+
+    const expected = [
+      { id: 1, doc: jsonValue, name: "alice" },
+      { id: 2, doc: [false, null, "x"], name: "bob" },
+      { id: 3, doc: null, name: "carol" },
+    ];
+    // Prepared → binary protocol; the surrounding columns prove the extended
+    // metadata block is consumed without desyncing the row decoder.
+    expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`).toEqual(expected);
+    // Re-running the same prepared statement re-decodes the column
+    // definitions (the server resends them on every execute).
+    expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`).toEqual(expected);
+    // `.simple()` → text protocol.
+    expect(await sql`SELECT id, doc, name FROM ${sql(table)} ORDER BY id`.simple()).toEqual(expected);
+
+    // JSON functions return LONGTEXT marked format=json, like MySQL's native
+    // JSON results.
+    expect(await sql`SELECT JSON_OBJECT('x', 1) AS j, JSON_EXTRACT(${jsonText}, '$.answer') AS n`).toEqual([
+      { j: { x: 1 }, n: 42 },
+    ]);
+
+    // `.raw()` still returns the bytes, not parsed values.
+    const [rawRow] = await sql`SELECT doc FROM ${sql(table)} WHERE id = 1`.raw();
+    expect(JSON.parse(Buffer.from(rawRow[0] as Uint8Array).toString("utf-8"))).toEqual(jsonValue);
+  });
+
+  test("extended type info for non-JSON MariaDB types is skipped, values stay strings", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: `mysql://root@${container.host}:${container.port}/bun_sql_test`, max: 1 });
+
+    const table = ("t_" + randomUUIDv7("hex").replaceAll("-", "")).toLowerCase();
+    // UUID and INET6 columns carry a kind-0 ("type") extended metadata entry;
+    // they must keep decoding as plain strings.
+    await sql`CREATE TEMPORARY TABLE ${sql(table)} (u UUID, addr INET6, note TEXT)`;
+    await sql`INSERT INTO ${sql(table)} VALUES ('5f8b6b9c-6b6f-11ee-8c99-0242ac120002', '::1', 'hi')`;
+
+    const expected = [{ u: "5f8b6b9c-6b6f-11ee-8c99-0242ac120002", addr: "::1", note: "hi" }];
+    expect(await sql`SELECT u, addr, note FROM ${sql(table)}`).toEqual(expected);
+    expect(await sql`SELECT u, addr, note FROM ${sql(table)}`.simple()).toEqual(expected);
+  });
+});

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -430,6 +430,8 @@ export function mysqlParseHandshakeResponse41(payload: Buffer): { username: stri
 // blob of (Int<1> kind, string<lenenc> value) pairs between org_name and the
 // fixed-length fields; pass `extendedTypeInfo` (possibly []) to emit it:
 // https://mariadb.com/kb/en/result-set-packets/#column-definition-packet
+// A raw Buffer is the fault-injection escape hatch (mirrors `declaredLength`
+// above): it becomes the blob's contents verbatim, however malformed.
 export function mysqlColumnDefinition(
   seq: number,
   opts: {
@@ -443,7 +445,7 @@ export function mysqlColumnDefinition(
     table?: string;
     orgTable?: string;
     orgName?: string;
-    extendedTypeInfo?: { kind: number; value: string }[];
+    extendedTypeInfo?: { kind: number; value: string }[] | Buffer;
   },
 ): Buffer {
   const fixed = Buffer.alloc(12);
@@ -457,7 +459,9 @@ export function mysqlColumnDefinition(
     opts.extendedTypeInfo === undefined
       ? Buffer.alloc(0)
       : mysqlLenencStr(
-          Buffer.concat(opts.extendedTypeInfo.flatMap(e => [Buffer.from([e.kind]), mysqlLenencStr(e.value)])),
+          Buffer.isBuffer(opts.extendedTypeInfo)
+            ? opts.extendedTypeInfo
+            : Buffer.concat(opts.extendedTypeInfo.flatMap(e => [Buffer.from([e.kind]), mysqlLenencStr(e.value)])),
         );
   return mysqlRawPacket(
     seq,

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -277,6 +277,7 @@ export async function pgMinimalReadyServer(): Promise<{ port: number; server: ne
 // ---------------------------------------------------------------------------
 
 // Capability flags — page_protocol_basic_capability_flags.html (subset used by the mocks).
+export const MYSQL_CLIENT_LONG_PASSWORD = 1 << 0; // CLIENT_MYSQL in MariaDB's dialect
 export const MYSQL_CLIENT_PROTOCOL_41 = 1 << 9;
 export const MYSQL_CLIENT_SSL = 1 << 11;
 export const MYSQL_CLIENT_SECURE_CONNECTION = 1 << 15;
@@ -289,6 +290,10 @@ export const MYSQL_DEFAULT_CAPABILITIES =
   MYSQL_CLIENT_PLUGIN_AUTH |
   MYSQL_CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
   MYSQL_CLIENT_DEPRECATE_EOF;
+
+// MariaDB extended capability flags (bits 32+ of the combined value, carried in
+// a separate 4-byte field): https://mariadb.com/kb/en/connection/#capabilities
+export const MARIADB_CLIENT_EXTENDED_TYPE_INFO = 1 << 3;
 
 // MySQL packet framing — page_protocol_basic_packets.html: Int<3>(payload_length) Int<1>(sequence_id) payload
 // `declaredLength` is the low-level escape hatch for fault-injection tests that need a
@@ -311,10 +316,22 @@ export const MYSQL_MOCK_AUTH_DATA_PART_2: Buffer = Buffer.concat([Buffer.alloc(1
 // MySQL Protocol::HandshakeV10 — page_protocol_connection_phase_packets_protocol_handshake_v10.html
 // Int<1>(10) NulString(server_version) Int<4>(thread_id) String<8>(auth1) Int<1>(0) Int<2>(cap_lo)
 // Int<1>(charset) Int<2>(status) Int<2>(cap_hi) Int<1>(auth_len) String<10>(reserved) String<13>(auth2) NulString(plugin)
+// A MariaDB 10.2+ server leaves CLIENT_LONG_PASSWORD unset and repurposes the
+// last 4 reserved bytes as its extended capability flags
+// (`mariadbExtendedCapabilities`): https://mariadb.com/kb/en/connection/
 export function mysqlHandshakeV10(
-  opts: { authPlugin?: string; capabilities?: number; serverVersion?: string } = {},
+  opts: {
+    authPlugin?: string;
+    capabilities?: number;
+    serverVersion?: string;
+    mariadbExtendedCapabilities?: number;
+  } = {},
 ): Buffer {
   const caps = opts.capabilities ?? MYSQL_DEFAULT_CAPABILITIES;
+  const reserved = Buffer.alloc(10, 0);
+  if (opts.mariadbExtendedCapabilities !== undefined) {
+    reserved.writeUInt32LE(opts.mariadbExtendedCapabilities, 6);
+  }
   const payload = Buffer.concat([
     Buffer.from([10]),
     Buffer.from(`${opts.serverVersion ?? "mock-5.7.0"}\0`),
@@ -326,7 +343,7 @@ export function mysqlHandshakeV10(
     Buffer.from([0x02, 0x00]), // status_flags (SERVER_STATUS_AUTOCOMMIT)
     Buffer.from([(caps >> 16) & 0xff, (caps >>> 24) & 0xff]), // capability_flags_2
     Buffer.from([21]), // auth_plugin_data_len
-    Buffer.alloc(10, 0), // reserved
+    reserved,
     MYSQL_MOCK_AUTH_DATA_PART_2,
     Buffer.from(`${opts.authPlugin ?? "mysql_native_password"}\0`),
   ]);
@@ -384,6 +401,12 @@ export function mysqlReadLenencInt(buf: Buffer, offset: number): { value: number
   throw new Error(`0x${first.toString(16)} is not a lenenc-int prefix`);
 }
 
+// The MariaDB extended client capabilities live in the last 4 of HandshakeResponse41's
+// 23 filler bytes (a MySQL client leaves them zero): https://mariadb.com/kb/en/connection/
+export function mysqlParseHandshakeResponseExtendedCaps(payload: Buffer): number {
+  return payload.readUInt32LE(4 + 4 + 1 + 19);
+}
+
 // MySQL Protocol::HandshakeResponse41 — page_protocol_connection_phase_packets_protocol_handshake_response.html:
 //   Int<4>(client_flag) Int<4>(max_packet) Int<1>(charset) String<23>(filler) NulString(username)
 //   then the auth_response as a string<lenenc> (CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA) or Int<1>-prefixed string.
@@ -403,6 +426,10 @@ export function mysqlParseHandshakeResponse41(payload: Buffer): { username: stri
 // MySQL Protocol::ColumnDefinition41 — page_protocol_com_query_response_text_resultset_column_definition.html:
 //   lenenc("def") lenenc(schema) lenenc(table) lenenc(org_table) lenenc(name) lenenc(org_name)
 //   lenenc(0x0c) Int<2>(charset) Int<4>(column_length) Int<1>(type) Int<2>(flags) Int<1>(decimals) Int<2>(0x0000)
+// When MARIADB_CLIENT_EXTENDED_TYPE_INFO is negotiated, MariaDB inserts a lenenc
+// blob of (Int<1> kind, string<lenenc> value) pairs between org_name and the
+// fixed-length fields; pass `extendedTypeInfo` (possibly []) to emit it:
+// https://mariadb.com/kb/en/result-set-packets/#column-definition-packet
 export function mysqlColumnDefinition(
   seq: number,
   opts: {
@@ -416,6 +443,7 @@ export function mysqlColumnDefinition(
     table?: string;
     orgTable?: string;
     orgName?: string;
+    extendedTypeInfo?: { kind: number; value: string }[];
   },
 ): Buffer {
   const fixed = Buffer.alloc(12);
@@ -425,6 +453,12 @@ export function mysqlColumnDefinition(
   fixed.writeUInt16LE(opts.flags ?? 0, 7);
   fixed[9] = opts.decimals ?? 0;
   // bytes 10-11 reserved zero
+  const extended =
+    opts.extendedTypeInfo === undefined
+      ? Buffer.alloc(0)
+      : mysqlLenencStr(
+          Buffer.concat(opts.extendedTypeInfo.flatMap(e => [Buffer.from([e.kind]), mysqlLenencStr(e.value)])),
+        );
   return mysqlRawPacket(
     seq,
     Buffer.concat([
@@ -434,6 +468,7 @@ export function mysqlColumnDefinition(
       mysqlLenencStr(opts.orgTable ?? ""),
       mysqlLenencStr(opts.name),
       mysqlLenencStr(opts.orgName ?? ""),
+      extended,
       Buffer.from([0x0c]),
       fixed,
     ]),


### PR DESCRIPTION
### Problem

`Bun.SQL` documents a `mariadb` adapter (an alias of `mysql`) and promises JSON columns are automatically parsed. That works on MySQL but not on MariaDB: selecting from a `json` column returns the raw JSON text as a string on both the binary and the text protocol.

```js
const sql = new SQL({ url: "mysql://root@127.0.0.1:3306/bun_sql_test", max: 1 });
await sql`CREATE TEMPORARY TABLE t (a json)`;
await sql`INSERT INTO t (a) VALUES (${JSON.stringify({ b: 1 })})`;
const [row] = await sql`SELECT a FROM t`;
console.log(typeof row.a, row.a); // MariaDB: string '{"b": 1}'  MySQL: object { b: 1 }
```

### Cause

JSON results are only parsed when a column's wire type is `MYSQL_TYPE_JSON` (0xf5). MariaDB has no server-side JSON type: `json` columns are `LONGTEXT` and arrive as `MYSQL_TYPE_BLOB` (0xfc) with a text charset, so the JSON arms in `DecodeBinaryValue.rs` / `ResultSet.rs` never fire.

MariaDB's way to tell them apart is the `MARIADB_CLIENT_EXTENDED_TYPE_INFO` capability. The server advertises its extended capabilities in the last 4 of the handshake's 10 reserved bytes (a MariaDB 10.2+ server marks itself by leaving `CLIENT_LONG_PASSWORD`, `CLIENT_MYSQL` in MariaDB's dialect, unset); the client requests them in the last 4 of the handshake response's 23 filler bytes. Once negotiated, every column definition carries an extended metadata block and JSON columns are marked `format=json`. Bun never negotiated the capability: it skipped the reserved bytes and always sent zero filler.

### Fix

- `Capabilities.rs`: add `MariaDBCapabilities` (same macro as `Capabilities`); request only `MARIADB_CLIENT_EXTENDED_TYPE_INFO`, intersected with what the server advertised.
- `HandshakeV10.rs`: parse the server's extended capabilities from the reserved bytes, gated on `CLIENT_LONG_PASSWORD` being unset; zero for MySQL.
- `HandshakeResponse41.rs` / `SSLRequest.rs`: write the negotiated extended capabilities into the last 4 filler bytes. For MySQL servers nothing is negotiated, so the bytes stay zero and the packets are byte-identical to before. On TLS connections the SSLRequest is the packet MariaDB reads the extended capabilities from, so it carries them too.
- `ColumnDefinition41.rs`: when the capability is negotiated, parse the extended metadata block (a lenenc blob of `(int<1> kind, string<lenenc> value)` pairs between `org_name` and the fixed-length fields). Columns marked `format=json` are remapped to `MYSQL_TYPE_JSON`, restricted to wire types whose values are length-encoded strings so the row decoders cannot desync. Kind-0 entries (type names like `uuid`, `inet4`) are skipped and those columns keep decoding as strings. Malformed blobs (truncated or overrunning lengths) reject with `InvalidEncodedInteger` / `InvalidEncodedLength`.

This fixes `json` columns and JSON function results (`JSON_OBJECT`, `JSON_EXTRACT`, ...) on both protocols, matching the existing MySQL behavior. Old MariaDB (pre-10.5) does not advertise the capability and keeps the previous behavior. This is the read-side counterpart of #37125, which fixed binding object parameters on MariaDB; the two are independent.

### Tests

`test/js/sql/sql-mariadb-json.test.ts`:

- Mock-server tests (no container needed) byte-assert the negotiation: against a MariaDB-style handshake advertising `0x3d`, the client must request exactly the extended-type-info bit and then parses a `format=json` `MYSQL_TYPE_BLOB` column into an object on both protocols. The mock only attaches extended metadata when the client actually negotiated it, like a real server, so these fail on an unfixed build (capability bytes 0, value returned as a string). Two guards pin the compat behavior: a server advertising nothing gets a zero request and keeps string results, and a MySQL-style server (`CLIENT_LONG_PASSWORD` set) gets all-zero filler even with garbage in the reserved bytes.
- A TLS mock (SSLRequest, then a mid-stream TLS upgrade) byte-asserts the SSLRequest payload (32 bytes, extended-type-info bit at offset 28) and decodes a `format=json` column end-to-end over TLS; that packet is the one a MariaDB server honors for TLS connections and was previously uncovered.
- Fault-injection mocks send corrupt extended metadata (a truncated inner length, and a length past the blob's end) and assert the query rejects with `ERR_MYSQL_INVALID_ENCODED_INTEGER` / `ERR_MYSQL_INVALID_ENCODED_LENGTH`, covering both error paths of the new parser on the prepared and text protocols.
- A docker-backed suite against real MariaDB (new `mariadb_plain` compose service, baked datadir like `Dockerfile.mysql-plain`) covers json columns mixed with other columns, json arrays/NULL, JSON function results, `.raw()`, re-executed prepared statements, and UUID/INET6 columns whose extended type entries must be skipped without desyncing the decoder. It auto-starts its container only under an explicit `BUN_TEST_SERVICE_mariadb_plain` override, the CI docker coordinator, or CI docker, so a machine with a half-provisioned docker daemon skips instead of failing. Verified locally against MariaDB 11.8.6 (all 9 tests pass; 5 of the mock tests fail before the fix).

Full `test/js/sql/` suite passes locally apart from pre-existing environment-dependent failures that reproduce identically on the released build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 13 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mariadb-json.test.ts
bun test v1.4.0 (04c48de26)

test/js/sql/sql-mariadb-json.test.ts:
190 | test.concurrent("MariaDB marks JSON columns via extended type info: text protocol parses them", async () => {
191 |   const { server, port, state } = await mariadbMockServer({ extendedCaps: 0x3d });
192 |   try {
193 |     await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
194 |     const rows = await sql`SELECT j`.simple();
195 |     expect(state.clientExtendedCaps).toBe(MARIADB_CLIENT_EXTENDED_TYPE_INFO);
                                           ^
error: expect(received).toBe(expected)

Expected: 8
Received: 0

      at <anonymous> (/workspace/bun/test/js/sql/sql-mariadb-json.test.ts:195:38)
(fail) MariaDB marks JSON columns via extended type info: text protocol parses them [1069.47ms]
178 |   try {
179 |     await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
180 |     const rows = await sql`SELECT j`;
181 |     // Of the advertised bits, the client must request ex
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (0ffabf64d)

test/js/sql/sql-mariadb-json.test.ts:
190 | test.concurrent("MariaDB marks JSON columns via extended type info: text protocol parses them", async () => {
191 |   const { server, port, state } = await mariadbMockServer({ extendedCaps: 0x3d });
192 |   try {
193 |     await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
194 |     const rows = await sql`SELECT j`.simple();
195 |     expect(state.clientExtendedCaps).toBe(MARIADB_CLIENT_EXTENDED_TYPE_INFO);
                                           ^
error: expect(received).toBe(expected)

Expected: 8
Received: 0

      at <anonymous> (/workspace/bun/test/js/sql/sql-mariadb-json.test.ts:195:38)
(fail) MariaDB marks JSON columns via extended type info: text protocol parses them [28.67ms]
284 |     // path, and both share the decoder.
285 |     const err = await sql`SELECT j`.simple().then(
286 |       () => ({ code: "UNEXPECTED_SUCCESS" }),
287 |       e => ({ code: e?.code ?? String(e) }),
288 |     );
289 |     expect(err).toEqual({ code: "ERR_MYSQL_INVALID_ENCODED_LENGTH" });
                      ^
error: expect(received).toEqual(expected)

  {
-   "co
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-mariadb-json.test.ts
bun test v1.4.0 (04c48de26)

test/js/sql/sql-mariadb-json.test.ts:
(pass) MariaDB marks JSON columns via extended type info: text protocol parses them [1083.81ms]
(pass) MariaDB marks JSON columns via extended type info: binary protocol parses them [1345.20ms]
(pass) MariaDB without extended type info keeps returning JSON text as strings [1149.15ms]
(pass) MySQL-style servers get an all-zero filler even with garbage in the reserved bytes [1130.35ms]
(pass) over TLS, the SSLRequest carries the extended capabilities [1148.81ms]
(pass) a truncated length in the extended metadata rejects the query [153.26ms]
(pass) an extended metadata length past the blob's end rejects the query [89.78ms]

 7 pass
 0 fail
 14 expect() calls
Ran 7 tests across 1 file. [3.96s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     04c48de267
  features     baseline

22 deps, 105 codegen, 1175 objects in 735ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1237] install /workspace/bun
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 107 installs across 153 packages (no changes) [14.00ms]
[2/1237] gen ErrorCode+*.h
[3/1237] gen bindgenv2
[4/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 1 install across 2 packages (no changes) [4.00ms]
[5/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[6/1237] fetch tinycc
[tinycc] up to date
[7/1236] fetch zlib
[zlib] up to date
[8/1236] fetch picohttpparser
[picohttpparser] up to date
[9/1236] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1236] gen .bind.ts → GeneratedBindings.cpp
[11/1236] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/mysql/Capabilities.rs                 |  51 +++-
 src/sql/mysql/protocol/ColumnDefinition41.rs  |  59 ++++-
 src/sql/mysql/protocol/HandshakeResponse41.rs |  10 +-
 src/sql/mysql/protocol/HandshakeV10.rs        |  16 +-
 src/sql/mysql/protocol/SSLRequest.rs          |   9 +-
 src/sql_jsc/mysql/MySQLConnection.rs          |  19 +-
 test/docker/Dockerfile.mariadb-plain          |  22 ++
 test/docker/docker-compose.yml                |  17 ++
 test/docker/index.ts                          |   2 +
 test/docker/prestart-map.mjs                  |   1 +
 test/harness.ts                               |   1 +
 test/js/sql/sql-mariadb-json.test.ts          | 360 ++++++++++++++++++++++++++
 test/js/sql/wire-frames.ts                    |  43 ++-
 13 files changed, 582 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/sql/mysql/Capabilities.rs                      2      5      0
src/sql/mysql/protocol/ColumnDefinition41.rs       2      7      0
src/sql/mysql/protocol/HandshakeResponse41.rs      2      5      0
src/sql/mysql/protocol/HandshakeV10.rs             2      6      0
src/sql/mysql/protocol/SSLRequest.rs               2      5      0
src/sql_jsc/mysql/MySQLConnection.rs               5     10      0
test/docker/Dockerfile.mariadb-plain               0      1      0
test/docker/docker-compose.yml                     1      1      0
test/docker/index.ts                               1      2      0
test/docker/prestart-map.mjs                       1      2      0
test/harness.ts                                    1      2      0
test/js/sql/sql-mariadb-json.test.ts               4     10      0
test/js/sql/wire-frames.ts                         1     10      0
```

</details>

<!-- robobun:evidence:end -->