### PR TITLE
install: support omit-lockfile-registry-resolved in .npmrc

### DIFF
--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -130,9 +130,9 @@ omit-lockfile-registry-resolved=true
 An empty URL resolves against whichever registry the reader has configured.
 Integrity hashes are unaffected and still pin package contents.
 
-Packages without a supported integrity hash keep their absolute URL, so a reader
-without this registry configured fails loudly instead of silently resolving a
-private package from the default registry.
+Packages without a supported integrity hash keep their absolute URL, so they stay
+pinned to the registry that served them rather than silently resolving against
+whichever registry the reader has configured.
 
 ### `ignore-scripts`: Skip lifecycle scripts
 

--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -111,6 +111,29 @@ The equivalent `bunfig.toml` option is [`install.exact`](/runtime/bunfig#install
 exact = true
 ```
 
+### `omit-lockfile-registry-resolved`: Keep the lockfile registry-agnostic
+
+By default `bun.lock` records an absolute tarball URL for packages not served by
+the default registry, pinning the lockfile to that host for everyone who shares
+it. Enable this option to write `""` instead, as default-registry entries already
+do:
+
+```ini .npmrc icon="npm"
+registry=https://npm.example.com/
+omit-lockfile-registry-resolved=true
+```
+
+```json bun.lock icon="lock"
+"lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57..."],
+```
+
+An empty URL resolves against whichever registry the reader has configured.
+Integrity hashes are unaffected and still pin package contents.
+
+Packages without a supported integrity hash keep their absolute URL, so a reader
+without this registry configured fails loudly instead of silently resolving a
+private package from the default registry.
+
 ### `ignore-scripts`: Skip lifecycle scripts
 
 Prevents running lifecycle scripts during installation:

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1404,6 +1404,12 @@ mod draft {
             }
         }
 
+        if let Some(omit_registry_resolved) = out.get(b"omit-lockfile-registry-resolved") {
+            if let Some(omit) = omit_registry_resolved.as_bool() {
+                install.omit_lockfile_registry_resolved = Some(omit);
+            }
+        }
+
         if let Some(install_strategy_expr) = out.get(b"install-strategy") {
             if let Some(install_strategy_str) = install_strategy_expr.as_string(bump) {
                 if install_strategy_str == b"hoisted" {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -56,6 +56,9 @@ pub struct Options {
     // if set to `false` in bunfig, save a binary lockfile
     pub(crate) save_text_lockfile: Option<bool>,
 
+    // if set in .npmrc, write `""` instead of the configured registry's URL
+    pub(crate) omit_lockfile_registry_resolved: bool,
+
     pub(crate) lockfile_only: bool,
 
     // `bun pm version` command options
@@ -140,6 +143,7 @@ impl Default for Options {
             ca: Box::default(),
             ca_file_name: b"",
             save_text_lockfile: None,
+            omit_lockfile_registry_resolved: false,
             lockfile_only: false,
             git_tag_version: true,
             allow_same_version: false,
@@ -539,6 +543,10 @@ impl Options {
 
             if let Some(save_text_lockfile) = config.save_text_lockfile {
                 self.save_text_lockfile = Some(save_text_lockfile);
+            }
+
+            if let Some(omit_lockfile_registry_resolved) = config.omit_lockfile_registry_resolved {
+                self.omit_lockfile_registry_resolved = omit_lockfile_registry_resolved;
             }
 
             if let Some(jobs) = config.concurrent_scripts {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -930,14 +930,29 @@ impl Stringifier {
                             // bind the union read to a local instead of slicing a temporary.
                             let url = res.npm().url;
                             let url_slice = url.slice(buf);
+                            // `omit-lockfile-registry-resolved` also collapses URLs under
+                            // the configured registry. Only with integrity: otherwise a
+                            // reader without this registry configured would silently
+                            // resolve from the default one instead of failing the hash.
+                            let omit_configured_registry = options.omit_lockfile_registry_resolved
+                                && pkg_meta.integrity.tag.is_supported()
+                                && url_is_under_registry(
+                                    url_slice,
+                                    options
+                                        .scope_for_package_name(pkg_name.slice(buf))
+                                        .url
+                                        .href(),
+                                );
                             write!(
                                 writer,
                                 "\"{}\", ",
                                 bun_core::fmt::format_json_string_utf8(
-                                    if url_is_under_registry(
-                                        url_slice,
-                                        Npm::Registry::DEFAULT_URL.as_bytes(),
-                                    ) {
+                                    if omit_configured_registry
+                                        || url_is_under_registry(
+                                            url_slice,
+                                            Npm::Registry::DEFAULT_URL.as_bytes(),
+                                        )
+                                    {
                                         b"" as &[u8]
                                     } else {
                                         url_slice

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -232,6 +232,7 @@ pub mod api {
         pub public_hoist_pattern: Option<PnpmMatcher>,
         pub hoist_pattern: Option<PnpmMatcher>,
         pub hoist: Option<bool>,
+        pub omit_lockfile_registry_resolved: Option<bool>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1012,3 +1012,77 @@ it("optional peer with a non-wildcard range is idempotent with two versions of t
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await run(["install", "--frozen-lockfile"]);
 });
+
+it("writes the configured registry's tarball URL into bun.lock by default", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "keeps-registry-resolved",
+      version: "1.0.0",
+      dependencies: { "no-deps": "1.0.0" },
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+
+  const lockfile = await file(join(packageDir, "bun.lock")).text();
+  expect(lockfile).toContain(`${registry.registryUrl()}no-deps/-/no-deps-1.0.0.tgz`);
+});
+
+it("omits the configured registry's tarball URL with omit-lockfile-registry-resolved", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "omits-registry-resolved",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    ),
+    write(join(packageDir, ".npmrc"), "omit-lockfile-registry-resolved=true\n"),
+  ]);
+
+  await runBunInstall(env, packageDir);
+
+  const lockfile = await file(join(packageDir, "bun.lock")).text();
+  expect(lockfile).toContain('"no-deps": ["no-deps@1.0.0", ""');
+  expect(lockfile).not.toContain(registry.registryUrl());
+
+  // integrity still pins the contents
+  expect(lockfile).toContain("sha512-");
+
+  // `""` still installs, and the URL does not come back
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(env, packageDir, { frozenLockfile: true });
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+});
+
+it("adding a dependency does not reintroduce registry URLs with omit-lockfile-registry-resolved", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "omits-registry-resolved-on-add",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    ),
+    write(join(packageDir, ".npmrc"), "omit-lockfile-registry-resolved=true\n"),
+  ]);
+
+  await runBunInstall(env, packageDir);
+
+  // a lockfile-updating install rewrites every entry, including the new one
+  await runBunInstall(env, packageDir, { packages: ["a-dep@1.0.1"] });
+
+  const lockfile = await file(join(packageDir, "bun.lock")).text();
+  expect(lockfile).toContain('"a-dep": ["a-dep@1.0.1", ""');
+  expect(lockfile).toContain('"no-deps": ["no-deps@1.0.0", ""');
+  expect(lockfile).not.toContain(registry.registryUrl());
+});

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -7,6 +7,7 @@ import {
   isWindows,
   readdirSorted,
   runBunInstall,
+  tempDir,
   toBeValidBin,
   VerdaccioRegistry,
 } from "harness";
@@ -1085,4 +1086,88 @@ it("adding a dependency does not reintroduce registry URLs with omit-lockfile-re
   expect(lockfile).toContain('"a-dep": ["a-dep@1.0.1", ""');
   expect(lockfile).toContain('"no-deps": ["no-deps@1.0.0", ""');
   expect(lockfile).not.toContain(registry.registryUrl());
+});
+
+it("omits the tarball URL for scoped packages with omit-lockfile-registry-resolved", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "omits-registry-resolved-scoped",
+        version: "1.0.0",
+        dependencies: { "@types/no-deps": "1.0.0" },
+      }),
+    ),
+    // a scope-specific registry goes through the scope lookup in
+    // `scope_for_package_name()` rather than falling back to the default scope
+    write(
+      join(packageDir, ".npmrc"),
+      `@types:registry=${registry.registryUrl()}\nomit-lockfile-registry-resolved=true\n`,
+    ),
+  ]);
+
+  await runBunInstall(env, packageDir);
+
+  const lockfile = await file(join(packageDir, "bun.lock")).text();
+  expect(lockfile).toContain('"@types/no-deps": ["@types/no-deps@1.0.0", ""');
+  expect(lockfile).toContain("sha512-");
+  expect(lockfile).not.toContain(registry.registryUrl());
+});
+
+it("keeps the tarball URL when the package has no supported integrity hash", async () => {
+  const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+
+  // a manifest with neither `integrity` nor `shasum`, so the resolution ends up
+  // with no supported integrity hash
+  await using mockRegistry = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname.endsWith(".tgz")) {
+        return new Response(Bun.file(tgz));
+      }
+      return Response.json({
+        name: "no-deps",
+        "dist-tags": { latest: "1.0.0" },
+        versions: {
+          "1.0.0": {
+            name: "no-deps",
+            version: "1.0.0",
+            dist: {
+              tarball: `http://127.0.0.1:${mockRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`,
+            },
+          },
+        },
+      });
+    },
+  });
+
+  using dir = tempDir("omit-registry-no-integrity", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "no-deps": "1.0.0" },
+    }),
+    ".npmrc": [`registry=http://127.0.0.1:${mockRegistry.port}/`, `omit-lockfile-registry-resolved=true`, ``].join(
+      "\n",
+    ),
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // no integrity to fall back on, so the URL stays and resolution remains
+  // pinned to the registry that served it
+  const lockfile = await file(join(String(dir), "bun.lock")).text();
+  expect(lockfile).toContain(`http://127.0.0.1:${mockRegistry.port}/no-deps/-/no-deps-1.0.0.tgz`);
+  expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: expect.stringContaining("Saved lockfile") });
 });


### PR DESCRIPTION
Implements `omit-lockfile-registry-resolved` (oven-sh/bun#15448).

## Problem

`bun.lock` records an absolute tarball URL for every package not served by the default registry:

```json
"lodash": ["lodash@4.17.21", "https://npm.example.com/lodash/-/lodash-4.17.21.tgz", {}, "sha512-..."],
```

Since the lockfile is committed, this pins the whole dependency graph to whichever registry host the last person to update it happened to be using. Anyone who can't reach that host — CI, a deploy environment, a teammate off the VPN — fails on every tarball:

```
error: GET https://npm.example.com/lodash/-/lodash-4.17.21.tgz - 401
```

The absolute URL also overrides the reader's own registry configuration, so it can't be worked around downstream.

npm has `omit-lockfile-registry-resolved` for exactly this. This adds the same option to bun, read from `.npmrc`.

## Cause

The round trip in `src/install/lockfile/bun.lock.rs` is asymmetric. The parser resolves `""` against the **configured** registry for the package's scope:

```rust
if registry_str.is_empty() {
    let registry_url = mgr.scope_for_package_name(name_str).url.href();
    let url = ExtractTarball::build_url(registry_url, ...);
```

but the writer only collapses URLs under the hardcoded **default** registry back to `""`:

```rust
if url_is_under_registry(url_slice, Npm::Registry::DEFAULT_URL.as_bytes()) {
    b"" as &[u8]
} else {
    url_slice
}
```

So the reader already understands a registry-agnostic lockfile; only the writer can't produce one.

## Change

With `omit-lockfile-registry-resolved=true`, the writer also collapses a URL served by the configured registry for that package's scope. `""` is bun's existing representation for "resolve from the configured registry", so no new lockfile semantics are introduced — the output is the same shape an install against the default registry already produces.

```ini
registry=https://npm.example.com/
omit-lockfile-registry-resolved=true
```

```json
"lodash": ["lodash@4.17.21", "", {}, "sha512-..."],
```

Plumbing follows the existing `save-exact`/`save_text_lockfile` path: `BunInstall` field → `.npmrc` parse in `src/ini/lib.rs` → `PackageManager::Options` → the writer. Opt-in, so default behavior is unchanged.

### Packages without a supported integrity hash keep their absolute URL

This is the one case where omitting the URL would be a real regression rather than a portability win. If a package has no integrity hash and its URL is dropped, a reader without this registry configured resolves it from the default registry and installs whatever is published there — silently. With an integrity hash, the same situation is a hash mismatch and a hard failure.

That's the dependency-confusion hazard the existing `version_to_write` comment already worries about for private scopes, so those packages are left alone. It also means `version_to_write`'s v1 stamping for them is unaffected, and no change was needed there.

## Verification

Three tests in `test/cli/install/bun-lock.test.ts`, using the existing `VerdaccioRegistry` (a non-default registry, so it exercises the real path):

- default behavior still writes the configured registry's tarball URL
- with the option, the entry is `""`, the lockfile contains no reference to the registry URL, integrity is still present, and `--frozen-lockfile` reinstall reproduces the lockfile byte-for-byte
- `bun install <pkg>` — which rewrites every entry — does not reintroduce URLs
