### PR TITLE
Fix use-after-free in Bun.inspect when user code mutates the object mid-format

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5453,6 +5453,21 @@ restart:
     if (fast) {
         bool anyHits = false;
         JSC::JSObject* objectToUse = prototypeObject.getObject();
+
+        // The iter callback can run user code (a nested value's inspect.custom, Proxy
+        // traps) that adds properties to this object, rehashing the PropertyTable
+        // mid-walk (use-after-free). Same for getters resolved through
+        // getIfPropertyExists. Collect the entries with no side effects first, then
+        // do the getter calls and callbacks on the snapshot.
+        struct SnapshottedProperty {
+            Identifier key;
+            unsigned attributes;
+        };
+        WTF::Vector<SnapshottedProperty, 16> snapshot;
+        // Parallel to `snapshot`; keeps the collected values visible to GC. Empty
+        // slots mark prototype properties that are fetched after the walk.
+        MarkedArgumentBuffer snapshotValues;
+
         structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
             if ((entry.attributes() & (PropertyAttribute::Function)) == 0 && (entry.attributes() & (PropertyAttribute::Builtin)) != 0) {
                 return true;
@@ -5472,18 +5487,25 @@ restart:
             }
             visitedProperties.append(Identifier::fromUid(vm, prop));
 
-            ZigString key = toZigString(prop);
             JSC::JSValue propertyValue = JSValue();
-
             if (objectToUse == object) {
                 propertyValue = objectToUse->getDirect(entry.offset());
-                if (!propertyValue) {
-                    (void)scope.tryClearException();
+                if (!propertyValue)
                     return true;
-                }
             }
 
-            if (!propertyValue || propertyValue.isGetterSetter() && !((entry.attributes() & PropertyAttribute::Accessor) != 0)) {
+            snapshot.append({ Identifier::fromUid(vm, prop), entry.attributes() });
+            snapshotValues.appendWithCrashOnOverflow(propertyValue);
+            return true;
+        });
+
+        for (size_t i = 0; i < snapshot.size(); i++) {
+            const auto& snapshotted = snapshot[i];
+            auto* prop = snapshotted.key.impl();
+            ZigString key = toZigString(prop);
+
+            JSC::JSValue propertyValue = snapshotValues.at(i);
+            if (!propertyValue || propertyValue.isGetterSetter() && !((snapshotted.attributes & PropertyAttribute::Accessor) != 0)) {
                 propertyValue = objectToUse->getIfPropertyExists(globalObject, prop);
             }
 
@@ -5491,24 +5513,20 @@ restart:
             CLEAR_IF_EXCEPTION(scope);
 
             if (!propertyValue)
-                return true;
+                continue;
 
             anyHits = true;
             JSC::EnsureStillAliveScope ensureStillAliveScope(propertyValue);
 
-            bool isPrivate = prop->isSymbol() && Identifier::fromUid(vm, prop).isPrivateName();
+            bool isPrivate = prop->isSymbol() && snapshotted.key.isPrivateName();
 
             if (isPrivate && !JSC::Options::showPrivateScriptsInStackTraces())
-                return true;
+                continue;
 
             iter(globalObject, arg2, &key, JSC::JSValue::encode(propertyValue), prop->isSymbol(), isPrivate);
             // Propagate exceptions from callbacks.
-            RETURN_IF_EXCEPTION(scope, false);
-            return true;
-        });
-
-        // Propagate exceptions from callbacks.
-        RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, );
+        }
 
         if (anyHits) {
             if (prototypeCount++ < 5) {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -802,4 +802,129 @@ it("CustomEvent", () => {
       BUBBLING_PHASE: 3,
     }"
   `);
+});
+
+describe.skipIf(!isASAN)("object mutated while being formatted", () => {
+  it("does not read freed property tables", async () => {
+    const fixture = `
+      function makeParent() {
+        const p = {};
+        for (let i = 0; i < 8; i++) p["k" + i] = i;
+        return p;
+      }
+      // Enough added properties to cross several PropertyTable capacity
+      // doublings; each rehash frees the previous index vector.
+      const addMany = o => { for (let i = 0; i < 256; i++) o["n" + i] = i; };
+      const custom = Symbol.for("nodejs.util.inspect.custom");
+
+      {
+        // inspect.custom on a nested value adds properties to the parent mid-walk.
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) addMany(p); return "a"; } };
+        p.z = 1;
+        const s = Bun.inspect(p);
+        console.log("custom add:", s.includes("z: 1"));
+      }
+      {
+        // Same mutation through console.log instead of Bun.inspect.
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) addMany(p); return "a"; } };
+        p.z = 1;
+        console.log(p);
+      }
+      {
+        // Deleting parent properties mid-walk.
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) { for (let i = 0; i < 8; i++) delete p["k" + i]; } return "a"; } };
+        p.z = 1;
+        const s = Bun.inspect(p);
+        console.log("custom delete:", s.includes("z: 1"));
+      }
+      {
+        // A getter on a built-in subclass (Map.size) is another way the
+        // formatter runs user code for a nested value.
+        const p = makeParent();
+        let fired = 0;
+        class M extends Map { get size() { if (!fired++) addMany(p); return super.size; } }
+        p.a = new M([[1, 2]]);
+        p.z = 1;
+        const s = Bun.inspect(p);
+        console.log("map size getter:", s.includes("z: 1"), fired > 0);
+      }
+      {
+        // An object with no own properties is formatted by fast-walking its
+        // prototype's structure; mutating the prototype mid-walk rehashes it.
+        const proto = makeParent();
+        let fired = 0;
+        proto.a = { [custom]() { if (!fired++) addMany(proto); return "a"; } };
+        proto.z = 1;
+        const s = Bun.inspect(Object.create(proto));
+        console.log("prototype walk:", s.includes("z: 1"), fired > 0);
+      }
+      {
+        // Allocation churn + GC inside the hook, with object-valued siblings
+        // formatted afterwards: catches a snapshot that is invisible to GC.
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() {
+          if (!fired++) {
+            addMany(p);
+            const junk = [];
+            for (let i = 0; i < 200; i++) { const o = {}; for (let j = 0; j < 20; j++) o["q" + j] = j; junk.push(o); }
+            Bun.gc(true);
+          }
+          return "a";
+        } };
+        for (let i = 0; i < 30; i++) p["s" + i] = { v: i };
+        p.z = 1;
+        const s = Bun.inspect(p);
+        console.log("gc churn:", s.includes("z: 1") && s.includes("v: 29"));
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: {
+        ...bunEnv,
+        ...(isWindows ? {} : { Malloc: "1" }),
+        // Skip symbolizing a failure report; symbolization of the debug
+        // binary takes longer than the test timeout.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe(
+      [
+        "custom add: true",
+        // console.log dump of the mutated parent: properties added by the
+        // inspect.custom hook mid-format are not shown (the walk snapshots
+        // the properties up front, like Node).
+        "{",
+        "  k0: 0,",
+        "  k1: 1,",
+        "  k2: 2,",
+        "  k3: 3,",
+        "  k4: 4,",
+        "  k5: 5,",
+        "  k6: 6,",
+        "  k7: 7,",
+        "  a: a,",
+        "  z: 1,",
+        "}",
+        "custom delete: true",
+        "map size getter: true true",
+        "prototype walk: true true",
+        "gc churn: true",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem

`Bun.inspect` and `console.log` have a heap-use-after-free when formatting a value runs user code that mutates the object being formatted. The default-enabled `Symbol.for("nodejs.util.inspect.custom")` hook on a nested value is enough to trigger it:

```js
// Malloc=1 <bun-asan> repro.mjs
const p = {};
for (let i = 0; i < 8; i++) p['k'+i] = i;
let f = 0;
p.a = { [Symbol.for('nodejs.util.inspect.custom')]() {
  if (!f++) for (let i = 0; i < 256; i++) p['n'+i] = i;
  return 'a';
} };
p.z = 1;
console.log(Bun.inspect(p).length);
```

ASAN (with `Malloc=1` so JSC's bmalloc routes through the system allocator):

```
heap-use-after-free READ of size 8
  #0 CompactPropertyTableEntry::key() Structure.h
  #1 PropertyTable::forEachProperty
  #2 Structure::forEachProperty
  #3 JSC__JSValue__forEachPropertyImpl bindings.cpp
freed by:
  PropertyTable::destroyIndexVector <- PropertyTable::rehash <- PropertyTable::add
  <- Structure::addNewPropertyTransition <- JSObject::putDirectInternal
```

### Cause

The fast path of `JSC__JSValue__forEachPropertyImpl` walks the structure's `PropertyTable` with `Structure::forEachProperty` and invokes the formatter callback from inside the walk. The callback recursively formats the property value, which can run user code: a nested value's `inspect.custom`, or a getter on a built-in subclass (for example an overridden `Map.prototype.size`). If that code adds or deletes properties on the parent object, JSC rehashes the shared table, freeing the index vector the outer walk is iterating, and every remaining entry is read from freed memory.

The fast-path guard only inspects the parent's structure, and a parent with plain data properties passes it; the hostile hook lives on a nested value. Same bug class as the deepEquals fix in #37168, which deliberately excluded this site.

### Fix

Collect the entries (key, attributes, direct value) under `forEachProperty` with no side effects, then resolve remaining values and invoke the callback on the snapshot after the walk finishes. The values go in a `MarkedArgumentBuffer` so GC in a callback cannot collect them; keys are retained as `Identifier`s. The snapshot is per structure walk, so the prototype-chain restart loop still re-reads each prototype's live structure.

Properties added to the object while it is being formatted are no longer printed: the walk now reflects the object as it was when formatting started. That matches Node, which collects the key list before formatting values. The other `forEachProperty` sites are unaffected: the non-indexed and ordered variants never take this fast path, and the remaining callers run no user code in the callback.

### Verification

- New test in `test/js/bun/util/inspect.test.js` (ASAN-only, child spawned with `Malloc=1`) covering: `inspect.custom` adding properties via `Bun.inspect` and `console.log`, deleting properties, a `Map` subclass `size` getter, the prototype fast-walk of an own-property-less object, and GC churn inside the hook with object-valued siblings formatted afterwards. Fails before the fix (ASAN abort, empty stdout), passes after.
- `test/js/bun/util/inspect.test.js`: 74 pass. `test/js/bun/console/`: 85 pass, 1 skip.
- `inspect-error.test.js` minified-file snapshots and `inspect-error-leak.test.js` fail identically with and without this diff locally (pre-existing, unrelated to property enumeration).