### PR TITLE
test(http): deflake the graceful-stop drain tests on darwin

### DIFF
--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -791,13 +791,21 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     // host the bytes can lag the client's write by longer than any fixed tick
     // budget, and a connection whose bytes the server never saw is closed as
     // idle) - that round proves nothing and is retried on a fresh server.
+    //
+    // Two variants run on confirmed-spared rounds:
+    // - destroy: the promise keeps pending until the client hangs up.
+    // - complete: the client finishes the head after stop(); the request must
+    //   still dispatch and be answered (the close-when-idle mark has to
+    //   survive the dispatch's response-state reset, which only spares
+    //   connection-scoped bits), and then the mark closes the served
+    //   connection and the drain resolves.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
           const net = require("net");
-          async function round() {
+          async function round(completeHead) {
             const server = Bun.serve({
               port: 0,
               hostname: "127.0.0.1",
@@ -839,21 +847,41 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
               c.destroy();
               return null;
             }
+            // Confirmed: the sweep spared the mid-request connection, so the
+            // partial head was parsed and the close-when-idle mark is set.
+            if (completeHead) {
+              // Finish the head: the request dispatches on the marked
+              // connection, its response reaches the client, then the mark
+              // closes the drained connection (the client never hangs up).
+              c.write("\\r\\n");
+              while (!state.closed) await new Promise(r => setImmediate(r));
+              await stopped;
+              return {
+                resolved: true,
+                closed: true,
+                secondServed: (state.buf.match(/\\r\\nok/g) || []).length === 2,
+              };
+            }
             c.destroy();
             await stopped;
             const until = Date.now() + 2000;
             while (!state.closed && Date.now() < until) await new Promise(r => setImmediate(r));
             return { resolved: true, closed: state.closed };
           }
-          for (let attempt = 1; attempt <= 8; attempt++) {
-            const r = await round();
+          const results = {};
+          for (let attempt = 1; attempt <= 16 && (!results.destroy || !results.complete); attempt++) {
+            const variant = results.destroy ? "complete" : "destroy";
+            const r = await round(variant === "complete");
             if (r === null) continue;
             if (r.fail) { console.error(r.fail); process.exit(1); }
-            console.log(JSON.stringify(r));
-            process.exit(0);
+            results[variant] = r;
           }
-          console.error("every round raced: the partial head never arrived before stop()");
-          process.exit(1);
+          if (!results.destroy || !results.complete) {
+            console.error("every round raced: the partial head never arrived before stop()");
+            process.exit(1);
+          }
+          console.log(JSON.stringify(results));
+          process.exit(0);
         `,
       ],
       env: bunEnv,
@@ -863,7 +891,10 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stderr, out: JSON.parse(stdout.trim() || "null"), exitCode }).toEqual({
       stderr: "",
-      out: { resolved: true, closed: true },
+      out: {
+        destroy: { resolved: true, closed: true },
+        complete: { resolved: true, closed: true, secondServed: true },
+      },
       exitCode: 0,
     });
   });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -601,10 +601,10 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
   // The drain promise must not resolve while a connection is still open, and
   // a graceful stop() must actively drain: idle keep-alive connections close
   // right away, busy ones close as soon as their in-flight work completes.
-  // The client never hangs up first (except in "partial" mode), so every
-  // observed close below is server-initiated; idleTimeout is long enough that
-  // a timeout-driven close would flake the runtime budget long before firing.
-  async function runDrainFixture(mode: "idle" | "inflight" | "inflightHead" | "force" | "partial") {
+  // The client never hangs up first, so every observed close below is
+  // server-initiated; idleTimeout is long enough that a timeout-driven close
+  // would flake the runtime budget long before firing.
+  async function runDrainFixture(mode: "idle" | "inflight" | "inflightHead" | "force") {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -637,23 +637,12 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
             c.on("connect", resolve);
             c.on("error", reject);
           });
-          if (mode === "partial") {
-            // Half a request head: enough to be accepted and parsed as an
-            // in-progress request (a zero-byte connection would sit in the
-            // TCP_DEFER_ACCEPT queue on Linux and never reach the server),
-            // never completed.
-            c.write("GET /slow HTTP/1.1\\r\\nHost: x\\r\\n");
-            // Wait until the server has accepted it (it shows up in
-            // pendingRequests only once parsed, so poll a tick batch).
-            for (let i = 0; i < 20; i++) await new Promise(r => setImmediate(r));
+          const method = mode === "inflightHead" ? "HEAD" : "GET";
+          c.write(method + " /" + (mode === "idle" ? "fast" : "slow") + " HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+          if (mode === "idle") {
+            while (!buf.includes("\\r\\nok")) await new Promise(r => setImmediate(r));
           } else {
-            const method = mode === "inflightHead" ? "HEAD" : "GET";
-            c.write(method + " /" + (mode === "idle" ? "fast" : "slow") + " HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
-            if (mode === "idle") {
-              while (!buf.includes("\\r\\nok")) await new Promise(r => setImmediate(r));
-            } else {
-              await inflight.promise;
-            }
+            await inflight.promise;
           }
           let resolved = false;
           const stopped = server.stop(false).then(() => { resolved = true; });
@@ -674,13 +663,6 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
             // the aborted request can settle.
             server.stop(true);
             release.resolve();
-          } else if (mode === "partial") {
-            // A connection mid-request ("sending a request", Node's idle
-            // definition excludes it) is spared; the promise stays pending
-            // until the client hangs up.
-            for (let i = 0; i < 20; i++) await new Promise(r => setImmediate(r));
-            if (resolved) throw new Error("stop() resolved while a mid-request connection was open");
-            c.destroy();
           }
           await stopped;
           // The client socket's 'close' and the server-side filter → promise
@@ -799,9 +781,89 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
   });
 
   test("a connection mid-request survives stop() until the client closes", async () => {
-    expect(await runDrainFixture("partial")).toEqual({
+    // A connection that is receiving a request ("sending a request" - Node's
+    // idle definition excludes it) is spared by the graceful sweep, and with
+    // no dispatched request the connection count is the only term holding the
+    // drain promise open. The mid-request state is staged as a partial second
+    // request head on a keep-alive connection that already completed a full
+    // request, so the server demonstrably owns the socket. If the sweep still
+    // closed it, the partial head had not arrived when stop() ran (on a loaded
+    // host the bytes can lag the client's write by longer than any fixed tick
+    // budget, and a connection whose bytes the server never saw is closed as
+    // idle) - that round proves nothing and is retried on a fresh server.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          async function round() {
+            const server = Bun.serve({
+              port: 0,
+              hostname: "127.0.0.1",
+              idleTimeout: 255,
+              fetch: () => new Response("ok"),
+            });
+            const c = net.connect(server.port, "127.0.0.1");
+            const state = { buf: "", closed: false };
+            c.on("data", d => (state.buf += d));
+            c.on("close", () => (state.closed = true));
+            c.on("error", () => {});
+            await new Promise((resolve, reject) => { c.on("connect", resolve); c.on("error", reject); });
+            c.write("GET /first HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+            while (!state.buf.includes("\\r\\nok")) await new Promise(r => setImmediate(r));
+            // Half of a second request's head: mid-request, nothing dispatched.
+            c.write("GET /second HTTP/1.1\\r\\nHost: x\\r\\n");
+            // Yield so the server's parser can consume the head (stop() runs
+            // its sweep synchronously, and a head still in the kernel buffer
+            // leaves the connection idle). No tick budget is guaranteed to be
+            // enough - the void-round classification below covers the misses.
+            for (let i = 0; i < 20; i++) await new Promise(r => setImmediate(r));
+            let resolved = false;
+            const stopped = server.stop(false).then(() => { resolved = true; });
+            // The promise must stay pending while the mid-request connection
+            // is open; the client never hangs up during this window, so only
+            // the sweep can close the socket.
+            for (let i = 0; i < 20 && !resolved && !state.closed; i++) {
+              await new Promise(r => setImmediate(r));
+            }
+            if (resolved || state.closed) {
+              // Server-initiated close: the sweep saw the connection idle
+              // because the partial head had not arrived yet. Correct for an
+              // idle connection, but not the state under test - void round.
+              // A resolution with the socket left open would be the bug.
+              const until = Date.now() + 2000;
+              while (!state.closed && Date.now() < until) await new Promise(r => setImmediate(r));
+              if (!state.closed) return { fail: "stop() resolved while a mid-request connection was open" };
+              await stopped;
+              c.destroy();
+              return null;
+            }
+            c.destroy();
+            await stopped;
+            const until = Date.now() + 2000;
+            while (!state.closed && Date.now() < until) await new Promise(r => setImmediate(r));
+            return { resolved: true, closed: state.closed };
+          }
+          for (let attempt = 1; attempt <= 8; attempt++) {
+            const r = await round();
+            if (r === null) continue;
+            if (r.fail) { console.error(r.fail); process.exit(1); }
+            console.log(JSON.stringify(r));
+            process.exit(0);
+          }
+          console.error("every round raced: the partial head never arrived before stop()");
+          process.exit(1);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, out: JSON.parse(stdout.trim() || "null"), exitCode }).toEqual({
       stderr: "",
-      out: { resolvedEarly: false, responseAfterStop: false, resolved: true, closed: true },
+      out: { resolved: true, closed: true },
       exitCode: 0,
     });
   });
@@ -887,8 +949,9 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     // internalEnd's post-uncork close gate must key on WHICH socket the
     // parser is on, not the context-wide isParsingHttp bit: B's parked
     // response below completes in the microtask drain inside A's onData
-    // dispatch (A resolves it), and B gets no later gate of its own. With the
-    // context-wide bit, B lingered until idleTimeout and stop() hung.
+    // (A's body completion resolves it), and B gets no later gate of its
+    // own. With the context-wide bit, B lingered until idleTimeout and
+    // stop() hung.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -897,6 +960,7 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
           const net = require("net");
           const releaseB = Promise.withResolvers();
           const bHeld = Promise.withResolvers();
+          const aStarted = Promise.withResolvers();
           const server = Bun.serve({
             port: 0,
             hostname: "127.0.0.1",
@@ -909,8 +973,12 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
                 return new Response("held");
               }
               if (path === "/poke") {
-                // B's completion runs in the microtask drain while A's
-                // socket is the one being parsed.
+                aStarted.resolve();
+                // Parks until the body arrives after stop(). The fin chunk is
+                // delivered inside A's parse window, so this continuation -
+                // and B's completion, which it unblocks - runs in that
+                // window's microtask drain.
+                await req.text();
                 releaseB.resolve();
                 return new Response("poked");
               }
@@ -932,20 +1000,23 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
           b.c.write("GET /hold HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
           await bHeld.promise;
           const a = await dial();
-          // Partial head: A is mid-request at the sweep, so it is spared and
-          // marked close-when-idle. Give the bytes a tick batch to arrive (a
-          // zero-byte connection would sit in the defer-accept queue and the
-          // sweep could not see it).
-          a.c.write("GET /poke HTTP/1.1\\r\\nHost: x\\r\\n");
-          for (let i = 0; i < 20; i++) await new Promise(r => setImmediate(r));
+          // Complete head, held body: once the handler has started, A is
+          // dispatched and demonstrably owned by the server, and it stays
+          // busy at the sweep, so it is spared and marked close-when-idle.
+          // (A partial head could not be awaited: nothing observable fires
+          // for it, and on a loaded host its bytes can lag the client's
+          // write past the sweep, leaving the connection invisible to it.)
+          a.c.write("POST /poke HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 2\\r\\n\\r\\n");
+          await aStarted.promise;
           let resolved = false;
           const stopped = server.stop(false).then(() => { resolved = true; });
           await new Promise(r => setImmediate(r));
           const resolvedEarly = resolved;
-          // Complete A's request; its dispatch resolves B inside A's parse
-          // window. Both responses must be delivered, then both connections
-          // close server-initiated and the drain promise resolves.
-          a.c.write("\\r\\n");
+          // Complete A's body; the handler resumes inside A's parse window
+          // and resolves B. Both responses must be delivered, then both
+          // connections close server-initiated and the drain promise
+          // resolves.
+          a.c.write("hi");
           while (!a.closed || !b.closed) await new Promise(r => setImmediate(r));
           await stopped;
           console.log(JSON.stringify({
@@ -1635,15 +1706,24 @@ test("request on a connection surviving graceful stop() never reaches a collecte
         if (round > MIN_ROUNDS && elapsed > MIN_MS) break;
         const tag = round;
         const kind = round % 2 ? "fetch" : "routes";
+        // Every server binds the loopback address the parks dial. A wildcard
+        // port-0 bind is not safe here: macOS's ephemeral allocator honors
+        // only exact-address conflicts, so a wildcard listener can be handed
+        // a port some other process already holds at 127.0.0.1 (a leaked
+        // verdaccio from an install test, say), and that listener - being
+        // more specific - would answer this fixture's dials. With hundreds
+        // of binds per run, this fixture reliably finds such a port.
         let server =
           kind === "fetch"
             ? Bun.serve({
                 port: 0,
+                hostname: "127.0.0.1",
                 idleTimeout: 60,
                 fetch() { return new Response("ok " + tag); },
               })
             : Bun.serve({
                 port: 0,
+                hostname: "127.0.0.1",
                 idleTimeout: 60,
                 routes: { "/r/:id": req => new Response("ok " + tag + " " + req.params.id) },
                 fetch() { return new Response("ok " + tag + " fallback"); },
@@ -1671,7 +1751,7 @@ test("request on a connection surviving graceful stop() never reaches a collecte
         churn();
         churn();
         const decoys = [];
-        for (let i = 0; i < 3; i++) decoys.push(Bun.serve({ port: 0, fetch() { return new Response("decoy"); } }));
+        for (let i = 0; i < 3; i++) decoys.push(Bun.serve({ port: 0, hostname: "127.0.0.1", fetch() { return new Response("decoy"); } }));
         churn();
         const rs = await Promise.all(
           entries.flatMap(({ parks, kind, want, token }) =>


### PR DESCRIPTION
`test/js/bun/http/bun-server.test.ts` has been flaking on darwin lanes since the graceful `stop()` drain work landed (#35130 on Aug 5, #37074 on Aug 6): about 30 failing builds in the 36 hours after the second merge, plus the 90s-timeout reported red in build [90105](https://buildkite.com/bun/bun/builds/90105). Three distinct failure modes, each with a verified cause. This PR is test-only; the code paths the tests pin are unchanged and still covered (see Verification).

## 1. GC churn test answered by a foreign server

`request on a connection surviving graceful stop() never reaches a collected handler` failed with

```
FAIL fetch round 11: bad initial response [{"status":200,"body":"\n    <!DOCTYPE html>\...//x/-/static/main.55cdd4aea43adabcb109.js\"></script>..."}]
```

That body is a verdaccio web UI page; the `routes` variant got verdaccio's 404 `{"error":"no such package available"}`. A freshly dialed connection to the fixture's own freshly bound port was answered by an npm test registry.

Cause, reproduced on a macOS 14 CI host: the ephemeral port allocator on macOS honors only exact-address conflicts. A wildcard `Bun.serve({ port: 0 })` bind gets handed a port that another process already holds at `127.0.0.1` (one collision per ~16,384 binds, i.e. once per wrap of the ephemeral range; a loopback-bound holder under both a real node and a bun process, same result). Connects to `127.0.0.1:port` then reach the more specific foreign listener. The churn fixture performs hundreds of wildcard binds per run, so it finds such a port regularly, and leaked verdaccio processes supply the listeners: `VerdaccioRegistry.stop()` calls `kill(0)`, which is a liveness probe rather than a kill (regressed in #16540; fix open in #36352).

Fix: bind the fixture's servers (and decoys) to `127.0.0.1`, the address the parks dial. Verified on the same host: 36,000 loopback-bound port-0 binds against a live loopback holder, zero collisions. This protects the test regardless of what else leaks on the machine; #36352 independently removes the main leak source.

## 2. Parse-window test 90s timeout (the build 90105 red)

```
✗ server.stop() drain promise counts open connections > a response completing inside another socket's parse window still closes its drained connection [90001.99ms]
  ^ this test timed out after 90000ms.
```

The fixture wrote a partial request head on connection A and waited 20 `setImmediate` ticks before `stop(false)`. A partial head gives the server nothing observable, and on a loaded darwin host those ticks can elapse before the server has even accepted the socket. Verified on a macOS 14 CI host: when `stop(false)` runs while a handshake-completed connection is still waiting in the accept queue, macOS strands it - never accepted, never counted, never closed, and the client side stays silently open. (Linux keeps the pending accept, which is why this never fired there.) In the fixture that means `/poke` never dispatches, `releaseB` never resolves, B stays parked, and `while (!a.closed || !b.closed)` spins until the test timeout with no other output - exactly the observed signature.

Fix: A's poke is now a `POST` with a held body. The handler's dispatch is awaited before `stop()` (so the sweep provably sees a busy connection), and writing the 2-byte body afterwards completes the request. The body's fin chunk is delivered inside A's parse window, so B's completion still runs in that window's microtask drain - the per-socket close-gate property the test exists to pin is exercised exactly as before.

## 3. Mid-request sparing test resolving early

Build [89946](https://buildkite.com/bun/bun/builds/89946) hit `error: stop() resolved while a mid-request connection was open` in `a connection mid-request survives stop() until the client closes`. Same root cause: the connection's partial head had not reached the server when `stop()` ran, so the server (correctly) had nothing to count and the drain promise resolved.

Fix: the mid-request state is staged as a partial second head on a keep-alive connection that already completed a full request, so the server demonstrably owns the socket. If the sweep still closes it, the head had not arrived and the connection was legitimately idle - that round proves nothing about sparing, so it is voided and retried on a fresh server (bounded, fails loudly if every round races). A resolution while the socket is left open is still reported as the bug it would be.

Confirmed-spared rounds run in two variants, and the test requires one success of each:

- destroy: the client hangs up and that resolves the drain (the original assertion).
- complete: the client finishes the head after `stop()`. The request must still dispatch and be answered, which requires the close-when-idle mark to survive the dispatch's response-state reset (`HTTP_CONNECTION_SCOPED` in uWS `HttpResponseData.h`), and the mark must then close the served connection. This preserves the dispatch-after-stop coverage the old parse-window staging provided incidentally (its partial head completed after `stop()`), which the redesign in section 2 otherwise moves ahead of the stop.

## Verification

- `bun bd test test/js/bun/http/bun-server.test.ts`: 74 pass / 3 fail, the 3 failures (`parse source map and fetch small stream`, `rejected promise handled by error method`, `abrubtly close a upload request`) fail identically on an unmodified checkout in this environment.
- Drain block run 5x, churn test 2x locally: all pass.
- Both redesigned fixtures extracted and run 30x on a macOS 14 CI host under the exact canary from build 90105 (`89d30ad11`): 60/60 pass, plus 40x under a 14-way CPU-spin load: all pass.
- Coverage check for the parse-window test: patching the `internalEnd` close gates back to the context-wide `isParsingHttp` bit (the bug #37074 guards against) makes the redesigned test fail by timeout, and restoring the per-socket gate makes it pass.
- Coverage check for the mid-request test's complete variant: dropping `HTTP_CLOSE_WHEN_IDLE` from `HTTP_CONNECTION_SCOPED` (so the mark is wiped when the post-stop request dispatches) makes it fail by timeout; restored, it passes. The updated fixture also runs 30/30 on the macOS 14 CI host under the build 90105 canary, and hangs as expected under a pre-#37074 build.

The remaining hazard - any long-running wildcard port-0 listener on darwin CI can have its loopback traffic stolen by a later explicit `127.0.0.1` bind such as `VerdaccioRegistry`'s `randomPort()` (range 1024-65535 overlaps the kernel's ephemeral range) - is worth addressing in the harness separately; noted on #36352.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->