### PR TITLE
shell: free in-flight subprocess stdio when the interpreter is finalized mid-run

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -452,6 +452,26 @@ impl Builtin {
         &self.args
     }
 
+    /// The owning VM is inside `Heap::lastChanceToFinalize`, where
+    /// `Heap::m_arrayBuffers` has already deleted the `JSC::ArrayBuffer`
+    /// impls: the unpin that `PinnedArrayBuf::drop` issues for a
+    /// `> ${arraybuffer}` redirect would write to a freed impl. Clear the
+    /// `pinned` flags so the drops skip it; the `Strong` handles still
+    /// release normally. Must only be called from the VM-shutdown finalizer
+    /// — on a live heap skipping the unpin would leak the pin.
+    #[cfg(not(windows))]
+    pub(crate) fn defuse_array_buf_pins(&mut self) {
+        if let BuiltinInput::ArrayBuf { buf, .. } = &mut self.stdin {
+            buf.pinned = false;
+        }
+        if let BuiltinIO::ArrayBuf { buf, .. } = &mut self.stdout {
+            buf.pinned = false;
+        }
+        if let BuiltinIO::ArrayBuf { buf, .. } = &mut self.stderr {
+            buf.pinned = false;
+        }
+    }
+
     /// Borrow `argv[1..][idx]` as `&[u8]` (NUL excluded).
     ///
     /// Every entry in `self.args` borrows into the owning `Cmd`'s

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -452,13 +452,10 @@ impl Builtin {
         &self.args
     }
 
-    /// The owning VM is inside `Heap::lastChanceToFinalize`, where
-    /// `Heap::m_arrayBuffers` has already deleted the `JSC::ArrayBuffer`
-    /// impls: the unpin that `PinnedArrayBuf::drop` issues for a
-    /// `> ${arraybuffer}` redirect would write to a freed impl. Clear the
-    /// `pinned` flags so the drops skip it; the `Strong` handles still
-    /// release normally. Must only be called from the VM-shutdown finalizer
-    /// — on a live heap skipping the unpin would leak the pin.
+    /// `PinnedArrayBuf::drop`'s unpin would write to a `JSC::ArrayBuffer`
+    /// impl the heap sweep already deleted; see
+    /// `ShellSubprocess::defuse_array_buffer_unpins`. VM-shutdown finalizer
+    /// only.
     #[cfg(not(windows))]
     pub(crate) fn defuse_array_buf_pins(&mut self) {
         if let BuiltinInput::ArrayBuf { buf, .. } = &mut self.stdin {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1344,6 +1344,27 @@ impl Interpreter {
 
         match this.cleanup_state.get() {
             CleanupState::NeedsFullCleanup => {
+                // The VM is shutting down with the script still in flight
+                // (e.g. `worker.terminate()` while a command runs), so no
+                // node was deinited the normal way and `Node` has no `Drop`
+                // for its raw-pointer-owned resources. Deinit every live
+                // `Cmd`: kills its child and frees the `ShellSubprocess`,
+                // its pipe readers and its redirection fd. Slots are left
+                // occupied (no `free_node`) so the env walk below still sees
+                // pipeline-duped Cmd envs; the arena `Vec` drops with the
+                // box. Windows: skipped, matching the leak-over-UAF tradeoff
+                // of `ShellSubprocess::abort_after_failed_start` (closing
+                // live uv sources here is unsafe).
+                #[cfg(not(windows))]
+                {
+                    let node_count = this.nodes.get().len();
+                    for i in 0..node_count {
+                        let id = NodeId(i as u32);
+                        if matches!(this.nodes.get()[id.idx()].kind(), StateKind::Cmd) {
+                            Cmd::deinit(&this, id);
+                        }
+                    }
+                }
                 // A node owns `base.shell` iff it was created via `dupe_for_subshell`,
                 // i.e. its `base.shell` differs from its parent's.
                 {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1361,7 +1361,7 @@ impl Interpreter {
                     for i in 0..node_count {
                         let id = NodeId(i as u32);
                         if matches!(this.nodes.get()[id.idx()].kind(), StateKind::Cmd) {
-                            Cmd::deinit(&this, id);
+                            Cmd::deinit_from_finalizer(&this, id);
                         }
                     }
                 }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1344,17 +1344,13 @@ impl Interpreter {
 
         match this.cleanup_state.get() {
             CleanupState::NeedsFullCleanup => {
-                // The VM is shutting down with the script still in flight
-                // (e.g. `worker.terminate()` while a command runs), so no
-                // node was deinited the normal way and `Node` has no `Drop`
-                // for its raw-pointer-owned resources. Deinit every live
-                // `Cmd`: kills its child and frees the `ShellSubprocess`,
-                // its pipe readers and its redirection fd. Slots are left
-                // occupied (no `free_node`) so the env walk below still sees
-                // pipeline-duped Cmd envs; the arena `Vec` drops with the
-                // box. Windows: skipped, matching the leak-over-UAF tradeoff
-                // of `ShellSubprocess::abort_after_failed_start` (closing
-                // live uv sources here is unsafe).
+                // The script is still in flight (e.g. `worker.terminate()`
+                // mid-command) and `Node` has no `Drop` for its raw-pointer
+                // resources: deinit every live `Cmd` (kills the child, frees
+                // the `ShellSubprocess`, readers, redirection fd). Slots stay
+                // occupied so the env walk below still sees pipeline-duped
+                // Cmd envs. Windows: leak-over-UAF, see
+                // `ShellSubprocess::abort_after_failed_start`.
                 #[cfg(not(windows))]
                 {
                     let node_count = this.nodes.get().len();

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -857,11 +857,9 @@ impl Cmd {
         Self::on_exec_done(interp, this, exit_code).run(interp);
     }
 
-    /// [`Self::deinit`] for the VM-shutdown finalizer. The heap is inside
-    /// `lastChanceToFinalize`, where the `JSC::ArrayBuffer` impls are
-    /// already deleted, so the unpins that the `PinnedArrayBuf` /
-    /// `BufferedOutput` drops would issue for `> ${arraybuffer}` redirects
-    /// must be defused first (they would write to freed impls).
+    /// [`Self::deinit`] for the VM-shutdown finalizer: defuses the
+    /// `> ${arraybuffer}` unpins first — the heap sweep already deleted the
+    /// `JSC::ArrayBuffer` impls they would write to.
     #[cfg(not(windows))]
     pub(crate) fn deinit_from_finalizer(interp: &Interpreter, this: NodeId) {
         {
@@ -891,10 +889,9 @@ impl Cmd {
             }
             core::mem::take(&mut me.exec)
         };
-        // Tear down the running exec. `me`'s borrow ended above:
-        // `deinit_in_flight_io` below can re-enter this Cmd through the
-        // subprocess's stdin `on_close_io` → `buffered_input_close` (a no-op
-        // now that `exec` is taken).
+        // `me`'s borrow ended above: the teardown below re-enters this Cmd
+        // via stdin `on_close_io` → `buffered_input_close` (a no-op once
+        // `exec` is taken).
         match exec {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
@@ -909,9 +906,8 @@ impl Cmd {
                         let _ = (*child).try_kill(9);
                     }
                     (*child).unref::<true>();
-                    // A VM-shutdown teardown reaches here with the command
-                    // still in flight; stop any still-active stdio before
-                    // the drop below (normal deinit already closed it all).
+                    // Stop any still-active stdio before the drop (only the
+                    // VM-shutdown path reaches here in flight).
                     #[cfg(not(windows))]
                     ShellSubprocess::deinit_in_flight_io(child);
                     drop(bun_core::heap::take(child));

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -857,6 +857,28 @@ impl Cmd {
         Self::on_exec_done(interp, this, exit_code).run(interp);
     }
 
+    /// [`Self::deinit`] for the VM-shutdown finalizer. The heap is inside
+    /// `lastChanceToFinalize`, where the `JSC::ArrayBuffer` impls are
+    /// already deleted, so the unpins that the `PinnedArrayBuf` /
+    /// `BufferedOutput` drops would issue for `> ${arraybuffer}` redirects
+    /// must be defused first (they would write to freed impls).
+    #[cfg(not(windows))]
+    pub(crate) fn deinit_from_finalizer(interp: &Interpreter, this: NodeId) {
+        {
+            let me = interp.as_cmd_mut(this);
+            match &mut me.exec {
+                Exec::Builtin(b) => b.defuse_array_buf_pins(),
+                Exec::Subproc(sub) if !sub.child.is_null() => {
+                    // SAFETY: `child` is the live heap::alloc'd subprocess;
+                    // the call only writes its own fields.
+                    unsafe { ShellSubprocess::defuse_array_buffer_unpins(sub.child) };
+                }
+                _ => {}
+            }
+        }
+        Self::deinit(interp, this);
+    }
+
     pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
         log!("Cmd {} deinit", this);
         let exec = {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -859,15 +859,21 @@ impl Cmd {
 
     pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
         log!("Cmd {} deinit", this);
-        let me = interp.as_cmd_mut(this);
-        me.args.clear();
-        me.redirection_file.clear();
-        if let Some(fd) = me.redirection_fd.take() {
-            // SAFETY: `fd` is the +1 ref held in `me.redirection_fd`.
-            CowFd::deref(fd);
-        }
-        // Tear down the running exec.
-        match core::mem::take(&mut me.exec) {
+        let exec = {
+            let me = interp.as_cmd_mut(this);
+            me.args.clear();
+            me.redirection_file.clear();
+            if let Some(fd) = me.redirection_fd.take() {
+                // SAFETY: `fd` is the +1 ref held in `me.redirection_fd`.
+                CowFd::deref(fd);
+            }
+            core::mem::take(&mut me.exec)
+        };
+        // Tear down the running exec. `me`'s borrow ended above:
+        // `deinit_in_flight_io` below can re-enter this Cmd through the
+        // subprocess's stdin `on_close_io` → `buffered_input_close` (a no-op
+        // now that `exec` is taken).
+        match exec {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
             Exec::Subproc(sub) if !sub.child.is_null() => {
@@ -875,12 +881,19 @@ impl Cmd {
                 // `heap::alloc(ShellSubprocess)` and stays valid until this
                 // drop. Single-threaded. Reclaiming the box runs
                 // `ShellSubprocess::drop` → `finalize_sync` (closes stdio).
-                let mut child = unsafe { bun_core::heap::take(sub.child) };
-                if !child.has_exited() {
-                    let _ = child.try_kill(9);
+                unsafe {
+                    let child = sub.child;
+                    if !(*child).has_exited() {
+                        let _ = (*child).try_kill(9);
+                    }
+                    (*child).unref::<true>();
+                    // A VM-shutdown teardown reaches here with the command
+                    // still in flight; stop any still-active stdio before
+                    // the drop below (normal deinit already closed it all).
+                    #[cfg(not(windows))]
+                    ShellSubprocess::deinit_in_flight_io(child);
+                    drop(bun_core::heap::take(child));
                 }
-                child.unref::<true>();
-                drop(child);
                 // `sub.buffered_closed` drops here, freeing any captured
                 // `Vec<u8>`s (spec `buffered_closed.deinit()`).
             }
@@ -891,7 +904,7 @@ impl Cmd {
         // Argv/env are heap-owned `Vec`s; there is no spawn arena to free.
         // `base.shell` is borrowed (or, when parent is Pipeline, freed by
         // `Pipeline::child_done` before this runs) — never freed here.
-        me.base.end_scope();
+        interp.as_cmd_mut(this).base.end_scope();
     }
 
     // ── Subprocess callbacks (legacy `*Cmd` backref shape) ────────────────

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -493,31 +493,23 @@ impl ShellSubprocess {
         }
     }
 
-    /// Stop stdio that is still active because the owning `Cmd` is being
-    /// deinited mid-flight (VM shutdown finalizing the interpreter while the
-    /// subprocess runs). Pipe readers are stopped without firing
-    /// `on_reader_done` (no Cmd state transitions), capture chunks still
-    /// queued on the shell's `IOWriter` are cancelled (its queue holds a raw
-    /// pointer into the `PipeReader` this teardown frees), and a still-pending
-    /// buffer-stdin writer is closed with `start()`'s +1 released. A no-op
-    /// when the command already closed its stdio the normal way.
-    ///
-    /// POSIX-only for the same reason as [`Self::abort_after_failed_start`]:
-    /// tearing down live libuv sources here is unsafe, so Windows callers
-    /// leak instead.
+    /// Stop stdio still active because the `Cmd` is deinited mid-flight (VM
+    /// shutdown); a no-op after a normal close. Readers stop without firing
+    /// `on_reader_done`, queued capture chunks are cancelled (the `IOWriter`
+    /// queue holds a raw pointer into the freed `PipeReader`), a pending
+    /// buffer-stdin writer is closed. POSIX-only, same tradeoff as
+    /// [`Self::abort_after_failed_start`].
     ///
     /// # Safety
     /// `this` must be the live `heap::alloc`'d subprocess with no outstanding
     /// borrows; single-threaded shell. Raw (not `&mut self`) because the
-    /// stdin close below re-enters `on_close_io(&mut Self)` through the
-    /// writer's process backref.
+    /// stdin close re-enters `on_close_io(&mut Self)` through the writer's
+    /// process backref.
     #[cfg(not(windows))]
     pub(crate) unsafe fn deinit_in_flight_io(this: *mut Self) {
-        // stdin: claim `start()`'s +1 (so no other release site can fire for
-        // it), close the writer — which drives `on_close` → `on_close_io`,
-        // swapping the slot to `Ignore` and releasing `create()`'s ref — then
-        // release the claimed ref. Same shape as the JS `Subprocess::close_io`
-        // stdin arm.
+        // Claim `start()`'s +1, `close()` (fires `on_close` → `on_close_io`:
+        // slot → `Ignore`, `create()`'s ref released), release the claimed
+        // ref — the JS `Subprocess::close_io` stdin shape.
         // SAFETY: caller contract; the `stdin` borrow ends before `close()`.
         let pending_start: *mut StaticPipeWriter = match unsafe { &(*this).stdin } {
             Writable::Buffer(buffer) => {
@@ -552,9 +544,8 @@ impl ShellSubprocess {
             // nor `cancel_chunks` fires a callback.
             unsafe {
                 if matches!((*pipe).state, PipeReaderState::Pending) {
-                    // Stop the `BufferedReader` without `on_reader_done`
-                    // (deregisters the poll, closes the fd) and record the
-                    // forced stop so `PipeReader::drop`'s done-assert holds.
+                    // Deregisters the poll and closes the fd without
+                    // `on_reader_done`; `Err` satisfies the drop's done-assert.
                     (*pipe).reader.deinit();
                     (*pipe).state = PipeReaderState::Err(None);
                 }
@@ -569,17 +560,14 @@ impl ShellSubprocess {
         }
     }
 
-    /// The owning VM is inside `Heap::lastChanceToFinalize`, where
-    /// `Heap::m_arrayBuffers` has already deleted the `JSC::ArrayBuffer`
-    /// impls: the unpin that `BufferedOutput::drop` issues for a
-    /// `> ${arraybuffer}` redirect would write to a freed impl. Clear the
-    /// pinned value so the drop skips it; the `Strong` handle in the same
-    /// struct still releases normally (handle sets outlive the sweep).
+    /// `Heap::lastChanceToFinalize` deletes the `JSC::ArrayBuffer` impls
+    /// before the sweep that reaches us, so the `> ${arraybuffer}` unpin in
+    /// `BufferedOutput::drop` would write to a freed impl. Clear the value
+    /// so the drop skips it; the `Strong` handle still releases normally.
     ///
     /// # Safety
-    /// Same contract as [`Self::deinit_in_flight_io`], and must only be
-    /// called from the VM-shutdown finalizer — on a live heap skipping the
-    /// unpin would leak the pin.
+    /// Same contract as [`Self::deinit_in_flight_io`]; VM-shutdown finalizer
+    /// only (on a live heap this would leak the pin).
     #[cfg(not(windows))]
     pub(crate) unsafe fn defuse_array_buffer_unpins(this: *mut Self) {
         // SAFETY: disjoint field projections of the live subprocess.

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -493,6 +493,82 @@ impl ShellSubprocess {
         }
     }
 
+    /// Stop stdio that is still active because the owning `Cmd` is being
+    /// deinited mid-flight (VM shutdown finalizing the interpreter while the
+    /// subprocess runs). Pipe readers are stopped without firing
+    /// `on_reader_done` (no Cmd state transitions), capture chunks still
+    /// queued on the shell's `IOWriter` are cancelled (its queue holds a raw
+    /// pointer into the `PipeReader` this teardown frees), and a still-pending
+    /// buffer-stdin writer is closed with `start()`'s +1 released. A no-op
+    /// when the command already closed its stdio the normal way.
+    ///
+    /// POSIX-only for the same reason as [`Self::abort_after_failed_start`]:
+    /// tearing down live libuv sources here is unsafe, so Windows callers
+    /// leak instead.
+    ///
+    /// # Safety
+    /// `this` must be the live `heap::alloc`'d subprocess with no outstanding
+    /// borrows; single-threaded shell. Raw (not `&mut self`) because the
+    /// stdin close below re-enters `on_close_io(&mut Self)` through the
+    /// writer's process backref.
+    #[cfg(not(windows))]
+    pub(crate) unsafe fn deinit_in_flight_io(this: *mut Self) {
+        // stdin: claim `start()`'s +1 (so no other release site can fire for
+        // it), close the writer — which drives `on_close` → `on_close_io`,
+        // swapping the slot to `Ignore` and releasing `create()`'s ref — then
+        // release the claimed ref. Same shape as the JS `Subprocess::close_io`
+        // stdin arm.
+        // SAFETY: caller contract; the `stdin` borrow ends before `close()`.
+        let pending_start: *mut StaticPipeWriter = match unsafe { &(*this).stdin } {
+            Writable::Buffer(buffer) => {
+                // SAFETY: single-threaded; temporary `&mut` for the flag swap.
+                let writer = unsafe { buffer_mut(buffer) };
+                if core::mem::replace(&mut writer.started, false) {
+                    buffer.as_ptr()
+                } else {
+                    core::ptr::null_mut()
+                }
+            }
+            _ => core::ptr::null_mut(),
+        };
+        if !pending_start.is_null() {
+            // SAFETY: live writer holding `create()`'s ref plus the claimed
+            // start ref.
+            unsafe { (*pending_start).close() };
+            // SAFETY: releases the claimed start ref; last use of the pointer.
+            unsafe { bun_ptr::RefCount::deref(pending_start) };
+        }
+
+        // SAFETY: disjoint field projections of the live subprocess.
+        let slots = unsafe { [&raw mut (*this).stdout, &raw mut (*this).stderr] };
+        for slot in slots {
+            // SAFETY: `slot` projects from `this`; borrow scoped to the match.
+            let pipe: *mut PipeReader = match unsafe { &*slot } {
+                Readable::Pipe(pipe) => arc_as_mut_ptr(pipe),
+                _ => continue,
+            };
+            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell, no other
+            // borrow of the `PipeReader` is live; neither `reader.deinit()`
+            // nor `cancel_chunks` fires a callback.
+            unsafe {
+                if matches!((*pipe).state, PipeReaderState::Pending) {
+                    // Stop the `BufferedReader` without `on_reader_done`
+                    // (deregisters the poll, closes the fd) and record the
+                    // forced stop so `PipeReader::drop`'s done-assert holds.
+                    (*pipe).reader.deinit();
+                    (*pipe).state = PipeReaderState::Err(None);
+                }
+                let captured: *mut CapturedWriter = &raw mut (*pipe).captured_writer;
+                if let Some(writer) = (*captured).writer.take() {
+                    writer.cancel_chunks(io_writer::ChildPtr::subproc_capture(
+                        captured.cast::<c_void>(),
+                    ));
+                    (*captured).dead = true;
+                }
+            }
+        }
+    }
+
     // `sh::Result`'s `ShellErr` is a shared shell-wide error type defined in
     // `shell_body.rs`; boxing it here would change `pub fn` signatures across
     // every `?`-propagating shell caller.

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -569,6 +569,39 @@ impl ShellSubprocess {
         }
     }
 
+    /// The owning VM is inside `Heap::lastChanceToFinalize`, where
+    /// `Heap::m_arrayBuffers` has already deleted the `JSC::ArrayBuffer`
+    /// impls: the unpin that `BufferedOutput::drop` issues for a
+    /// `> ${arraybuffer}` redirect would write to a freed impl. Clear the
+    /// pinned value so the drop skips it; the `Strong` handle in the same
+    /// struct still releases normally (handle sets outlive the sweep).
+    ///
+    /// # Safety
+    /// Same contract as [`Self::deinit_in_flight_io`], and must only be
+    /// called from the VM-shutdown finalizer — on a live heap skipping the
+    /// unpin would leak the pin.
+    #[cfg(not(windows))]
+    pub(crate) unsafe fn defuse_array_buffer_unpins(this: *mut Self) {
+        // SAFETY: disjoint field projections of the live subprocess.
+        let slots = unsafe { [&raw mut (*this).stdout, &raw mut (*this).stderr] };
+        for slot in slots {
+            // SAFETY: `slot` projects from `this`; borrow scoped to the match.
+            let pipe: *mut PipeReader = match unsafe { &*slot } {
+                Readable::Pipe(pipe) => arc_as_mut_ptr(pipe),
+                _ => continue,
+            };
+            // SAFETY: see `arc_as_mut_ptr` — single-threaded shell, no other
+            // borrow of the `PipeReader` is live.
+            unsafe {
+                if let BufferedOutput::ArrayBuffer { buf, .. } = &mut (*pipe).buffered_output {
+                    // `Default` has `value: JSValue::ZERO`, which
+                    // `BufferedOutput::drop` reads as "nothing to unpin".
+                    let _ = core::mem::take(&mut buf.array_buffer);
+                }
+            }
+        }
+    }
+
     // `sh::Result`'s `ShellErr` is a shared shell-wide error type defined in
     // `shell_body.rs`; boxing it here would change `pub fn` signatures across
     // every `?`-propagating shell caller.

--- a/test/js/bun/shell/shell-worker-terminate-leak.test.ts
+++ b/test/js/bun/shell/shell-worker-terminate-leak.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// Terminating a worker while a Bun.$ command's external subprocess is still
+// running used to leak the whole in-flight exec: the shell interpreter's VM
+// shutdown finalizer dropped its node arena without deiniting live Cmd nodes,
+// so the ShellSubprocess box, its stdout/stderr PipeReaders and a pending
+// buffer-stdin writer were never freed. Guard on the asan lane.
+//
+// The worker starts `sh` (never a shell builtin, so it is a real external
+// process), waits until the child proves it is alive by writing flag.txt,
+// then posts back; the parent terminates the worker while the child blocks.
+async function expectNoLeakAfterTerminate(workerSource: string) {
+  using dir = tempDir("shell-worker-terminate-leak", {
+    "main.ts": `
+      const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+      await new Promise(resolve => (worker.onmessage = resolve));
+      await worker.terminate();
+    `,
+    "worker.ts": workerSource,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+      LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+}
+
+test.skipIf(!isASAN || isWindows)(
+  "worker.terminate() with a live Bun.$ subprocess does not leak its pipe readers",
+  async () => {
+    await expectNoLeakAfterTerminate(`
+      const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100"\`.nothrow();
+      // Shell promises are lazy; awaiting starts the interpreter.
+      (async () => {
+        await running;
+      })();
+      while (!(await Bun.file("flag.txt").exists())) {
+        await Bun.sleep(5);
+      }
+      postMessage("ok");
+    `);
+  },
+  // LSan's report symbolization alone can take tens of seconds on the debug
+  // binary, so the failure mode needs far more than the default timeout.
+  90_000,
+);
+
+test.skipIf(!isASAN || isWindows)(
+  "worker.terminate() with a live Bun.$ subprocess does not leak a pending buffer-stdin writer",
+  async () => {
+    // Stdin is far larger than the pipe capacity and the child never reads
+    // it, so the shell's static stdin writer is still mid-write at terminate.
+    await expectNoLeakAfterTerminate(`
+      const stdin = Buffer.alloc(1 << 20, "x");
+      const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100" < \${stdin}\`.nothrow();
+      (async () => {
+        await running;
+      })();
+      while (!(await Bun.file("flag.txt").exists())) {
+        await Bun.sleep(5);
+      }
+      postMessage("ok");
+    `);
+  },
+  90_000,
+);

--- a/test/js/bun/shell/shell-worker-terminate-leak.test.ts
+++ b/test/js/bun/shell/shell-worker-terminate-leak.test.ts
@@ -17,7 +17,10 @@ async function runTerminateScenario(workerSource: string, extraEnv: Record<strin
   using dir = tempDir("shell-worker-terminate-leak", {
     "main.ts": `
       const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
-      await new Promise(resolve => (worker.onmessage = resolve));
+      const { promise, resolve, reject } = Promise.withResolvers();
+      worker.onmessage = resolve;
+      worker.onerror = e => reject(e.error ?? e.message);
+      await promise;
       await worker.terminate();
     `,
     "worker.ts": workerSource,
@@ -172,7 +175,10 @@ test.skipIf(!isLinux)(
       "main.ts": `
         import { readFileSync } from "node:fs";
         const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
-        const pid: number = await new Promise(resolve => (worker.onmessage = e => resolve(e.data)));
+        const { promise, resolve, reject } = Promise.withResolvers<number>();
+        worker.onmessage = e => resolve(e.data);
+        worker.onerror = e => reject(e.error ?? e.message);
+        const pid: number = await promise;
         await worker.terminate();
         const deadline = Date.now() + 20_000;
         let state = "alive";

--- a/test/js/bun/shell/shell-worker-terminate-leak.test.ts
+++ b/test/js/bun/shell/shell-worker-terminate-leak.test.ts
@@ -1,17 +1,19 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Terminating a worker while a Bun.$ command's external subprocess is still
 // running used to leak the whole in-flight exec: the shell interpreter's VM
 // shutdown finalizer dropped its node arena without deiniting live Cmd nodes,
-// so the ShellSubprocess box, its stdout/stderr PipeReaders and a pending
-// buffer-stdin writer were never freed. Guard on the asan lane.
+// so the ShellSubprocess box, its stdout/stderr PipeReaders, a pending
+// buffer-stdin writer and any redirection fd were never freed. Leak variants
+// guard on the asan lane; the kill test runs on every Linux lane.
 //
-// The worker starts `sh` (never a shell builtin, so it is a real external
-// process), waits until the child proves it is alive by writing flag.txt,
-// then posts back; the parent terminates the worker while the child blocks.
-async function expectNoLeakAfterTerminate(workerSource: string) {
+// Each worker starts `sh` (never a shell builtin, so it is a real external
+// process), waits until the child proves it is alive by writing its flag
+// file, then posts back; the parent terminates the worker while the child
+// blocks.
+async function runTerminateScenario(workerSource: string, extraEnv: Record<string, string> = {}) {
   using dir = tempDir("shell-worker-terminate-leak", {
     "main.ts": `
       const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
@@ -28,6 +30,7 @@ async function expectNoLeakAfterTerminate(workerSource: string) {
       BUN_DESTRUCT_VM_ON_EXIT: "1",
       ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
       LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      ...extraEnv,
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -36,10 +39,14 @@ async function expectNoLeakAfterTerminate(workerSource: string) {
   expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
 }
 
+// LSan's report symbolization alone can take tens of seconds on the debug
+// binary, so the failure mode needs far more than the default timeout.
+const LEAK_TEST_TIMEOUT = 90_000;
+
 test.skipIf(!isASAN || isWindows)(
   "worker.terminate() with a live Bun.$ subprocess does not leak its pipe readers",
   async () => {
-    await expectNoLeakAfterTerminate(`
+    await runTerminateScenario(`
       const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100"\`.nothrow();
       // Shell promises are lazy; awaiting starts the interpreter.
       (async () => {
@@ -51,9 +58,7 @@ test.skipIf(!isASAN || isWindows)(
       postMessage("ok");
     `);
   },
-  // LSan's report symbolization alone can take tens of seconds on the debug
-  // binary, so the failure mode needs far more than the default timeout.
-  90_000,
+  LEAK_TEST_TIMEOUT,
 );
 
 test.skipIf(!isASAN || isWindows)(
@@ -61,7 +66,7 @@ test.skipIf(!isASAN || isWindows)(
   async () => {
     // Stdin is far larger than the pipe capacity and the child never reads
     // it, so the shell's static stdin writer is still mid-write at terminate.
-    await expectNoLeakAfterTerminate(`
+    await runTerminateScenario(`
       const stdin = Buffer.alloc(1 << 20, "x");
       const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100" < \${stdin}\`.nothrow();
       (async () => {
@@ -73,5 +78,138 @@ test.skipIf(!isASAN || isWindows)(
       postMessage("ok");
     `);
   },
-  90_000,
+  LEAK_TEST_TIMEOUT,
+);
+
+test.skipIf(!isASAN || isWindows)(
+  "worker.terminate() with a live Bun.$ pipeline does not leak either subprocess",
+  async () => {
+    // Two live externals in one pipeline: exercises the finalizer walk over
+    // several occupied Cmd slots plus the Pipeline node's duped child envs.
+    await runTerminateScenario(`
+      const running = Bun.$\`sh -c "echo ok > flag1.txt && exec sleep 100" | sh -c "echo ok > flag2.txt && exec sleep 100"\`.nothrow();
+      (async () => {
+        await running;
+      })();
+      while (!(await Bun.file("flag1.txt").exists()) || !(await Bun.file("flag2.txt").exists())) {
+        await Bun.sleep(5);
+      }
+      postMessage("ok");
+    `);
+  },
+  LEAK_TEST_TIMEOUT,
+);
+
+test.skipIf(!isASAN || isWindows)(
+  "worker.terminate() with a live Bun.$ file redirect does not leak the redirection fd",
+  async () => {
+    // `> out.txt` opens a CowFd on the Cmd that only Cmd::deinit releases.
+    await runTerminateScenario(`
+      const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100" > out.txt\`.nothrow();
+      (async () => {
+        await running;
+      })();
+      while (!(await Bun.file("flag.txt").exists())) {
+        await Bun.sleep(5);
+      }
+      postMessage("ok");
+    `);
+  },
+  LEAK_TEST_TIMEOUT,
+);
+
+test.skipIf(!isASAN || isWindows)(
+  "worker.terminate() with a live Bun.$ arraybuffer redirect does not leak the pinned buffer",
+  async () => {
+    await runTerminateScenario(`
+      const out = new Uint8Array(1 << 16);
+      const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100" > \${out}\`.nothrow();
+      (async () => {
+        await running;
+      })();
+      while (!(await Bun.file("flag.txt").exists())) {
+        await Bun.sleep(5);
+      }
+      postMessage("ok");
+    `);
+  },
+  LEAK_TEST_TIMEOUT,
+);
+
+test.skipIf(!isASAN || isWindows)(
+  "worker.terminate() with a live Bun.$ arraybuffer redirect does not unpin a finalized ArrayBuffer",
+  async () => {
+    // During lastChanceToFinalize the JSC::ArrayBuffer impls are already
+    // deleted, so the teardown must not unpin through them. JSC memory is
+    // libpas-backed and invisible to ASAN, so force system malloc; leak
+    // detection stays off because Malloc=1 surfaces process-lifetime WTF
+    // allocations LSan would misreport.
+    await runTerminateScenario(
+      `
+      const out = new Uint8Array(1 << 16);
+      const running = Bun.$\`sh -c "echo ok > flag.txt && exec sleep 100" > \${out}\`.nothrow();
+      (async () => {
+        await running;
+      })();
+      while (!(await Bun.file("flag.txt").exists())) {
+        await Bun.sleep(5);
+      }
+      postMessage("ok");
+    `,
+      { Malloc: "1", ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") },
+    );
+  },
+  LEAK_TEST_TIMEOUT,
+);
+
+test.skipIf(!isLinux)(
+  "worker.terminate() kills a live Bun.$ subprocess",
+  async () => {
+    // The interpreter teardown SIGKILLs the child the same way Cmd::deinit
+    // does for a live child. Nothing reaps it afterwards (the watcher was
+    // detached), so "killed" shows as zombie or gone, read from /proc.
+    using dir = tempDir("shell-worker-terminate-kill", {
+      "main.ts": `
+        import { readFileSync } from "node:fs";
+        const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+        const pid: number = await new Promise(resolve => (worker.onmessage = e => resolve(e.data)));
+        await worker.terminate();
+        const deadline = Date.now() + 20_000;
+        let state = "alive";
+        while (Date.now() < deadline) {
+          try {
+            // "pid (comm) State ..." — comm is sh/sleep, never contains ")".
+            state = readFileSync(\`/proc/\${pid}/stat\`, "utf8").split(") ")[1][0];
+          } catch {
+            state = "gone";
+          }
+          if (state === "Z" || state === "gone") break;
+          await Bun.sleep(10);
+        }
+        console.log(state === "Z" || state === "gone" ? "killed" : "alive:" + state);
+      `,
+      "worker.ts": `
+        const running = Bun.$\`sh -c 'echo $$ > pid.txt && exec sleep 100'\`.nothrow();
+        (async () => {
+          await running;
+        })();
+        // Wait for the trailing newline so a partially-written pid is never
+        // parsed.
+        while (!(await Bun.file("pid.txt").exists()) || !(await Bun.file("pid.txt").text()).includes("\\n")) {
+          await Bun.sleep(5);
+        }
+        postMessage(parseInt((await Bun.file("pid.txt").text()).trim(), 10));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "killed\n", stderr: "", exitCode: 0 });
+  },
+  60_000,
 );


### PR DESCRIPTION
### Problem

Terminating a worker while a `Bun.$` command's external subprocess is still running leaks the whole in-flight exec. LSan on a debug build reports (among 6 allocations, 1592 bytes):

```
Indirect leak of 416 byte(s) in 1 object(s) allocated from:
    ... PipeReader::create ... Readable::init ...
    #12 <bun_runtime::shell::subproc::ShellSubprocess>::spawn_maybe_sync_impl /workspace/bun/src/runtime/shell/subproc.rs:699
```

With a buffer stdin redirect (`$\`cmd < ${buf}\``), the pending static stdin writer and its copied stdin bytes (1 MB in the repro) leak as well; a `> file` redirect leaks its `CowFd`; a `> ${arraybuffer}` redirect leaks the pinned buffer.

Repro: a worker starts `Bun.$` running an external command that blocks (e.g. `sh -c '... sleep ...'`), the main thread calls `worker.terminate()` while it runs, process exits under `ASAN_OPTIONS=detect_leaks=1`.

### Cause

`worker.terminate()` tears down the worker's VM while the shell command is in flight. `Heap::lastChanceToFinalize` sweeps the `JSShellInterpreter` wrapper regardless of its pending activity, so `Interpreter::deinit_from_finalizer` runs in the `NeedsFullCleanup` state. That path freed subshell-owned envs and the root shell/io, but dropped the node arena without deiniting live nodes. `Node` has no `Drop` for its raw-pointer-owned resources, so an in-flight `Cmd`'s `ShellSubprocess` box, its `Arc<PipeReader>`s (stdout/stderr), their file polls, the `Process`, a pending `StaticPipeWriter` stdin, and any `redirection_fd` were all leaked, and the child process was left running with no owner.

### Fix

- `Interpreter::deinit_from_finalizer`: on `NeedsFullCleanup`, deinit every live `Cmd` node before the existing env walk (slots are left occupied so the env walk still sees pipeline-duped Cmd envs; the arena `Vec` drops with the box). `Cmd::deinit` already kills the child and frees the subprocess.
- `ShellSubprocess::deinit_in_flight_io` (new): called from `Cmd::deinit` before freeing the box, it stops stdio that is still active, which only happens on this forced-teardown path. Mid-read pipe readers are stopped with `BufferedReader::deinit()` (deregisters the poll, closes the fd, fires no `on_reader_done`), mirroring how the JS `Subprocess` finalizer closes a mid-read reader. Capture chunks still queued on the shell's `IOWriter` are cancelled because its queue holds a raw pointer into the `PipeReader` being freed. A pending buffer-stdin writer is closed the same way `Subprocess::close_io` does it: claim `start()`'s outstanding ref, `close()` (which releases `create()`'s ref via `on_close_io`), then release the claimed ref.
- `Cmd::deinit`: restructured so no `&mut Cmd` borrow is live across the exec teardown, since the stdin close re-enters this same `Cmd` through `on_close_io` -> `buffered_input_close` (a no-op once `exec` is taken).
- `Cmd::deinit_from_finalizer` / unpin defusal: review of the first iteration caught that dropping a `> ${arraybuffer}` redirect's pinned buffer from inside `Heap::lastChanceToFinalize` calls `JSC__JSValue__unpinArrayBuffer` on a `JSC::ArrayBuffer` impl that `Heap::m_arrayBuffers.lastChanceToFinalize()` already deleted (verified as a heap-use-after-free under `Malloc=1`, which forces system malloc so ASAN can see JSC's libpas-backed memory; without it the write is silent). The finalizer walk now clears the pinned values first, for both the subprocess `BufferedOutput` and builtin `PinnedArrayBuf` holders, so the drops skip the unpin while the `Strong` handles still release normally. The builtin side of this was reachable before this PR too, via the node arena's `Vec` drop.

POSIX only: on Windows the forced teardown is skipped, matching the existing leak-over-UAF tradeoff of `abort_after_failed_start` (closing live libuv sources from the finalizer is unsafe there).

Behavior note: the child process is now killed (SIGKILL) when the interpreter is finalized mid-run, instead of being orphaned with nothing ever observing it. That is the same behavior `Cmd::deinit` already has for a live child, and after the owning VM is gone nothing could ever consume the child's pipes or exit status. The killed child is not reaped until the bun process exits (the process watcher was detached before the kill), so it shows as a zombie until then; the previous behavior left a live orphan running indefinitely plus the leak.

### Verification

`test/js/bun/shell/shell-worker-terminate-leak.test.ts`:

- Five LSan variants (asan lane): plain command, buffer stdin, two-command pipeline, `> file` redirect, `> ${arraybuffer}` redirect. All five fail on main with the leak reports above and pass with the fix.
- One `Malloc=1` ASAN variant pinning the unpin-after-finalize use-after-free: passes on main and with this PR, fails on the first iteration of this PR (which freed the buffer without defusing the pin).
- One functional Linux test, not gated on ASAN (so it also runs on main-branch CI where the asan lane is dropped): asserts the in-flight child is actually killed at terminate, observed via `/proc/<pid>/stat` as zombie-or-gone. Fails on main (the child stays alive), passes with the fix.

Full shell suite and worker suites pass (the only local failures are load-dependent RSS-timeout tests and a dns teardown test that fail identically on main; the latter is the separately tracked node_fs binding leak).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/shell-worker-terminate-leak.test.ts

<!-- robobun:evidence:end -->