### PR TITLE
bun object: don't report a propagating sql module failure as uncaught

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/test/js/bun/bun-object/lazy-getter-module-failure.test.ts
+++ b/test/js/bun/bun-object/lazy-getter-module-failure.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Clobbering a global that an internal module needs makes that module fail to
+// evaluate. The Bun.sql and Bun.SQL lazy getters used to report the failure
+// while the exception was still pending on the VM, which aborted debug builds
+// inside the uncaught exception handler (and in the process.emit path when
+// process._fatalException had not been reified yet). The access must instead
+// throw the evaluation error to the caller and leave the process healthy.
+describe.concurrent("Bun object lazy getters", () => {
+  for (const reifyFatalException of [false, true]) {
+    test(`sql getter module failure propagates cleanly (fatalException reified: ${reifyFatalException})`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            ${reifyFatalException ? "process._fatalException;" : ""}
+            globalThis.Object = undefined;
+            let caught = "";
+            try {
+              Bun.sql;
+            } catch (e) {
+              caught = e.constructor.name;
+            }
+            try {
+              Bun.SQL;
+            } catch (e) {}
+            console.log("caught " + caught);
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout.trim()).toBe("caught TypeError");
+      expect(exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
### What

Fuzzilli has been hitting this flaky assertion for a while (17 reports of the same fingerprint):

```
ASSERTION FAILED: !scope.exception() || vm.hasPendingTerminationException() || !hasProperty
JavaScriptCore/JSObjectInlines.h(137) : JSValue JSC::JSObject::get(JSGlobalObject *, PropertyName)
```

A report finally arrived with enough stderr context to reconstruct the donor-process state, and it reduces to a deterministic three liner:

```js
process._fatalException;          // reify the property
globalThis.Object = undefined;    // make internal module evaluation throw
Bun.sql;                          // abort (debug builds)
```

The chain: the `Bun.sql`/`Bun.SQL` lazy getters carry a debug-only block that, when the BunSql internal module fails to evaluate, passes the failure to `reportUncaughtExceptionAtEventLoop` with the exception still pending on the VM. That handler enters `Bun__handleUncaughtException`, which does `process->get(globalObject, "_fatalException")`; entering that get with a pending exception and an existing property is exactly the asserted condition. When `_fatalException` has not been reified yet, the handler instead falls into the `process.emit` path with the pending exception and trips a Structure assertion, so both crash signatures share this root cause.

The report is also semantically wrong: the exception is not uncaught. `RETURN_IF_EXCEPTION` on the next line propagates it, and the property access throws it to the caller (every other caller of the reporter clears the exception first, for example `constructStdioWriteStream`).

### Fix

Remove the two `#if BUN_DEBUG` report blocks. The module failure now propagates cleanly: `Bun.sql` throws the evaluation error as a catchable exception and the process stays healthy.

### Test

`test/js/bun/bun-object/lazy-getter-module-failure.test.ts` runs the reduced repro in a subprocess for both variants (with and without `_fatalException` reified). Both abort the unfixed debug build with the respective assertions and pass with the fix; release builds were unaffected (asserts compiled out), which is why the fuzzer only saw this on the ASAN lane.

Related: the fingerprint also has slower-burn instances in event-loop completion paths with swallowed settle errors; those are tracked separately (#37004 for the DNS drains, #34829 for valkey). This PR fixes the instance that made the fuzzer reports reproducible.