### PR TITLE
test(napi): keep node's stdout in program order in the napi-app fixture

### DIFF
--- a/test/napi/napi-app/main.js
+++ b/test/napi/napi-app/main.js
@@ -1,3 +1,8 @@
+// Node writes to a piped stdout asynchronously on POSIX: after one EAGAIN every
+// console.log is queued until the event loop runs while the addons' printf keeps
+// writing to the fd directly. Make it blocking so output stays in program order.
+if (!process.isBun) process.stdout._handle?.setBlocking?.(true);
+
 const tests = require("./module");
 if (process.argv[2] === "self") {
   console.log(

--- a/test/napi/napi-app/utils.h
+++ b/test/napi/napi-app/utils.h
@@ -13,18 +13,21 @@ public:
   BlockingStdoutScope() {
     original = fcntl(1, F_GETFL);
     fcntl(1, F_SETFL, original & ~O_NONBLOCK);
-    setvbuf(stdout, nullptr, _IOFBF, 8192);
     fflush(stdout);
+    // Both runtimes start with stdout unbuffered. glibc keeps the existing
+    // 1-byte buffer when setvbuf is given a null buffer, so pass a real one.
+    setvbuf(stdout, buffer, _IOFBF, sizeof(buffer));
   }
 
   ~BlockingStdoutScope() {
     fflush(stdout);
     fcntl(1, F_SETFL, original);
-    setvbuf(stdout, nullptr, _IOLBF, 0);
+    setvbuf(stdout, nullptr, _IONBF, 0);
   }
 
 private:
   int original;
+  inline static char buffer[8192];
 };
 
 #endif


### PR DESCRIPTION
### What does this PR do?

Fixes the `napi_get_value_string_* > behaves like node on edge cases` flake in `test/napi/napi.test.ts` (Linux only, ~20 of the last 80 main builds). This is a bug in the test fixture's **reference (Node) side**, not in Bun.

The test runs `main.js test_get_value_string` under Node and Bun with stdout piped and asserts identical output. The fixture prints from two producers on fd 1: JS `console.log` and the addon's `printf` inside `BlockingStdoutScope`. In every failure the diff is the same shape: Bun's output is correctly interleaved, Node's has its `console.log` lines moved to the very end.

Why Node reorders:

1. Node's stdout is [asynchronous when it is a pipe on POSIX](https://nodejs.org/api/process.html#a-note-on-process-io). libuv tries the write synchronously; if `write()` returns `EAGAIN` it queues it for `EPOLLOUT` and every later `console.log` queues behind it. `test_get_value_string` is fully synchronous, so the queue only drains after all the addon's `printf` output has already gone to the fd.
2. The `EAGAIN` comes from `BlockingStdoutScope`. Node and Bun both `setvbuf(stdout, NULL, _IONBF, 0)` at startup; on glibc a later `setvbuf(stdout, NULL, _IOFBF, 8192)` keeps the existing 1-byte `_shortbuf` instead of allocating, so each scope emitted its output as thousands of 1–2 byte `write()`s. On Linux Bun's child stdout is an `AF_UNIX` socketpair, where each write is its own skb charged ~700 B against `SO_SNDBUF` — ~300 undrained tiny writes fill it. The scope's own writes are blocking so they just wait, but the next JS write after the scope restores `O_NONBLOCK` gets `EAGAIN`.

`strace` of a failing Node run (128 concurrent runs on Linux reproduce it ~7% of the time):

```
write(1, "t", 1) = 1
write(1, "r", 1) = 1
write(1, "ied to fill 0/32 units of buffer"..., 55) = 55
...                                   (10,279 write(1) calls total)
write(1, "utf8\n", 5) = -1 EAGAIN
...
epoll_pwait(15, [{events=EPOLLOUT}], ...) = 1
write(1, "utf8\n", 5) = 5
writev(1, [{"utf16\n"}, {"test napi_get_value_string on ..."}, {"latin1\n"}, {"utf8\n"}, {"utf16\n"}], 5) = 110
```

Fix: make Node's stdout blocking in `main.js` (what Node itself does for TTYs and Windows pipes) so JS and native output cannot reorder, and give `BlockingStdoutScope` a real buffer (61 writes instead of 10,279) and restore `_IONBF` afterwards. Bun already writes `console.log` synchronously, which is why its side was always ordered. Test expectations are unchanged.

### How did you verify your code works?

Linux x64: 640 concurrent `node main.js test_get_value_string` runs under `Bun.spawn` went from 44 reordered to 0; `strace` shows no `EAGAIN` and 61 `write(1)` calls. `bun bd test test/napi/napi.test.ts` passes the `checkSameOutput` tests on macOS arm64.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->