### PR TITLE
node compile cache: create entry files 0600 like Node

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -971,13 +971,16 @@ fn write_persist_job_locked(
 
     cclog!("[compile cache] Creating temporary file for cache of {name} ({tname})...");
 
-    let mut tmpfile = match sys::Tmpfile::create(state.dir_handle.fd(), tmpname_zstr) {
-        Ok(t) => t,
-        Err(e) => {
-            cclog!("failed. {}\n", errno_name(&e));
-            return Err(());
-        }
-    };
+    // 0600 like Node: entries hold module source + bytecode, and the default
+    // cache dir is world-readable (`$TMPDIR/node-compile-cache/...`).
+    let mut tmpfile =
+        match sys::Tmpfile::create_with_mode(state.dir_handle.fd(), tmpname_zstr, 0o600) {
+            Ok(t) => t,
+            Err(e) => {
+                cclog!("failed. {}\n", errno_name(&e));
+                return Err(());
+            }
+        };
     let _close = sys::CloseOnDrop::new(tmpfile.fd);
 
     let tmp_display = if logging {

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -971,8 +971,7 @@ fn write_persist_job_locked(
 
     cclog!("[compile cache] Creating temporary file for cache of {name} ({tname})...");
 
-    // 0600 like Node: entries hold module source + bytecode, and the default
-    // cache dir is world-readable (`$TMPDIR/node-compile-cache/...`).
+    // 0600 like Node: entries contain the module's post-transpile source.
     let mut tmpfile =
         match sys::Tmpfile::create_with_mode(state.dir_handle.fd(), tmpname_zstr, 0o600) {
             Ok(t) => t,

--- a/src/sys/tmp.rs
+++ b/src/sys/tmp.rs
@@ -1,6 +1,6 @@
 use bun_core::ZStr;
 
-use crate::{E, ErrorCase, Fd, FdExt, O, Tag};
+use crate::{E, ErrorCase, Fd, FdExt, Mode, O, Tag};
 
 // O_TMPFILE doesn't seem to work very well.
 const ALLOW_TMPFILE: bool = false;
@@ -17,7 +17,14 @@ pub struct Tmpfile<'a> {
 
 impl<'a> Tmpfile<'a> {
     pub fn create(destination_dir: Fd, tmpfilename: &'a ZStr) -> crate::Result<Tmpfile<'a>> {
-        let perm = 0o644;
+        Self::create_with_mode(destination_dir, tmpfilename, 0o644)
+    }
+
+    pub fn create_with_mode(
+        destination_dir: Fd,
+        tmpfilename: &'a ZStr,
+        perm: Mode,
+    ) -> crate::Result<Tmpfile<'a>> {
         let mut tmpfile = Tmpfile {
             destination_dir,
             tmpfilename,

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -192,6 +192,29 @@ console.log("survived", require("./late.js"));`,
     }
   });
 
+  test.skipIf(isWindows)("compile cache entries are created 0600 like Node", async () => {
+    // Entries hold the module's post-transpile source, and the default cache
+    // location is a world-readable tmpdir; Node creates entry files 0600.
+    using dir = tempDir("compile-cache-mode", {
+      "main.js": `process.umask(0o022); console.log(require("./dep.js"));`,
+      "dep.js": "module.exports = 7;",
+    });
+    const cacheDir = path.join(String(dir), "cc");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: { ...bunEnv, NODE_COMPILE_CACHE: cacheDir },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("7");
+    expect(exitCode).toBe(0);
+    const files = [...new Bun.Glob("**/*").scanSync({ cwd: cacheDir, onlyFiles: true })];
+    expect(files.length).toBe(2);
+    const modes = files.map(f => (fs.statSync(path.join(cacheDir, f)).mode & 0o777).toString(8));
+    expect(modes).toEqual(["600", "600"]);
+  });
+
   test("native module functions are not constructors", () => {
     // Constructing these used to crash instead of throwing.
     const compile = new Module("not-a-constructor-test")._compile;

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -208,11 +208,12 @@ console.log("survived", require("./late.js"));`,
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout.trim()).toBe("7");
-    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
     const files = [...new Bun.Glob("**/*").scanSync({ cwd: cacheDir, onlyFiles: true })];
     expect(files.length).toBe(2);
     const modes = files.map(f => (fs.statSync(path.join(cacheDir, f)).mode & 0o777).toString(8));
     expect(modes).toEqual(["600", "600"]);
+    expect(exitCode).toBe(0);
   });
 
   test("native module functions are not constructors", () => {


### PR DESCRIPTION
### Problem

`NODE_COMPILE_CACHE` entry files contain the full post-transpile source and JSC bytecode of every loaded module. Bun created them with mode 0644 (so 0644 under the usual umask 022), inside 0755 directories. With `module.enableCompileCache()`'s default location (`$TMPDIR/node-compile-cache/v<ver>-<arch>-<sha>-<uid>/`) that lets any other local user read a user's cached module sources.

Node v26.3.0 creates entry files with an explicit mode of 0600 (verified empirically: 0600 even under umask 000), while its directories are plain `mkdir` masked by umask.

Repro (Linux, umask 022):

```sh
printf 'module.exports=1; console.log("A")\n' > A.cjs
NODE_COMPILE_CACHE=$PWD/cc bun A.cjs
stat -c '%a %n' cc/*/*   # bun: 644, node v26.3.0: 600
```

### Fix

`bun_sys::Tmpfile::create` hardcoded `0o644`. Added `Tmpfile::create_with_mode` (with `create` delegating at 0644 so the other callers are unchanged), and the compile cache persist path now creates its tmpfile with 0600. The tmpfile-plus-rename flow preserves that mode on the final entry. Directory modes are left as-is, matching Node.

### Verification

New test in `test/js/node/module/node-module-module.test.js` asserts both cache entries stat as 0600 (POSIX only; the fixture pins umask 022 so the assertion is deterministic). Fails on a build without this change (entries stat 644), passes with it. The existing compile cache tests (sha256 keying/acceptance, flush, self-kill persist) still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->