### PR TITLE
install: re-clone git dependency cache folders left incomplete by a killed install

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2350,6 +2350,17 @@ impl<'a> PackageInstall<'a> {
                                 ZStr::from_buf(&buf[..], subpath_len + 1 + b"package.json".len());
                             break 'package_json_exists sys::exists_at(self.cache_dir, subpath);
                         }
+                        resolution::Tag::Git => {
+                            // Git checkouts can legitimately lack `package.json`;
+                            // the `.bun-tag` written last by `Repository::checkout`
+                            // marks the folder complete.
+                            let mut join_buf = PathBuffer::uninit();
+                            let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+                                &mut join_buf.0,
+                                &[self.cache_dir_subpath.as_bytes(), b".bun-tag"],
+                            );
+                            sys::exists_at(self.cache_dir, tag_path)
+                        }
                         _ => sys::directory_exists_at(self.cache_dir, self.cache_dir_subpath)
                             .unwrap_or(false),
                     };

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2351,14 +2351,10 @@ impl<'a> PackageInstall<'a> {
                             break 'package_json_exists sys::exists_at(self.cache_dir, subpath);
                         }
                         resolution::Tag::Git => {
-                            // See `is_git_folder_in_cache`: `.bun-tag` marks a
-                            // git checkout complete.
-                            let mut join_buf = PathBuffer::uninit();
-                            let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
-                                &mut join_buf.0,
-                                &[self.cache_dir_subpath.as_bytes(), b".bun-tag"],
-                            );
-                            sys::exists_at(self.cache_dir, tag_path)
+                            crate::package_manager::directories::is_git_folder_in_cache_at(
+                                self.cache_dir,
+                                self.cache_dir_subpath.as_bytes(),
+                            )
                         }
                         _ => sys::directory_exists_at(self.cache_dir, self.cache_dir_subpath)
                             .unwrap_or(false),
@@ -2374,16 +2370,14 @@ impl<'a> PackageInstall<'a> {
                     });
                 let cache_dir_subpath_without_patch_hash =
                     &self.cache_dir_subpath.as_bytes()[..idx];
-                // Use a stack PathBuffer (no shared state).
-                let mut join_buf = PathBuffer::uninit();
                 let exists = if matches!(resolution_tag, resolution::Tag::Git) {
-                    // Same `.bun-tag` probe as the unpatched Git arm above.
-                    let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
-                        &mut join_buf.0,
-                        &[cache_dir_subpath_without_patch_hash, b".bun-tag"],
-                    );
-                    sys::exists_at(self.cache_dir, tag_path)
+                    crate::package_manager::directories::is_git_folder_in_cache_at(
+                        self.cache_dir,
+                        cache_dir_subpath_without_patch_hash,
+                    )
                 } else {
+                    // Use a stack PathBuffer (no shared state).
+                    let mut join_buf = PathBuffer::uninit();
                     join_buf[..cache_dir_subpath_without_patch_hash.len()]
                         .copy_from_slice(cache_dir_subpath_without_patch_hash);
                     join_buf[cache_dir_subpath_without_patch_hash.len()] = 0;

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2377,13 +2377,23 @@ impl<'a> PackageInstall<'a> {
                     &self.cache_dir_subpath.as_bytes()[..idx];
                 // Use a stack PathBuffer (no shared state).
                 let mut join_buf = PathBuffer::uninit();
-                join_buf[..cache_dir_subpath_without_patch_hash.len()]
-                    .copy_from_slice(cache_dir_subpath_without_patch_hash);
-                join_buf[cache_dir_subpath_without_patch_hash.len()] = 0;
-                // SAFETY: NUL written above.
-                let subpath =
-                    ZStr::from_buf(&join_buf[..], cache_dir_subpath_without_patch_hash.len());
-                let exists = sys::directory_exists_at(self.cache_dir, subpath).unwrap_or(false);
+                let exists = if matches!(resolution_tag, resolution::Tag::Git) {
+                    // Same as the unpatched arm above: the base checkout is only
+                    // complete once `.bun-tag` exists.
+                    let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+                        &mut join_buf.0,
+                        &[cache_dir_subpath_without_patch_hash, b".bun-tag"],
+                    );
+                    sys::exists_at(self.cache_dir, tag_path)
+                } else {
+                    join_buf[..cache_dir_subpath_without_patch_hash.len()]
+                        .copy_from_slice(cache_dir_subpath_without_patch_hash);
+                    join_buf[cache_dir_subpath_without_patch_hash.len()] = 0;
+                    // SAFETY: NUL written above.
+                    let subpath =
+                        ZStr::from_buf(&join_buf[..], cache_dir_subpath_without_patch_hash.len());
+                    sys::directory_exists_at(self.cache_dir, subpath).unwrap_or(false)
+                };
                 if exists {
                     manager.set_preinstall_state(package_id, crate::PreinstallState::Done);
                 }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2351,9 +2351,8 @@ impl<'a> PackageInstall<'a> {
                             break 'package_json_exists sys::exists_at(self.cache_dir, subpath);
                         }
                         resolution::Tag::Git => {
-                            // Git checkouts can legitimately lack `package.json`;
-                            // the `.bun-tag` written last by `Repository::checkout`
-                            // marks the folder complete.
+                            // See `is_git_folder_in_cache`: `.bun-tag` marks a
+                            // git checkout complete.
                             let mut join_buf = PathBuffer::uninit();
                             let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
                                 &mut join_buf.0,
@@ -2378,8 +2377,7 @@ impl<'a> PackageInstall<'a> {
                 // Use a stack PathBuffer (no shared state).
                 let mut join_buf = PathBuffer::uninit();
                 let exists = if matches!(resolution_tag, resolution::Tag::Git) {
-                    // Same as the unpatched arm above: the base checkout is only
-                    // complete once `.bun-tag` exists.
+                    // Same `.bun-tag` probe as the unpatched Git arm above.
                     let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
                         &mut join_buf.0,
                         &[cache_dir_subpath_without_patch_hash, b".bun-tag"],

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -755,10 +755,9 @@ pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool
 }
 
 /// Git checkouts can legitimately lack `package.json`, so their completeness
-/// marker is the `.bun-tag` that `Repository::checkout` writes as the last
-/// step of populating the folder. A bare folder without it is a leftover from
-/// an install that was killed mid-checkout; treating it as cached would
-/// silently install an empty package.
+/// marker is the `.bun-tag` that `Repository::checkout` writes last. A folder
+/// without it is a leftover from an interrupted checkout; installing it would
+/// produce an empty package.
 pub fn is_git_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
     let mut buf = PathBuffer::uninit();
     let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -759,12 +759,18 @@ pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool
 /// without it is a leftover from an interrupted checkout; installing it would
 /// produce an empty package.
 pub fn is_git_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
+    is_git_folder_in_cache_at(get_cache_directory(this), folder_path.as_bytes())
+}
+
+/// [`is_git_folder_in_cache`] for call sites that hold the cache dir `Fd` and
+/// folder subpath directly (the hoisted and isolated installers).
+pub fn is_git_folder_in_cache_at(cache_dir: Fd, folder_subpath: &[u8]) -> bool {
     let mut buf = PathBuffer::uninit();
     let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
         &mut buf.0,
-        &[folder_path.as_bytes(), b".bun-tag"],
+        &[folder_subpath, b".bun-tag"],
     );
-    sys::exists_at(get_cache_directory(this), tag_path)
+    sys::exists_at(cache_dir, tag_path)
 }
 
 // ─────────────────────────── global directories ───────────────────────────────

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -754,6 +754,20 @@ pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool
     sys::directory_exists_at(get_cache_directory(this), folder_path).unwrap_or(false)
 }
 
+/// Git checkouts can legitimately lack `package.json`, so their completeness
+/// marker is the `.bun-tag` that `Repository::checkout` writes as the last
+/// step of populating the folder. A bare folder without it is a leftover from
+/// an install that was killed mid-checkout; treating it as cached would
+/// silently install an empty package.
+pub fn is_git_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
+    let mut buf = PathBuffer::uninit();
+    let tag_path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+        &mut buf.0,
+        &[folder_path.as_bytes(), b".bun-tag"],
+    );
+    sys::exists_at(get_cache_directory(this), tag_path)
+}
+
 // ─────────────────────────── global directories ───────────────────────────────
 
 pub fn setup_global_dir(manager: &mut PackageManager, ctx: &Command::Context) -> Result<(), Error> {

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -177,7 +177,13 @@ impl PackageManager {
                     return PreinstallState::Extract;
                 }
 
-                if directories::is_folder_in_cache(self, folder_path) {
+                let folder_in_cache =
+                    if matches!(pkg.resolution.tag, ResolutionTag::Git) && patch_hash.is_none() {
+                        directories::is_git_folder_in_cache(self, folder_path)
+                    } else {
+                        directories::is_folder_in_cache(self, folder_path)
+                    };
+                if folder_in_cache {
                     self.set_preinstall_state(pkg.meta.id, PreinstallState::Done);
                     return PreinstallState::Done;
                 }
@@ -200,7 +206,12 @@ impl PackageManager {
                         });
                     // Owned NUL-terminated copy.
                     let non_patched_path = ZBox::from_bytes(&folder_path.as_bytes()[..idx]);
-                    if directories::is_folder_in_cache(self, &non_patched_path) {
+                    let base_in_cache = if matches!(pkg.resolution.tag, ResolutionTag::Git) {
+                        directories::is_git_folder_in_cache(self, &non_patched_path)
+                    } else {
+                        directories::is_folder_in_cache(self, &non_patched_path)
+                    };
+                    if base_in_cache {
                         self.set_preinstall_state(pkg.meta.id, PreinstallState::ApplyPatch);
                         // yay step 1 is already done for us
                         return PreinstallState::ApplyPatch;

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2370,6 +2370,20 @@ pub(crate) fn install_isolated_packages(
                                         pkg_cache_dir_subpath.set_length(cache_dir_path_save);
                                         exists
                                     }
+                                    ResolutionTag::Git => {
+                                        // Git checkouts can legitimately lack
+                                        // `package.json`; the `.bun-tag` written
+                                        // last by `Repository::checkout` marks
+                                        // the folder complete.
+                                        let cache_dir_path_save = pkg_cache_dir_subpath.len();
+                                        pkg_cache_dir_subpath.append(b".bun-tag").assume_ok();
+                                        let exists = sys::exists_at(
+                                            cache_dir,
+                                            pkg_cache_dir_subpath.slice_z(),
+                                        );
+                                        pkg_cache_dir_subpath.set_length(cache_dir_path_save);
+                                        exists
+                                    }
                                     _ => sys::directory_exists_at(
                                         cache_dir,
                                         pkg_cache_dir_subpath.slice_z(),

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2371,10 +2371,8 @@ pub(crate) fn install_isolated_packages(
                                         exists
                                     }
                                     ResolutionTag::Git => {
-                                        // Git checkouts can legitimately lack
-                                        // `package.json`; the `.bun-tag` written
-                                        // last by `Repository::checkout` marks
-                                        // the folder complete.
+                                        // See `is_git_folder_in_cache`: `.bun-tag`
+                                        // marks a git checkout complete.
                                         let cache_dir_path_save = pkg_cache_dir_subpath.len();
                                         pkg_cache_dir_subpath.append(b".bun-tag").assume_ok();
                                         let exists = sys::exists_at(

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2371,16 +2371,10 @@ pub(crate) fn install_isolated_packages(
                                         exists
                                     }
                                     ResolutionTag::Git => {
-                                        // See `is_git_folder_in_cache`: `.bun-tag`
-                                        // marks a git checkout complete.
-                                        let cache_dir_path_save = pkg_cache_dir_subpath.len();
-                                        pkg_cache_dir_subpath.append(b".bun-tag").assume_ok();
-                                        let exists = sys::exists_at(
+                                        package_manager::directories::is_git_folder_in_cache_at(
                                             cache_dir,
-                                            pkg_cache_dir_subpath.slice_z(),
-                                        );
-                                        pkg_cache_dir_subpath.set_length(cache_dir_path_save);
-                                        exists
+                                            pkg_cache_dir_subpath.slice_z().as_bytes(),
+                                        )
                                     }
                                     _ => sys::directory_exists_at(
                                         cache_dir,

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -982,7 +982,7 @@ impl RepositoryExt for Repository {
             // `.bun-tag` marks the folder complete (`is_safe_resolved_tag`
             // above guarantees `resolved` is non-empty). Publishing the folder
             // without it would make every later install re-clone it.
-            let tag_written = match dir.create_file_z(
+            let tag_error = match dir.create_file_z(
                 bun_core::zstr!(".bun-tag"),
                 bun_sys::CreateFlags {
                     truncate: true,
@@ -992,15 +992,19 @@ impl RepositoryExt for Repository {
                 Ok(git_tag) => {
                     let written = git_tag.write_all(resolved);
                     let _ = git_tag.close(); // close error is non-actionable
-                    written.is_ok()
+                    written.err()
                 }
-                Err(_) => false,
+                Err(err) => Some(err),
             };
-            if !tag_written {
+            if let Some(err) = tag_error {
                 log.add_error_fmt(
                     None,
                     bun_ast::Loc::EMPTY,
-                    format_args!("writing \".bun-tag\" for \"{}\" failed", BStr::new(name)),
+                    format_args!(
+                        "writing \".bun-tag\" for \"{}\" failed: {}",
+                        BStr::new(name),
+                        BStr::new(err.name()),
+                    ),
                 );
                 dir.close();
                 let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -979,22 +979,32 @@ impl RepositoryExt for Repository {
             };
             let _ = dir.delete_tree(b".git");
 
-            if !resolved.is_empty() {
-                'insert_tag: {
-                    let Ok(git_tag) = dir.create_file_z(
-                        bun_core::zstr!(".bun-tag"),
-                        bun_sys::CreateFlags {
-                            truncate: true,
-                            ..Default::default()
-                        },
-                    ) else {
-                        break 'insert_tag;
-                    };
-                    if git_tag.write_all(resolved).is_err() {
-                        let _ = dir.delete_file_z(bun_core::zstr!(".bun-tag"));
-                    }
+            // `.bun-tag` marks the folder complete (`is_safe_resolved_tag`
+            // above guarantees `resolved` is non-empty). Publishing the folder
+            // without it would make every later install re-clone it.
+            let tag_written = match dir.create_file_z(
+                bun_core::zstr!(".bun-tag"),
+                bun_sys::CreateFlags {
+                    truncate: true,
+                    ..Default::default()
+                },
+            ) {
+                Ok(git_tag) => {
+                    let written = git_tag.write_all(resolved);
                     let _ = git_tag.close(); // close error is non-actionable
+                    written.is_ok()
                 }
+                Err(_) => false,
+            };
+            if !tag_written {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!("writing \".bun-tag\" for \"{}\" failed", BStr::new(name)),
+                );
+                dir.close();
+                let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                return Err(crate::Error::InstallFailed);
             }
 
             // Close before the rename: Windows can't move a directory while a

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -729,61 +729,120 @@ impl RepositoryExt for Repository {
             bun_core::ZStr::from_buf(&folder_name_buf[..], written)
         };
 
-        match bun_sys::Dir::borrow(&cache_dir).open_dir_z(folder_name) {
-            Ok(dir) => {
-                let path = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
-                    &PackageManager::get().cache_directory_path,
-                    &[folder_name.as_bytes()],
-                );
+        let repo_dir = 'repo_dir: {
+            match bun_sys::Dir::borrow(&cache_dir).open_dir_z(folder_name) {
+                Ok(dir) => {
+                    // `git clone --bare` populates `HEAD`, `objects/` and
+                    // `refs/` before transferring data; a folder missing any of
+                    // them is a leftover from an interrupted clone that no
+                    // `git fetch` can ever repair. A structurally complete
+                    // mirror that fails to fetch (network, auth) is kept as-is.
+                    let complete = bun_sys::exists_at(dir.fd(), bun_core::zstr!("HEAD"))
+                        && bun_sys::directory_exists_at(dir.fd(), bun_core::zstr!("objects"))
+                            .unwrap_or(false)
+                        && bun_sys::directory_exists_at(dir.fd(), bun_core::zstr!("refs"))
+                            .unwrap_or(false);
+                    if complete {
+                        let path = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
+                            &PackageManager::get().cache_directory_path,
+                            &[folder_name.as_bytes()],
+                        );
 
-                if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"]) {
+                        if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"])
+                        {
+                            log.add_error_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!("\"git fetch\" for \"{}\" failed", BStr::new(name)),
+                            );
+                            return Err(err);
+                        }
+                        break 'repo_dir dir;
+                    }
+                    // Incomplete leftover: rebuild it (the rename below replaces it).
+                    dir.close();
+                }
+                Err(not_found) => {
+                    if not_found.get_errno() != bun_sys::E::ENOENT {
+                        return Err(not_found.into());
+                    }
+                }
+            }
+
+            // Clone into a temporary sibling and rename it into place once
+            // complete, so a kill can't leave a half-built mirror.
+            let mut tmp_name_buf = [0u8; 64];
+            let tmp_name: &[u8] = match bun_resolver::fs::FileSystem::tmpname(
+                b"tmp",
+                &mut tmp_name_buf,
+                bun_core::fast_random(),
+            ) {
+                Ok(name) => name.as_bytes(),
+                // max len is 1+16+1+8+1+3, well below 64
+                Err(_no_space_left) => unreachable!(),
+            };
+
+            let target = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
+                &PackageManager::get().cache_directory_path,
+                &[tmp_name],
+            );
+
+            if let Err(err) = exec(
+                env,
+                &[
+                    b"git",
+                    b"clone",
+                    b"-c",
+                    b"core.longpaths=true",
+                    b"--quiet",
+                    b"--bare",
+                    url,
+                    target,
+                ],
+            ) {
+                let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                if err == crate::Error::RepositoryNotFound || attempt > 1 {
                     log.add_error_fmt(
                         None,
                         bun_ast::Loc::EMPTY,
-                        format_args!("\"git fetch\" for \"{}\" failed", BStr::new(name)),
+                        format_args!("\"git clone\" for \"{}\" failed", BStr::new(name)),
                     );
-                    return Err(err);
                 }
-                Ok(dir)
+                return Err(err);
             }
-            Err(not_found) => {
-                if not_found.get_errno() != bun_sys::E::ENOENT {
-                    return Err(not_found.into());
-                }
 
-                let target = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
-                    &PackageManager::get().cache_directory_path,
-                    &[folder_name.as_bytes()],
+            if let Err(err) = bun_sys::renameat_concurrently_a(
+                cache_dir,
+                tmp_name,
+                cache_dir,
+                folder_name.as_bytes(),
+                bun_sys::RenameatConcurrentlyOptions {
+                    move_fallback: false,
+                },
+            ) {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "moving the repository for \"{}\" into the cache failed: {}",
+                        BStr::new(name),
+                        err,
+                    ),
                 );
-
-                if let Err(err) = exec(
-                    env,
-                    &[
-                        b"git",
-                        b"clone",
-                        b"-c",
-                        b"core.longpaths=true",
-                        b"--quiet",
-                        b"--bare",
-                        url,
-                        target,
-                    ],
-                ) {
-                    if err == crate::Error::RepositoryNotFound || attempt > 1 {
-                        log.add_error_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!("\"git clone\" for \"{}\" failed", BStr::new(name)),
-                        );
-                    }
-                    return Err(err);
-                }
-
-                bun_sys::Dir::borrow(&cache_dir)
-                    .open_dir_z(folder_name)
-                    .map_err(Into::into)
+                let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                return Err(crate::Error::InstallFailed);
             }
-        }
+
+            // A lost rename race (or a replaced stale folder) can leave a
+            // directory at `tmp_name`; drop it.
+            let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+
+            bun_sys::Dir::borrow(&cache_dir)
+                .open_dir_z(folder_name)
+                .map_err(Error::from)?
+        };
+
+        Ok(repo_dir)
     }
 
     fn find_commit(

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -421,13 +421,10 @@ fn exec(env: &bun_dotenv::Map, argv: &[&[u8]]) -> Result<Vec<u8>, Error> {
     Err(crate::Error::InstallFailed)
 }
 
-/// `.bun-tag` (containing `resolved`) is written as the last step of
-/// populating a per-commit cache folder, so it doubles as the completeness
-/// marker: a folder without a matching tag is a leftover from an install that
-/// was killed or failed between `git clone` and `git checkout` (git cannot
-/// clean up after SIGKILL). Such a folder has no `package.json`, and the
-/// missing-`package.json` fallback in `checkout` would silently resolve the
-/// dependency as an empty package.
+/// `.bun-tag` (containing `resolved`) is the last file written when
+/// populating a per-commit cache folder. A folder without a matching tag is a
+/// leftover from an interrupted or failed clone/checkout and would resolve as
+/// an empty package via the missing-`package.json` fallback in `checkout`.
 fn cached_checkout_is_complete(dir: &bun_sys::Dir, resolved: &[u8]) -> bool {
     match bun_sys::File::read_file_from(dir.fd(), b".bun-tag") {
         Ok((file, contents)) => {
@@ -897,8 +894,7 @@ impl RepositoryExt for Repository {
                     if cached_checkout_is_complete(&dir, resolved) {
                         break 'package_dir dir;
                     }
-                    // Leftover from an interrupted or failed clone/checkout.
-                    // Rebuild it; the rename below replaces it.
+                    // Incomplete leftover: rebuild it (the rename below replaces it).
                     dir.close();
                 }
                 Err(err) => {
@@ -908,9 +904,8 @@ impl RepositoryExt for Repository {
                 }
             }
 
-            // Clone + checkout into a temporary sibling and only rename it to
-            // `folder_name` once fully populated, so a killed install can't
-            // leave a half-built folder at the name later installs trust.
+            // Build the checkout in a temporary sibling and rename it into
+            // place once complete, so a kill can't leave a half-built folder.
             let mut tmp_name_buf = [0u8; 64];
             let tmp_name: &[u8] = match bun_resolver::fs::FileSystem::tmpname(
                 b"tmp",
@@ -1028,8 +1023,8 @@ impl RepositoryExt for Repository {
                 return Err(crate::Error::InstallFailed);
             }
 
-            // If a concurrent install won the rename race, the swap left its
-            // folder (or the stale one it replaced) at `tmp_name`; drop it.
+            // A lost rename race (or a replaced stale folder) can leave a
+            // directory at `tmp_name`; drop it.
             let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
 
             bun_sys::Dir::borrow(&cache_dir)

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -421,6 +421,23 @@ fn exec(env: &bun_dotenv::Map, argv: &[&[u8]]) -> Result<Vec<u8>, Error> {
     Err(crate::Error::InstallFailed)
 }
 
+/// `.bun-tag` (containing `resolved`) is written as the last step of
+/// populating a per-commit cache folder, so it doubles as the completeness
+/// marker: a folder without a matching tag is a leftover from an install that
+/// was killed or failed between `git clone` and `git checkout` (git cannot
+/// clean up after SIGKILL). Such a folder has no `package.json`, and the
+/// missing-`package.json` fallback in `checkout` would silently resolve the
+/// dependency as an empty package.
+fn cached_checkout_is_complete(dir: &bun_sys::Dir, resolved: &[u8]) -> bool {
+    match bun_sys::File::read_file_from(dir.fd(), b".bun-tag") {
+        Ok((file, contents)) => {
+            let _ = file.close(); // close error is non-actionable
+            contents == resolved
+        }
+        Err(_) => false,
+    }
+}
+
 impl RepositoryExt for Repository {
     fn parse_append_git(input: &[u8], buf: &mut StringBuf<'_>) -> Result<Repository, AllocError> {
         let mut remain = input;
@@ -874,92 +891,150 @@ impl RepositoryExt for Repository {
         )
         .as_bytes();
 
-        let package_dir = match bun_sys::Dir::borrow(&cache_dir)
-            .open_at(folder_name)
-            .map_err(Error::from)
-        {
-            Ok(d) => d,
-            Err(not_found) => 'brk: {
-                if not_found != crate::Error::Sys(bun_errno::SystemErrno::ENOENT) {
-                    return Err(not_found);
+        let package_dir = 'package_dir: {
+            match bun_sys::Dir::borrow(&cache_dir).open_at(folder_name) {
+                Ok(dir) => {
+                    if cached_checkout_is_complete(&dir, resolved) {
+                        break 'package_dir dir;
+                    }
+                    // Leftover from an interrupted or failed clone/checkout.
+                    // Rebuild it; the rename below replaces it.
+                    dir.close();
                 }
-
-                let target = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
-                    &PackageManager::get().cache_directory_path,
-                    &[folder_name],
-                );
-
-                let repo_path = bun_sys::get_fd_path(
-                    repo_dir,
-                    // Per-field accessor — disjoint from `folder_name_buf`
-                    // borrow above. See `TlBufs` accessor doc.
-                    TlBufs::final_path_buf(),
-                )?;
-
-                if let Err(err) = exec(
-                    env,
-                    &[
-                        b"git",
-                        b"clone",
-                        b"-c",
-                        b"core.longpaths=true",
-                        b"--quiet",
-                        b"--no-checkout",
-                        repo_path,
-                        target,
-                    ],
-                ) {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!("\"git clone\" for \"{}\" failed", BStr::new(name)),
-                    );
-                    return Err(err);
-                }
-
-                let folder = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
-                    &PackageManager::get().cache_directory_path,
-                    &[folder_name],
-                );
-
-                if let Err(err) = exec(
-                    env,
-                    // `is_safe_resolved_tag` above rejects a leading `-`, so
-                    // `resolved` cannot be parsed as a git option.
-                    &[b"git", b"-C", folder, b"checkout", b"--quiet", resolved],
-                ) {
-                    log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!("\"git checkout\" for \"{}\" failed", BStr::new(name)),
-                    );
-                    return Err(err);
-                }
-                let dir = bun_sys::Dir::borrow(&cache_dir)
-                    .open_at(folder_name)
-                    .map_err(Error::from)?;
-                let _ = dir.delete_tree(b".git");
-
-                if !resolved.is_empty() {
-                    'insert_tag: {
-                        let Ok(git_tag) = dir.create_file_z(
-                            bun_core::zstr!(".bun-tag"),
-                            bun_sys::CreateFlags {
-                                truncate: true,
-                                ..Default::default()
-                            },
-                        ) else {
-                            break 'insert_tag;
-                        };
-                        if git_tag.write_all(resolved).is_err() {
-                            let _ = dir.delete_file_z(bun_core::zstr!(".bun-tag"));
-                        }
-                        let _ = git_tag.close(); // close error is non-actionable
+                Err(err) => {
+                    if err.get_errno() != bun_sys::E::ENOENT {
+                        return Err(err.into());
                     }
                 }
-
-                break 'brk dir;
             }
+
+            // Clone + checkout into a temporary sibling and only rename it to
+            // `folder_name` once fully populated, so a killed install can't
+            // leave a half-built folder at the name later installs trust.
+            let mut tmp_name_buf = [0u8; 64];
+            let tmp_name: &[u8] = match bun_resolver::fs::FileSystem::tmpname(
+                b"tmp",
+                &mut tmp_name_buf,
+                bun_core::fast_random(),
+            ) {
+                Ok(name) => name.as_bytes(),
+                // max len is 1+16+1+8+1+3, well below 64
+                Err(_no_space_left) => unreachable!(),
+            };
+
+            let target = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
+                &PackageManager::get().cache_directory_path,
+                &[tmp_name],
+            );
+
+            let repo_path = bun_sys::get_fd_path(
+                repo_dir,
+                // Per-field accessor — disjoint from `folder_name_buf`
+                // borrow above. See `TlBufs` accessor doc.
+                TlBufs::final_path_buf(),
+            )?;
+
+            if let Err(err) = exec(
+                env,
+                &[
+                    b"git",
+                    b"clone",
+                    b"-c",
+                    b"core.longpaths=true",
+                    b"--quiet",
+                    b"--no-checkout",
+                    repo_path,
+                    target,
+                ],
+            ) {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!("\"git clone\" for \"{}\" failed", BStr::new(name)),
+                );
+                let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                return Err(err);
+            }
+
+            let folder = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
+                &PackageManager::get().cache_directory_path,
+                &[tmp_name],
+            );
+
+            if let Err(err) = exec(
+                env,
+                // `is_safe_resolved_tag` above rejects a leading `-`, so
+                // `resolved` cannot be parsed as a git option.
+                &[b"git", b"-C", folder, b"checkout", b"--quiet", resolved],
+            ) {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!("\"git checkout\" for \"{}\" failed", BStr::new(name)),
+                );
+                let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                return Err(err);
+            }
+            let dir = match bun_sys::Dir::borrow(&cache_dir).open_at(tmp_name) {
+                Ok(d) => d,
+                Err(err) => {
+                    let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                    return Err(err.into());
+                }
+            };
+            let _ = dir.delete_tree(b".git");
+
+            if !resolved.is_empty() {
+                'insert_tag: {
+                    let Ok(git_tag) = dir.create_file_z(
+                        bun_core::zstr!(".bun-tag"),
+                        bun_sys::CreateFlags {
+                            truncate: true,
+                            ..Default::default()
+                        },
+                    ) else {
+                        break 'insert_tag;
+                    };
+                    if git_tag.write_all(resolved).is_err() {
+                        let _ = dir.delete_file_z(bun_core::zstr!(".bun-tag"));
+                    }
+                    let _ = git_tag.close(); // close error is non-actionable
+                }
+            }
+
+            // Close before the rename: Windows can't move a directory while a
+            // handle into it is open.
+            dir.close();
+
+            if let Err(err) = bun_sys::renameat_concurrently_a(
+                cache_dir,
+                tmp_name,
+                cache_dir,
+                folder_name,
+                bun_sys::RenameatConcurrentlyOptions {
+                    move_fallback: false,
+                },
+            ) {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "moving git checkout of \"{}\" into the cache failed: {}",
+                        BStr::new(name),
+                        err,
+                    ),
+                );
+                let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+                return Err(crate::Error::InstallFailed);
+            }
+
+            // If a concurrent install won the rename race, the swap left its
+            // folder (or the stale one it replaced) at `tmp_name`; drop it.
+            let _ = bun_sys::Dir::borrow(&cache_dir).delete_tree(tmp_name);
+
+            bun_sys::Dir::borrow(&cache_dir)
+                .open_at(folder_name)
+                .map_err(Error::from)?
         };
 
         let (json_file, json_buf) =

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -748,8 +748,7 @@ impl RepositoryExt for Repository {
                             &[folder_name.as_bytes()],
                         );
 
-                        if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"])
-                        {
+                        if let Err(err) = exec(env, &[b"git", b"-C", path, b"fetch", b"--quiet"]) {
                             log.add_error_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5389,6 +5389,52 @@ describe.concurrent("bun-install", () => {
       version: "2.5.0",
     });
     expect(await file(join(cacheFolder, ".bun-tag")).text()).toBe(sha);
+
+    // A bare mirror left incomplete by an interrupted `git clone --bare`
+    // (named after the URL hash, so it is revisited forever) is rebuilt
+    // instead of failing every later `git fetch`.
+    const mirror = (await readdirSorted(cacheDir)).find(entry => entry.endsWith(".git"));
+    expect(mirror).toBeDefined();
+    await rm(join(cacheDir, mirror!), { recursive: true, force: true });
+    await mkdir(join(cacheDir, mirror!), { recursive: true });
+    await resetProject();
+    await install();
+    expect(await file(join(projectDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({
+      name: "real-dep-name",
+      version: "2.5.0",
+    });
+
+    // A failed `git checkout` (here: the tree object missing from the mirror,
+    // which `git log` during resolution does not notice but checkout cannot
+    // unpack) reports the failure and leaves neither a cache folder nor
+    // temporary junk behind.
+    const treeSha = (await git(["rev-parse", "HEAD^{tree}"], srcDir)).trim();
+    const blobPath = join(cacheDir, mirror!, "objects", treeSha.slice(0, 2), treeSha.slice(2));
+    const blobBytes = await file(blobPath).arrayBuffer();
+    await rm(blobPath, { force: true });
+    await rm(cacheFolder, { recursive: true, force: true });
+    await rm(join(projectDir, "node_modules"), { recursive: true, force: true });
+    {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: projectDir,
+        env: { ...gitEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+      expect(err).toContain(`"git checkout" for "my-git-dep" failed`);
+      expect(exitCode).not.toBe(0);
+    }
+    expect(
+      (await readdirSorted(cacheDir)).filter(entry => entry.startsWith("@G@") || entry.endsWith(".tmp")),
+    ).toEqual([]);
+    await write(blobPath, blobBytes);
+    await install();
+    expect(await file(join(projectDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({
+      name: "real-dep-name",
+      version: "2.5.0",
+    });
   });
 
   it("should fail on invalid Git URL", async () => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5248,6 +5248,148 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("re-clones a git dependency whose cache folder was left incomplete by an interrupted install", async () => {
+    using dir = tempDir("git-cache-incomplete", {
+      gitconfig: "[core]\n\tautocrlf = false\n",
+      "dep-src/package.json": `${JSON.stringify({ name: "real-dep-name", version: "2.5.0" })}\n`,
+      "dep-src/index.js": "module.exports = 'hello';\n",
+    });
+    const root = String(dir);
+    const gitEnv = {
+      ...env,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: join(root, "gitconfig"),
+      GIT_AUTHOR_NAME: "bun-test",
+      GIT_AUTHOR_EMAIL: "test@bun.sh",
+      GIT_COMMITTER_NAME: "bun-test",
+      GIT_COMMITTER_EMAIL: "test@bun.sh",
+    };
+    async function git(args: string[], cwd: string): Promise<string> {
+      await using proc = spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(err).not.toContain("fatal:");
+      expect(exitCode).toBe(0);
+      return out;
+    }
+    const srcDir = join(root, "dep-src");
+    await git(["init", "-q", "-b", "main"], srcDir);
+    await git(["add", "-A"], srcDir);
+    await git(["commit", "-qm", "init"], srcDir);
+    const sha = (await git(["rev-parse", "HEAD"], srcDir)).trim();
+    await git(["clone", "-q", "--bare", srcDir, join(root, "my-git-dep.git")], root);
+    // After `update-server-info` a bare repo is served over git's dumb HTTP
+    // protocol as plain static files.
+    await git(["update-server-info"], join(root, "my-git-dep.git"));
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const { pathname } = new URL(req.url);
+        if (!pathname.startsWith("/my-git-dep.git/")) return new Response("not found", { status: 404 });
+        const f = file(join(root, "my-git-dep.git", pathname.slice("/my-git-dep.git/".length)));
+        return (await f.exists()) ? new Response(f) : new Response("not found", { status: 404 });
+      },
+    });
+
+    const cacheDir = join(root, "bun-cache");
+    const cacheFolder = join(cacheDir, `@G@${sha}`);
+    const projectDir = join(root, "project");
+    await write(
+      join(projectDir, "package.json"),
+      JSON.stringify({
+        name: "my-app",
+        dependencies: { "my-git-dep": `git+http://127.0.0.1:${server.port}/my-git-dep.git` },
+      }),
+    );
+
+    async function install(cwd = projectDir, args: string[] = [], retries = 1): Promise<void> {
+      await using proc = spawn({
+        cmd: [bunExe(), "install", ...args],
+        cwd,
+        env: { ...gitEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+      // A loaded CI machine can OOM-kill the spawned git child; that is
+      // environmental, not the behavior under test. Retry once.
+      if (retries > 0 && err.includes("git failed with signal 9")) return install(cwd, args, retries - 1);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+    async function resetProject(): Promise<void> {
+      await rm(join(projectDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(projectDir, "bun.lock"), { force: true });
+    }
+    async function poisonCacheFolder(): Promise<void> {
+      await rm(cacheFolder, { recursive: true, force: true });
+      await mkdir(cacheFolder, { recursive: true });
+    }
+
+    // An install killed between `git clone --no-checkout` and `git checkout`
+    // leaves the per-commit cache folder behind without its files. It must not
+    // be trusted as a cached checkout: that silently resolves the dependency
+    // as an empty package named after the URL ("my-git-dep.git").
+    await poisonCacheFolder();
+    await install();
+    expect(await file(join(projectDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({
+      name: "real-dep-name",
+      version: "2.5.0",
+    });
+    expect(await exists(join(projectDir, "node_modules", "my-git-dep", "index.js"))).toBe(true);
+    expect(await file(join(projectDir, "bun.lock")).text()).toContain(
+      `real-dep-name@git+http://127.0.0.1:${server.port}/my-git-dep.git#${sha}`,
+    );
+    expect(await file(join(cacheFolder, ".bun-tag")).text()).toBe(sha);
+
+    // A complete cached checkout (matching .bun-tag) is reused, not re-cloned.
+    await write(join(cacheFolder, "cache-reused-sentinel.txt"), "reused");
+    await resetProject();
+    await install();
+    expect(await exists(join(projectDir, "node_modules", "my-git-dep", "cache-reused-sentinel.txt"))).toBe(true);
+
+    // A cache folder whose .bun-tag doesn't match the commit it is named after
+    // is rebuilt from the repository.
+    await write(join(cacheFolder, ".bun-tag"), "0000000000000000000000000000000000000000");
+    await resetProject();
+    await install();
+    expect(await exists(join(projectDir, "node_modules", "my-git-dep", "cache-reused-sentinel.txt"))).toBe(false);
+    expect(await file(join(projectDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({
+      name: "real-dep-name",
+    });
+    expect(await file(join(cacheFolder, ".bun-tag")).text()).toBe(sha);
+
+    // With the resolution already in bun.lock, the install phase checks the
+    // cache folder itself. An incomplete folder must be checked out again, not
+    // copied into node_modules as an empty package.
+    await poisonCacheFolder();
+    await rm(join(projectDir, "node_modules"), { recursive: true, force: true });
+    await install();
+    expect(await file(join(projectDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({
+      name: "real-dep-name",
+      version: "2.5.0",
+    });
+    expect(await file(join(cacheFolder, ".bun-tag")).text()).toBe(sha);
+
+    // Same for the isolated linker.
+    const isolatedDir = join(root, "project-isolated");
+    await write(
+      join(isolatedDir, "package.json"),
+      JSON.stringify({
+        name: "my-isolated-app",
+        dependencies: { "my-git-dep": `git+http://127.0.0.1:${server.port}/my-git-dep.git` },
+      }),
+    );
+    await install(isolatedDir, ["--linker=isolated"]);
+    await poisonCacheFolder();
+    await rm(join(isolatedDir, "node_modules"), { recursive: true, force: true });
+    await install(isolatedDir, ["--linker=isolated"]);
+    expect(await file(join(isolatedDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({
+      name: "real-dep-name",
+      version: "2.5.0",
+    });
+    expect(await file(join(cacheFolder, ".bun-tag")).text()).toBe(sha);
+  });
+
   it("should fail on invalid Git URL", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5422,9 +5422,9 @@ describe.concurrent("bun-install", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+      const [err, exitCode, out] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
       expect(err).toContain(`"git checkout" for "my-git-dep" failed`);
-      expect(exitCode).not.toBe(0);
+      expect({ out, err, exitCode }).not.toMatchObject({ exitCode: 0 });
     }
     expect((await readdirSorted(cacheDir)).filter(entry => entry.startsWith("@G@") || entry.endsWith(".tmp"))).toEqual(
       [],

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5309,12 +5309,13 @@ describe.concurrent("bun-install", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+      const [err, exitCode, out] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
       // A loaded CI machine can OOM-kill the spawned git child; that is
       // environmental, not the behavior under test. Retry once.
       if (retries > 0 && err.includes("git failed with signal 9")) return install(cwd, args, retries - 1);
       expect(err).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      // The object form surfaces both streams when the exit code is wrong.
+      expect({ out, err, exitCode }).toMatchObject({ exitCode: 0 });
     }
     async function resetProject(): Promise<void> {
       await rm(join(projectDir, "node_modules"), { recursive: true, force: true });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5426,9 +5426,9 @@ describe.concurrent("bun-install", () => {
       expect(err).toContain(`"git checkout" for "my-git-dep" failed`);
       expect(exitCode).not.toBe(0);
     }
-    expect(
-      (await readdirSorted(cacheDir)).filter(entry => entry.startsWith("@G@") || entry.endsWith(".tmp")),
-    ).toEqual([]);
+    expect((await readdirSorted(cacheDir)).filter(entry => entry.startsWith("@G@") || entry.endsWith(".tmp"))).toEqual(
+      [],
+    );
     await write(blobPath, blobBytes);
     await install();
     expect(await file(join(projectDir, "node_modules", "my-git-dep", "package.json")).json()).toMatchObject({


### PR DESCRIPTION
## What

If a `bun install` (or the `git` child process it spawns) is killed between the `git clone --no-checkout` and `git checkout` steps of caching a git dependency, the per-commit cache folder (`<cache>/@G@<sha>`) is left behind without its files. Every later install then trusts that folder, takes the "git dependencies without package.json" fallback, and silently resolves the dependency as an **empty package**: no files, no dependencies, exit code 0, and the package name in `bun.lock` falls back to the URL basename (`repo.git@git+http://host/repo.git#<sha>` instead of the real `package.json` name).

A plain `git checkout` failure (non-zero exit) poisoned the cache the same way, because the folder was created by the clone step and only populated afterwards.

The per-URL bare mirror (`<cache>/<hash>.git`) had the same non-atomic creation: a `git clone --bare` killed partway leaves a folder that makes every later `git fetch` fail (`"git fetch" for "x" failed`), permanently, because the folder name is a stable hash of the URL.

This was observed in CI: a loaded machine OOM-killed the spawned git child (`error: "git checkout" for "branch-dep" failed` / `git failed with signal 9`), and the retried install "succeeded" while writing `branch-dep.git@git+http://...#<sha>` with an empty package into `bun.lock`.

## Cause

`Repository::checkout` built the cache folder in place, in three non-atomic steps: `git clone --no-checkout <repo> <final-folder>`, then `git checkout <sha>` inside it, then write `.bun-tag`. Its cache-hit path (and the preinstall-state checks used when the resolution is already in the lockfile) accepted any existing folder without validating it, so a folder from an interrupted install was indistinguishable from a complete checkout. `Repository::download` cloned the bare mirror the same way and trusted any existing folder at the mirror name.

## Fix

- `Repository::checkout` now clones and checks out into a temporary sibling inside the cache directory and renames it onto `@G@<sha>` (via the same concurrent-rename helper the tarball extract path uses) only after the worktree, `.git` removal, and `.bun-tag` are all done. A kill at any point can no longer leave a half-built folder at the trusted name, and a failed checkout cleans up after itself.
- On a cache hit, `checkout` verifies that `.bun-tag` matches the resolved commit and rebuilds the folder otherwise. This heals caches that are already poisoned.
- The preinstall cache checks (hoisted and isolated linkers, plus `determine_preinstall_state`) now require `.bun-tag` for git resolutions instead of bare folder existence, so with an existing lockfile a poisoned folder is checked out again rather than copied into `node_modules` as an empty package. `.bun-tag` has been written by every bun version, so existing healthy caches are unaffected.
- `Repository::download` clones the bare mirror into a temporary sibling and renames it into place the same way, and on a cache hit rebuilds the mirror when it is missing `HEAD`, `objects/` or `refs/` (the layout git writes before transferring data). A structurally complete mirror that fails to fetch is kept as before, so transient network failures do not discard a usable cache.

`.bun-tag` presence is the right marker because git checkouts may legitimately have no `package.json`; the tag is written as the last step of populating the folder.

## Verification

New test in `test/cli/install/bun-install.test.ts` (local dumb-HTTP git server, no network) covering: an empty cache folder for the resolved commit (what a killed install leaves), a valid folder being reused without re-cloning, a folder with a mismatched `.bun-tag` being rebuilt, the lockfile-present install path for both the hoisted and isolated linkers, an empty bare mirror being rebuilt instead of failing `git fetch` forever, and a failing `git checkout` reporting the error while leaving neither a cache folder nor temporary junk behind.

```
# without src/ changes
(fail) re-clones a git dependency whose cache folder was left incomplete by an interrupted install
  ENOENT: .../node_modules/my-git-dep/package.json

# with src/ changes
(pass) re-clones a git dependency whose cache folder was left incomplete by an interrupted install
```

Existing git dependency tests in `bun-install.test.ts` (18), `isolated-install.test.ts` (62), `bun-install-patch.test.ts` (18), `bun-patch.test.ts` (31), and `bun-lock.test.ts` (17) pass. `bun run rust:check-all` clean on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->