### PR TITLE
inspect: resolve property values live after the mutation-safe key snapshot

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5453,15 +5453,11 @@ restart:
         bool anyHits = false;
         JSC::JSObject* objectToUse = prototypeObject.getObject();
 
-        // The iter callback can run user code (a nested value's inspect.custom, Proxy
-        // traps) that adds properties to this object, rehashing the PropertyTable
-        // mid-walk (use-after-free). Same for getters resolved through
-        // getIfPropertyExists. Collect the keys with no side effects first, then
-        // resolve the values and run the callbacks on the snapshot. Values are
-        // looked up by name on the live object so a property the callback
-        // overwrites reports its current value and a deleted one is re-resolved
-        // through the prototype chain (the shadowed inherited value if there is
-        // one, otherwise omitted), like the slow path below.
+        // The iter callback and getIfPropertyExists can run user code that mutates
+        // this object, rehashing the PropertyTable mid-walk (use-after-free).
+        // Snapshot the keys with no side effects, then resolve values by name on
+        // the live object and invoke the callbacks; mutation between callbacks
+        // behaves like the slow path below.
         WTF::Vector<Identifier, 16> snapshot;
 
         structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5453,11 +5453,8 @@ restart:
         bool anyHits = false;
         JSC::JSObject* objectToUse = prototypeObject.getObject();
 
-        // The iter callback and getIfPropertyExists can run user code that mutates
-        // this object, rehashing the PropertyTable mid-walk (use-after-free).
-        // Snapshot the keys with no side effects, then resolve values by name on
-        // the live object and invoke the callbacks; mutation between callbacks
-        // behaves like the slow path below.
+        // The iter callback runs user code that can rehash this PropertyTable mid-walk
+        // (use-after-free), so collect the keys first and resolve values by name after.
         WTF::Vector<Identifier, 16> snapshot;
 
         structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5458,9 +5458,10 @@ restart:
         // mid-walk (use-after-free). Same for getters resolved through
         // getIfPropertyExists. Collect the keys with no side effects first, then
         // resolve the values and run the callbacks on the snapshot. Values are
-        // looked up by name on the live structure so a property the callback
-        // deletes is omitted and one it overwrites reports the current value,
-        // like the slow path below and Node.
+        // looked up by name on the live object so a property the callback
+        // overwrites reports its current value and a deleted one is re-resolved
+        // through the prototype chain (the shadowed inherited value if there is
+        // one, otherwise omitted), like the slow path below.
         WTF::Vector<Identifier, 16> snapshot;
 
         structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
@@ -5494,8 +5495,6 @@ restart:
             unsigned attributes = 0;
             if (objectToUse == object) {
                 propertyValue = objectToUse->getDirect(vm, property, attributes);
-                if (!propertyValue)
-                    continue;
             }
 
             if (!propertyValue || propertyValue.isGetterSetter() && !((attributes & PropertyAttribute::Accessor) != 0)) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5490,7 +5490,20 @@ restart:
                 propertyValue = objectToUse->getDirect(vm, property, attributes);
             }
 
-            if (!propertyValue || propertyValue.isGetterSetter() && !((attributes & PropertyAttribute::Accessor) != 0)) {
+            if (!propertyValue) {
+                // Deleted mid-format, or a prototype-walk property: resolve through
+                // the prototype chain preserving accessors, like the slow path.
+                PropertySlot slot(objectToUse, PropertySlot::InternalMethodType::Get);
+                bool found = objectToUse->getPropertySlot(globalObject, property, slot);
+                CLEAR_IF_EXCEPTION(scope);
+                if (found) {
+                    if (slot.isAccessor()) {
+                        propertyValue = slot.isCacheableGetter() ? slot.getPureResult() : slot.getterSetter();
+                    } else {
+                        propertyValue = slot.getValue(globalObject, property);
+                    }
+                }
+            } else if (propertyValue.isGetterSetter() && !((attributes & PropertyAttribute::Accessor) != 0)) {
                 propertyValue = objectToUse->getIfPropertyExists(globalObject, prop);
             }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5456,16 +5456,12 @@ restart:
         // The iter callback can run user code (a nested value's inspect.custom, Proxy
         // traps) that adds properties to this object, rehashing the PropertyTable
         // mid-walk (use-after-free). Same for getters resolved through
-        // getIfPropertyExists. Collect the entries with no side effects first, then
-        // do the getter calls and callbacks on the snapshot.
-        struct SnapshottedProperty {
-            Identifier key;
-            unsigned attributes;
-        };
-        WTF::Vector<SnapshottedProperty, 16> snapshot;
-        // Parallel to `snapshot`; keeps the collected values visible to GC. Empty
-        // slots mark prototype properties that are fetched after the walk.
-        MarkedArgumentBuffer snapshotValues;
+        // getIfPropertyExists. Collect the keys with no side effects first, then
+        // resolve the values and run the callbacks on the snapshot. Values are
+        // looked up by name on the live structure so a property the callback
+        // deletes is omitted and one it overwrites reports the current value,
+        // like the slow path below and Node.
+        WTF::Vector<Identifier, 16> snapshot;
 
         structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
             if ((entry.attributes() & (PropertyAttribute::Function)) == 0 && (entry.attributes() & (PropertyAttribute::Builtin)) != 0) {
@@ -5486,25 +5482,23 @@ restart:
             }
             visitedProperties.append(Identifier::fromUid(vm, prop));
 
-            JSC::JSValue propertyValue = JSValue();
-            if (objectToUse == object) {
-                propertyValue = objectToUse->getDirect(entry.offset());
-                if (!propertyValue)
-                    return true;
-            }
-
-            snapshot.append({ Identifier::fromUid(vm, prop), entry.attributes() });
-            snapshotValues.appendWithCrashOnOverflow(propertyValue);
+            snapshot.append(Identifier::fromUid(vm, prop));
             return true;
         });
 
-        for (size_t i = 0; i < snapshot.size(); i++) {
-            const auto& snapshotted = snapshot[i];
-            auto* prop = snapshotted.key.impl();
+        for (const Identifier& property : snapshot) {
+            auto* prop = property.impl();
             ZigString key = toZigString(prop);
 
-            JSC::JSValue propertyValue = snapshotValues.at(i);
-            if (!propertyValue || propertyValue.isGetterSetter() && !((snapshotted.attributes & PropertyAttribute::Accessor) != 0)) {
+            JSC::JSValue propertyValue = JSValue();
+            unsigned attributes = 0;
+            if (objectToUse == object) {
+                propertyValue = objectToUse->getDirect(vm, property, attributes);
+                if (!propertyValue)
+                    continue;
+            }
+
+            if (!propertyValue || propertyValue.isGetterSetter() && !((attributes & PropertyAttribute::Accessor) != 0)) {
                 propertyValue = objectToUse->getIfPropertyExists(globalObject, prop);
             }
 
@@ -5517,7 +5511,7 @@ restart:
             anyHits = true;
             JSC::EnsureStillAliveScope ensureStillAliveScope(propertyValue);
 
-            bool isPrivate = prop->isSymbol() && snapshotted.key.isPrivateName();
+            bool isPrivate = prop->isSymbol() && property.isPrivateName();
 
             if (isPrivate && !JSC::Options::showPrivateScriptsInStackTraces())
                 continue;

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -876,6 +876,16 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         console.log("redefine later:", Bun.inspect(p).includes("z: [Getter]"));
       }
       {
+        // Deleting an own key that shadows an inherited one: the value is
+        // re-resolved through the prototype chain.
+        const p = Object.create({ z: "inherited" });
+        for (let i = 0; i < 8; i++) p["k" + i] = i;
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) delete p.z; return "a"; } };
+        p.z = 1;
+        console.log("shadowed delete:", Bun.inspect(p).includes('z: "inherited"'));
+      }
+      {
         // A getter on a built-in subclass (Map.size) is another way the
         // formatter runs user code for a nested value.
         const p = makeParent();
@@ -955,6 +965,7 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         "delete later: true",
         "delete+readd later: true",
         "redefine later: true",
+        "shadowed delete: true",
         "map size getter: true true",
         "prototype walk: true true",
         "gc churn: true",
@@ -963,5 +974,43 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     );
     expect(stderr).not.toContain("AddressSanitizer");
     expect(exitCode).toBe(0);
+  });
+});
+
+// Mutating a not-yet-formatted sibling from an inspect.custom hook must
+// produce the same output on every formatter path: the fast structure walk, the
+// slow path (forced by a getter on the parent), and the sorted/ordered walk.
+describe("mid-format sibling mutation agrees across formatter paths", () => {
+  const custom = Symbol.for("nodejs.util.inspect.custom");
+
+  function make(mutate, { slow = false, proto = null } = {}) {
+    const p = proto ? Object.create(proto) : {};
+    for (let i = 0; i < 8; i++) p["k" + i] = i;
+    if (slow) Object.defineProperty(p, "g", { get() { return 0; }, enumerable: true, configurable: true });
+    let fired = 0;
+    p.a = { [custom]() { if (!fired++) mutate(p); return "a"; } };
+    p.z = 1;
+    return p;
+  }
+
+  const zLine = s => s.match(/z: [^,}\n]*/)?.[0] ?? "omitted";
+
+  it.each([
+    ["overwrite", p => void (p.z = 777), null, "z: 777"],
+    ["delete", p => void delete p.z, null, "omitted"],
+    ["delete and re-add", p => void (delete p.z, (p.z = 999)), null, "z: 999"],
+    [
+      "redefine as getter",
+      p => void Object.defineProperty(p, "z", { get: () => 5, enumerable: true, configurable: true }),
+      null,
+      "z: [Getter]",
+    ],
+    ["delete a shadowing key", p => void delete p.z, { z: "inherited" }, 'z: "inherited"'],
+  ])("%s", (_name, mutate, proto, expected) => {
+    expect({
+      fast: zLine(Bun.inspect(make(mutate, { proto }))),
+      slow: zLine(Bun.inspect(make(mutate, { proto, slow: true }))),
+      sorted: zLine(Bun.inspect(make(mutate, { proto }), { sorted: true })),
+    }).toEqual({ fast: expected, slow: expected, sorted: expected });
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -844,6 +844,38 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         console.log("custom delete:", s.includes("z: 1"));
       }
       {
+        // Mutating a sibling that has not been formatted yet: only the key
+        // list is snapshotted, values resolve live. An overwrite shows the
+        // new value, a delete is omitted, and an accessor redefinition shows
+        // [Getter] (matches Node and the slow path).
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) p.z = 777; return "a"; } };
+        p.z = 1;
+        console.log("overwrite later:", Bun.inspect(p).includes("z: 777"));
+      }
+      {
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) delete p.z; return "a"; } };
+        p.z = 1;
+        console.log("delete later:", !Bun.inspect(p).includes("z:"));
+      }
+      {
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) { delete p.z; p.z = 999; } return "a"; } };
+        p.z = 1;
+        console.log("delete+readd later:", Bun.inspect(p).includes("z: 999"));
+      }
+      {
+        const p = makeParent();
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) Object.defineProperty(p, "z", { get() { return 5; }, enumerable: true, configurable: true }); return "a"; } };
+        p.z = 1;
+        console.log("redefine later:", Bun.inspect(p).includes("z: [Getter]"));
+      }
+      {
         // A getter on a built-in subclass (Map.size) is another way the
         // formatter runs user code for a nested value.
         const p = makeParent();
@@ -866,7 +898,8 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
       }
       {
         // Allocation churn + GC inside the hook, with object-valued siblings
-        // formatted afterwards: catches a snapshot that is invisible to GC.
+        // formatted afterwards: the snapshotted keys and the values resolved
+        // after the walk must survive the collection.
         const p = makeParent();
         let fired = 0;
         p.a = { [custom]() {
@@ -904,7 +937,7 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         "custom add: true",
         // console.log dump of the mutated parent: properties added by the
         // inspect.custom hook mid-format are not shown (the walk snapshots
-        // the properties up front, like Node).
+        // the key list up front, like Node).
         "{",
         "  k0: 0,",
         "  k1: 1,",
@@ -918,6 +951,10 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         "  z: 1,",
         "}",
         "custom delete: true",
+        "overwrite later: true",
+        "delete later: true",
+        "delete+readd later: true",
+        "redefine later: true",
         "map size getter: true true",
         "prototype walk: true true",
         "gc churn: true",

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -986,9 +986,21 @@ describe("mid-format sibling mutation agrees across formatter paths", () => {
   function make(mutate, { slow = false, proto = null } = {}) {
     const p = proto ? Object.create(proto) : {};
     for (let i = 0; i < 8; i++) p["k" + i] = i;
-    if (slow) Object.defineProperty(p, "g", { get() { return 0; }, enumerable: true, configurable: true });
+    if (slow)
+      Object.defineProperty(p, "g", {
+        get() {
+          return 0;
+        },
+        enumerable: true,
+        configurable: true,
+      });
     let fired = 0;
-    p.a = { [custom]() { if (!fired++) mutate(p); return "a"; } };
+    p.a = {
+      [custom]() {
+        if (!fired++) mutate(p);
+        return "a";
+      },
+    };
     p.z = 1;
     return p;
   }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -886,6 +886,16 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         console.log("shadowed delete:", Bun.inspect(p).includes('z: "inherited"'));
       }
       {
+        // Deleting an own key that shadows an inherited getter must show the
+        // accessor, not invoke it.
+        const p = Object.create({ get z() { throw new Error("must not invoke"); } });
+        for (let i = 0; i < 8; i++) p["k" + i] = i;
+        let fired = 0;
+        p.a = { [custom]() { if (!fired++) delete p.z; return "a"; } };
+        Object.defineProperty(p, "z", { value: 1, enumerable: true, configurable: true, writable: true });
+        console.log("shadowed getter delete:", Bun.inspect(p).includes("z: [Getter]"));
+      }
+      {
         // A getter on a built-in subclass (Map.size) is another way the
         // formatter runs user code for a nested value.
         const p = makeParent();
@@ -966,6 +976,7 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
         "delete+readd later: true",
         "redefine later: true",
         "shadowed delete: true",
+        "shadowed getter delete: true",
         "map size getter: true true",
         "prototype walk: true true",
         "gc churn: true",
@@ -1001,7 +1012,8 @@ describe("mid-format sibling mutation agrees across formatter paths", () => {
         return "a";
       },
     };
-    p.z = 1;
+    // defineProperty, not `p.z = 1`: a getter-only inherited z would reject the assignment.
+    Object.defineProperty(p, "z", { value: 1, enumerable: true, configurable: true, writable: true });
     return p;
   }
 
@@ -1018,6 +1030,16 @@ describe("mid-format sibling mutation agrees across formatter paths", () => {
       "z: [Getter]",
     ],
     ["delete a shadowing key", p => void delete p.z, { z: "inherited" }, 'z: "inherited"'],
+    [
+      "delete a key shadowing an inherited getter",
+      p => void delete p.z,
+      {
+        get z() {
+          throw new Error("inspect must not invoke the inherited getter");
+        },
+      },
+      "z: [Getter]",
+    ],
   ])("%s", (_name, mutate, proto, expected) => {
     expect({
       fast: zLine(Bun.inspect(make(mutate, { proto }))),


### PR DESCRIPTION
Follow-up to #37169.

### Problem

#37169 fixed the use-after-free in the `Bun.inspect` / `console.log` fast property walk by snapshotting entries before invoking the formatter callback. It captured both keys and values, which changed observable behavior: when a hook (for example `inspect.custom` on a nested value) mutates a sibling that has not been formatted yet, the frozen value was printed instead of the current one, and a deleted property was printed anyway.

```js
const p = {};
for (let i = 0; i < 8; i++) p['k'+i] = i;
let f = 0;
p.a = { [Symbol.for('nodejs.util.inspect.custom')]() { if (!f++) p.z = 777; return 'a'; } };
p.z = 1;
console.log(Bun.inspect(p));
```

| hook mutates `p.z` | Bun 1.4.0 (pre #37169) | after #37169 | Node v26 | this PR |
|---|---|---|---|---|
| `p.z = 777` | `z: 777` | `z: 1` (stale) | `z: 777` | `z: 777` |
| `delete p.z` | omitted | `z: 1` (resurrected) | throws (Node bug) | omitted |
| `delete p.z; p.z = 999` | `z: 999` | `z: 1` (stale) | `z: 999` | `z: 999` |
| redefine as getter | `z: [Getter]` | `z: 1` (stale) | `z: [Getter]` | `z: [Getter]` |
| `delete p.z` shadowing inherited `z` | `z: "inherited"` | `z: 1` (stale) | throws (Node bug) | `z: "inherited"` |

The slow path in the same function (taken when the object has getters or is a Proxy) reads values live, so the two paths also disagreed with each other.

### Fix

The use-after-free fix only requires that no user code runs while `Structure::forEachProperty` iterates the `PropertyTable`. So snapshot just the key list during the walk, and resolve each value by name in the post-walk loop: `getDirect(vm, propertyName, attributes)` against the live structure, falling back to a `PropertySlot` lookup with the slow path's accessor handling when the direct lookup misses. A by-name lookup holds no iteration state, so mutation between callbacks is fine: overwritten keys report the current value, a property redefined as an accessor shows `[Getter]` because the attributes are read live too, and a deleted key re-resolves through the prototype chain, printing the inherited value it was shadowing (an inherited accessor stays `[Getter]`, not invoked) or omitted when gone, exactly like the slow path.

This restores the pre-#37169 value semantics (which matched Node) while keeping its key-list snapshot semantics (which also match Node: properties added mid-format are not shown). The parallel `MarkedArgumentBuffer` value buffer is no longer needed and is removed; each value is now fetched right before its callback and protected by the existing `EnsureStillAliveScope`.

### Verification

- Extended the ASAN fixture in `test/js/bun/util/inspect.test.js` with overwrite, delete, delete+re-add, redefine-as-getter, delete-of-a-shadowing-key, and delete-of-a-key-shadowing-an-inherited-getter of a later-ordered sibling. The new assertions fail on current main (stale `z: 1`) and pass with this change; the use-after-free cases from #37169 still pass under ASAN with `Malloc=1`.
- Added a behavior matrix test (runs on every build, no ASAN needed) asserting the six mutation cases produce identical output on the fast path, the slow path (forced by a getter on the parent), and the sorted walk. The inherited-getter case throws if the formatter invokes it. Verified the combinations also match Bun 1.4.0.
- `test/js/bun/util/inspect.test.js`: 80 pass. `test/js/bun/console/`: 85 pass, 1 skip. `test/js/node/util/custom-inspect.test.js` + `bun-inspect.test.ts`: 56 pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->