### PR TITLE
bun test --parallel: hold the JSC API lock while draining the worker's final IPC backlog

### DIFF
--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -669,16 +669,21 @@ pub(crate) fn run_as_worker(
 
     worker_flush_aggregates(wloop.reporter, vm_ref, ctx, &mut wloop.cmds);
     // Drain any backpressure-buffered frames before exit so the coordinator
-    // sees repeat_bufs / junit_chunk / coverage_chunk.
-    while wloop.cmds.channel.has_pending_writes() && !wloop.cmds.channel.done.get() {
-        // SAFETY: event_loop pointer is valid while vm lives.
-        unsafe { (*vm_ref.event_loop()).tick() };
-        if !wloop.cmds.channel.has_pending_writes() || wloop.cmds.channel.done.get() {
-            break;
+    // sees repeat_bufs / junit_chunk / coverage_chunk. Ticking drains
+    // microtasks and releases weak refs, so it needs the JSC API lock (same
+    // as the ticks inside `begin()` above); on Windows every frame goes
+    // through an async uv_write, so this loop runs on every worker exit.
+    vm_ref.run_with_api_lock(|| {
+        while wloop.cmds.channel.has_pending_writes() && !wloop.cmds.channel.done.get() {
+            // SAFETY: event_loop pointer is valid while vm lives.
+            unsafe { (*vm_ref.event_loop()).tick() };
+            if !wloop.cmds.channel.has_pending_writes() || wloop.cmds.channel.done.get() {
+                break;
+            }
+            // SAFETY: event_loop pointer is valid while vm lives.
+            unsafe { (*vm_ref.event_loop()).auto_tick() };
         }
-        // SAFETY: event_loop pointer is valid while vm lives.
-        unsafe { (*vm_ref.event_loop()).auto_tick() };
-    }
+    });
     // Mirror TestCommand::exec's exit path so BUN_DESTRUCT_VM_ON_EXIT teardown
     // (lastChanceToFinalize) runs; bypassing it leaks JSC-owned native state.
     vm_ref.exit_handler.exit_code = 0;

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -669,10 +669,8 @@ pub(crate) fn run_as_worker(
 
     worker_flush_aggregates(wloop.reporter, vm_ref, ctx, &mut wloop.cmds);
     // Drain any backpressure-buffered frames before exit so the coordinator
-    // sees repeat_bufs / junit_chunk / coverage_chunk. Ticking drains
-    // microtasks and releases weak refs, so it needs the JSC API lock (same
-    // as the ticks inside `begin()` above); on Windows every frame goes
-    // through an async uv_write, so this loop runs on every worker exit.
+    // sees repeat_bufs / junit_chunk / coverage_chunk. Ticking runs JS
+    // (microtasks, weak-ref release), hence the API lock.
     vm_ref.run_with_api_lock(|| {
         while wloop.cmds.channel.has_pending_writes() && !wloop.cmds.channel.done.get() {
             // SAFETY: event_loop pointer is valid while vm lives.

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -830,6 +830,47 @@ test("--parallel: a test writing garbage to fd 3 does not hang the coordinator",
   expect(exitCode).toBe(1);
 });
 
+// After the last file, the worker flushes its aggregate frames (repeat bufs,
+// junit/coverage chunks) and ticks the event loop until the IPC backlog
+// drains. Those ticks run JS teardown (microtasks, weak-ref release) and must
+// hold the JSC API lock like the ticks during the run; debug builds assert
+// (currentThreadIsHoldingAPILock in VM::finalizeSynchronousJSExecution) into
+// the worker's stderr otherwise, which the coordinator streams through. On
+// Windows every frame takes the async uv_write path so the drain loop runs on
+// every worker exit; on POSIX it only runs when a frame overflows the
+// socketpair send buffer (~208KB on Linux), hence the ~1MB todo repeat
+// buffer. Debug-only: release builds compile the assertion out.
+test.skipIf(!isDebug)("--parallel: worker drains a backpressured final frame without JSC lock assertions", async () => {
+  using dir = tempDir("parallel-drain-lock", {
+    "big.test.js": `import {test} from "bun:test";
+      const pad = Buffer.alloc(340, "t").toString();
+      for (let i = 0; i < 3000; i++) test.todo(pad + "-" + i);
+      test("real", () => {});`,
+    "other.test.js": `import {test,expect} from "bun:test"; test("b1",()=>expect(1).toBe(1));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  // Filter instead of not.toContain so a failure prints the assertion lines,
+  // not the ~1MB of todo lines around them.
+  const assertionLines = stderr
+    .split("\n")
+    .filter(line => line.includes("ASSERTION FAILED") || line.includes("currentThreadIsHoldingAPILock"));
+  expect(assertionLines).toEqual([]);
+  // The backpressured frame is still delivered in full.
+  expect(stderr).toContain("3000 todo");
+  expect(stderr).toContain("-2999");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel --randomize without --seed is reproducible via the printed seed", async () => {
   const mk = (tag: string) =>
     `import {test,expect} from "bun:test";\n` +

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -833,43 +833,54 @@ test("--parallel: a test writing garbage to fd 3 does not hang the coordinator",
 // After the last file, the worker flushes its aggregate frames (repeat bufs,
 // junit/coverage chunks) and ticks the event loop until the IPC backlog
 // drains. Those ticks run JS teardown (microtasks, weak-ref release) and must
-// hold the JSC API lock like the ticks during the run; debug builds assert
-// (currentThreadIsHoldingAPILock in VM::finalizeSynchronousJSExecution) into
-// the worker's stderr otherwise, which the coordinator streams through. On
-// Windows every frame takes the async uv_write path so the drain loop runs on
-// every worker exit; on POSIX it only runs when a frame overflows the
-// socketpair send buffer (~208KB on Linux), hence the ~1MB todo repeat
-// buffer. Debug-only: release builds compile the assertion out.
-test.skipIf(!isDebug)("--parallel: worker drains a backpressured final frame without JSC lock assertions", async () => {
-  using dir = tempDir("parallel-drain-lock", {
-    "big.test.js": `import {test} from "bun:test";
-      const pad = Buffer.alloc(340, "t").toString();
-      for (let i = 0; i < 3000; i++) test.todo(pad + "-" + i);
-      test("real", () => {});`,
-    "other.test.js": `import {test,expect} from "bun:test"; test("b1",()=>expect(1).toBe(1));`,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--parallel=2"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toContain("PARALLEL");
-  // Filter instead of not.toContain so a failure prints the assertion lines,
-  // not the ~1MB of todo lines around them.
-  const assertionLines = stderr
-    .split("\n")
-    .filter(line => line.includes("ASSERTION FAILED") || line.includes("currentThreadIsHoldingAPILock"));
-  expect(assertionLines).toEqual([]);
-  // The backpressured frame is still delivered in full.
-  expect(stderr).toContain("3000 todo");
-  expect(stderr).toContain("-2999");
-  expect(stderr).toContain("2 pass");
-  expect(stderr).toContain("0 fail");
-  expect(exitCode).toBe(0);
-});
+// hold the JSC API lock like the ticks during the run; builds with JSC
+// assertions (debug and asan) otherwise print
+// "ASSERTION FAILED: currentThreadIsHoldingAPILock()" into the worker's
+// stderr, which the coordinator streams through. On Windows every frame takes
+// the async uv_write path so the drain loop runs on every worker exit; on
+// POSIX it only runs when a frame overflows the socketpair send buffer
+// (~208KB on Linux), hence the ~1MB todo repeat buffer. The 26 passes keep
+// the end-of-run repeat section printing (suppressed at <=20 passes), which
+// reprints the todo lines out of that backpressured frame on every build
+// flavor, so frame delivery is asserted even where assertions are compiled
+// out.
+test(
+  "--parallel: worker drains a backpressured final frame under the JSC API lock",
+  async () => {
+    using dir = tempDir("parallel-drain-lock", {
+      "big.test.js": `import {test} from "bun:test";
+        const pad = Buffer.alloc(340, "t").toString();
+        for (let i = 0; i < 3000; i++) test.todo(pad + "-" + i);
+        for (let i = 0; i < 25; i++) test("p" + i, () => {});`,
+      "other.test.js": `import {test,expect} from "bun:test"; test("b1",()=>expect(1).toBe(1));`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("PARALLEL");
+    // Filter instead of not.toContain so a failure prints the assertion lines,
+    // not the ~1MB of todo lines around them.
+    const assertionLines = stderr
+      .split("\n")
+      .filter(line => line.includes("ASSERTION FAILED") || line.includes("currentThreadIsHoldingAPILock"));
+    expect(assertionLines).toEqual([]);
+    // The backpressured RepeatBufs frame crossed the IPC intact: the last
+    // todo line appears exactly twice, streamed live and again in the
+    // end-of-run repeat section built from the frame.
+    expect(stderr).toContain("3000 tests todo:");
+    expect(stderr.split("-2999").length - 1).toBe(2);
+    expect(stderr).toContain("3000 todo");
+    expect(stderr).toContain("26 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  },
+  isASAN || isDebug ? 60_000 : 20_000,
+);
 
 test("--parallel --randomize without --seed is reproducible via the printed seed", async () => {
   const mk = (tag: string) =>


### PR DESCRIPTION
### Symptom

On Windows debug builds, every `bun test --parallel` worker prints a JSC assertion into stderr while exiting:

```
ASSERTION FAILED: currentThreadIsHoldingAPILock()
1  JSC::VM::finalizeSynchronousJSExecution
2  JSC__VM__releaseWeakRefs
3  bun_jsc::vm::VM::release_weak_refs
4  bun_jsc::event_loop::EventLoop::drain_microtasks_with_global
5  bun_jsc::event_loop::EventLoop::tick
6  bun_runtime::cli::test::parallel::runner::run_as_worker
```

The coordinator streams worker stderr through, so the trace lands in the run's output and breaks several tests in `test/cli/test/parallel.test.ts` on Windows debug builds ("aggregates totals" asserts stderr never mentions workers; the trace contains `run_as_worker`). The assertion is compiled out of release builds, but the missing lock is real on any build.

### Cause

After its last file, a worker flushes its aggregate frames (repeat buffers, junit/coverage chunks) and then ticks the event loop until the IPC backlog drains (`run_as_worker` in `src/runtime/cli/test/parallel/runner.rs`). That drain loop was the only tick site in the worker outside `run_with_api_lock`: `begin()` and `global_exit()` both hold the lock. Ticking drains microtasks and calls `JSC__VM__releaseWeakRefs`, which requires the API lock.

Why only Windows in practice: the worker IPC channel is a libuv named pipe there, and `uv_try_write` on a Windows pipe always returns `EAGAIN`, so every frame goes through an async `uv_write` and `has_pending_writes()` is true on every worker exit. On POSIX the socketpair write usually completes synchronously, so the drain loop only runs when a final frame overflows the send buffer (~208KB on Linux), e.g. a large todo/failure repeat buffer. Forcing that overflow reproduces the identical assertion on Linux debug builds.

### Fix

Wrap the drain loop in `run_with_api_lock`, matching the ticks inside `begin()` and the `global_exit` path.

### Verification

- New test in `test/cli/test/parallel.test.ts` builds a ~1MB todo repeat buffer so the final frame is backpressured on POSIX too (on Windows the drain loop runs regardless). The assertion check fails on an unfixed build wherever JSC assertions are compiled in (debug and asan builds; assertions default to `debug || asan`), and passes with the fix. The test runs on every build flavor: where assertions are compiled out it still verifies the backpressured frame was delivered, by requiring the end-of-run repeat section to reprint the last todo line (so that line appears exactly twice). Verified green on the unfixed release canary on both Linux and Windows, so it cannot false-fail on release lanes.
- On Windows debug at main, `bun bd test test/cli/test/parallel.test.ts -t "aggregates totals"` fails with the trace above (once per worker); with this change the full file passes except one pre-existing load-sensitive failure ("lazily scales workers") that fails identically on a clean main build on both Linux and Windows in this environment.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->