### PR TITLE
fetch: reclaim the tasklet when its last ref drops on the HTTP thread at exit

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -266,6 +266,11 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
+    // Test-only fault injection for test/js/web/fetch/exiting.test.ts: delays
+    // `FetchTasklet::deref_from_thread` so the HTTP thread's last-ref handoff
+    // deterministically lands between the event loop's final drain and
+    // `is_shutting_down`.
+    new_feature_flag!(pub BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD, "BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -266,8 +266,7 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
-    // Debug-only fault injection for test/js/web/fetch/exiting.test.ts (delays
-    // `FetchTasklet::deref_from_thread` into the exit window).
+    // Debug-only fault injection for test/js/web/fetch/exiting.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD, "BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -266,10 +266,8 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
-    // Test-only fault injection for test/js/web/fetch/exiting.test.ts: delays
-    // `FetchTasklet::deref_from_thread` so the HTTP thread's last-ref handoff
-    // deterministically lands between the event loop's final drain and
-    // `is_shutting_down`.
+    // Test-only fault injection for test/js/web/fetch/exiting.test.ts (delays
+    // `FetchTasklet::deref_from_thread` into the exit window).
     new_feature_flag!(pub BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD, "BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -266,7 +266,7 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
-    // Test-only fault injection for test/js/web/fetch/exiting.test.ts (delays
+    // Debug-only fault injection for test/js/web/fetch/exiting.test.ts (delays
     // `FetchTasklet::deref_from_thread` into the exit window).
     new_feature_flag!(pub BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD, "BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -88,6 +88,7 @@ pub mod task_tag {
         FChown,
         Fdatasync,
         FetchTasklet,
+        FetchTaskletDeinit,       // last-ref handoff from the HTTP thread (deref_from_thread)
         FetchTaskletPromiseSettle,
         FileResponseStreamEof,
         Fstat,

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -89,6 +89,7 @@ pub mod task_tag {
         Fdatasync,
         FetchTasklet,
         FetchTaskletDeinit,       // last-ref handoff from the HTTP thread (deref_from_thread)
+        FetchTaskletResumeRequestStream, // request-body drain hop; the queued entry owns a +1
         FetchTaskletPromiseSettle,
         FileResponseStreamEof,
         Fstat,

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -410,8 +410,7 @@ pub(crate) fn run_task(
         task_tag::FetchTasklet => {
             cast!(FetchTasklet).on_progress_update()?;
         }
-        // Last-ref handoff from the HTTP thread; frees the tasklet, so no
-        // `&mut` at this boundary.
+        // Frees the tasklet, so no `&mut` at this boundary.
         task_tag::FetchTaskletDeinit => {
             FetchTasklet::deinit_queued(cast_ptr!(FetchTasklet));
         }
@@ -1288,12 +1287,8 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
             FetchTasklet::deref(task.ptr.cast::<FetchTasklet>());
             true
         }
-        // `deref_from_thread` handed the tasklet's final ref to this entry;
-        // the loop will never dispatch it, so reclaim now — same
-        // JS-thread-before-`destructOnExit` window the parked
-        // `dealloc_for_shutdown` reclaim uses. Leaving it to `EventLoop::deinit`
-        // would drop the queued box without running it and orphan the
-        // tasklet ⇄ `Box<AsyncHTTP>` cycle.
+        // A last-ref handoff the loop never dispatched; deinit here (still
+        // before `destructOnExit`) or the tasklet ⇄ `Box<AsyncHTTP>` cycle leaks.
         task_tag::FetchTaskletDeinit => {
             FetchTasklet::deinit_queued(task.ptr.cast::<FetchTasklet>());
             true

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -414,6 +414,10 @@ pub(crate) fn run_task(
         task_tag::FetchTaskletDeinit => {
             FetchTasklet::deinit_queued(cast_ptr!(FetchTasklet));
         }
+        // May drop the queued entry's ref, so no `&mut` at this boundary.
+        task_tag::FetchTaskletResumeRequestStream => {
+            FetchTasklet::resume_request_data_stream(cast_ptr!(FetchTasklet));
+        }
         // `cast_ptr!` yields the heap-allocated S3 task; JS-thread dispatch
         // is the sole owner here.
         task_tag::S3HttpSimpleTask => {
@@ -702,7 +706,7 @@ fn run_task_cold(task: Task) {
 /// Compile-time guard that the arm count above tracks
 /// `bun_event_loop::task_tag::COUNT`. Bump when adding a variant.
 const _: () = assert!(
-    task_tag::COUNT == 113,
+    task_tag::COUNT == 114,
     "dispatch::run_task arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1290,6 +1294,14 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
         // A handoff the loop never dispatched; deinit before `destructOnExit`.
         task_tag::FetchTaskletDeinit => {
             FetchTasklet::deinit_queued(task.ptr.cast::<FetchTasklet>());
+            true
+        }
+        // Drop the queued drain hop's ref without running `sink.on_drain`
+        // (the loop is past its last tick; there is nothing left to resume).
+        task_tag::FetchTaskletResumeRequestStream => {
+            // SAFETY: `task.ptr` is the live heap `FetchTasklet`; the queued
+            // entry owns the `on_write_request_data_drain` ref released here.
+            FetchTasklet::deref(task.ptr.cast::<FetchTasklet>());
             true
         }
         task_tag::SendQueueDeferred => {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -410,6 +410,11 @@ pub(crate) fn run_task(
         task_tag::FetchTasklet => {
             cast!(FetchTasklet).on_progress_update()?;
         }
+        // Last-ref handoff from the HTTP thread; frees the tasklet, so no
+        // `&mut` at this boundary.
+        task_tag::FetchTaskletDeinit => {
+            FetchTasklet::deinit_queued(cast_ptr!(FetchTasklet));
+        }
         // `cast_ptr!` yields the heap-allocated S3 task; JS-thread dispatch
         // is the sole owner here.
         task_tag::S3HttpSimpleTask => {
@@ -698,7 +703,7 @@ fn run_task_cold(task: Task) {
 /// Compile-time guard that the arm count above tracks
 /// `bun_event_loop::task_tag::COUNT`. Bump when adding a variant.
 const _: () = assert!(
-    task_tag::COUNT == 112,
+    task_tag::COUNT == 113,
     "dispatch::run_task arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1281,6 +1286,16 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
             // SAFETY: `task.ptr` is the live heap `FetchTasklet`; HTTP daemon is
             // already parked so we hold the sole reference.
             FetchTasklet::deref(task.ptr.cast::<FetchTasklet>());
+            true
+        }
+        // `deref_from_thread` handed the tasklet's final ref to this entry;
+        // the loop will never dispatch it, so reclaim now — same
+        // JS-thread-before-`destructOnExit` window the parked
+        // `dealloc_for_shutdown` reclaim uses. Leaving it to `EventLoop::deinit`
+        // would drop the queued box without running it and orphan the
+        // tasklet ⇄ `Box<AsyncHTTP>` cycle.
+        task_tag::FetchTaskletDeinit => {
+            FetchTasklet::deinit_queued(task.ptr.cast::<FetchTasklet>());
             true
         }
         task_tag::SendQueueDeferred => {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1287,8 +1287,7 @@ fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool {
             FetchTasklet::deref(task.ptr.cast::<FetchTasklet>());
             true
         }
-        // A last-ref handoff the loop never dispatched; deinit here (still
-        // before `destructOnExit`) or the tasklet ⇄ `Box<AsyncHTTP>` cycle leaks.
+        // A handoff the loop never dispatched; deinit before `destructOnExit`.
         task_tag::FetchTaskletDeinit => {
             FetchTasklet::deinit_queued(task.ptr.cast::<FetchTasklet>());
             true

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -406,22 +406,36 @@ impl FetchTasklet {
             unsafe { FetchTasklet::dealloc_for_shutdown(this) };
             return;
         }
-        // this is really unlikely to happen, but can happen
-        // lets make sure that we always call deinit from main thread
-        // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`; the queue
-        // takes ownership of it.
+        // The HTTP thread dropped the last ref while the VM is still running
+        // (it lost the `callback()` unlock handoff to the JS thread's final
+        // `on_progress_update` deref). Hand the reclaim to the JS thread under
+        // its own tag — NOT `ConcurrentTask::from_callback` (a `ManagedTask`):
+        // if the event loop never ticks again (the script just finished),
+        // `release_queued_tasks_for_shutdown` re-queues ManagedTasks unrun and
+        // `EventLoop::deinit` drops the box without its callback, orphaning
+        // the tasklet ⇄ `Box<AsyncHTTP>` ⇄ native `Response` cycle (LSan
+        // reports it at exit). The `FetchTaskletDeinit` shutdown-release arm
+        // runs `deinit_queued` before `destructOnExit` instead.
         Self::enqueue_concurrent(
             self_.javascript_vm,
-            ConcurrentTask::from_callback(this, FetchTasklet::deinit_callback),
+            ConcurrentTask::create(Task::new(
+                bun_event_loop::task_tag::FetchTaskletDeinit,
+                this.cast(),
+            )),
         );
     }
 
-    // ConcurrentTask::from_callback takes `fn(*mut T) -> bun_event_loop::JsResult<()>`
-    // (cycle-broken erased error).
-    fn deinit_callback(this: *mut FetchTasklet) -> ElJsResult<()> {
-        // SAFETY: enqueued with last ref; exclusive access on main thread
+    /// Reclaim a tasklet whose last ref was handed off by [`Self::deref_from_thread`]
+    /// (`task_tag::FetchTaskletDeinit`). Runs on the JS thread: normal dispatch,
+    /// or `release_queued_tasks_for_shutdown` when the loop will never tick
+    /// again (both precede `destructOnExit`, so dropping the JSC handles in
+    /// `deinit` is still safe).
+    // Signature stays `*mut`: this frees the allocation.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub(crate) fn deinit_queued(this: *mut FetchTasklet) {
+        // SAFETY: enqueued by `deref_from_thread` on the 1→0 transition — the
+        // queued task is the sole owner of a live heap allocation from `get()`.
         unsafe { FetchTasklet::deinit(this) };
-        Ok(())
     }
 
     fn clear_sink(&mut self) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -36,9 +36,6 @@ use crate::webcore::streams::{SourceHandle, StreamError, StreamResult, Writable}
 use crate::webcore::{AbortSignal, DrainResult, FetchHeaders, InternalBlob, Response, SinkHandle};
 
 use bun_jsc::JsTerminatedResult;
-// `bun_event_loop::JsResult` (cycle-broken erased error) — used by
-// ConcurrentTask callbacks at the tier-3 layer.
-type ElJsResult<T> = bun_event_loop::JsResult<T>;
 
 use boringssl::c::{X509_free, d2i_X509};
 
@@ -2178,34 +2175,31 @@ impl FetchTasklet {
         }
         // ref until the main thread callback is called
         this_ref.ref_();
-        // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`; the queue
-        // takes ownership of it.
+        // Tagged task for the same reason as `deref_from_thread`: the shutdown
+        // release pass must be able to drop the queued ref if the loop never
+        // dispatches this.
         Self::enqueue_concurrent(
             this_ref.javascript_vm,
-            ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream),
+            ConcurrentTask::create(Task::new(
+                bun_event_loop::task_tag::FetchTaskletResumeRequestStream,
+                this.cast(),
+            )),
         );
     }
 
     /// This is ALWAYS called from the main thread
-    // ConcurrentTask::from_callback expects `fn(*mut T) -> bun_event_loop::JsResult<()>`.
-    fn resume_request_data_stream(this: *mut FetchTasklet) -> ElJsResult<()> {
+    pub(crate) fn resume_request_data_stream(this: *mut FetchTasklet) {
         let this_ref = Self::from_raw_mut(this);
         bun_output::scoped_log!(FetchTasklet, "resumeRequestDataStream");
-        let result = (|| {
-            if this_ref.signal_aborted() {
-                // already aborted; nothing to drain
-                return;
-            }
+        if !this_ref.signal_aborted() {
             let global_this = this_ref.global_this;
             if let Some(sink) = this_ref.sink_mut() {
                 sink.on_drain(&global_this);
             }
-        })();
+        }
         // deref when done because we ref inside onWriteRequestDataDrain
         // SAFETY: `this` is the live heap tasklet; we hold a ref.
         FetchTasklet::deref(this);
-        let () = result;
-        Ok(())
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -406,16 +406,9 @@ impl FetchTasklet {
             unsafe { FetchTasklet::dealloc_for_shutdown(this) };
             return;
         }
-        // The HTTP thread dropped the last ref while the VM is still running
-        // (it lost the `callback()` unlock handoff to the JS thread's final
-        // `on_progress_update` deref). Hand the reclaim to the JS thread under
-        // its own tag — NOT `ConcurrentTask::from_callback` (a `ManagedTask`):
-        // if the event loop never ticks again (the script just finished),
-        // `release_queued_tasks_for_shutdown` re-queues ManagedTasks unrun and
-        // `EventLoop::deinit` drops the box without its callback, orphaning
-        // the tasklet ⇄ `Box<AsyncHTTP>` ⇄ native `Response` cycle (LSan
-        // reports it at exit). The `FetchTaskletDeinit` shutdown-release arm
-        // runs `deinit_queued` before `destructOnExit` instead.
+        // Dedicated tag, not `from_callback`: a queued `ManagedTask` the loop
+        // never dispatches is freed unrun at shutdown, leaking the tasklet ⇄
+        // `Box<AsyncHTTP>` cycle. The `FetchTaskletDeinit` shutdown arm reclaims it.
         Self::enqueue_concurrent(
             self_.javascript_vm,
             ConcurrentTask::create(Task::new(
@@ -425,11 +418,9 @@ impl FetchTasklet {
         );
     }
 
-    /// Reclaim a tasklet whose last ref was handed off by [`Self::deref_from_thread`]
-    /// (`task_tag::FetchTaskletDeinit`). Runs on the JS thread: normal dispatch,
-    /// or `release_queued_tasks_for_shutdown` when the loop will never tick
-    /// again (both precede `destructOnExit`, so dropping the JSC handles in
-    /// `deinit` is still safe).
+    /// Reclaim a tasklet queued by [`Self::deref_from_thread`]'s last-ref
+    /// handoff. JS thread only; both callers (dispatch, shutdown release)
+    /// precede `destructOnExit`, so `deinit` may still drop JSC handles.
     // Signature stays `*mut`: this frees the allocation.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn deinit_queued(this: *mut FetchTasklet) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -389,6 +389,14 @@ impl FetchTasklet {
     // stay `*mut` because the call may drop the last ref and free the allocation.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn deref_from_thread(this: *mut FetchTasklet) {
+        // Test-only fault injection (exiting.test.ts): hold the HTTP thread so
+        // the JS thread wins the final-deref race and the handoff below lands
+        // in the exit window.
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD.get()
+            == Some(true)
+        {
+            std::thread::sleep(core::time::Duration::from_millis(200));
+        }
         // SAFETY: caller contract.
         if !unsafe { bun_ptr::ThreadSafeRefCount::<Self>::release(this) } {
             return;
@@ -562,6 +570,10 @@ impl FetchTasklet {
     /// `has_schedule_callback` is written exclusively by the HTTP-thread
     /// `callback` and the JS-thread `on_progress_update`; the JS thread is
     /// parked in `wait_timeout_while` here, so the load is race-free.
+    ///
+    /// Drain-hop refs (`on_write_request_data_drain`'s `+1`) are outside this
+    /// ledger: each is owned by its queued `FetchTaskletResumeRequestStream`
+    /// entry and released by `release_queued_tasks_for_shutdown`.
     ///
     /// SAFETY: `this` is the live `*mut FetchTasklet` registered as
     /// `result_callback.ctx` in `get()`; HTTP-thread-only at this point.

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -389,9 +389,8 @@ impl FetchTasklet {
     // stay `*mut` because the call may drop the last ref and free the allocation.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn deref_from_thread(this: *mut FetchTasklet) {
-        // Test-only fault injection (exiting.test.ts): hold the HTTP thread so
-        // the JS thread wins the final-deref race and the handoff below lands
-        // in the exit window.
+        // Test-only fault injection (exiting.test.ts): lets the JS thread win
+        // the final-deref race so the handoff below lands in the exit window.
         if bun_core::env_var::feature_flag::BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD.get()
             == Some(true)
         {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -389,8 +389,9 @@ impl FetchTasklet {
     // stay `*mut` because the call may drop the last ref and free the allocation.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn deref_from_thread(this: *mut FetchTasklet) {
-        // Test-only fault injection (exiting.test.ts): lets the JS thread win
+        // Debug-only fault injection (exiting.test.ts): lets the JS thread win
         // the final-deref race so the handoff below lands in the exit window.
+        #[cfg(debug_assertions)]
         if bun_core::env_var::feature_flag::BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD.get()
             == Some(true)
         {

--- a/test/js/web/fetch/exiting.test.ts
+++ b/test/js/web/fetch/exiting.test.ts
@@ -75,11 +75,7 @@ test.skipIf(!isASAN || isWindows)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [buildOut, buildErr, buildCode] = await Promise.all([
-      build.stdout.text(),
-      build.stderr.text(),
-      build.exited,
-    ]);
+    const [buildOut, buildErr, buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect({ buildErr: buildErr.includes("error") ? buildErr : "", buildOut: "", buildCode }).toEqual({
       buildErr: "",
       buildOut: "",
@@ -105,11 +101,7 @@ test.skipIf(!isASAN || isWindows)(
       );
       const results = await Promise.all(
         procs.map(async proc => {
-          const [stdout, stderr, exitCode] = await Promise.all([
-            proc.stdout.text(),
-            proc.stderr.text(),
-            proc.exited,
-          ]);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           return { stdout, stderr, exitCode };
         }),
       );

--- a/test/js/web/fetch/exiting.test.ts
+++ b/test/js/web/fetch/exiting.test.ts
@@ -50,7 +50,23 @@ test.skipIf(!isASAN || isWindows)(
             "/": home,
             "/about": about,
           },
+          fetch: async req => new Response(String((await req.bytes()).length)),
         });
+
+        // A streaming upload first, so the request-body drain hop runs under
+        // this test's leak-checked exit regime. The two GETs stay last: the
+        // leak race is between the final response and process exit.
+        const chunk = new Uint8Array(65536);
+        const echoRes = await fetch(server.url + "echo", {
+          method: "POST",
+          body: new ReadableStream({
+            pull(controller) {
+              controller.enqueue(chunk);
+              if ((this.sent = (this.sent ?? 0) + 1) >= 8) controller.close();
+            },
+          }),
+        });
+        console.log("Echo bytes:", await echoRes.text());
 
         const homeRes = await fetch(server.url);
         console.log("Home status:", homeRes.status);
@@ -89,26 +105,36 @@ test.skipIf(!isASAN || isWindows)(
       ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1", "abort_on_error=1"].filter(Boolean).join(":"),
       LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
     };
-    const expectedStdout = "Home status: 200\nHome has content: true\nAbout status: 200\nAbout has content: true\n";
+    const expectedStdout =
+      "Echo bytes: 524288\nHome status: 200\nHome has content: true\nAbout status: 200\nAbout has content: true\n";
 
-    for (let round = 0; round < 24; round++) {
-      const procs = Array.from({ length: 8 }, () =>
-        Bun.spawn({
-          cmd: [join(String(dir), "server")],
-          env,
-          stdout: "pipe",
-          stderr: "pipe",
-        }),
-      );
-      const results = await Promise.all(
-        procs.map(async proc => {
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          return { stdout, stderr, exitCode };
-        }),
-      );
-      for (const result of results) {
-        expect(result).toEqual({ stdout: expectedStdout, stderr: "", exitCode: 0 });
+    const procs: Bun.Subprocess<"ignore", "pipe", "pipe">[] = [];
+    try {
+      for (let round = 0; round < 24; round++) {
+        procs.length = 0;
+        for (let i = 0; i < 8; i++) {
+          procs.push(
+            Bun.spawn({
+              cmd: [join(String(dir), "server")],
+              env,
+              stdout: "pipe",
+              stderr: "pipe",
+            }),
+          );
+        }
+        const results = await Promise.all(
+          procs.map(async proc => {
+            const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+            return { stdout, stderr, exitCode };
+          }),
+        );
+        for (const result of results) {
+          expect(result).toEqual({ stdout: expectedStdout, stderr: "", exitCode: 0 });
+        }
       }
+    } finally {
+      // On a mid-batch spawn failure or assertion, don't orphan the rest.
+      for (const proc of procs) proc.kill();
     }
   },
   // 192 compiled-binary runs; LSan symbolizes through llvm-symbolizer on

--- a/test/js/web/fetch/exiting.test.ts
+++ b/test/js/web/fetch/exiting.test.ts
@@ -75,10 +75,11 @@ test.skipIf(!isASAN || isWindows)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [buildOut, buildErr, buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect({ buildErr: buildErr.includes("error") ? buildErr : "", buildOut: "", buildCode }).toEqual({
+    // stdout is drained but not asserted: `bun build --compile` prints
+    // progress there on success.
+    const [, buildErr, buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ buildErr: buildErr.includes("error") ? buildErr : "", buildCode }).toEqual({
       buildErr: "",
-      buildOut: "",
       buildCode: 0,
     });
 

--- a/test/js/web/fetch/exiting.test.ts
+++ b/test/js/web/fetch/exiting.test.ts
@@ -1,6 +1,8 @@
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:http";
+import { join } from "node:path";
 test("abort the request on the other side if the stream is canceled", async () => {
   const { promise: abort, resolve: resolveAbort } = Promise.withResolvers();
   await using server = createServer((req, res) => {
@@ -26,3 +28,97 @@ test("abort the request on the other side if the stream is canceled", async () =
 
   await abort;
 });
+
+// When a fetch finishes right as the process exits, the HTTP thread can drop
+// the tasklet's last reference while the VM is still running and hand the
+// reclaim to an event loop that never ticks again. That handoff used to be
+// dropped unrun at shutdown, orphaning the FetchTasklet / AsyncHTTP / native
+// Response cycle, which LeakSanitizer reported at exit (SIGABRT) in compiled
+// server binaries. The handoff is a scheduling race, so this runs the compiled
+// server repeatedly, in parallel batches; every run must exit cleanly.
+test.skipIf(!isASAN || isWindows)(
+  "compiled server exiting right after its fetches complete does not leak the fetch tasklet",
+  async () => {
+    using dir = tempDir("fetch-exit-leak", {
+      "entry.ts": `
+        import home from "./home.html";
+        import about from "./about.html";
+
+        using server = Bun.serve({
+          port: 0,
+          routes: {
+            "/": home,
+            "/about": about,
+          },
+        });
+
+        const homeRes = await fetch(server.url);
+        console.log("Home status:", homeRes.status);
+        const homeHtml = await homeRes.text();
+        console.log("Home has content:", homeHtml.includes("Home Page"));
+
+        const aboutRes = await fetch(server.url + "about");
+        console.log("About status:", aboutRes.status);
+        const aboutHtml = await aboutRes.text();
+        console.log("About has content:", aboutHtml.includes("About Page"));
+      `,
+      "home.html": `<!DOCTYPE html><html><head><title>Home</title><link rel="stylesheet" href="./styles.css"></head><body><h1>Home Page</h1><script src="./app.js"></script></body></html>`,
+      "about.html": `<!DOCTYPE html><html><head><title>About</title><link rel="stylesheet" href="./styles.css"></head><body><h1>About Page</h1><script src="./app.js"></script></body></html>`,
+      "styles.css": `body { margin: 0; }`,
+      "app.js": `console.log("App loaded");`,
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./entry.ts", "--outfile=server"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildOut, buildErr, buildCode] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect({ buildErr: buildErr.includes("error") ? buildErr : "", buildOut: "", buildCode }).toEqual({
+      buildErr: "",
+      buildOut: "",
+      buildCode: 0,
+    });
+
+    const env = {
+      ...bunEnv,
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1", "abort_on_error=1"].filter(Boolean).join(":"),
+      LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+    };
+    const expectedStdout = "Home status: 200\nHome has content: true\nAbout status: 200\nAbout has content: true\n";
+
+    for (let round = 0; round < 24; round++) {
+      const procs = Array.from({ length: 8 }, () =>
+        Bun.spawn({
+          cmd: [join(String(dir), "server")],
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        }),
+      );
+      const results = await Promise.all(
+        procs.map(async proc => {
+          const [stdout, stderr, exitCode] = await Promise.all([
+            proc.stdout.text(),
+            proc.stderr.text(),
+            proc.exited,
+          ]);
+          return { stdout, stderr, exitCode };
+        }),
+      );
+      for (const result of results) {
+        expect(result).toEqual({ stdout: expectedStdout, stderr: "", exitCode: 0 });
+      }
+    }
+  },
+  // 192 compiled-binary runs; LSan symbolizes through llvm-symbolizer on
+  // failure, which is slow against the debug binary.
+  240_000,
+);

--- a/test/js/web/fetch/exiting.test.ts
+++ b/test/js/web/fetch/exiting.test.ts
@@ -34,8 +34,101 @@ test("abort the request on the other side if the stream is canceled", async () =
 // reclaim to an event loop that never ticks again. That handoff used to be
 // dropped unrun at shutdown, orphaning the FetchTasklet / AsyncHTTP / native
 // Response cycle, which LeakSanitizer reported at exit (SIGABRT) in compiled
-// server binaries. The handoff is a scheduling race, so this runs the compiled
-// server repeatedly, in parallel batches; every run must exit cleanly.
+// server binaries.
+//
+// Deterministic variant: the fault-injection flag holds the HTTP thread's
+// trailing deref so the JS thread always wins the final-deref race, and the
+// process.on("exit") spin keeps `is_shutting_down` unset long enough that the
+// handoff always lands after the event loop's last drain. Every run reclaims
+// the handoff through the shutdown release pass (or leaks, before the fix).
+test.skipIf(!isASAN || isWindows)(
+  "fetch tasklet handed off to an exiting event loop is reclaimed (deterministic)",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+          server.unref();
+          const res = await fetch(server.url);
+          await res.text();
+          process.on("exit", () => {
+            const end = Date.now() + 1000;
+            while (Date.now() < end) {}
+          });
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1", "abort_on_error=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  30_000,
+);
+
+// Exit in the middle of a streaming upload: the request is still in
+// `in_flight` on the HTTP thread, the request-body sink holds a tasklet ref,
+// and a queued drain hop may be pending. The shutdown reclaim path must
+// release all of them (LSan reports whatever it misses).
+test.skipIf(!isASAN || isWindows)(
+  "exiting mid streaming upload reclaims the in-flight fetch tasklet",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+              const reader = req.body.getReader();
+              await reader.read();
+              // First chunk arrived; the upload is in flight. Exit now.
+              process.exit(0);
+            },
+          });
+          const chunk = new Uint8Array(65536);
+          fetch(server.url, {
+            method: "POST",
+            body: new ReadableStream({
+              pull(controller) {
+                controller.enqueue(chunk);
+                // never closes
+              },
+            }),
+          }).catch(() => {});
+          // Park until the server handler exits the process.
+          await new Promise(() => {});
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1", "abort_on_error=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  30_000,
+);
+
+// The original CI reproduction: a compiled server whose fetches complete right
+// before exit. The handoff is a scheduling race here, so this runs the
+// compiled server repeatedly, in parallel batches; every run must exit
+// cleanly.
 test.skipIf(!isASAN || isWindows)(
   "compiled server exiting right after its fetches complete does not leak the fetch tasklet",
   async () => {


### PR DESCRIPTION
Fixes a LeakSanitizer SIGABRT at exit in compiled server binaries whose fetches complete right before the process exits. Seen on the debian 13 x64-asan lane in `test/bundler/bundler_html_server.test.ts` (`compile/cli/HTMLServerMultipleRoutes`), e.g. [build 90301](https://buildkite.com/bun/bun/builds/90301): the binary prints all four expected lines, then aborts at exit with:

```
==12327==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 2168 byte(s) in 1 object(s) allocated from:
    ...
    #11 in new<bun_http::async_http::AsyncHTTP>
    #12 in get src/runtime/webcore/fetch/FetchTasklet.rs
```

7 indirect leaks total, all one cycle: the `FetchTasklet`, its `Box<AsyncHTTP>`, the native `Response` from `on_resolve`, and the `ProxySettings` allocations owned by the `AsyncHTTP`.

### Cause

`FetchTasklet::callback` (HTTP thread) enqueues the final `on_progress_update`, unlocks the tasklet mutex, and then drops the HTTP-side ref via `deref_from_thread`. The JS thread is often already parked on that mutex inside `on_progress_update`, so the unlock hands execution straight over: the JS thread runs the entire final update, drops the JS-side ref, and the HTTP thread's trailing deref then observes the 1→0 transition with the VM still running. In a compiled two-fetch server this handoff ordering happens in roughly 10-15% of runs.

`deref_from_thread` handled that case by queueing the deinit to the JS event loop as a generic `ManagedTask` (`ConcurrentTask::from_callback`, `cleanup: None`). If the script has already finished, that task never runs:

1. `release_queued_tasks_for_shutdown` deliberately re-queues `ManagedTask`s unrun (their owners cancel raw back-pointers from `Drop` during `destructOnExit`, so they cannot be freed there), and
2. `EventLoop::deinit` then frees the queued box without invoking its callback.

The tasklet pointer is discarded with the box. The tasklet ⇄ `Box<AsyncHTTP>` ⇄ native `Response` cycle has no other owner visible to LSan (the JS `Response` wrapper's pointer lives in the JSC heap, which LSan does not scan), so the whole chain is reported as indirect leaks and the process aborts.

Instrumented builds confirm the sequence: every failing run logs the handoff enqueue followed by `EventLoop::deinit` dropping exactly that task, and no deinit for that tasklet; passing runs show the handoff being dispatched normally.

### Fix

Queue the handoff under its own task tag, `FetchTaskletDeinit`, instead of a generic `ManagedTask`:

- normal dispatch runs the same `deinit` the `ManagedTask` callback ran before, and
- the shutdown release pass (`__bun_release_task_at_shutdown`, JS thread, before `destructOnExit`) now reclaims a never-dispatched handoff in the same window the parked HTTP-thread reclaims (`dealloc_for_shutdown` → `shutdown_for_exit` drain) already use.

The request-body drain hop queued by `on_write_request_data_drain` had the same shape (a `ManagedTask` owning a +1 on the tasklet), with a much narrower trigger (a streaming upload racing a forced exit). It now uses its own tag as well; its shutdown-release arm just drops the queued ref.

### Verification

The handoff losing the race against the last event-loop drain is a scheduling coincidence, so the numbers are statistical:

- unfixed: LSan abort in 3/168 and 3/416 compiled-server runs under parallel CPU load; the new test fails 2 of 3 executions (192 child runs each) on an idle 16-core machine.
- fixed: 0 aborts in 640 runs under identical load. One of those runs hit the exact failing interleaving (handoff enqueued after the loop's last drain) and was reclaimed by the shutdown pass, exiting clean. The new test passes 3/3, and `test/bundler/bundler_html_server.test.ts` passes.

Three tests in `test/js/web/fetch/exiting.test.ts`, all ASAN-only, all under `detect_leaks=1` + `BUN_DESTRUCT_VM_ON_EXIT=1`:

- a deterministic variant: a test-only fault-injection flag (`BUN_INTERNAL_FETCH_DELAY_DEREF_FROM_THREAD`) holds the HTTP thread's trailing deref, and a `process.on("exit")` spin keeps `is_shutting_down` unset, so the handoff lands in the leak window and is reclaimed through the shutdown release pass on every run (verified via log ordering, 5/5);
- an exit-mid-streaming-upload scenario, the state `release_at_shutdown` and the drain-hop shutdown arm exist for;
- the original CI shape: the compiled two-fetch HTML server run 192 times in parallel batches. The organic window is a few hundred nanoseconds wide on the HTTP thread, so this one is probabilistic: it reproduced the leak in most, but not all, executions against an unfixed build.

Related: #32707 closes the same unlock window from the other side (holding the mutex through the HTTP thread's deref so it is never the final one) to fix the `assert_no_refs` panic in the deferred deinit. The two changes compose; this one makes the handoff safe whenever it does happen.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/exiting.test.ts

<!-- robobun:evidence:end -->