### PR TITLE
Decode module sources with the // @bun pragma as UTF-8

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -994,7 +994,7 @@ impl TranspilerJob {
                 _ => (ptr::null_mut(), 0),
             };
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
+                source_code: String::clone_utf8(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache,
                 bytecode_cache_size,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2931,6 +2931,14 @@ fn transpile_source_code_inner(
                     };
                     let (bytecode_cache, bytecode_cache_size) =
                         node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
+                    if is_main {
+                        // Without this, a cache hit for the entry point leaves
+                        // `has_loaded` false and later imports with unknown
+                        // extensions fall back to `Loader::Tsx` instead of
+                        // `Loader::File`.
+                        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                        unsafe { (*jsc_vm).has_loaded = true };
+                    }
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
                         source_code,
                         specifier: input_specifier.dupe_ref(),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2788,7 +2788,7 @@ fn transpile_source_code_inner(
                         _ => (core::ptr::null_mut(), 0),
                     };
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
+                        source_code: bun_core::String::clone_utf8(&source.contents),
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         already_bundled: true,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2787,6 +2787,13 @@ fn transpile_source_code_inner(
                         }
                         _ => (core::ptr::null_mut(), 0),
                     };
+                    if is_main {
+                        // Same as the transpiler-cache-hit return below: leaving
+                        // `has_loaded` false sends unknown-extension imports to
+                        // the `Loader::Tsx` fallback instead of `Loader::File`.
+                        // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                        unsafe { (*jsc_vm).has_loaded = true };
+                    }
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
                         source_code: bun_core::String::clone_utf8(&source.contents),
                         specifier: input_specifier.dupe_ref(),

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -67,6 +67,23 @@ describe("// @bun", () => {
     expect(text).toBe(nonAscii);
   });
 
+  test("entry point with pragma keeps unknown-extension imports on the file loader", async () => {
+    using dir = tempDir("bun-pragma-file-loader", {
+      "asset.hbs": "<!DOCTYPE html>\n<html></html>\n",
+      "entry.js": `// @bun\nimport asset from "./asset.hbs";\nconsole.log(typeof asset);\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("string\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("raw utf-8 decodes as utf-8, not latin-1 (entry point)", async () => {
     using dir = tempDir("bun-pragma-utf8-entry", {
       "pragma.js": `// @bun\nconst DASH = "\u2014";\nconsole.log([...DASH].map(c => c.codePointAt(0).toString(16)).join(" "));\n`,

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -48,6 +48,40 @@ describe("// @bun", () => {
     expect(stdout.toString()).toBe("Hello world!\n");
     expect(exitCode).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/37161
+  const nonAscii = "\u2014\u00b7\u2713 K\u00e4ufer";
+  test("raw utf-8 decodes as utf-8, not latin-1 (import)", async () => {
+    using dir = tempDir("bun-pragma-utf8-import", {
+      "pragma.js": `// @bun\nexport const text = "${nonAscii}";\n`,
+    });
+    const { text } = await import(`${dir}/pragma.js`);
+    expect(text).toBe(nonAscii);
+  });
+
+  test("raw utf-8 decodes as utf-8, not latin-1 (require)", async () => {
+    using dir = tempDir("bun-pragma-utf8-require", {
+      "pragma.js": `// @bun\nexport const text = "${nonAscii}";\n`,
+    });
+    const { text } = require(`${dir}/pragma.js`);
+    expect(text).toBe(nonAscii);
+  });
+
+  test("raw utf-8 decodes as utf-8, not latin-1 (entry point)", async () => {
+    using dir = tempDir("bun-pragma-utf8-entry", {
+      "pragma.js": `// @bun\nconst DASH = "\u2014";\nconsole.log([...DASH].map(c => c.codePointAt(0).toString(16)).join(" "));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pragma.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("2014\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("json imports", () => {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -81,6 +81,16 @@ describe("transpiler cache", () => {
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("a");
     expect(!existsSync(cache_dir)).toBeTrue();
   });
+  test("cache hit on the entry point keeps unknown-extension imports on the file loader", async () => {
+    writeFileSync(join(temp_dir, "asset.hbs"), "<!DOCTYPE html>\n<html></html>\n");
+    const padding = "// " + Buffer.alloc(8 * 1024, "x").toString() + "\n";
+    writeFileSync(join(temp_dir, "a.js"), `import asset from "./asset.hbs";\n${padding}console.log(typeof asset);\n`);
+    expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("string");
+    expect(newCacheCount()).toBe(1);
+    // The second run loads the entry point from the transpiler cache; the
+    // unknown extension must still get the file loader, not the tsx fallback.
+    expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("string");
+  });
   test("it is indeed content addressable", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("b");

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -90,6 +90,7 @@ describe("transpiler cache", () => {
     // The second run loads the entry point from the transpiler cache; the
     // unknown extension must still get the file loader, not the tsx fallback.
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("string");
+    expect(newCacheCount()).toBe(0);
   });
   test("it is indeed content addressable", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));


### PR DESCRIPTION
Fixes #37161

A file with the `// @bun` pragma had its non-ASCII string literals decoded as latin-1 at runtime, one code point per UTF-8 byte, so `"\u2014"` (U+2014) became U+00E2 U+0080 U+0094. `Bun.build` writes the pragma into its output, so bundles that contain raw UTF-8 bytes were corrupted without anyone opting in.

Repro:

```console
$ printf 'const DASH = "\xe2\x80\x94"\nconsole.log([...DASH].map(c => c.codePointAt(0).toString(16)).join(" "))\n' > repro.js
$ bun repro.js
2014
$ printf '// @bun\n' | cat - repro.js > repro-pragma.js
$ bun repro-pragma.js
e2 80 94
```

Cause: the pragma makes the loader skip the transpiler and hand the raw source bytes to JSC directly, and both the sync path (`src/runtime/jsc_hooks.rs`) and the async transpiler-store path (`src/jsc/RuntimeTranspilerStore.rs`) built the source string with `String::clone_latin1`, which maps each byte to one code point. That is only correct for pure ASCII.

Fix: use `String::clone_utf8` at both sites. It keeps the Latin-1 fast path for all-ASCII sources and does a real UTF-8 decode otherwise, matching how the non-pragma path decodes the same bytes.

Bytecode sidecars (`// @bun @bytecode`) are safe: `bun build --bytecode` forces `--target=bun`, whose printer escapes to ASCII, so the SourceCodeKey hash is unchanged for bundler output. If a source with a sidecar does contain raw non-ASCII bytes, the key no longer matches and JSC silently falls back to parsing (verified manually with an edited bundle, no crash, correct output).

Tests: added import, require, and entry-point cases with raw UTF-8 to `test/bundler/transpiler/runtime-transpiler.test.ts`. All three fail on bun 1.3.6 (`e2 80 94` instead of `2014`) and pass with this change, along with the rest of the file.

---

Second commit: fixing this surfaced a related pre-existing bug in the same loader path. The transpiler-cache-hit branch for the entry point returns early and skips the `is_main -> has_loaded = true` write the full parse path does. With `has_loaded` still false, an import of a file with an unknown extension (for example `./template.hbs`) falls into the "potentially the main module" fallback and is parsed as tsx, failing with `Expected JSX element name but found "!"`. So an entry point above the 4 KiB cache minimum that imports such an asset works on the first run and fails on every cache-hit run after. Debug builds discard restored cache entries, which is why this only reproduces in release builds (the existing `// @bun > async transpiler` and `require()` tests in `runtime-transpiler.test.ts` fail on any release build with a warm cache, including current main). Fixed by setting `has_loaded` on the cache-hit path too, with a test in `test/cli/run/transpiler-cache.test.ts` that enables cache restore in debug builds via `BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE`.

Third commit: review found the same `has_loaded` gap in the already-bundled early return itself, so a `// @bun` entry point importing an unknown-extension asset hit the same tsx fallback in every build type. Same guard applied there, with a test in `runtime-transpiler.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/runtime-transpiler.test.ts test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (2f3024cfd)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [919.71ms]
(pass) transpiler cache > works with empty files [639.78ms]
(pass) transpiler cache > ignores files under the minimum cache size [383.84ms]
87 |     writeFileSync(join(temp_dir, "a.js"), `import asset from "./asset.hbs";\n${padding}console.log(typeof asset);\n`);
88 |     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("string");
89 |     expect(newCacheCount()).toBe(1);
90 |     // The second run loads the entry point from the transpiler cache; the
91 |     // unknown extension must still get the file loader, not the tsx fallback.
92 |     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("string");
                                                           ^
error: expect(received).toSpawn(expectedStdout)

Expected process to exit with code 0 but got 1
stderr: 1 | <!DOCTYPE html>
     ^
error: Expected JSX element name 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (89b7b73f9)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [20.99ms]
(pass) transpiler cache > works with empty files [29.09ms]
(pass) transpiler cache > ignores files under the minimum cache size [8.20ms]
(pass) transpiler cache > cache hit on the entry point keeps unknown-extension imports on the file loader [19.50ms]
(pass) transpiler cache > it is indeed content addressable [26.79ms]
(pass) transpiler cache > doing 50 buns at once does not crash [94.25ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [20.05ms]
(pass) transpiler cache > works if the cache is not user-readable [25.83ms]
(pass) transpiler cache > works if the cache is not user-writable [9.39ms]
(pass) transpiler cache > does not inline process.env [17.54ms]
(pass) transpiler cache > --feature flag invalidates cache [50.60ms]
(pass) rejects cached module records containing out-of-range string indices [59.55ms]

test/bundler/transpiler/runtime-transpiler.test.ts:
(pass) use strict causes CommonJS [34.62ms]
(pass) non-ascii regexp literals [0.11ms]
(pass) ascii regex with escapes [0.03ms]
(pass) // @b
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/runtime-transpiler.test.ts test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (2f3024cfd)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [640.65ms]
(pass) transpiler cache > works with empty files [702.36ms]
(pass) transpiler cache > ignores files under the minimum cache size [288.93ms]
(pass) transpiler cache > cache hit on the entry point keeps unknown-extension imports on the file loader [734.73ms]
(pass) transpiler cache > it is indeed content addressable [1011.56ms]
(pass) transpiler cache > doing 50 buns at once does not crash [3252.26ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [662.35ms]
(pass) transpiler cache > works if the cache is not user-readable [947.88ms]
(pass) transpiler cache > works if the cache is not user-writable [306.76ms]
(pass) transpiler cache > does not inline process.env [786.99ms]
(pass) transpiler cache > --feature flag invalidates cache [1896.98ms]
(pass) rejects cached module records containing o
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 747ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/12] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 239 extern-C blocks audited
[1/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_paths 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/RuntimeTranspilerStore.rs                  |  2 +-
 src/runtime/jsc_hooks.rs                           | 17 +++++++-
 test/bundler/transpiler/runtime-transpiler.test.ts | 51 ++++++++++++++++++++++
 test/cli/run/transpiler-cache.test.ts              | 11 +++++
 4 files changed, 79 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/RuntimeTranspilerStore.rs                       1      1      0
src/runtime/jsc_hooks.rs                                4      3      0
test/bundler/transpiler/runtime-transpiler.test.ts      1      3      0
test/cli/run/transpiler-cache.test.ts                   1      2      0
```

</details>

**root cause** · written by the author bot

When a file carried the // @bun pragma, the already-bundled fast path in the module loader converted the raw source bytes with a Latin-1 decode instead of a UTF-8 decode, so every non-ASCII character was expanded into one code point per UTF-8 byte, producing mojibake like U+2014 becoming U+00E2 U+0080 U+0094. The fix switches both affected sites, the synchronous loader path and the async transpiler worker path, to the UTF-8 decoding helper already used elsewhere, which still takes the Latin-1 fast path for all-ASCII sources so pure-ASCII behavior is unchanged. It also sets the VM's has_load…

<!-- robobun:evidence:end -->
