### PR TITLE
module loader: fix ENAMETOOLONG when importing long data: URLs

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2873,6 +2873,11 @@ fn normalize_specifier_for_resolution<'a>(
     specifier_: &'a [u8],
     query_string: &mut &'a [u8],
 ) -> &'a [u8] {
+    // In a `data:` URL everything after the comma is the payload; a `?` is
+    // part of the data, not a query string.
+    if bun_core::strings::has_prefix_comptime(specifier_, b"data:") {
+        return specifier_;
+    }
     if let Some(i) = bun_core::strings::index_of_char_usize(specifier_, b'?') {
         *query_string = &specifier_[i..];
         &specifier_[..i]
@@ -4143,7 +4148,12 @@ impl VirtualMachine {
         mode: ResolveMode,
     ) -> JsResult<()> {
         const MAX_LEN: usize = (bun_paths::MAX_PATH_BYTES as f64 * 1.5) as usize;
-        if IS_A_FILE_PATH && specifier.length() > MAX_LEN {
+        // `data:` URLs carry the module source inline and never touch the
+        // filesystem, so the path-length cap does not apply to them.
+        if IS_A_FILE_PATH
+            && specifier.length() > MAX_LEN
+            && !specifier.has_prefix_comptime(b"data:")
+        {
             let specifier_utf8 = specifier.to_utf8();
             let source_utf8 = source.to_utf8();
             let import_kind = mode.import_kind();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3901,6 +3901,11 @@ unsafe fn normalize_specifier_for_loader<'a>(
     if slice.is_empty() {
         return (slice, slice, b"");
     }
+    // In a `data:` URL everything after the comma is the payload; a `?` is
+    // part of the data, not a query string.
+    if bun_core::strings::has_prefix_comptime(slice, b"data:") {
+        return (slice, slice, b"");
+    }
     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
     let host = unsafe { &*jsc_vm }.origin.host;
     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -17,3 +17,25 @@ test("should import and execute ES module from string (base64)", async () => {
 test("should throw when importing malformed string (base64)", async () => {
   expect(() => import("data:text/javascript;base64,asdasdasd")).toThrowError("Base64DecodeError");
 });
+
+// data: URLs carry the module source inline and never touch the filesystem,
+// so no path-length limit applies. 200000 exceeds the largest platform cap
+// (Windows, ~147 KB); the smallest (macOS) is ~1.5 KB.
+test("should import a data: URL longer than the path-length limit", async () => {
+  const big = Buffer.alloc(200000, "x").toString();
+  const url = "data:text/javascript," + encodeURIComponent(`export default "${big}";`);
+  const mod = await import(url);
+  expect(mod.default).toBe(big);
+});
+
+test("should import a base64 data: URL longer than the path-length limit", async () => {
+  const big = Buffer.alloc(200000, "y").toString();
+  const url = "data:text/javascript;base64," + btoa(`export default "${big}";`);
+  const mod = await import(url);
+  expect(mod.default).toBe(big);
+});
+
+test("should keep '?' as part of the data in a data: URL", async () => {
+  const mod = await import(`data:text/javascript,export default "a?b=c";`);
+  expect(mod.default).toBe("a?b=c");
+});


### PR DESCRIPTION
### Problem

Importing a `data:` URL longer than the platform path cap fails:

```js
const code = "export default 'hello';" + "// " + "x".repeat(8000);
await import("data:text/javascript," + encodeURIComponent(code));
```

```
error: ENAMETOOLONG while resolving package 'data:text/javascript,export%20default%20...' from '/tmp/repro.mjs'
```

The limit is `MAX_PATH_BYTES * 1.5`, so the threshold is ~1.5 KB on macOS, ~6 KB on Linux, ~147 KB on Windows. Node imports the same URLs fine.

### Cause

`data:` specifiers went through the module resolver's file-path handling before the scheme was recognized:

- `VirtualMachine::resolve_maybe_needs_trailing_slash` rejects any specifier over the path-length cap with `ENAMETOOLONG` before the resolver's `data:` branch ever runs.
- `normalize_specifier_for_resolution` and `normalize_specifier_for_loader` split the specifier at the first `?` as if it were a file query string. For a `data:` URL the `?` is part of the payload, so `import('data:text/javascript,export default "a?b=c"')` loaded truncated source and failed with `Unterminated string literal` (works in Node).

### Fix

Skip the path-length cap and the query-string split when the specifier starts with `data:`, at both resolution and load. The payload is inline and never touches the filesystem, so neither path rule applies. Malformed `data:` specifiers (no comma) still fail with `InvalidDataURL` as before.

This also fixes `new Worker(url)` with a long `data:` URL, which resolved through the same path.

### Verification

New tests in `test/js/node/string-module.test.js` (the existing data-URL import coverage): a 200 KB percent-encoded import, a 200 KB base64 import (both exceed every platform's cap), and a `?` in the payload. All three fail on Bun 1.4.0 and pass with this change; the pre-existing tests in the file, `test/js/bun/resolve/import-query.test.ts` (file query-string semantics), `test/js/bun/resolve/esModule.test.ts`, `test/js/bun/resolve/import-meta.test.js`, and `test/bundler/esbuild/loader.test.ts` still pass.


Verified the Worker scenario from #33596 directly: `new Worker("data:application/javascript;base64,...")` above the length cap fails with `NameTooLong` on Bun 1.4.0 and loads with this change.

Fixes #20374
Fixes #33596

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/string-module.test.js
bun test v1.4.0 (004234294)

test/js/node/string-module.test.js:
(pass) should import and execute ES module from string [17.62ms]
(pass) should import and execute ES module from string (base64) [8.43ms]
(pass) should throw when importing malformed string (base64) [4.80ms]
error: ENAMETOOLONG while resolving package 'data:text/javascript,export%20default%20%22xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (0ffabf64d)

test/js/node/string-module.test.js:
(pass) should import and execute ES module from string [0.27ms]
(pass) should import and execute ES module from string (base64) [0.16ms]
(pass) should throw when importing malformed string (base64) [0.08ms]
error: ENAMETOOLONG while resolving package 'data:text/javascript,export%20default%20%22xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/string-module.test.js
bun test v1.4.0 (004234294)

test/js/node/string-module.test.js:
(pass) should import and execute ES module from string [28.11ms]
(pass) should import and execute ES module from string (base64) [8.22ms]
(pass) should throw when importing malformed string (base64) [4.49ms]
(pass) should import a data: URL longer than the path-length limit [243.55ms]
(pass) should import a base64 data: URL longer than the path-length limit [257.03ms]
(pass) should keep '?' as part of the data in a data: URL [11.84ms]

 6 pass
 0 fail
 6 expect() calls
Ran 6 tests across 1 file. [2.58s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 658ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs          | 12 +++++++++++-
 src/runtime/jsc_hooks.rs           |  5 +++++
 test/js/node/string-module.test.js | 22 ++++++++++++++++++++++
 3 files changed, 38 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/VirtualMachine.rs               4      2      0
src/runtime/jsc_hooks.rs                2      1      0
test/js/node/string-module.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->