### PR TITLE
Fix crashes when inspecting objects whose property enumeration throws

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -449,8 +449,13 @@ export function windowsEnv(
   editWindowsEnvVar: EditWindowsEnvVarCb,
   coerceForWrite,
   resetForDelete,
+  inspectCustomSymbol: symbol,
 ) {
-  (internalEnv as any)[Bun.inspect.custom] = () => {
+  // The symbol is passed from C++ rather than read off Bun.inspect.custom:
+  // reading Bun.inspect here reifies a lazy property on the Bun object, and env
+  // setup can run inside another Bun lazy property's initializer, where that
+  // structure transition poisons the outer property lookup if it then throws.
+  (internalEnv as any)[inspectCustomSymbol] = () => {
     let o = {};
     for (let k of envMapList) {
       o[k] = internalEnv[k.toUpperCase()];

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1528,7 +1528,11 @@ function parseSQLiteOptions(
 
 const DEFAULT_PROTOCOL: Bun.SQL.__internal.Adapter = "postgres";
 
-const env = Bun.env;
+// Same object as Bun.env, but reading it through process keeps this module's
+// evaluation from reifying a property on the Bun object: it runs inside the
+// Bun.sql / Bun.SQL lazy initializers, and a structure transition there
+// followed by a throw later in the tree breaks the in-progress lookup.
+const env = process.env;
 
 /**
  * Reads environment variables to try and find a connnection string

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -27,6 +27,7 @@
 #include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/PropertyDescriptor.h>
+#include <JavaScriptCore/Symbol.h>
 #include "BunProcess.h"
 #include "ScriptExecutionContext.h"
 #include "SharedEnvStore.h"
@@ -1142,6 +1143,7 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     args.append(editWindowsEnvVar);
     args.append(JSC::JSFunction::create(vm, globalObject, 2, "coerceForWrite"_s, jsProcessEnvCoerceForWrite, ImplementationVisibility::Private));
     args.append(JSC::JSFunction::create(vm, globalObject, 1, "resetForDelete"_s, jsProcessEnvResetForDelete, ImplementationVisibility::Private));
+    args.append(JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey("nodejs.util.inspect.custom"_s).get()));
     auto clientData = WebCore::clientData(vm);
     JSC::CallData callData = JSC::getCallData(getSourceEvent);
     NakedPtr<JSC::Exception> returnedException = nullptr;

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -49,12 +49,16 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // If node:util fails to evaluate (e.g. a clobbered global), returning the
+    // receiver makes the formatter fall back to default formatting for this
+    // value; nothing is cached, so a later inspect retries the load.
     JSFunction* inspectFn = globalObject->utilInspectFunction();
-    JSObject* options = inspectFn ? Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors) : nullptr;
-    if (!options) [[unlikely]] {
-        // node:util failed to evaluate (e.g. a clobbered global). Returning the
-        // receiver makes the formatter fall back to default formatting for this
-        // value; nothing is cached, so a later inspect retries the load.
+    if (scope.exception() || !inspectFn) [[unlikely]] {
+        (void)scope.tryClearException();
+        return JSValue::encode(thisValue);
+    }
+    JSObject* options = Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors);
+    if (scope.exception() || !options) [[unlikely]] {
         (void)scope.tryClearException();
         return JSValue::encode(thisValue);
     }

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -49,16 +49,12 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSObject* options = Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors);
-    if (scope.exception() || !options) [[unlikely]] {
-        // node:util failed to evaluate (e.g. a clobbered global). Returning the
-        // receiver makes the formatter fall back to default formatting.
-        (void)scope.tryClearException();
-        return JSValue::encode(thisValue);
-    }
-
     JSFunction* inspectFn = globalObject->utilInspectFunction();
-    if (scope.exception()) [[unlikely]] {
+    JSObject* options = inspectFn ? Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors) : nullptr;
+    if (!options) [[unlikely]] {
+        // node:util failed to evaluate (e.g. a clobbered global). Returning the
+        // receiver makes the formatter fall back to default formatting for this
+        // value; nothing is cached, so a later inspect retries the load.
         (void)scope.tryClearException();
         return JSValue::encode(thisValue);
     }

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -50,10 +50,18 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* options = Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception() || !options) [[unlikely]] {
+        // node:util failed to evaluate (e.g. a clobbered global). Returning the
+        // receiver makes the formatter fall back to default formatting.
+        (void)scope.tryClearException();
+        return JSValue::encode(thisValue);
+    }
 
     JSFunction* inspectFn = globalObject->utilInspectFunction();
-    RETURN_IF_EXCEPTION(scope, {});
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return JSValue::encode(thisValue);
+    }
     auto callData = JSC::getCallData(functionToCall);
     MarkedArgumentBuffer arguments;
     arguments.append(jsNumber(depth));

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1929,16 +1929,6 @@ extern "C" napi_env ZigGlobalObject__makeNapiEnvForFFI(Zig::GlobalObject* global
     return globalObject->makeNapiEnvForFFI();
 }
 
-// Fallback for m_utilInspectFunction when the node:util module fails to
-// evaluate (e.g. the script clobbered a global it depends on). LazyProperty
-// initializers must always set a value, so this stands in for util.inspect.
-JSC_DEFINE_HOST_FUNCTION(jsFunctionUtilInspectFallback, (JSGlobalObject * globalObject, CallFrame* callframe))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_AND_RETURN(scope, JSValue::encode(callframe->argument(0).toString(globalObject)));
-}
-
 JSC_DEFINE_HOST_FUNCTION(jsFunctionPerformMicrotaskVariadic, (JSGlobalObject * globalObject, CallFrame* callframe))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -2313,24 +2303,6 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(JSFunction::create(init.vm, init.owner, 4, "performMicrotaskVariadic"_s, jsFunctionPerformMicrotaskVariadic, ImplementationVisibility::Public));
         });
 
-    m_utilInspectFunction.initLater(
-        [](const Initializer<JSFunction>& init) {
-            auto scope = DECLARE_THROW_SCOPE(init.vm);
-            JSValue prop;
-            JSValue nodeUtilValue = uncheckedDowncast<Zig::GlobalObject>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-            if (!scope.exception()) [[likely]] {
-                RELEASE_ASSERT(nodeUtilValue.isObject());
-                prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-            }
-            // A LazyProperty initializer must set a value even when the module
-            // fails to evaluate; the exception stays pending for the caller.
-            if (scope.exception() || !prop) [[unlikely]] {
-                init.set(JSFunction::create(init.vm, init.owner, 2, String(), jsFunctionUtilInspectFallback, ImplementationVisibility::Private));
-                return;
-            }
-            init.set(uncheckedDowncast<JSFunction>(prop));
-        });
-
     m_utilInspectOptionsStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(Bun::createUtilInspectOptionsStructure(init.vm, init.owner));
@@ -2343,31 +2315,6 @@ void GlobalObject::finishCreation(VM& vm)
                 init.owner);
 
             init.set(ErrorCodeCache::create(init.vm, structure));
-        });
-
-    m_utilInspectStylizeColorFunction.initLater(
-        [](const Initializer<JSFunction>& init) {
-            auto scope = DECLARE_THROW_SCOPE(init.vm);
-            JSValue result;
-            JSC::MarkedArgumentBuffer args;
-            args.append(uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction());
-            if (!scope.exception()) [[likely]] {
-                JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-
-                JSC::CallData callData = JSC::getCallData(getStylize);
-                NakedPtr<JSC::Exception> returnedException = nullptr;
-                result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-                if (returnedException && !scope.exception()) {
-                    throwException(init.owner, scope, returnedException.get());
-                }
-            }
-            // A LazyProperty initializer must set a value even on failure; fall
-            // back to the no-color stylize and leave the exception pending.
-            if (scope.exception() || !result) [[unlikely]] {
-                init.set(JSC::JSFunction::create(init.vm, init.owner, utilInspectStylizeWithNoColorCodeGenerator(init.vm), init.owner));
-                return;
-            }
-            init.set(uncheckedDowncast<JSFunction>(result));
         });
 
     m_utilInspectStylizeNoColorFunction.initLater(
@@ -3096,6 +3043,48 @@ EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
 JSC::JSObject* GlobalObject::navigatorObject()
 {
     return this->m_navigatorObject.get(this);
+}
+
+// Not a LazyProperty: those are set-once, and evaluating node:util can fail
+// transiently (stack overflow, a clobbered global the script restores later).
+// On failure this returns null with the exception pending and nothing is
+// cached, so the next caller retries the load.
+JSC::JSFunction* GlobalObject::utilInspectFunction()
+{
+    if (auto* cached = m_utilInspectFunction.get())
+        return cached;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue nodeUtilValue = internalModuleRegistry()->requireId(this, vm, Bun::InternalModuleRegistry::Field::NodeUtil);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_ASSERT(nodeUtilValue.isObject());
+    JSValue inspect = nodeUtilValue.getObject()->getIfPropertyExists(this, Identifier::fromString(vm, "inspect"_s));
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    ASSERT(inspect);
+    auto* inspectFunction = uncheckedDowncast<JSFunction>(inspect);
+    m_utilInspectFunction.set(vm, this, inspectFunction);
+    return inspectFunction;
+}
+
+JSC::JSFunction* GlobalObject::utilInspectStylizeColorFunction()
+{
+    if (auto* cached = m_utilInspectStylizeColorFunction.get())
+        return cached;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSFunction* inspect = utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    JSFunction* getStylize = JSFunction::create(vm, this, utilInspectGetStylizeWithColorCodeGenerator(vm), this);
+    MarkedArgumentBuffer args;
+    args.append(inspect);
+    JSValue stylize = JSC::profiledCall(this, ProfilingReason::API, getStylize, JSC::getCallData(getStylize), jsNull(), args);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    auto* stylizeFunction = uncheckedDowncast<JSFunction>(stylize);
+    m_utilInspectStylizeColorFunction.set(vm, this, stylizeFunction);
+    return stylizeFunction;
 }
 
 JSC_DEFINE_CUSTOM_GETTER(functionLazyNavigatorGetter,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1929,6 +1929,16 @@ extern "C" napi_env ZigGlobalObject__makeNapiEnvForFFI(Zig::GlobalObject* global
     return globalObject->makeNapiEnvForFFI();
 }
 
+// Fallback for m_utilInspectFunction when the node:util module fails to
+// evaluate (e.g. the script clobbered a global it depends on). LazyProperty
+// initializers must always set a value, so this stands in for util.inspect.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionUtilInspectFallback, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    RELEASE_AND_RETURN(scope, JSValue::encode(callframe->argument(0).toString(globalObject)));
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionPerformMicrotaskVariadic, (JSGlobalObject * globalObject, CallFrame* callframe))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -2306,12 +2316,18 @@ void GlobalObject::finishCreation(VM& vm)
     m_utilInspectFunction.initLater(
         [](const Initializer<JSFunction>& init) {
             auto scope = DECLARE_THROW_SCOPE(init.vm);
+            JSValue prop;
             JSValue nodeUtilValue = uncheckedDowncast<Zig::GlobalObject>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-            RETURN_IF_EXCEPTION(scope, );
-            RELEASE_ASSERT(nodeUtilValue.isObject());
-            auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-            RETURN_IF_EXCEPTION(scope, );
-            ASSERT(prop);
+            if (!scope.exception()) [[likely]] {
+                RELEASE_ASSERT(nodeUtilValue.isObject());
+                prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
+            }
+            // A LazyProperty initializer must set a value even when the module
+            // fails to evaluate; the exception stays pending for the caller.
+            if (scope.exception() || !prop) [[unlikely]] {
+                init.set(JSFunction::create(init.vm, init.owner, 2, String(), jsFunctionUtilInspectFallback, ImplementationVisibility::Private));
+                return;
+            }
             init.set(uncheckedDowncast<JSFunction>(prop));
         });
 
@@ -2332,22 +2348,25 @@ void GlobalObject::finishCreation(VM& vm)
     m_utilInspectStylizeColorFunction.initLater(
         [](const Initializer<JSFunction>& init) {
             auto scope = DECLARE_THROW_SCOPE(init.vm);
+            JSValue result;
             JSC::MarkedArgumentBuffer args;
             args.append(uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction());
-            RETURN_IF_EXCEPTION(scope, );
+            if (!scope.exception()) [[likely]] {
+                JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
 
-            JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-            RETURN_IF_EXCEPTION(scope, );
-
-            JSC::CallData callData = JSC::getCallData(getStylize);
-            NakedPtr<JSC::Exception> returnedException = nullptr;
-            auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-            RETURN_IF_EXCEPTION(scope, );
-
-            if (returnedException) {
-                throwException(init.owner, scope, returnedException.get());
+                JSC::CallData callData = JSC::getCallData(getStylize);
+                NakedPtr<JSC::Exception> returnedException = nullptr;
+                result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
+                if (returnedException && !scope.exception()) {
+                    throwException(init.owner, scope, returnedException.get());
+                }
             }
-            RETURN_IF_EXCEPTION(scope, );
+            // A LazyProperty initializer must set a value even on failure; fall
+            // back to the no-color stylize and leave the exception pending.
+            if (scope.exception() || !result) [[unlikely]] {
+                init.set(JSC::JSFunction::create(init.vm, init.owner, utilInspectStylizeWithNoColorCodeGenerator(init.vm), init.owner));
+                return;
+            }
             init.set(uncheckedDowncast<JSFunction>(result));
         });
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -296,8 +296,9 @@ public:
     JSC::JSFunction* performMicrotaskVariadicFunction() const { return m_performMicrotaskVariadicFunction.getInitializedOnMainThread(this); }
 
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
-    JSC::JSFunction* utilInspectFunction() const { return m_utilInspectFunction.getInitializedOnMainThread(this); }
-    JSC::JSFunction* utilInspectStylizeColorFunction() const { return m_utilInspectStylizeColorFunction.getInitializedOnMainThread(this); }
+    // These two return null with an exception pending if node:util fails to evaluate.
+    JSC::JSFunction* utilInspectFunction();
+    JSC::JSFunction* utilInspectStylizeColorFunction();
     JSC::JSFunction* utilInspectStylizeNoColorFunction() const { return m_utilInspectStylizeNoColorFunction.getInitializedOnMainThread(this); }
 
     JSC::JSFunction* wasmStreamingConsumeStreamFunction() const { return m_wasmStreamingConsumeStreamFunction.getInitializedOnMainThread(this); }
@@ -635,9 +636,9 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketHandlersStructure)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_performMicrotaskVariadicFunction)                   \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectFunction)                                \
+    V(private, WriteBarrier<JSFunction>, m_utilInspectFunction)                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_utilInspectOptionsStructure)                         \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeColorFunction)                    \
+    V(private, WriteBarrier<JSFunction>, m_utilInspectStylizeColorFunction)                                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeNoColorFunction)                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_wasmStreamingConsumeStreamFunction)                 \
     V(private, WebCore::JSStreamsRuntime, m_streamsRuntime)                                                  \

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7049,6 +7049,11 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
     // Get the util.inspect function from the global object
     auto* bunGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     JSC::JSValue inspectFn = bunGlobal->utilInspectFunction();
+    if (scope.exception()) [[unlikely]] {
+        // node:util failed to evaluate; use the toString fallback below.
+        (void)scope.tryClearException();
+        inspectFn = {};
+    }
 
     if (!inspectFn || !inspectFn.isCallable()) {
         // Fallback to toString if util.inspect is not available

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7036,51 +7036,6 @@ extern "C" JSC::EncodedJSValue Bun__REPL__getProperty(
     return JSC::JSValue::encode(result ? result : JSC::jsUndefined());
 }
 
-// Format a value for REPL output using util.inspect style
-extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
-    JSC::JSGlobalObject* globalObject,
-    JSC::EncodedJSValue valueEncoded,
-    int32_t depth,
-    bool colors)
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // Get the util.inspect function from the global object
-    auto* bunGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
-    JSC::JSValue inspectFn = bunGlobal->utilInspectFunction();
-    if (scope.exception()) [[unlikely]] {
-        // node:util failed to evaluate; use the toString fallback below.
-        (void)scope.tryClearException();
-        inspectFn = {};
-    }
-
-    if (!inspectFn || !inspectFn.isCallable()) {
-        // Fallback to toString if util.inspect is not available
-        JSC::JSValue value = JSC::JSValue::decode(valueEncoded);
-        JSString* str = value.toString(globalObject);
-        RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
-        return JSC::JSValue::encode(str);
-    }
-
-    // Create options object
-    JSC::JSObject* options = JSC::constructEmptyObject(globalObject);
-    options->putDirect(vm, JSC::Identifier::fromString(vm, "depth"_s), JSC::jsNumber(depth));
-    options->putDirect(vm, JSC::Identifier::fromString(vm, "colors"_s), JSC::jsBoolean(colors));
-    options->putDirect(vm, JSC::Identifier::fromString(vm, "maxArrayLength"_s), JSC::jsNumber(100));
-    options->putDirect(vm, JSC::Identifier::fromString(vm, "maxStringLength"_s), JSC::jsNumber(10000));
-    options->putDirect(vm, JSC::Identifier::fromString(vm, "breakLength"_s), JSC::jsNumber(80));
-
-    JSC::MarkedArgumentBuffer args;
-    args.append(JSC::JSValue::decode(valueEncoded));
-    args.append(options);
-
-    JSC::JSValue result = JSC::call(globalObject, inspectFn, JSC::ArgList(args), "util.inspect"_s);
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
-
-    return JSC::JSValue::encode(result);
-}
-
 // Collects every ArrayBufferView in a JSArray and the (data, byteLength) span
 // of each. Two passes, mirroring Buffer.concat: the first reads every element
 // into a MarkedArgumentBuffer, so any user code an indexed read can run

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5627,10 +5627,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5702,7 +5703,13 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from "getPrototypeOf" proxy traps.
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                break;
+            }
+            iterating = prototype.getObject();
         }
     }
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -168,7 +168,6 @@ CPP_DECL void JSC__JSFunction__optimizeSoon(JSC::EncodedJSValue JSValue0);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__evaluate(JSC::JSGlobalObject* globalObject, const unsigned char* sourcePtr, size_t sourceLen, const unsigned char* filenamePtr, size_t filenameLen, JSC::EncodedJSValue* exception);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__getCompletions(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue targetValue, const unsigned char* prefixPtr, size_t prefixLen);
 CPP_DECL JSC::EncodedJSValue Bun__REPL__getProperty(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue baseValue, const unsigned char* namePtr, size_t nameLen);
-CPP_DECL JSC::EncodedJSValue Bun__REPL__formatValue(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue valueEncoded, int32_t depth, bool colors);
 
 #pragma mark - JSC::JSGlobalObject
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2077,7 +2077,10 @@ extern "C" napi_status napi_get_all_property_names(
             if (key_mode == napi_key_include_prototypes) {
                 // Climb up the prototype chain to find inherited properties
                 while (!owner->getOwnPropertyDescriptor(globalObject, propKey, desc)) {
-                    JSObject* proto = owner->getPrototype(globalObject).getObject();
+                    JSValue protoValue = owner->getPrototype(globalObject);
+                    // A throwing proxy trap leaves protoValue empty; getObject() on it is a null deref.
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSObject* proto = protoValue.getObject();
                     if (!proto) {
                         break;
                     }

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2091,6 +2091,7 @@ extern "C" napi_status napi_get_all_property_names(
                 }
             } else {
                 owner->getOwnPropertyDescriptor(globalObject, propKey, desc);
+                NAPI_RETURN_IF_EXCEPTION(env);
             }
 
             // V8 never applies ONLY_WRITABLE/ONLY_CONFIGURABLE to Proxy keys

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2077,6 +2077,9 @@ extern "C" napi_status napi_get_all_property_names(
             if (key_mode == napi_key_include_prototypes) {
                 // Climb up the prototype chain to find inherited properties
                 while (!owner->getOwnPropertyDescriptor(globalObject, propKey, desc)) {
+                    // A throwing "getOwnPropertyDescriptor" proxy trap must stop the walk
+                    // before getPrototype runs more JS with the exception pending.
+                    NAPI_RETURN_IF_EXCEPTION(env);
                     JSValue protoValue = owner->getPrototype(globalObject);
                     // A throwing proxy trap leaves protoValue empty; getObject() on it is a null deref.
                     NAPI_RETURN_IF_EXCEPTION(env);

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -898,22 +898,29 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsError,
         // node util.isError relies on toString
         // https://github.com/nodejs/node/blob/cf8c6994e0f764af02da4fa70bc5962142181bf3/doc/api/util.md#L2923
         // util.isError is deprecated and removed in node 23
-        PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
-        bool has = object->getPropertySlot(globalObject, vm.propertyNames->toStringTagSymbol, slot);
-        scope.assertNoException();
-        if (has) {
-            if (slot.isValue()) {
-                JSValue value = slot.getValue(globalObject, vm.propertyNames->toStringTagSymbol);
-                if (value.isString()) {
-                    String tag = asString(value)->value(globalObject);
-                    CLEAR_IF_EXCEPTION(scope);
-                    if (tag == "Error"_s)
-                        return JSValue::encode(jsBoolean(true));
+        {
+            // Scoped: a live VMInquiry slot forbids VM entry, and getPrototype
+            // below can enter JS through a "getPrototypeOf" proxy trap.
+            PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
+            bool has = object->getPropertySlot(globalObject, vm.propertyNames->toStringTagSymbol, slot);
+            scope.assertNoException();
+            if (has) {
+                if (slot.isValue()) {
+                    JSValue value = slot.getValue(globalObject, vm.propertyNames->toStringTagSymbol);
+                    if (value.isString()) {
+                        String tag = asString(value)->value(globalObject);
+                        CLEAR_IF_EXCEPTION(scope);
+                        if (tag == "Error"_s)
+                            return JSValue::encode(jsBoolean(true));
+                    }
                 }
             }
         }
 
         JSValue proto = object->getPrototype(globalObject);
+        // A throwing "getPrototypeOf" proxy trap leaves proto empty, and isCell()
+        // is true for the empty value, so the checks below would deref null.
+        RETURN_IF_EXCEPTION(scope, {});
         if (proto.isCell() && (proto.inherits<JSC::ErrorInstance>() || proto.asCell()->type() == ErrorInstanceType || proto.inherits<JSC::ErrorPrototype>()))
             return JSValue::encode(jsBoolean(true));
     }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -826,13 +826,24 @@ it.concurrent("console.log(Bun) survives a lazy property initializer throwing", 
   expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });
 
-// If node:util fails to evaluate (clobbered globals), custom inspect must fall
-// back to default formatting instead of corrupting the lazy util.inspect slot.
-it.concurrent("console.log falls back when node:util cannot load for custom inspect", async () => {
+// If node:util fails to evaluate (clobbered globals), custom inspect falls back
+// to default formatting for that call, with and without colors, and nothing is
+// cached: repeating the call still falls back, and once node:util can load
+// again the custom hook works, so a transient failure does not degrade inspect
+// for the rest of the process.
+it.concurrent("custom inspect falls back while node:util cannot load and recovers afterwards", async () => {
   const code = `
     const o = { [Symbol.for("nodejs.util.inspect.custom")]() { return "custom!"; } };
+    const RealSymbol = Symbol;
+    const strip = s => s.replace(/\\x1b\\[[0-9;]*m/g, "");
     globalThis.Symbol = -6;
-    console.log(o);
+    console.log("plain:", Bun.inspect(o).includes("custom!") ? "hook ran" : "fell back");
+    const colored = Bun.inspect(o, { colors: true });
+    console.log("colors:", colored.includes("custom!") ? "hook ran" : colored !== strip(colored) ? "fell back with colors" : "fell back without colors");
+    console.log("plain again:", Bun.inspect(o).includes("custom!") ? "hook ran" : "fell back");
+    globalThis.Symbol = RealSymbol;
+    console.log("restored:", Bun.inspect(o));
+    console.log("restored colors:", Bun.inspect(o, { colors: true }));
     console.log("after-inspect");
   `;
   await using proc = Bun.spawn({
@@ -842,10 +853,15 @@ it.concurrent("console.log falls back when node:util cannot load for custom insp
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // The custom hook must not run; the object falls back to default rendering.
-  expect(stdout).toContain("Symbol(nodejs.util.inspect.custom)");
-  expect(stdout).not.toContain("custom!");
-  expect(stdout).toContain("after-inspect");
+  expect(stdout).toMatchInlineSnapshot(`
+    "plain: fell back
+    colors: fell back with colors
+    plain again: fell back
+    restored: custom!
+    restored colors: custom!
+    after-inspect
+    "
+  `);
   expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -842,8 +842,10 @@ it.concurrent("custom inspect falls back while node:util cannot load and recover
     console.log("colors:", colored.includes("custom!") ? "hook ran" : colored !== strip(colored) ? "fell back with colors" : "fell back without colors");
     console.log("plain again:", Bun.inspect(o).includes("custom!") ? "hook ran" : "fell back");
     globalThis.Symbol = RealSymbol;
-    console.log("restored:", Bun.inspect(o));
+    // Colors first: the first successful load and the color stylize setup
+    // then happen inside a single custom inspect call.
     console.log("restored colors:", Bun.inspect(o, { colors: true }));
+    console.log("restored:", Bun.inspect(o));
     console.log("after-inspect");
   `;
   await using proc = Bun.spawn({
@@ -857,8 +859,8 @@ it.concurrent("custom inspect falls back while node:util cannot load and recover
     "plain: fell back
     colors: fell back with colors
     plain again: fell back
-    restored: custom!
     restored colors: custom!
+    restored: custom!
     after-inspect
     "
   `);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -804,6 +804,48 @@ it("CustomEvent", () => {
   `);
 });
 
+// Lazy properties on the Bun object run JS to initialize. If one of them
+// throws during enumeration (here: a clobbered global Symbol breaks Bun.$),
+// the exception must not leak into materializing the next property.
+it.concurrent("console.log(Bun) survives a lazy property initializer throwing", async () => {
+  const code = `
+    globalThis.Symbol = -6;
+    console.log(Bun);
+    console.log("after-inspect");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // Enumeration must make it past the throwing initializers to the end of the table.
+  expect(stdout).toContain("zstdDecompress");
+  expect(stdout).toContain("after-inspect");
+  expect(exitCode).toBe(0);
+});
+
+it.concurrent("console.log survives a throwing getPrototypeOf trap in the prototype chain", async () => {
+  const code = `
+    const proxy = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("trap"); } });
+    const obj = Object.create(proxy);
+    obj.y = 2;
+    console.log(obj);
+    console.log("after-inspect");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toContain("y: 2");
+  expect(stdout).toContain("after-inspect");
+  expect(exitCode).toBe(0);
+});
+
 describe.skipIf(!isASAN)("object mutated while being formatted", () => {
   it("does not read freed property tables", async () => {
     const fixture = `

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -842,6 +842,9 @@ it.concurrent("console.log falls back when node:util cannot load for custom insp
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The custom hook must not run; the object falls back to default rendering.
+  expect(stdout).toContain("Symbol(nodejs.util.inspect.custom)");
+  expect(stdout).not.toContain("custom!");
   expect(stdout).toContain("after-inspect");
   expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -819,11 +819,11 @@ it.concurrent("console.log(Bun) survives a lazy property initializer throwing", 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // Enumeration must make it past the throwing initializers to the end of the table.
   expect(stdout).toContain("zstdDecompress");
   expect(stdout).toContain("after-inspect");
-  expect(exitCode).toBe(0);
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });
 
 it.concurrent("console.log survives a throwing getPrototypeOf trap in the prototype chain", async () => {
@@ -840,10 +840,10 @@ it.concurrent("console.log survives a throwing getPrototypeOf trap in the protot
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toContain("y: 2");
   expect(stdout).toContain("after-inspect");
-  expect(exitCode).toBe(0);
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });
 
 describe.skipIf(!isASAN)("object mutated while being formatted", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -826,6 +826,26 @@ it.concurrent("console.log(Bun) survives a lazy property initializer throwing", 
   expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });
 
+// If node:util fails to evaluate (clobbered globals), custom inspect must fall
+// back to default formatting instead of corrupting the lazy util.inspect slot.
+it.concurrent("console.log falls back when node:util cannot load for custom inspect", async () => {
+  const code = `
+    const o = { [Symbol.for("nodejs.util.inspect.custom")]() { return "custom!"; } };
+    globalThis.Symbol = -6;
+    console.log(o);
+    console.log("after-inspect");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("after-inspect");
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+});
+
 it.concurrent("console.log survives a throwing getPrototypeOf trap in the prototype chain", async () => {
   const code = `
     const proxy = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("trap"); } });

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -23,7 +23,7 @@
 
 import assert from "assert";
 import { describe, expect, it } from "bun:test";
-import "harness";
+import { bunEnv, bunExe } from "harness";
 import util from "util";
 // const context = require('vm').runInNewContext; // TODO: Use a vm polyfill
 
@@ -153,16 +153,27 @@ describe("util", () => {
       strictEqual(util.isError(err8), true);
     });
 
-    it("propagates a throwing getPrototypeOf proxy trap instead of crashing", () => {
-      const proxy = new Proxy(
-        {},
-        {
-          getPrototypeOf() {
-            throw new Error("trap");
-          },
-        },
-      );
-      expect(() => util.isError(proxy)).toThrow("trap");
+    // Spawned: the unfixed binary segfaults on this input, which would take
+    // down the whole test runner if it ran in-process.
+    it("propagates a throwing getPrototypeOf proxy trap instead of crashing", async () => {
+      const code = `
+        const proxy = new Proxy({}, { getPrototypeOf() { throw new Error("trap"); } });
+        try {
+          require("util").isError(proxy);
+          console.log("no-throw");
+        } catch (e) {
+          console.log("caught:", e.message);
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("caught: trap\n");
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
     });
   });
 

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -152,6 +152,18 @@ describe("util", () => {
       let err8 = new Error3();
       strictEqual(util.isError(err8), true);
     });
+
+    it("propagates a throwing getPrototypeOf proxy trap instead of crashing", () => {
+      const proxy = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      );
+      expect(() => util.isError(proxy)).toThrow("trap");
+    });
   });
 
   describe("isObject", () => {

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -1,6 +1,6 @@
 import { SQL } from "bun";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
-import { isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { unlinkSync } from "js/node/fs/export-star-from";
 
 declare module "bun" {
@@ -769,4 +769,34 @@ describe("SQL adapter environment variable precedence", () => {
       });
     });
   });
+});
+
+// The sql module tree is evaluated inside the Bun.sql / Bun.SQL / Bun.postgres
+// lazy property initializers. Its module-scope code must not reify other Bun
+// properties (it used to read Bun.env), because if the tree then fails to
+// evaluate, the Bun object has changed shape underneath the lookup that is
+// still in progress, which debug builds catch as a structure assertion.
+// Spawned because the failure mode is a process abort.
+test("a sql module tree that fails to evaluate throws from the Bun lazy properties", async () => {
+  const code = `
+    globalThis.Error = -6;
+    for (const name of ["sql", "SQL", "postgres"]) {
+      try {
+        Bun[name];
+        console.log(name + ": no throw");
+      } catch (e) {
+        console.log(name + ": threw");
+      }
+    }
+    console.log("after");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("sql: threw\nSQL: threw\npostgres: threw\nafter\n");
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 });

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2203,6 +2203,55 @@ static napi_value test_napi_object_coercion(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// The descriptor-filter walk in napi_get_all_property_names must return
+// napi_pending_exception when a proxy's getOwnPropertyDescriptor trap throws,
+// for both napi_key_own_only and napi_key_include_prototypes. The traps are
+// stateless (keyed on the property name) so Bun and Node print identically.
+static napi_value test_napi_get_all_property_names_throwing_traps(
+    const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+#ifndef _WIN32
+  BlockingStdoutScope blocking_stdout;
+#endif
+
+  napi_value setup;
+  NODE_API_CALL(
+      env,
+      napi_create_string_utf8(
+          env,
+          "(() => {"
+          "  const handler = {"
+          "    getOwnPropertyDescriptor(t, k) {"
+          "      if (k === 'b') throw new Error('gopd trap');"
+          "      return Object.getOwnPropertyDescriptor(t, k);"
+          "    },"
+          "  };"
+          "  return ["
+          "    new Proxy({ a: 1, b: 2 }, handler),"
+          "    Object.create(new Proxy({ a: 1, b: 2 }, handler)),"
+          "  ];"
+          "})()",
+          NAPI_AUTO_LENGTH, &setup));
+  napi_value objects;
+  NODE_API_CALL(env, napi_run_script(env, setup, &objects));
+
+  napi_value own_proxy, proto_proxy;
+  NODE_API_CALL(env, napi_get_element(env, objects, 0, &own_proxy));
+  NODE_API_CALL(env, napi_get_element(env, objects, 1, &proto_proxy));
+
+  napi_value out;
+  report_status(env, "own_only enumerable filter",
+                napi_get_all_property_names(env, own_proxy, napi_key_own_only,
+                                            napi_key_enumerable,
+                                            napi_key_numbers_to_strings, &out));
+  report_status(env, "include_prototypes enumerable filter",
+                napi_get_all_property_names(
+                    env, proto_proxy, napi_key_include_prototypes,
+                    napi_key_enumerable, napi_key_numbers_to_strings, &out));
+
+  return ok(env);
+}
+
 // Test for napi_create_external_buffer with empty/null data
 static void empty_buffer_finalizer(napi_env env, void *data, void *hint) {
   // No-op finalizer for empty buffers
@@ -4425,6 +4474,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_null_env_and_result);
   REGISTER_FUNCTION(env, exports, test_napi_freeze_seal_indexed);
   REGISTER_FUNCTION(env, exports, test_napi_object_coercion);
+  REGISTER_FUNCTION(env, exports, test_napi_get_all_property_names_throwing_traps);
   REGISTER_FUNCTION(env, exports, test_napi_create_external_buffer_empty);
   REGISTER_FUNCTION(env, exports, test_napi_v10_surface);
   REGISTER_FUNCTION(env, exports, test_napi_empty_buffer_info);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1762,6 +1762,12 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
       expect(output).toContain("numbers_to_strings key0 typeof=string");
     });
 
+    it("returns napi_pending_exception when a proxy descriptor trap throws", async () => {
+      const output = await checkSameOutput("test_napi_get_all_property_names_throwing_traps", []);
+      expect(output).toContain("own_only enumerable filter: status=10 pending=1");
+      expect(output).toContain("include_prototypes enumerable filter: status=10 pending=1");
+    });
+
     it("coerces primitives for define_properties/freeze/seal/type_tag/set_prototype", async () => {
       const output = await checkSameOutput("test_napi_toobject_coercion_node26", []);
       expect(output).toContain("define_properties(number): status=0 pending=0");


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (flaky under the fuzzer because it depends on global state from earlier iterations in the same process; deterministic repro below), plus several more crashes in the same family that surfaced while fixing it.

Inspecting an object can run arbitrary JS: lazy property initializers on native objects, getters, and proxy traps. The property enumeration loop used by `console.log` and `Bun.inspect` (`JSC__JSValue__forEachPropertyImpl`) mishandled exceptions from that JS in two places, and several things downstream of it crashed once those were fixed.

**1. Exception leaked across loop iterations.** When `getPropertySlot` reported not-found with an exception pending (a lazy property initializer threw), the `continue` skipped `CLEAR_IF_EXCEPTION`, so the next property's initializer ran with the exception still set and tripped exception scope verification in debug builds:

```js
globalThis.Symbol = -6;
console.log(Bun); // aborts debug builds: Bun.$'s initializer evaluates shell.ts, which calls Symbol("cwd")
```

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Symbol is not a function. (In 'Symbol("cwd")', 'Symbol' is -6)
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

In release builds the stale exception silently made later properties vanish from the output. The fix clears the exception before the `continue`, matching what `JSC__JSValue__forEachPropertyOrdered` already does.

**2. Null deref in the prototype walk.** The same loop advanced with `iterating->getPrototype(globalObject).getObject()`. A `Proxy` `getPrototypeOf` trap that throws makes `getPrototype` return an empty `JSValue`, and `getObject()` on an empty value calls a member function on a null `JSCell`. This crashes release builds:

```js
const p = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("trap"); } });
console.log(Object.create(p)); // SIGSEGV in current releases
```

The same pattern had two other live occurrences: the prototype walk in `napi_get_all_property_names` (napi.cpp, both the `include_prototypes` and `own_only` arms now check for a pending exception after each trap) and `util.isError` (NodeUtilTypesModule.cpp). The `util.isError` one had a second problem at the same line: a `VMInquiry` PropertySlot was still alive when `getPrototype` ran the trap, and a live VMInquiry slot forbids VM entry (debug builds abort in `checkVMEntryPermission`; in release the blocked entry is what produced the empty value). The slot is now scoped to die before the prototype read. `util.isError(new Proxy({}, { getPrototypeOf() { throw 0 } }))` segfaults current releases.

**3. Debug-only re-entry with a pending exception, and the Bun.sql module tree.** `defaultBunSQLObject` and `constructBunSQLObject` called `reportUncaughtExceptionAtEventLoop` while the exception was still pending; that re-enters JS and trips a structure assertion. Every other caller clears first and these two propagate right after, so the calls are removed. With them gone, the sql tree had the same hazard as item 4 below: `internal/sql/shared.ts` read `Bun.env` at module scope, which reifies a property on the Bun object while the `Bun.sql` / `Bun.SQL` lookup evaluating the module is still in progress, so a tree that then fails to evaluate (`globalThis.Error = -6; Bun.sql`) left debug builds asserting in `storedPrototype`. It now reads `process.env`, which is the same object. That is the only module-scope read of a Bun property in the sql tree.

**4. Windows: env setup reified a Bun property mid-lookup.** The `windowsEnv` builtin read `Bun.inspect.custom` while building the `process.env` proxy. `Bun.$`'s initializer evaluates `process.env` before `Symbol("cwd")`, so on Windows the first `Bun.$` access transitioned the Bun object's structure and then threw, poisoning the in-progress static property lookup (caught by this PR's Windows CI). The symbol is now passed in from C++.

**5. util.inspect lazy slots could not fail.** `m_utilInspectFunction` and `m_utilInspectStylizeColorFunction` were set-once `LazyProperty` slots whose initializers bailed without `init.set` when requiring `node:util` threw, which violates the LazyProperty contract and aborts both debug and release builds:

```js
const o = { [Symbol.for("nodejs.util.inspect.custom")]() { return "x"; } };
globalThis.Symbol = -6;
console.log(o); // SIGABRT in current releases; same with Bun.inspect(o, { colors: true })
```

The failure is usually transient (the registry does not cache a failed load; a stack overflow during the first custom inspect is enough), so caching a fallback would leave inspect degraded for the rest of the process. The two slots are now `WriteBarrier` members filled by accessors: on failure the accessor returns null with the exception pending and caches nothing, so the next inspect retries. `callCustomInspectFunction` clears it and falls back to default formatting for that one value; the other callers (URL, URLSearchParams, BroadcastChannel, streams) already propagate a pending exception. The unused `Bun__REPL__formatValue` is deleted.

Not in this PR: `globalThis.Symbol = -6; require.cache` aborts in the same way through `m_lazyRequireCacheObject` (NodeModuleModule.cpp). It is a different subsystem and is tracked for a separate fix using the same retryable-slot shape. Also left out: the Rust side has its own prototype read, `JSValue::get_prototype`, which returns a bare value with no way to report a throwing trap. Its formatter callers are not reachable with a throwing trap (the formatter unwraps proxies to their targets first; checked under exception scope validation), but `napi_get_prototype` returns `napi_ok` with an empty result and the exception left pending where Node returns `napi_pending_exception`. That is a parity bug rather than a crash and the right fix is at the `get_prototype` signature, so it is tracked separately as well.

### How did you verify your code works?

Regression tests, each verified against the unfixed binary:

- `test/js/bun/util/inspect.test.js`: the clobbered-Symbol enumeration of `Bun`, the throwing `getPrototypeOf` trap, and the custom inspect fallback. The fallback test pins that the fallback applies with and without colors, that a repeated call still falls back (nothing cached), and that the hook works again once the global is restored. All fail or crash on current releases.
- `test/js/node/util/util.test.js`: spawned `util.isError` repro (segfaults current releases).
- `test/napi/napi.test.ts` + addon: `napi_get_all_property_names` with a throwing descriptor trap in both key modes, asserting byte parity with Node (the `include_prototypes` case segfaults current releases).
- `test/js/sql/adapter-env-var-precedence.test.ts`: spawned failing-sql-tree repro. This one is a debug assertion only: it aborts the debug build without the `shared.ts` change (verified by reverting just that file) and passes release builds either way. The rest of that file exercises the env resolution that `shared.ts` does, and passes unchanged with `process.env`.

Full files pass on Linux (`bun bd test` on inspect, util, bun-inspect, custom-inspect, url, broadcast-channel, napi, and the sql env file) and items 1, 2, 4 and the earlier version of 5 were also verified on a Windows machine. The original fuzzer reproduction exits cleanly on the fixed debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js test/js/sql/adapter-env-var-precedence.test.ts test/napi/napi.test.ts

<!-- robobun:evidence:end -->
