### PR TITLE
Don't block worker/VM teardown on fs thread-pool ops that never complete

### DIFF
--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -60,7 +60,6 @@ bun_dispatch::link_interface! {
         fn exit();
         fn enqueue_task(task: Task);
         fn enqueue_task_concurrent(task: core::ptr::NonNull<ConcurrentTask::ConcurrentTask>);
-        fn concurrent_poster_end();
         fn env() -> *mut bun_dotenv::Loader;
         fn top_level_dir() -> *const [u8];
         fn create_null_delimited_env_map() -> Result<bun_dotenv::NullDelimitedEnvMap, bun_core::AllocError>;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -790,6 +790,14 @@ impl VirtualMachine {
         unsafe { &*self.event_loop }
     }
 
+    /// Close both loops' [`crate::event_loop::ConcurrentPosterGate`]s (macro mode can have
+    /// pointed tasks at either loop) ahead of the final queue drain: no work-pool completion can
+    /// post after this returns. See the gate type for why this never waits on a blocked syscall.
+    pub fn close_concurrent_posters(&mut self) {
+        self.regular_event_loop.close_concurrent_posters();
+        self.macro_event_loop.close_concurrent_posters();
+    }
+
     /// Alias for [`Self::event_loop_mut`]. Kept for callers migrated on the
     /// `runtime-hostfn-safe` branch; both names funnel into the single audited
     /// `unsafe` deref above.
@@ -1638,10 +1646,11 @@ impl VirtualMachine {
             bun_http::shutdown_for_exit();
 
             // Release tasks the HTTP daemon posted before observing `is_shutting_down` (else the
-            // tasklet ⇄ `Box<AsyncHTTP>` cycle leaks); must precede `destructOnExit`. Wait for
-            // work-pool fs completions first — they post without a shutdown check, so a post
-            // landing after the drain leaks.
-            self.event_loop_mut().wait_for_concurrent_posters();
+            // tasklet ⇄ `Box<AsyncHTTP>` cycle leaks); must precede `destructOnExit`. Close the
+            // poster gates first so no work-pool fs completion can post after the drain; a
+            // completion still blocked in its syscall is refused at its gate later and frees
+            // itself without touching the VM.
+            self.close_concurrent_posters();
             self.event_loop_mut().release_queued_tasks_for_shutdown();
 
             if let Some(rare) = self.rare_data.as_deref_mut() {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -790,9 +790,8 @@ impl VirtualMachine {
         unsafe { &*self.event_loop }
     }
 
-    /// Close both loops' [`crate::event_loop::ConcurrentPosterGate`]s (macro mode can have
-    /// pointed tasks at either loop) ahead of the final queue drain: no work-pool completion can
-    /// post after this returns. See the gate type for why this never waits on a blocked syscall.
+    /// Refuse all future work-pool completion posts (see `ConcurrentPosterGate`). Both loops:
+    /// macro mode can have pointed tasks at either.
     pub fn close_concurrent_posters(&mut self) {
         self.regular_event_loop.close_concurrent_posters();
         self.macro_event_loop.close_concurrent_posters();
@@ -1647,9 +1646,7 @@ impl VirtualMachine {
 
             // Release tasks the HTTP daemon posted before observing `is_shutting_down` (else the
             // tasklet ⇄ `Box<AsyncHTTP>` cycle leaks); must precede `destructOnExit`. Close the
-            // poster gates first so no work-pool fs completion can post after the drain; a
-            // completion still blocked in its syscall is refused at its gate later and frees
-            // itself without touching the VM.
+            // poster gates first so no work-pool fs completion can post after the drain.
             self.close_concurrent_posters();
             self.event_loop_mut().release_queued_tasks_for_shutdown();
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -88,11 +88,9 @@ pub struct EventLoop {
 
     pub entered_event_loop_count: isize,
     pub concurrent_ref: AtomicI32,
-    /// Gate shared (via `Arc` clones) with every scheduled work-pool task whose completion posts
-    /// back through [`Self::enqueue_task_concurrent`]. Shutdown closes it before the final queue
-    /// drain so a completion can't land after the drain; a poster that arrives later observes the
-    /// closed gate and frees its task without touching this (possibly already freed) loop. `None`
-    /// only after [`Self::deinit`].
+    /// Shared with every scheduled work-pool task whose completion posts back through
+    /// [`Self::enqueue_task_concurrent`]; see [`ConcurrentPosterGate`]. `None` only after
+    /// [`Self::deinit`].
     pub concurrent_poster_gate: Option<std::sync::Arc<ConcurrentPosterGate>>,
     /// Atomic nullable pointer to the next-due `WTFTimer`.
     ///
@@ -144,22 +142,13 @@ impl Default for EventLoop {
     }
 }
 
-/// Gate between work-pool completion posts and event-loop teardown.
-///
-/// A scheduled fs operation can block indefinitely (a `read()` from a FIFO or pipe with no
-/// writer), so shutdown must not wait for it — the old whole-operation poster count turned
-/// `worker.terminate()` into an unbounded spin. Instead, each poster wraps ONLY its completion
-/// post in [`Self::begin_post`]/[`Self::end_post`], and [`Self::close`] refuses everything that
-/// comes later. The gate is `Arc`-shared with every in-flight task precisely so a poster that
-/// outlives the VM can still load the closed state from live memory.
-///
-/// Protocol guarantees, in terms of the single `state` word's modification order:
-/// - `begin_post() == true` ⇒ the increment preceded `close()`'s closed-bit store, so `close()`
-///   cannot return before the matching [`Self::end_post`] — the event loop and its VM stay live
-///   for the whole post.
-/// - `begin_post() == false` ⇒ the loop may already be freed; the caller still owns its task and
-///   must dispose of it without touching the VM or the JS heap (`dispose_without_post` in
-///   `node_fs.rs`).
+/// Gate between work-pool completion posts and event-loop teardown. Posters bracket only the
+/// enqueue itself in [`Self::begin_post`]/[`Self::end_post`] — never the fs syscall, which can
+/// block forever (a `read()` from a FIFO with no writer) — so shutdown's [`Self::close`] waits
+/// only for posts already mid-enqueue and refuses everything later. `Arc`-shared with every
+/// in-flight task so a poster whose syscall outlives the VM still reads the closed state from
+/// live memory; a refused poster frees its own task without touching the VM or the JS heap
+/// (`dispose_without_post` in `node_fs.rs`).
 #[derive(Default)]
 pub struct ConcurrentPosterGate {
     /// Bit 31: closed. Bits 0..31: posters currently between `begin_post` and `end_post`.
@@ -170,7 +159,7 @@ impl ConcurrentPosterGate {
     const CLOSED: u32 = 1 << 31;
 
     /// Work-pool thread: begin a completion post. On `true`, the loop is guaranteed live until
-    /// the matching [`Self::end_post`].
+    /// the matching [`Self::end_post`] ([`Self::close`] cannot return in between).
     #[must_use]
     pub fn begin_post(&self) -> bool {
         let mut state = self.state.load(Ordering::Relaxed);
@@ -190,15 +179,14 @@ impl ConcurrentPosterGate {
         }
     }
 
-    /// Work-pool thread: the post finished. Last touch of the event loop; after this the JS
-    /// thread may drain the queue and tear the VM down.
+    /// Work-pool thread: the post finished. Last touch of the event loop.
     pub fn end_post(&self) {
         let prev = self.state.fetch_sub(1, Ordering::Release);
         debug_assert!(prev & !Self::CLOSED > 0);
     }
 
-    /// JS thread, shutdown: no post begun after this returns can succeed, and every post that
-    /// already began has finished. Bounded by an enqueue, not by the underlying fs operation.
+    /// JS thread, shutdown: after this returns no further post can land. Bounded by an enqueue,
+    /// not by the underlying fs operation.
     pub fn close(&self) {
         self.state.fetch_or(Self::CLOSED, Ordering::AcqRel);
         while self.state.load(Ordering::Acquire) & !Self::CLOSED != 0 {
@@ -835,10 +823,8 @@ impl EventLoop {
     }
 
     pub fn deinit(&mut self) {
-        // Drop this loop's ref to the poster gate (closed by now on every path that deinits a
-        // loop with posters). The VM box is raw-dealloc'd without field `Drop`s, so the `Arc`
-        // must be released here; stranded posters hold their own clones and free the allocation
-        // when the last one finishes.
+        // The VM box is raw-dealloc'd without field `Drop`s, so release the gate `Arc` here;
+        // stranded posters hold their own clones.
         drop(self.concurrent_poster_gate.take());
         // Free (don't run — running could re-enter the dying VM) queued
         // ManagedTask boxes. Other tags are left in place: they were re-queued
@@ -1080,8 +1066,8 @@ impl EventLoop {
         self.wakeup();
     }
 
-    /// Clone of [`Self::concurrent_poster_gate`] for a work-pool task scheduled on the JS
-    /// thread. Panics after [`Self::deinit`] — tasks are only created while the VM is live.
+    /// Clone of [`Self::concurrent_poster_gate`]. Panics after [`Self::deinit`] — tasks are
+    /// only created while the VM is live.
     pub fn poster_gate(&self) -> std::sync::Arc<ConcurrentPosterGate> {
         self.concurrent_poster_gate
             .as_ref()
@@ -1089,11 +1075,8 @@ impl EventLoop {
             .clone()
     }
 
-    /// Close [`Self::concurrent_poster_gate`]: refuse all future work-pool completion posts and
-    /// wait out the ones already mid-enqueue. Called on the JS thread during shutdown, after the
-    /// last JS has run and before the final queue drain, so the drain sees every post that will
-    /// ever land. Unlike the fs operations themselves (which can block forever on a pipe/FIFO),
-    /// the wait here is bounded by an enqueue + wakeup.
+    /// Close [`Self::concurrent_poster_gate`]. Shutdown calls this before the final queue drain
+    /// so the drain sees every post that will ever land.
     pub fn close_concurrent_posters(&self) {
         if let Some(gate) = self.concurrent_poster_gate.as_ref() {
             gate.close();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1069,10 +1069,11 @@ impl EventLoop {
     /// Clone of [`Self::concurrent_poster_gate`]. Panics after [`Self::deinit`] — tasks are
     /// only created while the VM is live.
     pub fn poster_gate(&self) -> std::sync::Arc<ConcurrentPosterGate> {
-        self.concurrent_poster_gate
-            .as_ref()
-            .expect("poster_gate() after EventLoop::deinit()")
-            .clone()
+        std::sync::Arc::clone(
+            self.concurrent_poster_gate
+                .as_ref()
+                .expect("poster_gate() after EventLoop::deinit()"),
+        )
     }
 
     /// Close [`Self::concurrent_poster_gate`]. Shutdown calls this before the final queue drain

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -88,10 +88,12 @@ pub struct EventLoop {
 
     pub entered_event_loop_count: isize,
     pub concurrent_ref: AtomicI32,
-    /// Work-pool tasks that will post to `concurrent_tasks` when they finish (counted on the JS
-    /// thread before hand-off, decremented on the pool thread after the post). Shutdown waits for
-    /// zero before the final queue drain so a completion can't land after it and leak.
-    pub concurrent_posters: AtomicU32,
+    /// Gate shared (via `Arc` clones) with every scheduled work-pool task whose completion posts
+    /// back through [`Self::enqueue_task_concurrent`]. Shutdown closes it before the final queue
+    /// drain so a completion can't land after the drain; a poster that arrives later observes the
+    /// closed gate and frees its task without touching this (possibly already freed) loop. `None`
+    /// only after [`Self::deinit`].
+    pub concurrent_poster_gate: Option<std::sync::Arc<ConcurrentPosterGate>>,
     /// Atomic nullable pointer to the next-due `WTFTimer`.
     ///
     /// Note (§Dispatch): payload is `*mut ()` — the real
@@ -132,12 +134,75 @@ impl Default for EventLoop {
             uws_loop: (),
             entered_event_loop_count: 0,
             concurrent_ref: AtomicI32::new(0),
-            concurrent_posters: AtomicU32::new(0),
+            concurrent_poster_gate: Some(std::sync::Arc::new(ConcurrentPosterGate::default())),
             imminent_gc_timer: AtomicPtr::new(core::ptr::null_mut()),
             #[cfg(unix)]
             signal_handler: None,
             #[cfg(not(unix))]
             signal_handler: (),
+        }
+    }
+}
+
+/// Gate between work-pool completion posts and event-loop teardown.
+///
+/// A scheduled fs operation can block indefinitely (a `read()` from a FIFO or pipe with no
+/// writer), so shutdown must not wait for it — the old whole-operation poster count turned
+/// `worker.terminate()` into an unbounded spin. Instead, each poster wraps ONLY its completion
+/// post in [`Self::begin_post`]/[`Self::end_post`], and [`Self::close`] refuses everything that
+/// comes later. The gate is `Arc`-shared with every in-flight task precisely so a poster that
+/// outlives the VM can still load the closed state from live memory.
+///
+/// Protocol guarantees, in terms of the single `state` word's modification order:
+/// - `begin_post() == true` ⇒ the increment preceded `close()`'s closed-bit store, so `close()`
+///   cannot return before the matching [`Self::end_post`] — the event loop and its VM stay live
+///   for the whole post.
+/// - `begin_post() == false` ⇒ the loop may already be freed; the caller still owns its task and
+///   must dispose of it without touching the VM or the JS heap (`dispose_without_post` in
+///   `node_fs.rs`).
+#[derive(Default)]
+pub struct ConcurrentPosterGate {
+    /// Bit 31: closed. Bits 0..31: posters currently between `begin_post` and `end_post`.
+    state: AtomicU32,
+}
+
+impl ConcurrentPosterGate {
+    const CLOSED: u32 = 1 << 31;
+
+    /// Work-pool thread: begin a completion post. On `true`, the loop is guaranteed live until
+    /// the matching [`Self::end_post`].
+    #[must_use]
+    pub fn begin_post(&self) -> bool {
+        let mut state = self.state.load(Ordering::Relaxed);
+        loop {
+            if state & Self::CLOSED != 0 {
+                return false;
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => state = actual,
+            }
+        }
+    }
+
+    /// Work-pool thread: the post finished. Last touch of the event loop; after this the JS
+    /// thread may drain the queue and tear the VM down.
+    pub fn end_post(&self) {
+        let prev = self.state.fetch_sub(1, Ordering::Release);
+        debug_assert!(prev & !Self::CLOSED > 0);
+    }
+
+    /// JS thread, shutdown: no post begun after this returns can succeed, and every post that
+    /// already began has finished. Bounded by an enqueue, not by the underlying fs operation.
+    pub fn close(&self) {
+        self.state.fetch_or(Self::CLOSED, Ordering::AcqRel);
+        while self.state.load(Ordering::Acquire) & !Self::CLOSED != 0 {
+            std::thread::yield_now();
         }
     }
 }
@@ -770,6 +835,11 @@ impl EventLoop {
     }
 
     pub fn deinit(&mut self) {
+        // Drop this loop's ref to the poster gate (closed by now on every path that deinits a
+        // loop with posters). The VM box is raw-dealloc'd without field `Drop`s, so the `Arc`
+        // must be released here; stranded posters hold their own clones and free the allocation
+        // when the last one finishes.
+        drop(self.concurrent_poster_gate.take());
         // Free (don't run — running could re-enter the dying VM) queued
         // ManagedTask boxes. Other tags are left in place: they were re-queued
         // by `release_queued_tasks_for_shutdown` because their callback can't
@@ -1010,26 +1080,23 @@ impl EventLoop {
         self.wakeup();
     }
 
-    /// See `concurrent_posters`. Call on the JS thread before scheduling a
-    /// work-pool task whose completion posts via `enqueue_task_concurrent`.
-    pub fn concurrent_poster_begin(&self) {
-        let _ = self.concurrent_posters.fetch_add(1, Ordering::SeqCst);
+    /// Clone of [`Self::concurrent_poster_gate`] for a work-pool task scheduled on the JS
+    /// thread. Panics after [`Self::deinit`] — tasks are only created while the VM is live.
+    pub fn poster_gate(&self) -> std::sync::Arc<ConcurrentPosterGate> {
+        self.concurrent_poster_gate
+            .as_ref()
+            .expect("poster_gate() after EventLoop::deinit()")
+            .clone()
     }
 
-    /// Pool-thread pair of [`Self::concurrent_poster_begin`]. Must be the
-    /// poster's last touch of this event loop: once the count hits zero the
-    /// shutdown thread may drain the queue and tear the VM down.
-    pub fn concurrent_poster_end(&self) {
-        let prev = self.concurrent_posters.fetch_sub(1, Ordering::Release);
-        debug_assert!(prev > 0);
-    }
-
-    /// Spin until every counted poster has finished its post. Called on the JS thread during
-    /// shutdown, after the last JS has run and before the final queue drain. Each pending fs
-    /// operation is finite, so the wait is bounded by syscall latency.
-    pub fn wait_for_concurrent_posters(&self) {
-        while self.concurrent_posters.load(Ordering::Acquire) > 0 {
-            std::thread::yield_now();
+    /// Close [`Self::concurrent_poster_gate`]: refuse all future work-pool completion posts and
+    /// wait out the ones already mid-enqueue. Called on the JS thread during shutdown, after the
+    /// last JS has run and before the final queue drain, so the drain sees every post that will
+    /// ever land. Unlike the fs operations themselves (which can block forever on a pipe/FIFO),
+    /// the wait here is bounded by an enqueue + wakeup.
+    pub fn close_concurrent_posters(&self) {
+        if let Some(gate) = self.concurrent_poster_gate.as_ref() {
+            gate.close();
         }
     }
 
@@ -1343,7 +1410,6 @@ bun_event_loop::link_impl_JsEventLoop! {
         exit() => (*this).exit(),
         enqueue_task(task) => (*this).enqueue_task(task),
         enqueue_task_concurrent(task) => (*this).enqueue_task_concurrent(task),
-        concurrent_poster_end() => (*this).concurrent_poster_end(),
         env() => (*this).vm_ref().transpiler.env,
         top_level_dir() => core::ptr::from_ref::<[u8]>((*this).vm_ref().top_level_dir()),
         create_null_delimited_env_map() =>

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1359,10 +1359,11 @@ pub use self::event_loop as EventLoop;
 pub mod any_task_job;
 pub use self::any_task_job::{AnyTaskJob, AnyTaskJobCtx};
 pub use self::event_loop::{
-    AnyEventLoop, AnyTaskWithExtraContext, ConcurrentCppTask, ConcurrentPromiseTask,
-    ConcurrentTask, CppTask, DeferredTaskQueue, EventLoopHandle, EventLoopTask, EventLoopTaskPtr,
-    GarbageCollectionController, JsTerminated, JsTerminatedResult, ManagedTask, MiniEventLoop,
-    PosixSignalHandle, PosixSignalTask, Task, WorkPool, WorkPoolTask, WorkTask, WorkTaskContext,
+    AnyEventLoop, AnyTaskWithExtraContext, ConcurrentCppTask, ConcurrentPosterGate,
+    ConcurrentPromiseTask, ConcurrentTask, CppTask, DeferredTaskQueue, EventLoopHandle,
+    EventLoopTask, EventLoopTaskPtr, GarbageCollectionController, JsTerminated,
+    JsTerminatedResult, ManagedTask, MiniEventLoop, PosixSignalHandle, PosixSignalTask, Task,
+    WorkPool, WorkPoolTask, WorkTask, WorkTaskContext,
 };
 #[cfg(unix)]
 pub type PlatformEventLoop = bun_uws::Loop;

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1361,9 +1361,9 @@ pub use self::any_task_job::{AnyTaskJob, AnyTaskJobCtx};
 pub use self::event_loop::{
     AnyEventLoop, AnyTaskWithExtraContext, ConcurrentCppTask, ConcurrentPosterGate,
     ConcurrentPromiseTask, ConcurrentTask, CppTask, DeferredTaskQueue, EventLoopHandle,
-    EventLoopTask, EventLoopTaskPtr, GarbageCollectionController, JsTerminated,
-    JsTerminatedResult, ManagedTask, MiniEventLoop, PosixSignalHandle, PosixSignalTask, Task,
-    WorkPool, WorkPoolTask, WorkTask, WorkTaskContext,
+    EventLoopTask, EventLoopTaskPtr, GarbageCollectionController, JsTerminated, JsTerminatedResult,
+    ManagedTask, MiniEventLoop, PosixSignalHandle, PosixSignalTask, Task, WorkPool, WorkPoolTask,
+    WorkTask, WorkTaskContext,
 };
 #[cfg(unix)]
 pub type PlatformEventLoop = bun_uws::Loop;

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -60,7 +60,7 @@ impl<T: Unprotect> ThreadSafe<T> {
         // SAFETY: `this` is `ManuallyDrop`, so `ThreadSafe::drop` (the
         // unprotect) never runs and the inner value is read out exactly once;
         // its own `Drop` frees the owned payloads.
-        drop(unsafe { core::ptr::read(&this.0) });
+        drop(unsafe { core::ptr::read(&raw const this.0) });
     }
 }
 

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -53,11 +53,8 @@ impl<T: Unprotect> ThreadSafe<T> {
     }
 
     /// Drop the inner `T` (freeing its owned Rust payloads) WITHOUT running
-    /// [`Unprotect::unprotect`]. Only for teardown paths where the VM that
-    /// held the protect counts is already gone — the GC roots died with the
-    /// heap, and touching them would be a use-after-free. `to_thread_safe()`
-    /// already converted any thread-affine strings, so the inner drop is safe
-    /// off the JS thread.
+    /// [`Unprotect::unprotect`]: for teardown paths where the VM that held
+    /// the protect counts is already freed, so touching them would be a UAF.
     pub fn dispose_skip_unprotect(self) {
         let this = core::mem::ManuallyDrop::new(self);
         // SAFETY: `this` is `ManuallyDrop`, so `ThreadSafe::drop` (the

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -51,6 +51,20 @@ impl<T: Unprotect> ThreadSafe<T> {
     pub fn adopt(value: T) -> Self {
         Self(value)
     }
+
+    /// Drop the inner `T` (freeing its owned Rust payloads) WITHOUT running
+    /// [`Unprotect::unprotect`]. Only for teardown paths where the VM that
+    /// held the protect counts is already gone — the GC roots died with the
+    /// heap, and touching them would be a use-after-free. `to_thread_safe()`
+    /// already converted any thread-affine strings, so the inner drop is safe
+    /// off the JS thread.
+    pub fn dispose_skip_unprotect(self) {
+        let this = core::mem::ManuallyDrop::new(self);
+        // SAFETY: `this` is `ManuallyDrop`, so `ThreadSafe::drop` (the
+        // unprotect) never runs and the inner value is read out exactly once;
+        // its own `Drop` frees the owned payloads.
+        drop(unsafe { core::ptr::read(&this.0) });
+    }
 }
 
 impl<T: Unprotect> core::ops::Deref for ThreadSafe<T> {

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -33,6 +33,12 @@ use crate::array_buffer::MarkedArrayBuffer;
 /// [`ThreadSafe<T>`].
 pub trait Unprotect {
     fn unprotect(&mut self);
+
+    /// The VM died before the JS thread could run [`Self::unprotect`] or `Drop`: clear every
+    /// cleanup that would touch the JS heap or VM-owned state (buffer pins, AbortSignal refs)
+    /// so the plain `Drop` is safe off the JS thread. Protect counts died with the heap and
+    /// need no balancing. Required (no default) so every impl accounts for its fields.
+    fn disarm_for_dead_vm(&mut self);
 }
 
 /// RAII guard returned by `into_thread_safe()`: a `T` whose JS-backed buffers
@@ -52,14 +58,15 @@ impl<T: Unprotect> ThreadSafe<T> {
         Self(value)
     }
 
-    /// Drop the inner `T` (freeing its owned Rust payloads) WITHOUT running
-    /// [`Unprotect::unprotect`]: for teardown paths where the VM that held
-    /// the protect counts is already freed, so touching them would be a UAF.
-    pub fn dispose_skip_unprotect(self) {
-        let this = core::mem::ManuallyDrop::new(self);
+    /// Dispose on a work-pool thread after the VM died: skip [`Unprotect::unprotect`], clear
+    /// the JS-heap-touching `Drop` behavior via [`Unprotect::disarm_for_dead_vm`], then drop
+    /// the inner `T` to free its owned Rust payloads.
+    pub fn dispose_for_dead_vm(self) {
+        let mut this = core::mem::ManuallyDrop::new(self);
+        this.0.disarm_for_dead_vm();
         // SAFETY: `this` is `ManuallyDrop`, so `ThreadSafe::drop` (the
         // unprotect) never runs and the inner value is read out exactly once;
-        // its own `Drop` frees the owned payloads.
+        // its disarmed `Drop` frees the owned payloads.
         drop(unsafe { core::ptr::read(&raw const this.0) });
     }
 }
@@ -236,6 +243,13 @@ impl Unprotect for PathLike {
             b.buffer.value.unprotect();
         }
     }
+
+    fn disarm_for_dead_vm(&mut self) {
+        // `Drop` unpins a pinned Buffer path — a JS-cell deref the dead heap can't take.
+        if let Self::Buffer(b) = self {
+            b.pinned = false;
+        }
+    }
 }
 
 /// `node.PathOrFileDescriptor`.
@@ -302,6 +316,12 @@ impl Unprotect for PathOrFileDescriptor {
     fn unprotect(&mut self) {
         if let Self::Path(p) = self {
             p.unprotect();
+        }
+    }
+
+    fn disarm_for_dead_vm(&mut self) {
+        if let Self::Path(p) = self {
+            p.disarm_for_dead_vm();
         }
     }
 }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1309,9 +1309,7 @@ impl WebWorker {
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
             // Reclaim queued CppTasks while JSC is still live (after teardownJSCVM the worker VM is
             // dealloc'd-without-Drop so anything still in self.tasks leaks). Close the poster gates
-            // first so the drain below sees every work-pool fs completion that will ever land; a
-            // completion whose syscall is still blocked (pipe/FIFO with no writer) is refused at
-            // its gate later and frees itself without touching this VM.
+            // first so the drain below sees every work-pool fs completion that will ever land.
             vm.close_concurrent_posters();
             vm.event_loop_mut().release_queued_tasks_for_shutdown();
             if let Some(rare) = vm.rare_data.as_deref_mut() {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1308,10 +1308,11 @@ impl WebWorker {
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
             // Reclaim queued CppTasks while JSC is still live (after teardownJSCVM the worker VM is
-            // dealloc'd-without-Drop so anything still in self.tasks leaks). Work-pool fs completions
-            // post without a shutdown check; wait for in-flight ones so the drain below sees every
-            // post.
-            vm.event_loop_mut().wait_for_concurrent_posters();
+            // dealloc'd-without-Drop so anything still in self.tasks leaks). Close the poster gates
+            // first so the drain below sees every work-pool fs completion that will ever land; a
+            // completion whose syscall is still blocked (pipe/FIFO with no writer) is refused at
+            // its gate later and frees itself without touching this VM.
+            vm.close_concurrent_posters();
             vm.event_loop_mut().release_queued_tasks_for_shutdown();
             if let Some(rare) = vm.rare_data.as_deref_mut() {
                 rare.release_js_handles();

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -255,6 +255,11 @@ impl bun_jsc::Unprotect for PBKDF2 {
         self.password.unprotect();
         self.salt.unprotect();
     }
+
+    fn disarm_for_dead_vm(&mut self) {
+        self.password.disarm_for_dead_vm();
+        self.salt.disarm_for_dead_vm();
+    }
 }
 
 pub(crate) struct Pbkdf2Ctx {

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -1126,6 +1126,11 @@ mod _impl {
             bun_jsc::Unprotect::unprotect(&mut self.password);
             bun_jsc::Unprotect::unprotect(&mut self.salt);
         }
+
+        fn disarm_for_dead_vm(&mut self) {
+            bun_jsc::Unprotect::disarm_for_dead_vm(&mut self.password);
+            bun_jsc::Unprotect::disarm_for_dead_vm(&mut self.salt);
+        }
     }
 
     impl CryptoJobCtx for Scrypt {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1016,9 +1016,8 @@ mod _async_tasks {
             // SAFETY: caller guarantees `this` is the live Box-leaked allocation;
             // reclaim ownership (paired with the Box::leak in create()).
             let mut task = unsafe { bun_core::heap::take(this) };
-            // On the normal path `run_from_js_thread` already swapped `result` for the sentinel
-            // error; on the shutdown-drain path the real result is still here and the payloads
-            // `to_js` would have transferred (a readFile Buffer's bytes) have no other owner.
+            // `run_from_js_thread` leaves the sentinel error here; only the shutdown-drain path
+            // still holds a real result, whose payloads only `fs_to_js` would otherwise free.
             if let Ok(result) = task.result.as_mut() {
                 result.fs_discard();
             }
@@ -1166,10 +1165,8 @@ mod _async_tasks {
     pub trait FsReturn {
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue>;
 
-        /// Release payloads whose ownership [`Self::fs_to_js`] would have transferred to JS,
-        /// for a result that will never reach the JS thread (shutdown drain, or a completion
-        /// post refused by the loop's `ConcurrentPosterGate`). Types whose `Drop` already
-        /// frees everything keep the default no-op.
+        /// Release payloads only [`Self::fs_to_js`] would free, for a result that will never
+        /// reach the JS thread. Types whose `Drop` already frees everything keep the no-op.
         fn fs_discard(&mut self) {}
     }
     impl FsReturn for JSValue {
@@ -1214,8 +1211,7 @@ mod _async_tasks {
             self.to_js(global)
         }
         fn fs_discard(&mut self) {
-            // `Drop for StringOrBuffer` derefs the string variants but deliberately skips
-            // `Buffer` — its bytes normally transfer to a JSC finalizer in `to_js`.
+            // `Drop for StringOrBuffer` deliberately skips `Buffer` (bytes transfer in `to_js`).
             if let StringOrBuffer::Buffer(buffer) = self {
                 buffer.destroy();
             }
@@ -1261,8 +1257,7 @@ mod _async_tasks {
             owned.to_js(global)
         }
         fn fs_discard(&mut self) {
-            // Mirrors `ResultListEntryValue::deinit`: entries hold WTF string refs /
-            // owned byte slices that `to_js` would have transferred; no `Drop` releases them.
+            // Mirrors `ResultListEntryValue::deinit`; no `Drop` releases the entries.
             match self {
                 ret::Readdir::WithFileTypes(items) => {
                     for item in items.iter() {
@@ -1315,8 +1310,8 @@ mod _async_tasks {
         pub(crate) result: Maybe<R>,
         pub(crate) r#ref: KeepAlive,
         pub(crate) tracker: AsyncTaskTracker,
-        /// Keeps the loop's [`ConcurrentPosterGate`] reachable from the work-pool thread even
-        /// after the VM is torn down (the blocking syscall can outlive it; see the gate type).
+        /// Keeps the loop's [`ConcurrentPosterGate`] readable after the VM is torn down (the
+        /// blocking syscall can outlive it).
         pub(crate) gate: Arc<ConcurrentPosterGate>,
     }
 
@@ -1387,8 +1382,8 @@ mod _async_tasks {
             // `sys::Error::path` is `Box<[u8]>` boxed at the
             // `errno_sys_p` construction site, so no clone is needed — `node_fs` may drop.
 
-            // Clone (not borrow) the gate: after a successful enqueue the JS thread may free
-            // `this` — and with it the task's own `Arc` — before `end_post` runs.
+            // Clone, not borrow: the JS thread may free `this` (and its `Arc`) right after the
+            // enqueue, before `end_post`.
             // SAFETY: `this` is still exclusively owned here (see above).
             let gate = unsafe { (*this).gate.clone() };
             if gate.begin_post() {
@@ -1480,8 +1475,7 @@ mod _async_tasks {
             // SAFETY: caller guarantees `this` is the live Box-leaked allocation;
             // reclaim ownership (paired with the Box::leak in create()).
             let mut task = unsafe { bun_core::heap::take(this) };
-            // Same as `UVFSRequest::destroy`: only the shutdown-drain path still holds a real
-            // result here, and its `to_js`-transferred payloads have no other owner.
+            // Same as `UVFSRequest::destroy`: only the shutdown-drain path holds a real result.
             if let Ok(result) = task.result.as_mut() {
                 result.fs_discard();
             }
@@ -1535,8 +1529,7 @@ mod _async_tasks {
         /// outlives this task; `ParentRef` gives a safe `&ShellCpTask` projection
         /// for `cp_on_copy` and round-trips the `*mut` for `cp_on_finish`.
         pub(crate) shelltask: Option<bun_ptr::ParentRef<ShellCpTask, bun_ptr::Mut>>,
-        /// `Some` iff `evtloop` is the JS loop (see [`AsyncFSTask::gate`]); the mini loop's
-        /// completion path has no VM to outlive.
+        /// `Some` iff `evtloop` is the JS loop (see [`AsyncFSTask::gate`]).
         pub(crate) gate: Option<Arc<ConcurrentPosterGate>>,
     }
 
@@ -1816,16 +1809,15 @@ mod _async_tasks {
             // provenance from `Box::leak`, so the enqueued callback may safely
             // form `&mut *this` on the JS thread.
             if let EventLoopHandle::Js { .. } = this_ref.evtloop {
-                // Clone (not borrow) the gate: after a successful enqueue the JS thread may
-                // free the task — and its `Arc` — before `end_post` runs.
+                // Clone, not borrow: the JS thread may free the task (and its `Arc`) right
+                // after the enqueue, before `end_post`.
                 let gate = this_ref
                     .gate
                     .clone()
                     .expect("JS-loop cp task always carries the poster gate");
                 if gate.begin_post() {
-                    // SAFETY (`evtloop` deref): `begin_post()` returned true, so the VM and its
-                    // event loop stay live until the matching `end_post()`; ownership of `this`
-                    // transfers to the JS thread at the enqueue.
+                    // SAFETY (`evtloop` deref): `begin_post()` pins the VM and its event loop
+                    // live until `end_post()`; ownership of `this` transfers at the enqueue.
                     this_ref.evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
                         js: ConcurrentTask::from_callback(this, |p| {
                             // SAFETY: `p` is the `Box::leak`'d task; subtask count hit zero so this
@@ -2697,8 +2689,8 @@ mod _async_tasks {
                 }
             }
 
-            // Clone (not borrow) the gate: after a successful enqueue the JS thread may free
-            // `self` — and with it the task's own `Arc` — before `end_post` runs.
+            // Clone, not borrow: the JS thread may free `self` (and its `Arc`) right after the
+            // enqueue, before `end_post`.
             let gate = self.gate.clone();
             let this = std::ptr::from_mut::<Self>(self);
             if gate.begin_post() {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1939,7 +1939,12 @@ mod _async_tasks {
         unsafe fn dispose_without_post(this: *mut Self) {
             // SAFETY: caller guarantees `this` is the live Box-leaked allocation.
             let task = unsafe { bun_core::heap::take(this) };
-            let Self { promise, args, shelltask, .. } = *task;
+            let Self {
+                promise,
+                args,
+                shelltask,
+                ..
+            } = *task;
             // Intentionally never dropped: the Strong handle died with the VM heap.
             let _ = core::mem::ManuallyDrop::new(promise);
             args.dispose_skip_unprotect();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1076,6 +1076,7 @@ mod _async_tasks {
         }
         impl Unprotect for $ty {
             #[inline] fn unprotect(&mut self) {}
+            #[inline] fn disarm_for_dead_vm(&mut self) {}
         } )+
     };
 }
@@ -1203,6 +1204,13 @@ mod _async_tasks {
         #[inline]
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
             Ok(crate::node::types::FdJsc::to_js(*self, global))
+        }
+        fn fs_discard(&mut self) {
+            // `fs_to_js` would have transferred the descriptor to JS; nothing else closes it.
+            let fd = core::mem::replace(self, FD::INVALID);
+            if fd != FD::INVALID {
+                fd.close();
+            }
         }
     }
     impl FsReturn for StringOrBuffer {
@@ -1421,7 +1429,7 @@ mod _async_tasks {
             let Self { promise, args, .. } = *task;
             // Intentionally never dropped: the Strong handle died with the VM heap.
             let _ = core::mem::ManuallyDrop::new(promise);
-            args.dispose_skip_unprotect();
+            args.dispose_for_dead_vm();
         }
 
         pub(crate) fn run_from_js_thread(&mut self) -> Result<(), bun_jsc::JsTerminated> {
@@ -1947,7 +1955,7 @@ mod _async_tasks {
             } = *task;
             // Intentionally never dropped: the Strong handle died with the VM heap.
             let _ = core::mem::ManuallyDrop::new(promise);
-            args.dispose_skip_unprotect();
+            args.dispose_for_dead_vm();
             // `cp_on_finish` (JS thread) never runs for a refused post, so reclaim the shell
             // parent here: its interpreter died with the VM, its fields are plain heap.
             if let Some(parent) = shelltask {
@@ -2845,7 +2853,7 @@ mod _async_tasks {
             let Self { promise, args, .. } = *task;
             // Intentionally never dropped: the Strong handle died with the VM heap.
             let _ = core::mem::ManuallyDrop::new(promise);
-            args.dispose_skip_unprotect();
+            args.dispose_for_dead_vm();
         }
     }
 
@@ -2928,6 +2936,7 @@ pub mod args {
         ($ty:ident; $($field:ident),+ $(,)?) => {
             impl Unprotect for $ty {
                 #[inline] fn unprotect(&mut self) { $( self.$field.unprotect(); )+ }
+                #[inline] fn disarm_for_dead_vm(&mut self) { $( self.$field.disarm_for_dead_vm(); )+ }
             }
             impl $ty {
                 pub fn to_thread_safe(&mut self) { $( self.$field.to_thread_safe(); )+ }
@@ -3005,6 +3014,9 @@ pub mod args {
             self.buffers.value.unprotect();
             // `self.buffers.buffers`: `Vec` frees on drop.
         }
+
+        // The element roots/pins are released only in `unprotect`; `Drop` touches no JS state.
+        fn disarm_for_dead_vm(&mut self) {}
     }
     impl FdVectorIo {
         pub(crate) fn to_thread_safe(&mut self) {
@@ -3054,6 +3066,9 @@ pub mod args {
     impl Unprotect for FTruncate {
         #[inline]
         fn unprotect(&mut self) {}
+
+        #[inline]
+        fn disarm_for_dead_vm(&mut self) {}
     }
     impl FTruncate {
         pub(crate) fn to_thread_safe(&self) {}
@@ -3557,6 +3572,11 @@ pub mod args {
         fn unprotect(&mut self) {
             self.0.unprotect();
         }
+
+        #[inline]
+        fn disarm_for_dead_vm(&mut self) {
+            self.0.disarm_for_dead_vm();
+        }
     }
     impl Rm {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Rm> {
@@ -3953,6 +3973,11 @@ pub mod args {
         fn unprotect(&mut self) {
             self.buffer.unprotect();
         }
+
+        #[inline]
+        fn disarm_for_dead_vm(&mut self) {
+            self.buffer.disarm_for_dead_vm();
+        }
     }
     impl Write {
         pub(crate) fn to_thread_safe(&mut self) {
@@ -4121,6 +4146,10 @@ pub mod args {
                 self.buffer.buffer.unpin();
             }
             self.buffer.buffer.value.unprotect();
+        }
+
+        fn disarm_for_dead_vm(&mut self) {
+            self.pinned = false;
         }
     }
     impl Read {
@@ -4357,6 +4386,14 @@ pub mod args {
             self.path.unprotect();
             // Signal unref handled by `Drop` (idempotent via `.take()`).
         }
+
+        fn disarm_for_dead_vm(&mut self) {
+            self.path.disarm_for_dead_vm();
+            // `Drop` would deref the signal's non-atomic WebCore refcount.
+            if let Some(signal) = self.signal.take() {
+                let _ = core::mem::ManuallyDrop::new(signal);
+            }
+        }
     }
     impl ReadFile {
         pub(crate) fn to_thread_safe(&mut self) {
@@ -4447,6 +4484,15 @@ pub mod args {
             self.file.unprotect();
             self.data.unprotect();
             // Signal unref handled by `Drop` (idempotent via `.take()`).
+        }
+
+        fn disarm_for_dead_vm(&mut self) {
+            self.file.disarm_for_dead_vm();
+            self.data.disarm_for_dead_vm();
+            // `Drop` would deref the signal's non-atomic WebCore refcount.
+            if let Some(signal) = self.signal.take() {
+                let _ = core::mem::ManuallyDrop::new(signal);
+            }
         }
     }
     impl WriteFile {
@@ -4552,6 +4598,11 @@ pub mod args {
         fn unprotect(&mut self) {
             self.0.unprotect();
         }
+
+        #[inline]
+        fn disarm_for_dead_vm(&mut self) {
+            self.0.disarm_for_dead_vm();
+        }
     }
 
     pub struct Exists {
@@ -4569,6 +4620,12 @@ pub mod args {
         fn unprotect(&mut self) {
             if let Some(p) = &mut self.path {
                 p.unprotect();
+            }
+        }
+
+        fn disarm_for_dead_vm(&mut self) {
+            if let Some(p) = &mut self.path {
+                p.disarm_for_dead_vm();
             }
         }
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1385,7 +1385,7 @@ mod _async_tasks {
             // Clone, not borrow: the JS thread may free `this` (and its `Arc`) right after the
             // enqueue, before `end_post`.
             // SAFETY: `this` is still exclusively owned here (see above).
-            let gate = unsafe { (*this).gate.clone() };
+            let gate = Arc::clone(unsafe { &(*this).gate });
             if gate.begin_post() {
                 // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
                 // documented accessor for off-thread (work-pool) callers; the
@@ -1419,7 +1419,8 @@ mod _async_tasks {
                 result.fs_discard();
             }
             let Self { promise, args, .. } = *task;
-            core::mem::forget(promise);
+            // Intentionally never dropped: the Strong handle died with the VM heap.
+            let _ = core::mem::ManuallyDrop::new(promise);
             args.dispose_skip_unprotect();
         }
 
@@ -1811,10 +1812,12 @@ mod _async_tasks {
             if let EventLoopHandle::Js { .. } = this_ref.evtloop {
                 // Clone, not borrow: the JS thread may free the task (and its `Arc`) right
                 // after the enqueue, before `end_post`.
-                let gate = this_ref
-                    .gate
-                    .clone()
-                    .expect("JS-loop cp task always carries the poster gate");
+                let gate = Arc::clone(
+                    this_ref
+                        .gate
+                        .as_ref()
+                        .expect("JS-loop cp task always carries the poster gate"),
+                );
                 if gate.begin_post() {
                     // SAFETY (`evtloop` deref): `begin_post()` pins the VM and its event loop
                     // live until `end_post()`; ownership of `this` transfers at the enqueue.
@@ -1929,17 +1932,23 @@ mod _async_tasks {
 
         /// The loop's gate refused the completion post: the VM is torn down (or mid-teardown).
         /// Free the task on the work-pool thread without touching the JS heap — the promise
-        /// `Strong` and the args' protect counts died with it. The shell parent (if any) died
-        /// with the VM too, so it is not continued.
+        /// `Strong` and the args' protect counts died with it.
         ///
         /// SAFETY: `this` must be the Box::leak'd task, exclusively owned by the caller (the
         /// subtask count hit zero and the post never happened); called at most once.
         unsafe fn dispose_without_post(this: *mut Self) {
             // SAFETY: caller guarantees `this` is the live Box-leaked allocation.
             let task = unsafe { bun_core::heap::take(this) };
-            let Self { promise, args, .. } = *task;
-            core::mem::forget(promise);
+            let Self { promise, args, shelltask, .. } = *task;
+            // Intentionally never dropped: the Strong handle died with the VM heap.
+            let _ = core::mem::ManuallyDrop::new(promise);
             args.dispose_skip_unprotect();
+            // `cp_on_finish` (JS thread) never runs for a refused post, so reclaim the shell
+            // parent here: its interpreter died with the VM, its fields are plain heap.
+            if let Some(parent) = shelltask {
+                // SAFETY: subtask count hit zero and the interpreter is gone — sole reference.
+                drop(unsafe { bun_core::heap::take(parent.as_mut_ptr()) });
+            }
         }
 
         /// Directory scanning + clonefile will block this thread, then each individual file copy (what the sync version
@@ -2691,7 +2700,7 @@ mod _async_tasks {
 
             // Clone, not borrow: the JS thread may free `self` (and its `Arc`) right after the
             // enqueue, before `end_post`.
-            let gate = self.gate.clone();
+            let gate = Arc::clone(&self.gate);
             let this = std::ptr::from_mut::<Self>(self);
             if gate.begin_post() {
                 // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
@@ -2829,7 +2838,8 @@ mod _async_tasks {
             task.free_root_path();
             task.clear_result_list();
             let Self { promise, args, .. } = *task;
-            core::mem::forget(promise);
+            // Intentionally never dropped: the Strong handle died with the VM heap.
+            let _ = core::mem::ManuallyDrop::new(promise);
             args.dispose_skip_unprotect();
         }
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6,6 +6,7 @@ use bun_paths::strings;
 use core::ffi::{c_char, c_int, c_uint, c_void};
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use crate::api::bun::process::event_loop_handle_to_ctx;
 use crate::webcore;
@@ -18,7 +19,10 @@ use bun_jsc::AbortSignal;
 use bun_jsc::EventLoopTaskPtr;
 use bun_jsc::debugger::AsyncTaskTracker;
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::{EventLoopHandle, JSGlobalObject, JSValue, JsResult, Task, ThreadSafe, Unprotect};
+use bun_jsc::{
+    ConcurrentPosterGate, EventLoopHandle, JSGlobalObject, JSValue, JsResult, Task, ThreadSafe,
+    Unprotect,
+};
 use bun_paths::{self as paths, OSPathBuffer, OSPathChar, OSPathSliceZ, PathBuffer};
 use bun_sys::FdExt as _;
 use bun_sys::{self as sys, E, Fd as FD, Maybe, Mode, SystemErrno};
@@ -1012,6 +1016,12 @@ mod _async_tasks {
             // SAFETY: caller guarantees `this` is the live Box-leaked allocation;
             // reclaim ownership (paired with the Box::leak in create()).
             let mut task = unsafe { bun_core::heap::take(this) };
+            // On the normal path `run_from_js_thread` already swapped `result` for the sentinel
+            // error; on the shutdown-drain path the real result is still here and the payloads
+            // `to_js` would have transferred (a readFile Buffer's bytes) have no other owner.
+            if let Ok(result) = task.result.as_mut() {
+                result.fs_discard();
+            }
             // `bun_sys::Error` frees its path on Drop.
             task.r#ref.unref(bun_io::js_vm_ctx());
         }
@@ -1155,6 +1165,12 @@ mod _async_tasks {
     /// Each `ret::*` type implements this by forwarding to its inherent method.
     pub trait FsReturn {
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue>;
+
+        /// Release payloads whose ownership [`Self::fs_to_js`] would have transferred to JS,
+        /// for a result that will never reach the JS thread (shutdown drain, or a completion
+        /// post refused by the loop's `ConcurrentPosterGate`). Types whose `Drop` already
+        /// frees everything keep the default no-op.
+        fn fs_discard(&mut self) {}
     }
     impl FsReturn for JSValue {
         #[inline]
@@ -1197,11 +1213,25 @@ mod _async_tasks {
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
             self.to_js(global)
         }
+        fn fs_discard(&mut self) {
+            // `Drop for StringOrBuffer` derefs the string variants but deliberately skips
+            // `Buffer` — its bytes normally transfer to a JSC finalizer in `to_js`.
+            if let StringOrBuffer::Buffer(buffer) = self {
+                buffer.destroy();
+            }
+        }
     }
     impl FsReturn for StringOrUndefined {
         #[inline]
         fn fs_to_js(&mut self, global: &JSGlobalObject) -> JsResult<JSValue> {
             self.to_js(global)
+        }
+        fn fs_discard(&mut self) {
+            // `transfer_to_js` would have consumed the ref; `BunString` has no `Drop`.
+            if let StringOrUndefined::String(s) = core::mem::replace(self, StringOrUndefined::None)
+            {
+                s.deref();
+            }
         }
     }
     impl FsReturn for ret::Read {
@@ -1229,6 +1259,28 @@ mod _async_tasks {
             // JS). Swap in an empty `Files` payload so `&mut self` stays valid.
             let owned = core::mem::replace(self, ret::Readdir::Files(Box::default()));
             owned.to_js(global)
+        }
+        fn fs_discard(&mut self) {
+            // Mirrors `ResultListEntryValue::deinit`: entries hold WTF string refs /
+            // owned byte slices that `to_js` would have transferred; no `Drop` releases them.
+            match self {
+                ret::Readdir::WithFileTypes(items) => {
+                    for item in items.iter() {
+                        item.deref();
+                    }
+                }
+                ret::Readdir::Buffers(items) => {
+                    for item in items.iter_mut() {
+                        item.destroy();
+                    }
+                }
+                ret::Readdir::Files(items) => {
+                    for item in items.iter() {
+                        item.deref();
+                    }
+                }
+            }
+            *self = ret::Readdir::Files(Box::default());
         }
     }
     impl FsReturn for StatOrNotFound {
@@ -1263,6 +1315,9 @@ mod _async_tasks {
         pub(crate) result: Maybe<R>,
         pub(crate) r#ref: KeepAlive,
         pub(crate) tracker: AsyncTaskTracker,
+        /// Keeps the loop's [`ConcurrentPosterGate`] reachable from the work-pool thread even
+        /// after the VM is torn down (the blocking syscall can outlive it; see the gate type).
+        pub(crate) gate: Arc<ConcurrentPosterGate>,
     }
 
     bun_threading::intrusive_work_task!([R, A: Unprotect, const F: NodeFSFunctionEnum] AsyncFSTask<R, A, F>, task);
@@ -1305,16 +1360,14 @@ mod _async_tasks {
                 task: work_pool_task(Self::work_pool_callback),
                 r#ref: KeepAlive::default(),
                 tracker: AsyncTaskTracker::init(vm),
+                // SAFETY: `event_loop()` is a value field of the live `vm`.
+                gate: unsafe { (*vm.event_loop()).poster_gate() },
             });
             // KeepAlive::ref_ now takes the type-erased aio EventLoopCtx; the JS
             // event loop is the only one that owns AsyncFSTask/UVFSRequest.
             task.r#ref.ref_(bun_io::js_vm_ctx());
             task.tracker.did_schedule(global_object);
             let promise = task.promise.value();
-            // Counted so shutdown's `wait_for_concurrent_posters` covers the
-            // work-pool completion post; paired in `work_pool_callback`.
-            // SAFETY: `event_loop()` is a value field of the live `vm`.
-            unsafe { (*vm.event_loop()).concurrent_poster_begin() };
             WorkPool::schedule(&raw mut bun_core::heap::release(task).task);
             promise
         }
@@ -1334,20 +1387,45 @@ mod _async_tasks {
             // `sys::Error::path` is `Box<[u8]>` boxed at the
             // `errno_sys_p` construction site, so no clone is needed — `node_fs` may drop.
 
-            // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
-            // documented accessor for off-thread (work-pool) callers; the
-            // event-loop's concurrent queue is MPSC-safe.
+            // Clone (not borrow) the gate: after a successful enqueue the JS thread may free
+            // `this` — and with it the task's own `Arc` — before `end_post` runs.
             // SAFETY: `this` is still exclusively owned here (see above).
-            let vm = unsafe { (*this).global_object().bun_vm_concurrently() };
-            // SAFETY: VirtualMachine and its event loop are process-static
-            // (LIFETIMES.tsv); the concurrent queue is MPSC-safe. Ownership of
-            // `this` transfers to the JS thread here — no use after this call.
-            unsafe {
-                (*(*vm).event_loop()).enqueue_task_concurrent(ConcurrentTask::create_from(this));
-                // Pairs with `concurrent_poster_begin` in `create()`. The JS thread may free `this`
-                // once popped and tear the VM down at zero — this is the pool thread's last touch.
-                (*(*vm).event_loop()).concurrent_poster_end();
+            let gate = unsafe { (*this).gate.clone() };
+            if gate.begin_post() {
+                // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
+                // documented accessor for off-thread (work-pool) callers; the
+                // event-loop's concurrent queue is MPSC-safe.
+                // SAFETY: `begin_post()` returned true, so the VM, its event loop, and the
+                // global object all stay live until the matching `end_post()`. Ownership of
+                // `this` transfers to the JS thread at the enqueue — no use after it.
+                unsafe {
+                    let vm = (*this).global_object().bun_vm_concurrently();
+                    (*(*vm).event_loop())
+                        .enqueue_task_concurrent(ConcurrentTask::create_from(this));
+                }
+                gate.end_post();
+            } else {
+                // The VM shut down while the syscall was blocked; the completion has nowhere
+                // to go. SAFETY: the post was refused, so this thread still owns `this`.
+                unsafe { Self::dispose_without_post(this) };
             }
+        }
+
+        /// The loop's gate refused the completion post: the VM is torn down (or mid-teardown).
+        /// Free the task on the work-pool thread without touching the JS heap — the promise
+        /// `Strong` and the args' protect counts died with it.
+        ///
+        /// SAFETY: `this` must be the pointer Box::leak'd in `create()`, exclusively owned by
+        /// the caller (the post never happened); called at most once.
+        unsafe fn dispose_without_post(this: *mut Self) {
+            // SAFETY: caller guarantees `this` is the live Box-leaked allocation.
+            let mut task = unsafe { bun_core::heap::take(this) };
+            if let Ok(result) = task.result.as_mut() {
+                result.fs_discard();
+            }
+            let Self { promise, args, .. } = *task;
+            core::mem::forget(promise);
+            args.dispose_skip_unprotect();
         }
 
         pub(crate) fn run_from_js_thread(&mut self) -> Result<(), bun_jsc::JsTerminated> {
@@ -1402,6 +1480,11 @@ mod _async_tasks {
             // SAFETY: caller guarantees `this` is the live Box-leaked allocation;
             // reclaim ownership (paired with the Box::leak in create()).
             let mut task = unsafe { bun_core::heap::take(this) };
+            // Same as `UVFSRequest::destroy`: only the shutdown-drain path still holds a real
+            // result here, and its `to_js`-transferred payloads have no other owner.
+            if let Ok(result) = task.result.as_mut() {
+                result.fs_discard();
+            }
             // `bun_sys::Error` frees its path on Drop.
             task.r#ref.unref(bun_io::js_vm_ctx());
         }
@@ -1452,6 +1535,9 @@ mod _async_tasks {
         /// outlives this task; `ParentRef` gives a safe `&ShellCpTask` projection
         /// for `cp_on_copy` and round-trips the `*mut` for `cp_on_finish`.
         pub(crate) shelltask: Option<bun_ptr::ParentRef<ShellCpTask, bun_ptr::Mut>>,
+        /// `Some` iff `evtloop` is the JS loop (see [`AsyncFSTask::gate`]); the mini loop's
+        /// completion path has no VM to outlive.
+        pub(crate) gate: Option<Arc<ConcurrentPosterGate>>,
     }
 
     bun_threading::intrusive_work_task!([const IS_SHELL: bool] NewAsyncCpTask<IS_SHELL>, task);
@@ -1622,16 +1708,14 @@ mod _async_tasks {
                 // SAFETY: `shelltask` (when non-null) is the live heap-alloc'd `ShellCpTask`
                 // that owns and outlives this task; pointer carries write provenance.
                 shelltask: unsafe { bun_ptr::ParentRef::from_nullable_mut(shelltask) },
+                // SAFETY: `event_loop()` is a value field of the live `vm`.
+                gate: Some(unsafe { (*vm.event_loop()).poster_gate() }),
             });
             if !IS_SHELL {
                 task.r#ref.ref_(event_loop_handle_to_ctx(task.evtloop));
             }
             task.tracker.did_schedule(global_object);
 
-            // Counted so shutdown's `wait_for_concurrent_posters` covers the completion post;
-            // paired in `on_subtask_done`'s Js arm (the mini path never touches the JS event loop).
-            // SAFETY: `event_loop()` is a value field of the live `vm`.
-            unsafe { (*vm.event_loop()).concurrent_poster_begin() };
             let raw = bun_core::heap::release(task);
             WorkPool::schedule(&raw mut raw.task);
             raw
@@ -1661,6 +1745,7 @@ mod _async_tasks {
                 // SAFETY: `shelltask` (when non-null) is the live heap-alloc'd `ShellCpTask`
                 // that owns and outlives this task; pointer carries write provenance.
                 shelltask: unsafe { bun_ptr::ParentRef::from_nullable_mut(shelltask) },
+                gate: None,
             });
             if !IS_SHELL {
                 task.r#ref.ref_(event_loop_handle_to_ctx(task.evtloop));
@@ -1730,18 +1815,31 @@ mod _async_tasks {
             // Count reached zero ⇒ exclusive access. `this` carries mutable
             // provenance from `Box::leak`, so the enqueued callback may safely
             // form `&mut *this` on the JS thread.
-            if let EventLoopHandle::Js { owner } = this_ref.evtloop {
-                this_ref.evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
-                    js: ConcurrentTask::from_callback(this, |p| {
-                        // SAFETY: `p` is the `Box::leak`'d task; subtask count hit zero so this
-                        // JS-thread callback holds the only live reference (exclusive `&mut`).
-                        unsafe { (&mut *p).run_from_js_thread().map_err(Into::into) }
-                    })
-                    .as_ptr(),
-                });
-                // Pairs with `concurrent_poster_begin` in `create_with_shell_task`. The JS thread
-                // may free the task once popped and tear the VM down at zero — last touch of loop.
-                owner.concurrent_poster_end();
+            if let EventLoopHandle::Js { .. } = this_ref.evtloop {
+                // Clone (not borrow) the gate: after a successful enqueue the JS thread may
+                // free the task — and its `Arc` — before `end_post` runs.
+                let gate = this_ref
+                    .gate
+                    .clone()
+                    .expect("JS-loop cp task always carries the poster gate");
+                if gate.begin_post() {
+                    // SAFETY (`evtloop` deref): `begin_post()` returned true, so the VM and its
+                    // event loop stay live until the matching `end_post()`; ownership of `this`
+                    // transfers to the JS thread at the enqueue.
+                    this_ref.evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
+                        js: ConcurrentTask::from_callback(this, |p| {
+                            // SAFETY: `p` is the `Box::leak`'d task; subtask count hit zero so this
+                            // JS-thread callback holds the only live reference (exclusive `&mut`).
+                            unsafe { (&mut *p).run_from_js_thread().map_err(Into::into) }
+                        })
+                        .as_ptr(),
+                    });
+                    gate.end_post();
+                } else {
+                    // The VM shut down while a copy was blocked; the completion has nowhere to
+                    // go. SAFETY: the post was refused, so this thread still owns `this`.
+                    unsafe { Self::dispose_without_post(this) };
+                }
             } else {
                 this_ref.evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
                     mini: AnyTaskWithExtraContext::from_callback_auto_deinit(
@@ -1835,6 +1933,21 @@ mod _async_tasks {
             }
             // `Drop for ThreadSafe<args::Cp>` releases the `protect()` taken by
             // `to_thread_safe()` when `src`/`dest` are Buffers, so nothing leaks here.
+        }
+
+        /// The loop's gate refused the completion post: the VM is torn down (or mid-teardown).
+        /// Free the task on the work-pool thread without touching the JS heap — the promise
+        /// `Strong` and the args' protect counts died with it. The shell parent (if any) died
+        /// with the VM too, so it is not continued.
+        ///
+        /// SAFETY: `this` must be the Box::leak'd task, exclusively owned by the caller (the
+        /// subtask count hit zero and the post never happened); called at most once.
+        unsafe fn dispose_without_post(this: *mut Self) {
+            // SAFETY: caller guarantees `this` is the live Box-leaked allocation.
+            let task = unsafe { bun_core::heap::take(this) };
+            let Self { promise, args, .. } = *task;
+            core::mem::forget(promise);
+            args.dispose_skip_unprotect();
         }
 
         /// Directory scanning + clonefile will block this thread, then each individual file copy (what the sync version
@@ -2228,6 +2341,8 @@ mod _async_tasks {
 
         pub(crate) pending_err: Option<sys::Error>,
         pub(crate) pending_err_mutex: bun_threading::Mutex,
+        /// See [`AsyncFSTask::gate`].
+        pub(crate) gate: Arc<ConcurrentPosterGate>,
     }
 
     bun_threading::intrusive_work_task!(AsyncReaddirRecursiveTask, task);
@@ -2405,14 +2520,12 @@ mod _async_tasks {
                 root_fd: FD::INVALID,
                 pending_err: None,
                 pending_err_mutex: bun_threading::Mutex::default(),
+                // SAFETY: `event_loop()` is a value field of the live `vm`.
+                gate: unsafe { (*vm.event_loop()).poster_gate() },
             });
             task.r#ref.ref_(bun_io::js_vm_ctx());
             task.tracker.did_schedule(global_object);
             let promise = task.promise.value();
-            // Counted so shutdown's `wait_for_concurrent_posters` covers the
-            // single CAS-gated completion post; paired in `finish_concurrently`.
-            // SAFETY: `event_loop()` is a value field of the live `vm`.
-            unsafe { (*vm.event_loop()).concurrent_poster_begin() };
             WorkPool::schedule(&raw mut bun_core::heap::release(task).task);
             promise
         }
@@ -2584,22 +2697,30 @@ mod _async_tasks {
                 }
             }
 
-            // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
-            // documented accessor for off-thread (work-pool) callers.
-            let vm = self.global_object().bun_vm_concurrently();
-            // `ConcurrentTask::create` heap-allocates a fresh task; the
-            // queue takes ownership of it.
-            // SAFETY: `vm` is the process-singleton VM (LIFETIMES.tsv); the
-            // concurrent queue is MPSC-safe and the borrow is scoped to the call.
-            unsafe {
-                (*vm).enqueue_task_concurrent(ConcurrentTask::create(Task::init(
-                    std::ptr::from_mut::<Self>(self),
-                )));
+            // Clone (not borrow) the gate: after a successful enqueue the JS thread may free
+            // `self` — and with it the task's own `Arc` — before `end_post` runs.
+            let gate = self.gate.clone();
+            let this = std::ptr::from_mut::<Self>(self);
+            if gate.begin_post() {
+                // `bun_vm_concurrently()` skips the JS-thread debug assert and is the
+                // documented accessor for off-thread (work-pool) callers.
+                // `ConcurrentTask::create` heap-allocates a fresh task; the
+                // queue takes ownership of it.
+                // SAFETY: `begin_post()` returned true, so the VM, its event loop, and the
+                // global object all stay live until the matching `end_post()`; the concurrent
+                // queue is MPSC-safe. The JS thread may free `this` once popped — the enqueue
+                // is this thread's last touch of it.
+                unsafe {
+                    let vm = (*this).global_object().bun_vm_concurrently();
+                    (*vm).enqueue_task_concurrent(ConcurrentTask::create(Task::init(this)));
+                }
+                gate.end_post();
+            } else {
+                // The VM shut down while the scan was blocked; the completion has nowhere to
+                // go. SAFETY: the post was refused and the subtask count hit zero, so this
+                // thread exclusively owns `this`.
+                unsafe { Self::dispose_without_post(this) };
             }
-            // Pairs with `concurrent_poster_begin` in `create()`. The JS thread may free `self`
-            // once popped and tear the VM down at zero — last touch of both.
-            // SAFETY: `event_loop()` is a value field of the process-static VM.
-            unsafe { (*(*vm).event_loop()).concurrent_poster_end() };
         }
 
         fn clear_result_list(&mut self) {
@@ -2699,6 +2820,25 @@ mod _async_tasks {
             task.r#ref.unref(bun_io::js_vm_ctx());
             task.free_root_path();
             task.clear_result_list();
+        }
+
+        /// The loop's gate refused the completion post: the VM is torn down (or mid-teardown).
+        /// Free the task on the work-pool thread without touching the JS heap — the promise
+        /// `Strong` and the args' protect counts died with it. Entry disposal
+        /// (`clear_result_list`) is already off-thread-safe: `finish_concurrently` runs it on
+        /// pool threads on the error path.
+        ///
+        /// SAFETY: `this` must be the pointer Box::leak'd in `create()`, exclusively owned by
+        /// the caller (the post never happened); called at most once.
+        unsafe fn dispose_without_post(this: *mut Self) {
+            // SAFETY: caller guarantees `this` is the live Box-leaked allocation.
+            let mut task = unsafe { bun_core::heap::take(this) };
+            debug_assert!(task.root_fd == FD::INVALID); // closed by finish_concurrently
+            task.free_root_path();
+            task.clear_result_list();
+            let Self { promise, args, .. } = *task;
+            core::mem::forget(promise);
+            args.dispose_skip_unprotect();
         }
     }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -289,6 +289,13 @@ impl bun_jsc::Unprotect for BlobOrStringOrBuffer {
             sob.unprotect();
         }
     }
+
+    fn disarm_for_dead_vm(&mut self) {
+        // `Blob` never rides a work-pool fs task (no `FsArgument` impl), so no arm for it.
+        if let Self::StringOrBuffer(sob) = self {
+            sob.disarm_for_dead_vm();
+        }
+    }
 }
 
 impl bun_jsc::Unprotect for StringOrBuffer {
@@ -304,6 +311,12 @@ impl bun_jsc::Unprotect for StringOrBuffer {
                 buffer.buffer.unpin();
             }
             buffer.buffer.value.unprotect();
+        }
+    }
+
+    fn disarm_for_dead_vm(&mut self) {
+        if let Self::Buffer(buffer) = self {
+            buffer.pinned = false;
         }
     }
 }

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1808,8 +1808,9 @@ test.concurrent.skipIf(isWindows)("terminate() settles while the worker has an f
     cwd: String(dir),
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("exit event\nterminate resolved\n");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 
@@ -1827,7 +1828,8 @@ test.concurrent.skipIf(isWindows)(
       cwd: String(dir),
       stderr: "pipe",
     });
-    const exitCode = await proc.exited;
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   },
 );
@@ -1851,8 +1853,11 @@ test.concurrent.skipIf(isWindows)(
                 if (err) throw err;
                 fs.write(fd, "x", () => {
                   fs.close(fd, () => {
-                    // Slack for the detached pool thread to finish the refused
-                    // completion under ASAN; the assertions do not depend on it.
+                    // The refused completion runs on a detached pool thread in
+                    // the torn-down worker VM; no cross-process signal for it
+                    // exists, so this delay is best-effort scheduling slack
+                    // (an ASAN fault there still fails the run). The
+                    // assertions do not depend on it.
                     setTimeout(() => {
                       console.log("done");
                       process.exit(0);
@@ -1876,8 +1881,9 @@ test.concurrent.skipIf(isWindows)(
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("terminate resolved\ndone\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   },
 );

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1774,3 +1774,113 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+// A pending node:fs thread-pool operation that can never complete (here: a
+// FIFO whose open-for-read blocks until a writer appears) must not block
+// worker/VM teardown: the completion is instead refused at the event loop's
+// poster gate and freed on the pool thread. The fs ops below block forever by
+// design, so these tests hang (and time out) if shutdown ever waits on them.
+test.concurrent.skipIf(isWindows)(
+  "terminate() settles while the worker has an fs read blocked on a FIFO",
+  async () => {
+    using dir = tempDir("worker-terminate-blocked-read", {
+      "main.cjs": `
+        const { Worker, isMainThread, parentPort, workerData } = require("worker_threads");
+        if (isMainThread) {
+          const w = new Worker(__filename, { workerData: process.argv[2] });
+          w.on("exit", () => console.log("exit event"));
+          w.on("message", () => {
+            w.terminate().then(() => {
+              console.log("terminate resolved");
+              process.exit(0);
+            });
+          });
+        } else {
+          // Blocks a thread-pool worker forever: a FIFO with no writer.
+          require("fs").readFile(workerData, () => {});
+          parentPort.postMessage("pending");
+        }
+      `,
+    });
+    const fifo = join(String(dir), "pipe.fifo");
+    expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs", fifo],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("exit event\nterminate resolved\n");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(isWindows)(
+  "process.exit() with a blocked fs read pending completes under BUN_DESTRUCT_VM_ON_EXIT",
+  async () => {
+    using dir = tempDir("exit-blocked-read", {
+      "main.cjs": `require("fs").readFile(process.argv[2], () => {}); process.exit(0);`,
+    });
+    const fifo = join(String(dir), "pipe.fifo");
+    expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs", fifo],
+      env: { ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(isWindows)(
+  "fs op completing after terminate() is discarded without touching the dead worker VM",
+  async () => {
+    using dir = tempDir("worker-terminate-late-completion", {
+      "main.cjs": `
+        const { Worker, isMainThread, parentPort, workerData } = require("worker_threads");
+        const fs = require("fs");
+        if (isMainThread) {
+          const fifo = process.argv[2];
+          const w = new Worker(__filename, { workerData: fifo });
+          w.on("message", () => {
+            w.terminate().then(() => {
+              console.log("terminate resolved");
+              // Unblock the stranded read now that the worker VM is gone; its
+              // completion must be refused at the gate and freed off-thread.
+              fs.open(fifo, "w", (err, fd) => {
+                if (err) throw err;
+                fs.write(fd, "x", () => {
+                  fs.close(fd, () => {
+                    // Slack for the detached pool thread to finish the refused
+                    // completion under ASAN; the assertions do not depend on it.
+                    setTimeout(() => {
+                      console.log("done");
+                      process.exit(0);
+                    }, 250);
+                  });
+                });
+              });
+            });
+          });
+        } else {
+          fs.readFile(workerData, () => {});
+          parentPort.postMessage("pending");
+        }
+      `,
+    });
+    const fifo = join(String(dir), "pipe.fifo");
+    expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs", fifo],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("terminate resolved\ndone\n");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1868,7 +1868,11 @@ test.concurrent.skipIf(isWindows)(
             });
           });
         } else {
-          fs.readFile(workerData, () => {});
+          // Buffer path + AbortSignal: their normal teardown cleanup (unpin,
+          // signal unref) must be skipped by the refused-post disposal, since
+          // both would touch the dead JS heap.
+          const controller = new AbortController();
+          fs.readFile(Buffer.from(workerData), { signal: controller.signal }, () => {});
           parentPort.postMessage("pending");
         }
       `,
@@ -1877,7 +1881,9 @@ test.concurrent.skipIf(isWindows)(
     expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
     await using proc = Bun.spawn({
       cmd: [bunExe(), "main.cjs", fifo],
-      env: bunEnv,
+      // Malloc=1 forces system malloc for the JSC heap so ASAN can see a
+      // use-after-free if the disposal ever touches it.
+      env: { ...bunEnv, Malloc: "1" },
       cwd: String(dir),
       stderr: "pipe",
     });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1780,11 +1780,9 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
 // worker/VM teardown: the completion is instead refused at the event loop's
 // poster gate and freed on the pool thread. The fs ops below block forever by
 // design, so these tests hang (and time out) if shutdown ever waits on them.
-test.concurrent.skipIf(isWindows)(
-  "terminate() settles while the worker has an fs read blocked on a FIFO",
-  async () => {
-    using dir = tempDir("worker-terminate-blocked-read", {
-      "main.cjs": `
+test.concurrent.skipIf(isWindows)("terminate() settles while the worker has an fs read blocked on a FIFO", async () => {
+  using dir = tempDir("worker-terminate-blocked-read", {
+    "main.cjs": `
         const { Worker, isMainThread, parentPort, workerData } = require("worker_threads");
         if (isMainThread) {
           const w = new Worker(__filename, { workerData: process.argv[2] });
@@ -1801,20 +1799,19 @@ test.concurrent.skipIf(isWindows)(
           parentPort.postMessage("pending");
         }
       `,
-    });
-    const fifo = join(String(dir), "pipe.fifo");
-    expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.cjs", fifo],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout).toBe("exit event\nterminate resolved\n");
-    expect(exitCode).toBe(0);
-  },
-);
+  });
+  const fifo = join(String(dir), "pipe.fifo");
+  expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.cjs", fifo],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("exit event\nterminate resolved\n");
+  expect(exitCode).toBe(0);
+});
 
 test.concurrent.skipIf(isWindows)(
   "process.exit() with a blocked fs read pending completes under BUN_DESTRUCT_VM_ON_EXIT",


### PR DESCRIPTION
### Symptom

`worker.terminate()` never settles, no `exit` event fires, and the worker OS thread spins a core at 40-85% forever whenever the worker has any pending `node:fs` thread-pool operation that cannot complete: `fs.readFile`/`fs.promises.readFile`/`fs.createReadStream`/`fs.open` on a FIFO with no writer, a pipe nobody writes to, or a hung mount. The same wait makes plain `process.exit(0)` hang under `BUN_DESTRUCT_VM_ON_EXIT=1`. Regression from #34660 (the poster counter + wait it introduced); stock 1.4.0-canary terminates in ~200ms.

```js
// bun repro.cjs < <(sleep 999)   (or any FIFO with no writer)
const { Worker, isMainThread, parentPort } = require('worker_threads');
if (isMainThread) {
  const w = new Worker(__filename);
  w.on('message', () => w.terminate().then(c => { console.log('terminate() resolved', c); process.exit(0); }));
  setInterval(() => {}, 1000);
} else {
  require('fs').readFile('/dev/stdin', () => {});
  setTimeout(() => parentPort.postMessage('pending'), 50);
}
```

Hot-thread stack: `sched_yield <- EventLoop::wait_for_concurrent_posters (event_loop.rs) <- WebWorker::shutdown (web_worker.rs)`.

### Cause

#34660 made shutdown wait for in-flight work-pool fs completions so their posts cannot land after the final queue drain (a post into a torn-down VM leaked, or worse). But the counter brackets the whole fs operation, from schedule on the JS thread to the completion post on the pool thread, so the `while count > 0 { yield_now() }` loop is bounded by syscall latency. A read from a writer-less FIFO never returns, so teardown spins forever.

### Fix

Replace the whole-operation counter with `ConcurrentPosterGate`, an `Arc`-shared state word (closed bit + active-post count) that brackets only the enqueue itself:

- Pool threads wrap just the completion post in `begin_post()`/`end_post()`. A successful `begin_post()` guarantees the VM stays live until the matching `end_post()` (shutdown cannot finish closing the gate in between).
- Shutdown closes the gate before the final queue drain. The close waits only for posts already mid-enqueue (bounded by an enqueue + wakeup), never for the underlying syscall.
- A poster that arrives after close is refused and frees its task on the pool thread without touching the dead VM: JS handles (promise `Strong`, protect counts) died with the heap and are deliberately not released; owned Rust payloads are freed via the new `FsReturn::fs_discard` hook and `ThreadSafe::dispose_skip_unprotect`.
- The gate is `Arc`-cloned into each in-flight task, so a pool thread stranded in a blocked syscall can still read the closed state after the VM's memory is gone.

`fs_discard` in `destroy()` also fixes an adjacent leak: the shutdown drain dropped `readFile`/`readdir` results whose buffers are normally freed only by the JSC finalizer installed in `to_js()`.

Ops that hold JS-heap-backed buffers while blocked (e.g. `fs.write` of a Buffer into a full pipe) are unchanged by this PR: their completions are now refused safely, but the buffer lifetime question during teardown is the known pre-existing class that also covers crypto/zlib completions, and is out of scope here.

### Verification

On an ASAN debug build of main, both repros hang forever (killed at 20s); with this change `terminate()` resolves (~2s debug/ASAN, ~200ms release-equivalent path) and the `BUN_DESTRUCT_VM_ON_EXIT=1` exit completes. A FIFO-unblock-after-terminate run exercises the refused-post disposal under ASAN+LSan with no errors and no new leaks.

Tests added to `test/js/node/worker_threads/worker_threads.test.ts` (POSIX; the libuv completion path on Windows runs on the JS thread and never had the wait):
- `terminate()` settles while the worker has an fs read blocked on a FIFO
- `process.exit()` with a blocked fs read pending completes under `BUN_DESTRUCT_VM_ON_EXIT`
- an fs op completing after `terminate()` is discarded without touching the dead worker VM

All three time out on main and pass with the fix. Also green locally: the #34660 guard test (`worker-shutdown-post-leak.test.ts`), `worker_threads.test.ts` (91 tests), `fs.test.ts` (457), `cp.test.ts`, `fs-leak.test.js`, worker destruction/terminate-stress, and `rust:check-all` (10/10 targets). The abort-signal fs benchmark shows no per-op overhead change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/worker_threads/worker_threads.test.ts

<!-- robobun:evidence:end -->