### PR TITLE
tls: harden SNI name matching (ASCII case folding, one-label wildcards on HTTP/3)

### DIFF
--- a/packages/bun-usockets/src/crypto/sni_tree.cpp
+++ b/packages/bun-usockets/src/crypto/sni_tree.cpp
@@ -37,10 +37,30 @@
 /* This cannot be shared */
 thread_local void (*sni_free_cb)(void *);
 
+/* DNS hostnames are case-insensitive (RFC 4343), and so is SNI matching in
+ * Node.js, so labels compare with an ASCII-only case fold (ASCII-only to
+ * avoid locale surprises like the Turkish dotless i). */
+struct sni_label_less {
+    static unsigned char fold(unsigned char c) {
+        return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;
+    }
+
+    bool operator()(std::string_view a, std::string_view b) const {
+        size_t n = std::min(a.length(), b.length());
+        for (size_t i = 0; i < n; i++) {
+            unsigned char ca = fold(a[i]), cb = fold(b[i]);
+            if (ca != cb) {
+                return ca < cb;
+            }
+        }
+        return a.length() < b.length();
+    }
+};
+
 struct sni_node {
     /* Empty nodes must always hold null */
     void *user = nullptr;
-    std::map<std::string_view, std::unique_ptr<sni_node>> children;
+    std::map<std::string_view, std::unique_ptr<sni_node>, sni_label_less> children;
 
     ~sni_node() {
         for (auto &p : children) {

--- a/packages/bun-usockets/src/crypto/sni_tree.cpp
+++ b/packages/bun-usockets/src/crypto/sni_tree.cpp
@@ -37,23 +37,10 @@
 /* This cannot be shared */
 thread_local void (*sni_free_cb)(void *);
 
-/* DNS hostnames are case-insensitive (RFC 4343), and so is SNI matching in
- * Node.js, so labels compare with an ASCII-only case fold (ASCII-only to
- * avoid locale surprises like the Turkish dotless i). */
+/* Labels are keyed with the shared SNI name comparison (ASCII case-insensitive). */
 struct sni_label_less {
-    static unsigned char fold(unsigned char c) {
-        return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;
-    }
-
     bool operator()(std::string_view a, std::string_view b) const {
-        size_t n = std::min(a.length(), b.length());
-        for (size_t i = 0; i < n; i++) {
-            unsigned char ca = fold(a[i]), cb = fold(b[i]);
-            if (ca != cb) {
-                return ca < cb;
-            }
-        }
-        return a.length() < b.length();
+        return us_sni_name_cmp(a.data(), a.length(), b.data(), b.length()) < 0;
     }
 };
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -400,7 +400,9 @@ struct us_listen_socket_t *us_socket_group_listen_fd(us_socket_group_r group,
 void us_listen_socket_close(struct us_listen_socket_t *ls) nonnull_fn_decl;
 
 /* SNI: tree hangs off the listen socket. ssl_ctx is up_ref'd; user is opaque
- * (uWS stores a per-domain HttpRouter*). user may be NULL. */
+ * (uWS stores a per-domain HttpRouter*). user may be NULL. Names are matched
+ * label by label without regard to ASCII case; a `*` label matches any one
+ * label. Adding a name that is already registered (in any case) fails. */
 int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
     const char *hostname_pattern, struct ssl_ctx_st *ssl_ctx, void *user)
     __attribute__((nonnull(1, 2, 3)));

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -399,10 +399,26 @@ struct us_listen_socket_t *us_socket_group_listen_fd(us_socket_group_r group,
     __attribute__((nonnull(1, 8)));  /* ssl_ctx nullable */
 void us_listen_socket_close(struct us_listen_socket_t *ls) nonnull_fn_decl;
 
+/* The one comparison every SNI name lookup uses (listen socket tree, HTTP/3
+ * matcher, uWS pending-name queue). Server names are DNS names, which are
+ * case-insensitive (RFC 4343); the fold is ASCII-only so the locale cannot
+ * change a match. Orders like memcmp over the folded bytes, shorter first on
+ * a shared prefix, so it also serves as a strict weak ordering. */
+static inline int us_sni_name_cmp(const char *a, size_t alen, const char *b, size_t blen) {
+    size_t n = alen < blen ? alen : blen;
+    for (size_t i = 0; i < n; i++) {
+        unsigned char ca = (unsigned char) a[i], cb = (unsigned char) b[i];
+        if (ca >= 'A' && ca <= 'Z') ca += 'a' - 'A';
+        if (cb >= 'A' && cb <= 'Z') cb += 'a' - 'A';
+        if (ca != cb) return (int) ca - (int) cb;
+    }
+    return alen < blen ? -1 : alen > blen ? 1 : 0;
+}
+
 /* SNI: tree hangs off the listen socket. ssl_ctx is up_ref'd; user is opaque
  * (uWS stores a per-domain HttpRouter*). user may be NULL. Names are matched
- * label by label without regard to ASCII case; a `*` label matches any one
- * label. Adding a name that is already registered (in any case) fails. */
+ * label by label with us_sni_name_cmp; a `*` label matches any one label.
+ * Adding a name that is already registered (in any case) fails. */
 int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
     const char *hostname_pattern, struct ssl_ctx_st *ssl_ctx, void *user)
     __attribute__((nonnull(1, 2, 3)));

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -385,7 +385,9 @@ static int us_quic_sni_eq(const char *a, const char *b, size_t len) {
     return 1;
 }
 
-/* Exact match, then `*.tail` wildcards (matches "a.tail" but not "tail"). */
+/* Exact match, then `*.tail` wildcards. Like the TCP listener's SNI tree
+ * (crypto/sni_tree.cpp), the `*` stands for exactly one label: "a.tail"
+ * matches, "tail" and "a.b.tail" do not. */
 static SSL_CTX *us_quic_match_sni(us_quic_socket_context_t *ctx, const char *sni) {
     if (!sni) return ctx->ssl_ctx;
     size_t sl = strlen(sni);
@@ -397,7 +399,9 @@ static SSL_CTX *us_quic_match_sni(us_quic_socket_context_t *ctx, const char *sni
         const char *n = ctx->sni[i].name;
         if (n[0] == '*' && n[1] == '.') {
             size_t tl = strlen(n + 1);
-            if (sl > tl && us_quic_sni_eq(sni + sl - tl, n + 1, tl)) return ctx->sni[i].ctx;
+            if (sl > tl && !memchr(sni, '.', sl - tl) && us_quic_sni_eq(sni + sl - tl, n + 1, tl)) {
+                return ctx->sni[i].ctx;
+            }
         }
     }
     return ctx->ssl_ctx;

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -373,18 +373,31 @@ static void us_quic_udp_on_close(struct us_udp_socket_t *u) {
 
 /* ───── SSL ───── */
 
+/* DNS names are case-insensitive (RFC 4343); fold ASCII only to avoid locale
+ * surprises (strcasecmp is locale-dependent). */
+static int us_quic_sni_eq(const char *a, const char *b, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        unsigned char ca = (unsigned char) a[i], cb = (unsigned char) b[i];
+        if (ca >= 'A' && ca <= 'Z') ca += 'a' - 'A';
+        if (cb >= 'A' && cb <= 'Z') cb += 'a' - 'A';
+        if (ca != cb) return 0;
+    }
+    return 1;
+}
+
 /* Exact match, then `*.tail` wildcards (matches "a.tail" but not "tail"). */
 static SSL_CTX *us_quic_match_sni(us_quic_socket_context_t *ctx, const char *sni) {
     if (!sni) return ctx->ssl_ctx;
     size_t sl = strlen(sni);
     for (unsigned i = 0; i < ctx->sni_count; i++) {
-        if (strcmp(ctx->sni[i].name, sni) == 0) return ctx->sni[i].ctx;
+        const char *n = ctx->sni[i].name;
+        if (strlen(n) == sl && us_quic_sni_eq(n, sni, sl)) return ctx->sni[i].ctx;
     }
     for (unsigned i = 0; i < ctx->sni_count; i++) {
         const char *n = ctx->sni[i].name;
         if (n[0] == '*' && n[1] == '.') {
             size_t tl = strlen(n + 1);
-            if (sl > tl && memcmp(sni + sl - tl, n + 1, tl) == 0) return ctx->sni[i].ctx;
+            if (sl > tl && us_quic_sni_eq(sni + sl - tl, n + 1, tl)) return ctx->sni[i].ctx;
         }
     }
     return ctx->ssl_ctx;

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -373,33 +373,21 @@ static void us_quic_udp_on_close(struct us_udp_socket_t *u) {
 
 /* ───── SSL ───── */
 
-/* DNS names are case-insensitive (RFC 4343); fold ASCII only to avoid locale
- * surprises (strcasecmp is locale-dependent). */
-static int us_quic_sni_eq(const char *a, const char *b, size_t len) {
-    for (size_t i = 0; i < len; i++) {
-        unsigned char ca = (unsigned char) a[i], cb = (unsigned char) b[i];
-        if (ca >= 'A' && ca <= 'Z') ca += 'a' - 'A';
-        if (cb >= 'A' && cb <= 'Z') cb += 'a' - 'A';
-        if (ca != cb) return 0;
-    }
-    return 1;
-}
-
-/* Exact match, then `*.tail` wildcards. Like the TCP listener's SNI tree
- * (crypto/sni_tree.cpp), the `*` stands for exactly one label: "a.tail"
- * matches, "tail" and "a.b.tail" do not. */
+/* Exact match, then `*.tail` wildcards, both with us_sni_name_cmp. Like the
+ * TCP listener's SNI tree (crypto/sni_tree.cpp), the `*` stands for exactly
+ * one label: "a.tail" matches, "tail" and "a.b.tail" do not. */
 static SSL_CTX *us_quic_match_sni(us_quic_socket_context_t *ctx, const char *sni) {
     if (!sni) return ctx->ssl_ctx;
     size_t sl = strlen(sni);
     for (unsigned i = 0; i < ctx->sni_count; i++) {
         const char *n = ctx->sni[i].name;
-        if (strlen(n) == sl && us_quic_sni_eq(n, sni, sl)) return ctx->sni[i].ctx;
+        if (us_sni_name_cmp(n, strlen(n), sni, sl) == 0) return ctx->sni[i].ctx;
     }
     for (unsigned i = 0; i < ctx->sni_count; i++) {
         const char *n = ctx->sni[i].name;
         if (n[0] == '*' && n[1] == '.') {
             size_t tl = strlen(n + 1);
-            if (sl > tl && !memchr(sni, '.', sl - tl) && us_quic_sni_eq(sni + sl - tl, n + 1, tl)) {
+            if (sl > tl && !memchr(sni, '.', sl - tl) && us_sni_name_cmp(sni + sl - tl, tl, n + 1, tl) == 0) {
                 return ctx->sni[i].ctx;
             }
         }

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -55,7 +55,9 @@ us_quic_socket_context_t *us_create_quic_socket_context(
 void us_quic_socket_context_shutdown(us_quic_socket_context_t *ctx);
 void us_quic_socket_context_free(us_quic_socket_context_t *ctx);
 
-/* Register an additional SSL_CTX for the given SNI hostname (exact or `*.`). */
+/* Register an additional SSL_CTX for the given SNI hostname: an exact name or
+ * a `*.suffix` pattern whose `*` covers one label. Names are matched without
+ * regard to ASCII case, as in the TCP listener's SNI tree. */
 int us_quic_socket_context_add_server_name(us_quic_socket_context_t *ctx,
     const char *hostname, struct us_bun_socket_context_options_t options);
 

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -114,6 +114,18 @@ private:
         HttpRouter<typename HttpContextData<SSL>::RouterData> *router;
     };
     std::vector<PendingServerName> pendingServerNames;
+    /* Same equivalence as the listeners' SNI tree (ASCII case-insensitive), so
+     * this queue and the trees agree on which entry a name refers to. */
+    static bool sameServerName(std::string_view a, std::string_view b) {
+        if (a.length() != b.length()) return false;
+        for (size_t i = 0; i < a.length(); i++) {
+            unsigned char ca = (unsigned char) a[i], cb = (unsigned char) b[i];
+            if (ca >= 'A' && ca <= 'Z') ca += 'a' - 'A';
+            if (cb >= 'A' && cb <= 'Z') cb += 'a' - 'A';
+            if (ca != cb) return false;
+        }
+        return true;
+    }
     /* No raw us_listen_socket_t* cache here. src/runtime/server/mod.rs's non-abrupt stop calls
      * us_listen_socket_close(ls) directly; the listener is queued for free in
      * loop_post, so any vector we kept would dangle by the time the deferred
@@ -191,7 +203,7 @@ public:
                 us_listen_socket_remove_server_name(ls, hostname_pattern.c_str());
             });
             for (auto it = pendingServerNames.begin(); it != pendingServerNames.end(); ) {
-                if (it->hostname == hostname_pattern) {
+                if (sameServerName(it->hostname, hostname_pattern)) {
                     us_internal_ssl_ctx_unref(it->ctx);
                     delete it->router;
                     it = pendingServerNames.erase(it);
@@ -619,7 +631,7 @@ public:
 
         void *domainRouter = nullptr;
         for (auto &p : pendingServerNames) {
-            if (p.hostname == serverName) { domainRouter = p.router; break; }
+            if (sameServerName(p.hostname, serverName)) { domainRouter = p.router; break; }
         }
         if (domainRouter) {
             httpContextData->currentRouter = (decltype(httpContextData->currentRouter)) domainRouter;

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -113,19 +113,10 @@ private:
         struct ssl_ctx_st *ctx;
         HttpRouter<typename HttpContextData<SSL>::RouterData> *router;
     };
+    /* Entries are looked up with us_sni_name_cmp, the same comparison as the
+     * listeners' SNI trees, so the queue and the trees agree on which entry a
+     * name refers to. */
     std::vector<PendingServerName> pendingServerNames;
-    /* Same equivalence as the listeners' SNI tree (ASCII case-insensitive), so
-     * this queue and the trees agree on which entry a name refers to. */
-    static bool sameServerName(std::string_view a, std::string_view b) {
-        if (a.length() != b.length()) return false;
-        for (size_t i = 0; i < a.length(); i++) {
-            unsigned char ca = (unsigned char) a[i], cb = (unsigned char) b[i];
-            if (ca >= 'A' && ca <= 'Z') ca += 'a' - 'A';
-            if (cb >= 'A' && cb <= 'Z') cb += 'a' - 'A';
-            if (ca != cb) return false;
-        }
-        return true;
-    }
     /* No raw us_listen_socket_t* cache here. src/runtime/server/mod.rs's non-abrupt stop calls
      * us_listen_socket_close(ls) directly; the listener is queued for free in
      * loop_post, so any vector we kept would dangle by the time the deferred
@@ -203,7 +194,7 @@ public:
                 us_listen_socket_remove_server_name(ls, hostname_pattern.c_str());
             });
             for (auto it = pendingServerNames.begin(); it != pendingServerNames.end(); ) {
-                if (sameServerName(it->hostname, hostname_pattern)) {
+                if (us_sni_name_cmp(it->hostname.data(), it->hostname.size(), hostname_pattern.data(), hostname_pattern.size()) == 0) {
                     us_internal_ssl_ctx_unref(it->ctx);
                     delete it->router;
                     it = pendingServerNames.erase(it);
@@ -631,7 +622,7 @@ public:
 
         void *domainRouter = nullptr;
         for (auto &p : pendingServerNames) {
-            if (sameServerName(p.hostname, serverName)) { domainRouter = p.router; break; }
+            if (us_sni_name_cmp(p.hostname.data(), p.hostname.size(), serverName.data(), serverName.size()) == 0) { domainRouter = p.router; break; }
         }
         if (domainRouter) {
             httpContextData->currentRouter = (decltype(httpContextData->currentRouter)) domainRouter;

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -225,10 +225,9 @@ describe("Bun.serve per-serverName client certificate policy", () => {
     });
   });
 
-  test("a case-variant SNI cannot bypass a gated serverName entry", async () => {
-    // SNI server names are DNS names, so matching is case-insensitive
-    // (RFC 4343). A byte-for-byte match would let ADMIN.EXAMPLE.COM fall
-    // through to the ungated default context.
+  test("the entry's policy applies however the client spells the name", async () => {
+    // SNI server names are DNS names (RFC 4343): ADMIN.EXAMPLE.COM selects the
+    // admin.example.com entry, not the default one.
     using server = Bun.serve({
       port: 0,
       tls: [

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -225,6 +225,35 @@ describe("Bun.serve per-serverName client certificate policy", () => {
     });
   });
 
+  test("a case-variant SNI cannot bypass a gated serverName entry", async () => {
+    // SNI server names are DNS names, so matching is case-insensitive
+    // (RFC 4343). A byte-for-byte match would let ADMIN.EXAMPLE.COM fall
+    // through to the ungated default context.
+    using server = Bun.serve({
+      port: 0,
+      tls: [
+        { key: serverKey, cert: serverCert },
+        {
+          serverName: "admin.example.com",
+          key: serverKey,
+          cert: serverCert,
+          ca: clientCa,
+          requestCert: true,
+          rejectUnauthorized: true,
+        },
+      ],
+      fetch: req => new Response(`served ${req.headers.get("host")}`),
+    });
+    const { status: upperNoCert } = await request(server.port, "ADMIN.EXAMPLE.COM");
+    const { status: mixedNoCert } = await request(server.port, "Admin.Example.com");
+    const { status: upperTrustedCert } = await request(server.port, "ADMIN.EXAMPLE.COM", trustedClient);
+    expect({ upperNoCert, mixedNoCert, upperTrustedCert }).toEqual({
+      upperNoCert: "connection closed without a response",
+      mixedNoCert: "connection closed without a response",
+      upperTrustedCert: "HTTP/1.1 200 OK",
+    });
+  });
+
   test("a session established on the open default name cannot be resumed to bypass a gated name", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { createHash, createPrivateKey, randomBytes } from "crypto";
+import { createHash, createPrivateKey, randomBytes, X509Certificate } from "crypto";
 import { readFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
 import { connect, QuicEndpoint } from "node:quic";
@@ -1531,6 +1531,68 @@ describe("Bun.serve HTTP/3 request handlers run to completion before the callbac
       responses: { fetch: "200 ok", route: "200 ok" },
       fetch: expectedOrder,
       route: expectedOrder,
+    });
+  });
+});
+
+describe("Bun.serve HTTP/3 SNI", () => {
+  const tlsFixtures = join(import.meta.dir, "..", "..", "node", "tls", "fixtures");
+  // Each agent certificate has its own CN, which tells the contexts apart.
+  const identity = (agent: string) => ({
+    key: readFileSync(join(tlsFixtures, `${agent}-key.pem`), "utf8"),
+    cert: readFileSync(join(tlsFixtures, `${agent}-cert.pem`), "utf8"),
+  });
+
+  // fetch() takes the SNI from the URL host, which URL parsing lowercases, so
+  // the handshake is driven with node:quic: it sends `servername` as written
+  // and exposes the certificate the server picked. The server runs in-process
+  // because nothing here touches fetch()'s shared HTTP/3 client engine.
+  async function servedCN(port: number, servername: string): Promise<string> {
+    const session = await connect({ address: "127.0.0.1", port }, { alpn: "h3", servername, verifyPeer: "manual" });
+    try {
+      await session.opened;
+      const cert = session.peerCertificate;
+      const x509 = cert instanceof X509Certificate ? cert : new X509Certificate(Buffer.from(cert));
+      return x509.subject.match(/CN=([^\s,]+)/)![1];
+    } finally {
+      await session.close();
+    }
+  }
+
+  test("serverName entries match regardless of case and a wildcard covers one label", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: [
+        identity("agent1"),
+        { serverName: "Agent2.Example", ...identity("agent2") },
+        { serverName: "*.wild.example", ...identity("agent3") },
+      ],
+      http3: true,
+      fetch: () => new Response("ok"),
+    });
+    const served: Record<string, string> = {};
+    for (const servername of [
+      "Agent2.Example",
+      "agent2.example",
+      "AGENT2.EXAMPLE",
+      "a.wild.example",
+      "A.WILD.EXAMPLE",
+      "a.b.wild.example",
+      "wild.example",
+      "other.example",
+    ]) {
+      served[servername] = await servedCN(server.port, servername);
+    }
+    // The same names select the same entries on the TCP listener.
+    expect(served).toEqual({
+      "Agent2.Example": "agent2",
+      "agent2.example": "agent2",
+      "AGENT2.EXAMPLE": "agent2",
+      "a.wild.example": "agent3",
+      "A.WILD.EXAMPLE": "agent3",
+      "a.b.wild.example": "agent1",
+      "wild.example": "agent1",
+      "other.example": "agent1",
     });
   });
 });

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -523,6 +523,7 @@ describe("SNI matching is case-insensitive", () => {
     server.addContext("*.test.com", SNIContexts["asterisk.test.com"]); // agent3
     try {
       const listening = Promise.withResolvers<void>();
+      server.once("error", listening.reject);
       server.listen(0, listening.resolve);
       await listening.promise;
       const port = (server.address() as AddressInfo).port;

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -502,6 +502,74 @@ describe("Bun.serve SNI", () => {
   });
 });
 
+describe("SNI matching is case-insensitive", () => {
+  // DNS names are case-insensitive (RFC 4343); Node compiles addContext names
+  // into /.../i regexes, so ADMIN.EXAMPLE.COM selects the admin.example.com
+  // context instead of falling through to the default one.
+  function servedCN(port: number, servername: string) {
+    const { promise, resolve, reject } = Promise.withResolvers<string | undefined>();
+    const socket = tls.connect({ host: "127.0.0.1", port, servername, rejectUnauthorized: false }, () => {
+      resolve(socket.getPeerCertificate()?.subject?.CN);
+      socket.end();
+    });
+    socket.on("error", reject);
+    return promise;
+  }
+
+  it("tls.Server addContext", async () => {
+    const server = tls.createServer({ key: agent2Key, cert: agent2Cert }, s => s.end());
+    server.addContext("a.example.com", SNIContexts["a.example.com"]); // agent1
+    server.addContext("UPPER.EXAMPLE.COM", SNIContexts["asterisk.test.com"]); // agent3
+    server.addContext("*.test.com", SNIContexts["asterisk.test.com"]); // agent3
+    try {
+      const listening = Promise.withResolvers<void>();
+      server.listen(0, listening.resolve);
+      await listening.promise;
+      const port = (server.address() as AddressInfo).port;
+      expect({
+        exact: await servedCN(port, "a.example.com"),
+        upper: await servedCN(port, "A.EXAMPLE.COM"),
+        mixed: await servedCN(port, "A.Example.Com"),
+        registeredUpper: await servedCN(port, "upper.example.com"),
+        wildcardUpper: await servedCN(port, "B.TEST.COM"),
+        noMatch: await servedCN(port, "other.example.org"),
+      }).toEqual({
+        exact: "agent1",
+        upper: "agent1",
+        mixed: "agent1",
+        registeredUpper: "agent3",
+        wildcardUpper: "agent3",
+        noMatch: "agent2",
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("Bun.serve tls array", async () => {
+    using server = Bun.serve({
+      port: 0,
+      tls: [
+        { key: agent2Key, cert: agent2Cert },
+        { serverName: "a.example.com", ...SNIContexts["a.example.com"] },
+        { serverName: "*.test.com", ...SNIContexts["asterisk.test.com"] },
+      ],
+      fetch: () => new Response("OK"),
+    });
+    expect({
+      upper: await servedCN(server.port, "A.EXAMPLE.COM"),
+      mixed: await servedCN(server.port, "a.Example.com"),
+      wildcardUpper: await servedCN(server.port, "B.TEST.COM"),
+      noMatch: await servedCN(server.port, "other.example.org"),
+    }).toEqual({
+      upper: "agent1",
+      mixed: "agent1",
+      wildcardUpper: "agent3",
+      noMatch: "agent2",
+    });
+  });
+});
+
 describe("server certificate chain built from `ca`", () => {
   it("presents an intermediate known only to the default store (NODE_EXTRA_CA_CERTS)", async () => {
     // With no `ca`, Node seeds the context's store with the default roots


### PR DESCRIPTION
### What does this PR do?

Fixes #37193.

Hardens server-side SNI matching so that the per-`serverName` entry of `Bun.serve({ tls: [...] })` and of `tls.Server#addContext()` is selected whatever the case the client spells the name in. DNS names are case-insensitive (RFC 4343) and Node compiles `addContext()` names into `/.../i` regexes, but Bun compared the SNI byte for byte, so `A.EXAMPLE.COM` (or a name registered in upper case and requested in lower case) was served by the default entry instead of its own:

```js
const server = tls.createServer(DEFAULT, s => s.end());
server.addContext("admin.example.com", ALT);

// CN of the certificate each connection receives
admin.example.com    -> ALT
ADMIN.EXAMPLE.COM    -> DEFAULT     (Node: ALT)
Admin.Example.com    -> DEFAULT     (Node: ALT)
```

Whatever else is configured on the entry (its own `ca`, `requestCert`, per-domain routes) follows the entry, so it only applied to the exact spelling as well.

### Cause

`packages/bun-usockets/src/crypto/sni_tree.cpp` splits names on `.` and keeps the labels in a `std::map<std::string_view>` with the default byte-wise comparator. Both server lookup paths in `openssl.c` (`sni_cb` and `us_select_cert_cb`), and therefore `node:tls` and `Bun.serve`, resolve through this tree. The HTTP/3 listener has its own flat matcher, `us_quic_match_sni` in `quic.c`, with the same byte-wise comparison, and it additionally let a `*.suffix` entry match any number of leading labels where the TCP tree matches exactly one.

### Fix

One comparison, `us_sni_name_cmp` in `libusockets.h`, is what every server-name lookup uses. It folds ASCII case only (so locale rules such as the Turkish dotless i cannot affect matching) and orders like `memcmp` over the folded bytes, so it serves both as an equality check and as the ordering of the label map.

- `sni_tree.cpp`: the label map's comparator calls it. That covers registration, lookup, removal and wildcard labels, in both directions; registering the same name twice in different case is now reported as a duplicate like an exact duplicate is.
- `quic.c`: exact and wildcard entries use it, and the wildcard covers one label, matching the TCP tree and `node:quic`'s matcher.
- `App.h`: uWS's queue of pending serverName entries (replayed onto each listener) uses it, so `removeServerName()`/`domain()` agree with the trees about which entry a name refers to.

### How did you verify your code works?

- `test/js/node/tls/node-tls-context.test.ts`: `addContext()` and the `Bun.serve` tls array serve the per-name certificate for `A.EXAMPLE.COM` / `A.Example.Com`, a name registered as `UPPER.EXAMPLE.COM` is selected by a lower-case SNI, `*.test.com` is selected by `B.TEST.COM`, and an unrelated name still gets the default certificate.
- `test/js/bun/http/bun-serve-ssl.test.ts`: the options of a `serverName` entry (here `requestCert`/`rejectUnauthorized`) apply to case variants of the name too.
- `test/js/bun/http/serve-http3.test.ts`: drives the HTTP/3 listener with a `node:quic` client (fetch() lowercases the URL host, `node:quic` sends `servername` as written and exposes the certificate that was served). Checks both directions of the fold plus `a.b.wild.example` / `wild.example` not matching `*.wild.example`.

All of them fail on the current release (`USE_SYSTEM_BUN=1`) and pass with `bun bd test`; the rest of those three files still passes.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts "test/js/bun/http/serve-http3.test.ts" test/js/node/tls/node-tls-context.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.40ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.18ms]
(pass) Bun.serve SSL validations > invalid cert development [2.05ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [30.14ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.30ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [2.03ms]
(pass) Bun.serve SSL validations > invalid key production [2.06ms]
(pass) Bun.serve SSL validations > invalid key #2 production [2.32ms]
(pass) Bun.serve SSL validations > invalid cert production [1.78ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.82ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [2.01ms]
(pass) Bun.serve SSL val
... (truncated)

release without fix: 4 failed, 1 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [0.35ms]
(pass) Bun.serve SSL validations > invalid key #2 development [0.06ms]
(pass) Bun.serve SSL validations > invalid cert development [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [3.58ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [0.04ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [0.01ms]
(pass) Bun.serve SSL validations > invalid key production [0.04ms]
(pass) Bun.serve SSL validations > invalid key #2 production [0.05ms]
(pass) Bun.serve SSL validations > invalid cert production [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [0.27ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [0.01ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production
(pass) Bun.serve SSL validations > valid development [7.33ms]
(pass) Bun.serve SSL validations > valid 2 development [3.05ms]
(pass) Bun.serve SSL validations > valid production [1.96ms
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts "test/js/bun/http/serve-http3.test.ts" test/js/node/tls/node-tls-context.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [25.74ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.41ms]
(pass) Bun.serve SSL validations > invalid cert development [1.59ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.10ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.95ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [1.73ms]
(pass) Bun.serve SSL validations > invalid key production [2.42ms]
(pass) Bun.serve SSL validations > invalid key #2 production [1.73ms]
(pass) Bun.serve SSL validations > invalid cert production [2.22ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.40ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.71ms]
(pass) Bun.serve SSL va
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 602ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/27] cc obj/packages/bun-usockets/src/bsd.c.o
[2/27] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[3/27] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[4/27] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[5/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[6/27] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[7/27] cxx obj/src/jsc/bindings/bindings.cpp.o
[8/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[9/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[10/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[11/27] cc obj/packages/bun-usockets/src/context.c.o
[12/27] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[13/27] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[14/27] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[15/27] cc obj/packages/bun-usockets/src/fault_inject.c.o
[16/27] cc obj/packages/bun-usockets/src/loop.c.o
[17/27] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/sni_tree.cpp |  9 +++-
 packages/bun-usockets/src/libusockets.h       | 20 +++++++-
 packages/bun-usockets/src/quic.c              | 11 +++--
 packages/bun-usockets/src/quic.h              |  4 +-
 packages/bun-uws/src/App.h                    |  7 ++-
 test/js/bun/http/bun-serve-ssl.test.ts        | 28 +++++++++++
 test/js/bun/http/serve-http3.test.ts          | 64 ++++++++++++++++++++++++-
 test/js/node/tls/node-tls-context.test.ts     | 69 +++++++++++++++++++++++++++
 8 files changed, 203 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-usockets/src/crypto/sni_tree.cpp      2      2     25
packages/bun-usockets/src/libusockets.h            1      1     25
packages/bun-usockets/src/quic.c                   2      3     25
packages/bun-usockets/src/quic.h                   0      0     25
packages/bun-uws/src/App.h                         3      2     26
test/js/bun/http/bun-serve-ssl.test.ts             1      1      7
test/js/bun/http/serve-http3.test.ts               5      5     14
test/js/node/tls/node-tls-context.test.ts          3      4      9
```

</details>

**root cause** · written by the author bot

Bun selected per-hostname TLS contexts by comparing the client's SNI name byte-for-byte against the registered server names, so a name that differed only in ASCII case fell through to the default context and skipped any per-name certificate, client-certificate, or rejection policy. The fix introduces a shared ASCII case-insensitive comparator, `us_sni_name_cmp`, and uses it for ordering and lookup in the SNI tree, for HTTP/3 exact and wildcard matching, and for the queued server-name handling in uWS. Exact names and single-label wildcards now match regardless of case, consistent with Node's…

<!-- robobun:evidence:end -->

