### PR TITLE
Fix stale exception when a lazy property initializer throws during property enumeration

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5378,10 +5378,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and throwing lazy property callbacks.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -803,3 +803,30 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+it("skips lazy properties whose initializer throws without leaving a stale exception", async () => {
+  // With the global Symbol overwritten, reifying Bun.$ (and Bun.sql) throws.
+  // The exception must be cleared before moving to the next property:
+  // enumeration should keep the remaining properties, and a direct access
+  // should throw a catchable error.
+  const code = `
+    globalThis.Symbol = 0;
+    const out = Bun.inspect(Bun);
+    for (const name of ["Archive", "CryptoHasher", "serve", "spawn"]) {
+      if (!out.includes(name)) throw new Error("missing " + name);
+    }
+    let caught = 0;
+    try { Bun.$; } catch { caught++; }
+    try { Bun.sql; } catch { caught++; }
+    console.log("OK", caught);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("OK 2");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes a fuzzer-found abort (fingerprint `45150bc578c49ad4`).

### Repro

```js
globalThis.Symbol = 0;
Bun.inspect(Bun); // debug build: ASSERTION FAILED: Unexpected exception observed
```

The fuzzer hit this through `Bun.jest(...).expect(Bun).toBeNil()`, whose failure message formats the `Bun` object. The global `Symbol` had been clobbered by an earlier iteration in the same fuzzer process, so reifying the lazy `Bun.$` property threw `Symbol is not a function. (In 'Symbol("cwd")', 'Symbol' is 0)` from the shell builtin.

### Bug 1: `JSC__JSValue__forEachPropertyImpl` leaks the exception

A static hash-table property with a `PropertyCallback` that throws during reification makes `getPropertySlot` return `false` with the exception still pending. The enumeration loop did:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;                 // skips the clear below
CLEAR_IF_EXCEPTION(scope);
```

so the stale exception leaked into the next property's lazy callback, whose host-call wrapper release-asserts no pending exception, aborting the process in debug/ASAN builds. In release builds the stale exception made every subsequent static-table lookup report not-found, so `Bun.inspect(Bun)` silently dropped most properties (output shrinks from ~13 KB to ~1.4 KB). The fix clears before deciding to skip, matching what `forEachPropertyOrdered` already does.

### Bug 2: `Bun.sql` initializer runs the uncaughtException machinery mid-reification

With bug 1 fixed, the same repro then died in the debug-only block in `defaultBunSQLObject`:

```cpp
#if BUN_DEBUG
    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(...);
#endif
```

This runs `Bun__handleUncaughtException` while the module-load error is still pending on the VM. Its `process->get(globalObject, "_fatalException")` then reifies `_fatalException` (a structure transition) but reports it missing because `setUpStaticFunctionSlot` sees the pending exception, and `JSObject::getPropertySlot` hits the `storedPrototype` stale-structure assertion:

```
ASSERTION FAILED: isCompilationThread() || Thread::mayBeGCThread() || object->structure() == this
```

Reproducible on its own with `globalThis.Symbol = 0; Bun.sql` in a debug build. The report call also misclassifies a propagated error as uncaught: the very next line rethrows it to the property access, where user code can catch it. Removed both blocks; the error now propagates like every other lazy property callback.

### Test

`test/js/bun/util/inspect.test.js`: tampers `Symbol` in a subprocess, checks `Bun.inspect(Bun)` still contains later properties, and that `Bun.$` / `Bun.sql` throw catchable errors. Fails on an unfixed release build (missing properties) and an unfixed debug build (abort); passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (3565abebd)

test/js/bun/util/inspect.test.js:
(pass) prototype [305.33ms]
(pass) getters [4.89ms]
(pass) setters [3.86ms]
(pass) getter/setters [1.86ms]
(pass) Timeout [5.03ms]
(pass) when prototype defines the same property, don't print the same property twice [2.11ms]
(pass) Blob inspect [8.56ms]
(pass) utf16 property name [59.94ms]
(pass) latin1 [4.01ms]
(pass) Request object [2.80ms]
(pass) MessageEvent [1.83ms]
(pass) MessageEvent with no data set [1.91ms]
(pass) MessageEvent with deleted data [2.61ms]
(pass) TypedArray prints [93.22ms]
(pass) BigIntArray [30.67ms]
(pass) Float32Array 42.68000030517578 [4.04ms]
(pass) Float32Array 42.68 [3.97ms]
(pass) Float64Array 42.68000030517578 [1.36ms]
(pass) Float64Array 42.68 [1.34ms]
(pass) jsx with two elements [28.02ms]
(pass) jsx with anon component [2.63ms]
(pass) jsx with fragment [4.47ms]
(pass) inspect [67.97ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [1.85ms]
(pass) latin1 supplemental > latin1 (input) "cbä" 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0ffabf64d)

test/js/bun/util/inspect.test.js:
(pass) prototype [4.09ms]
(pass) getters [0.10ms]
(pass) setters [0.04ms]
(pass) getter/setters [0.03ms]
(pass) Timeout [0.10ms]
(pass) when prototype defines the same property, don't print the same property twice [0.04ms]
(pass) Blob inspect [0.23ms]
(pass) utf16 property name [4.99ms]
(pass) latin1 [0.05ms]
(pass) Request object [0.05ms]
(pass) MessageEvent [0.03ms]
(pass) MessageEvent with no data set [0.02ms]
(pass) MessageEvent with deleted data [0.03ms]
(pass) TypedArray prints [0.94ms]
(pass) BigIntArray [0.30ms]
(pass) Float32Array 42.68000030517578 [0.07ms]
(pass) Float32Array 42.68 [0.05ms]
(pass) Float64Array 42.68000030517578
(pass) Float64Array 42.68
(pass) jsx with two elements [0.53ms]
(pass) jsx with anon component [0.03ms]
(pass) jsx with fragment [0.06ms]
(pass) inspect [0.69ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.03ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 supplemental > latin1 (
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (3565abebd)

test/js/bun/util/inspect.test.js:
(pass) prototype [301.25ms]
(pass) getters [4.89ms]
(pass) setters [3.96ms]
(pass) getter/setters [1.93ms]
(pass) Timeout [5.66ms]
(pass) when prototype defines the same property, don't print the same property twice [2.19ms]
(pass) Blob inspect [8.40ms]
(pass) utf16 property name [61.34ms]
(pass) latin1 [4.12ms]
(pass) Request object [2.65ms]
(pass) MessageEvent [1.85ms]
(pass) MessageEvent with no data set [1.90ms]
(pass) MessageEvent with deleted data [2.54ms]
(pass) TypedArray prints [90.64ms]
(pass) BigIntArray [30.50ms]
(pass) Float32Array 42.68000030517578 [3.99ms]
(pass) Float32Array 42.68 [3.93ms]
(pass) Float64Array 42.68000030517578 [1.31ms]
(pass) Float64Array 42.68 [1.61ms]
(pass) jsx with two elements [27.04ms]
(pass) jsx with anon component [2.61ms]
(pass) jsx with fragment [4.84ms]
(pass) inspect [66.58ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [1.72ms]
(pass) latin1 supplemental > latin1 (input) "cbä" 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3565abebd8
  features     baseline

22 deps, 105 codegen, 1175 objects in 717ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1237] install /workspace/bun
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 107 installs across 153 packages (no changes) [4.00ms]
[2/1237] gen ErrorCode+*.h
[3/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1237] gen bindgenv2
[5/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (0ffabf64d)

Checked 129 installs across 147 packages (no changes) [15.00ms]
[6/1237] fetch picohttpparser
[picohttpparser] up to date
[7/1237] fetch tinycc
[tinycc] up to date
[8/1236] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1236] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunObject.cpp   |  6 ------
 src/jsc/bindings/bindings.cpp    |  7 ++++---
 test/js/bun/util/inspect.test.js | 27 +++++++++++++++++++++++++++
 3 files changed, 31 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/bindings/BunObject.cpp        4      2      0
src/jsc/bindings/bindings.cpp         2      1      0
test/js/bun/util/inspect.test.js      0      0      0
```

</details>

<!-- robobun:evidence:end -->