### PR TITLE
Keep CompressionStream's native coder alive during in-flight off-thread transforms

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.h
@@ -35,11 +35,10 @@ public:
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM&);
 
-    // the Rust CompressionStreamCoder. The cell's reference is released eagerly at
-    // ClearAlgorithms (post-flush / error / cancel); a vm.heap.addFinalizer registered
-    // in the constructor is the idempotent fallback for an abandoned stream. An
-    // in-flight off-thread transform holds its own reference, so the finalizer running
-    // at VM teardown (lastChanceToFinalize) cannot free the coder under the pool thread.
+    // the Rust CompressionStreamCoder, refcounted (ownership rules on its
+    // `ref_count` field). This cell's reference is released eagerly at
+    // ClearAlgorithms (post-flush / error / cancel); a vm.heap.addFinalizer
+    // registered in the constructor is the idempotent fallback.
     void* m_coder { nullptr };
 
 private:

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.h
@@ -35,9 +35,11 @@ public:
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM&);
 
-    // the Rust CompressionStreamCoder. Freed eagerly at ClearAlgorithms (post-flush /
-    // error / cancel); a vm.heap.addFinalizer registered in the constructor is the
-    // idempotent fallback for an abandoned stream.
+    // the Rust CompressionStreamCoder. The cell's reference is released eagerly at
+    // ClearAlgorithms (post-flush / error / cancel); a vm.heap.addFinalizer registered
+    // in the constructor is the idempotent fallback for an abandoned stream. An
+    // in-flight off-thread transform holds its own reference, so the finalizer running
+    // at VM teardown (lastChanceToFinalize) cannot free the coder under the pool thread.
     void* m_coder { nullptr };
 
 private:

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -7,8 +7,7 @@
 
 // CompressionStreamCoder.rs
 extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress);
-// Releases the cell's reference; the coder is freed once no in-flight async
-// transform holds one either.
+// Releases the cell's reference (in-flight async transforms hold their own).
 extern "C" void CompressionStreamCoder__destroy(void* coder);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr);

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -7,6 +7,8 @@
 
 // CompressionStreamCoder.rs
 extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress);
+// Releases the cell's reference; the coder is freed once no in-flight async
+// transform holds one either.
 extern "C" void CompressionStreamCoder__destroy(void* coder);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr);

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -11,6 +11,7 @@
 
 use core::ffi::c_int;
 use core::ptr::{self, NonNull};
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::work_task::{WorkTask, WorkTaskContext};
@@ -74,6 +75,12 @@ enum Backend {
 
 pub struct CompressionStreamCoder {
     backend: Backend,
+    /// Shared-ownership count: 1 for the JS cell (released by its finalizer /
+    /// `nativeTransformReleaseState` via `__destroy`), plus 1 per in-flight
+    /// `CompressionAsyncCtx`. VM teardown (`lastChanceToFinalize`) runs the
+    /// cell's finalizer even while a pool thread is inside `transform` — the
+    /// ctx's reference is what keeps the coder alive through that.
+    refs: AtomicU32,
     /// DecompressionStream only: the codec has reported end-of-stream. Any
     /// further input is the spec's "trailing junk" TypeError.
     ended: bool,
@@ -201,6 +208,7 @@ impl CompressionStreamCoder {
         };
         Ok(Box::new(Self {
             backend,
+            refs: AtomicU32::new(1),
             ended: false,
             zstd_head: [0; 4],
             zstd_head_len: 0,
@@ -647,13 +655,31 @@ pub extern "C" fn CompressionStreamCoder__create(
     }
 }
 
+/// Drops one reference; frees the coder when it was the last. See
+/// [`CompressionStreamCoder::refs`].
+unsafe fn release(this: *mut CompressionStreamCoder) {
+    // SAFETY: the caller holds one of the coder's references, so `this` is
+    // live. `Release`/`Acquire` pair so the freeing thread observes every
+    // write made under the other references before the backend is torn down.
+    if unsafe { &(*this).refs }.fetch_sub(1, Ordering::Release) == 1 {
+        core::sync::atomic::fence(Ordering::Acquire);
+        // SAFETY: `this` came from `Box::into_raw` in `__create` and the last
+        // reference is gone; no other thread can reach the coder now.
+        drop(unsafe { Box::from_raw(this) });
+    }
+}
+
+/// Releases the C++ cell's reference (the finalizer / eager
+/// `nativeTransformReleaseState` path; the cell clears its pointer before
+/// calling). An in-flight async transform holds its own reference, so the
+/// backend stays alive until that task's ctx drops.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCoder) {
     if !this.is_null() {
         // SAFETY: `this` was returned by `CompressionStreamCoder__create` and
-        // has not been freed (the C++ cell clears its pointer before calling).
-        drop(unsafe { Box::from_raw(this) });
+        // the cell's reference has not been released yet.
+        unsafe { release(this) };
     }
 }
 
@@ -791,15 +817,28 @@ unsafe extern "C" {
 }
 
 pub struct CompressionAsyncCtx {
+    /// Holds one of the coder's references (`refs`), taken in
+    /// `__transformAsync` and released by `Drop`. The cell's finalizer can
+    /// run at VM teardown while the pool thread is still inside `transform`;
+    /// this reference is what keeps the coder alive through that.
     coder: *mut CompressionStreamCoder,
     input: AsyncInput,
     finish: bool,
     /// GC root for the `JSTransformStream` cell that owns `coder`; its
-    /// `m_asyncCodecInFlight` flag defers `m_coder` teardown while this task
-    /// holds it, and its `m_asyncCodecPromise` WriteBarrier keeps the pending
-    /// transform-algorithm promise alive.
+    /// `m_asyncCodecInFlight` flag defers the eager ClearAlgorithms release
+    /// while this task holds it, and its `m_asyncCodecPromise` WriteBarrier
+    /// keeps the pending transform-algorithm promise alive.
     stream: Strong,
     error: Option<CodecError>,
+}
+
+impl Drop for CompressionAsyncCtx {
+    fn drop(&mut self) {
+        // SAFETY: `coder` was ref'd in `__transformAsync`; this ctx owns that
+        // reference and drops exactly once (JS thread, in `then` or the
+        // shutdown drain).
+        unsafe { release(self.coder) };
+    }
 }
 
 pub type CompressionStreamCoderTask = WorkTask<CompressionAsyncCtx>;
@@ -810,8 +849,9 @@ impl WorkTaskContext for CompressionAsyncCtx {
 
     fn run(this: *mut Self, task: *mut WorkTask<Self>) {
         // SAFETY: work-pool hand-off; `this`/`task` are live and exclusive.
-        // `coder` is kept alive by `m_asyncCodecInFlight` on the rooted stream
-        // cell, and TransformStream serializes writes so nothing else aliases it.
+        // `coder` is kept alive by the reference this ctx holds (the cell's
+        // finalizer only releases its own), and TransformStream serializes
+        // writes so nothing else aliases it.
         unsafe {
             let ctx = &mut *this;
             ctx.error = (*ctx.coder).transform(ctx.input.slice(), ctx.finish).err();
@@ -826,8 +866,9 @@ impl WorkTaskContext for CompressionAsyncCtx {
         let stream = ctx.stream.get();
         let (out, out_len, err) = match ctx.error {
             None => {
-                // SAFETY: `m_asyncCodecInFlight` still holds; `coder` (and its
-                // `out` buffer) stay live until `deliverAsync` copies and clears it.
+                // SAFETY: `ctx` holds a coder reference until it drops at the
+                // end of this fn, so `coder` (and its `out` buffer) stay live
+                // while `deliverAsync` copies.
                 let coder = unsafe { &*ctx.coder };
                 (coder.out.as_ptr(), coder.out.len(), JSValue::ZERO)
             }
@@ -862,6 +903,11 @@ pub extern "C" fn CompressionStreamCoder__transformAsync(
         // `fallback` is ignored) or copied into an owned Vec.
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
+    // The ctx shares ownership of the coder (released in its `Drop`): VM
+    // teardown runs the cell's finalizer regardless of the `Strong` below,
+    // so the cell's reference alone cannot cover the pool-thread `transform`.
+    // SAFETY: `this` is the live coder owned by the calling JS cell.
+    unsafe { &(*this).refs }.fetch_add(1, Ordering::Relaxed);
     let ctx = bun_core::heap::into_raw(Box::new(CompressionAsyncCtx {
         coder: this,
         input: AsyncInput::new(global, chunk, fallback),

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -11,7 +11,6 @@
 
 use core::ffi::c_int;
 use core::ptr::{self, NonNull};
-use core::sync::atomic::{AtomicU32, Ordering};
 
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::work_task::{WorkTask, WorkTaskContext};
@@ -73,6 +72,7 @@ enum Backend {
     ZstdDecode(NonNull<zstd::ZSTD_DStream>),
 }
 
+#[derive(bun_ptr::ThreadSafeRefCounted)]
 pub struct CompressionStreamCoder {
     backend: Backend,
     /// Shared-ownership count: 1 for the JS cell (released by its finalizer /
@@ -80,7 +80,7 @@ pub struct CompressionStreamCoder {
     /// `CompressionAsyncCtx`. VM teardown (`lastChanceToFinalize`) runs the
     /// cell's finalizer even while a pool thread is inside `transform` — the
     /// ctx's reference is what keeps the coder alive through that.
-    refs: AtomicU32,
+    ref_count: bun_ptr::ThreadSafeRefCount<CompressionStreamCoder>,
     /// DecompressionStream only: the codec has reported end-of-stream. Any
     /// further input is the spec's "trailing junk" TypeError.
     ended: bool,
@@ -208,7 +208,7 @@ impl CompressionStreamCoder {
         };
         Ok(Box::new(Self {
             backend,
-            refs: AtomicU32::new(1),
+            ref_count: bun_ptr::ThreadSafeRefCount::init(),
             ended: false,
             zstd_head: [0; 4],
             zstd_head_len: 0,
@@ -655,31 +655,18 @@ pub extern "C" fn CompressionStreamCoder__create(
     }
 }
 
-/// Drops one reference; frees the coder when it was the last. See
-/// [`CompressionStreamCoder::refs`].
-unsafe fn release(this: *mut CompressionStreamCoder) {
-    // SAFETY: the caller holds one of the coder's references, so `this` is
-    // live. `Release`/`Acquire` pair so the freeing thread observes every
-    // write made under the other references before the backend is torn down.
-    if unsafe { &(*this).refs }.fetch_sub(1, Ordering::Release) == 1 {
-        core::sync::atomic::fence(Ordering::Acquire);
-        // SAFETY: `this` came from `Box::into_raw` in `__create` and the last
-        // reference is gone; no other thread can reach the coder now.
-        drop(unsafe { Box::from_raw(this) });
-    }
-}
-
 /// Releases the C++ cell's reference (the finalizer / eager
 /// `nativeTransformReleaseState` path; the cell clears its pointer before
 /// calling). An in-flight async transform holds its own reference, so the
-/// backend stays alive until that task's ctx drops.
+/// backend stays alive until that task's ctx drops. See
+/// [`CompressionStreamCoder::ref_count`].
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCoder) {
     if !this.is_null() {
         // SAFETY: `this` was returned by `CompressionStreamCoder__create` and
         // the cell's reference has not been released yet.
-        unsafe { release(this) };
+        unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::deref(this) };
     }
 }
 
@@ -837,7 +824,7 @@ impl Drop for CompressionAsyncCtx {
         // SAFETY: `coder` was ref'd in `__transformAsync`; this ctx owns that
         // reference and drops exactly once (JS thread, in `then` or the
         // shutdown drain).
-        unsafe { release(self.coder) };
+        unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::deref(self.coder) };
     }
 }
 
@@ -907,7 +894,7 @@ pub extern "C" fn CompressionStreamCoder__transformAsync(
     // teardown runs the cell's finalizer regardless of the `Strong` below,
     // so the cell's reference alone cannot cover the pool-thread `transform`.
     // SAFETY: `this` is the live coder owned by the calling JS cell.
-    unsafe { &(*this).refs }.fetch_add(1, Ordering::Relaxed);
+    unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::ref_(this) };
     let ctx = bun_core::heap::into_raw(Box::new(CompressionAsyncCtx {
         coder: this,
         input: AsyncInput::new(global, chunk, fallback),

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -655,11 +655,7 @@ pub extern "C" fn CompressionStreamCoder__create(
     }
 }
 
-/// Releases the C++ cell's reference (the finalizer / eager
-/// `nativeTransformReleaseState` path; the cell clears its pointer before
-/// calling). An in-flight async transform holds its own reference, so the
-/// backend stays alive until that task's ctx drops. See
-/// [`CompressionStreamCoder::ref_count`].
+/// Releases the C++ cell's reference; see [`CompressionStreamCoder::ref_count`].
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCoder) {
@@ -804,10 +800,8 @@ unsafe extern "C" {
 }
 
 pub struct CompressionAsyncCtx {
-    /// Holds one of the coder's references (`refs`), taken in
-    /// `__transformAsync` and released by `Drop`. The cell's finalizer can
-    /// run at VM teardown while the pool thread is still inside `transform`;
-    /// this reference is what keeps the coder alive through that.
+    /// Holds one coder reference (taken in `__transformAsync`, released by
+    /// `Drop`); see [`CompressionStreamCoder::ref_count`].
     coder: *mut CompressionStreamCoder,
     input: AsyncInput,
     finish: bool,
@@ -890,10 +884,8 @@ pub extern "C" fn CompressionStreamCoder__transformAsync(
         // `fallback` is ignored) or copied into an owned Vec.
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
-    // The ctx shares ownership of the coder (released in its `Drop`): VM
-    // teardown runs the cell's finalizer regardless of the `Strong` below,
-    // so the cell's reference alone cannot cover the pool-thread `transform`.
-    // SAFETY: `this` is the live coder owned by the calling JS cell.
+    // SAFETY: `this` is the live coder owned by the calling JS cell; the ctx
+    // takes its own reference (see `CompressionStreamCoder::ref_count`).
     unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::ref_(this) };
     let ctx = bun_core::heap::into_raw(Box::new(CompressionAsyncCtx {
         coder: this,

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import zlib from "node:zlib";
 
 // CompressionStream et al are C++ subclasses of JSTransformStream so that
@@ -772,3 +772,50 @@ test("errored pipeline releases the compression coder eagerly", async () => {
   expect(deltaMiB).toBeLessThan(64);
   expect(exitCode).toBe(0);
 }, 60_000);
+
+// Chunks > 128 KiB run the codec on a WorkPool thread. VM teardown
+// (Heap::lastChanceToFinalize) runs the cell's CFinalizer even while that
+// transform is mid-flight — it must release the cell's reference, not free
+// the coder under the pool thread (heap-use-after-free in the brotli encoder,
+// caught by ASAN). BUN_DESTRUCT_VM_ON_EXIT=1 (which CI's test runner sets)
+// makes process.exit() take that teardown path on the main thread. ASAN-only:
+// without ASAN the stray write into freed pages is not reliably observable.
+// The 30s timeout covers the debug/ASAN child's startup plus teardown.
+test.skipIf(!isASAN)(
+  "process.exit during an in-flight off-thread transform does not free the coder under the pool thread",
+  async () => {
+    const src = `
+      const s = new CompressionStream("brotli");
+      const w = s.writable.getWriter();
+      const big = new Uint8Array(6 << 20);
+      for (let i = 0; i < big.length; i += 3) big[i] = (i * 2654435761) >>> 24;
+      w.write(big).catch(() => {});
+      w.close().catch(() => {});
+      s.readable.getReader().read().catch(() => {});
+      // One macrotask turn so the write's transform step has dispatched to the
+      // pool; the 6 MiB brotli step runs for seconds, so exit lands mid-flight.
+      setTimeout(() => {
+        console.log("exiting");
+        process.exit(0);
+      }, 15);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        // Exiting mid-transform deliberately abandons the in-flight task (and
+        // the coder reference it holds); LSAN would report that bounded leak.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stdout).toContain("exiting");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
### Repro

`CompressionStream('brotli')` with a chunk over 128 KiB runs the codec step on a WorkPool thread. Tearing down the VM while that step is in flight frees the native coder under the pool thread:

```js
// ASAN build, BUN_DESTRUCT_VM_ON_EXIT=1 (the CI test runner sets this)
const s = new CompressionStream("brotli");
const w = s.writable.getWriter();
const big = new Uint8Array(6 << 20);
for (let i = 0; i < big.length; i += 3) big[i] = (i * 2654435761) >>> 24;
w.write(big).catch(() => {});
w.close().catch(() => {});
s.readable.getReader().read().catch(() => {});
setTimeout(() => process.exit(0), 15);
```

```
==ERROR: AddressSanitizer: heap-use-after-free ... thread (Bun Pool 0)
    #0 UpdateNodes vendor/brotli/c/enc/backward_references_hq.c:468
    ...
    #4 BrotliEncoderCompressStream vendor/brotli/c/enc/encode.c:1661
    #5 CompressionStreamCoder::transform src/runtime/webcore/CompressionStreamCoder.rs:367
freed by:
    BrotliEncoderDestroyInstance
    CompressionStreamCoder__destroy
    JSCompressionStream.cpp:176 (CFinalizer)
    JSC::Heap::CFinalizerOwner::finalize -> Heap::lastChanceToFinalize
```

The same free-under-the-pool-thread happens on `worker.terminate()` / `process.exit()` inside a worker while a large write is in flight (`WebWorker::shutdown` -> `WebWorker__teardownJSCVM` -> `lastChanceToFinalize`). Other faces of the same report: READ 1 in `BrotliEstimateBitCostsForLiterals` / `UpdateNodes`, WRITE 4 in `StoreAndFindMatchesH10`. `DecompressionStream` has the identical finalizer shape, and zstd/zlib formats share the path.

### Cause

The stream cell's CFinalizer (registered in the constructor) destroys `m_coder` unconditionally. During normal operation the in-flight task's `Strong` root keeps the cell from being swept, and the eager ClearAlgorithms release already defers on `m_asyncCodecInFlight`. But `Heap::lastChanceToFinalize` at VM teardown runs every finalizer regardless of roots, so the coder (brotli ring buffer + hasher, zlib window, zstd ctx) is freed while the pool thread is still inside `transform`.

### Fix

Reference-count the coder. The JS cell holds one reference, released where it released before (finalizer, or the eager ClearAlgorithms path; both already null the cell's pointer first, so `CompressionStreamCoder__destroy` keeps its signature and call sites). Each in-flight `CompressionAsyncCtx` takes its own reference when the async step is scheduled and drops it with the ctx on the JS thread. The backend is freed when the last reference drops, so teardown releases the cell's hold but can no longer free the state under the pool thread. On the teardown paths where the completion never gets delivered, the coder is abandoned with the dying process instead of freed early, which is the bounded-leak tradeoff the worker teardown path already takes elsewhere.

Related: #36983 fences `WebWorker::shutdown` on outstanding off-thread jobs, which closes the worker-terminate door from the other side (and is still needed for it: after this change, the worker repro's surviving report moves to `EventLoop::enqueue_task_concurrent` via `WorkTask::on_finish` on the freed worker loop, which is exactly the bug that PR addresses, now with a `WorkTask` stack). This change covers what the fence cannot: the main-thread `BUN_DESTRUCT_VM_ON_EXIT=1` exit path, and the coder's own lifetime independent of teardown ordering.

### Verification

- New test in `test/js/web/streams/compression.test.ts` (ASAN-gated): fails on the unfixed build with the ASan report above, passes with the fix.
- Main-thread repro: 5/5 clean runs with the fix (was UAF on every run before).
- `test/js/web/streams/compression.test.ts` (37), `test/regression/issue/18413-all-compressions.test.ts`, `test/regression/issue/23314/zstd-large-decompression.test.ts`, and the four node webstreams compression compat tests all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/compression.test.ts
bun test v1.4.0 (38b3183e8)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [13.39ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.50ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.66ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.27ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [15.13ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [21.20ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [51.32ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [9.46ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [18.82ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [36.88ms]
(
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (0ac8ea9f3)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [0.42ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [0.07ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [0.06ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [0.03ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [0.91ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [0.78ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [1.80ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [0.58ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [0.43ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [1.02ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [0.28ms]
(pass) CompressionStream and DecompressionStream > zstd > decompr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/compression.test.ts
bun test v1.4.0 (38b3183e8)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [13.88ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.67ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.66ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.15ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [15.57ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [22.42ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [51.98ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [10.10ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [18.91ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [38.62ms]

... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 820ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/12] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[1/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../bindings/webcore/streams/JSCompressionStream.h |  7 ++--
 .../webcore/streams/JSCompressionStreamShared.h    |  1 +
 src/runtime/webcore/CompressionStreamCoder.rs      | 43 +++++++++++++++----
 test/js/web/streams/compression.test.ts            | 49 +++++++++++++++++++++-
 4 files changed, 87 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/streams/JSCompressionStream.h        2      2      0
…sc/bindings/webcore/streams/JSCompressionStreamShared.h      2      2      0
src/runtime/webcore/CompressionStreamCoder.rs                 3      6      0
test/js/web/streams/compression.test.ts                       1      1      0
```

</details>

<!-- robobun:evidence:end -->