### PR TITLE
install: fix isolated-linker deadlock installing patched git/github dependencies in workspaces

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -32,7 +32,7 @@ use bun_collections::{
     ArrayHashMap, DynamicBitSet, DynamicBitSetList, DynamicBitSetUnmanaged, HashMap, LinearFifo,
     StringArrayHashMap,
 };
-use bun_core::{Environment, Global, Output, fast_random, fmt as bun_fmt};
+use bun_core::{Environment, Global, Output, fast_random, fmt as bun_fmt, strings};
 use bun_paths::path_options::AssumeOk as _;
 use bun_paths::{self as paths, AutoAbsPath as AbsPath, AutoRelPath, PathBuffer};
 use bun_semver as semver;
@@ -2356,37 +2356,61 @@ pub(crate) fn install_isolated_packages(
                     {
                         install::PreinstallState::Done => false,
                         _ => 'missing_from_cache: {
-                            if matches!(patch_info, installer::PatchInfo::None) {
-                                let exists = match pkg_res_tag {
-                                    ResolutionTag::Npm => {
-                                        // Reshaped for borrowck — capture length
-                                        // instead of `save()` so the path stays unborrowed.
-                                        let cache_dir_path_save = pkg_cache_dir_subpath.len();
-                                        pkg_cache_dir_subpath.append(b"package.json").assume_ok();
-                                        let exists = sys::exists_at(
-                                            cache_dir,
-                                            pkg_cache_dir_subpath.slice_z(),
-                                        );
-                                        pkg_cache_dir_subpath.set_length(cache_dir_path_save);
-                                        exists
-                                    }
-                                    _ => sys::directory_exists_at(
-                                        cache_dir,
-                                        pkg_cache_dir_subpath.slice_z(),
+                            // For a patched dependency the subpath ends in
+                            // `_patch_hash=<hash>`, but downloads only ever
+                            // extract the unpatched folder; the patched folder
+                            // is derived from it by `apply_package_patch`
+                            // below. Check for the unpatched folder here (like
+                            // the hoisted installer's
+                            // `package_missing_from_cache`): when the resolve
+                            // phase already downloaded this tarball,
+                            // re-enqueueing it would push this entry onto that
+                            // completed task's already-drained callback list
+                            // and hang the install.
+                            let full_len = pkg_cache_dir_subpath.len();
+                            if matches!(patch_info, installer::PatchInfo::Patch(_)) {
+                                let idx = strings::last_index_of(
+                                    pkg_cache_dir_subpath.slice(),
+                                    b"_patch_hash=",
+                                )
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "Patched dependency cache dir subpath does not have the \
+                                         \"_patch_hash=HASH\" suffix. This is a bug, please file \
+                                         a GitHub issue."
                                     )
-                                    .unwrap_or(false),
-                                };
-                                if exists {
-                                    installer.manager_mut().set_preinstall_state(
-                                        pkg_id,
-                                        install::PreinstallState::Done,
-                                    );
-                                }
-                                break 'missing_from_cache !exists;
+                                });
+                                pkg_cache_dir_subpath.set_length(idx);
                             }
-
-                            // TODO: why does this look like it will never work?
-                            break 'missing_from_cache true;
+                            let exists = match pkg_res_tag {
+                                // `Remove` also lands here: its subpath is
+                                // already the unpatched folder
+                                // (`contents_hash()` is None).
+                                ResolutionTag::Npm
+                                    if !matches!(patch_info, installer::PatchInfo::Patch(_)) =>
+                                {
+                                    // Reshaped for borrowck — capture length
+                                    // instead of `save()` so the path stays unborrowed.
+                                    let cache_dir_path_save = pkg_cache_dir_subpath.len();
+                                    pkg_cache_dir_subpath.append(b"package.json").assume_ok();
+                                    let exists =
+                                        sys::exists_at(cache_dir, pkg_cache_dir_subpath.slice_z());
+                                    pkg_cache_dir_subpath.set_length(cache_dir_path_save);
+                                    exists
+                                }
+                                _ => sys::directory_exists_at(
+                                    cache_dir,
+                                    pkg_cache_dir_subpath.slice_z(),
+                                )
+                                .unwrap_or(false),
+                            };
+                            pkg_cache_dir_subpath.set_length(full_len);
+                            if exists {
+                                installer
+                                    .manager_mut()
+                                    .set_preinstall_state(pkg_id, install::PreinstallState::Done);
+                            }
+                            break 'missing_from_cache !exists;
                         }
                     };
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2356,11 +2356,9 @@ pub(crate) fn install_isolated_packages(
                     {
                         install::PreinstallState::Done => false,
                         _ => 'missing_from_cache: {
-                            // Downloads only produce the unpatched folder
-                            // (`apply_package_patch` derives the `_patch_hash=`
-                            // one), so check for that. Re-enqueueing a tarball
-                            // the resolve phase already extracted deadlocks the
-                            // install (#37136).
+                            // Downloads only produce the unpatched folder;
+                            // re-enqueueing one the resolve phase already
+                            // extracted deadlocks the install (#37136).
                             if matches!(patch_info, installer::PatchInfo::Patch(_)) {
                                 let idx = strings::last_index_of(
                                     pkg_cache_dir_subpath.slice(),

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2356,18 +2356,11 @@ pub(crate) fn install_isolated_packages(
                     {
                         install::PreinstallState::Done => false,
                         _ => 'missing_from_cache: {
-                            // For a patched dependency the subpath ends in
-                            // `_patch_hash=<hash>`, but downloads only ever
-                            // extract the unpatched folder; the patched folder
-                            // is derived from it by `apply_package_patch`
-                            // below. Check for the unpatched folder here (like
-                            // the hoisted installer's
-                            // `package_missing_from_cache`): when the resolve
-                            // phase already downloaded this tarball,
-                            // re-enqueueing it would push this entry onto that
-                            // completed task's already-drained callback list
-                            // and hang the install.
-                            let full_len = pkg_cache_dir_subpath.len();
+                            // Downloads only produce the unpatched folder
+                            // (`apply_package_patch` derives the `_patch_hash=`
+                            // one), so check for that. Re-enqueueing a tarball
+                            // the resolve phase already extracted deadlocks the
+                            // install (#37136).
                             if matches!(patch_info, installer::PatchInfo::Patch(_)) {
                                 let idx = strings::last_index_of(
                                     pkg_cache_dir_subpath.slice(),
@@ -2383,9 +2376,7 @@ pub(crate) fn install_isolated_packages(
                                 pkg_cache_dir_subpath.set_length(idx);
                             }
                             let exists = match pkg_res_tag {
-                                // `Remove` also lands here: its subpath is
-                                // already the unpatched folder
-                                // (`contents_hash()` is None).
+                                // `Remove`'s subpath is already unpatched.
                                 ResolutionTag::Npm
                                     if !matches!(patch_info, installer::PatchInfo::Patch(_)) =>
                                 {
@@ -2404,7 +2395,6 @@ pub(crate) fn install_isolated_packages(
                                 )
                                 .unwrap_or(false),
                             };
-                            pkg_cache_dir_subpath.set_length(full_len);
                             if exists {
                                 installer
                                     .manager_mut()

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -788,7 +788,7 @@ test("adding and removing a patch for a github dependency in a workspace complet
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
     expect(err).not.toContain("error:");
     expect(exitCode).toBe(0);
   }
@@ -839,13 +839,143 @@ index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f
   await install();
   expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
 
+  // Cold cache with the patch still in the lockfile: the install phase itself
+  // downloads the tarball and applies the patch after extraction.
+  await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await rm(join(packageDir, "packages", "member", "node_modules"), { recursive: true, force: true });
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
+
   // Removing the patch re-resolves again and rebuilds the store entry from
   // the unpatched cache folder (the PatchInfo::Remove path, which hung the
   // same way).
   await write(packageJson, JSON.stringify(rootPackageJson));
   await install();
   expect(await installedIndexJs.text()).toBe('console.log("original");\n');
-}, 90_000);
+});
+
+// Same deadlock through the git: task-id space (clone + checkout tasks
+// instead of a tarball download). The repo is served over git's dumb HTTP
+// protocol: after `git update-server-info`, a bare repo is plain static
+// files.
+test("adding and removing a patch for a git dependency in a workspace completes", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  const srcDir = join(packageDir, "git-src");
+  const bareDir = join(packageDir, "repo.git");
+  // Isolate git from system/global config (e.g. core.autocrlf on Windows
+  // would rewrite the checked-out file contents this test asserts on).
+  const gitConfigEnv = {
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: join(packageDir, "gitconfig"),
+  };
+  const gitEnv = {
+    ...bunEnv,
+    ...gitConfigEnv,
+    GIT_AUTHOR_NAME: "bun-test",
+    GIT_AUTHOR_EMAIL: "test@bun.sh",
+    GIT_COMMITTER_NAME: "bun-test",
+    GIT_COMMITTER_EMAIL: "test@bun.sh",
+  };
+  async function git(args: string[], cwd: string): Promise<string> {
+    await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("fatal:");
+    expect(exitCode).toBe(0);
+    return out;
+  }
+
+  await write(join(packageDir, "gitconfig"), "[core]\n\tautocrlf = false\n");
+  await write(join(srcDir, "package.json"), JSON.stringify({ name: "git-dep", version: "1.0.0" }));
+  await write(join(srcDir, "index.js"), 'console.log("original");\n');
+  await git(["init", "-q"], srcDir);
+  await git(["add", "-A"], srcDir);
+  await git(["commit", "-qm", "init"], srcDir);
+  const sha = (await git(["rev-parse", "HEAD"], srcDir)).trim();
+  await git(["clone", "-q", "--bare", srcDir, bareDir], packageDir);
+  await git(["update-server-info"], bareDir);
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (!pathname.startsWith("/repo.git/")) return new Response("not found", { status: 404 });
+      const f = file(join(bareDir, pathname.slice("/repo.git/".length)));
+      return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
+    },
+  });
+  const repoUrl = `git+http://127.0.0.1:${server.port}/repo.git`;
+
+  const env = {
+    ...bunEnv,
+    ...gitConfigEnv,
+    BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+  };
+
+  async function install() {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  const rootPackageJson = {
+    name: "patched-git-workspace",
+    workspaces: ["packages/*"],
+  };
+  await write(packageJson, JSON.stringify(rootPackageJson));
+  await write(
+    join(packageDir, "packages", "member", "package.json"),
+    JSON.stringify({
+      name: "member",
+      version: "1.0.0",
+      dependencies: {
+        "git-dep": repoUrl,
+      },
+    }),
+  );
+  await write(
+    join(packageDir, "patches", "git-dep.patch"),
+    `diff --git a/index.js b/index.js
+index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1d 100644
+--- a/index.js
++++ b/index.js
+@@ -1 +1 @@
+-console.log("original");
++console.log("patched");
+`,
+  );
+
+  const installedIndexJs = file(join(packageDir, "packages", "member", "node_modules", "git-dep", "index.js"));
+
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("original");\n');
+
+  // The patchedDependencies key must carry the resolved commit; a key without
+  // it is silently ignored, which the patched-content assertion would catch.
+  await write(
+    packageJson,
+    JSON.stringify({
+      ...rootPackageJson,
+      patchedDependencies: {
+        [`git-dep@${repoUrl}#${sha}`]: "patches/git-dep.patch",
+      },
+    }),
+  );
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
+
+  await write(packageJson, JSON.stringify(rootPackageJson));
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("original");\n');
+});
 
 for (const backend of ["clonefile", "hardlink", "copyfile"]) {
   test(`isolated install with backend: ${backend}`, async () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -730,89 +730,87 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
 // re-enqueued the same tarball task and parked the store entry on the
 // completed task's already-drained callback list, so the pending-task count
 // never reached zero.
-test(
-  "adding and removing a patch for a github dependency in a workspace completes",
-  async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+test("adding and removing a patch for a github dependency in a workspace completes", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
-    // Minimal gzipped tarball shaped like a github codeload tarball: a single
-    // root directory wrapping the package contents.
-    function tarHeader(name: string, size: number, isDir: boolean): Uint8Array {
-      const header = new Uint8Array(512);
-      const encoder = new TextEncoder();
-      header.set(encoder.encode(name), 0);
-      header.set(encoder.encode(isDir ? "0000755 " : "0000644 "), 100);
-      header.set(encoder.encode("0000000 "), 108);
-      header.set(encoder.encode("0000000 "), 116);
-      header.set(encoder.encode(size.toString(8).padStart(11, "0") + " "), 124);
-      header.set(encoder.encode("00000000000 "), 136);
-      header.set(encoder.encode("        "), 148);
-      header[156] = (isDir ? "5" : "0").charCodeAt(0);
-      header.set(encoder.encode("ustar"), 257);
-      header.set(encoder.encode("00"), 263);
-      let checksum = 0;
-      for (const byte of header) checksum += byte;
-      header.set(encoder.encode(checksum.toString(8).padStart(6, "0") + "\0 "), 148);
-      return header;
-    }
-    const blocks: Uint8Array[] = [];
-    blocks.push(tarHeader("testowner-testrepo-aaaaaaa/", 0, true));
-    for (const [name, contents] of [
-      ["package.json", JSON.stringify({ name: "gh-dep", version: "1.0.0" })],
-      ["index.js", 'console.log("original");\n'],
-    ]) {
-      const bytes = new TextEncoder().encode(contents);
-      blocks.push(tarHeader(`testowner-testrepo-aaaaaaa/${name}`, bytes.length, false));
-      blocks.push(bytes);
-      if (bytes.length % 512 !== 0) blocks.push(new Uint8Array(512 - (bytes.length % 512)));
-    }
-    blocks.push(new Uint8Array(1024));
-    const tarball = Bun.gzipSync(Buffer.concat(blocks));
+  // Minimal gzipped tarball shaped like a github codeload tarball: a single
+  // root directory wrapping the package contents.
+  function tarHeader(name: string, size: number, isDir: boolean): Uint8Array {
+    const header = new Uint8Array(512);
+    const encoder = new TextEncoder();
+    header.set(encoder.encode(name), 0);
+    header.set(encoder.encode(isDir ? "0000755 " : "0000644 "), 100);
+    header.set(encoder.encode("0000000 "), 108);
+    header.set(encoder.encode("0000000 "), 116);
+    header.set(encoder.encode(size.toString(8).padStart(11, "0") + " "), 124);
+    header.set(encoder.encode("00000000000 "), 136);
+    header.set(encoder.encode("        "), 148);
+    header[156] = (isDir ? "5" : "0").charCodeAt(0);
+    header.set(encoder.encode("ustar"), 257);
+    header.set(encoder.encode("00"), 263);
+    let checksum = 0;
+    for (const byte of header) checksum += byte;
+    header.set(encoder.encode(checksum.toString(8).padStart(6, "0") + "\0 "), 148);
+    return header;
+  }
+  const blocks: Uint8Array[] = [];
+  blocks.push(tarHeader("testowner-testrepo-aaaaaaa/", 0, true));
+  for (const [name, contents] of [
+    ["package.json", JSON.stringify({ name: "gh-dep", version: "1.0.0" })],
+    ["index.js", 'console.log("original");\n'],
+  ]) {
+    const bytes = new TextEncoder().encode(contents);
+    blocks.push(tarHeader(`testowner-testrepo-aaaaaaa/${name}`, bytes.length, false));
+    blocks.push(bytes);
+    if (bytes.length % 512 !== 0) blocks.push(new Uint8Array(512 - (bytes.length % 512)));
+  }
+  blocks.push(new Uint8Array(1024));
+  const tarball = Bun.gzipSync(Buffer.concat(blocks));
 
-    using server = Bun.serve({
-      port: 0,
-      fetch: () => new Response(tarball, { headers: { "Content-Type": "application/gzip" } }),
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(tarball, { headers: { "Content-Type": "application/gzip" } }),
+  });
+
+  const env = {
+    ...bunEnv,
+    GITHUB_API_URL: `http://localhost:${server.port}`,
+    // CI exports BUN_INSTALL_CACHE_DIR; pin it so this test's cache state is
+    // its own.
+    BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+  };
+
+  async function install() {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
     });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
 
-    const env = {
-      ...bunEnv,
-      GITHUB_API_URL: `http://localhost:${server.port}`,
-      // CI exports BUN_INSTALL_CACHE_DIR; pin it so this test's cache state is
-      // its own.
-      BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
-    };
-
-    async function install() {
-      await using proc = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(err).not.toContain("error:");
-      expect(exitCode).toBe(0);
-    }
-
-    const rootPackageJson = {
-      name: "patched-github-workspace",
-      workspaces: ["packages/*"],
-    };
-    await write(packageJson, JSON.stringify(rootPackageJson));
-    await write(
-      join(packageDir, "packages", "member", "package.json"),
-      JSON.stringify({
-        name: "member",
-        version: "1.0.0",
-        dependencies: {
-          "gh-dep": "github:testowner/testrepo#aaaaaaa",
-        },
-      }),
-    );
-    await write(
-      join(packageDir, "patches", "gh-dep.patch"),
-      `diff --git a/index.js b/index.js
+  const rootPackageJson = {
+    name: "patched-github-workspace",
+    workspaces: ["packages/*"],
+  };
+  await write(packageJson, JSON.stringify(rootPackageJson));
+  await write(
+    join(packageDir, "packages", "member", "package.json"),
+    JSON.stringify({
+      name: "member",
+      version: "1.0.0",
+      dependencies: {
+        "gh-dep": "github:testowner/testrepo#aaaaaaa",
+      },
+    }),
+  );
+  await write(
+    join(packageDir, "patches", "gh-dep.patch"),
+    `diff --git a/index.js b/index.js
 index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1d 100644
 --- a/index.js
 +++ b/index.js
@@ -820,36 +818,34 @@ index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f
 -console.log("original");
 +console.log("patched");
 `,
-    );
+  );
 
-    const installedIndexJs = file(join(packageDir, "packages", "member", "node_modules", "gh-dep", "index.js"));
+  const installedIndexJs = file(join(packageDir, "packages", "member", "node_modules", "gh-dep", "index.js"));
 
-    await install();
-    expect(await installedIndexJs.text()).toBe('console.log("original");\n');
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("original");\n');
 
-    // Adding the patch triggers a re-resolution; this install hung forever
-    // before the fix.
-    await write(
-      packageJson,
-      JSON.stringify({
-        ...rootPackageJson,
-        patchedDependencies: {
-          "gh-dep@github:testowner/testrepo#aaaaaaa": "patches/gh-dep.patch",
-        },
-      }),
-    );
-    await install();
-    expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
+  // Adding the patch triggers a re-resolution; this install hung forever
+  // before the fix.
+  await write(
+    packageJson,
+    JSON.stringify({
+      ...rootPackageJson,
+      patchedDependencies: {
+        "gh-dep@github:testowner/testrepo#aaaaaaa": "patches/gh-dep.patch",
+      },
+    }),
+  );
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
 
-    // Removing the patch re-resolves again and rebuilds the store entry from
-    // the unpatched cache folder (the PatchInfo::Remove path, which hung the
-    // same way).
-    await write(packageJson, JSON.stringify(rootPackageJson));
-    await install();
-    expect(await installedIndexJs.text()).toBe('console.log("original");\n');
-  },
-  90_000,
-);
+  // Removing the patch re-resolves again and rebuilds the store entry from
+  // the unpatched cache folder (the PatchInfo::Remove path, which hung the
+  // same way).
+  await write(packageJson, JSON.stringify(rootPackageJson));
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("original");\n');
+}, 90_000);
 
 for (const backend of ["clonefile", "hardlink", "copyfile"]) {
   test(`isolated install with backend: ${backend}`, async () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -724,6 +724,133 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
   await checkInstall();
 });
 
+// Adding a patchedDependencies entry for a github: dependency of a workspace
+// member deadlocked `bun install` forever with the isolated linker:
+// re-resolution re-downloaded the github tarball, and the install phase then
+// re-enqueued the same tarball task and parked the store entry on the
+// completed task's already-drained callback list, so the pending-task count
+// never reached zero.
+test(
+  "adding and removing a patch for a github dependency in a workspace completes",
+  async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    // Minimal gzipped tarball shaped like a github codeload tarball: a single
+    // root directory wrapping the package contents.
+    function tarHeader(name: string, size: number, isDir: boolean): Uint8Array {
+      const header = new Uint8Array(512);
+      const encoder = new TextEncoder();
+      header.set(encoder.encode(name), 0);
+      header.set(encoder.encode(isDir ? "0000755 " : "0000644 "), 100);
+      header.set(encoder.encode("0000000 "), 108);
+      header.set(encoder.encode("0000000 "), 116);
+      header.set(encoder.encode(size.toString(8).padStart(11, "0") + " "), 124);
+      header.set(encoder.encode("00000000000 "), 136);
+      header.set(encoder.encode("        "), 148);
+      header[156] = (isDir ? "5" : "0").charCodeAt(0);
+      header.set(encoder.encode("ustar"), 257);
+      header.set(encoder.encode("00"), 263);
+      let checksum = 0;
+      for (const byte of header) checksum += byte;
+      header.set(encoder.encode(checksum.toString(8).padStart(6, "0") + "\0 "), 148);
+      return header;
+    }
+    const blocks: Uint8Array[] = [];
+    blocks.push(tarHeader("testowner-testrepo-aaaaaaa/", 0, true));
+    for (const [name, contents] of [
+      ["package.json", JSON.stringify({ name: "gh-dep", version: "1.0.0" })],
+      ["index.js", 'console.log("original");\n'],
+    ]) {
+      const bytes = new TextEncoder().encode(contents);
+      blocks.push(tarHeader(`testowner-testrepo-aaaaaaa/${name}`, bytes.length, false));
+      blocks.push(bytes);
+      if (bytes.length % 512 !== 0) blocks.push(new Uint8Array(512 - (bytes.length % 512)));
+    }
+    blocks.push(new Uint8Array(1024));
+    const tarball = Bun.gzipSync(Buffer.concat(blocks));
+
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(tarball, { headers: { "Content-Type": "application/gzip" } }),
+    });
+
+    const env = {
+      ...bunEnv,
+      GITHUB_API_URL: `http://localhost:${server.port}`,
+      // CI exports BUN_INSTALL_CACHE_DIR; pin it so this test's cache state is
+      // its own.
+      BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+    };
+
+    async function install() {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    const rootPackageJson = {
+      name: "patched-github-workspace",
+      workspaces: ["packages/*"],
+    };
+    await write(packageJson, JSON.stringify(rootPackageJson));
+    await write(
+      join(packageDir, "packages", "member", "package.json"),
+      JSON.stringify({
+        name: "member",
+        version: "1.0.0",
+        dependencies: {
+          "gh-dep": "github:testowner/testrepo#aaaaaaa",
+        },
+      }),
+    );
+    await write(
+      join(packageDir, "patches", "gh-dep.patch"),
+      `diff --git a/index.js b/index.js
+index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1d 100644
+--- a/index.js
++++ b/index.js
+@@ -1 +1 @@
+-console.log("original");
++console.log("patched");
+`,
+    );
+
+    const installedIndexJs = file(join(packageDir, "packages", "member", "node_modules", "gh-dep", "index.js"));
+
+    await install();
+    expect(await installedIndexJs.text()).toBe('console.log("original");\n');
+
+    // Adding the patch triggers a re-resolution; this install hung forever
+    // before the fix.
+    await write(
+      packageJson,
+      JSON.stringify({
+        ...rootPackageJson,
+        patchedDependencies: {
+          "gh-dep@github:testowner/testrepo#aaaaaaa": "patches/gh-dep.patch",
+        },
+      }),
+    );
+    await install();
+    expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
+
+    // Removing the patch re-resolves again and rebuilds the store entry from
+    // the unpatched cache folder (the PatchInfo::Remove path, which hung the
+    // same way).
+    await write(packageJson, JSON.stringify(rootPackageJson));
+    await install();
+    expect(await installedIndexJs.text()).toBe('console.log("original");\n');
+  },
+  90_000,
+);
+
 for (const backend of ["clonefile", "hardlink", "copyfile"]) {
   test(`isolated install with backend: ${backend}`, async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -858,8 +858,9 @@ index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f
 // Same deadlock through the git: task-id space (clone + checkout tasks
 // instead of a tarball download). The repo is served over git's dumb HTTP
 // protocol: after `git update-server-info`, a bare repo is plain static
-// files.
-test("adding and removing a patch for a git dependency in a workspace completes", async () => {
+// files. Requires the git executable to build the fixture repository.
+const gitExecutable = Bun.which("git");
+test.skipIf(!gitExecutable)("adding and removing a patch for a git dependency in a workspace completes", async () => {
   const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
   const srcDir = join(packageDir, "git-src");
@@ -879,7 +880,7 @@ test("adding and removing a patch for a git dependency in a workspace completes"
     GIT_COMMITTER_EMAIL: "test@bun.sh",
   };
   async function git(args: string[], cwd: string): Promise<string> {
-    await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+    await using proc = spawn({ cmd: [gitExecutable!, ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).not.toContain("fatal:");
     expect(exitCode).toBe(0);
@@ -969,6 +970,14 @@ index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f
       },
     }),
   );
+  await install();
+  expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
+
+  // Cold cache with the patch still in the lockfile: the install phase
+  // clones and checks out itself, applying the patch after the checkout.
+  await rm(join(packageDir, ".bun-cache"), { recursive: true, force: true });
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await rm(join(packageDir, "packages", "member", "node_modules"), { recursive: true, force: true });
   await install();
   expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
 


### PR DESCRIPTION
### Symptom

`bun install` hangs forever (no output after `Resolved, downloaded and extracted [N]`, main thread asleep in the event loop) when all of the following hold:

- the project is a workspace,
- `patchedDependencies` has an entry for a `github:` (or `git:`) dependency of a workspace member,
- the isolated linker is in use (the `configVersion: 1` default).

No `bun patch` commands are involved; a plain `bun install` after adding the `patchedDependencies` entry deadlocks. The same project completes with `--linker hoisted`. Reproduced on `1.4.0-canary.1 (0ffabf64d)` for both the `github:` and `git:` protocols. This is the hang documented as a known limitation in #37124 (the internal reinstall run by `bun patch --commit` reaches it the same way).

Repro (offline, fake GitHub API):

1. Serve any tgz with a single root folder (package.json name `gh-dep`) from a local HTTP server, set `GITHUB_API_URL=http://localhost:PORT` and a fresh `BUN_INSTALL_CACHE_DIR`.
2. Workspace root `{"name":"ws-root","workspaces":["packages/*"]}`; member depends on `"gh-dep": "github:testowner/testrepo#aaaaaaa"`. `bun install --linker isolated` succeeds.
3. Add `"patchedDependencies": {"gh-dep@github:testowner/testrepo#aaaaaaa": "patches/gh-dep.patch"}` to the root and run `bun install --linker isolated` again: hangs forever. Removing an existing entry hangs the same way.

### Cause

Adding (or removing) the patch entry triggers a re-resolution. The member's github dependency misses `lockfile.get_package_id` during re-resolution (the re-parsed version's `package_name` is still empty, so the lookup uses the wrong name hash) and the resolve phase re-downloads the tarball, registering it in `task_queue` and `network_dedupe_map` under `Task::Id::for_tarball(url)`. When the extract completes in the resolve phase its callback list is drained, but the (now empty) `task_queue` entry and the dedupe entry stay behind. The extract appends a transient duplicate package and marks that id `Done`, while the dependency ends up resolved to the original package, whose preinstall state stays `Unknown` through the lockfile clean. (The duplicate itself is in-memory only; the clean prunes it, so `bun.lock` stays correct. The redundant re-download on re-resolution is an upstream inefficiency tracked separately.)

The isolated install loop then hits this in `install_isolated_packages` (`src/install/isolated_install.rs`):

```rust
// TODO: why does this look like it will never work?
break 'missing_from_cache true;
```

Every patched package whose preinstall state is not `Done` was unconditionally treated as missing from the cache, so the installer called `enqueue_tarball_for_download` for the same URL the resolve phase already downloaded. `task_queue.get_or_put` found the stale entry (`found_existing`), pushed the store entry's install context onto the already-drained callback list, and returned without scheduling anything. That context is never drained, the entry's pending-task slot never releases, and `Wait::is_done` spins on `pending_task_count() > 0` forever.

`git:` dependencies deadlock the same way through their own task-id space: the isolated installer enqueues them via `enqueue_git_for_checkout`, which parks the entry context on the resolve phase's completed checkout task and returns.

The hoisted installer is structurally immune: its `package_missing_from_cache` checks the cache for the **unpatched** folder (the patched `_patch_hash=<hash>` folder is always derived locally from it), so it never re-requests a tarball the resolve phase already extracted.

### Fix

Give the isolated loop the same cache check the hoisted installer has, replacing the `break true`:

- `PatchInfo::Patch`: strip the `_patch_hash=<hash>` suffix and check for the unpatched cache folder. If present, mark the package `Done` and fall through to the existing path that runs `apply_package_patch` (which builds the patched folder from the unpatched one) and starts the store task. Only enqueue a download when the unpatched folder is genuinely absent, in which case no stale resolve-phase task can exist for that URL (a failed resolve-phase download removes its `task_queue` entry and marks the dedupe entry failed, which surfaces as an install error rather than a hang).
- `PatchInfo::Remove`: its computed subpath is already the unpatched folder (`contents_hash()` is `None`), so it now uses the same existence check as unpatched packages instead of always re-downloading. This also fixes the identical hang when removing a patch entry.

This also stops isolated installs from re-downloading patched npm tarballs that are already extracted in the cache.

### Verification

Two new tests in `test/cli/install/isolated-install.test.ts`, both asserting patched/unpatched file contents across install -> add patch -> install -> remove patch -> install:

- `adding and removing a patch for a github dependency in a workspace completes`: fake GitHub API via `Bun.serve` with a hand-built tarball. Includes a cold-cache leg while the patch is active (cache and node_modules wiped, patch still in the lockfile), which exercises the other half of the fix: the install phase downloads the tarball itself and applies the patch after extraction.
- `adding and removing a patch for a git dependency in a workspace completes`: a real local repository served over git's dumb HTTP protocol (`git update-server-info` + static file serving), covering the `git:` clone/checkout task path.

On unfixed bun each variant deadlocks at the add-patch install until the test times out; with the fix both run in under a second.

- `bun bd test test/cli/install/isolated-install.test.ts`: 64 pass
- `bun bd test test/cli/install/bun-install-patch.test.ts`: 18 pass
- `bun bd test test/cli/install/bun-patch.test.ts`: 31 pass

Also verified manually against the shell repros: add/remove/re-add patch, cold-cache install from a patched lockfile, and warm-cache reinstall all complete on isolated and hoisted, with patched content where expected.

Two related pre-existing issues reproduce on released bun without this change and are tracked separately: the re-resolution re-download of git/github dependencies described above, and an isolated-linker staleness where re-adding a previously removed patch is skipped as "no changes" because a stale `.bun-tag-<hash>` marker survives the store entry rebuild.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->