### PR TITLE
node:stream: deliver child stdio 'data' listener throws as uncaughtException

### DIFF
--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -12,11 +12,6 @@ const transferToNativeReadable = $newCppFunction(
   1,
 );
 const { errorOrDestroy } = require("internal/streams/destroy");
-
-// Node emits 'data' for process stdio from the native read callback (via
-// MakeCallback), so a throw from a listener becomes an uncaughtException. Our
-// pull-based reader can emit from a pull-promise reaction; a throw there would
-// otherwise reject a promise nobody observes and surface as unhandledRejection.
 const { reportUncaughtException } = require("internal/shared");
 
 const kRefCount = Symbol("refCount");
@@ -217,10 +212,10 @@ function pushAndCheck(stream: NativeReadable, chunk: any) {
   try {
     wantMore = stream.push(chunk);
   } catch (e) {
+    // A 'data' listener threw inside the pull-promise reaction. Node fires
+    // these from the native read callback, so reroute to uncaughtException,
+    // and schedule the read the unwound addChunk would have done.
     reportUncaughtException(e);
-    // The throw unwound addChunk before its maybeReadMore call, so nothing is
-    // scheduled to read again; without this the flowing stream stalls and
-    // never reaches EOF. The chunk was emitted, not buffered, so keep reading.
     wantMore = true;
     process.nextTick(readAfterListenerThrow, stream);
   }
@@ -231,8 +226,7 @@ function pushAndCheck(stream: NativeReadable, chunk: any) {
 }
 
 function readAfterListenerThrow(stream: NativeReadable) {
-  // When the native side already signaled close, handleResult scheduled the
-  // EOF push(null); pulling again is unnecessary.
+  // On native close, handleResult already scheduled the EOF push(null).
   if (stream.destroyed || stream[kCloseState][0]) return;
   stream.read(0);
 }

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -17,7 +17,7 @@ const { errorOrDestroy } = require("internal/streams/destroy");
 // MakeCallback), so a throw from a listener becomes an uncaughtException. Our
 // pull-based reader can emit from a pull-promise reaction; a throw there would
 // otherwise reject a promise nobody observes and surface as unhandledRejection.
-const reportUncaughtException = $newCppFunction("BunProcess.cpp", "jsFunctionReportUncaughtException", 1);
+const { reportUncaughtException } = require("internal/shared");
 
 const kRefCount = Symbol("refCount");
 const kCloseState = Symbol("closeState");

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -212,11 +212,10 @@ function pushAndCheck(stream: NativeReadable, chunk: any) {
   try {
     wantMore = stream.push(chunk);
   } catch (e) {
-    // A 'data' listener threw inside the pull-promise reaction. Node fires
-    // these from the native read callback, so reroute to uncaughtException,
-    // and schedule the read the unwound addChunk would have done.
+    // Node dispatches 'data' from its native read callback, where a listener throw is an uncaughtException.
     reportUncaughtException(e);
     wantMore = true;
+    // The throw unwound addChunk before maybeReadMore; keep the stream reading.
     process.nextTick(readAfterListenerThrow, stream);
   }
   if (!wantMore) {

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -13,6 +13,12 @@ const transferToNativeReadable = $newCppFunction(
 );
 const { errorOrDestroy } = require("internal/streams/destroy");
 
+// Node emits 'data' for process stdio from the native read callback (via
+// MakeCallback), so a throw from a listener becomes an uncaughtException. Our
+// pull-based reader can emit from a pull-promise reaction; a throw there would
+// otherwise reject a promise nobody observes and surface as unhandledRejection.
+const reportUncaughtException = $newCppFunction("BunProcess.cpp", "jsFunctionReportUncaughtException", 1);
+
 const kRefCount = Symbol("refCount");
 const kCloseState = Symbol("closeState");
 const kConstructed = Symbol("constructed");
@@ -207,10 +213,28 @@ function handleResult(stream: NativeReadable, result: any, chunk: Buffer, isClos
 // the consumer paused); stop the native reader so kernel backpressure reaches
 // the writer (readStop, like net.Socket). The next `_read()` re-enables it.
 function pushAndCheck(stream: NativeReadable, chunk: any) {
-  if (!stream.push(chunk)) {
+  let wantMore: boolean;
+  try {
+    wantMore = stream.push(chunk);
+  } catch (e) {
+    reportUncaughtException(e);
+    // The throw unwound addChunk before its maybeReadMore call, so nothing is
+    // scheduled to read again; without this the flowing stream stalls and
+    // never reaches EOF. The chunk was emitted, not buffered, so keep reading.
+    wantMore = true;
+    process.nextTick(readAfterListenerThrow, stream);
+  }
+  if (!wantMore) {
     const ptr = stream.$bunNativePtr;
     if (ptr) ptr.setFlowing?.(false);
   }
+}
+
+function readAfterListenerThrow(stream: NativeReadable) {
+  // When the native side already signaled close, handleResult scheduled the
+  // EOF push(null); pulling again is unnecessary.
+  if (stream.destroyed || stream[kCloseState][0]) return;
+  stream.read(0);
 }
 
 function handleNumberResult(stream: NativeReadable, result: number, chunk: any, isClosed: boolean) {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1145,3 +1145,49 @@ describe("spawn/execFile({signal}) does not leak abort listeners on spawn failur
     expect(errors.map(e => e.code)).toEqual(["ENOENT"]);
   });
 });
+
+// A throw inside a child stdio 'data' listener must surface as an
+// uncaughtException, as in node, where these events dispatch from the native
+// read callback. When the internal reader takes its async pull path the emit
+// runs from a promise reaction, which used to turn the throw into an
+// unhandledRejection and stall the stream before EOF (so 'close' never fired).
+it("throw from a child stdio 'data' listener is an uncaughtException and the stream still ends", async () => {
+  const script = `
+    const { spawn } = require("node:child_process");
+    let ue = 0, ur = 0, data = 0, closes = 0, n = 0;
+    const N = 3;
+    process.on("uncaughtException", (e, origin) => {
+      if (origin !== "uncaughtException" || !String(e.message).startsWith("data-throw-")) {
+        console.log("unexpected: origin=" + origin + " message=" + (e && e.message));
+        process.exit(1);
+      }
+      ue++;
+      next();
+    });
+    process.on("unhandledRejection", () => { ur++; next(); });
+    process.on("exit", () => {
+      console.log("spawned=" + n + " data=" + data + " closes=" + closes + " ue=" + ue + " ur=" + ur);
+    });
+    function next() {
+      if (n >= N) return;
+      n++;
+      // The delayed write guarantees the parent's pull is pending when data
+      // arrives, so the 'data' emit runs from the async (promise) path.
+      const c = spawn(process.execPath, ["-e", "setTimeout(() => console.log('hi'), 50)"], {
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      c.on("close", () => closes++);
+      c.stdout.on("data", () => { data++; throw new Error("data-throw-" + n); });
+    }
+    next();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe("spawned=3 data=3 closes=3 ue=3 ur=0");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1187,7 +1187,10 @@ it("throw from a child stdio 'data' listener is an uncaughtException and the str
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout.trim()).toBe("spawned=3 data=3 closes=3 ue=3 ur=0");
-  expect(exitCode).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "spawned=3 data=3 closes=3 ue=3 ur=0",
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1146,11 +1146,8 @@ describe("spawn/execFile({signal}) does not leak abort listeners on spawn failur
   });
 });
 
-// A throw inside a child stdio 'data' listener must surface as an
-// uncaughtException, as in node, where these events dispatch from the native
-// read callback. When the internal reader takes its async pull path the emit
-// runs from a promise reaction, which used to turn the throw into an
-// unhandledRejection and stall the stream before EOF (so 'close' never fired).
+// Node dispatches child stdio 'data' from its native read callback, so a
+// listener throw is an uncaughtException, never an unhandledRejection.
 it("throw from a child stdio 'data' listener is an uncaughtException and the stream still ends", async () => {
   const script = `
     const { spawn } = require("node:child_process");
@@ -1171,8 +1168,9 @@ it("throw from a child stdio 'data' listener is an uncaughtException and the str
     function next() {
       if (n >= N) return;
       n++;
-      // The delayed write guarantees the parent's pull is pending when data
-      // arrives, so the 'data' emit runs from the async (promise) path.
+      // The parent queues its first pipe read on the next tick, while the
+      // child needs process startup plus the timer before it first writes,
+      // so the write always lands on the async (pending-pull) path.
       const c = spawn(process.execPath, ["-e", "setTimeout(() => console.log('hi'), 50)"], {
         stdio: ["ignore", "pipe", "ignore"],
       });


### PR DESCRIPTION
### Repro

```js
import { spawn } from "node:child_process";
let ue = 0, ur = 0, data = 0, n = 0; const N = 40;
process.on("uncaughtException", (e, origin) => { origin === "unhandledRejection" ? ur++ : ue++; next(); });
process.on("unhandledRejection", () => { ur++; next(); });
process.on("exit", (code) => console.log(`exit=${code} spawned=${n} data=${data} uncaughtException=${ue} unhandledRejection=${ur}`));
function next() {
  if (n >= N) return; n++;
  const c = spawn("/bin/sh", ["-c", "echo hi"], { stdio: ["ignore", "pipe", "ignore"] });
  c.stdout.on("data", () => { data++; throw new Error("data-throw-" + n); });
}
next();
```

node: `exit=0 spawned=40 data=40 uncaughtException=40 unhandledRejection=0`

bun before this change: `exit=0 spawned=3 data=2 uncaughtException=1 unhandledRejection=1`. After a few children the listener throw arrives as an unhandledRejection, the rejection is only noticed at loop exit (after `beforeExit`), and the child spawned from that handler never runs. With only an uncaughtException handler installed the flipped throw is fatal (rc 1). The throwing stream also stalls: its `'close'` never fires.

Delaying the child's first write makes the failure deterministic, because the parent's pull is then always pending when data arrives: bun reports `ue=0 ur=3 closes=0` vs node `ue=3 ur=0 closes=3` on every run.

### Cause

`internal/streams/native-readable.ts` drives child stdio pipes. When `ptr.pull()` returns a promise, `handleResult()` -> `push()` -> `emit('data')` runs inside the `.then` fulfillment reaction, and nothing observes `_read()`'s returned promise. A throw from the user's listener therefore rejects an unobserved promise and surfaces as unhandledRejection, where node, which dispatches these events from the native read callback, produces an uncaughtException. The throw also unwinds `addChunk` before its `maybeReadMore` call and `handleResult` before its EOF scheduling, so nothing ever reads again: the stream stalls and `'close'` never fires, which is why a child spawned from the late rejection handler was lost.

This is the same callback-dispatch class #34660 fixed for fs/dns/pbkdf2 callbacks, at a site it did not cover.

### Fix

Catch the throw at the push boundary in `pushAndCheck`, report it through the same `jsFunctionReportUncaughtException` path the guarded callbacks use, and schedule the read the throw unwound so the stream still reaches EOF. This applies to native-handle-backed streams (child stdio, and `Readable.fromWeb` over native streams such as fetch bodies), matching node's behavior for its native-handle-backed streams. JS-backed `fromWeb` adapters keep their existing promise semantics; node surfaces those as unhandledRejection too (verified against node v26).

### Verification

- New test in `test/js/node/child_process/child_process.test.ts` fails unfixed (`spawned=3 data=3 closes=0 ue=0 ur=3`) and passes fixed (`spawned=3 data=3 closes=3 ue=3 ur=0`).
- The 40-child repro above matches node exactly with the fix, 3/3 runs.
- With only an uncaughtException handler installed: exit 0 and all children complete (was fatal rc 1).
- With no handler installed: still fatal with rc 1, as in node.
- `child_process.test.ts` (61 pass; 2 env-dependent failures reproduce on clean main in the same container), `child-process-stdio.test.js`, `child_process-node.test.js`, `node-stream.test.js`, `process-stdin.test.ts`, and `test/js/bun/spawn/spawn.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->