### PR TITLE
bun -p/--print: report a throw raised while formatting the result

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -259,7 +259,7 @@ fn vm_console(global: &JSGlobalObject) -> *mut ConsoleObject {
 /// box. Consolidates the open-coded `&mut *vm_console(global)` deref at the
 /// `Bun__ConsoleObject__*` FFI entry points (each is a top-level JS-thread
 /// host call, so the `&mut` is exclusive for the duration). Callers that need
-/// to interleave borrows across a deferred guard (`message_with_type_and_level_`)
+/// to interleave borrows across a deferred guard (`try_message_with_type_and_level`)
 /// keep using the raw [`vm_console`] pointer instead.
 #[inline]
 unsafe fn vm_console_mut<'a>(global: &JSGlobalObject) -> &'a mut ConsoleObject {
@@ -351,14 +351,16 @@ impl Drop for FlushOnDrop<'_> {
 /// <https://console.spec.whatwg.org/#formatter>
 #[crate::host_call]
 pub extern "C" fn message_with_type_and_level(
-    ctype: *mut ConsoleObject,
+    _ctype: *mut ConsoleObject,
     message_type: MessageType,
     level: MessageLevel,
     global: &JSGlobalObject,
     vals: *const JSValue,
     len: usize,
 ) {
-    if let Err(err) = message_with_type_and_level_(ctype, message_type, level, global, vals, len) {
+    // SAFETY: forwards our own caller's `vals`/`len` contract.
+    let result = unsafe { try_message_with_type_and_level(message_type, level, global, vals, len) };
+    if let Err(err) = result {
         // The exception is already set on the VM (`JsError::Thrown`); for OOM
         // make sure something is pending. Mirrors `host_fn::void_from_js_error`.
         if matches!(err, jsc::JsError::OutOfMemory) {
@@ -368,8 +370,14 @@ pub extern "C" fn message_with_type_and_level(
     }
 }
 
-fn message_with_type_and_level_(
-    _ctype: *mut ConsoleObject,
+/// Fallible form of [`message_with_type_and_level`] for callers that must
+/// observe a throw raised while formatting (a custom `inspect`, getter, or
+/// Proxy trap). On `Err(Thrown)` the exception is pending on the VM;
+/// `Err(OutOfMemory)` has nothing pending yet (`take_exception` throws it).
+///
+/// # Safety
+/// `vals` must point to `len` readable `JSValue`s that outlive the call.
+pub unsafe fn try_message_with_type_and_level(
     message_type: MessageType,
     level: MessageLevel,
     global: &JSGlobalObject,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -371,9 +371,8 @@ pub extern "C" fn message_with_type_and_level(
 }
 
 /// Fallible form of [`message_with_type_and_level`] for callers that must
-/// observe a throw raised while formatting (a custom `inspect`, getter, or
-/// Proxy trap). On `Err(Thrown)` the exception is pending on the VM;
-/// `Err(OutOfMemory)` has nothing pending yet (`take_exception` throws it).
+/// observe a formatter throw. On `Err(Thrown)` the exception is pending on
+/// the VM; on `Err(OutOfMemory)` nothing is pending yet.
 ///
 /// # Safety
 /// `vals` must point to `len` readable `JSValue`s that outlive the call.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -16,7 +16,7 @@ use bun_core::{pretty, pretty_errorln, prettyln};
 use bun_dotenv as DotEnv;
 use bun_jsc::js_promise::Status as PromiseStatus;
 use bun_jsc::virtual_machine::{InitOptions as VmInitOptions, VirtualMachine};
-use bun_jsc::{JSGlobalObject, JSValue};
+use bun_jsc::{JSGlobalObject, JSValue, JsResultExt};
 use bun_md::root as md;
 use bun_options_types::schema::api;
 #[cfg(windows)]
@@ -1607,18 +1607,22 @@ impl Run {
                     }
                     result
                 };
-                // SAFETY: `vals[..1]` is the single stack `to_print`; null
-                // `ctype` routes to the VM's stdout/stderr default.
-                unsafe {
-                    bun_jsc::ConsoleObject::message_with_type_and_level(
-                        ::core::ptr::null_mut(),
+                // SAFETY: `vals[..1]` is the single stack `to_print`.
+                let printed = unsafe {
+                    bun_jsc::ConsoleObject::try_message_with_type_and_level(
                         bun_jsc::ConsoleObject::MessageType::Log,
                         bun_jsc::ConsoleObject::MessageLevel::Log,
                         vm.global(),
                         &raw const to_print,
                         1,
-                    );
-                }
+                    )
+                };
+                // A throw raised while formatting the result (a custom
+                // inspect, getter, or Proxy trap) is an uncaughtException in
+                // node's `-p`: report it so it prints and sets a non-zero
+                // exit code instead of being swallowed. The fall-through
+                // shutdown below picks up the exit code.
+                printed.report_unhandled(vm.global());
             }
 
             vm.on_before_exit();

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1617,11 +1617,9 @@ impl Run {
                         1,
                     )
                 };
-                // A throw raised while formatting the result (a custom
-                // inspect, getter, or Proxy trap) is an uncaughtException in
-                // node's `-p`: report it so it prints and sets a non-zero
-                // exit code instead of being swallowed. The fall-through
-                // shutdown below picks up the exit code.
+                // node's `-p` reports a formatter throw as an
+                // uncaughtException; the shutdown below picks up the exit
+                // code it sets.
                 printed.report_unhandled(vm.global());
             }
 

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -23,7 +23,7 @@
 use core::ffi::c_void;
 
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::{CallFrame, JSGlobalObject, JSInternalPromise, JSValue, ZigStackFrame};
+use bun_jsc::{CallFrame, JSGlobalObject, JSInternalPromise, JSValue, JsResultExt, ZigStackFrame};
 
 // ─── VirtualMachine ──────────────────────────────────────────────────────────
 //
@@ -310,19 +310,20 @@ pub fn on_resolve_entry_point_result(
     callframe: &CallFrame,
 ) -> bun_jsc::JsResult<JSValue> {
     let result = callframe.argument(0);
-    // SAFETY: `vals[..len]` is the single stack `result`; `ctype` is ignored by
-    // `message_with_type_and_level` (it always resolves the per-VM console via
-    // `vm_console(global)`), so null is fine.
-    unsafe {
-        bun_jsc::ConsoleObject::message_with_type_and_level(
-            core::ptr::null_mut(),
+    // SAFETY: `vals[..len]` is the single stack `result`.
+    let printed = unsafe {
+        bun_jsc::ConsoleObject::try_message_with_type_and_level(
             bun_jsc::ConsoleObject::MessageType::Log,
             bun_jsc::ConsoleObject::MessageLevel::Log,
             global,
             &raw const result,
             1,
-        );
-    }
+        )
+    };
+    // A throw raised while formatting the `--print` result (a custom inspect,
+    // getter, or Proxy trap) is an uncaughtException in node: report it so it
+    // prints and sets a non-zero exit code instead of being swallowed.
+    printed.report_unhandled(global);
     // SAFETY: bun_vm() never null for a Bun-owned global.
     bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
 }
@@ -333,19 +334,19 @@ pub fn on_reject_entry_point_result(
     callframe: &CallFrame,
 ) -> bun_jsc::JsResult<JSValue> {
     let result = callframe.argument(0);
-    // SAFETY: `vals[..len]` is the single stack `result`; `ctype` is ignored by
-    // `message_with_type_and_level` (it always resolves the per-VM console via
-    // `vm_console(global)`), so null is fine.
-    unsafe {
-        bun_jsc::ConsoleObject::message_with_type_and_level(
-            core::ptr::null_mut(),
+    // SAFETY: `vals[..len]` is the single stack `result`.
+    let printed = unsafe {
+        bun_jsc::ConsoleObject::try_message_with_type_and_level(
             bun_jsc::ConsoleObject::MessageType::Log,
             bun_jsc::ConsoleObject::MessageLevel::Log,
             global,
             &raw const result,
             1,
-        );
-    }
+        )
+    };
+    // See on_resolve_entry_point_result: a formatter throw must be reported,
+    // not swallowed.
+    printed.report_unhandled(global);
     // SAFETY: bun_vm() never null for a Bun-owned global.
     bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
 }

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -320,9 +320,8 @@ pub fn on_resolve_entry_point_result(
             1,
         )
     };
-    // A throw raised while formatting the `--print` result (a custom inspect,
-    // getter, or Proxy trap) is an uncaughtException in node: report it so it
-    // prints and sets a non-zero exit code instead of being swallowed.
+    // node's `-p` reports a formatter throw as an uncaughtException;
+    // `exit_handler.exit_code` reflects it in the exit below.
     printed.report_unhandled(global);
     // SAFETY: bun_vm() never null for a Bun-owned global.
     bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
@@ -344,8 +343,7 @@ pub fn on_reject_entry_point_result(
             1,
         )
     };
-    // See on_resolve_entry_point_result: a formatter throw must be reported,
-    // not swallowed.
+    // Same as on_resolve_entry_point_result: report a formatter throw.
     printed.report_unhandled(global);
     // SAFETY: bun_vm() never null for a Bun-owned global.
     bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -175,6 +175,44 @@ describe("--print for cjs/esm", () => {
   });
 });
 
+describe.concurrent("--print reports a throw raised while formatting the result", () => {
+  const throwingInspect = '({ [Symbol.for("nodejs.util.inspect.custom")]() { throw new Error("inspect failed"); } })';
+
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--print", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("sync result", async () => {
+    const { stdout, stderr, exitCode } = await run(throwingInspect);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("inspect failed");
+    expect(exitCode).toBe(1);
+  });
+
+  test("awaited result", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `await new Promise(resolve => setTimeout(() => resolve(${throwingInspect}), 1))`,
+    );
+    expect(stdout).toBe("");
+    expect(stderr).toContain("inspect failed");
+    expect(exitCode).toBe(1);
+  });
+
+  test("an uncaughtException handler observes the throw", async () => {
+    const { stderr, exitCode } = await run(
+      `process.on("uncaughtException", err => console.error("caught:", err.message)); ${throwingInspect}`,
+    );
+    expect(stderr).toContain("caught: inspect failed");
+    expect(exitCode).toBe(0);
+  });
+});
+
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {
   test("it works", async () => {
     const { stdout } = run('console.log("hello world")');

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -204,6 +204,18 @@ describe.concurrent("--print reports a throw raised while formatting the result"
     expect(exitCode).toBe(1);
   });
 
+  test("result settled after the event loop drains", async () => {
+    // An unref'd timer made overdue by a sync sleep: the event loop drains
+    // with the entry promise still pending, so this prints via the
+    // entry-point promise reactions instead of the settled-result path.
+    const { stdout, stderr, exitCode } = await run(
+      `await new Promise(resolve => { setTimeout(() => resolve(${throwingInspect}), 1).unref(); Bun.sleepSync(50); })`,
+    );
+    expect(stdout).toBe("");
+    expect(stderr).toContain("inspect failed");
+    expect(exitCode).toBe(1);
+  });
+
   test("an uncaughtException handler observes the throw", async () => {
     const { stderr, exitCode } = await run(
       `process.on("uncaughtException", err => console.error("caught:", err.message)); ${throwingInspect}`,


### PR DESCRIPTION
### Problem

`bun --print` (and `-p` / `-pe`) swallows an exception thrown while formatting the result: bun prints nothing and exits 0. Node prints the error with its stack and exits 1.

```sh
bun --print '({ [Symbol.for("nodejs.util.inspect.custom")]() { throw new Error("inspect failed"); } })'
echo "exit=$?"
# bun:  <no output>   exit=0
# node -p: [eval]:1 ... Error: inspect failed  (stack)   exit=1
```

A script using `bun -p` as a probe sees success with empty output. `console.log` of the same value throws catchably, so only the entry-point print path dropped it.

### Cause

All three places that print the `--print` result (the settled-result path in `run_command.rs`, and the entry-point promise resolve/reject handlers in `hw_exports.rs`) call the console formatter through the void C-ABI wrapper, which leaves a formatter throw pending on the VM, and then exit with the stale exit code. The exception (from a custom `util.inspect.custom`, a getter, or a Proxy trap) is never reported and never reflected in the exit code.

### Fix

Expose the formatter's fallible form (`ConsoleObject::try_message_with_type_and_level`) and route the error through `JsResultExt::report_unhandled` at the three print sites. That is the same uncaughtException machinery node uses here: `process.on("uncaughtException")` handlers observe the throw, and when unhandled the error is printed and the exit code set to 1. The C-ABI wrapper used by `console.log` keeps its existing behavior (exception stays pending for JSC to propagate).

```sh
# after
bun --print '({ [Symbol.for("nodejs.util.inspect.custom")]() { throw new Error("inspect failed"); } })'
# error: inspect failed
#       at [nodejs.util.inspect.custom] ([eval]:1:83)
# exit=1
```

`process.exitCode` set from a handler is honored (exit 7 if the handler sets 7), matching node.

### Verification

Three new tests in `test/cli/run/run-eval.test.ts` (sync result, awaited result, uncaughtException handler): all fail on the released 1.4.0 canary and pass with this change. Full `run-eval.test.ts` (40 tests) and the console suites pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->