### PR TITLE
Fix main build: restore PartTag::JsxImport

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1089,6 +1089,7 @@ pub type PartList<'a> = bun_alloc::ArenaVec<'a, Part>;
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum PartTag {
     None,
+    JsxImport,
     Runtime,
     ReactCompiler,
     DirnameFilename,

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1146,6 +1146,26 @@ describe("bundler", () => {
       },
     });
 
+    // Transpile-only output (--no-bundle, same single-file path as the
+    // runtime transpiler) never tree-shakes parts, so the synthesized runtime
+    // import must survive even when every JSX expression is dead.
+    itBundled("jsx/AutoImportKeptWhenNotBundling", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const unused = <div>dead</div>;
+          console.log('only-this');
+        `,
+      },
+      bundling: false,
+      jsx: { runtime: "automatic" },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).toMatch(/from\s*"react\/jsx-(dev-)?runtime"/);
+        // Transpile-only keeps the hashed import alias, e.g. `jsx_w77yafs4(`.
+        expect(file).toMatch(/jsx(DEV)?(_\w+)?\(/);
+      },
+    });
+
     // Two entry modules: one where JSX survives, one where it is all dead.
     // The JSX source must be bundled (for the live entry) without leaking an
     // extra import into the dead entry's chunk.


### PR DESCRIPTION
### What does this PR do?

Main at 6089d0e83f does not compile:

```
error[E0599]: no variant, associated function, or constant named `JsxImport` found for enum `PartTag`
    --> src/js_parser/p.rs:1917:45
```

(also at `src/js_parser/parse/parse_entry.rs:1966` and `:1981`)

This is a semantic conflict between two PRs that each passed CI on their own merge base:

- #36833 removed the then-unused `JsxImport`, `CjsImports`, and `ReactFastRefresh` variants from `PartTag` in `src/ast/nodes.rs` as dead code.
- #35472, written before that removal, started tagging synthesized JSX runtime imports with `PartTag::JsxImport` in the parser and matching on it in `LinkerContext.rs`.

The fix re-adds the `JsxImport` variant in its old position. The other two removed variants are still unused and stay gone. `PartTag` has no explicit `repr` and is never serialized, so the variant's position carries no meaning; matching the old order keeps the diff minimal against history.

### Why a test change?

The build failure itself is the regression, so any test proves fail-before. The added test pins the one path of #35472's feature the suite did not cover: transpile-only output (`--no-bundle`, the same single-file path the runtime transpiler uses) never tree-shakes parts, so the synthesized JSX runtime import must survive even when every JSX expression is dead. Verified the other direction (bundler drops the import for dead JSX) is already covered by the `autoImportTreeShaking` tests from #35472, which now compile and pass again.

### Verification

- `cargo check -p bun_js_parser` fails with 3x E0599 before, clean after
- `bun bd` builds
- `bun bd test test/bundler/bundler_jsx.test.ts`: 48 pass, 4 todo (pre-existing), 0 fail