### PR TITLE
url: reject special-scheme hosts made only of IDNA-ignored code points

### DIFF
--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -150,9 +150,7 @@ static String applyIDNADeltaToURLAuthority(const String& urlString, StringView s
         return {};
 
     auto mappedHost = Bun::applyUnicode16IDNADelta(hostView.toString());
-    // An all-ignored host maps to empty, which is domain-to-ASCII failure; splicing
-    // "" in would instead reparse http://\u180E/a as http:///a (host "a"). Skip the
-    // rewrite so the parser rejects the original code points.
+    // All-ignored host: splicing "" in would reparse http://\u180E/a as http:///a (host "a"); skip so the parser rejects it.
     if (mappedHost.isEmpty())
         return {};
     StringBuilder builder;

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -150,11 +150,9 @@ static String applyIDNADeltaToURLAuthority(const String& urlString, StringView s
         return {};
 
     auto mappedHost = Bun::applyUnicode16IDNADelta(hostView.toString());
-    // A host of only ignored-class code points maps to the empty string, which is
-    // domain-to-ASCII failure (node throws ERR_INVALID_URL). Splicing an empty host
-    // back in would instead let the special-authority-ignore-slashes state promote
-    // the first path segment to the host (http://\u180E/a -> http:///a -> host "a").
-    // Leave the input untouched so the parser rejects the original code points.
+    // An all-ignored host maps to empty, which is domain-to-ASCII failure; splicing
+    // "" in would instead reparse http://\u180E/a as http:///a (host "a"). Skip the
+    // rewrite so the parser rejects the original code points.
     if (mappedHost.isEmpty())
         return {};
     StringBuilder builder;

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -117,14 +117,7 @@ static String applyIDNADeltaToURLAuthority(const String& urlString, StringView s
     // The authority ends at the first path/query/fragment terminator;
     // backslash terminates it for special schemes and never appears in a
     // valid host, so treating it as a terminator is safe for both kinds.
-    size_t authorityEnd = view.length();
-    for (size_t i = authorityStart; i < view.length(); i++) {
-        char16_t ch = view[i];
-        if (ch == '/' || ch == '?' || ch == '#' || ch == '\\') {
-            authorityEnd = i;
-            break;
-        }
-    }
+    size_t authorityEnd = Bun::findURLHostTerminator(view, authorityStart);
 
     // Userinfo is percent-encoded, not IDNA-mapped, in node too: only the
     // host span after the last '@' gets the delta.

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -150,6 +150,13 @@ static String applyIDNADeltaToURLAuthority(const String& urlString, StringView s
         return {};
 
     auto mappedHost = Bun::applyUnicode16IDNADelta(hostView.toString());
+    // A host of only ignored-class code points maps to the empty string, which is
+    // domain-to-ASCII failure (node throws ERR_INVALID_URL). Splicing an empty host
+    // back in would instead let the special-authority-ignore-slashes state promote
+    // the first path segment to the host (http://\u180E/a -> http:///a -> host "a").
+    // Leave the input untouched so the parser rejects the original code points.
+    if (mappedHost.isEmpty())
+        return {};
     StringBuilder builder;
     builder.append(view.left(hostStart));
     builder.append(mappedHost);

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -124,6 +124,16 @@ String applyUnicode16IDNADelta(const String& input)
     return builder.toString();
 }
 
+size_t findURLHostTerminator(StringView view, size_t start)
+{
+    for (size_t i = start; i < view.length(); i++) {
+        char16_t c = view[i];
+        if (c == '/' || c == '\\' || c == '?' || c == '#')
+            return i;
+    }
+    return view.length();
+}
+
 // Port of Node's icu-based ToASCII (removed in nodejs/node#55156):
 // https://github.com/nodejs/node/blob/9f5000e0f2a2^/src/node_i18n.cc — filter
 // the CheckHyphens/VerifyDnsLength error classes, fail otherwise unless lenient.
@@ -187,14 +197,7 @@ static String parseDomainAsHost(const String& rawDomain)
     // The hostname setter's basic-URL parse stops at the first path, query,
     // fragment, or backslash (special scheme) terminator.
     StringView view { domain };
-    size_t end = view.length();
-    for (size_t i = 0; i < view.length(); i++) {
-        char16_t c = view[i];
-        if (c == '/' || c == '?' || c == '#' || c == '\\') {
-            end = i;
-            break;
-        }
-    }
+    size_t end = findURLHostTerminator(view);
     String host = domain.left(end);
     if (host.isEmpty())
         return {};

--- a/src/jsc/bindings/NodeURLHelpers.h
+++ b/src/jsc/bindings/NodeURLHelpers.h
@@ -20,4 +20,8 @@ bool containsUnicode16IDNADeltaSource(WTF::StringView view);
 // the input unchanged when no delta source is present.
 WTF::String applyUnicode16IDNADelta(const WTF::String& input);
 
+// Index of the first WHATWG host-state terminator (/ \ ? #) at or after
+// `start`, or view.length() when none.
+size_t findURLHostTerminator(WTF::StringView view, size_t start = 0);
+
 } // namespace Bun

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -125,8 +125,7 @@ void URLDecomposition::setHost(StringView value)
         auto hostSpan = hostEnd == notFound ? value : value.left(hostEnd);
         if (Bun::containsUnicode16IDNADeltaSource(hostSpan)) {
             auto mappedHost = Bun::applyUnicode16IDNADelta(hostSpan.toString());
-            // A non-empty host span mapping to empty is domain-to-ASCII failure
-            // (setter no-ops, even for file: where a literal "" is assignable).
+            // A host mapping to empty is a failed host parse, not an assignable literal "".
             if (mappedHost.isEmpty())
                 return;
             mappedValue = hostEnd == notFound ? mappedHost : makeString(mappedHost, value.substring(hostEnd));

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -113,17 +113,6 @@ static unsigned countASCIIDigits(StringView string)
     return length;
 }
 
-// The WHATWG host/hostname states stop at the first of these; the IDNA delta must not touch anything past it.
-static size_t findHostTerminator(StringView value)
-{
-    for (size_t i = 0; i < value.length(); i++) {
-        char16_t c = value[i];
-        if (c == '/' || c == '\\' || c == '?' || c == '#')
-            return i;
-    }
-    return value.length();
-}
-
 void URLDecomposition::setHost(StringView value)
 {
     auto fullURL = this->fullURL();
@@ -132,7 +121,7 @@ void URLDecomposition::setHost(StringView value)
     // Non-special schemes and '['-prefixed (IPv6) hosts never run IDNA.
     String mappedValue;
     if (fullURL.hasSpecialScheme() && !value.startsWith('[')) {
-        size_t terminator = findHostTerminator(value);
+        size_t terminator = Bun::findURLHostTerminator(value);
         size_t hostEnd = value.left(terminator).reverseFind(':');
         size_t hostSpanEnd = hostEnd == notFound ? terminator : hostEnd;
         auto hostSpan = value.left(hostSpanEnd);
@@ -190,7 +179,7 @@ void URLDecomposition::setHostname(StringView host)
     // schemes run IDNA on it.
     String mappedHost;
     if (fullURL.hasSpecialScheme() && !host.startsWith('[')) {
-        size_t terminator = findHostTerminator(host);
+        size_t terminator = Bun::findURLHostTerminator(host);
         auto hostSpan = host.left(terminator);
         if (Bun::containsUnicode16IDNADeltaSource(hostSpan)) {
             auto mappedSpan = Bun::applyUnicode16IDNADelta(hostSpan.toString());

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -125,6 +125,10 @@ void URLDecomposition::setHost(StringView value)
         auto hostSpan = hostEnd == notFound ? value : value.left(hostEnd);
         if (Bun::containsUnicode16IDNADeltaSource(hostSpan)) {
             auto mappedHost = Bun::applyUnicode16IDNADelta(hostSpan.toString());
+            // A non-empty host span mapping to empty is domain-to-ASCII failure
+            // (setter no-ops, even for file: where a literal "" is assignable).
+            if (mappedHost.isEmpty())
+                return;
             mappedValue = hostEnd == notFound ? mappedHost : makeString(mappedHost, value.substring(hostEnd));
             value = mappedValue;
         }
@@ -175,6 +179,9 @@ void URLDecomposition::setHostname(StringView host)
     String mappedHost;
     if (fullURL.hasSpecialScheme() && !host.startsWith('[') && Bun::containsUnicode16IDNADeltaSource(host)) {
         mappedHost = Bun::applyUnicode16IDNADelta(host.toString());
+        // See setHost: mapping a non-empty hostname to empty is failure, not "".
+        if (mappedHost.isEmpty())
+            return;
         host = mappedHost;
     }
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -113,6 +113,18 @@ static unsigned countASCIIDigits(StringView string)
     return length;
 }
 
+// The WHATWG host/hostname states stop consuming at the first of these; the
+// IDNA delta must not touch anything at or past it (see DOMURL.cpp).
+static size_t findHostTerminator(StringView value)
+{
+    for (size_t i = 0; i < value.length(); i++) {
+        char16_t c = value[i];
+        if (c == '/' || c == '\\' || c == '?' || c == '#')
+            return i;
+    }
+    return value.length();
+}
+
 void URLDecomposition::setHost(StringView value)
 {
     auto fullURL = this->fullURL();
@@ -121,14 +133,16 @@ void URLDecomposition::setHost(StringView value)
     // Non-special schemes and '['-prefixed (IPv6) hosts never run IDNA.
     String mappedValue;
     if (fullURL.hasSpecialScheme() && !value.startsWith('[')) {
-        size_t hostEnd = value.reverseFind(':');
-        auto hostSpan = hostEnd == notFound ? value : value.left(hostEnd);
+        size_t terminator = findHostTerminator(value);
+        size_t hostEnd = value.left(terminator).reverseFind(':');
+        size_t hostSpanEnd = hostEnd == notFound ? terminator : hostEnd;
+        auto hostSpan = value.left(hostSpanEnd);
         if (Bun::containsUnicode16IDNADeltaSource(hostSpan)) {
             auto mappedHost = Bun::applyUnicode16IDNADelta(hostSpan.toString());
             // A host mapping to empty is a failed host parse, not an assignable literal "".
             if (mappedHost.isEmpty())
                 return;
-            mappedValue = hostEnd == notFound ? mappedHost : makeString(mappedHost, value.substring(hostEnd));
+            mappedValue = makeString(mappedHost, value.substring(hostSpanEnd));
             value = mappedValue;
         }
     }
@@ -176,12 +190,17 @@ void URLDecomposition::setHostname(StringView host)
     // See setHost: the input is a hostname by definition, and only special
     // schemes run IDNA on it.
     String mappedHost;
-    if (fullURL.hasSpecialScheme() && !host.startsWith('[') && Bun::containsUnicode16IDNADeltaSource(host)) {
-        mappedHost = Bun::applyUnicode16IDNADelta(host.toString());
-        // See setHost: mapping a non-empty hostname to empty is failure, not "".
-        if (mappedHost.isEmpty())
-            return;
-        host = mappedHost;
+    if (fullURL.hasSpecialScheme() && !host.startsWith('[')) {
+        size_t terminator = findHostTerminator(host);
+        auto hostSpan = host.left(terminator);
+        if (Bun::containsUnicode16IDNADeltaSource(hostSpan)) {
+            auto mappedSpan = Bun::applyUnicode16IDNADelta(hostSpan.toString());
+            // See setHost: mapping a non-empty hostname to empty is failure, not "".
+            if (mappedSpan.isEmpty())
+                return;
+            mappedHost = makeString(mappedSpan, host.substring(terminator));
+            host = mappedHost;
+        }
     }
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -113,8 +113,7 @@ static unsigned countASCIIDigits(StringView string)
     return length;
 }
 
-// The WHATWG host/hostname states stop consuming at the first of these; the
-// IDNA delta must not touch anything at or past it (see DOMURL.cpp).
+// The WHATWG host/hostname states stop at the first of these; the IDNA delta must not touch anything past it.
 static size_t findHostTerminator(StringView value)
 {
     for (size_t i = 0; i < value.length(); i++) {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -184,7 +184,10 @@ describe("url", () => {
     // Scheme-relative input and an all-ignored base reach the same host span.
     expect(() => new URL("//\u180E/evil.example/", "http://good.example/")).toThrow(errInvalidURL);
     expect(URL.canParse("//\u180E/evil.example/", "http://good.example/")).toBe(false);
+    expect(URL.parse("//\u180E/evil.example/", "http://good.example/")).toBeNull();
     expect(() => new URL("/x", "http://\u206A/base.example/")).toThrow(errInvalidURL);
+    expect(URL.canParse("/x", "http://\u206A/base.example/")).toBe(false);
+    expect(URL.parse("/x", "http://\u206A/base.example/")).toBeNull();
     // Mixed hosts still strip the ignored code point rather than failing.
     expect(new URL("http://a\u180Eb/").href).toBe("http://ab/");
     expect(new URL("file://a\u180Eb/x").host).toBe("ab");
@@ -199,6 +202,9 @@ describe("url", () => {
     const f3 = new URL("file://server/share");
     f3.host = "";
     expect(f3.href).toBe("file:///share");
+    const f4 = new URL("file://server/share");
+    f4.hostname = "";
+    expect(f4.href).toBe("file:///share");
     // A terminator after the ignored code points must not smuggle the tail
     // past the empty-host guard: the host span ends at the first / \ ? #.
     for (const tail of ["/x", "\\x", "?x", "#x"]) {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -199,6 +199,18 @@ describe("url", () => {
     const f3 = new URL("file://server/share");
     f3.host = "";
     expect(f3.href).toBe("file:///share");
+    // A terminator after the ignored code points must not smuggle the tail
+    // past the empty-host guard: the host span ends at the first / \ ? #.
+    for (const tail of ["/x", "\\x", "?x", "#x"]) {
+      for (const base of ["file://server/share", "http://ok.example/p"]) {
+        const withHost = new URL(base);
+        withHost.host = "\u180E" + tail;
+        expect(withHost.href).toBe(base);
+        const withHostname = new URL(base);
+        withHostname.hostname = "\u180E" + tail;
+        expect(withHostname.href).toBe(base);
+      }
+    }
   });
 
   it("prints", () => {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -161,6 +161,45 @@ describe("url", () => {
     expect(h2.host).toBe("xn--foo-7ka:81");
   });
 
+  it("rejects special-scheme hosts made only of IDNA-ignored code points", () => {
+    // U+180E and U+206A..U+206F map to nothing under UTS #46, so these hosts
+    // map to the empty string: domain-to-ASCII failure (node throws
+    // ERR_INVALID_URL), never "promote the first path segment to the host".
+    const inputs = [
+      "http://\u180E/evil.example/x",
+      "https://\u206A\u206F/other.example/p",
+      "ws://\u180E/h/p",
+      "file://\u180E/some/dir/f",
+      "http://\u180E\u206B:8080/x",
+      "http://user@\u180E/x",
+    ];
+    for (const input of inputs) {
+      expect(() => new URL(input)).toThrow();
+      expect(URL.canParse(input)).toBe(false);
+      expect(URL.parse(input)).toBeNull();
+      const u = new URL("http://ok.example/");
+      expect(() => (u.href = input)).toThrow();
+    }
+    // Scheme-relative input and an all-ignored base reach the same host span.
+    expect(() => new URL("//\u180E/evil.example/", "http://good.example/")).toThrow();
+    expect(URL.canParse("//\u180E/evil.example/", "http://good.example/")).toBe(false);
+    expect(() => new URL("/x", "http://\u206A/base.example/")).toThrow();
+    // Mixed hosts still strip the ignored code point rather than failing.
+    expect(new URL("http://a\u180Eb/").href).toBe("http://ab/");
+    expect(new URL("file://a\u180Eb/x").host).toBe("ab");
+    // Setters: a non-empty host that maps to empty is a failed host parse and
+    // no-ops, even for file: where assigning a literal "" clears the host.
+    const f1 = new URL("file://server/share");
+    f1.host = "\u180E";
+    expect(f1.href).toBe("file://server/share");
+    const f2 = new URL("file://server/share");
+    f2.hostname = "\u180E";
+    expect(f2.href).toBe("file://server/share");
+    const f3 = new URL("file://server/share");
+    f3.host = "";
+    expect(f3.href).toBe("file:///share");
+  });
+
   it("prints", () => {
     // URL.prototype carries [Symbol.for("nodejs.util.inspect.custom")], so
     // Bun.inspect matches node's util.inspect output.

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -173,17 +173,18 @@ describe("url", () => {
       "http://\u180E\u206B:8080/x",
       "http://user@\u180E/x",
     ];
+    const errInvalidURL = expect.objectContaining({ code: "ERR_INVALID_URL" });
     for (const input of inputs) {
-      expect(() => new URL(input)).toThrow();
+      expect(() => new URL(input)).toThrow(errInvalidURL);
       expect(URL.canParse(input)).toBe(false);
       expect(URL.parse(input)).toBeNull();
       const u = new URL("http://ok.example/");
-      expect(() => (u.href = input)).toThrow();
+      expect(() => (u.href = input)).toThrow(errInvalidURL);
     }
     // Scheme-relative input and an all-ignored base reach the same host span.
-    expect(() => new URL("//\u180E/evil.example/", "http://good.example/")).toThrow();
+    expect(() => new URL("//\u180E/evil.example/", "http://good.example/")).toThrow(errInvalidURL);
     expect(URL.canParse("//\u180E/evil.example/", "http://good.example/")).toBe(false);
-    expect(() => new URL("/x", "http://\u206A/base.example/")).toThrow();
+    expect(() => new URL("/x", "http://\u206A/base.example/")).toThrow(errInvalidURL);
     // Mixed hosts still strip the ignored code point rather than failing.
     expect(new URL("http://a\u180Eb/").href).toBe("http://ab/");
     expect(new URL("file://a\u180Eb/x").host).toBe("ab");


### PR DESCRIPTION
### Repro

```js
// node v26.3.0 and bun before #34660: ERR_INVALID_URL for all of these
const I = "\u180E", J = "\u206A\u206F";
new URL("http://" + I + "/evil.example/x");  // main: host "evil.example"
new URL("https://" + J + "/other.example/p"); // main: host "other.example"
new URL("ws://" + I + "/h/p");                // main: host "h"
new URL("file://" + I + "/some/dir/f");       // main: file:///some/dir/f
new URL("//" + I + "/evil.example/", "http://good.example/"); // main: http://evil.example/
```

`URL.canParse` returned true and `URL.parse` non-null for each; the `href` setter behaved the same. A string every WHATWG parser (node, browsers, previous bun) rejects instead parsed with a host taken from the path, which is the validator/consumer-disagreement shape. Regression from the Unicode 16 IDNA delta pre-scanner in #34660.

### Cause

`applyIDNADeltaToURLAuthority` (DOMURL.cpp) maps the host span through the Unicode 16 IDNA delta, under which U+180E and U+206A..U+206F are ignored (deleted). A host made only of those code points maps to the empty string, and splicing that empty host back into the input rebuilt `http://\u180E/evil.example/x` as `http:///evil.example/x`. The special-authority-ignore-slashes state then consumes the slash run and takes `evil.example` as the host. Per the URL spec an empty domain-to-ASCII result is parse failure, which is what node (ada) does.

### Fix

When the mapped host is empty while the original host span was not, skip the rewrite and leave the input untouched. The parser then rejects the original code points (bundled ICU treats them as disallowed), producing `ERR_INVALID_URL` exactly as before the pre-scanner.

The host/hostname setters (URLDecomposition.cpp) had the same conflation: assigning `"\u180E"` mapped to `""` and cleared a `file:` host, where node no-ops like any failed host parse. The setters also applied the delta to the whole input, so a terminator after the ignored code points (`u.host = "\u180E/x"`) smuggled a non-empty string past the empty check and cleared a `file:` host or promoted the first path segment on http. Both setters now bound the delta span (and the empty-host check) at the first `/ \ ? #`, matching the WHATWG host state and the constructor path. Assigning a literal empty string still clears a file host, matching node.

### Verification

- New test in `test/js/web/url/url.test.ts` fails on main, passes with the fix: constructor, `canParse`, `parse`, and `href` setter for http/https/ws/file plus userinfo/port and base-URL variants, the setter no-ops (bare and with each of the four terminators, on file: and http), and mixed hosts (`a\u180Eb` -> `ab`) still mapping.
- Output of the repro above matches node v26.3.0 byte-for-byte with the fix.
- `test/js/web/url/`, `test/js/node/url/`, and the WPT runners (`test-whatwg-url-custom-parsing`, `custom-setters`, `toascii`, `canparse`, `custom-domainto`, `custom-href-side-effect`) pass. The one exception is `url-canParse-whatwg.test.js` "repeatedly called produces same result", which loops `URL.canParse` 100k times and exceeds its 5s timeout under a debug+ASAN build regardless of this change (the all-ASCII input returns from the delta scanner on its first line).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (3c1dd0fcb)

test/js/web/url/url.test.ts:
(pass) url > URL throws [11.37ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.40ms]
(pass) url > should have correct origin and protocol [12.28ms]
(pass) url > blob urls [8.03ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [18.60ms]
173 |       "http://\u180E\u206B:8080/x",
174 |       "http://user@\u180E/x",
175 |     ];
176 |     const errInvalidURL = expect.objectContaining({ code: "ERR_INVALID_URL" });
177 |     for (const input of inputs) {
178 |       expect(() => new URL(input)).toThrow(errInvalidURL);
                                         ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: URL {
  href: 'http://evil.example/x',
  origin: 'http://evil.example',
  protocol: 'http:',
  username: '',
  password: '',
  host: 'evil.example',
  hostname: 'evil.example',
  port: '',
  pathname: '/x',
  search: '',
  sea
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0b20ff578)

test/js/web/url/url.test.ts:
(pass) url > URL throws [3.22ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [0.12ms]
(pass) url > should have correct origin and protocol [0.10ms]
(pass) url > blob urls [0.07ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [2.10ms]
(pass) url > rejects special-scheme hosts made only of IDNA-ignored code points [0.44ms]
(pass) url > prints [1.92ms]
(pass) url > URLContext offsets account for the /. pathname guard [0.65ms]
(pass) url > works [0.16ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [0.02ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:b)
(pass) url > URL.canParse > URL.canParse(a:/b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:/b)
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined)
(pass) url > URL.canParse > URL.canParse(a, https://b/)
(pass) url > URL.canParse > URL.canParse.length should be 1 [0.01ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [0.06ms]
(pass) url.searchPara
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (3c1dd0fcb)

test/js/web/url/url.test.ts:
(pass) url > URL throws [10.92ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.39ms]
(pass) url > should have correct origin and protocol [11.68ms]
(pass) url > blob urls [7.89ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [18.30ms]
(pass) url > rejects special-scheme hosts made only of IDNA-ignored code points [38.37ms]
(pass) url > prints [96.89ms]
(pass) url > URLContext offsets account for the /. pathname guard [43.81ms]
(pass) url > works [12.53ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.38ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.66ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.31ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.24ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.29ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.26ms]
(pass) url > URL.canParse > URL.canParse(a, h
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 729ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen cpp.rs (cppbind)
[1/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/DOMURL.cpp           | 12 +++-----
 src/jsc/bindings/NodeURL.cpp          | 19 +++++++-----
 src/jsc/bindings/NodeURLHelpers.h     |  4 +++
 src/jsc/bindings/URLDecomposition.cpp | 25 +++++++++++----
 test/js/web/url/url.test.ts           | 58 +++++++++++++++++++++++++++++++++++
 5 files changed, 96 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/DOMURL.cpp                3      5      0
src/jsc/bindings/NodeURL.cpp               2      1      0
src/jsc/bindings/NodeURLHelpers.h          2      2      0
src/jsc/bindings/URLDecomposition.cpp      4      7      0
test/js/web/url/url.test.ts                2      5      0
```

</details>

<!-- robobun:evidence:end -->
