### PR TITLE
test(spawn): wait for background pipe closes before counting fds

### DIFF
--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -63,7 +63,13 @@ test("spawn can write to stdin multiple chunks", async () => {
     remaining -= concurrency;
   }
 
-  const newMaxFD = getMaxFD();
+  // Pipe fds are closed on a background thread after their streams finish, so
+  // the last batch's closes may still be in flight here; wait for them to land.
+  let newMaxFD = getMaxFD();
+  for (let i = 0; i < 100 && newMaxFD !== maxFD; i++) {
+    await Bun.sleep(10);
+    newMaxFD = getMaxFD();
+  }
 
   // assert we didn't leak any file descriptors
   expect(newMaxFD).toBe(maxFD);

--- a/test/js/bun/spawn/spawn-streaming-stdout.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdout.test.ts
@@ -52,14 +52,16 @@ test("spawn can read from stdout multiple chunks", async () => {
       }
     }
   }
-  // Same race for the last batch's closes; wait for the fd count to return to
-  // the baseline before asserting.
+  // Same race for the last batch's closes; wait for the fd count to drop back
+  // to the baseline before asserting. The settled baseline can still come out
+  // slightly high (it has no pre-spawn ground truth; #6724 moved it after the
+  // first batch on purpose), so ending below it is fine; only above is a leak.
   let newMaxFD = getMaxFD();
-  for (let i = 0; i < 100 && newMaxFD !== maxFD; i++) {
+  for (let i = 0; i < 100 && newMaxFD > maxFD; i++) {
     await Bun.sleep(10);
     newMaxFD = getMaxFD();
   }
-  expect(newMaxFD).toBe(maxFD);
+  expect(newMaxFD).toBeLessThanOrEqual(maxFD);
   clearInterval(interval);
   await expectMaxObjectTypeCount(expect, "ReadableStream", 10);
   await expectMaxObjectTypeCount(expect, "ReadableStreamDefaultReader", 10);

--- a/test/js/bun/spawn/spawn-streaming-stdout.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdout.test.ts
@@ -40,10 +40,25 @@ test("spawn can read from stdout multiple chunks", async () => {
     await Promise.all(promises);
     i += concurrency;
     if (maxFD === -1) {
+      // Pipe fds are closed on a background thread after their streams finish,
+      // so the first batch's closes may still be in flight here; poll until the
+      // count settles so the baseline isn't inflated.
       maxFD = getMaxFD();
+      for (let j = 0; j < 100; j++) {
+        await Bun.sleep(10);
+        const settled = getMaxFD();
+        if (settled === maxFD) break;
+        maxFD = settled;
+      }
     }
   }
-  const newMaxFD = getMaxFD();
+  // Same race for the last batch's closes; wait for the fd count to return to
+  // the baseline before asserting.
+  let newMaxFD = getMaxFD();
+  for (let i = 0; i < 100 && newMaxFD !== maxFD; i++) {
+    await Bun.sleep(10);
+    newMaxFD = getMaxFD();
+  }
   expect(newMaxFD).toBe(maxFD);
   clearInterval(interval);
   await expectMaxObjectTypeCount(expect, "ReadableStream", 10);


### PR DESCRIPTION
### What does this PR do?

Fixes the `test/js/bun/spawn/spawn-streaming-stdin.test.ts` flake (debian x64/aarch64, builds 89694, 89561, 88187):

```
68 |   // assert we didn't leak any file descriptors
69 |   expect(newMaxFD).toBe(maxFD);
Expected: 21
Received: 56
```

Nothing is leaked; the test samples too early. After `await Promise.all(proms)` for the last batch of 16 subprocesses, every stream has finished from JS's point of view (stdout EOF, `stdin.end()` resolved, `exited` resolved), but a pipe fd that had a poll registered is closed by `bun_io::Closer` on the work pool rather than on the JS thread (`src/io/pipes.rs` `close_impl` → `Closer::close`, by design so a blocking `close()` never stalls the loop). On a loaded machine those pool tasks can lag the JS thread by a few ms, so the last batch's stdin/stdout/pidfd descriptors (~44) are still open at the instant `getMaxFD()` runs. Reproduced on Linux x64 with 2×nproc busy loops running: 5 of 30 rounds of the same spawn/await/count loop saw `maxFD 7 -> 51` immediately after the await and `7` again 10 ms later; 0/30 idle, and macOS didn't reproduce at all (which matches the CI distribution).

The assertion is unchanged; it now polls for the count to return to the baseline (10 ms steps, up to 1 s) before asserting, the same way `expectMaxObjectTypeCount` right below it already waits for object counts. With that loop the loaded Linux reproduction is 0/40.

Review pointed out that `spawn-streaming-stdout.test.ts` has the same shape, at both sample points: the final count is read right after the last batch's `Promise.all`, and the baseline is read right after batch 1's, so in-flight closes can inflate the baseline as well (a failure the final poll alone can't recover from). That file now settle-polls the baseline, then polls the final count down only while it is above the baseline and asserts `<=` instead of exact equality: the baseline there is a heuristic with no pre-spawn ground truth (46a337c in #6724 moved it after the first batch on purpose), so a count below it is not a leak, and a max-based settle check can rarely stop a little high. The stdin test keeps its exact `toBe` since its baseline is taken before any spawn.

### How did you verify your code works?

Reproduction/verification above (release binary on Linux); `bun bd test test/js/bun/spawn/spawn-streaming-stdin.test.ts` passes locally. Both test files also pass under a debug ASAN build and 8/8 rounds each under 2×nproc CPU load on the release binary.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/spawn/spawn-streaming-stdin.test.ts' 'test/js/bun/spawn/spawn-streaming-stdout.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/spawn/spawn-streaming-stdin.test.ts test/js/bun/spawn/spawn-streaming-stdout.test.ts
bun test v1.4.0 (10c944d94)

test/js/bun/spawn/spawn-streaming-stdout.test.ts:
{
  objects: {
    "Array Iterator": 1,
    Array: 85,
    ArrayBuffer: 2,
    AsyncDisposableStack: 1,
    AsyncFromSyncIterator: 1,
    AsyncFunction: 111,
    AsyncFunctionGenerator: 14,
    AsyncGenerator: 1,
    AsyncGeneratorFunction: 2,
    AsyncIterator: 1,
    BigInt: 3,
    BigInt64ArrayPrototype: 1,
    BigUint64ArrayPrototype: 1,
    Blob: 1,
    Boolean: 1,
    Buffer: 1,
    Bun: 1,
    Callee: 3,
    "Cell Butterfly": 32,
    CustomEvent: 2,
    CustomGetterSetter: 83,
    DOMAttributeGetterSetter: 89,
    Dirent: 2,
    DisposableStack: 1,
    Error: 6,
    ErrorCodeCache: 1,
    Event: 2,
    EventEmitter: 1,
    EventTarget: 2,
    Expect: 1,
    ExpectStatic: 1,
    ExpectTypeOf: 1,
    FileInternalReadableStreamSource: 14,
    FileSink: 3,
    FinalizationRegistry: 1,
    Float16ArrayPrototype: 1,
    Float32ArrayPrototype: 1,
    Float64ArrayPrototype: 1,
    FrameworkFileSystemRouter: 1,
    FullPromiseReaction: 15,
    Function: 2668,
    FunctionCodeBlock: 135,
    FunctionExecutable: 1441,
    FunctionRareData: 264,
    Generator: 1,
    GeneratorFunction: 2,
    GetterSetter: 191,
    GlobalObject: 1,
    ImportMeta: 3,
    Int16ArrayPrototype: 1,
    Int32ArrayPrototype: 1,
    Int8Array: 1,
    Int8ArrayPrototype: 1,
    InternalFieldTuple: 24,
    InternalModuleRegistry: 1,
    Intl: 1,
    "Iterator Helper": 1,
    Iterator: 2,
    JSAsyncGeneratorFunction: 8,
    JSGlobalLexicalEnvironment: 1,
    JSGlobalProxy: 1,
    JSLexicalEnvironment: 241,
    JSModuleEnvironment: 11,
    JSON: 1,
    JSPropertyNameEnumerator: 5,
    JSSourceCode: 11,
    "Map Iterator": 1,
    Map: 6,
    Math: 1,
    Module: 3,
    ModuleLoader: 1,
    ModuleNamespaceObject: 4,
    ModuleProgramCode
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/spawn/spawn-streaming-stdin.test.ts  |  8 +++++++-
 test/js/bun/spawn/spawn-streaming-stdout.test.ts | 21 +++++++++++++++++++--
 2 files changed, 26 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
test/js/bun/spawn/spawn-streaming-stdin.test.ts       1      0      0
test/js/bun/spawn/spawn-streaming-stdout.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->