### PR TITLE
install: classify bare words starting with ssh or http as dist-tags

### DIFF
--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -968,8 +968,7 @@ impl TagExt for Tag {
             // ssh://git@example.com/repo.git
             // sshlatest (a dist-tag, not a URL)
             b's' => {
-                // "ssh:" is always a clone URL, like "git+ssh:" above; it can
-                // never be a github shortcut, so hosted_git_info is not needed.
+                // an ssh URL is never a github shortcut, so always a git clone
                 if dependency.starts_with(b"ssh:") {
                     return Tag::Git;
                 }

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -938,65 +938,45 @@ impl TagExt for Tag {
             // hello/world
             // hello.tar.gz
             // https://github.com/user/repo
+            // httplatest (a dist-tag, not a URL)
             b'h' => {
-                if dependency.starts_with(b"http") {
+                // Without the ':' a bare word like "httplatest" would be
+                // misclassified as a tarball; npm treats it as a dist-tag.
+                if dependency.starts_with(b"http:") || dependency.starts_with(b"https:") {
                     let mut url = &dependency[b"http".len()..];
-                    if url.len() > 2 {
-                        match url[0] {
-                            b':' => {
-                                if url.starts_with(b"://") {
-                                    url = &url[b"://".len()..];
-                                }
-                            }
-                            b's' => {
-                                if url.starts_with(b"s://") {
-                                    url = &url[b"s://".len()..];
-                                }
-                            }
-                            _ => {}
-                        }
-
-                        if url.starts_with(b"github.com/") {
-                            let path = &url[b"github.com/".len()..];
-                            if is_github_tarball_path(path) {
-                                return Tag::Tarball;
-                            }
-                            if hosted_git_info::is_github_shorthand(path) {
-                                return Tag::Github;
-                            }
-                        }
-
-                        if let Ok(Some(info)) = hosted_git_info::HostedGitInfo::from_url(dependency)
-                        {
-                            return hgi_to_tag(&info);
-                        }
-
-                        return Tag::Tarball;
+                    if url.starts_with(b"://") {
+                        url = &url[b"://".len()..];
+                    } else if url.starts_with(b"s://") {
+                        url = &url[b"s://".len()..];
                     }
+
+                    if url.starts_with(b"github.com/") {
+                        let path = &url[b"github.com/".len()..];
+                        if is_github_tarball_path(path) {
+                            return Tag::Tarball;
+                        }
+                        if hosted_git_info::is_github_shorthand(path) {
+                            return Tag::Github;
+                        }
+                    }
+
+                    if let Ok(Some(info)) = hosted_git_info::HostedGitInfo::from_url(dependency) {
+                        return hgi_to_tag(&info);
+                    }
+
+                    return Tag::Tarball;
                 }
             }
+            // ssh://git@example.com/repo.git
+            // sshlatest (a dist-tag, not a URL)
             b's' => {
-                if dependency.starts_with(b"ssh") {
-                    let mut url = &dependency[b"ssh".len()..];
-                    if url.len() > 2 {
-                        if url[0] == b':' {
-                            if url.starts_with(b"://") {
-                                url = &url[b"://".len()..];
-                            }
-                        }
-
-                        if url.len() > 4 && &url[0..b"git@".len()] == b"git@" {
-                            url = &url[b"git@".len()..];
-                        }
-
-                        let _ = url; // not used after this point
-
-                        if let Ok(Some(info)) = hosted_git_info::HostedGitInfo::from_url(dependency)
-                        {
-                            return hgi_to_tag(&info);
-                        }
-                        return Tag::Git;
+                // Without the ':' a bare word like "sshlatest" would be
+                // misclassified as git; npm treats it as a dist-tag.
+                if dependency.starts_with(b"ssh:") {
+                    if let Ok(Some(info)) = hosted_git_info::HostedGitInfo::from_url(dependency) {
+                        return hgi_to_tag(&info);
                     }
+                    return Tag::Git;
                 }
             }
             // lisp.tgz

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -940,8 +940,6 @@ impl TagExt for Tag {
             // https://github.com/user/repo
             // httplatest (a dist-tag, not a URL)
             b'h' => {
-                // Without the ':' a bare word like "httplatest" would be
-                // misclassified as a tarball; npm treats it as a dist-tag.
                 if dependency.starts_with(b"http:") || dependency.starts_with(b"https:") {
                     let mut url = &dependency[b"http".len()..];
                     if url.starts_with(b"://") {
@@ -970,8 +968,6 @@ impl TagExt for Tag {
             // ssh://git@example.com/repo.git
             // sshlatest (a dist-tag, not a URL)
             b's' => {
-                // Without the ':' a bare word like "sshlatest" would be
-                // misclassified as git; npm treats it as a dist-tag.
                 if dependency.starts_with(b"ssh:") {
                     if let Ok(Some(info)) = hosted_git_info::HostedGitInfo::from_url(dependency) {
                         return hgi_to_tag(&info);

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -968,10 +968,9 @@ impl TagExt for Tag {
             // ssh://git@example.com/repo.git
             // sshlatest (a dist-tag, not a URL)
             b's' => {
+                // "ssh:" is always a clone URL, like "git+ssh:" above; it can
+                // never be a github shortcut, so hosted_git_info is not needed.
                 if dependency.starts_with(b"ssh:") {
-                    if let Ok(Some(info)) = hosted_git_info::HostedGitInfo::from_url(dependency) {
-                        return hgi_to_tag(&info);
-                    }
                     return Tag::Git;
                 }
             }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -16,7 +16,8 @@ import {
   toBeWorkspaceLink,
   toHaveBins,
 } from "harness";
-import { join, resolve, sep } from "path";
+import { npmTag } from "bun:internal-for-testing";
+import { basename, join, resolve, sep } from "path";
 import {
   createTestContext,
   destroyTestContext,
@@ -10151,5 +10152,115 @@ it.each([
     expect(tarballRequests).toEqual([]);
     expect(out).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);
+  });
+});
+
+describe("version specifier classification", () => {
+  it("treats bare words starting with ssh or http as dist-tags", () => {
+    const specs = [
+      // previously misclassified as git (ssh) or tarball (http/https)
+      "sshlatest",
+      "httplatest",
+      "httpslatest",
+      "ssh",
+      "http",
+      "https",
+      "latest",
+      // URL and URL-ish forms keep their classification
+      "ssh://git@example.com/repo.git",
+      "ssh://git@github.com/user/repo.git",
+      "git+ssh://git@example.com/repo.git",
+      "http://example.com/foo.tgz",
+      "https://example.com/foo.tgz",
+      "https://github.com/user/repo",
+      // non-URL shapes fall through to the generic classifiers
+      "sshuser@example.com:repo.git",
+      "sshuser/repo",
+      "ssh.tar.gz",
+    ];
+    expect(Object.fromEntries(specs.map(s => [s, npmTag(s)]))).toEqual({
+      "sshlatest": "dist_tag",
+      "httplatest": "dist_tag",
+      "httpslatest": "dist_tag",
+      "ssh": "dist_tag",
+      "http": "dist_tag",
+      "https": "dist_tag",
+      "latest": "dist_tag",
+      "ssh://git@example.com/repo.git": "git",
+      "ssh://git@github.com/user/repo.git": "git",
+      "git+ssh://git@example.com/repo.git": "git",
+      "http://example.com/foo.tgz": "tarball",
+      "https://example.com/foo.tgz": "tarball",
+      "https://github.com/user/repo": "github",
+      "sshuser@example.com:repo.git": "git",
+      "sshuser/repo": "github",
+      "ssh.tar.gz": "tarball",
+    });
+  });
+
+  it("installs dist-tags whose names start with ssh or http from the registry", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, async request => {
+        urls.push(request.url);
+        const url = new URL(request.url.replaceAll("%2f", "/"));
+        if (url.pathname.endsWith(".tgz")) {
+          return new Response(file(join(import.meta.dir, basename(url.pathname).toLowerCase())));
+        }
+        const name = basename(url.pathname);
+        return new Response(
+          JSON.stringify({
+            name,
+            versions: {
+              "0.0.3": {
+                name,
+                version: "0.0.3",
+                dist: { tarball: `${ctx.registry_url}baz-0.0.3.tgz` },
+              },
+            },
+            "dist-tags": {
+              latest: "0.0.3",
+              sshlatest: "0.0.3",
+              httplatest: "0.0.3",
+              httpslatest: "0.0.3",
+            },
+          }),
+        );
+      });
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            "baz": "sshlatest",
+            "http-tagged": "npm:baz@httplatest",
+            "https-tagged": "npm:baz@httpslatest",
+          },
+        }),
+      );
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(err).not.toContain("error:");
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("+ baz@0.0.3");
+      expect(out).toContain("+ http-tagged@0.0.3");
+      expect(out).toContain("+ https-tagged@0.0.3");
+      expect(exitCode).toBe(0);
+      expect(urls).toContain(`${ctx.registry_url}baz`);
+      for (const dir of ["baz", "http-tagged", "https-tagged"]) {
+        expect(await file(join(ctx.package_dir, "node_modules", dir, "package.json")).json()).toMatchObject({
+          name: "baz",
+          version: "0.0.3",
+        });
+      }
+    });
   });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10173,10 +10173,17 @@ describe("version specifier classification", () => {
       "http://example.com/foo.tgz",
       "https://example.com/foo.tgz",
       "https://github.com/user/repo",
+      "https://github.com/user/repo.git",
+      "https://gitlab.com/user/repo",
+      "https://bitbucket.org/user/repo.git",
       // non-URL shapes fall through to the generic classifiers
       "sshuser@example.com:repo.git",
       "sshuser/repo",
       "ssh.tar.gz",
+      "httpuser@example.com:repo.git",
+      "httpsuser@example.com:repo.git",
+      "httpuser/repo",
+      "http.tar.gz",
     ];
     expect(Object.fromEntries(specs.map(s => [s, npmTag(s)]))).toEqual({
       "sshlatest": "dist_tag",
@@ -10192,9 +10199,16 @@ describe("version specifier classification", () => {
       "http://example.com/foo.tgz": "tarball",
       "https://example.com/foo.tgz": "tarball",
       "https://github.com/user/repo": "github",
+      "https://github.com/user/repo.git": "github",
+      "https://gitlab.com/user/repo": "git",
+      "https://bitbucket.org/user/repo.git": "git",
       "sshuser@example.com:repo.git": "git",
       "sshuser/repo": "github",
       "ssh.tar.gz": "tarball",
+      "httpuser@example.com:repo.git": "git",
+      "httpsuser@example.com:repo.git": "git",
+      "httpuser/repo": "github",
+      "http.tar.gz": "tarball",
     });
   });
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,4 +1,5 @@
 import { file, listen, Socket, spawn, write } from "bun";
+import { npmTag } from "bun:internal-for-testing";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
 import { readlinkSync, realpathSync } from "fs";
 import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
@@ -16,7 +17,6 @@ import {
   toBeWorkspaceLink,
   toHaveBins,
 } from "harness";
-import { npmTag } from "bun:internal-for-testing";
 import { basename, join, resolve, sep } from "path";
 import {
   createTestContext,


### PR DESCRIPTION
### Problem

A dependency whose version is a bare word starting with `ssh` is classified as a git dependency, and one starting with `http`/`https` as a remote tarball:

```sh
mkdir p && cd p
echo '{"name":"p","dependencies":{"foo":"sshlatest"}}' > package.json
bun install
# error: no commit matching "" found for "foo" (but repository exists)
# error: foo@sshlatest failed to resolve
```

`{"foo":"httplatest"}` fails the same way with `error: ENOENT extracting tarball from foo`.

npm parses both as registry dist-tags (npm-package-arg returns type `tag` for `sshlatest`, `httplatest`, `httpslatest`), so any package using a dist-tag name that starts with `ssh` or `http` installs with npm and fails with bun.

### Cause

In `Tag::infer` (src/install/dependency.rs), the `ssh` and `http` arms only check the prefix word before committing to `Tag::Git` / `Tag::Tarball`; stripping of `://` is optional. Every other protocol arm (`git:`, `file:`, `npm:`, `link:`, `workspace:`, ...) requires the `:`. npm-package-arg only treats a specifier as a URL when it matches `^[a-z]+:`.

### Fix

Require `ssh:` / `http:` / `https:` before the URL-ish classification. Bare words fall through to the generic classifiers at the end of `Tag::infer` (tarball filename, github shorthand, scp-like path, dist-tag), same as words starting with `git`. The `ssh:` arm now returns `Tag::Git` directly, like the `git+ssh:` arm: `hosted_git_info` maps every `ssh:` URL to git (an ssh URL can never be a github shortcut), so the lookup was a no-op.

Resulting classification changes:

| specifier | before | after | npm |
|---|---|---|---|
| `sshlatest`, `httplatest`, `httpslatest` | git / tarball (fails) | dist-tag | dist-tag |
| `ssh.tar.gz` | git (fails) | local tarball | local file |
| `httpuser@example.com:repo.git` (scp-like with http prefix) | tarball (fails) | git | git via CLI (`npm i foo@...`); the package.json form rejects non-hosted scp-like outright |

The scp-like row matches bun's existing rule for every other first letter (`vuser@example.com:repo.git` was already git); the old tarball classification matched neither npm form and always failed.

Unchanged: `ssh://`, `git+ssh://`, `http(s)://` tarballs, `https://github.com/user/repo(.git)` (github), hosted gitlab/bitbucket https URLs (git), scp-like paths generally, and `sshuser/repo`-style github shorthands.

### Verification

New tests in `test/cli/install/bun-install.test.ts`:
- a classification table over the affected and neighboring specifier shapes, including the scp-like flips and the hosted-git https URL branch of the rewritten `http` arm (gitlab/bitbucket/github `.git` URLs)
- an install test where packages resolve through dist-tags named `sshlatest`, `httplatest`, and `httpslatest` (direct and via `npm:` alias) from the local dummy registry

Both fail on bun without the fix (6 table rows flip) and pass with it. With the fix, a dist-tag that does not exist now reports `Package "foo" with tag "sshlatest" not found, but package exists` instead of a git clone failure.

Note: #37126 (open) adds a test that asserts the old classification of `sshlatest` as git; whichever lands second needs to reconcile that test.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->