### PR TITLE
install: remove files deleted from a folder dependency on reinstall with the isolated linker

### DIFF
--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -910,17 +910,16 @@ impl Task {
                             // linker's uninstall-before-install. (Lifecycle
                             // scripts re-run on every install for folder
                             // entries, so artifacts they write are recreated.)
-                            //
-                            // Root entries only reach LinkPackage as a
-                            // dependency on the root package (`"x": "file:."`);
-                            // for those `append_store_path` yields the store
-                            // entry's package dir, never the project dir.
-                            debug_assert!(
-                                pkg_res.tag != ResolutionTag::Root
-                                    || dep_id != invalid_dependency_id
-                            );
                             let mut prev_build = AutoPath::init_top_level_dir();
+                            let top_level_len = prev_build.len();
                             installer.append_store_path(&mut prev_build, self.entry_id);
+                            // `append_store_path` appends the entry's package
+                            // dir for everything that reaches LinkPackage
+                            // (Root entries only reach it as a dependency on
+                            // the root package, `"x": "file:."`). Release-mode
+                            // assert: through an unextended path the delete
+                            // below would remove the project directory itself.
+                            assert!(prev_build.len() > top_level_len);
                             if let Some(e) = Fd::cwd().delete_tree(prev_build.slice()).err() {
                                 return Ok(Yield::failure(TaskError::LinkPackage(e)));
                             }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -902,6 +902,29 @@ impl Task {
                             };
                             let _folder_dir_guard = sys::CloseOnDrop::new(folder_dir);
 
+                            // The hardlink/copy walk below only visits names
+                            // present in the source folder, so rebuilding in
+                            // place merges: a file deleted from the folder
+                            // dependency would survive in the store entry
+                            // forever. Delete to replace, matching the hoisted
+                            // linker's uninstall-before-install. (Lifecycle
+                            // scripts re-run on every install for folder
+                            // entries, so artifacts they write are recreated.)
+                            //
+                            // Root entries only reach LinkPackage as a
+                            // dependency on the root package (`"x": "file:."`);
+                            // for those `append_store_path` yields the store
+                            // entry's package dir, never the project dir.
+                            debug_assert!(
+                                pkg_res.tag != ResolutionTag::Root
+                                    || dep_id != invalid_dependency_id
+                            );
+                            let mut prev_build = AutoPath::init_top_level_dir();
+                            installer.append_store_path(&mut prev_build, self.entry_id);
+                            if let Some(e) = Fd::cwd().delete_tree(prev_build.slice()).err() {
+                                return Ok(Yield::failure(TaskError::LinkPackage(e)));
+                            }
+
                             let mut backend = InstallMethod::Hardlink;
                             'backend: loop {
                                 match backend {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -903,22 +903,16 @@ impl Task {
                             let _folder_dir_guard = sys::CloseOnDrop::new(folder_dir);
 
                             // The hardlink/copy walk below only visits names
-                            // present in the source folder, so rebuilding in
-                            // place merges: a file deleted from the folder
-                            // dependency would survive in the store entry
-                            // forever. Delete to replace, matching the hoisted
-                            // linker's uninstall-before-install. (Lifecycle
-                            // scripts re-run on every install for folder
-                            // entries, so artifacts they write are recreated.)
+                            // in the source folder, so rebuilding in place
+                            // merges: a file deleted from the folder
+                            // dependency would survive every reinstall.
+                            // Delete to replace, like the hoisted linker's
+                            // uninstall-before-install.
                             let mut prev_build = AutoPath::init_top_level_dir();
                             let top_level_len = prev_build.len();
                             installer.append_store_path(&mut prev_build, self.entry_id);
-                            // `append_store_path` appends the entry's package
-                            // dir for everything that reaches LinkPackage
-                            // (Root entries only reach it as a dependency on
-                            // the root package, `"x": "file:."`). Release-mode
-                            // assert: through an unextended path the delete
-                            // below would remove the project directory itself.
+                            // Unextended = the project dir itself; never
+                            // delete that.
                             assert!(prev_build.len() > top_level_len);
                             if let Some(e) = Fd::cwd().delete_tree(prev_build.slice()).err() {
                                 return Ok(Yield::failure(TaskError::LinkPackage(e)));

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -908,14 +908,18 @@ impl Task {
                             // dependency would survive every reinstall.
                             // Delete to replace, like the hoisted linker's
                             // uninstall-before-install.
-                            let mut prev_build = AutoPath::init_top_level_dir();
-                            let top_level_len = prev_build.len();
-                            installer.append_store_path(&mut prev_build, self.entry_id);
-                            // Unextended = the project dir itself; never
-                            // delete that.
-                            assert!(prev_build.len() > top_level_len);
-                            if let Some(e) = Fd::cwd().delete_tree(prev_build.slice()).err() {
-                                return Ok(Yield::failure(TaskError::LinkPackage(e)));
+                            //
+                            // To be safe only delete inside the store: a Root
+                            // entry that is not a dependency on the root
+                            // package has the project dir as its store path.
+                            if pkg_res.tag == ResolutionTag::Folder
+                                || dep_id != invalid_dependency_id
+                            {
+                                let mut prev_build = AutoPath::init_top_level_dir();
+                                installer.append_store_path(&mut prev_build, self.entry_id);
+                                if let Some(e) = Fd::cwd().delete_tree(prev_build.slice()).err() {
+                                    return Ok(Yield::failure(TaskError::LinkPackage(e)));
+                                }
                             }
 
                             let mut backend = InstallMethod::Hardlink;

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -385,6 +385,47 @@ test("file deleted from a folder dependency is removed on reinstall", async () =
   ).toMatchObject({ name: "no-deps", version: "1.0.0" });
 });
 
+test("missing folder dependency source fails without destroying the previous build", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-folder-dep-missing-source",
+        dependencies: {
+          "folder-dep": "file:./pkg-1",
+        },
+      }),
+    ),
+    write(join(packageDir, "pkg-1", "package.json"), JSON.stringify({ name: "folder-dep", version: "1.0.0" })),
+    write(join(packageDir, "pkg-1", "index.js"), "module.exports = 1;"),
+  ]);
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const storeIndex = join(
+    packageDir,
+    "node_modules",
+    ".bun",
+    "folder-dep@file+pkg-1",
+    "node_modules",
+    "folder-dep",
+    "index.js",
+  );
+  expect(await file(storeIndex).exists()).toBe(true);
+
+  // The relink opens the source folder before deleting the previous build,
+  // so a missing source fails the install but keeps the old build intact.
+  await rm(join(packageDir, "pkg-1"), { recursive: true });
+  await runBunInstall(bunEnv, packageDir, { allowErrors: true, expectedExitCode: 1, savesLockfile: false });
+
+  expect(await file(storeIndex).exists()).toBe(true);
+  expect(readlinkSync(join(packageDir, "node_modules", "folder-dep"))).toBe(
+    join(".bun", "folder-dep@file+pkg-1", "node_modules", "folder-dep"),
+  );
+});
+
 test("can install folder dependencies on root package", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
@@ -408,6 +449,7 @@ test("can install folder dependencies on root package", async () => {
         },
       }),
     ),
+    write(join(packageDir, "extra.js"), "module.exports = 1;"),
   ]);
 
   await runBunInstall(bunEnv, packageDir);
@@ -423,6 +465,24 @@ test("can install folder dependencies on root package", async () => {
     join("..", "..", "..", "node_modules", ".bun", "root-file-dep@root", "node_modules", "root-file-dep"),
     await file(packageJson).json(),
   ]);
+
+  // The root-as-dependency store entry also rebuilds from the project dir on
+  // every install; a file deleted from the project must not survive in it,
+  // and the rebuild must not touch the project's own files.
+  expect(await file(join(packageDir, "node_modules", "self", "extra.js")).exists()).toBe(true);
+
+  await rm(join(packageDir, "extra.js"));
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect(await file(join(packageDir, "node_modules", "self", "extra.js")).exists()).toBe(false);
+  expect(await file(packageJson).exists()).toBe(true);
+  expect(await file(join(packageDir, "packages", "pkg1", "package.json")).exists()).toBe(true);
+  expect(readlinkSync(join(packageDir, "node_modules", "self"))).toBe(
+    join(".bun", "root-file-dep@root", "node_modules", "root-file-dep"),
+  );
+  expect(await file(join(packageDir, "node_modules", "self", "package.json")).json()).toEqual(
+    await file(packageJson).json(),
+  );
 });
 
 describe("isolated workspaces", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -327,6 +327,64 @@ test("can install folder dependencies", async () => {
   ).toBe("module.exports = 'hello from pkg-1';");
 });
 
+test("file deleted from a folder dependency is removed on reinstall", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-folder-dep-prune",
+        dependencies: {
+          "folder-dep": "file:./pkg-1",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "pkg-1", "package.json"),
+      JSON.stringify({
+        name: "folder-dep",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    ),
+    write(join(packageDir, "pkg-1", "index.js"), "module.exports = 1;"),
+    write(join(packageDir, "pkg-1", "extra.js"), "module.exports = 2;"),
+    write(join(packageDir, "pkg-1", "nested", "inner.js"), "module.exports = 3;"),
+  ]);
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const installedDep = join(packageDir, "node_modules", "folder-dep");
+  expect(await file(join(installedDep, "extra.js")).exists()).toBe(true);
+  expect(await file(join(installedDep, "nested", "inner.js")).exists()).toBe(true);
+
+  // The store entry rebuilds from the source folder on every install, so a
+  // file or directory deleted from the source must not survive the rebuild.
+  await Promise.all([
+    rm(join(packageDir, "pkg-1", "extra.js")),
+    rm(join(packageDir, "pkg-1", "nested"), { recursive: true }),
+    write(join(packageDir, "pkg-1", "index.js"), "module.exports = 'updated';"),
+  ]);
+
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect(await file(join(installedDep, "extra.js")).exists()).toBe(false);
+  expect(existsSync(join(installedDep, "nested"))).toBe(false);
+  expect(await file(join(installedDep, "index.js")).text()).toBe("module.exports = 'updated';");
+
+  // The rebuild replaces only the package dir inside the store entry; the
+  // entry's dependency symlinks still resolve.
+  expect(readlinkSync(join(packageDir, "node_modules", "folder-dep"))).toBe(
+    join(".bun", "folder-dep@file+pkg-1", "node_modules", "folder-dep"),
+  );
+  expect(
+    await file(
+      join(packageDir, "node_modules", ".bun", "folder-dep@file+pkg-1", "node_modules", "no-deps", "package.json"),
+    ).json(),
+  ).toMatchObject({ name: "no-deps", version: "1.0.0" });
+});
+
 test("can install folder dependencies on root package", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 


### PR DESCRIPTION
## Repro

```console
$ cat package.json
{"dependencies":{"local":"file:./local-pkg"}}
$ cat bunfig.toml
[install]
linker = "isolated"
$ ls local-pkg
foo.js  index.js  package.json
$ bun install && ls node_modules/local
foo.js  index.js  package.json
$ rm local-pkg/foo.js
$ bun install && ls node_modules/local
foo.js  index.js  package.json   # foo.js is back from the dead, on every install
```

With `linker = "hoisted"` the second install correctly removes `node_modules/local/foo.js`.

## Cause

The isolated linker relinks folder (`file:`) dependencies on every install to keep them up to date. The `LinkPackage` step's `Folder | Root` arm (`src/install/isolated_install/Installer.rs`) rebuilds the store entry by walking the source folder with `Hardlinker`/`FileCopier`, which only visits names present in the source: existing destination files are overwritten, but files that exist only in the destination are never touched. So the rebuild merges over the previous build, and a file deleted from the dependency's folder survives in `node_modules/.bun/<name>@file+<path>/node_modules/<name>` forever.

The hoisted linker runs `uninstall_before_install` (delete, then copy) for the same case, so the two linkers diverged.

## Fix

Delete the store entry's package directory before the walk, once per relink, after the source folder has been opened (a missing source still fails without destroying the previous build). Only the package directory inside the entry is removed; the entry's `node_modules` siblings (dependency symlinks) are left for the later steps, which re-run on every install for folder entries.

This matches hoisted semantics for lifecycle scripts too: both linkers re-run a folder dependency's scripts on every install, and hoisted already wipes the destination first, so artifacts scripts write into the package directory are recreated the same way under both linkers.

Root resolutions reach this arm only as a dependency on the root package (`"x": "file:."`), where `append_store_path` yields the store entry's package dir. The delete is additionally scoped by resolution tag, the same way `on_task_fail` guards its cleanup delete: a Root entry that is not a dependency on the root package (whose store path is the project dir itself) never reaches it, in release builds too.

Same defect class as #37137 (npm/git/tarball arm of the same step); the two changes are in different arms and independent.

## Verification

Tests in `test/cli/install/isolated-install.test.ts` cover a deleted file, a deleted nested directory, a modified file, and that the entry's dependency symlinks still resolve after the rebuild; the root-as-dependency case (`"self": "file:."`) reinstalling over an existing build with a file deleted from the project (and the project's own files untouched); and that a folder dependency whose source folder disappeared fails the install while the previous build and the `node_modules` symlink survive. It fails on bun 1.4.0-canary.1 (`extra.js` still exists after reinstall) and passes with this change. All 63 tests in the file pass, as does `bun-install-hardlink-fallback.test.ts` (exercises the copyfile fallback in the same arm).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->