### PR TITLE
install: reuse lockfile-resolved git packages for branch and bare refs when re-resolving

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1182,6 +1182,16 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
+            // Second: reuse the package an identical dependency is already
+            // bound to. A branch, tag, or bare committish can never match the
+            // lookup above after a lockfile round-trip.
+            if let Some(pkg_id) =
+                find_locked_git_package(this, id, dependency, &dep, ResolutionTag::Git)
+            {
+                success_fn(this, id, pkg_id);
+                return Ok(());
+            }
+
             // reshaped for borrowck — `alias`/`url` borrow
             // `this.lockfile.buffers.string_bytes`; detach the slice
             // lifetimes so the `&mut PackageManager` reborrows for the
@@ -1288,6 +1298,16 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 
             // First: see if we already loaded the github package in-memory
             if let Some(pkg_id) = this.lockfile.get_package_id(name_hash, None, &res) {
+                success_fn(this, id, pkg_id);
+                return Ok(());
+            }
+
+            // Second: reuse the package an identical dependency is already
+            // bound to. A branch, tag, or bare committish can never match the
+            // lookup above after a lockfile round-trip.
+            if let Some(pkg_id) =
+                find_locked_git_package(this, id, dependency, dep, ResolutionTag::Github)
+            {
                 success_fn(this, id, pkg_id);
                 return Ok(());
             }
@@ -1931,6 +1951,79 @@ fn update_name_and_name_hash_from_version_replacement(
         }
         _ => (original_name, original_name_hash),
     }
+}
+
+/// Finds the package an identical, already-resolved dependency is bound to, so
+/// a git/github dependency re-enqueued during re-resolution (most commonly a
+/// workspace member edit re-parsing the member's whole dependency list) reuses
+/// it instead of fetching the remote again.
+///
+/// The `get_package_id` lookup in the git/github arms can only match a
+/// committish equal to the loaded one, and the text lockfile writes the
+/// *resolved* commit in the committish position of the resolution string, so a
+/// branch, tag, or bare ref never matches again after a lockfile round-trip.
+/// Dependency entries keep their original version literals, so an identical
+/// literal bound to a package of the same repository is the lossless record of
+/// what this dependency previously resolved to.
+fn find_locked_git_package(
+    this: &PackageManager,
+    id: DependencyID,
+    dependency: &Dependency,
+    repo: &Repository,
+    resolution_tag: ResolutionTag,
+) -> Option<PackageID> {
+    if this.lockfile.buffers.resolutions[id as usize] != invalid_package_id {
+        return None;
+    }
+
+    // `bun update` re-resolves git refs against the remote; reusing the locked
+    // commit here would turn the update into a no-op. Same update-target test
+    // as `Diff::generate` (an empty request list is a bare `bun update`).
+    if this.to_update
+        && (this.update_requests.is_empty()
+            || this
+                .update_requests
+                .iter()
+                .any(|request| request.name_hash == dependency.name_hash))
+    {
+        return None;
+    }
+
+    let buf = this.lockfile.buffers.string_bytes.as_slice();
+    let package_resolutions = this.lockfile.packages.items_resolution();
+    let dependencies = this.lockfile.buffers.dependencies.as_slice();
+    let resolutions = this.lockfile.buffers.resolutions.as_slice();
+
+    for (other, &package_id) in dependencies.iter().zip(resolutions) {
+        if package_id == invalid_package_id || (package_id as usize) >= package_resolutions.len() {
+            continue;
+        }
+        if other.name_hash != dependency.name_hash
+            || other.version.tag != dependency.version.tag
+            || !other
+                .version
+                .literal
+                .eql(dependency.version.literal, buf, buf)
+        {
+            continue;
+        }
+        // Overrides and catalogs replace the version after parsing, so an
+        // identical literal does not guarantee an identical resolution; the
+        // resolved repository must match the effective one too. (A changed
+        // override/catalog also invalidates the old binding before
+        // re-enqueueing, so a stale binding is never reachable here.)
+        let resolution = &package_resolutions[package_id as usize];
+        if resolution.tag != resolution_tag {
+            continue;
+        }
+        let locked = resolution.repository();
+        if !locked.repo.eql(repo.repo, buf, buf) || !locked.owner.eql(repo.owner, buf, buf) {
+            continue;
+        }
+        return Some(package_id);
+    }
+
+    None
 }
 
 pub(crate) enum ResolvedPackageTask {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1182,9 +1182,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
-            // Second: reuse the package an identical dependency is already
-            // bound to. A branch, tag, or bare committish can never match the
-            // lookup above after a lockfile round-trip.
+            // Second: the package an identical dependency literal resolved to
             if let Some(pkg_id) =
                 find_locked_git_package(this, id, dependency, &dep, ResolutionTag::Git)
             {
@@ -1302,9 +1300,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
-            // Second: reuse the package an identical dependency is already
-            // bound to. A branch, tag, or bare committish can never match the
-            // lookup above after a lockfile round-trip.
+            // Second: the package an identical dependency literal resolved to
             if let Some(pkg_id) =
                 find_locked_git_package(this, id, dependency, dep, ResolutionTag::Github)
             {
@@ -1953,18 +1949,12 @@ fn update_name_and_name_hash_from_version_replacement(
     }
 }
 
-/// Finds the package an identical, already-resolved dependency is bound to, so
-/// a git/github dependency re-enqueued during re-resolution (most commonly a
-/// workspace member edit re-parsing the member's whole dependency list) reuses
-/// it instead of fetching the remote again.
-///
-/// The `get_package_id` lookup in the git/github arms can only match a
-/// committish equal to the loaded one, and the text lockfile writes the
-/// *resolved* commit in the committish position of the resolution string, so a
-/// branch, tag, or bare ref never matches again after a lockfile round-trip.
-/// Dependency entries keep their original version literals, so an identical
-/// literal bound to a package of the same repository is the lossless record of
-/// what this dependency previously resolved to.
+/// The package an identical git/github dependency (same name and version
+/// literal) is already bound to. `bun.lock` writes the resolved commit in the
+/// committish position of the resolution string, so after a reload a branch,
+/// tag, or bare ref never matches `get_package_id`'s committish comparison;
+/// the unchanged dependency literal is the lossless record of the previous
+/// resolution, and reusing its binding keeps re-resolution off the network.
 fn find_locked_git_package(
     this: &PackageManager,
     id: DependencyID,
@@ -1976,9 +1966,8 @@ fn find_locked_git_package(
         return None;
     }
 
-    // `bun update` re-resolves git refs against the remote; reusing the locked
-    // commit here would turn the update into a no-op. Same update-target test
-    // as `Diff::generate` (an empty request list is a bare `bun update`).
+    // An update target must re-resolve against the remote (same test as
+    // `Diff::generate`; an empty request list is a bare `bun update`).
     if this.to_update
         && (this.update_requests.is_empty()
             || this
@@ -2007,11 +1996,9 @@ fn find_locked_git_package(
         {
             continue;
         }
-        // Overrides and catalogs replace the version after parsing, so an
-        // identical literal does not guarantee an identical resolution; the
-        // resolved repository must match the effective one too. (A changed
-        // override/catalog also invalidates the old binding before
-        // re-enqueueing, so a stale binding is never reachable here.)
+        // Overrides/catalogs replace the version after parsing, so the bound
+        // package must also match the effective repository (changed overrides
+        // and catalogs invalidate old bindings before re-enqueueing).
         let resolution = &package_resolutions[package_id as usize];
         if resolution.tag != resolution_tag {
             continue;

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2004,7 +2004,19 @@ fn find_locked_git_package(
             continue;
         }
         let locked = resolution.repository();
-        if !locked.repo.eql(repo.repo, buf, buf) || !locked.owner.eql(repo.owner, buf, buf) {
+        if !locked.owner.eql(repo.owner, buf, buf) {
+            continue;
+        }
+        // The lockfile writer prefixes an scp-like repo ("git@host:path") with
+        // "ssh://", so a reloaded resolution carries the prefix while the
+        // freshly parsed dependency does not.
+        let locked_repo = locked.repo.slice(buf);
+        let dep_repo = repo.repo.slice(buf);
+        let repo_matches = strings::eql(locked_repo, dep_repo)
+            || (strings::has_prefix_comptime(locked_repo, b"ssh://")
+                && dependency::is_scp_like_path(dep_repo)
+                && strings::eql(&locked_repo[b"ssh://".len()..], dep_repo));
+        if !repo_matches {
             continue;
         }
         return Some(package_id);

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1218,14 +1218,41 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
 
             if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-                let resolved = Repository::find_commit(
-                    this.env_mut(),
-                    this.log_mut(),
-                    repo_fd,
-                    alias,
-                    this.lockfile.str(&dep.committish),
-                    clone_id,
-                )?;
+                // A dependency already bound to a package checks out that
+                // package's locked commit. `find_commit` follows the ref,
+                // which may have moved since it was locked, and the isolated
+                // installer's store entry waits on the locked checkout id
+                // (the clone-failure drain in runTasks.rs keys the same way).
+                let bound_resolved: Option<Vec<u8>> = {
+                    let bound = this.lockfile.buffers.resolutions[id as usize];
+                    if bound != invalid_package_id
+                        && (bound as usize) < this.lockfile.packages.len()
+                    {
+                        let bound_res = &this.lockfile.packages.items_resolution()[bound as usize];
+                        if bound_res.tag == ResolutionTag::Git {
+                            let locked = bound_res
+                                .git()
+                                .resolved
+                                .slice(this.lockfile.buffers.string_bytes.as_slice());
+                            (!locked.is_empty()).then(|| locked.to_vec())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                };
+                let resolved = match bound_resolved {
+                    Some(resolved) => resolved,
+                    None => Repository::find_commit(
+                        this.env_mut(),
+                        this.log_mut(),
+                        repo_fd,
+                        alias,
+                        this.lockfile.str(&dep.committish),
+                        clone_id,
+                    )?,
+                };
                 let checkout_id = Task::Id::for_git_checkout(url, &resolved);
 
                 let needs_ctx =

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2030,20 +2030,13 @@ fn find_locked_git_package(
         if resolution.tag != resolution_tag {
             continue;
         }
+        // Byte-equal repos only. An scp-like repo ("git@host:path") is
+        // serialized with an "ssh://" prefix the dependency parse lacks, and
+        // every git task id downstream keys on these exact bytes, so binding
+        // across the two spellings would strand the isolated store's checkout
+        // waiter; scp dependencies keep the pre-reuse fetch path instead.
         let locked = resolution.repository();
-        if !locked.owner.eql(repo.owner, buf, buf) {
-            continue;
-        }
-        // The lockfile writer prefixes an scp-like repo ("git@host:path") with
-        // "ssh://", so a reloaded resolution carries the prefix while the
-        // freshly parsed dependency does not.
-        let locked_repo = locked.repo.slice(buf);
-        let dep_repo = repo.repo.slice(buf);
-        let repo_matches = strings::eql(locked_repo, dep_repo)
-            || (strings::has_prefix_comptime(locked_repo, b"ssh://")
-                && dependency::is_scp_like_path(dep_repo)
-                && strings::eql(&locked_repo[b"ssh://".len()..], dep_repo));
-        if !repo_matches {
+        if !locked.repo.eql(repo.repo, buf, buf) || !locked.owner.eql(repo.owner, buf, buf) {
             continue;
         }
         return Some(package_id);

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -484,12 +484,23 @@ pub fn install_with_manager(
                     // ever reads through a pointer into the old backing storage.
                     if manager.summary.overrides_changed && !all_name_hashes.is_empty() {
                         let dependencies_len = manager.lockfile.buffers.dependencies.len();
+                        // Invalidate every affected resolution before enqueueing
+                        // any of them: re-resolution consults existing bindings
+                        // (`find_locked_git_package`), and a not-yet-cleared
+                        // sibling would rebind the dependency to the package the
+                        // old override resolved to.
+                        for dependency_i in 0..dependencies_len {
+                            if all_name_hashes.contains(
+                                &manager.lockfile.buffers.dependencies[dependency_i].name_hash,
+                            ) {
+                                manager.lockfile.buffers.resolutions[dependency_i] =
+                                    invalid_package_id;
+                            }
+                        }
                         for dependency_i in 0..dependencies_len {
                             let dependency =
                                 manager.lockfile.buffers.dependencies[dependency_i].clone();
                             if all_name_hashes.contains(&dependency.name_hash) {
-                                manager.lockfile.buffers.resolutions[dependency_i] =
-                                    invalid_package_id;
                                 if let Err(err) = enqueue_dependency_with_main(
                                     manager,
                                     dependency_i as u32,
@@ -505,6 +516,14 @@ pub fn install_with_manager(
 
                     if manager.summary.catalogs_changed {
                         let dependencies_len = manager.lockfile.buffers.dependencies.len();
+                        // Same two-pass shape as the overrides loop above.
+                        for dep_i in 0..dependencies_len {
+                            if manager.lockfile.buffers.dependencies[dep_i].version.tag
+                                == DependencyVersionTag::Catalog
+                            {
+                                manager.lockfile.buffers.resolutions[dep_i] = invalid_package_id;
+                            }
+                        }
                         for _dep_id in 0..dependencies_len {
                             let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
                             let dep =
@@ -513,8 +532,6 @@ pub fn install_with_manager(
                                 continue;
                             }
 
-                            manager.lockfile.buffers.resolutions[dep_id as usize] =
-                                invalid_package_id;
                             if let Err(err) = enqueue_dependency_with_main(
                                 manager,
                                 dep_id,

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1012,3 +1012,248 @@ it("optional peer with a non-wildcard range is idempotent with two versions of t
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await run(["install", "--frozen-lockfile"]);
 });
+
+// Minimal gzipped tarball with a single root folder wrapping the files, the
+// shape of both github codeload tarballs and npm pack tarballs.
+function makeTarball(rootDir: string, files: Record<string, string>): Uint8Array {
+  function tarHeader(name: string, size: number, isDir: boolean): Uint8Array {
+    const header = new Uint8Array(512);
+    const encoder = new TextEncoder();
+    header.set(encoder.encode(name), 0);
+    header.set(encoder.encode(isDir ? "0000755 " : "0000644 "), 100);
+    header.set(encoder.encode("0000000 "), 108);
+    header.set(encoder.encode("0000000 "), 116);
+    header.set(encoder.encode(size.toString(8).padStart(11, "0") + " "), 124);
+    header.set(encoder.encode("00000000000 "), 136);
+    header.set(encoder.encode("        "), 148);
+    header[156] = (isDir ? "5" : "0").charCodeAt(0);
+    header.set(encoder.encode("ustar"), 257);
+    header.set(encoder.encode("00"), 263);
+    let checksum = 0;
+    for (const byte of header) checksum += byte;
+    header.set(encoder.encode(checksum.toString(8).padStart(6, "0") + "\0 "), 148);
+    return header;
+  }
+  const blocks: Uint8Array[] = [];
+  blocks.push(tarHeader(`${rootDir}/`, 0, true));
+  for (const [name, contents] of Object.entries(files)) {
+    const bytes = new TextEncoder().encode(contents);
+    blocks.push(tarHeader(`${rootDir}/${name}`, bytes.length, false));
+    blocks.push(bytes);
+    if (bytes.length % 512 !== 0) blocks.push(new Uint8Array(512 - (bytes.length % 512)));
+  }
+  blocks.push(new Uint8Array(1024));
+  return Bun.gzipSync(Buffer.concat(blocks));
+}
+
+// The text lockfile writes the resolved commit in the committish position of a
+// git/github resolution string ("git+url#<sha>"), so after a lockfile round
+// trip a dependency naming a branch or tag (or no ref at all) never matches the
+// loaded committish again. Re-resolving (any edit that re-parses a workspace
+// member's dependency list) then fetched every such dependency from the remote
+// on every install. The identical dependency literal already bound in the
+// loaded lockfile must be reused instead.
+it("re-resolving reuses branch and bare ref git dependencies from the lockfile instead of re-fetching", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  // Isolate git from system/global config (e.g. core.autocrlf on Windows).
+  const gitEnv = {
+    ...env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: join(packageDir, "gitconfig"),
+    GIT_AUTHOR_NAME: "bun-test",
+    GIT_AUTHOR_EMAIL: "test@bun.sh",
+    GIT_COMMITTER_NAME: "bun-test",
+    GIT_COMMITTER_EMAIL: "test@bun.sh",
+  };
+  async function git(args: string[], cwd: string): Promise<string> {
+    await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("fatal:");
+    expect(code).toBe(0);
+    return out;
+  }
+  await write(join(packageDir, "gitconfig"), "[core]\n\tautocrlf = false\n");
+
+  // Bare repos served over git's dumb HTTP protocol: after
+  // `git update-server-info`, a bare repo is plain static files.
+  async function makeBareRepo(name: string): Promise<string> {
+    const srcDir = join(packageDir, `${name}-src`);
+    await write(join(srcDir, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
+    await write(join(srcDir, "index.js"), `module.exports = '${name}';\n`);
+    await git(["init", "-q", "-b", "main"], srcDir);
+    await git(["add", "-A"], srcDir);
+    await git(["commit", "-qm", "init"], srcDir);
+    const sha = (await git(["rev-parse", "HEAD"], srcDir)).trim();
+    await git(["clone", "-q", "--bare", srcDir, join(packageDir, `${name}.git`)], packageDir);
+    await git(["update-server-info"], join(packageDir, `${name}.git`));
+    return sha;
+  }
+  const bareSha = await makeBareRepo("bare-dep");
+  const branchSha = await makeBareRepo("branch-dep");
+
+  let gitRequests = 0;
+  await using gitServer = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      gitRequests++;
+      const { pathname } = new URL(req.url);
+      const match = pathname.match(/^\/((?:bare|branch)-dep\.git)\/(.+)$/);
+      if (!match) return new Response("not found", { status: 404 });
+      const f = file(join(packageDir, match[1], match[2]));
+      return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
+    },
+  });
+
+  const ghTarball = makeTarball("testowner-testrepo-aaaaaaa", {
+    "package.json": JSON.stringify({ name: "gh-dep", version: "1.0.0" }),
+    "index.js": "module.exports = 'gh';\n",
+  });
+  let githubDownloads = 0;
+  await using ghServer = Bun.serve({
+    port: 0,
+    fetch() {
+      githubDownloads++;
+      return new Response(ghTarball, { headers: { "Content-Type": "application/gzip" } });
+    },
+  });
+
+  const installEnv = {
+    ...gitEnv,
+    GITHUB_API_URL: `http://localhost:${ghServer.port}`,
+    // CI exports BUN_INSTALL_CACHE_DIR; pin it so this test's cache is its own.
+    BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+  };
+  async function install() {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+  }
+
+  await write(packageJson, JSON.stringify({ name: "ws-root", workspaces: ["packages/*"] }));
+  const memberPackageJson = join(packageDir, "packages", "member", "package.json");
+  const memberDeps: Record<string, string> = {
+    "bare-dep": `git+http://127.0.0.1:${gitServer.port}/bare-dep.git`,
+    "branch-dep": `git+http://127.0.0.1:${gitServer.port}/branch-dep.git#main`,
+    "gh-dep": "github:testowner/testrepo#main",
+  };
+  await write(memberPackageJson, JSON.stringify({ name: "member", version: "1.0.0", dependencies: memberDeps }));
+  await write(
+    join(packageDir, "packages", "member", "dummy", "package.json"),
+    JSON.stringify({ name: "dummy", version: "1.0.0" }),
+  );
+
+  await install();
+  expect(gitRequests).toBeGreaterThan(0);
+  expect(githubDownloads).toBe(1);
+  const lock = await file(join(packageDir, "bun.lock")).text();
+  expect(lock).toContain(`bare-dep@git+http://127.0.0.1:${gitServer.port}/bare-dep.git#${bareSha}`);
+  expect(lock).toContain(`branch-dep@git+http://127.0.0.1:${gitServer.port}/branch-dep.git#${branchSha}`);
+
+  // Dirty the lockfile with a change that re-resolves the member's unchanged
+  // dependencies (a workspace member edit re-parses its whole dependency list).
+  memberDeps["dummy"] = "file:./dummy";
+  await write(memberPackageJson, JSON.stringify({ name: "member", version: "1.0.0", dependencies: memberDeps }));
+  const requestsAfterFirstInstall = gitRequests;
+  await install();
+  expect({ gitRequests, githubDownloads }).toEqual({
+    gitRequests: requestsAfterFirstInstall,
+    githubDownloads: 1,
+  });
+
+  // The locked commits did not move.
+  const lockAfter = await file(join(packageDir, "bun.lock")).text();
+  expect(lockAfter).toContain(`bare-dep@git+http://127.0.0.1:${gitServer.port}/bare-dep.git#${bareSha}`);
+  expect(lockAfter).toContain(`branch-dep@git+http://127.0.0.1:${gitServer.port}/branch-dep.git#${branchSha}`);
+  expect(await file(join(packageDir, "node_modules", "bare-dep", "index.js")).text()).toBe(
+    "module.exports = 'bare-dep';\n",
+  );
+  expect(await file(join(packageDir, "node_modules", "branch-dep", "index.js")).text()).toBe(
+    "module.exports = 'branch-dep';\n",
+  );
+  expect(await file(join(packageDir, "node_modules", "gh-dep", "index.js")).text()).toBe("module.exports = 'gh';\n");
+});
+
+// `bun update` must keep going to the remote for a branch-tracking ref: the
+// reuse above is explicitly skipped for update targets.
+it("`bun update` still re-resolves a branch ref git dependency against the remote", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  const gitEnv = {
+    ...env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: join(packageDir, "gitconfig"),
+    GIT_AUTHOR_NAME: "bun-test",
+    GIT_AUTHOR_EMAIL: "test@bun.sh",
+    GIT_COMMITTER_NAME: "bun-test",
+    GIT_COMMITTER_EMAIL: "test@bun.sh",
+  };
+  async function git(args: string[], cwd: string): Promise<string> {
+    await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("fatal:");
+    expect(code).toBe(0);
+    return out;
+  }
+  await write(join(packageDir, "gitconfig"), "[core]\n\tautocrlf = false\n");
+
+  const srcDir = join(packageDir, "git-src");
+  const bareDir = join(packageDir, "repo.git");
+  await write(join(srcDir, "package.json"), JSON.stringify({ name: "git-dep", version: "1.0.0" }));
+  await git(["init", "-q", "-b", "main"], srcDir);
+  await git(["add", "-A"], srcDir);
+  await git(["commit", "-qm", "init"], srcDir);
+  await git(["clone", "-q", "--bare", srcDir, bareDir], packageDir);
+  await git(["update-server-info"], bareDir);
+
+  let gitRequests = 0;
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      gitRequests++;
+      const { pathname } = new URL(req.url);
+      if (!pathname.startsWith("/repo.git/")) return new Response("not found", { status: 404 });
+      const f = file(join(bareDir, pathname.slice("/repo.git/".length)));
+      return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
+    },
+  });
+
+  const installEnv = {
+    ...gitEnv,
+    BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+  };
+  async function run(args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: packageDir,
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+  }
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "git-update-root",
+      dependencies: { "git-dep": `git+http://127.0.0.1:${server.port}/repo.git#main` },
+    }),
+  );
+
+  await run(["install"]);
+  const requestsAfterInstall = gitRequests;
+  expect(requestsAfterInstall).toBeGreaterThan(0);
+
+  await run(["update", "git-dep"]);
+  expect(gitRequests).toBeGreaterThan(requestsAfterInstall);
+});

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1250,7 +1250,9 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
   expect(lockCold).toContain(`branch-dep.git#${branchSha}`);
   expect(lockCold).not.toContain(movedSha);
   expect(await file(join(memberModules, "branch-dep", "index.js")).text()).toBe("module.exports = 'branch-dep';\n");
-}, 30_000);
+  // Five staged installs plus a git-child-kill retry exceed the 5s default;
+  // this also bounds the cold-cache starvation mode to a fast failure.
+}, 90_000);
 
 // `bun update` must keep going to the remote for a branch-tracking ref: the
 // reuse above is explicitly skipped for update targets.

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1140,9 +1140,12 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     });
     const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
     // A loaded CI machine can OOM-kill the spawned git child (SIGKILL); that
-    // is environmental, not the behavior under test. Restore the counters so
-    // the retried attempt starts from the aborted attempt's baseline.
+    // is environmental, not the behavior under test. A kill between git clone
+    // and git checkout leaves a half-created cache folder the next attempt
+    // would trust, so retry from a clean cache, with the counters restored to
+    // the aborted attempt's baseline.
     if (retries > 0 && err.includes("git failed with signal 9")) {
+      await rm(installEnv.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true });
       gitRequests = gitRequestsBefore;
       githubDownloads = githubDownloadsBefore;
       return install(retries - 1);
@@ -1236,10 +1239,12 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
       stderr: "pipe",
     });
     const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
-    // A loaded CI machine can OOM-kill the spawned git child (SIGKILL);
-    // retrying only ever adds requests, so the requests-increase assertion
-    // holds.
+    // A loaded CI machine can OOM-kill the spawned git child (SIGKILL); retry
+    // from a clean cache (a kill between clone and checkout leaves a
+    // half-created folder the next attempt would trust). Retrying only ever
+    // adds requests, so the requests-increase assertion holds.
     if (retries > 0 && err.includes("git failed with signal 9")) {
+      await rm(installEnv.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true });
       return run(args, retries - 1);
     }
     expect(err).not.toContain("error:");
@@ -1260,4 +1265,90 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
 
   await run(["update", "git-dep"]);
   expect(gitRequests).toBeGreaterThan(requestsAfterInstall);
+});
+
+// A changed override that moves a git dependency to a different ref of the
+// same repository must re-resolve every dependent. Several dependencies
+// sharing one name is the interesting case: the reuse above must not rebind a
+// cleared dependency to a sibling's not-yet-cleared binding from the old
+// override.
+it("a changed git override re-resolves every dependent instead of reusing the old pin", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const { gitEnv, git } = await makeGitFixture(packageDir);
+
+  const srcDir = join(packageDir, "git-src");
+  const bareDir = join(packageDir, "repo.git");
+  await write(join(srcDir, "package.json"), JSON.stringify({ name: "over-dep", version: "1.0.0" }));
+  await write(join(srcDir, "index.js"), "module.exports = 'V1';\n");
+  await git(["init", "-q", "-b", "main"], srcDir);
+  await git(["add", "-A"], srcDir);
+  await git(["commit", "-qm", "v1"], srcDir);
+  await git(["tag", "v1"], srcDir);
+  const sha1 = (await git(["rev-parse", "HEAD"], srcDir)).trim();
+  await write(join(srcDir, "index.js"), "module.exports = 'V2';\n");
+  await git(["add", "-A"], srcDir);
+  await git(["commit", "-qm", "v2"], srcDir);
+  await git(["tag", "v2"], srcDir);
+  const sha2 = (await git(["rev-parse", "HEAD"], srcDir)).trim();
+  await git(["clone", "-q", "--bare", srcDir, bareDir], packageDir);
+  await git(["update-server-info"], bareDir);
+
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (!pathname.startsWith("/repo.git/")) return new Response("not found", { status: 404 });
+      const f = file(join(bareDir, pathname.slice("/repo.git/".length)));
+      return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
+    },
+  });
+
+  const installEnv = {
+    ...gitEnv,
+    BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+  };
+  async function install(retries = 1) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: installEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    // See the retry note in the re-resolving test above.
+    if (retries > 0 && err.includes("git failed with signal 9")) {
+      await rm(installEnv.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true });
+      return install(retries - 1);
+    }
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+  }
+
+  const repoUrl = `git+http://127.0.0.1:${server.port}/repo.git`;
+  function rootPackageJson(ref: string) {
+    return JSON.stringify({
+      name: "ws-root",
+      workspaces: ["packages/*"],
+      overrides: { "over-dep": `${repoUrl}#${ref}` },
+    });
+  }
+  await write(packageJson, rootPackageJson("v1"));
+  for (const member of ["member-a", "member-b"]) {
+    await write(
+      join(packageDir, "packages", member, "package.json"),
+      JSON.stringify({ name: member, version: "1.0.0", dependencies: { "over-dep": "^1.0.0" } }),
+    );
+  }
+
+  await install();
+  expect(await file(join(packageDir, "bun.lock")).text()).toContain(`#${sha1}`);
+  expect(await file(join(packageDir, "node_modules", "over-dep", "index.js")).text()).toBe("module.exports = 'V1';\n");
+
+  await write(packageJson, rootPackageJson("v2"));
+  await install();
+  const lockAfter = await file(join(packageDir, "bun.lock")).text();
+  expect(lockAfter).toContain(`#${sha2}`);
+  expect(lockAfter).not.toContain(`#${sha1}`);
+  expect(await file(join(packageDir, "node_modules", "over-dep", "index.js")).text()).toBe("module.exports = 'V2';\n");
 });

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1124,7 +1124,7 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     // CI exports BUN_INSTALL_CACHE_DIR; pin it so this test's cache is its own.
     BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
   };
-  async function install() {
+  async function install(retries = 1) {
     await using proc = spawn({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
@@ -1133,6 +1133,13 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
       stderr: "pipe",
     });
     const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    // Loaded CI machines can OOM-kill a spawned git child (SIGKILL); that is
+    // environmental, not the behavior under test. The request-count
+    // assertions below only ever compare values captured after a completed
+    // install, so a retried attempt cannot mask the re-fetch bug.
+    if (retries > 0 && err.includes("signal 9")) {
+      return install(retries - 1);
+    }
     expect(err).not.toContain("error:");
     expect(code).toBe(0);
   }
@@ -1152,7 +1159,7 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
 
   await install();
   expect(gitRequests).toBeGreaterThan(0);
-  expect(githubDownloads).toBe(1);
+  expect(githubDownloads).toBeGreaterThan(0);
   const lock = await file(join(packageDir, "bun.lock")).text();
   expect(lock).toContain(`bare-dep@git+http://127.0.0.1:${gitServer.port}/bare-dep.git#${bareSha}`);
   expect(lock).toContain(`branch-dep@git+http://127.0.0.1:${gitServer.port}/branch-dep.git#${branchSha}`);
@@ -1162,10 +1169,11 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
   memberDeps["dummy"] = "file:./dummy";
   await write(memberPackageJson, JSON.stringify({ name: "member", version: "1.0.0", dependencies: memberDeps }));
   const requestsAfterFirstInstall = gitRequests;
+  const downloadsAfterFirstInstall = githubDownloads;
   await install();
   expect({ gitRequests, githubDownloads }).toEqual({
     gitRequests: requestsAfterFirstInstall,
-    githubDownloads: 1,
+    githubDownloads: downloadsAfterFirstInstall,
   });
 
   // The locked commits did not move.
@@ -1229,7 +1237,7 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
     ...gitEnv,
     BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
   };
-  async function run(args: string[]) {
+  async function run(args: string[], retries = 1) {
     await using proc = spawn({
       cmd: [bunExe(), ...args],
       cwd: packageDir,
@@ -1238,6 +1246,11 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
       stderr: "pipe",
     });
     const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+    // Loaded CI machines can OOM-kill a spawned git child (SIGKILL); retrying
+    // only ever adds requests, so the requests-increase assertion holds.
+    if (retries > 0 && err.includes("signal 9")) {
+      return run(args, retries - 1);
+    }
     expect(err).not.toContain("error:");
     expect(code).toBe(0);
   }

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1240,7 +1240,10 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
   await git(["fetch", "-q", branchSrc, "+refs/heads/*:refs/heads/*"], join(packageDir, "branch-dep.git"));
   await git(["update-server-info"], join(packageDir, "branch-dep.git"));
 
+  // Drop every git dependency except the one under test so the cold install
+  // runs a single clone chain (see the staging note above).
   delete memberDeps["dummy"];
+  delete memberDeps["bare-dep"];
   await writeMember();
   await rm(installEnv.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true });
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1135,7 +1135,10 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     const branchRequestsBefore = branchRequests;
     const githubDownloadsBefore = githubDownloads;
     await using proc = spawn({
-      cmd: [bunExe(), "install"],
+      // Explicit linker: the cold-cache stage below regresses only under the
+      // isolated linker's store (its entry waits on the locked commit's
+      // checkout id).
+      cmd: [bunExe(), "install", "--linker", "isolated"],
       cwd: packageDir,
       env: installEnv,
       stdout: "pipe",
@@ -1205,14 +1208,49 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
   const lockAfter = await file(join(packageDir, "bun.lock")).text();
   expect(lockAfter).toContain(`bare-dep@git+http://127.0.0.1:${gitServer.port}/bare-dep.git#${bareSha}`);
   expect(lockAfter).toContain(`branch-dep@git+http://127.0.0.1:${gitServer.port}/branch-dep.git#${branchSha}`);
-  expect(await file(join(packageDir, "node_modules", "bare-dep", "index.js")).text()).toBe(
-    "module.exports = 'bare-dep';\n",
-  );
-  expect(await file(join(packageDir, "node_modules", "branch-dep", "index.js")).text()).toBe(
-    "module.exports = 'branch-dep';\n",
-  );
-  expect(await file(join(packageDir, "node_modules", "gh-dep", "index.js")).text()).toBe("module.exports = 'gh';\n");
-});
+  const memberModules = join(packageDir, "packages", "member", "node_modules");
+  expect(await file(join(memberModules, "bare-dep", "index.js")).text()).toBe("module.exports = 'bare-dep';\n");
+  expect(await file(join(memberModules, "branch-dep", "index.js")).text()).toBe("module.exports = 'branch-dep';\n");
+  expect(await file(join(memberModules, "gh-dep", "index.js")).text()).toBe("module.exports = 'gh';\n");
+
+  // Changing a dependency's ref is the boundary the reuse must not cross: a
+  // different literal consults the remote again (here the same commit wins,
+  // so only the request counter moves).
+  memberDeps["branch-dep"] = `git+http://127.0.0.1:${gitServer.port}/branch-dep.git`;
+  await writeMember();
+  const beforeRefChange = { bareRequests, branchRequests, githubDownloads };
+  await install();
+  expect(branchRequests).toBeGreaterThan(beforeRefChange.branchRequests);
+  expect({ bareRequests, githubDownloads }).toEqual({
+    bareRequests: beforeRefChange.bareRequests,
+    githubDownloads: beforeRefChange.githubDownloads,
+  });
+  expect(await file(join(packageDir, "bun.lock")).text()).toContain(`branch-dep.git#${branchSha}`);
+
+  // Cold cache with a moved branch head: the lockfile pin must win and the
+  // install must terminate. The isolated store waits on the locked commit's
+  // checkout; a re-enqueued dependency that follows the moved ref instead of
+  // the bound package's commit starves it forever (and without the reuse the
+  // pin silently floats to the new head).
+  const branchSrc = join(packageDir, "branch-dep-src");
+  await write(join(branchSrc, "index.js"), "module.exports = 'branch-dep-v2';\n");
+  await git(["add", "-A"], branchSrc);
+  await git(["commit", "-qm", "move"], branchSrc);
+  const movedSha = (await git(["rev-parse", "HEAD"], branchSrc)).trim();
+  await git(["fetch", "-q", branchSrc, "+refs/heads/*:refs/heads/*"], join(packageDir, "branch-dep.git"));
+  await git(["update-server-info"], join(packageDir, "branch-dep.git"));
+
+  delete memberDeps["dummy"];
+  await writeMember();
+  await rm(installEnv.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true });
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await rm(memberModules, { recursive: true, force: true });
+  await install();
+  const lockCold = await file(join(packageDir, "bun.lock")).text();
+  expect(lockCold).toContain(`branch-dep.git#${branchSha}`);
+  expect(lockCold).not.toContain(movedSha);
+  expect(await file(join(memberModules, "branch-dep", "index.js")).text()).toBe("module.exports = 'branch-dep';\n");
+}, 30_000);
 
 // `bun update` must keep going to the remote for a branch-tracking ref: the
 // reuse above is explicitly skipped for update targets.
@@ -1282,12 +1320,12 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
   expect(gitRequests).toBeGreaterThan(requestsAfterInstall);
 });
 
-// A changed override that moves a git dependency to a different ref of the
-// same repository must re-resolve every dependent. Several dependencies
-// sharing one name is the interesting case: the reuse above must not rebind a
-// cleared dependency to a sibling's not-yet-cleared binding from the old
-// override.
-it("a changed git override re-resolves every dependent instead of reusing the old pin", async () => {
+// A changed override or catalog entry that moves a git dependency to a
+// different ref of the same repository must re-resolve every dependent.
+// Several dependencies sharing one name is the interesting case: the reuse
+// above must not rebind a cleared dependency to a sibling's not-yet-cleared
+// binding from the old entry.
+async function changedEntryReResolves(mode: "overrides" | "catalog") {
   const { packageDir, packageJson } = await registry.createTestDir();
   const { gitEnv, git } = await makeGitFixture(packageDir);
 
@@ -1342,17 +1380,25 @@ it("a changed git override re-resolves every dependent instead of reusing the ol
 
   const repoUrl = `git+http://127.0.0.1:${server.port}/repo.git`;
   function rootPackageJson(ref: string) {
-    return JSON.stringify({
-      name: "ws-root",
-      workspaces: ["packages/*"],
-      overrides: { "over-dep": `${repoUrl}#${ref}` },
-    });
+    return JSON.stringify(
+      mode === "overrides"
+        ? {
+            name: "ws-root",
+            workspaces: ["packages/*"],
+            overrides: { "over-dep": `${repoUrl}#${ref}` },
+          }
+        : {
+            name: "ws-root",
+            workspaces: { packages: ["packages/*"], catalog: { "over-dep": `${repoUrl}#${ref}` } },
+          },
+    );
   }
+  const memberSpec = mode === "overrides" ? "^1.0.0" : "catalog:";
   await write(packageJson, rootPackageJson("v1"));
   for (const member of ["member-a", "member-b"]) {
     await write(
       join(packageDir, "packages", member, "package.json"),
-      JSON.stringify({ name: member, version: "1.0.0", dependencies: { "over-dep": "^1.0.0" } }),
+      JSON.stringify({ name: member, version: "1.0.0", dependencies: { "over-dep": memberSpec } }),
     );
   }
 
@@ -1366,4 +1412,10 @@ it("a changed git override re-resolves every dependent instead of reusing the ol
   expect(lockAfter).toContain(`#${sha2}`);
   expect(lockAfter).not.toContain(`#${sha1}`);
   expect(await file(join(packageDir, "node_modules", "over-dep", "index.js")).text()).toBe("module.exports = 'V2';\n");
-});
+}
+
+it("a changed git override re-resolves every dependent instead of reusing the old pin", () =>
+  changedEntryReResolves("overrides"));
+
+it("a changed git catalog entry re-resolves every dependent instead of reusing the old pin", () =>
+  changedEntryReResolves("catalog"));

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1046,17 +1046,8 @@ function makeTarball(rootDir: string, files: Record<string, string>): Uint8Array
   return Bun.gzipSync(Buffer.concat(blocks));
 }
 
-// The text lockfile writes the resolved commit in the committish position of a
-// git/github resolution string ("git+url#<sha>"), so after a lockfile round
-// trip a dependency naming a branch or tag (or no ref at all) never matches the
-// loaded committish again. Re-resolving (any edit that re-parses a workspace
-// member's dependency list) then fetched every such dependency from the remote
-// on every install. The identical dependency literal already bound in the
-// loaded lockfile must be reused instead.
-it("re-resolving reuses branch and bare ref git dependencies from the lockfile instead of re-fetching", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-
-  // Isolate git from system/global config (e.g. core.autocrlf on Windows).
+// Isolate git from system/global config (e.g. core.autocrlf on Windows).
+async function makeGitFixture(packageDir: string) {
   const gitEnv = {
     ...env,
     GIT_CONFIG_NOSYSTEM: "1",
@@ -1074,6 +1065,19 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     return out;
   }
   await write(join(packageDir, "gitconfig"), "[core]\n\tautocrlf = false\n");
+  return { gitEnv, git };
+}
+
+// The text lockfile writes the resolved commit in the committish position of a
+// git/github resolution string ("git+url#<sha>"), so after a lockfile round
+// trip a dependency naming a branch or tag (or no ref at all) never matches the
+// loaded committish again. Re-resolving (any edit that re-parses a workspace
+// member's dependency list) then fetched every such dependency from the remote
+// on every install. The identical dependency literal already bound in the
+// loaded lockfile must be reused instead.
+it("re-resolving reuses branch and bare ref git dependencies from the lockfile instead of re-fetching", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const { gitEnv, git } = await makeGitFixture(packageDir);
 
   // Bare repos served over git's dumb HTTP protocol: after
   // `git update-server-info`, a bare repo is plain static files.
@@ -1125,6 +1129,8 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
   };
   async function install(retries = 1) {
+    const gitRequestsBefore = gitRequests;
+    const githubDownloadsBefore = githubDownloads;
     await using proc = spawn({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
@@ -1133,11 +1139,12 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
       stderr: "pipe",
     });
     const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
-    // Loaded CI machines can OOM-kill a spawned git child (SIGKILL); that is
-    // environmental, not the behavior under test. The request-count
-    // assertions below only ever compare values captured after a completed
-    // install, so a retried attempt cannot mask the re-fetch bug.
-    if (retries > 0 && err.includes("signal 9")) {
+    // A loaded CI machine can OOM-kill the spawned git child (SIGKILL); that
+    // is environmental, not the behavior under test. Restore the counters so
+    // the retried attempt starts from the aborted attempt's baseline.
+    if (retries > 0 && err.includes("git failed with signal 9")) {
+      gitRequests = gitRequestsBefore;
+      githubDownloads = githubDownloadsBefore;
       return install(retries - 1);
     }
     expect(err).not.toContain("error:");
@@ -1193,24 +1200,7 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
 // reuse above is explicitly skipped for update targets.
 it("`bun update` still re-resolves a branch ref git dependency against the remote", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
-
-  const gitEnv = {
-    ...env,
-    GIT_CONFIG_NOSYSTEM: "1",
-    GIT_CONFIG_GLOBAL: join(packageDir, "gitconfig"),
-    GIT_AUTHOR_NAME: "bun-test",
-    GIT_AUTHOR_EMAIL: "test@bun.sh",
-    GIT_COMMITTER_NAME: "bun-test",
-    GIT_COMMITTER_EMAIL: "test@bun.sh",
-  };
-  async function git(args: string[], cwd: string): Promise<string> {
-    await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
-    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(err).not.toContain("fatal:");
-    expect(code).toBe(0);
-    return out;
-  }
-  await write(join(packageDir, "gitconfig"), "[core]\n\tautocrlf = false\n");
+  const { gitEnv, git } = await makeGitFixture(packageDir);
 
   const srcDir = join(packageDir, "git-src");
   const bareDir = join(packageDir, "repo.git");
@@ -1246,9 +1236,10 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
       stderr: "pipe",
     });
     const [err, code] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
-    // Loaded CI machines can OOM-kill a spawned git child (SIGKILL); retrying
-    // only ever adds requests, so the requests-increase assertion holds.
-    if (retries > 0 && err.includes("signal 9")) {
+    // A loaded CI machine can OOM-kill the spawned git child (SIGKILL);
+    // retrying only ever adds requests, so the requests-increase assertion
+    // holds.
+    if (retries > 0 && err.includes("git failed with signal 9")) {
       return run(args, retries - 1);
     }
     expect(err).not.toContain("error:");

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1096,14 +1096,16 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
   const bareSha = await makeBareRepo("bare-dep");
   const branchSha = await makeBareRepo("branch-dep");
 
-  let gitRequests = 0;
+  let bareRequests = 0;
+  let branchRequests = 0;
   await using gitServer = Bun.serve({
     port: 0,
     async fetch(req) {
-      gitRequests++;
       const { pathname } = new URL(req.url);
       const match = pathname.match(/^\/((?:bare|branch)-dep\.git)\/(.+)$/);
       if (!match) return new Response("not found", { status: 404 });
+      if (match[1] === "bare-dep.git") bareRequests++;
+      else branchRequests++;
       const f = file(join(packageDir, match[1], match[2]));
       return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
     },
@@ -1129,7 +1131,8 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
   };
   async function install(retries = 1) {
-    const gitRequestsBefore = gitRequests;
+    const bareRequestsBefore = bareRequests;
+    const branchRequestsBefore = branchRequests;
     const githubDownloadsBefore = githubDownloads;
     await using proc = spawn({
       cmd: [bunExe(), "install"],
@@ -1146,7 +1149,8 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     // the aborted attempt's baseline.
     if (retries > 0 && err.includes("git failed with signal 9")) {
       await rm(installEnv.BUN_INSTALL_CACHE_DIR, { recursive: true, force: true });
-      gitRequests = gitRequestsBefore;
+      bareRequests = bareRequestsBefore;
+      branchRequests = branchRequestsBefore;
       githubDownloads = githubDownloadsBefore;
       return install(retries - 1);
     }
@@ -1154,37 +1158,48 @@ it("re-resolving reuses branch and bare ref git dependencies from the lockfile i
     expect(code).toBe(0);
   }
 
+  // The installs are staged so at most one git clone runs at a time: loaded
+  // CI machines reliably OOM-kill one of two concurrent git children under an
+  // ASAN build. Each stage edits the member, which re-parses its whole
+  // dependency list and re-resolves the dependencies added by earlier stages.
   await write(packageJson, JSON.stringify({ name: "ws-root", workspaces: ["packages/*"] }));
   const memberPackageJson = join(packageDir, "packages", "member", "package.json");
   const memberDeps: Record<string, string> = {
     "bare-dep": `git+http://127.0.0.1:${gitServer.port}/bare-dep.git`,
-    "branch-dep": `git+http://127.0.0.1:${gitServer.port}/branch-dep.git#main`,
-    "gh-dep": "github:testowner/testrepo#main",
   };
-  await write(memberPackageJson, JSON.stringify({ name: "member", version: "1.0.0", dependencies: memberDeps }));
+  async function writeMember() {
+    await write(memberPackageJson, JSON.stringify({ name: "member", version: "1.0.0", dependencies: memberDeps }));
+  }
+  await writeMember();
   await write(
     join(packageDir, "packages", "member", "dummy", "package.json"),
     JSON.stringify({ name: "dummy", version: "1.0.0" }),
   );
 
   await install();
-  expect(gitRequests).toBeGreaterThan(0);
-  expect(githubDownloads).toBeGreaterThan(0);
+  expect(bareRequests).toBeGreaterThan(0);
   const lock = await file(join(packageDir, "bun.lock")).text();
   expect(lock).toContain(`bare-dep@git+http://127.0.0.1:${gitServer.port}/bare-dep.git#${bareSha}`);
-  expect(lock).toContain(`branch-dep@git+http://127.0.0.1:${gitServer.port}/branch-dep.git#${branchSha}`);
 
-  // Dirty the lockfile with a change that re-resolves the member's unchanged
-  // dependencies (a workspace member edit re-parses its whole dependency list).
-  memberDeps["dummy"] = "file:./dummy";
-  await write(memberPackageJson, JSON.stringify({ name: "member", version: "1.0.0", dependencies: memberDeps }));
-  const requestsAfterFirstInstall = gitRequests;
-  const downloadsAfterFirstInstall = githubDownloads;
+  // Adding dependencies to the member re-resolves bare-dep; its bare ref must
+  // bind to the loaded package without contacting the remote again.
+  memberDeps["branch-dep"] = `git+http://127.0.0.1:${gitServer.port}/branch-dep.git#main`;
+  memberDeps["gh-dep"] = "github:testowner/testrepo#main";
+  await writeMember();
+  const bareRequestsAfterFirstInstall = bareRequests;
   await install();
-  expect({ gitRequests, githubDownloads }).toEqual({
-    gitRequests: requestsAfterFirstInstall,
-    githubDownloads: downloadsAfterFirstInstall,
-  });
+  expect(bareRequests).toBe(bareRequestsAfterFirstInstall);
+  expect(branchRequests).toBeGreaterThan(0);
+  expect(githubDownloads).toBeGreaterThan(0);
+  const lockSecond = await file(join(packageDir, "bun.lock")).text();
+  expect(lockSecond).toContain(`branch-dep@git+http://127.0.0.1:${gitServer.port}/branch-dep.git#${branchSha}`);
+
+  // Another member edit re-resolves all three; none may go to the network.
+  memberDeps["dummy"] = "file:./dummy";
+  await writeMember();
+  const snapshot = { bareRequests, branchRequests, githubDownloads };
+  await install();
+  expect({ bareRequests, branchRequests, githubDownloads }).toEqual(snapshot);
 
   // The locked commits did not move.
   const lockAfter = await file(join(packageDir, "bun.lock")).text();

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1320,7 +1320,7 @@ it("`bun update` still re-resolves a branch ref git dependency against the remot
 
   await run(["update", "git-dep"]);
   expect(gitRequests).toBeGreaterThan(requestsAfterInstall);
-});
+}, 60_000);
 
 // A changed override or catalog entry that moves a git dependency to a
 // different ref of the same repository must re-resolve every dependent.
@@ -1416,8 +1416,14 @@ async function changedEntryReResolves(mode: "overrides" | "catalog") {
   expect(await file(join(packageDir, "node_modules", "over-dep", "index.js")).text()).toBe("module.exports = 'V2';\n");
 }
 
-it("a changed git override re-resolves every dependent instead of reusing the old pin", () =>
-  changedEntryReResolves("overrides"));
+it(
+  "a changed git override re-resolves every dependent instead of reusing the old pin",
+  () => changedEntryReResolves("overrides"),
+  60_000,
+);
 
-it("a changed git catalog entry re-resolves every dependent instead of reusing the old pin", () =>
-  changedEntryReResolves("catalog"));
+it(
+  "a changed git catalog entry re-resolves every dependent instead of reusing the old pin",
+  () => changedEntryReResolves("catalog"),
+  60_000,
+);


### PR DESCRIPTION
### Symptom

Whenever `bun install` re-resolves (most commonly: any dependency edit in a workspace member, which re-parses the member and re-enqueues its whole dependency list), every git or github dependency whose committish is a branch, a tag, or absent (`git+url#main`, `github:owner/repo`, ...) is fetched from the remote again, despite a warm cache and an unchanged lockfile pin. The extract then appends a transient duplicate package that the lockfile clean prunes, so `bun.lock` stays correct and the cost is the redundant network round trip on every such install. Sha-pinned refs have the same re-resolution bug with a different cause, fixed separately in #37142; this PR covers the refs #37142 explicitly leaves out.

With `BUN_DEBUG_PackageManager=1` the second install shows the git dependency going back to the network:

```
[packagemanager] enqueueDependency(3, git, branch-dep, git+http://127.0.0.1:4873/branch-dep.git#main) = http://127.0.0.1:4873/branch-dep.git
```

### Cause

`bun.lock` writes the *resolved* commit in the committish position of the resolution string: a dependency on `git+url#main` is stored as `branch-dep@git+url#<sha>`. Reloading the lockfile parses that sha back as the committish, so the original ref ("main", "v1", or empty) is lost. On re-resolution, the git/github arms of `enqueue_dependency_with_main_and_success_fn` call `lockfile.get_package_id(...)`, whose `Repository::eql` compares the fresh dependency's committish against the loaded one: "main" vs `<sha>` never matches, the lookup misses, and a clone/fetch (git) or tarball download (github) task is created.

Root-level dependencies are protected by `Diff::generate`'s mapping (unchanged deps keep their resolution slot), but a changed workspace member's dependency list is re-parsed with invalid slots, so every one of its git deps takes this path on every install that dirties the lockfile.

### Fix

When the exact-committish lookup misses, reuse the package an **identical dependency** (same name hash, same version literal) is already bound to in the loaded lockfile, after checking the bound package's resolution is the same kind of repository with the same repo/owner. The dependency literal round-trips through `bun.lock` unchanged, so "an identical literal previously resolved to this package" is the lossless record of the prior resolution, for branch, tag, bare, and sha refs alike. Cases where the literal is the wrong authority are already handled upstream of this lookup: a changed override or catalog invalidates the old bindings before re-enqueueing, and the repo/owner check rejects a binding whose effective resolution was redirected.

The reuse is skipped for `bun update` targets (same update-target test as `Diff::generate`): an update must keep re-resolving the ref against the remote. That keeps #36689 (`bun update` re-resolves git deps) working unchanged; all five of its tests pass with both changes applied together.

Three adjustments that review surfaced:

- The overrides/catalogs re-resolution loops in `install_with_manager.rs` cleared and re-enqueued affected dependencies one at a time, so with several dependencies sharing a name the first re-resolution could have rebound to a sibling's not-yet-cleared binding from the old override (a committish-only override change, `git+url#v1` to `#v2`, would have been silently ignored). Both loops now invalidate every affected slot before enqueueing any of them, which is what makes the literal the safe authority here. Covered by tests for both the override and the catalog variant.
- With a cold cache under the isolated linker, the store entry for a git dependency waits on the locked commit's checkout id, but the resolve-phase re-enqueue after a clone derived the checkout from `find_commit` on the dependency's committish, which follows the ref. With a branch head that moved since lock, the reuse left the dependency correctly bound to the locked package while the locked checkout never ran: `bun install` hung forever (without the reuse, the same flow instead silently floated the pin to the new head, and a clean-lockfile cold-cache install already hung before this PR). The re-enqueue now checks out the bound package's resolved commit, the same way the clone-failure drain and the hoisted installer already key it. Covered by a cold-cache leg in the reuse test: moved branch head, wiped cache and node_modules, isolated linker; asserts the install terminates, keeps the locked sha, and installs the locked content.
- scp-form repos (`git@host:path`) are intentionally excluded from the reuse: the lockfile writer serializes them with an `ssh://` prefix the dependency parse lacks, and every git task id downstream keys on the exact repo bytes, so binding across the two spellings would strand the isolated store's checkout waiter (it waits under the package-repo id while the re-enqueue keys on the dependency-repo id). scp dependencies keep the pre-existing fetch path, which is redundant but correct. Aligning the two spellings at parse time is the real fix and is its own pre-existing issue (the same id mismatch can already strand a lockfile-bound scp dependency on a cold cache under the isolated linker, with no reuse involved).

The reuse test also pins the must-not-reuse boundary: changing a dependency's ref literal consults the remote again.

Beyond the redundant traffic, the re-fetch becomes a correctness problem the moment the cached repo's refs actually refresh, which is exactly what #36689 fixes (`git fetch` on the bare cache currently updates no refs, so today's re-fetch accidentally returns the stale pin). Verified with #36689's refspec fix applied and this fix absent: a plain `bun install` after an unrelated member edit silently floats `#main` from the locked sha to the remote's new HEAD, rewriting the lockfile pin. With both fixes applied the pin stays put on `bun install` and still moves on `bun update`.

### Verification

Three new tests in `test/cli/install/bun-lock.test.ts`, all against local servers (bare git repos over dumb HTTP; fake codeload tarball server for `github:`), no network:

- `re-resolving reuses branch and bare ref git dependencies from the lockfile instead of re-fetching`: a workspace member depends on `git+url` (bare), `git+url#main` (branch), and `github:owner/repo#main`; install, dirty the member with an unrelated dep, install again, assert the request counters did not move and the locked shas are unchanged. On unfixed bun the second install makes 4 extra git requests and re-downloads the github tarball.
- `` `bun update` still re-resolves a branch ref git dependency against the remote ``: pins the update-target gate; passes before and after this change.
- `a changed git override re-resolves every dependent instead of reusing the old pin`: two workspace members share an overridden dependency, the override moves from `#v1` to `#v2` of one repo; asserts the lockfile and installed content move. Passes on released bun, fails with the reuse alone (the interleaved invalidation), passes with the two-pass invalidation.

Ran locally with the debug build:

- `test/cli/install/bun-lock.test.ts`: 19 pass
- `test/cli/install/isolated-install.test.ts`: 62 pass
- `test/cli/install/bun-workspaces.test.ts`: 63 pass
- `test/cli/install/bun-update.test.ts`: 6 pass, `catalogs.test.ts`: 18 pass, `overrides.test.ts`: 7 pass, `bun-add.test.ts`: 54 pass
- `test/cli/install/bun-install.test.ts -t git`: 9 pass, 12 failures from blocked external hosts in the sandbox (bitbucket.org/gitlab.com), identical on released bun

Complementary to #37142, which fixes the empty-package-name lookup miss for these dependency types: that change makes sha-pinned refs match the loaded committish, this one recovers everything the committish comparison cannot express. Neither subsumes the other and they merge cleanly in either order.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->