### PR TITLE
test(fetch-leak): keep the RSS leak thresholds clear of measurement noise

### DIFF
--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -764,7 +764,7 @@ test("should not leak using readable stream", async () => {
       // The fixture asserts RSS stabilizes after iteration 250, but with the
       // default 256 MB quarantine the freed 128 KB bodies are never reused and
       // RSS keeps climbing through all 500 iterations (~97 MB past the sample
-      // point, over the 64 MB allowance). Cap the quarantine so freed churn
+      // point, far over the allowance). Cap the quarantine so freed churn
       // recycles and the stabilization the test asserts can actually happen.
       ...(isASAN && { ASAN_OPTIONS: `${bunEnv.ASAN_OPTIONS ?? ""}:quarantine_size_mb=32`.replace(/^:/, "") }),
     },

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -711,15 +711,22 @@ describe("Request body HiveRef pool returns slot via Body.Value.deinit (does not
         // 32 cycles * 512 Requests * 16 KiB = 256 MiB through the pool. If deinit() is
         // skipped for any heap-backed variant, RSS climbs by ~256 MiB; with the
         // Zig semantics it stays flat. 64 MiB is well above GC/allocator noise.
-        // ASAN's quarantine retains freed allocations so widen the threshold there.
-        if (deltaMB > ${isASAN ? 320 : 64}) {
+        // The ASAN bound must also stay below that 256 MiB signal; the child's
+        // quarantine is capped (env below) so freed churn recycles, and 128 MiB
+        // covers what ASAN still retains (observed delta ~6 MiB).
+        if (deltaMB > ${isASAN ? 128 : 64}) {
           throw new Error("Request body (${kind}) leaked " + Math.round(deltaMB) + " MB over 32 cycles of 512 Requests");
         }
       `;
 
         await using proc = Bun.spawn({
           cmd: [bunExe(), "--smol", "-e", script],
-          env: bunEnv,
+          env: {
+            ...bunEnv,
+            // Cap the quarantine so it cannot retain freed bodies toward the
+            // default 256 MB, which would cross the 128 MiB leak threshold.
+            ...(isASAN && { ASAN_OPTIONS: `${bunEnv.ASAN_OPTIONS ?? ""}:quarantine_size_mb=32`.replace(/^:/, "") }),
+          },
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -747,10 +754,11 @@ test("should not leak using readable stream", async () => {
       SERVER_URL: server.url.href,
       // The regression this guards retained the 128 KiB body per request, i.e.
       // ~32 MiB over the 250 sampled iterations; RSS of a non-leaking run still
-      // drifts by several MiB over that window (allocator high-water, lazily
-      // freed pages), so the allowance sits between the two. ASAN's quarantine
+      // drifts over that window (allocator high-water, lazily freed pages):
+      // a few MiB on Linux, up to 14 observed on Windows lanes. The allowance
+      // sits between that drift and the 32 MiB signal. ASAN's quarantine
       // retains freed allocations so RSS stays elevated under bun-asan.
-      MAX_MEMORY_INCREASE: isASAN ? "64" : "16", // in MB
+      MAX_MEMORY_INCREASE: isASAN ? "64" : "20", // in MB
       // The fixture asserts RSS stabilizes after iteration 250, but with the
       // default 256 MB quarantine the freed 128 KB bodies are never reused and
       // RSS keeps climbing through all 500 iterations (~97 MB past the sample

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -756,9 +756,11 @@ test("should not leak using readable stream", async () => {
       // ~32 MiB over the 250 sampled iterations; RSS of a non-leaking run still
       // drifts over that window (allocator high-water, lazily freed pages):
       // a few MiB on Linux, up to 14 observed on Windows lanes. The allowance
-      // sits between that drift and the 32 MiB signal. ASAN's quarantine
-      // retains freed allocations so RSS stays elevated under bun-asan.
-      MAX_MEMORY_INCREASE: isASAN ? "64" : "20", // in MB
+      // sits between that drift and the 32 MiB signal. Under bun-asan the
+      // capped quarantine (below) saturates before the sample point: clean
+      // runs measure 1-3 MiB, a simulated regression ~76, so 24 keeps this
+      // bound below the signal there too.
+      MAX_MEMORY_INCREASE: isASAN ? "24" : "20", // in MB
       // The fixture asserts RSS stabilizes after iteration 250, but with the
       // default 256 MB quarantine the freed 128 KB bodies are never reused and
       // RSS keeps climbing through all 500 iterations (~97 MB past the sample

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -673,7 +673,10 @@ describe("Request body HiveRef pool returns slot via Body.Value.deinit (does not
       kind,
       async () => {
         const script = `
-        const payload = Buffer.alloc(128 * 1024, 0x61); // 128 KiB of 'a'
+        // 16 KiB bodies: cycle() keeps 512 alive at once and gc() may not have returned that
+        // memory to the OS by the time rss() is sampled, so one cycle's live set (8 MiB here)
+        // is the noise floor of this measurement and must stay far below the threshold.
+        const payload = Buffer.alloc(16 * 1024, 0x61); // 16 KiB of 'a'
         const str = payload.toString("latin1");
         const sharedBlob = new Blob([payload]);
         const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
@@ -705,8 +708,8 @@ describe("Request body HiveRef pool returns slot via Body.Value.deinit (does not
 
         const deltaMB = (final - baseline) / 1024 / 1024;
         console.log(JSON.stringify({ kind: "${kind}", baselineMB: (baseline / 1024 / 1024) | 0, finalMB: (final / 1024 / 1024) | 0, deltaMB: Math.round(deltaMB) }));
-        // 32 cycles * 512 Requests * 128 KiB = 2 GiB through the pool. If deinit() is
-        // skipped for any heap-backed variant, RSS climbs by ~2 GiB; with the
+        // 32 cycles * 512 Requests * 16 KiB = 256 MiB through the pool. If deinit() is
+        // skipped for any heap-backed variant, RSS climbs by ~256 MiB; with the
         // Zig semantics it stays flat. 64 MiB is well above GC/allocator noise.
         // ASAN's quarantine retains freed allocations so widen the threshold there.
         if (deltaMB > ${isASAN ? 320 : 64}) {
@@ -742,9 +745,12 @@ test("should not leak using readable stream", async () => {
     env: {
       ...bunEnv,
       SERVER_URL: server.url.href,
-      // ASAN's quarantine retains freed allocations so RSS stays elevated
-      // under bun-asan; the fixture only allows MAX_MEMORY_INCREASE MiB.
-      MAX_MEMORY_INCREASE: isASAN ? "64" : "5", // in MB
+      // The regression this guards retained the 128 KiB body per request, i.e.
+      // ~32 MiB over the 250 sampled iterations; RSS of a non-leaking run still
+      // drifts by several MiB over that window (allocator high-water, lazily
+      // freed pages), so the allowance sits between the two. ASAN's quarantine
+      // retains freed allocations so RSS stays elevated under bun-asan.
+      MAX_MEMORY_INCREASE: isASAN ? "64" : "16", // in MB
       // The fixture asserts RSS stabilizes after iteration 250, but with the
       // default 256 MB quarantine the freed 128 KB bodies are never reused and
       // RSS keeps climbing through all 500 iterations (~97 MB past the sample


### PR DESCRIPTION
### What does this PR do?

`test/js/web/fetch/fetch-leak.test.ts` was flaky in 13 of the last ~80 main builds through two RSS-based checks. Neither is a leak; both compare an RSS delta against a threshold that sits inside the measurement's own noise. This is the "adjust a memory threshold" kind of change, so the numbers:

**1. `Request body HiveRef pool returns slot via Body.Value.deinit (does not leak) > String`** (Windows arm64, alpine x64)

```
error: Request body (String) leaked 68 MB over 32 cycles of 512 Requests      {"baselineMB":43,"finalMB":110,"deltaMB":68}
```

Each `cycle()` builds 512 Requests with unique 128 KiB string bodies — 64 MiB live at once, deliberately >256 to hit both the hive and the fallback path — drops them and calls `Bun.gc(true)`. The test takes `rss()` after 8 warm-up cycles and again after 32 more and requires the delta ≤ 64 MiB. But memory freed by `gc()` isn't necessarily back with the OS when `rss()` is read (decommit is lazy/asynchronous), so *each* sample carries up to one cycle's live set of slack. On a current release build, same script, no leak:

| body | baseline / final / delta (macOS ×3) | (Linux ×3) |
|---|---|---|
| 128 KiB | 95/22/**-73**, 95/25/**-69**, 95/75/**-20** | 107/94/-14, 106/96/-10, 102/91/-11 |
| 16 KiB | 28/28/0, 24/25/+1, 25/25/0 | 38/39/+1, 40/36/-5, 39/39/0 |

The noise amplitude with 128 KiB bodies is ~70 MiB in either direction — the CI failures (+68, +74) are the same thing with the signs the other way round — and the threshold is 64. Rather than raise the threshold, shrink the bodies to 16 KiB: one cycle is then 8 MiB (noise ≤ ~5 MiB observed), a genuine "deinit() skipped" leak is still 32 × 512 × 16 KiB = 256 MiB, and the 64 MiB threshold now sits well clear of both. Request count and structure are unchanged.

The ASAN bound scales down alongside the signal, 320 to 128 MiB (review catch: 320 would sit above the now-256 MiB leak signature, making the ASAN lane unable to fail). The child's quarantine is capped at 32 MB, the same idiom the readable-stream test already uses, so quarantine retention cannot approach the bound. Under the debug ASAN build, clean runs measure deltaMB 5-7; a simulated leak (Requests retained instead of dropped) measures +278 MiB, comfortably past 128.

**2. `should not leak using readable stream`** (alpine x64, debian aarch64, Windows x64)

```
expect(rssSample).toBeGreaterThanOrEqual(memoryUsage - maxMemoryIncrease)
Expected: >= 40.53515625
Received: 40.4375            ← RSS grew 5.1 MiB between iteration 250 and 500; allowance is 5
```

The fixture fetches a 128 KiB body 500 times through `getReader()` and allows RSS to grow `MAX_MEMORY_INCREASE` = 5 MiB over the second half. The regression it was added for (#23697, handing the whole response buffer to the stream as `owned_and_done`) retained the body per request — ~32 MiB over those 250 iterations. A non-leaking run's RSS still drifts over that window (allocator high-water / lazily-freed pages): +1–2 MiB on idle Linux, ~+2 MiB loaded, and every CI failure was at +5.05–5.1. Sampling every 250 iterations out to 4000 shows it plateauing (…51.8 → 55.9 → 55.9 → 55.9 → 56.2), i.e. warm-up, not growth. The allowance moves from 5 to 20 MiB: the Buildkite scan in #33988 saw non-leak growth of 6 to 14 MiB on Windows lanes over this same window, so 20 keeps headroom over the worst observation while staying well under the 32 MiB the guarded regression produces. (macOS runs use `memoryFootprint`, which stays flat at ~8.5 MiB throughout, which is why darwin never hit this.)

The ASAN branch gets the same treatment as the HiveRef bound (review catch): 64 sat above the ~32 MiB signal. The capped quarantine saturates before the sample point, so the measured window is clean of quarantine growth; under the debug ASAN build, clean runs drift 1-3 MiB and a simulated regression (every read chunk retained) measures +76 MiB. The allowance there is 24 MiB.

### Overlapping PRs

- #36981 fixed the same HiveRef flake by setting `MIMALLOC_PURGE_DELAY=0`; its diagnosis (mimalloc's purge delay leaves one cycle's freed working set committed, producing the flat 68/74 MB offsets) matches the table above and confirms the body-shrink math. Superseded by this PR, closed.
- #33988 widens two compress-test thresholds this PR does not touch, and stays open for those. Its Windows measurements are what size the 20 MiB allowance here.

### How did you verify your code works?

Measurements above (release binaries, macOS arm64 + Linux x64). `bun bd test test/js/web/fetch/fetch-leak.test.ts` passes under debug+ASAN: the HiveRef test holds at deltaMB 5-7 across repeated runs (simulated leak +278 MiB against the 128 MiB bound), the readable-stream fixture at 1-3 MiB across repeated runs (simulated leak +76 MiB against the 24 MiB bound).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->