### PR TITLE
Fix lost wakeup when a worker message arrives during a nested event-loop wait

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -437,13 +437,13 @@ bool MessagePort::virtualHasPendingActivity() const
 
     // Keep alive while a drain task is pending or mid-dispatch. drainAndDispatch
     // pops each message (queued -> 0) before invoking listeners, so the in-hand
-    // message is invisible to the queued count; without this bit a concurrent GC
+    // message is invisible to the queued count; without these bits a concurrent GC
     // running inside that window (queue empty, peer already closed) severs the
     // wrapper weak and the dispatch hits a dead JSEventListener wrapper (debug
-    // ASSERT m_wrapper). DrainScheduled is set from schedule until the inbox is
-    // observed empty, covering every dispatch.
+    // ASSERT m_wrapper). DrainScheduled covers schedule -> drain start;
+    // Dispatching covers the dispatch loop itself.
     uint64_t s = m_pipe->state(m_side);
-    if (s & MessagePortPipe::DrainScheduled)
+    if (s & (MessagePortPipe::DrainScheduled | MessagePortPipe::Dispatching))
         return true;
 
     // Keep alive if the peer is still open and could send more, or messages are

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -73,7 +73,7 @@ void MessagePortPipe::scheduleDrain(uint8_t side, ScriptExecutionContextIdentifi
     }
 }
 
-void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx)
+void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx, bool fromYieldContinuation)
 {
     // Mirrors Node's MessagePort::OnMessage (src/node_messaging.cc): one
     // drain task processes the whole inbox in a loop, draining microtasks
@@ -104,6 +104,14 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
             return;
         port = s.port.get();
         uint64_t st = s.state.load(std::memory_order_relaxed);
+        // A spent budget hands the rest to an after-yield continuation so a
+        // self-feeding message loop cannot starve timers and I/O; wakeup tasks
+        // posted by send() in the meantime stand down until it has run.
+        if (st & YieldPending) {
+            if (!fromYieldContinuation)
+                return;
+            st &= ~uint64_t(YieldPending);
+        }
         if (!port || (s.draining.isEmpty() && s.inbox.isEmpty())) {
             s.state.store(st & ~DrainScheduled, std::memory_order_release);
             return;
@@ -167,13 +175,14 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
             }
             if (s.draining.isEmpty()) {
                 if (!limit) {
-                    // Budget spent; yield. If a racing send already posted a
-                    // wakeup let that task drain the rest, else claim the flag
-                    // and reschedule after the loop has polled.
-                    if (!(st & DrainScheduled)) {
-                        st |= DrainScheduled;
-                        rescheduleCtx = s.ctxId;
-                    }
+                    // Budget spent; the after-yield continuation posted below
+                    // is the only invocation allowed to keep draining, so
+                    // timers and I/O get a turn even when a racing send
+                    // already posted a regular wakeup task (which will stand
+                    // down on YieldPending). Nested waits still progress: the
+                    // loop tick they spin promotes after-yield tasks.
+                    st |= YieldPending;
+                    rescheduleCtx = s.ctxId;
                     if (ownsDispatching)
                         st &= ~uint64_t(Dispatching);
                     s.state.store(st, std::memory_order_release);
@@ -217,7 +226,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
     // its next loop iteration (after I/O and timers), not in this drain.
     if (rescheduleCtx) {
         context->postTaskAfterYield([pipe = Ref { *this }, side, rescheduleCtx](ScriptExecutionContext&) {
-            pipe->drainAndDispatch(side, rescheduleCtx);
+            pipe->drainAndDispatch(side, rescheduleCtx, /* fromYieldContinuation */ true);
         });
     }
 }
@@ -298,12 +307,12 @@ void MessagePortPipe::detach(uint8_t side)
         s.inbox.prepend(s.draining.takeLast());
     s.ctxId = 0;
     s.port = nullptr;
-    // Drop Attached, DrainScheduled and Dispatching. A drain task already in
-    // flight on the old context can't be recalled, but it captured the old
-    // ctxId and drainAndDispatch()'s s.ctxId != expectedCtx check makes it a
-    // no-op — even if a new owner attach()es to a different context before
-    // it runs. Messages remain queued for the next owner.
-    s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled | Dispatching), std::memory_order_acq_rel);
+    // Drop Attached, DrainScheduled, Dispatching and YieldPending. A drain
+    // task already in flight on the old context can't be recalled, but it
+    // captured the old ctxId and drainAndDispatch()'s s.ctxId != expectedCtx
+    // check makes it a no-op — even if a new owner attach()es to a different
+    // context before it runs. Messages remain queued for the next owner.
+    s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled | Dispatching | YieldPending), std::memory_order_acq_rel);
 }
 
 void MessagePortPipe::close(uint8_t side, CloseKind kind)

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -92,6 +92,7 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
 
     RefPtr<MessagePort> port;
     size_t limit;
+    bool ownsDispatching = false;
     {
         Locker locker { s.lock };
         // This task was posted to `expectedCtx` (and is running there). If
@@ -108,20 +109,36 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
             return;
         }
         limit = 1024;
+        // Trade DrainScheduled for Dispatching before user JS runs: a handler
+        // can park this loop in a nested event-loop wait, and a send() arriving
+        // then must post a fresh drain task (#37189). Dispatching keeps
+        // hasPendingActivity() true across the dispatch window DrainScheduled
+        // used to cover. A nested drain (posted by such a send) finds the bit
+        // already set and leaves clearing it to this outer invocation.
+        ownsDispatching = !(st & Dispatching);
+        s.state.store((st & ~DrainScheduled) | Dispatching, std::memory_order_release);
     }
+
+    // Clear Dispatching only if this invocation set it and still owns the
+    // side; after a detach the bit belongs to the next owner's drain.
+    auto finish = [&] {
+        if (!ownsDispatching)
+            return;
+        Locker locker { s.lock };
+        if (s.ctxId == expectedCtx && s.port.get() == port)
+            s.state.fetch_and(~uint64_t(Dispatching), std::memory_order_acq_rel);
+    };
 
     // All 'message' listeners removed: the port is paused. Leave the inbox buffered
     // and stop draining; a later addEventListener re-schedules this drain.
     if (!port->hasMessageEventListener()) {
-        Locker locker { s.lock };
-        s.state.fetch_and(~uint64_t(DrainScheduled), std::memory_order_acq_rel);
+        finish();
         return;
     }
 
     auto* context = port->scriptExecutionContext();
     if (!context || !context->globalObject()) {
-        Locker locker { s.lock };
-        s.state.fetch_and(~uint64_t(DrainScheduled), std::memory_order_acq_rel);
+        finish();
         return;
     }
     auto* globalObject = defaultGlobalObject(context->globalObject());
@@ -138,19 +155,28 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
             // MessagePort, so compare port identity too — dispatching to
             // the stale (now m_isDetached) `port` would silently drop.
             // The new owner's attach() scheduled its own drain, and detach()
-            // already returned anything we had taken to the inbox.
+            // already returned anything we had taken to the inbox (and reset
+            // the flags).
             if (s.ctxId != expectedCtx || s.port.get() != port)
-                break;
+                return;
             uint64_t st = s.state.load(std::memory_order_relaxed);
             if (!(st & Attached) || (s.draining.isEmpty() && s.inbox.isEmpty())) {
-                s.state.store(st & ~DrainScheduled, std::memory_order_release);
+                if (ownsDispatching)
+                    s.state.store(st & ~uint64_t(Dispatching), std::memory_order_release);
                 break;
             }
             if (s.draining.isEmpty()) {
                 if (!limit) {
-                    // Yield to the rest of the event loop; DrainScheduled stays
-                    // set so concurrent sends don't double-schedule.
-                    rescheduleCtx = s.ctxId;
+                    // Budget spent; yield. If a racing send already posted a
+                    // wakeup let that task drain the rest, else claim the flag
+                    // and reschedule after the loop has polled.
+                    if (!(st & DrainScheduled)) {
+                        st |= DrainScheduled;
+                        rescheduleCtx = s.ctxId;
+                    }
+                    if (ownsDispatching)
+                        st &= ~uint64_t(Dispatching);
+                    s.state.store(st, std::memory_order_release);
                     break;
                 }
                 // Refill: this is the only acquisition that contends with senders
@@ -169,17 +195,21 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
         // Node's MakeCallback wraps each emit in an InternalCallbackScope,
         // which drains nextTick + microtasks on exit; match that so
         // queueMicrotask(cb) inside onmessage runs before the next message.
-        if (globalObject->drainMicrotasks())
-            break; // termination pending
+        if (globalObject->drainMicrotasks()) {
+            finish();
+            return; // termination pending
+        }
 
         // Listeners may have been removed mid-drain (port.off()); pause like the
         // pre-loop check instead of dispatching the rest to zero listeners.
         if (!port->hasMessageEventListener()) {
-            Locker locker { s.lock };
-            while (!s.draining.isEmpty())
-                s.inbox.prepend(s.draining.takeLast());
-            s.state.fetch_and(~uint64_t(DrainScheduled), std::memory_order_acq_rel);
-            break;
+            {
+                Locker locker { s.lock };
+                while (!s.draining.isEmpty())
+                    s.inbox.prepend(s.draining.takeLast());
+            }
+            finish();
+            return;
         }
     }
 
@@ -268,12 +298,12 @@ void MessagePortPipe::detach(uint8_t side)
         s.inbox.prepend(s.draining.takeLast());
     s.ctxId = 0;
     s.port = nullptr;
-    // Drop Attached and DrainScheduled. A drain task already in flight on
-    // the old context can't be recalled, but it captured the old ctxId and
-    // drainAndDispatch()'s s.ctxId != expectedCtx check makes it a no-op —
-    // even if a new owner attach()es to a different context before it runs.
-    // Messages remain queued for the next owner.
-    s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled), std::memory_order_acq_rel);
+    // Drop Attached, DrainScheduled and Dispatching. A drain task already in
+    // flight on the old context can't be recalled, but it captured the old
+    // ctxId and drainAndDispatch()'s s.ctxId != expectedCtx check makes it a
+    // no-op — even if a new owner attach()es to a different context before
+    // it runs. Messages remain queued for the next owner.
+    s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled | Dispatching), std::memory_order_acq_rel);
 }
 
 void MessagePortPipe::close(uint8_t side, CloseKind kind)

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -43,10 +43,11 @@ public:
     // lives in the upper bits so it can be bumped with fetch_add(QueuedOne).
     enum State : uint64_t {
         Closed = 1ull << 0, // close() was called on this side; drops further deliveries.
-        DrainScheduled = 1ull << 1, // a drain task for this side is in flight.
+        DrainScheduled = 1ull << 1, // a posted drain task for this side has not yet started draining.
         Attached = 1ull << 2, // ctxId/port are valid; ok to schedule drains.
         ContextKnown = 1ull << 3, // ctxId/port are valid for close-notification only (no drains).
         ClosedByRequest = 1ull << 4, // the Closed above came from close(), not from the port being collected.
+        Dispatching = 1ull << 5, // drainAndDispatch is mid-dispatch on this side (GC liveness; see hasPendingActivity).
 
         QueuedShift = 8,
         QueuedOne = 1ull << QueuedShift,

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -48,6 +48,7 @@ public:
         ContextKnown = 1ull << 3, // ctxId/port are valid for close-notification only (no drains).
         ClosedByRequest = 1ull << 4, // the Closed above came from close(), not from the port being collected.
         Dispatching = 1ull << 5, // drainAndDispatch is mid-dispatch on this side (GC liveness; see hasPendingActivity).
+        YieldPending = 1ull << 6, // budget spent; only the posted after-yield continuation drains (anti-starvation).
 
         QueuedShift = 8,
         QueuedOne = 1ull << QueuedShift,
@@ -92,7 +93,7 @@ private:
 
     void scheduleDrain(uint8_t side, ScriptExecutionContextIdentifier, BunLoopKind);
     void notifyPeerClosed(uint8_t peerSide);
-    void drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx);
+    void drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx, bool fromYieldContinuation = false);
 
     struct Side {
         WTF::Lock lock;

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -295,7 +295,7 @@ enum class DrainBudget { Bounded,
 static constexpr size_t drainBatchLimit = 1024;
 
 template<typename Dispatch>
-static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObject& globalObject, ScriptExecutionContext& context, DrainBudget budget, Dispatch&& dispatch)
+static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObject& globalObject, ScriptExecutionContext& context, DrainBudget budget, bool fromYieldContinuation, Dispatch&& dispatch)
 {
     auto& vm = globalObject.vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -304,6 +304,16 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
 
     {
         Locker locker { inbox.lock };
+        // A spent budget hands the rest to an after-yield continuation so a
+        // self-feeding message loop cannot starve timers and I/O; wakeup tasks
+        // posted by a send in the meantime stand down until it has run. An
+        // UntilEmpty flush overrides it: the sender has exited and everything
+        // queued precedes 'close'.
+        if (inbox.yieldPending) {
+            if (!fromYieldContinuation && budget != DrainBudget::UntilEmpty)
+                return false;
+            inbox.yieldPending = false;
+        }
         inbox.drainScheduled = false;
     }
 
@@ -315,12 +325,11 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
                 if (inbox.queue.isEmpty())
                     return false;
                 if (!remaining) {
-                    // Budget spent; yield. If a racing send already posted a
-                    // wakeup let that task drain the rest, else claim the flag
-                    // and have the caller reschedule.
-                    if (inbox.drainScheduled)
-                        return false;
-                    inbox.drainScheduled = true;
+                    // Budget spent; the caller posts the after-yield
+                    // continuation that this marks as the only invocation
+                    // allowed to keep draining. Nested waits still progress:
+                    // the loop tick they spin promotes after-yield tasks.
+                    inbox.yieldPending = true;
                     return true;
                 }
                 size_t n = std::min({ takeAtOnce, remaining, static_cast<size_t>(inbox.queue.size()) });
@@ -353,38 +362,39 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
     }
 }
 
-void WorkerMessagingProxy::drainMessagesToWorkerGlobalScope(ScriptExecutionContext& context)
+void WorkerMessagingProxy::drainMessagesToWorkerGlobalScope(ScriptExecutionContext& context, bool fromYieldContinuation)
 {
     auto& globalObject = *defaultGlobalObject(context.globalObject());
-    bool more = drainInbox(m_toWorker, globalObject, context, DrainBudget::Bounded, [&](Event& event) {
+    bool more = drainInbox(m_toWorker, globalObject, context, DrainBudget::Bounded, fromYieldContinuation, [&](Event& event) {
         globalObject.globalEventScope->dispatchEvent(event);
     });
     if (more) {
         // Budget spent with messages left: continue after the loop has polled,
         // or a producer faster than this drain starves timers and I/O for good.
         context.postTaskAfterYield([protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            protectedThis->drainMessagesToWorkerGlobalScope(context);
+            protectedThis->drainMessagesToWorkerGlobalScope(context, /* fromYieldContinuation */ true);
         });
     }
 }
 
-void WorkerMessagingProxy::drainMessagesToWorkerObject(ScriptExecutionContext& context, DrainBudget budget)
+void WorkerMessagingProxy::drainMessagesToWorkerObject(ScriptExecutionContext& context, DrainBudget budget, bool fromYieldContinuation)
 {
     if (!m_workerObject) {
         Locker locker { m_toParent.lock };
         m_toParent.queue.clear();
         m_toParent.draining.clear();
         m_toParent.drainScheduled = false;
+        m_toParent.yieldPending = false;
         return;
     }
     Ref workerObject = *m_workerObject;
     auto& globalObject = *defaultGlobalObject(context.globalObject());
-    bool more = drainInbox(m_toParent, globalObject, context, budget, [&](Event& event) {
+    bool more = drainInbox(m_toParent, globalObject, context, budget, fromYieldContinuation, [&](Event& event) {
         workerObject->dispatchEvent(event);
     });
     if (more) {
         context.postTaskAfterYield([protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            protectedThis->drainMessagesToWorkerObject(context, DrainBudget::Bounded);
+            protectedThis->drainMessagesToWorkerObject(context, DrainBudget::Bounded, /* fromYieldContinuation */ true);
         });
     }
 }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -283,9 +283,13 @@ void WorkerMessagingProxy::rejectAllCrossVMRequests()
 // a fixed count rather than "everything that was queued when the drain began": with a producer on
 // another thread that snapshot can be arbitrarily large, and the receiving loop's timers and I/O
 // wait behind it. `UntilEmpty` is for the sender having exited: the queue is finite and everything
-// in it precedes 'close'. Worker inboxes never change owner, so up to a budget's worth is moved out
-// under one lock acquisition and dispatched uncontended; the queue itself is only swapped out whole
-// when it fits the budget, so a continuation never has to hand a tail back.
+// in it precedes 'close'.
+//
+// drainScheduled is cleared before any user JS runs: a handler (or a promise continuation its
+// microtask drain unblocks) can park this loop in a nested event-loop wait, and a send arriving
+// then has to post a fresh wakeup task or that wait never wakes (#37189). Messages move
+// queue -> `draining` a small batch per lock acquisition and are popped from `draining` one at a
+// time, so such a nested drain observes the shared deques and delivery stays FIFO.
 enum class DrainBudget { Bounded,
     UntilEmpty };
 static constexpr size_t drainBatchLimit = 1024;
@@ -296,48 +300,56 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
     auto& vm = globalObject.vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     size_t remaining = budget == DrainBudget::UntilEmpty ? std::numeric_limits<size_t>::max() : drainBatchLimit;
+    static constexpr size_t takeAtOnce = 64;
+
+    {
+        Locker locker { inbox.lock };
+        inbox.drainScheduled = false;
+    }
 
     while (true) {
-        Deque<MessageWithMessagePorts> batch;
+        std::optional<MessageWithMessagePorts> message;
         {
             Locker locker { inbox.lock };
-            if (inbox.queue.isEmpty()) {
-                inbox.drainScheduled = false;
-                return false;
-            }
-            if (!remaining)
-                return true; // budget spent, messages left
-            if (inbox.queue.size() <= remaining)
-                batch = std::exchange(inbox.queue, {});
-            else {
-                for (size_t i = 0; i < remaining; ++i)
-                    batch.append(inbox.queue.takeFirst());
-            }
-        }
-        if (budget == DrainBudget::Bounded)
-            remaining -= batch.size();
-
-        while (!batch.isEmpty()) {
-            // The receiving VM is being stopped: nothing more is delivered (the
-            // rest is dropped with the proxy).
-            if (context.isJSExecutionForbidden())
-                return false;
-            auto message = batch.takeFirst();
-            auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
-            // message port post message steps (7.3): if deserializing throws, catch it and fire messageerror.
-            auto event = MessageEvent::create(globalObject, message.message.releaseNonNull(), nullptr, WTF::move(ports));
-            if (scope.exception()) [[unlikely]] {
-                if (vm.hasPendingTerminationException())
+            if (inbox.draining.isEmpty()) {
+                if (inbox.queue.isEmpty())
                     return false;
-                scope.clearException();
-                dispatch(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull() }, MessageEvent::IsTrusted::Yes));
-            } else
-                dispatch(event->event);
-            bool terminating = globalObject.drainMicrotasks();
-            RETURN_IF_EXCEPTION(scope, false);
-            if (terminating)
-                return false; // termination pending
+                if (!remaining) {
+                    // Budget spent; yield. If a racing send already posted a
+                    // wakeup let that task drain the rest, else claim the flag
+                    // and have the caller reschedule.
+                    if (inbox.drainScheduled)
+                        return false;
+                    inbox.drainScheduled = true;
+                    return true;
+                }
+                size_t n = std::min({ takeAtOnce, remaining, static_cast<size_t>(inbox.queue.size()) });
+                for (size_t i = 0; i < n; ++i)
+                    inbox.draining.append(inbox.queue.takeFirst());
+                if (budget == DrainBudget::Bounded)
+                    remaining -= n;
+            }
+            message = inbox.draining.takeFirst();
         }
+
+        // The receiving VM is being stopped: nothing more is delivered (the
+        // rest is dropped with the proxy).
+        if (context.isJSExecutionForbidden())
+            return false;
+        auto ports = MessagePort::entanglePorts(context, WTF::move(message->transferredPorts));
+        // message port post message steps (7.3): if deserializing throws, catch it and fire messageerror.
+        auto event = MessageEvent::create(globalObject, message->message.releaseNonNull(), nullptr, WTF::move(ports));
+        if (scope.exception()) [[unlikely]] {
+            if (vm.hasPendingTerminationException())
+                return false;
+            scope.clearException();
+            dispatch(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull() }, MessageEvent::IsTrusted::Yes));
+        } else
+            dispatch(event->event);
+        bool terminating = globalObject.drainMicrotasks();
+        RETURN_IF_EXCEPTION(scope, false);
+        if (terminating)
+            return false; // termination pending
     }
 }
 
@@ -361,6 +373,7 @@ void WorkerMessagingProxy::drainMessagesToWorkerObject(ScriptExecutionContext& c
     if (!m_workerObject) {
         Locker locker { m_toParent.lock };
         m_toParent.queue.clear();
+        m_toParent.draining.clear();
         m_toParent.drainScheduled = false;
         return;
     }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -113,6 +113,10 @@ public:
     struct MessageInbox {
         Lock lock;
         Deque<MessageWithMessagePorts> queue WTF_GUARDED_BY_LOCK(lock);
+        // Messages taken out of `queue` for dispatch, popped one at a time so a
+        // nested drain observes the same order (see drainInbox).
+        Deque<MessageWithMessagePorts> draining WTF_GUARDED_BY_LOCK(lock);
+        // True only while a posted drain task has not yet started draining.
         bool drainScheduled WTF_GUARDED_BY_LOCK(lock) { false };
     };
 

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -104,7 +104,7 @@ public:
     // The thread's global scope, VM and per-thread state are gone; only the OS thread remains.
     // stoppedByParent: it stopped because it was asked to and never called process.exit() itself.
     void workerGlobalScopeDestroyed(int32_t exitCode, bool stoppedByParent);
-    void drainMessagesToWorkerGlobalScope(ScriptExecutionContext&);
+    void drainMessagesToWorkerGlobalScope(ScriptExecutionContext&, bool fromYieldContinuation = false);
 
     // -- Either thread ---------------------------------------------------------------------------
     WorkerOptions& options() { return m_options; }
@@ -118,6 +118,10 @@ public:
         Deque<MessageWithMessagePorts> draining WTF_GUARDED_BY_LOCK(lock);
         // True only while a posted drain task has not yet started draining.
         bool drainScheduled WTF_GUARDED_BY_LOCK(lock) { false };
+        // Budget spent; only the posted after-yield continuation (or an
+        // UntilEmpty flush) may drain, so a message flood cannot starve the
+        // rest of the event loop.
+        bool yieldPending WTF_GUARDED_BY_LOCK(lock) { false };
     };
 
 private:
@@ -125,7 +129,7 @@ private:
 
     void workerGlobalScopeDestroyedInternal(int32_t exitCode, bool stoppedByParent);
     void releaseWorkerThread();
-    void drainMessagesToWorkerObject(ScriptExecutionContext&, DrainBudget);
+    void drainMessagesToWorkerObject(ScriptExecutionContext&, DrainBudget, bool fromYieldContinuation = false);
     void rejectAllCrossVMRequests();
     void postMessageErrorToWorkerObject(String&& message);
     bool postSerializedErrorToWorkerObject(Zig::GlobalObject&, JSC::JSValue error);

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -363,6 +363,39 @@ describe("MessagePort pipe", () => {
     expect(stdout.trim()).toBe("OK");
     expect(exitCode).toBe(0);
   });
+
+  // Each onmessage enqueues the next message mid-drain, so the drain's budget
+  // (1000 when the inbox starts with one message) runs out with the inbox
+  // non-empty while the in-handler send has already posted the continuation
+  // drain task. Exercises the budget-yield handoff; out-of-order or missing
+  // delivery fails.
+  test("self-feeding chain outlives the drain budget and stays in order", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { port1, port2 } = new MessageChannel();
+          const N = 2500;
+          let next = 0;
+          port1.onmessage = e => {
+            if (e.data !== next) { console.error("out of order", e.data, next); process.exit(1); }
+            next++;
+            if (next === N) { console.log("OK"); port1.close(); port2.close(); return; }
+            port2.postMessage(next);
+          };
+          port2.postMessage(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
 });
 
 // worker.postMessage / parentPort.postMessage go through the same coalesced

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -275,12 +275,14 @@ describe("MessagePort pipe", () => {
   //
   // Sanitizer-gated: the race being exercised is a memory-safety bug that
   // only surfaces deterministically under ASAN/UBSan.
-  test.skipIf(!isDebug && !isASAN)("concurrent MessageChannel creation across workers is race-free", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+  test.skipIf(!isDebug && !isASAN)(
+    "concurrent MessageChannel creation across workers is race-free",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
           const { Worker } = require("worker_threads");
           const workerSrc = \`
             const { parentPort, MessageChannel } = require("worker_threads");
@@ -310,18 +312,20 @@ describe("MessagePort pipe", () => {
           await Promise.all(workers);
           console.log("OK");
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-    // 10000 MessageChannels across 5 threads take 10s+ under a loaded debug
-    // ASAN build; the 5s default flakes.
-  }, 60_000);
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("OK");
+      expect(exitCode).toBe(0);
+      // 10000 MessageChannels across 5 threads take 10s+ under a loaded debug
+      // ASAN build; the 5s default flakes.
+    },
+    60_000,
+  );
 
   test.skipIf(!isDebug && !isASAN)("burst of postMessage across threads delivers every message in order", async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -322,7 +322,10 @@ describe("MessagePort pipe", () => {
       expect(stdout.trim()).toBe("OK");
       expect(exitCode).toBe(0);
       // 10000 MessageChannels across 5 threads take 10s+ under a loaded debug
-      // ASAN build; the 5s default flakes.
+      // ASAN build; the 5s default flakes. The iteration count is the
+      // race-detection budget of this sanitizer test, so shrinking the
+      // workload to fit the default would weaken it; raise the ceiling
+      // instead.
     },
     60_000,
   );

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -319,7 +319,9 @@ describe("MessagePort pipe", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("OK");
     expect(exitCode).toBe(0);
-  });
+    // 10000 MessageChannels across 5 threads take 10s+ under a loaded debug
+    // ASAN build; the 5s default flakes.
+  }, 60_000);
 
   test.skipIf(!isDebug && !isASAN)("burst of postMessage across threads delivers every message in order", async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -370,11 +370,10 @@ describe("MessagePort pipe", () => {
     expect(exitCode).toBe(0);
   });
 
-  // Each onmessage enqueues the next message mid-drain, so the drain's budget
-  // (1000 when the inbox starts with one message) runs out with the inbox
-  // non-empty while the in-handler send has already posted the continuation
-  // drain task. Exercises the budget-yield handoff; out-of-order or missing
-  // delivery fails.
+  // Each onmessage enqueues the next message mid-drain, so the drain's fixed
+  // budget runs out with the inbox non-empty while the in-handler send has
+  // already posted a wakeup task. Exercises the budget-yield handoff;
+  // out-of-order or missing delivery fails.
   test("self-feeding chain outlives the drain budget and stays in order", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/regression/issue/37189.test.ts
+++ b/test/regression/issue/37189.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/37189
+// Regression in 1.3.14: a Worker/MessagePort message arriving while the
+// receiver was parked in a nested event-loop wait (expect().rejects) reached
+// from a previous message's continuation was enqueued without posting a
+// wakeup, deadlocking the process. The first awaited call below makes the
+// second call's assertion run as a continuation of the message dispatch,
+// with the drain loop still on the native stack.
+
+const channelMain = `import { expect } from "bun:test";
+const { port1, port2 } = new MessageChannel();
+port2.onmessage = e => {
+  port2.postMessage({ type: "reply", id: e.data.id, error: "boom" });
+};
+const pending = new Map();
+port1.onmessage = e => {
+  const msg = e.data;
+  if (msg.type !== "reply") return;
+  const reject = pending.get(msg.id);
+  pending.delete(msg.id);
+  reject?.(new Error(msg.error));
+};
+let seq = 0;
+const call = () => new Promise((_resolve, reject) => {
+  const id = ++seq;
+  pending.set(id, reject);
+  port1.postMessage({ id });
+});
+
+await call().catch(() => {});
+await expect(call()).rejects.toThrow("boom");
+port1.close();
+port2.close();
+console.log("OK");`;
+
+const workerMain = `import { expect } from "bun:test";
+const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+const pending = new Map();
+worker.onmessage = e => {
+  const msg = e.data;
+  if (msg.type !== "reply") return;
+  const reject = pending.get(msg.id);
+  pending.delete(msg.id);
+  reject?.(new Error(msg.error));
+};
+let seq = 0;
+const call = () => new Promise((_resolve, reject) => {
+  const id = ++seq;
+  pending.set(id, reject);
+  worker.postMessage({ id });
+});
+
+await call().catch(() => {});
+await expect(call()).rejects.toThrow("boom");
+worker.terminate();
+console.log("OK");`;
+
+async function expectExitsCleanly(proc: Bun.Subprocess<"ignore", "pipe", "pipe">) {
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+}
+
+test.concurrent(
+  "expect().rejects settles when the rejection arrives from a Worker message during a nested wait",
+  async () => {
+    using dir = tempDir("issue-37189-worker", {
+      "worker.js": `self.onmessage = e => {
+      self.postMessage({ type: "reply", id: e.data.id, error: "boom" });
+    };`,
+      "main.js": workerMain,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+    });
+    await expectExitsCleanly(proc);
+  },
+);
+
+test.concurrent(
+  "expect().rejects settles when the rejection arrives from a MessageChannel message during a nested wait",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", channelMain],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+    });
+    await expectExitsCleanly(proc);
+  },
+);


### PR DESCRIPTION
Fixes #37189
Fixes #39584

### Problem

```js
// worker replies to every request with an error
await call().catch(() => {});                     // first worker round trip
await expect(call()).rejects.toThrow("boom");     // hangs forever on 1.3.14+
```

The second assertion never settles; the test times out and `bun test` then hangs and must be killed. A same-thread `MessageChannel` RPC hits the identical deadlock. Regression introduced in 1.3.14 by #29937; still reproduces on today's main.

- `expect(p).rejects` awaits synchronously: the matcher enters `EventLoop.waitForPromise`, which spins the event loop from inside the current dispatch.
- The coalesced drain loops keep the drain-scheduled flag set for the whole dispatch, including the microtask drain, and `WorkerMessagingProxy::postMessageToWorkerObject` / `MessagePortPipe::send` skip posting a wakeup task while the flag is set.
- So when the test continuation (run from the previous message's microtask drain, with the drain loop still on the native stack) issues a second call and parks in `waitForPromise`, the reply is appended to the inbox with no wakeup. The code that would clear the flag sits below the nested wait on the same stack, so the wait parks forever and every later message on that channel is silently queued.

### Fix

Clear the flag before dispatching any user JS, so a racing send posts a fresh drain task (at most one extra no-op drain per racing send):

- `WorkerMessagingProxy.cpp` `drainInbox`: clear `drainScheduled` up front, and pop messages one at a time from a shared `draining` deque (refilled a small batch per lock acquisition) instead of a local batch, so a nested drain task observes the same deques and delivery stays FIFO. The budget-yield path lets a racing send's already-posted task continue instead of double-scheduling.
- Anti-starvation: a drain that spends its budget marks the inbox yield-pending and posts an after-yield continuation; other drain invocations (including the wakeup tasks racing sends post) stand down until it has run, so a self-feeding message loop cannot chain regular-priority tasks ahead of timers and I/O (covered by Node's test-worker-message-port-infinite-message-loop). Nested waits still progress because the loop tick they spin promotes after-yield tasks before polling.
- `MessagePortPipe.cpp` `drainAndDispatch`: hand `DrainScheduled` off to a new `Dispatching` state bit before dispatching. `MessagePort::hasPendingActivity()` needs the dispatch window covered for GC wrapper liveness (the in-hand message is invisible to the queued count), so it now checks `DrainScheduled | Dispatching`. The bit is owned by the invocation that set it (a nested drain leaves it alone), and is cleared when the owning drain finishes or by `detach()`/`close()`; a stale drain never clears it after losing ownership, so it cannot clobber a new owner's drain after a transfer.

### Verification

- New test `test/regression/issue/37189.test.ts` covers both the `Worker` and the `MessageChannel` shape. Both child processes deadlock and get killed by the spawn timeout without the fix (verified against current main via the stash check); both print `OK` and exit 0 with it.
- All 5 repro tests from the issue pass with the fix, including the microtask-barrier variant.
- New test in `test/js/web/workers/message-port-pipe.test.ts`: a self-feeding MessageChannel chain that outlives the drain budget, covering the budget-yield handoff and FIFO across it.
- `test/js/web/workers/` and `test/js/node/worker_threads/` suites were run with and without the diff on the same machine: the failure sets are identical or smaller with the diff (several terminate()-lifecycle tests and the cross-worker MessageChannel stress test currently fail on clean main under a debug ASAN build; none are affected by this change).

### Background

- The drain loops coalesce message delivery: a sender posts one drain task per burst instead of one per message, guarded by a drain-scheduled flag. The bug was the flag staying set during dispatch, which suppressed the wakeup that a nested event-loop wait depends on.
- `waitForPromise` is bun's synchronous promise wait (used by `expect().rejects/.resolves`): it runs event-loop ticks from inside a native frame, so anything on the stack below it cannot make progress until the promise settles.
- `hasPendingActivity()` is the GC's liveness query for a wrapper object; the drain flags feed it so a port's JS wrapper cannot be collected while a message is mid-dispatch.

<details>
<summary>History: rebase over the Worker refactor (#37075)</summary>

The PR originally patched `Worker.cpp`'s drain loop. #37075 landed on main afterwards, splitting `Worker` into the script object and a `WorkerMessagingProxy` that owns the inboxes, and restructuring `MessagePortPipe::drainAndDispatch` around a two-stage `inbox`/`draining` queue with a fixed budget and `postTaskAfterYield` continuation. The fix was ported onto that shape: same protocol (flag covers only schedule-to-drain-start; `Dispatching` covers dispatch for GC liveness), re-expressed in the new code's structure. The regression tests were re-verified to fail on post-refactor main without the fix and pass with it.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-port-pipe.test.ts "test/regression/issue/37189.test.ts"
bun test v1.4.1 (861e9ae04)

test/regression/issue/37189.test.ts:
(fail) expect().rejects settles when the rejection arrives from a Worker message during a nested wait [5005.51ms]
  ^ this test timed out after 5000ms.
(fail) expect().rejects settles when the rejection arrives from a MessageChannel message during a nested wait [5004.13ms]
  ^ this test timed out after 5000ms.

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [20.95ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [9.56ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [209.22ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [20.34ms]
(pass) MessagePort pipe > messages queued on a port follow it across transfer [29.65ms]
(pass) MessagePort pipe > same-context re-attach inside handler: inbox follow
... (truncated)

release without fix: 2 failed, 3 skipped
bun test v1.4.1-canary.1 (861e9ae04)

test/regression/issue/37189.test.ts:
(fail) expect().rejects settles when the rejection arrives from a Worker message during a nested wait [5000.43ms]
  ^ this test timed out after 5000ms.
(fail) expect().rejects settles when the rejection arrives from a MessageChannel message during a nested wait [5000.08ms]
  ^ this test timed out after 5000ms.

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [4.42ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [0.22ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [1.20ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [0.32ms]
(pass) MessagePort pipe > messages queued on a port follow it across transfer [0.37ms]
(pass) MessagePort pipe > same-context re-attach inside handler: inbox follows new wrapper [4.37ms]
(pass) MessagePort pipe > chained transfer delivers through every hop [0.35ms]
(pass) MessagePort pipe > objectTypeCounts drop after close + GC; peer-open pins listening port [23.04ms]
(pass
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-port-pipe.test.ts "test/regression/issue/37189.test.ts"
bun test v1.4.1 (861e9ae04)

test/regression/issue/37189.test.ts:
(pass) expect().rejects settles when the rejection arrives from a MessageChannel message during a nested wait [317.87ms]
(pass) expect().rejects settles when the rejection arrives from a Worker message during a nested wait [552.86ms]

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [14.02ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [8.74ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [135.72ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [12.24ms]
(pass) MessagePort pipe > messages queued on a port follow it across transfer [16.32ms]
(pass) MessagePort pipe > same-context re-attach inside handler: inbox follows new wrapper [12.02ms]
(pass) MessagePort pipe > chained transfer delivers th
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8c889087ac
  features     baseline

23 deps, 129 codegen, 1172 objects in 790ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] gen ErrorCode+*.h
[3/1244] fetch zlib
[zlib] up to date
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] fetch tinycc
[tinycc] up to date
[6/1216] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [46.00ms]
[7/1216] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [1.00ms]
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [46.00ms]
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/MessagePort.cpp          |   8 +-
 src/jsc/bindings/webcore/MessagePortPipe.cpp      |  87 ++++++++++++-----
 src/jsc/bindings/webcore/MessagePortPipe.h        |   6 +-
 src/jsc/bindings/webcore/WorkerMessagingProxy.cpp | 111 +++++++++++++---------
 src/jsc/bindings/webcore/WorkerMessagingProxy.h   |  12 ++-
 test/js/web/workers/message-port-pipe.test.ts     |  73 ++++++++++----
 test/regression/issue/37189.test.ts               | 100 +++++++++++++++++++
 7 files changed, 305 insertions(+), 92 deletions(-)
```

</details>

**gate history** · 6 passed · 3 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/webcore/MessagePort.cpp               4      4      0
src/jsc/bindings/webcore/MessagePortPipe.cpp           7     11      0
src/jsc/bindings/webcore/MessagePortPipe.h             2      3      0
src/jsc/bindings/webcore/WorkerMessagingProxy.cpp      7      7      0
src/jsc/bindings/webcore/WorkerMessagingProxy.h        3      4      0
test/js/web/workers/message-port-pipe.test.ts          4      6      0
test/regression/issue/37189.test.ts                    1      3      0
```

</details>

**root cause** · written by the author bot

The coalesced drain in MessagePort and Worker kept its wakeup flag set for the entire dispatch window, so a message posted while user code was inside a nested event-loop wait, such as expect().rejects reached from a worker message continuation, saw the flag already set, skipped posting a wakeup task, and was never drained, deadlocking the wait. The fix clears the scheduled-drain flag before dispatching user JavaScript so racing senders post a fresh wakeup, and introduces a separate Dispatching bit to preserve GC-thread liveness plus a YieldPending bit so that after the drain budget is spent…

<!-- robobun:evidence:end -->
