### PR TITLE
bun run --filter: resolve literal workspace paths directly

### DIFF
--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -11,7 +11,7 @@ use bun_install::package_manager::workspace_selection::{
 };
 use bun_parsers::json;
 use bun_paths::path_buffer_pool;
-use bun_paths::{PathBuffer, platform, resolve_path};
+use bun_paths::{PathBuffer, Platform, platform, resolve_path};
 use bun_resolver::package_json::{IncludeDependencies, IncludeScripts};
 use bun_sys;
 
@@ -352,6 +352,42 @@ impl<'a> PackageFilterIterator<'a> {
         })
     }
 
+    fn can_resolve_pattern_directly(pattern: &[u8]) -> bool {
+        // Keep raw glob tokens on GlobWalker, including escaped tokens that it must unescape.
+        // Relative literals can use the host filesystem's native case semantics directly.
+        !Platform::AUTO.is_absolute(pattern)
+            && pattern.first() != Some(&b'!')
+            && !strings::contains_char(pattern, 0)
+            && strings::index_of_any(pattern, b"*{[?!").is_none()
+            && !strings::split_any(pattern, b"/\\").any(|component| {
+                component.eq_ignore_ascii_case(b"node_modules")
+                    || component.eq_ignore_ascii_case(b".git")
+            })
+    }
+
+    fn resolve_literal_pattern(&mut self) -> Result<Option<glob::walk::MatchedPath>, crate::Error> {
+        let pattern: &[u8] = &self.patterns[self.pattern_idx];
+        let mut spill = Vec::new();
+        let path =
+            resolve_path::join_z_spill::<platform::Auto>(&mut spill, &[self.root_dir, pattern]);
+        let stat_result = bun_sys::stat(path);
+        self.pattern_idx += 1;
+
+        match stat_result {
+            Ok(stat) if bun_sys::S::ISREG(stat.st_mode as _) => {
+                Ok(Some(Box::<[u8]>::from(path.as_bytes())))
+            }
+            Ok(_) => Ok(None),
+            Err(err)
+                if err.get_errno() == bun_sys::E::ENOENT
+                    || err.get_errno() == bun_sys::E::ENOTDIR =>
+            {
+                Ok(None)
+            }
+            Err(err) => Err(err.with_path(path.as_bytes()).into()),
+        }
+    }
+
     fn start_walk(&self) -> Result<ActiveWalk, crate::Error> {
         // pattern_idx < patterns.len() checked by caller.
         let pattern: &[u8] = &self.patterns[self.pattern_idx];
@@ -384,6 +420,13 @@ impl<'a> PackageFilterIterator<'a> {
             let Some(active) = &mut self.active else {
                 if self.pattern_idx >= self.patterns.len() {
                     return Ok(None);
+                }
+                let pattern: &[u8] = &self.patterns[self.pattern_idx];
+                if Self::can_resolve_pattern_directly(pattern) {
+                    if let Some(path) = self.resolve_literal_pattern()? {
+                        return Ok(Some(path));
+                    }
+                    continue;
                 }
                 self.active = Some(self.start_walk()?);
                 continue;

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { existsSync, symlinkSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { join } from "path";
@@ -224,6 +224,110 @@ describe("bun", () => {
       });
     }
   }
+
+  const expectMixedCaseWorkspacePaths = (workspaces: string[], expectUpper = true) => {
+    using dir = tempDir("filter-workspace-case", {
+      packages: {
+        UpperPkg: {
+          "package.json": JSON.stringify({
+            name: "upper-pkg",
+            scripts: { hi: "echo hello-from-upper" },
+          }),
+        },
+        lowerpkg: {
+          "package.json": JSON.stringify({
+            name: "lower-pkg",
+            scripts: { hi: "echo hello-from-lower" },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces,
+      }),
+    });
+
+    const run = (filter: string, stderrContains?: string) => {
+      const { exitCode, stdout, stderr } = spawnSync({
+        cwd: dir,
+        cmd: [bunExe(), "run", "--filter", filter, "hi"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (stderrContains) expect(stderr.toString()).toContain(stderrContains);
+      const output = stdout.toString();
+      const count = (marker: string) => output.split(marker).length - 1;
+      return {
+        exitCode,
+        upper: count("hello-from-upper"),
+        lower: count("hello-from-lower"),
+      };
+    };
+
+    expect({
+      lower: run("lower-pkg"),
+      upper: run("upper-pkg", expectUpper ? undefined : "No workspace packages matched the filter"),
+      all: run("*"),
+    }).toEqual({
+      lower: { exitCode: 0, upper: 0, lower: 1 },
+      upper: expectUpper ? { exitCode: 0, upper: 1, lower: 0 } : { exitCode: 1, upper: 0, lower: 0 },
+      all: expectUpper ? { exitCode: 0, upper: 1, lower: 1 } : { exitCode: 0, upper: 0, lower: 1 },
+    });
+  };
+
+  // https://github.com/oven-sh/bun/issues/36004
+  test("exact workspace paths preserve directory casing", () => {
+    expectMixedCaseWorkspacePaths(["packages/UpperPkg", "packages/lowerpkg"]);
+  });
+
+  test.skipIf(!isWindows)("exact workspace paths use case-insensitive lookup on Windows", () => {
+    expectMixedCaseWorkspacePaths(["packages/upperpkg", "packages/lowerpkg"]);
+    expectMixedCaseWorkspacePaths(["./packages/upperpkg", "./packages/lowerpkg"]);
+    expectMixedCaseWorkspacePaths([String.raw`packages\upperpkg`, String.raw`packages\lowerpkg`]);
+  });
+
+  test.skipIf(isWindows || isMacOS)("exact workspace paths remain case-sensitive on POSIX", () => {
+    expectMixedCaseWorkspacePaths(["packages/upperpkg", "packages/lowerpkg"], false);
+  });
+
+  test.skipIf(isWindows)("escaped glob syntax in workspace paths remains supported", () => {
+    using dir = tempDir("filter-workspace-escaped-glob", {
+      packages: {
+        "foo*bar": {
+          "package.json": JSON.stringify({
+            name: "escaped-star",
+            scripts: { hi: "echo hello-from-escaped-star" },
+          }),
+        },
+        "!foo": {
+          "package.json": JSON.stringify({
+            name: "escaped-bang",
+            scripts: { hi: "echo hello-from-escaped-bang" },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces: [String.raw`packages/foo\*bar`, String.raw`packages/\!foo`],
+      }),
+    });
+
+    runInCwdSuccess({
+      cwd: dir,
+      pattern: "escaped-star",
+      target_pattern: /hello-from-escaped-star/,
+      command: ["hi"],
+    });
+    runInCwdSuccess({
+      cwd: dir,
+      pattern: "escaped-bang",
+      target_pattern: /hello-from-escaped-bang/,
+      command: ["hi"],
+    });
+  });
 
   for (const d of dirs) {
     test(`resolve '*' from ${d}`, () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #36004.

Plain relative workspace entries are literal filesystem paths, but `bun run --filter` currently sends them through the resolver-backed glob walker. The resolver directory cache exposes lowercased keys, so a correctly spelled path such as `packages/UpperPkg/package.json` is dropped before package-name filtering.

This resolves only plain relative workspace paths through the host filesystem. Windows therefore preserves its case-insensitive literal lookup, while case-sensitive filesystems continue to require matching casing. Glob and escaped-glob entries, ignored paths, absolute paths, and negated patterns retain the existing walker behavior. This does not change global glob or package-name matching semantics.

Prior art: #23076, #29941, and the unmerged follow-up commit [`7f5c5b1e7`](https://github.com/oven-sh/bun/commit/7f5c5b1e7). The accessor-based implementations restore original-case names for glob traversal and fix #36004's correctly-cased reproduction. Native Windows validation showed that the same approach is not sufficient when a literal manifest path differs from the on-disk casing: walker matching is byte-exact, while host filesystem lookup is case-insensitive. This patch is the complementary literal-path side of that split.

### How did you verify your code works?

- Reproduced the exact-name failure and wildcard omission on the unfixed `1.4.0-canary.1+d18ddfc1a` build.
- Rebased onto current `main` and ran full `test/cli/run/filter-workspace.test.ts` on a patched Linux debug build: 61 pass, 0 fail, 3 platform skips.
- Full owning test file on a patched native Windows x64 release build: 60 pass, 0 fail, 2 POSIX-only skips.
- Native Windows matrix for matching casing, mismatched casing, `./` paths, and backslash paths; exact-name and wildcard outputs occur exactly once. POSIX tests also protect escaped `*` and escaped `!` workspace paths from bypassing walker unescaping.
- `cargo check -p bun_runtime`, `bun run rust:clippy`, and `bun run rust:check-all` (10/10 configured targets, including x64/aarch64 Windows MSVC).
- `cargo fmt --all -- --check`, repository source lints, `bun lint`, `bun run codegen:verify`, Prettier, and `git diff --check`.

Native macOS, FreeBSD, and Windows ARM64 runtime execution were not available; Windows ARM64 was compile-checked.
