### PR TITLE
Don't change ESM evaluation order when the Node compile cache is enabled

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -5,11 +5,12 @@
 use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 use bstr::ByteSlice;
+use bun_ast::Loader;
 use bun_boringssl::c as boring;
 use bun_collections::{HashMap, IdentityContext};
 use bun_core::String as BunString;
 use bun_core::{Mutex, ZStr, env_var};
-use bun_options_types::Format;
+use bun_options_types::{Format, ModuleType};
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 use bun_sys::{self as sys, Fd, O};
 
@@ -510,6 +511,38 @@ pub fn get_dir() -> Option<Vec<u8>> {
 // ──────────────────────────────────────────────────────────────────────────
 // Fetch-time hook (read + validate)
 // ──────────────────────────────────────────────────────────────────────────
+
+/// Guarded [`fetch`] for the transpile paths (synchronous and concurrent):
+/// only file-backed, JS-like modules participate. `code` is the exact
+/// post-transpile byte text and is copied, so callers may reuse or replace
+/// their buffer afterwards. Returns `(null, 0)` when the cache is disabled,
+/// the module does not participate, or no on-disk entry validates.
+pub fn fetch_for_transpiled_module(
+    path: &bun_paths::fs::Path<'_>,
+    loader: Loader,
+    is_cjs: bool,
+    code: &[u8],
+) -> (*mut u8, usize) {
+    if !is_enabled() || !path.is_file() || !loader.is_java_script_like() {
+        return (core::ptr::null_mut(), 0);
+    }
+    fetch(path.text, is_cjs, code).unwrap_or((core::ptr::null_mut(), 0))
+}
+
+/// Guarded [`note_parse_failure`] for the transpile paths: register the
+/// failed module so exit-time persist logs the "was not initialized" skip
+/// (Node parity). `module_type` is the extension-sniffed type
+/// ([`ModuleType::from_extension`]); `Unknown` records as CommonJS, like Node.
+pub fn note_parse_failure_for_module(
+    path: &bun_paths::fs::Path<'_>,
+    loader: Loader,
+    module_type: ModuleType,
+) {
+    if !is_enabled() || !path.is_file() || !loader.is_java_script_like() {
+        return;
+    }
+    note_parse_failure(path.text, !matches!(module_type, ModuleType::Esm));
+}
 
 /// Module-fetch hook: register/refresh the entry for `filename`; returns the
 /// validated bytecode blob when the on-disk cache matches `code` (post-

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -892,24 +892,13 @@ impl TranspilerJob {
                 }
             }
 
-            // Node compile cache: record the failed module so exit-time
-            // persist logs the "was not initialized" skip (Node parity).
-            if crate::node_compile_cache::is_enabled()
-                && loader.is_java_script_like()
-                && path.is_file()
-            {
-                // `module_type` here comes from package.json alone; mirror the
-                // synchronous path's extension sniff (transpile_file) so both
-                // paths record the same type: the extension wins over
-                // package.json "type", and only .js/.ts consult it.
-                let is_cjs = match path.name().ext {
-                    b".cjs" | b".cts" => true,
-                    b".mjs" | b".mts" => false,
-                    b".js" | b".ts" => !matches!(module_type, ModuleType::Esm),
-                    _ => true,
-                };
-                crate::node_compile_cache::note_parse_failure(path.text, is_cjs);
-            }
+            // Extension-sniffed, not the package.json-only `module_type` the
+            // parse used, so both transpile paths record the same type.
+            crate::node_compile_cache::note_parse_failure_for_module(
+                &path,
+                loader,
+                ModuleType::from_extension(path.name().ext, module_type),
+            );
             self.parse_error = Some(crate::CrateError::ParseError);
             return;
         };
@@ -980,23 +969,19 @@ impl TranspilerJob {
             };
 
             let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
-            // Node compile cache hook (transpiler-cache-hit path). UTF-16
-            // output would hash differently than the print path, so skip it.
-            let node_compile_cache_blob = if crate::node_compile_cache::is_enabled()
-                && path.is_file()
-                && loader.is_java_script_like()
-                && !matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
-            {
-                crate::node_compile_cache::fetch(
-                    path.text,
-                    is_commonjs_module,
-                    entry.output_code.byte_slice(),
-                )
-            } else {
-                None
-            };
+            // UTF-16 transpiler-cache output cannot byte-match the printed
+            // form, so it never reaches the compile cache.
             let (bytecode_cache, bytecode_cache_size) =
-                node_compile_cache_blob.unwrap_or((ptr::null_mut(), 0));
+                if matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16()) {
+                    (ptr::null_mut(), 0)
+                } else {
+                    crate::node_compile_cache::fetch_for_transpiled_module(
+                        &path,
+                        loader,
+                        is_commonjs_module,
+                        entry.output_code.byte_slice(),
+                    )
+                };
 
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
                 source_code: match &mut entry.output_code {
@@ -1171,22 +1156,13 @@ impl TranspilerJob {
             dump_source(vm, specifier, source_code_printer);
         }
 
-        // Node compile cache hook (concurrent transpile path). `fetch` copies
-        // the printed bytes, so replacing the print buffer below is safe.
-        let node_compile_cache_blob = if crate::node_compile_cache::is_enabled()
-            && path.is_file()
-            && loader.is_java_script_like()
-        {
-            crate::node_compile_cache::fetch(
-                path.text,
+        let (bytecode_cache, bytecode_cache_size) =
+            crate::node_compile_cache::fetch_for_transpiled_module(
+                &path,
+                loader,
                 is_commonjs_module,
                 source_code_printer.ctx.get_written(),
-            )
-        } else {
-            None
-        };
-        let (bytecode_cache, bytecode_cache_size) =
-            node_compile_cache_blob.unwrap_or((ptr::null_mut(), 0));
+            );
 
         let source_code = 'brk: {
             let written = source_code_printer.ctx.get_written();

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -898,10 +898,17 @@ impl TranspilerJob {
                 && loader.is_java_script_like()
                 && path.is_file()
             {
-                crate::node_compile_cache::note_parse_failure(
-                    path.text,
-                    !matches!(module_type, ModuleType::Esm),
-                );
+                // `module_type` here comes from package.json alone; mirror the
+                // synchronous path's extension sniff (transpile_file) so both
+                // paths record the same type: the extension wins over
+                // package.json "type", and only .js/.ts consult it.
+                let is_cjs = match path.name().ext {
+                    b".cjs" | b".cts" => true,
+                    b".mjs" | b".mts" => false,
+                    b".js" | b".ts" => !matches!(module_type, ModuleType::Esm),
+                    _ => true,
+                };
+                crate::node_compile_cache::note_parse_failure(path.text, is_cjs);
             }
             self.parse_error = Some(crate::CrateError::ParseError);
             return;

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -892,6 +892,17 @@ impl TranspilerJob {
                 }
             }
 
+            // Node compile cache: record the failed module so exit-time
+            // persist logs the "was not initialized" skip (Node parity).
+            if crate::node_compile_cache::is_enabled()
+                && loader.is_java_script_like()
+                && path.is_file()
+            {
+                crate::node_compile_cache::note_parse_failure(
+                    path.text,
+                    !matches!(module_type, ModuleType::Esm),
+                );
+            }
             self.parse_error = Some(crate::CrateError::ParseError);
             return;
         };
@@ -961,6 +972,25 @@ impl TranspilerJob {
                 ptr::null_mut()
             };
 
+            let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
+            // Node compile cache hook (transpiler-cache-hit path). UTF-16
+            // output would hash differently than the print path, so skip it.
+            let node_compile_cache_blob = if crate::node_compile_cache::is_enabled()
+                && path.is_file()
+                && loader.is_java_script_like()
+                && !matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
+            {
+                crate::node_compile_cache::fetch(
+                    path.text,
+                    is_commonjs_module,
+                    entry.output_code.byte_slice(),
+                )
+            } else {
+                None
+            };
+            let (bytecode_cache, bytecode_cache_size) =
+                node_compile_cache_blob.unwrap_or((ptr::null_mut(), 0));
+
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
                 source_code: match &mut entry.output_code {
                     OutputCode::String(s) => *s,
@@ -970,9 +1000,11 @@ impl TranspilerJob {
                         result
                     }
                 },
-                is_commonjs_module: entry.metadata.module_type == CacheModuleType::Cjs,
+                is_commonjs_module,
                 module_info,
                 tag: this_tag,
+                bytecode_cache,
+                bytecode_cache_size,
                 ..Default::default()
             });
 
@@ -1132,6 +1164,23 @@ impl TranspilerJob {
             dump_source(vm, specifier, source_code_printer);
         }
 
+        // Node compile cache hook (concurrent transpile path). `fetch` copies
+        // the printed bytes, so replacing the print buffer below is safe.
+        let node_compile_cache_blob = if crate::node_compile_cache::is_enabled()
+            && path.is_file()
+            && loader.is_java_script_like()
+        {
+            crate::node_compile_cache::fetch(
+                path.text,
+                is_commonjs_module,
+                source_code_printer.ctx.get_written(),
+            )
+        } else {
+            None
+        };
+        let (bytecode_cache, bytecode_cache_size) =
+            node_compile_cache_blob.unwrap_or((ptr::null_mut(), 0));
+
         let source_code = 'brk: {
             let written = source_code_printer.ctx.get_written();
 
@@ -1172,6 +1221,8 @@ impl TranspilerJob {
                 })
                 .unwrap_or(ptr::null_mut()),
             tag: this_tag,
+            bytecode_cache,
+            bytecode_cache_size,
             ..Default::default()
         });
 

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -971,17 +971,17 @@ impl TranspilerJob {
             let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
             // UTF-16 transpiler-cache output cannot byte-match the printed
             // form, so it never reaches the compile cache.
-            let (bytecode_cache, bytecode_cache_size) =
-                if matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16()) {
-                    (ptr::null_mut(), 0)
-                } else {
-                    crate::node_compile_cache::fetch_for_transpiled_module(
-                        &path,
-                        loader,
-                        is_commonjs_module,
-                        entry.output_code.byte_slice(),
-                    )
-                };
+            let (bytecode_cache, bytecode_cache_size) = if matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
+            {
+                (ptr::null_mut(), 0)
+            } else {
+                crate::node_compile_cache::fetch_for_transpiled_module(
+                    &path,
+                    loader,
+                    is_commonjs_module,
+                    entry.output_code.byte_slice(),
+                )
+            };
 
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
                 source_code: match &mut entry.output_code {

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -112,6 +112,20 @@ pub enum ModuleType {
 
 impl ModuleType {
     pub const LIST: __ComptimeStringMap_MODULE_TYPE_LIST = __ComptimeStringMap_MODULE_TYPE_LIST(());
+
+    /// Module type from a file extension (dot included). The extension is
+    /// authoritative; `package_json_type` (the enclosing package.json
+    /// `"type"`, [`ModuleType::Unknown`] when absent) applies only to
+    /// `.js`/`.ts`, and other extensions (`.jsx`, `.tsx`, ...) stay
+    /// [`ModuleType::Unknown`] so the file contents decide.
+    pub fn from_extension(ext: &[u8], package_json_type: ModuleType) -> ModuleType {
+        match ext {
+            b".cjs" | b".cts" => ModuleType::Cjs,
+            b".mjs" | b".mts" => ModuleType::Esm,
+            b".js" | b".ts" => package_json_type,
+            _ => ModuleType::Unknown,
+        }
+    }
 }
 
 bun_core::comptime_string_map! {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2025,21 +2025,6 @@ fn to_jsc_fetch_error(err: &crate::Error) -> bun_jsc::CrateError {
         _ => bun_jsc::CrateError::ParseError,
     }
 }
-/// Shared guard for the two parse-failure exits: register the module with the
-/// Node compile cache (Unknown module type maps to CJS, matching Node).
-fn note_compile_cache_parse_failure(
-    path: &bun_resolver::fs::Path<'_>,
-    loader: Loader,
-    module_type: ModuleType,
-) {
-    if bun_jsc::node_compile_cache::is_enabled() && loader.is_java_script_like() && path.is_file() {
-        bun_jsc::node_compile_cache::note_parse_failure(
-            path.text,
-            !matches!(module_type, ModuleType::Esm),
-        );
-    }
-}
-
 /// `ModuleLoader.transpileSourceCode(...)` — the runtime-transpiler path:
 /// read file → `Transpiler::parse`
 /// → `js_printer::print` → `ResolvedSource`.
@@ -2608,9 +2593,7 @@ fn transpile_source_code_inner(
                         );
                     }
                     arena_guard.2 = false; // give_back_arena = false
-                    // Node compile cache: record the failed module so exit-time
-                    // persist logs the "was not initialized" skip (Node parity).
-                    note_compile_cache_parse_failure(path, loader, module_type);
+                    bun_jsc::node_compile_cache::note_parse_failure_for_module(path, loader, module_type);
                     return Err(crate::Error::ParseError);
                 };
 
@@ -2664,9 +2647,7 @@ fn transpile_source_code_inner(
                 // `transpiler.log` was swapped to non-null `args.log` above.
                 if unsafe { (*(*jsc_vm).transpiler.log).errors > 0 } {
                     arena_guard.2 = false;
-                    // Node compile cache: record the failed module so exit-time
-                    // persist logs the "was not initialized" skip (Node parity).
-                    note_compile_cache_parse_failure(path, loader, module_type);
+                    bun_jsc::node_compile_cache::note_parse_failure_for_module(path, loader, module_type);
                     return Err(crate::Error::ParseError);
                 }
 
@@ -2855,22 +2836,19 @@ fn transpile_source_code_inner(
                         core::ptr::null_mut()
                     };
                     let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
-                    // Node compile cache hook (transpiler-cache-hit path); must
-                    // read `output_code` before it is consumed below. UTF-16
-                    // output would hash differently than the print path — skip.
-                    let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
-                        && source.path.is_file()
-                        && loader.is_java_script_like()
-                        && !matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
-                    {
-                        bun_jsc::node_compile_cache::fetch(
-                            source.path.text,
-                            is_commonjs_module,
-                            entry.output_code.byte_slice(),
-                        )
-                    } else {
-                        None
-                    };
+                    // UTF-16 transpiler-cache output cannot byte-match the
+                    // printed form, so it never reaches the compile cache.
+                    let (bytecode_cache, bytecode_cache_size) =
+                        if matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16()) {
+                            (core::ptr::null_mut(), 0)
+                        } else {
+                            bun_jsc::node_compile_cache::fetch_for_transpiled_module(
+                                &source.path,
+                                loader,
+                                is_commonjs_module,
+                                entry.output_code.byte_slice(),
+                            )
+                        };
                     let source_code = match &mut entry.output_code {
                         OutputCode::String(s) => *s,
                         OutputCode::Utf8(utf8) => {
@@ -2929,8 +2907,6 @@ fn transpile_source_code_inner(
                     } else {
                         ResolvedSourceTag::Javascript
                     };
-                    let (bytecode_cache, bytecode_cache_size) =
-                        node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
                         source_code,
                         specifier: input_specifier.dupe_ref(),
@@ -3121,14 +3097,13 @@ fn transpile_source_code_inner(
                     let printer: &mut bun_js_printer::BufferPrinter =
                         unsafe { &mut *(*extra).source_code_printer };
                     let written = printer.ctx.get_written();
-                    let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
-                        && path.is_file()
-                        && loader.is_java_script_like()
-                    {
-                        bun_jsc::node_compile_cache::fetch(path.text, is_commonjs_module, written)
-                    } else {
-                        None
-                    };
+                    let (bytecode_cache, bytecode_cache_size) =
+                        bun_jsc::node_compile_cache::fetch_for_transpiled_module(
+                            path,
+                            loader,
+                            is_commonjs_module,
+                            written,
+                        );
                     // SAFETY: per fn contract — `jsc_vm` is the live per-thread
                     // VM; `printer.ctx.get_written()` borrows thread-local data.
                     let mut resolved_source = unsafe {
@@ -3141,10 +3116,8 @@ fn transpile_source_code_inner(
                     };
                     resolved_source.is_commonjs_module = is_commonjs_module;
                     resolved_source.module_info = module_info;
-                    if let Some((ptr, size)) = node_compile_cache_blob {
-                        resolved_source.bytecode_cache = ptr;
-                        resolved_source.bytecode_cache_size = size;
-                    }
+                    resolved_source.bytecode_cache = bytecode_cache;
+                    resolved_source.bytecode_cache_size = bytecode_cache_size;
                     return Ok(OwnedResolvedSource::from(resolved_source));
                 }
 
@@ -3205,16 +3178,13 @@ fn transpile_source_code_inner(
                 let printer: &mut bun_js_printer::BufferPrinter =
                     unsafe { &mut *(*extra).source_code_printer };
                 let written = printer.ctx.get_written();
-                // Node compile cache hook (sync transpile path). `fetch` copies
-                // `written`; the printer may be replaced below.
-                let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
-                    && path.is_file()
-                    && loader.is_java_script_like()
-                {
-                    bun_jsc::node_compile_cache::fetch(path.text, is_commonjs_module, written)
-                } else {
-                    None
-                };
+                let (bytecode_cache, bytecode_cache_size) =
+                    bun_jsc::node_compile_cache::fetch_for_transpiled_module(
+                        path,
+                        loader,
+                        is_commonjs_module,
+                        written,
+                    );
                 // The `Jsc` vtable bridge `put()` does not write
                 // `cache.output_code` (only the `r#impl == None` fallback
                 // does, and `r#impl` is `Some(Jsc)` here), so it is always
@@ -3236,8 +3206,6 @@ fn transpile_source_code_inner(
                 // (fd close handled by `_fd_guard` registered above; spec
                 // :251-256 `defer` fires on every exit path.)
 
-                let (bytecode_cache, bytecode_cache_size) =
-                    node_compile_cache_blob.unwrap_or((core::ptr::null_mut(), 0));
                 return Ok(OwnedResolvedSource::from(ResolvedSource {
                     source_code,
                     specifier: input_specifier.dupe_ref(),
@@ -4344,34 +4312,12 @@ unsafe fn transpile_file(
     }
 
     // ── module_type sniff from extension / package.json ─────────────────────
-    let module_type: ModuleType = 'brk: {
-        let ext = lr.path.name().ext;
-        // regex /\.[cm][jt]s$/
-        if ext.len() == b".cjs".len() {
-            if ext == b".cjs" {
-                break 'brk ModuleType::Cjs;
-            }
-            if ext == b".mjs" {
-                break 'brk ModuleType::Esm;
-            }
-            if ext == b".cts" {
-                break 'brk ModuleType::Cjs;
-            }
-            if ext == b".mts" {
-                break 'brk ModuleType::Esm;
-            }
-        }
-        // regex /\.[jt]s$/
-        if ext.len() == b".ts".len() && (ext == b".js" || ext == b".ts") {
-            // Use the package.json module type if it exists.
-            break 'brk lr
-                .package_json
-                .map(|pkg| pkg.module_type)
-                .unwrap_or(ModuleType::Unknown);
-        }
-        // For JSX/TSX and other extensions, let the file contents decide.
-        ModuleType::Unknown
-    };
+    let module_type = ModuleType::from_extension(
+        lr.path.name().ext,
+        lr.package_json
+            .map(|pkg| pkg.module_type)
+            .unwrap_or(ModuleType::Unknown),
+    );
     let pkg_name: Option<&[u8]> = lr
         .package_json
         .and_then(|pkg| (!pkg.name.is_empty()).then_some(&*pkg.name));

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2593,7 +2593,11 @@ fn transpile_source_code_inner(
                         );
                     }
                     arena_guard.2 = false; // give_back_arena = false
-                    bun_jsc::node_compile_cache::note_parse_failure_for_module(path, loader, module_type);
+                    bun_jsc::node_compile_cache::note_parse_failure_for_module(
+                        path,
+                        loader,
+                        module_type,
+                    );
                     return Err(crate::Error::ParseError);
                 };
 
@@ -2647,7 +2651,11 @@ fn transpile_source_code_inner(
                 // `transpiler.log` was swapped to non-null `args.log` above.
                 if unsafe { (*(*jsc_vm).transpiler.log).errors > 0 } {
                     arena_guard.2 = false;
-                    bun_jsc::node_compile_cache::note_parse_failure_for_module(path, loader, module_type);
+                    bun_jsc::node_compile_cache::note_parse_failure_for_module(
+                        path,
+                        loader,
+                        module_type,
+                    );
                     return Err(crate::Error::ParseError);
                 }
 
@@ -2838,17 +2846,17 @@ fn transpile_source_code_inner(
                     let is_commonjs_module = entry.metadata.module_type == CacheModuleType::Cjs;
                     // UTF-16 transpiler-cache output cannot byte-match the
                     // printed form, so it never reaches the compile cache.
-                    let (bytecode_cache, bytecode_cache_size) =
-                        if matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16()) {
-                            (core::ptr::null_mut(), 0)
-                        } else {
-                            bun_jsc::node_compile_cache::fetch_for_transpiled_module(
-                                &source.path,
-                                loader,
-                                is_commonjs_module,
-                                entry.output_code.byte_slice(),
-                            )
-                        };
+                    let (bytecode_cache, bytecode_cache_size) = if matches!(&entry.output_code, OutputCode::String(s) if s.is_utf16())
+                    {
+                        (core::ptr::null_mut(), 0)
+                    } else {
+                        bun_jsc::node_compile_cache::fetch_for_transpiled_module(
+                            &source.path,
+                            loader,
+                            is_commonjs_module,
+                            entry.output_code.byte_slice(),
+                        )
+                    };
                     let source_code = match &mut entry.output_code {
                         OutputCode::String(s) => *s,
                         OutputCode::Utf8(utf8) => {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4401,9 +4401,6 @@ unsafe fn transpile_file(
             // TODO: allow running concurrently when no onLoad handlers match a plugin.
             && plugin_runner_is_none
             && store_enabled
-            // With the Node compile cache enabled, transpile on-thread so the
-            // fetch hook sees every module.
-            && !bun_jsc::node_compile_cache::is_enabled()
         {
             // Disgusting workaround: polyfills like
             // `reflect-metadata` are CJS-with-side-effects that other ESM

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -122,26 +122,29 @@ describe.concurrent("node-module-module", () => {
       "preload.cjs": `require("node:module").enableCompileCache(__dirname + "/cc-api");`,
     });
     const cacheDir = path.join(String(dir), "cc");
+    const apiCacheDir = path.join(String(dir), "cc-api");
     const run = async (args, env) => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), ...args],
-        env: { ...bunEnv, ...env },
+        env: { ...bunEnv, NODE_COMPILE_CACHE: undefined, ...env },
         cwd: String(dir),
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim()).toBe("esm,cjs");
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
-      return stdout.trim();
     };
-    expect(await run(["main.mjs"], {})).toBe("esm,cjs");
-    expect(await run(["main.mjs"], { NODE_COMPILE_CACHE: cacheDir })).toBe("esm,cjs"); // cold
-    expect(await run(["main.mjs"], { NODE_COMPILE_CACHE: cacheDir })).toBe("esm,cjs"); // warm
-    expect(await run(["--preload", "./preload.cjs", "main.mjs"], {})).toBe("esm,cjs");
+    await run(["main.mjs"], {});
+    await run(["main.mjs"], { NODE_COMPILE_CACHE: cacheDir }); // cold
+    await run(["main.mjs"], { NODE_COMPILE_CACHE: cacheDir }); // warm
+    await run(["--preload", "./preload.cjs", "main.mjs"], {});
     // The cached runs only prove anything if the cache was actually active.
-    const tagged = fs.readdirSync(cacheDir);
-    expect(tagged).toHaveLength(1);
-    expect(fs.readdirSync(path.join(cacheDir, tagged[0])).length).toBeGreaterThanOrEqual(3);
+    for (const dirToCheck of [cacheDir, apiCacheDir]) {
+      const tagged = fs.readdirSync(dirToCheck);
+      expect(tagged).toHaveLength(1);
+      expect(fs.readdirSync(path.join(dirToCheck, tagged[0])).length).toBeGreaterThanOrEqual(3);
+    }
   });
 
   test("compile cache records a parse-failed .mjs as ESM regardless of package type", async () => {
@@ -158,7 +161,8 @@ describe.concurrent("node-module-module", () => {
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toMatch(/skip persisting ESM file:.*broken\.mjs because the cache was not initialized/);
     expect(exitCode).not.toBe(0);
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -144,6 +144,25 @@ describe.concurrent("node-module-module", () => {
     expect(fs.readdirSync(path.join(cacheDir, tagged[0])).length).toBeGreaterThanOrEqual(3);
   });
 
+  test("compile cache records a parse-failed .mjs as ESM regardless of package type", async () => {
+    // Parse-failure bookkeeping keys off the file extension like the
+    // synchronous loader and Node, not the enclosing package.json "type".
+    using dir = tempDir("compile-cache-parse-failure-type", {
+      "main.mjs": `import "./pkg/broken.mjs";`,
+      "pkg/package.json": `{"type":"commonjs"}`,
+      "pkg/broken.mjs": `import {;`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: { ...bunEnv, NODE_COMPILE_CACHE: path.join(String(dir), "cc"), NODE_DEBUG_NATIVE: "COMPILE_CACHE" },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toMatch(/skip persisting ESM file:.*broken\.mjs because the cache was not initialized/);
+    expect(exitCode).not.toBe(0);
+  });
+
   test.skipIf(process.platform === "win32")(
     "compile cache persists modules loaded after a non-fatal self-kill",
     async () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -111,6 +111,39 @@ describe.concurrent("node-module-module", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("compile cache does not change ESM evaluation order", async () => {
+    // A `.cjs` sibling with no CommonJS features is loaded as ESM and must
+    // evaluate after the `.mjs` module imported before it, with or without
+    // the compile cache (cold and warm), and via the API enable path.
+    using dir = tempDir("compile-cache-eval-order", {
+      "main.mjs": `import "./e.mjs";\nimport "./c.cjs";\nconsole.log(globalThis.o.join(","));`,
+      "e.mjs": `(globalThis.o ??= []).push("esm");\nexport {};`,
+      "c.cjs": `(globalThis.o ??= []).push("cjs");`,
+      "preload.cjs": `require("node:module").enableCompileCache(__dirname + "/cc-api");`,
+    });
+    const cacheDir = path.join(String(dir), "cc");
+    const run = async (args, env) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args],
+        env: { ...bunEnv, ...env },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout.trim();
+    };
+    expect(await run(["main.mjs"], {})).toBe("esm,cjs");
+    expect(await run(["main.mjs"], { NODE_COMPILE_CACHE: cacheDir })).toBe("esm,cjs"); // cold
+    expect(await run(["main.mjs"], { NODE_COMPILE_CACHE: cacheDir })).toBe("esm,cjs"); // warm
+    expect(await run(["--preload", "./preload.cjs", "main.mjs"], {})).toBe("esm,cjs");
+    // The cached runs only prove anything if the cache was actually active.
+    const tagged = fs.readdirSync(cacheDir);
+    expect(tagged).toHaveLength(1);
+    expect(fs.readdirSync(path.join(cacheDir, tagged[0])).length).toBeGreaterThanOrEqual(3);
+  });
+
   test.skipIf(process.platform === "win32")(
     "compile cache persists modules loaded after a non-fatal self-kill",
     async () => {


### PR DESCRIPTION
Enabling the Node compile cache changed ESM evaluation order: a CommonJS module statically imported after an ESM sibling evaluated before it.

```sh
# main.mjs:  import "./e.mjs"; import "./c.cjs"; console.log(globalThis.o.join(","));
# e.mjs:     (globalThis.o ??= []).push("esm"); export {};
# c.cjs:     (globalThis.o ??= []).push("cjs");
bun main.mjs                            # esm,cjs  (matches Node)
NODE_COMPILE_CACHE=$PWD/cc bun main.mjs # cjs,esm  <- flipped, cold and warm alike
```

The API enable path (`require("node:module").enableCompileCache(dir)` in a preload) flipped it the same way; `NODE_DISABLE_COMPILE_CACHE=1` restored the order.

**Cause.** With the cache enabled, `transpile_file` skipped the concurrent transpiler for every import so the cache's fetch hook (which only existed on the synchronous path) would see each module. The two paths classify this file differently:

- The synchronous path sniffs `module_type` from the extension, so a `.cjs` file with no CommonJS features is classified CommonJS. CommonJS imported from ESM evaluates eagerly while the module graph is still loading (`makeModule` runs the synthetic source generator, which calls `evaluateCommonJSModuleOnce`), so its side effects run before any ESM sibling evaluates.
- The concurrent path (`RuntimeTranspilerStore`) derives `module_type` from package.json alone, classifies the featureless `.cjs` as ESM, and it evaluates in graph order.

So turning the cache on silently moved every import onto the path with the other classification. The same flip was already reachable without the cache via anything else that forces the synchronous path (for example `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1`).

**Fix.** Make the cache work on the concurrent path instead of forcing everything off it:

- `RuntimeTranspilerStore` now calls the compile cache fetch hook after printing (and on the runtime-transpiler-cache hit path, skipping UTF-16 output like the synchronous path does), attaching validated bytecode to the `ResolvedSource`, and mirrors the parse-failure bookkeeping.
- The `!node_compile_cache::is_enabled()` condition on the concurrent-transpiler dispatch is removed.

The cache no longer changes which pipeline a module goes through, so evaluation order is identical with and without it. The hook is thread-safe (the cache state is behind a mutex; blobs live for the process).

**Verification.** The repro prints `esm,cjs` in all variants (no cache, cold, warm, `NODE_DISABLE_COMPILE_CACHE`, API enable via preload), and `NODE_DEBUG_NATIVE=COMPILE_CACHE` confirms warm runs accept the cached bytecode for modules transpiled on the concurrent path, including real CommonJS deps. All 14 ported `test-compile-cache-*.js` Node tests pass, as do the `--watch` persist test and the module loading suites. New test covers the order in all variants and asserts the cache directory was actually populated so the cached runs prove something.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->