### PR TITLE
test(s3): isolate the mock-server fixtures from an inherited proxy

### DIFF
--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1714,6 +1714,16 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
   });
 });
 
+// The S3 client does not honor NO_PROXY, so an inherited proxy would hijack the
+// requests to the mock servers below.
+const envWithoutProxy = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
 describe("s3 multipart upload id validation", () => {
   it("rejects a CreateMultipartUpload response whose upload id contains non-ASCII bytes", async () => {
     // The whole scenario runs in a subprocess so a misbehaving runtime cannot take down the test runner.
@@ -1786,7 +1796,7 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: envWithoutProxy,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1844,7 +1854,7 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: envWithoutProxy,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1905,7 +1915,7 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: envWithoutProxy,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1988,7 +1998,7 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: envWithoutProxy,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1867,7 +1867,8 @@ describe("s3 upload stream body error", () => {
         port: 0,
         async fetch(req) {
           if (req.method === "PUT") {
-            putBytes += (await req.arrayBuffer()).byteLength;
+            const body = await req.arrayBuffer();
+            putBytes += body.byteLength;
           }
           return new Response(undefined, { status: 200, headers: { ETag: '"etag"' } });
         },
@@ -1953,6 +1954,8 @@ describe("s3 upload stream body error", () => {
             );
           }
           if (req.method === "PUT") {
+            // Both parts arrive concurrently; "received += (await ...)" would read
+            // received before the await and lose one part's count.
             const { byteLength } = await req.arrayBuffer();
             received += byteLength;
             return new Response(undefined, { status: 200, headers: { ETag: '"etag"' } });


### PR DESCRIPTION
### What does this PR do?

Rebased after #40478 landed. That PR fixed the `received += (await ...)` race in the `s3 upload stream body error` mock server, which was the original subject of this PR (the test lost one part's byte count because `a += b` reads `a` before `b`, so two concurrent PUT handlers each computed `0 + 5242880`). What remains here:

- The neighbouring `putBytes` site had the same `+= (await ...)` construct. It is harmless there (the test asserts `0`) but gets the same treatment so the pattern is not copied further. A comment at the fixed `received` site explains the hazard.
- The four mock-server fixtures in `s3.test.ts` (`s3 multipart upload id validation` and `s3 upload stream body error`) spawned bun with `env: bunEnv`, which forwards an inherited `HTTP_PROXY`. The S3 client does not honor `NO_PROXY`, so in a proxied environment the fixtures' requests to their loopback mock servers are sent to the proxy and the tests fail. They now spawn with `envWithoutProxy`, the same idiom `s3-connection-close.test.ts` and `s3-list-checksum-algorithm.test.ts` already use.

<details><summary>Original description</summary>

Fixes the `s3.test.ts` flake `s3 upload stream body error > uploads a fetch response body via the native ByteStream -> NetworkSink path` (darwin + Windows, e.g. builds 89843, 89500, 89483, 88526):

```
expect(received).toBe(totalBytes)
Expected: 10485760
Received: 5242880
```

This is a bug in the test's mock server, not in the S3 client. The fixture streams a 10 MiB fetch body into `S3Client.write`, which becomes a 2 × 5 MiB multipart upload, and the mock counts what it got with

```js
if (req.method === "PUT") {
  received += (await req.arrayBuffer()).byteLength;
```

`a += b` evaluates `a` before `b` ([EvaluateStringOrNumericBinaryExpression](https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation) takes `GetValue(lref)` first), so with an `await` on the right each handler computes `0 + 5242880` from the `received` it read *before* suspending. When the two part uploads are handled concurrently, which is the normal case on a release build (a debug build is slow enough that part 2 usually arrives after part 1's handler finished), the second assignment overwrites the first and the total is exactly one part. The client did send both parts and the CompleteMultipartUpload (verified by logging the requests: two `PUT ?partNumber=N` with `content-length: 5242880`, then the `POST ?uploadId=`), and the received value is always exactly `partSize`, never a torn byte count.

Reproduces deterministically outside CI: running the fixture 10× against a release binary gave `received: 5242880` 9 times; with only this change, 20/20 report 10485760.

</details>

### How did you verify your code works?

`bun bd test test/js/bun/s3/s3.test.ts` on the rebased branch: 12 pass, 0 fail (the rest skip without S3 credentials or docker). Before the proxy change, the two mock-server tests failed under an inherited `HTTP_PROXY` with `S3Error: egress denied by ... proxy`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 4 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/s3/s3.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/s3/s3.test.ts"
bun test v1.4.1 (861e9ae04)

test/js/bun/s3/s3.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(skip) R2 > s3 > fetch > bucket in path > should download file via fetch GET
(skip) R2 > s3 > fetch > bucket in path > should download range
(skip) R2 > s3 > fetch > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > fetch > bucket in path > should check if a key does not exist
(skip) R2 > s3 > fetch > bucket in path > should be able to set content-type
(skip) R2 > s3 > fetch > bucket in path > should be able to upload large files
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download file via Bun.s3().text()
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range
(skip) R2 > s3 > Bun.S3Client > bucket in path > should download range with 0 offset
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key exists or content-length
(skip) R2 > s3 > Bun.S3Client > bucket in path > should check if a key does not exist
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-type
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-disposition
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-disposition in writer
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-encoding
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to set content-encoding in writer
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to upload large files using bucket.write + readable Request
(skip) R2 > s3 > Bun.S3Client > bucket in path > should be able to upload large files in one go using bucket.write
(skip) R2 > s3 > Bun.S3Client > bucke
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/s3/s3.test.ts | 23 ++++++++++++++++++-----
 1 file changed, 18 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                       reads  edits  tests
test/js/bun/s3/s3.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->