### PR TITLE
bun run --parallel/--sequential: finish a script only after its output is read

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -56,6 +56,9 @@ pub(crate) struct ProcessHandle<'a> {
 
     stdout: BufferedReader,
     stderr: BufferedReader,
+    /// Pipes started and not yet at EOF/error; a script is finished only when
+    /// its process has exited and this is 0 (see `State::maybe_finish`).
+    remaining_fds: i8,
     buffer: Vec<u8>,
 
     process: Option<ProcessInfo>,
@@ -159,16 +162,20 @@ impl<'a> ProcessHandle<'a> {
         {
             if let Some(stdout) = stdout_fd {
                 let _ = sys::set_nonblocking(stdout);
+                handle.remaining_fds += 1;
                 handle.stdout.start(stdout, true)?;
             }
             if let Some(stderr) = stderr_fd {
                 let _ = sys::set_nonblocking(stderr);
+                handle.remaining_fds += 1;
                 handle.stderr.start(stderr, true)?;
             }
         }
         #[cfg(not(unix))]
         {
+            handle.remaining_fds += 1;
             handle.stdout.start_with_current_pipe()?;
+            handle.remaining_fds += 1;
             handle.stderr.start_with_current_pipe()?;
         }
 
@@ -210,10 +217,23 @@ impl<'a> ProcessHandle<'a> {
         true
     }
 
-    fn on_reader_done(&mut self) {}
+    fn on_reader_done(&mut self) {
+        debug_assert!(self.remaining_fds > 0);
+        self.remaining_fds -= 1;
+        let mut state_ref = self.state;
+        // SAFETY: state backref valid (see start()).
+        let state = unsafe { state_ref.get_mut() };
+        let _ = state.maybe_finish(self);
+    }
 
     fn on_reader_error(&mut self, err: &sys::Error) {
         let _ = err;
+        debug_assert!(self.remaining_fds > 0);
+        self.remaining_fds -= 1;
+        let mut state_ref = self.state;
+        // SAFETY: state backref valid (see start()).
+        let state = unsafe { state_ref.get_mut() };
+        let _ = state.maybe_finish(self);
     }
 }
 
@@ -233,7 +253,7 @@ impl<'a> ProcessHandle<'a> {
         let mut state_ref = self.state;
         // SAFETY: state backref valid (see start()).
         let state = unsafe { state_ref.get_mut() };
-        let _ = state.process_exit(self);
+        let _ = state.maybe_finish(self);
     }
 
     fn loop_(&self) -> *mut bun_io::Loop {
@@ -339,7 +359,15 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    fn process_exit(&mut self, handle: &mut ProcessHandle<'a>) -> crate::Result<()> {
+    /// A script is finished once its process has exited *and* both pipes have
+    /// reached EOF: the exit notification can arrive before the last output
+    /// has been read, and finishing then would drop that output (or, for the
+    /// last script, exit before printing it).
+    fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> crate::Result<()> {
+        let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
+        if !exited || handle.remaining_fds != 0 {
+            return Ok(());
+        }
         self.remaining_scripts -= 1;
         if !self.aborted {
             for &dependent in &handle.dependents {
@@ -953,6 +981,7 @@ pub(crate) fn run_scripts_with_filter(
             stdout: BufferedReader::init::<ProcessHandle>(),
             stderr: BufferedReader::init::<ProcessHandle>(),
             buffer: Vec::new(),
+            remaining_fds: 0,
             process: None,
             options: SpawnOptions {
                 stdin: spawn::Stdio::Ignore,
@@ -1042,14 +1071,20 @@ pub(crate) fn run_scripts_with_filter(
         }
     }
 
-    // start inital scripts
-    for handle in state.handles.iter_mut() {
-        if handle.remaining_dependencies == 0 {
-            if handle.start().is_err() {
-                // todo this should probably happen in "start"
-                bun_core::pretty_errorln!("<r><red>error<r>: Failed to start process");
-                Global::exit(1);
-            }
+    // Collect the roots before starting any: a script that has already exited
+    // when `start()` watches it can finish (and cascade) inside `start()`,
+    // which zeroes `remaining_dependencies` of later handles it started.
+    let roots: Vec<*mut ProcessHandle> = state
+        .handles
+        .iter_mut()
+        .filter(|handle| handle.remaining_dependencies == 0)
+        .map(|handle| std::ptr::from_mut(handle))
+        .collect();
+    for handle in roots {
+        // SAFETY: points into `state.handles`, which lives for the whole loop.
+        if unsafe { (*handle).start() }.is_err() {
+            bun_core::pretty_errorln!("<r><red>error<r>: Failed to start process");
+            Global::exit(1);
         }
     }
 

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -59,6 +59,10 @@ pub(crate) struct ProcessHandle<'a> {
     /// Pipes started and not yet at EOF/error; a script is finished only when
     /// its process has exited and this is 0 (see `State::maybe_finish`).
     remaining_fds: i8,
+    /// Set by the `maybe_finish` that counts this script out of
+    /// `remaining_scripts`, so a later pipe/exit event or the abort sweep
+    /// cannot finish it twice.
+    finished: bool,
     buffer: Vec<u8>,
 
     process: Option<ProcessInfo>,
@@ -362,12 +366,14 @@ impl<'a> State<'a> {
     /// A script is finished once its process has exited *and* both pipes have
     /// reached EOF: the exit notification can arrive before the last output
     /// has been read, and finishing then would drop that output (or, for the
-    /// last script, exit before printing it).
+    /// last script, exit before printing it). On abort, exit alone suffices:
+    /// a leftover child holding the pipes must not keep the aborted run alive.
     fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> crate::Result<()> {
         let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
-        if !exited || handle.remaining_fds != 0 {
+        if handle.finished || !exited || (handle.remaining_fds != 0 && !self.aborted) {
             return Ok(());
         }
+        handle.finished = true;
         self.remaining_scripts -= 1;
         if !self.aborted {
             for &dependent in &handle.dependents {
@@ -605,15 +611,28 @@ impl<'a> State<'a> {
     }
 
     fn abort(&mut self) {
+        if self.aborted {
+            return;
+        }
         // we perform an abort by sending SIGINT to all processes
         self.aborted = true;
-        for handle in self.handles.iter_mut() {
+        // Raw ptrs so `self.maybe_finish` can be called while walking (the
+        // file-wide State/handle backref pattern).
+        let handles: Vec<*mut ProcessHandle<'a>> =
+            self.handles.iter_mut().map(std::ptr::from_mut).collect();
+        for handle in handles {
+            // SAFETY: points into `self.handles`, live for the whole run loop.
+            let handle = unsafe { &mut *handle };
             if let Some(proc) = &mut handle.process {
                 // if we get an error here we simply ignore it
                 // SAFETY: proc.ptr is a live `*mut Process` (set in start(); leaked
                 // until program exit per on_process_exit note).
                 let _ = unsafe { (*proc.ptr).kill(bun_sys::SignalCode::SIGINT.0) };
             }
+            // An already-exited handle may be waiting on pipes a grandchild
+            // still holds; with `aborted` set this finishes it now. Killed
+            // handles finish when their exit arrives.
+            let _ = self.maybe_finish(handle);
         }
     }
 
@@ -982,6 +1001,7 @@ pub(crate) fn run_scripts_with_filter(
             stderr: BufferedReader::init::<ProcessHandle>(),
             buffer: Vec::new(),
             remaining_fds: 0,
+            finished: false,
             process: None,
             options: SpawnOptions {
                 stdin: spawn::Stdio::Ignore,
@@ -1097,6 +1117,9 @@ pub(crate) fn run_scripts_with_filter(
             // This can be useful if one of the processes is stuck and doesn't react to SIGINT.
             AbortHandler::uninstall();
             state.abort();
+            // The abort sweep may have finished the last script; re-check
+            // before blocking in a tick no event may ever wake.
+            continue;
         }
         // SAFETY: event_loop is the live thread-local MiniEventLoop singleton.
         unsafe { (*event_loop).tick_once(&raw const state as *mut c_void) };

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -49,8 +49,10 @@ struct ScriptConfig {
 /// so output can be routed to the correct parent stream.
 pub struct PipeReader<'a> {
     reader: BufferedReader,
-    handle: *const ProcessHandle<'a>, // set in ProcessHandle::start()
+    handle: *mut ProcessHandle<'a>, // set in ProcessHandle::start()
     is_stderr: bool,
+    /// Reached EOF or errored; no more chunks will arrive.
+    ended: bool,
     line_buffer: Vec<u8>,
 }
 
@@ -59,8 +61,9 @@ impl<'a> PipeReader<'a> {
         Self {
             // BufferedReader::init(This) — the parent type fills the vtable.
             reader: BufferedReader::init::<Self>(),
-            handle: ptr::null(),
+            handle: ptr::null_mut(),
             is_stderr,
+            ended: false,
             line_buffer: Vec::new(),
         }
     }
@@ -72,9 +75,9 @@ impl<'a> PipeReader<'a> {
     }
 }
 
-// Callbacks here touch only `line_buffer` / `handle` / the State backref,
-// never `reader`. Backrefs set in `ProcessHandle::start()`; `State` outlives
-// all handles (lives on `run`'s stack frame for the whole event loop).
+// Callbacks here touch only `line_buffer` / `ended` / `handle` / the State
+// backref, never `reader`. Backrefs set in `ProcessHandle::start()`; `State`
+// outlives all handles (lives on `run`'s stack frame for the whole event loop).
 bun_io::impl_buffered_reader_parent! {
     MultiRunPipeReader for PipeReader<'a>;
     has_on_read_chunk = true;
@@ -83,8 +86,18 @@ bun_io::impl_buffered_reader_parent! {
         let _ = state.read_chunk(&mut *this, chunk);
         true
     };
-    on_reader_done  = |_this| {};
-    on_reader_error = |_this, _err| {};
+    on_reader_done  = |this| {
+        (*this).ended = true;
+        let handle = (*this).handle;
+        let state = &mut *(*handle).state.cast_mut();
+        let _ = state.maybe_finish(&mut *handle);
+    };
+    on_reader_error = |this, _err| {
+        (*this).ended = true;
+        let handle = (*this).handle;
+        let state = &mut *(*handle).state.cast_mut();
+        let _ = state.maybe_finish(&mut *handle);
+    };
     loop_           = |this| bun_io::uws_to_native((*(*this).event_loop_ptr()).loop_);
     event_loop      = |this| (*(*(*this).handle).state).event_loop_handle.as_event_loop_ctx();
 }
@@ -176,8 +189,8 @@ impl<'a> ProcessHandle<'a> {
         let stderr_fd = spawned.stderr;
         let process = spawned.to_process(EventLoopHandle::init_mini(state.event_loop));
 
-        self.stdout_reader.handle = std::ptr::from_ref(self);
-        self.stderr_reader.handle = std::ptr::from_ref(self);
+        self.stdout_reader.handle = std::ptr::from_mut(self);
+        self.stderr_reader.handle = std::ptr::from_mut(self);
         // Compute parent ptrs before calling `set_parent` to avoid
         // borrowck seeing two simultaneous &mut borrows of the same field.
         let stdout_parent = (&raw mut self.stdout_reader).cast::<c_void>();
@@ -273,7 +286,7 @@ bun_spawn::link_impl_ProcessExit! {
             (*this).process.as_mut().unwrap().status = status;
             (*this).end_time = Instant::now().into();
             let state = &mut *(*this).state.cast_mut();
-            let _ = state.process_exit(&mut *this);
+            let _ = state.maybe_finish(&mut *this);
         },
     }
 }
@@ -384,7 +397,15 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    fn process_exit(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
+    /// A script is finished once its process has exited *and* both pipes have
+    /// reached EOF: the exit notification can arrive before the last output
+    /// has been read, and finishing then would drop that output (or, for the
+    /// last script, exit before printing it).
+    fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
+        let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
+        if !exited || !handle.stdout_reader.ended || !handle.stderr_reader.ended {
+            return Ok(());
+        }
         self.remaining_scripts -= 1;
 
         // Flush remaining buffers (stdout first, then stderr)
@@ -1208,13 +1229,20 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         }
     }
 
-    // Start handles with no dependencies
-    for handle in state.handles.iter_mut() {
-        if handle.remaining_dependencies == 0 {
-            if handle.start().is_err() {
-                bun_core::pretty_errorln!("<r><red>error<r>: Failed to start process");
-                Global::exit(1);
-            }
+    // Collect the roots before starting any: a script that has already exited
+    // when `start()` watches it can finish (and cascade) inside `start()`, which
+    // zeroes `remaining_dependencies` of later handles it started or skipped.
+    let roots: Vec<*mut ProcessHandle> = state
+        .handles
+        .iter_mut()
+        .filter(|handle| handle.remaining_dependencies == 0)
+        .map(|handle| std::ptr::from_mut(handle))
+        .collect();
+    for handle in roots {
+        // SAFETY: points into `state.handles`, which lives for the whole loop.
+        if unsafe { (*handle).start() }.is_err() {
+            bun_core::pretty_errorln!("<r><red>error<r>: Failed to start process");
+            Global::exit(1);
         }
     }
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -123,6 +123,11 @@ pub(crate) struct ProcessHandle<'a> {
     start_time: Option<Instant>,
     end_time: Option<Instant>,
 
+    /// Set by the `maybe_finish` that counts this script out of
+    /// `remaining_scripts`, so a later pipe/exit event or the abort sweep
+    /// cannot finish it twice.
+    finished: bool,
+
     remaining_dependencies: usize,
     /// Dependents within the same script group (pre->main->post chain).
     /// These are NOT started if this handle fails, even with --no-exit-on-error.
@@ -400,12 +405,15 @@ impl<'a> State<'a> {
     /// A script is finished once its process has exited *and* both pipes have
     /// reached EOF: the exit notification can arrive before the last output
     /// has been read, and finishing then would drop that output (or, for the
-    /// last script, exit before printing it).
+    /// last script, exit before printing it). On abort, exit alone suffices:
+    /// a leftover child holding the pipes must not keep the aborted run alive.
     fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
         let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
-        if !exited || !handle.stdout_reader.ended || !handle.stderr_reader.ended {
+        let pipes_open = !handle.stdout_reader.ended || !handle.stderr_reader.ended;
+        if handle.finished || !exited || (pipes_open && !self.aborted) {
             return Ok(());
         }
+        handle.finished = true;
         self.remaining_scripts -= 1;
 
         // Flush remaining buffers (stdout first, then stderr)
@@ -522,8 +530,17 @@ impl<'a> State<'a> {
     }
 
     fn abort(&mut self) {
+        if self.aborted {
+            return;
+        }
         self.aborted = true;
-        for handle in self.handles.iter_mut() {
+        // Raw ptrs so `self.maybe_finish` can be called while walking (the
+        // file-wide State/handle backref pattern).
+        let handles: Vec<*mut ProcessHandle<'a>> =
+            self.handles.iter_mut().map(std::ptr::from_mut).collect();
+        for handle in handles {
+            // SAFETY: points into `self.handles`, live for the whole run loop.
+            let handle = unsafe { &mut *handle };
             if let Some(proc) = &mut handle.process {
                 if matches!(proc.status, Status::Running) {
                     // SAFETY: proc.ptr is a live intrusively-ref-counted Process
@@ -531,6 +548,10 @@ impl<'a> State<'a> {
                     let _ = unsafe { (*proc.ptr).kill(bun_sys::SignalCode::SIGINT.0) };
                 }
             }
+            // An already-exited handle may be waiting on pipes a grandchild
+            // still holds; with `aborted` set this finishes it now. Killed
+            // handles finish when their exit arrives.
+            let _ = self.maybe_finish(handle);
         }
     }
 
@@ -1166,6 +1187,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             process: None,
             start_time: None,
             end_time: None,
+            finished: false,
             remaining_dependencies: 0,
             group_dependents: Vec::new(),
             next_dependents: Vec::new(),
@@ -1252,6 +1274,9 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         if SHOULD_ABORT.load(Ordering::SeqCst) && !state.aborted {
             AbortHandler::uninstall();
             state.abort();
+            // The abort sweep may have finished the last script; re-check
+            // before blocking in a tick no event may ever wake.
+            continue;
         }
         // SAFETY: event_loop points at the thread-lifetime MiniEventLoop singleton.
         unsafe { (*event_loop).tick_once((&raw const state).cast_mut().cast::<c_void>()) };

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -811,6 +811,8 @@ describe("output timing", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toContain("early-line");
     expect(stdout).toContain("late-line");
+    // The exit status line is printed at finish, after the output has ended.
+    expect(stdout.indexOf("late-line")).toBeLessThan(stdout.indexOf("Exited with code 0"));
     expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
-import { symlinkSync } from "node:fs";
+import { existsSync, symlinkSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { join } from "path";
 
@@ -814,5 +814,47 @@ describe("output timing", () => {
     // The exit status line is printed at finish, after the output has ended.
     expect(stdout.indexOf("late-line")).toBeLessThan(stdout.indexOf("Exited with code 0"));
     expect(exitCode).toBe(0);
+  });
+
+  // On abort (here: SIGINT), exit alone finishes a script; waiting for pipe
+  // EOF would hang on the detached child that still holds go's stdout.
+  test.skipIf(isWindows)("SIGINT does not wait for a child holding the script's pipes", async () => {
+    using dir = tempDir("filter-abort-late", {
+      "package.json": JSON.stringify({
+        name: "ws-abort",
+        workspaces: ["packages/*"],
+      }),
+      "packages/bg/package.json": JSON.stringify({
+        name: "pkg-bg",
+        scripts: {
+          go: `${bunExe()} go.js`,
+        },
+      }),
+      "packages/bg/go.js": `
+        Bun.spawn({
+          cmd: [process.execPath, "-e", "await Bun.sleep(10_000)"],
+          stdio: ["ignore", "inherit", "inherit"],
+          detached: true,
+        }).unref();
+        await Bun.write("ready.txt", "1");
+        await Bun.sleep(15_000);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "pkg-bg", "go"],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_NO_ORPHANS: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      // New session, so the group signal below cannot reach the test runner.
+      detached: true,
+    });
+    const ready = join(String(dir), "packages", "bg", "ready.txt");
+    while (!existsSync(ready)) await Bun.sleep(10);
+    // Ctrl-C semantics: the terminal signals the foreground process group
+    // (bun run and the script), but not the detached grandchild.
+    process.kill(-proc.pid, "SIGINT");
+    // 128 + SIGINT: go is killed by the signal and is the only script.
+    expect(await proc.exited).toBe(130);
   });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -831,12 +831,13 @@ describe("output timing", () => {
         },
       }),
       "packages/bg/go.js": `
-        Bun.spawn({
+        const child = Bun.spawn({
           cmd: [process.execPath, "-e", "await Bun.sleep(10_000)"],
           stdio: ["ignore", "inherit", "inherit"],
           detached: true,
-        }).unref();
-        await Bun.write("ready.txt", "1");
+        });
+        child.unref();
+        await Bun.write("ready.txt", String(child.pid));
         await Bun.sleep(15_000);
       `,
     });
@@ -850,11 +851,29 @@ describe("output timing", () => {
       detached: true,
     });
     const ready = join(String(dir), "packages", "bg", "ready.txt");
-    while (!existsSync(ready)) await Bun.sleep(10);
+    const deadline = Date.now() + 15_000;
+    while (!existsSync(ready)) {
+      if (Date.now() > deadline || proc.exitCode !== null) {
+        proc.kill();
+        const [o, e] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+        throw new Error(`go never wrote ready.txt; stdout: ${o}stderr: ${e}`);
+      }
+      await Bun.sleep(10);
+    }
     // Ctrl-C semantics: the terminal signals the foreground process group
     // (bun run and the script), but not the detached grandchild.
     process.kill(-proc.pid, "SIGINT");
-    // 128 + SIGINT: go is killed by the signal and is the only script.
-    expect(await proc.exited).toBe(130);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Reap the pipe-holding grandchild so nothing outlives the test.
+    try {
+      process.kill(Number(await Bun.file(ready).text()), "SIGKILL");
+    } catch {}
+    // 128 + SIGINT: go is killed by the signal and is the only script. stderr
+    // rides along so a regression surfaces it in the failure output.
+    expect({ exitCode, stdout, stderr }).toEqual({
+      exitCode: 130,
+      stdout: expect.any(String),
+      stderr: expect.any(String),
+    });
   });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -833,7 +833,7 @@ describe("output timing", () => {
       }),
       "packages/bg/go.js": `
         const child = Bun.spawn({
-          cmd: [process.execPath, "-e", "await Bun.sleep(10_000)"],
+          cmd: [process.execPath, "-e", "await Bun.sleep(30_000)"],
           stdio: ["ignore", "inherit", "inherit"],
           detached: true,
         });
@@ -863,6 +863,7 @@ describe("output timing", () => {
     }
     // Ctrl-C semantics: the terminal signals the foreground process group
     // (bun run and the script), but not the detached grandchild.
+    const start = Date.now();
     process.kill(-proc.pid, "SIGINT");
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // Reap the pipe-holding grandchild so nothing outlives the test. Guard the
@@ -878,5 +879,7 @@ describe("output timing", () => {
       stdout: expect.any(String),
       stderr: expect.any(String),
     });
+    // Waiting out the grandchild's 30s sleep means the abort bypass regressed.
+    expect(Date.now() - start).toBeLessThan(15000);
   });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -772,3 +772,43 @@ describe.skipIf(!isWindows).each([
     30000,
   );
 });
+
+describe("output timing", () => {
+  // A script is finished when its process has exited AND its output has reached
+  // EOF; treating the exit alone as "finished" drops output that hasn't been
+  // read yet (here: written by a child the script left behind).
+  test("output written after the script's shell exits is not dropped", async () => {
+    using dir = tempDir("filter-late-output", {
+      "package.json": JSON.stringify({
+        name: "ws-late",
+        workspaces: ["packages/*"],
+      }),
+      "packages/late/package.json": JSON.stringify({
+        name: "pkg-late",
+        scripts: {
+          go: `${bunExe()} late.js`,
+        },
+      }),
+      "packages/late/late.js": `
+        Bun.spawn({
+          cmd: [process.execPath, "-e", "await Bun.sleep(300); console.log('late-line')"],
+          stdio: ["ignore", "inherit", "inherit"],
+          // Windows: keep the child out of this process's kill-on-close job.
+          detached: true,
+        }).unref();
+        console.log("early-line");
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "pkg-late", "go"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("early-line");
+    expect(stdout).toContain("late-line");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -811,6 +811,7 @@ describe("output timing", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toContain("early-line");
     expect(stdout).toContain("late-line");
+    expect(stdout).toContain("Exited with code 0");
     // The exit status line is printed at finish, after the output has ended.
     expect(stdout.indexOf("late-line")).toBeLessThan(stdout.indexOf("Exited with code 0"));
     expect(exitCode).toBe(0);
@@ -864,9 +865,11 @@ describe("output timing", () => {
     // (bun run and the script), but not the detached grandchild.
     process.kill(-proc.pid, "SIGINT");
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Reap the pipe-holding grandchild so nothing outlives the test.
+    // Reap the pipe-holding grandchild so nothing outlives the test. Guard the
+    // pid: kill(0) would signal this whole process group.
     try {
-      process.kill(Number(await Bun.file(ready).text()), "SIGKILL");
+      const pid = Number(await Bun.file(ready).text());
+      if (Number.isInteger(pid) && pid > 0) process.kill(pid, "SIGKILL");
     } catch {}
     // 128 + SIGINT: go is killed by the signal and is the only script. stderr
     // rides along so a regression surfaces it in the failure output.

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -801,7 +801,9 @@ describe("output timing", () => {
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", "--filter", "pkg-late", "go"],
-      env: bunEnv,
+      // CI ASAN lanes set BUN_FEATURE_FLAG_NO_ORPHANS, which makes the script's
+      // bun SIGKILL the detached child on exit, defeating the late write.
+      env: { ...bunEnv, BUN_FEATURE_FLAG_NO_ORPHANS: undefined },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1003,7 +1003,7 @@ describe.concurrent("timing edge cases", () => {
     using dir = tempDir("mr-abort-late", {
       "bg.js": `
         const child = Bun.spawn({
-          cmd: [process.execPath, "-e", "await Bun.sleep(10_000)"],
+          cmd: [process.execPath, "-e", "await Bun.sleep(30_000)"],
           stdio: ["ignore", "inherit", "inherit"],
           detached: true,
         });
@@ -1021,6 +1021,7 @@ describe.concurrent("timing edge cases", () => {
         },
       }),
     });
+    const start = Date.now();
     const r = await runMulti(["run", "--parallel", "fail", "bg"], String(dir), {
       BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
     });
@@ -1032,6 +1033,8 @@ describe.concurrent("timing edge cases", () => {
     } catch {}
     expectExited(r.stderr, "fail", 1);
     expect(r.exitCode).toBe(1);
+    // Waiting out the child's 30s sleep means the abort bypass regressed.
+    expect(Date.now() - start).toBeLessThan(15000);
   });
 });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1002,12 +1002,13 @@ describe.concurrent("timing edge cases", () => {
   test("failure abort does not wait for a child holding another script's pipes", async () => {
     using dir = tempDir("mr-abort-late", {
       "bg.js": `
-        Bun.spawn({
+        const child = Bun.spawn({
           cmd: [process.execPath, "-e", "await Bun.sleep(10_000)"],
           stdio: ["ignore", "inherit", "inherit"],
           detached: true,
-        }).unref();
-        await Bun.write("ready.txt", "1");
+        });
+        child.unref();
+        await Bun.write("ready.txt", String(child.pid));
       `,
       "fail.js": `
         while (!(await Bun.file("ready.txt").exists())) await Bun.sleep(10);
@@ -1023,6 +1024,10 @@ describe.concurrent("timing edge cases", () => {
     const r = await runMulti(["run", "--parallel", "fail", "bg"], String(dir), {
       BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
     });
+    // Reap the pipe-holding child so nothing outlives the test.
+    try {
+      process.kill(Number(await Bun.file(path.join(String(dir), "ready.txt")).text()), "SIGKILL");
+    } catch {}
     expectExited(r.stderr, "fail", 1);
     expect(r.exitCode).toBe(1);
   });

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1024,9 +1024,11 @@ describe.concurrent("timing edge cases", () => {
     const r = await runMulti(["run", "--parallel", "fail", "bg"], String(dir), {
       BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
     });
-    // Reap the pipe-holding child so nothing outlives the test.
+    // Reap the pipe-holding child so nothing outlives the test. Guard the pid:
+    // kill(0) would signal this whole process group.
     try {
-      process.kill(Number(await Bun.file(path.join(String(dir), "ready.txt")).text()), "SIGKILL");
+      const pid = Number(await Bun.file(path.join(String(dir), "ready.txt")).text());
+      if (Number.isInteger(pid) && pid > 0) process.kill(pid, "SIGKILL");
     } catch {}
     expectExited(r.stderr, "fail", 1);
     expect(r.exitCode).toBe(1);

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -995,6 +995,37 @@ describe.concurrent("timing edge cases", () => {
     expectDone(r.stderr, "other");
     expect(r.exitCode).toBe(0);
   });
+
+  // On abort (here: a failing script with exit-on-error), exit alone finishes
+  // a script; waiting for pipe EOF would hang on the detached child that still
+  // holds bg's stdout.
+  test("failure abort does not wait for a child holding another script's pipes", async () => {
+    using dir = tempDir("mr-abort-late", {
+      "bg.js": `
+        Bun.spawn({
+          cmd: [process.execPath, "-e", "await Bun.sleep(10_000)"],
+          stdio: ["ignore", "inherit", "inherit"],
+          detached: true,
+        }).unref();
+        await Bun.write("ready.txt", "1");
+      `,
+      "fail.js": `
+        while (!(await Bun.file("ready.txt").exists())) await Bun.sleep(10);
+        process.exit(1);
+      `,
+      "package.json": JSON.stringify({
+        scripts: {
+          fail: `${bunExe()} fail.js`,
+          bg: `${bunExe()} bg.js`,
+        },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "fail", "bg"], String(dir), {
+      BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
+    });
+    expectExited(r.stderr, "fail", 1);
+    expect(r.exitCode).toBe(1);
+  });
 });
 
 // ─── EXIT CODE PROPAGATION ───────────────────────────────────────────────────

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -991,6 +991,8 @@ describe.concurrent("timing edge cases", () => {
     expectPrefixed(r.stdout, "late", "late-line");
     expectPrefixed(r.stdout, "other", "other-ran");
     expect(r.stdout.indexOf("late-line")).toBeLessThan(r.stdout.indexOf("other-ran"));
+    expectDone(r.stderr, "late");
+    expectDone(r.stderr, "other");
     expect(r.exitCode).toBe(0);
   });
 });

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -7,7 +7,7 @@ import path from "path";
 async function runMulti(
   args: string[],
   dir: string,
-  extraEnv?: Record<string, string>,
+  extraEnv?: Record<string, string | undefined>,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
@@ -982,7 +982,11 @@ describe.concurrent("timing edge cases", () => {
         },
       }),
     });
-    const r = await runMulti(["run", "--sequential", "late", "other"], String(dir));
+    // CI ASAN lanes set BUN_FEATURE_FLAG_NO_ORPHANS, which makes the script's
+    // bun SIGKILL the detached child on exit, defeating the late write.
+    const r = await runMulti(["run", "--sequential", "late", "other"], String(dir), {
+      BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
+    });
     expectPrefixed(r.stdout, "late", "early-line");
     expectPrefixed(r.stdout, "late", "late-line");
     expectPrefixed(r.stdout, "other", "other-ran");

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -960,6 +960,35 @@ describe.concurrent("timing edge cases", () => {
     expect(ib).toBeLessThan(ic);
     expect(r.exitCode).toBe(0);
   });
+
+  // A script is finished when its process has exited AND its output has reached
+  // EOF; treating the exit alone as "finished" drops output that hasn't been
+  // read yet (here: written by a child the script left behind).
+  test("output written after the script's shell exits is not dropped", async () => {
+    using dir = tempDir("mr-late-output", {
+      "late.js": `
+        Bun.spawn({
+          cmd: [process.execPath, "-e", "await Bun.sleep(300); console.log('late-line')"],
+          stdio: ["ignore", "inherit", "inherit"],
+          // Windows: keep the child out of this process's kill-on-close job.
+          detached: true,
+        }).unref();
+        console.log("early-line");
+      `,
+      "package.json": JSON.stringify({
+        scripts: {
+          late: `${bunExe()} late.js`,
+          other: `echo other-ran`,
+        },
+      }),
+    });
+    const r = await runMulti(["run", "--sequential", "late", "other"], String(dir));
+    expectPrefixed(r.stdout, "late", "early-line");
+    expectPrefixed(r.stdout, "late", "late-line");
+    expectPrefixed(r.stdout, "other", "other-ran");
+    expect(r.stdout.indexOf("late-line")).toBeLessThan(r.stdout.indexOf("other-ran"));
+    expect(r.exitCode).toBe(0);
+  });
 });
 
 // ─── EXIT CODE PROPAGATION ───────────────────────────────────────────────────


### PR DESCRIPTION
### What does this PR do?

Fixes the `test/cli/run/multi-run.test.ts` flake on the macOS runners (13 of the last ~80 main builds; darwin 14/26, x64 and arm64). The failures look unrelated at first — a script's output missing entirely (`Received: ""`), only the *last* script's output missing (`third-output`, `post-ran`), or a script running that should have been skipped:

```
✗ sequential: pre failure with --no-exit-on-error still runs next group
Expected to not contain: "build-shouldnt"
Received: "test  | test-ran\nbuild | build-shouldnt\n"        (prebuild is `exit 1`; build ran anyway, and after test)
```

They share one trigger: the script's process has **already exited** when `ProcessHandle::start()` calls `process.watch_or_reap()`. On macOS registering `EVFILT_PROC` on an exited pid fails with `ESRCH`, `watch_or_reap` falls back to a blocking `wait4`, and the exit handler runs *synchronously inside `start()`*. That needs a few ms of scheduling delay between `posix_spawn` and the kevent call — routine on the loaded mac fleet, never on Linux (a pidfd on a zombie just polls readable later). Two bugs then fire in `multi_run.rs`:

1. **Exit was treated as "finished".** `process_exit` flushed the partial-line buffers, printed `Done`, decremented `remaining_scripts` and cascaded to dependents without waiting for the stdout/stderr `BufferedReader`s to reach EOF. Whatever hadn't been read yet was dropped, and if this was the last script `while !state.is_done()` ended and `bun run` exited before reading a byte → the empty / truncated outputs.
2. **The initial start loop re-read `remaining_dependencies` while iterating.** A synchronous finish inside `prebuild.start()` cascades: `skip_dependents` zeroes `build`'s counter (meaning "skipped") and starts `test`. The loop then reaches `build`, sees `0`, and starts it → `build-shouldnt`, after `test`. (It also re-started `test`; in a debug build that's a `subtract with overflow` panic in `start_dependents`.)

Both reproduce exactly with a `sleep(50ms)` inserted before `watch_or_reap()` on an otherwise unmodified build: `run --sequential --no-exit-on-error build test` prints `build | Done` after `test | Done` and panics; `run --parallel x` for `x: "echo a; echo b"` prints only `x | Done in 61ms`.

**Fix:** a script is finished when its process has exited *and* both pipes have ended (the same rule `lifecycle_script_runner.rs` already uses; also what `concurrently` does by waiting for `'close'`), and the roots are collected before any is started. With the same artificial 50 ms delay the whole test file passes.

Behaviour note: because a script now finishes when its output ends, a script that leaves a background process holding its stdout keeps `bun run --parallel` alive until that process closes it (previously the output was cut off at the shell's exit). Ctrl-C behaviour is unchanged.

### How did you verify your code works?

- New test `timing edge cases > output written after the script's shell exits is not dropped` (a script whose detached child writes 300 ms after the shell exits): fails on the current canary (`Received: "late  | early-line\nother | other-ran\n"`), passes with this change.
- `bun bd test test/cli/run/multi-run.test.ts`: 119 pass, both as-is and with the 50 ms delay simulating the CI condition. There is no hook to force the already-exited-at-watch timing from a test, so the double-start half is covered by the existing tests only under that condition.

### Same class: `bun run --filter` (filter_run.rs)

Review caught that `filter_run.rs`, the sibling copy of this code path (dispatched for `--filter`/`--workspaces` without `--parallel`/`--sequential`), has the same two bugs verbatim: exit treated as finished without waiting for pipe EOF, and the initial start loop re-reading `remaining_dependencies` while iterating. This PR now applies the same fix there. Since both of its `BufferedReader`s share the `ProcessHandle` as their parent (the done callback cannot tell which pipe ended), it tracks not-yet-ended pipes with a per-handle `remaining_fds` counter, the same pattern `lifecycle_script_runner.rs` uses, and collects the roots before starting any.

Verification: same-shape test in `test/cli/run/filter-workspace.test.ts` fails on the current canary (`Received: "pkg-late go: early-line\npkg-late go: Exited with code 0\n"`, the late line dropped) and passes with this change; `bun bd test test/cli/run/filter-workspace.test.ts` 57 pass, `test/cli/run/run-quote.test.ts` 6 pass, `test/cli/install/bun-run.test.ts` 292 pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts test/cli/run/multi-run.test.ts

<!-- robobun:evidence:end -->

### Abort semantics (review catch)

Review also caught that the EOF gate broke aborts: a script that exited leaving a detached child holding its pipes would keep an aborted run (failing script with exit-on-error, or Ctrl-C) alive until that child closed them, where it previously exited immediately. Fixed in both runners: finishing is idempotent (a `finished` flag), `abort()` sweeps `maybe_finish` over every handle after killing so exit alone finishes a script once aborted, and the run loops re-check `is_done()` after an abort instead of blocking in a tick that no event may wake. Covered by two new tests (a failure abort under `--parallel`, and a process-group SIGINT under `--filter`), which pass on this branch and on the unfixed baseline (the EOF gate introduced the hang, so the gate relies on the late-output tests for fail-before).
