### PR TITLE
node:child_process: avoid duplicate execFile timeout kill

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -234,8 +234,6 @@ function execFile(file, args, options, callback) {
   const child = spawn(file, args, {
     cwd: options.cwd,
     env: options.env,
-    timeout: options.timeout,
-    killSignal: options.killSignal,
     uid: options.uid,
     gid: options.gid,
     windowsHide: options.windowsHide,

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { getEventListeners, once, setMaxListeners } from "node:events";
+import { constants as osConstants } from "node:os";
 import { promisify } from "node:util";
 import path from "path";
 const debug = process.env.DEBUG ? console.log : () => {};
@@ -1151,15 +1152,28 @@ it.if(!isWindows)("execFile timeout invokes ChildProcess.kill once", async () =>
   const closed = once(child, "close");
   const originalKill = child.kill.bind(child);
   const timeoutKillCalls: unknown[] = [];
+  const { promise: timeoutKill, resolve: resolveTimeoutKill } = Promise.withResolvers<void>();
 
   child.kill = signal => {
     timeoutKillCalls.push(signal);
+    resolveTimeoutKill();
     return originalKill(signal);
   };
 
   try {
-    await Bun.sleep(600);
-    expect(timeoutKillCalls).toHaveLength(1);
+    await Promise.race([
+      timeoutKill,
+      closed.then(() => {
+        throw new Error("Child closed before execFile timeout kill");
+      }),
+    ]);
+
+    const deadline = Date.now() + 100;
+    while (timeoutKillCalls.length === 1 && Date.now() < deadline) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+
+    expect(timeoutKillCalls).toEqual([osConstants.signals.SIGCONT]);
     expect(child.exitCode).toBeNull();
   } finally {
     originalKill("SIGKILL");

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1145,3 +1145,24 @@ describe("spawn/execFile({signal}) does not leak abort listeners on spawn failur
     expect(errors.map(e => e.code)).toEqual(["ENOENT"]);
   });
 });
+
+it.if(!isWindows)("execFile timeout invokes ChildProcess.kill once", async () => {
+  const child = execFile("sleep", ["10"], { timeout: 300, killSignal: "SIGCONT" }, () => {});
+  const closed = once(child, "close");
+  const originalKill = child.kill.bind(child);
+  const timeoutKillCalls: unknown[] = [];
+
+  child.kill = signal => {
+    timeoutKillCalls.push(signal);
+    return originalKill(signal);
+  };
+
+  try {
+    await Bun.sleep(600);
+    expect(timeoutKillCalls).toHaveLength(1);
+    expect(child.exitCode).toBeNull();
+  } finally {
+    originalKill("SIGKILL");
+    await closed;
+  }
+});


### PR DESCRIPTION
### What does this PR do?

`execFile()` currently forwards `timeout` and `killSignal` to its internal `spawn()` call, while also handling the timeout itself.

So, one `execFile()` timeout gets two independent kill paths. With a non-terminating signal such as `SIGCONT`, one timeout causes `ChildProcess.kill()` to be called twice.

Node keeps the timeout at the `execFile()` layer without forwarding `timeout` or `killSignal` to `spawn()`.

This removes those two forwarded options and adds a regression test asserting that one `execFile()` timeout invokes `ChildProcess.kill()` only once.

### How did you verify your code works?

The new regression fails before the change:

```
Expected length: 1
Received length: 2
✗ execFile timeout invokes ChildProcess.kill once
```

and passes after removing the two forwarded options:

```
✓ execFile timeout invokes ChildProcess.kill once
1 pass
0 fail
```

Also verified:

```
bun bd test test/js/node/child_process/child_process.test.ts
```

passes, and these existing Node compatibility tests both exit successfully:

```
test-child-process-exec-timeout-expire.js
test-child-process-exec-timeout-kill.js
```