### PR TITLE
Clear pending exceptions from lazy property getters during property enumeration

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2307,12 +2307,18 @@ void GlobalObject::finishCreation(VM& vm)
         [](const Initializer<JSFunction>& init) {
             auto scope = DECLARE_THROW_SCOPE(init.vm);
             JSValue nodeUtilValue = uncheckedDowncast<Zig::GlobalObject>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-            RETURN_IF_EXCEPTION(scope, );
-            RELEASE_ASSERT(nodeUtilValue.isObject());
-            auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-            RETURN_IF_EXCEPTION(scope, );
-            ASSERT(prop);
-            init.set(uncheckedDowncast<JSFunction>(prop));
+            if (!scope.exception()) [[likely]] {
+                RELEASE_ASSERT(nodeUtilValue.isObject());
+                auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
+                if (!scope.exception() && prop) [[likely]] {
+                    init.set(uncheckedDowncast<JSFunction>(prop));
+                    return;
+                }
+            }
+            // A LazyProperty initializer must always set a value. Keep the
+            // exception pending for the caller and install a stub.
+            scope.release();
+            init.set(JSFunction::create(init.vm, init.owner, 0, "inspect"_s, jsFunctionNotImplemented, ImplementationVisibility::Public));
         });
 
     m_utilInspectOptionsStructure.initLater(
@@ -2334,21 +2340,23 @@ void GlobalObject::finishCreation(VM& vm)
             auto scope = DECLARE_THROW_SCOPE(init.vm);
             JSC::MarkedArgumentBuffer args;
             args.append(uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction());
-            RETURN_IF_EXCEPTION(scope, );
-
-            JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-            RETURN_IF_EXCEPTION(scope, );
-
-            JSC::CallData callData = JSC::getCallData(getStylize);
-            NakedPtr<JSC::Exception> returnedException = nullptr;
-            auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-            RETURN_IF_EXCEPTION(scope, );
-
-            if (returnedException) {
-                throwException(init.owner, scope, returnedException.get());
+            if (!scope.exception()) [[likely]] {
+                JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
+                JSC::CallData callData = JSC::getCallData(getStylize);
+                NakedPtr<JSC::Exception> returnedException = nullptr;
+                auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
+                if (returnedException) [[unlikely]] {
+                    throwException(init.owner, scope, returnedException.get());
+                }
+                if (!scope.exception() && result) [[likely]] {
+                    init.set(uncheckedDowncast<JSFunction>(result));
+                    return;
+                }
             }
-            RETURN_IF_EXCEPTION(scope, );
-            init.set(uncheckedDowncast<JSFunction>(result));
+            // A LazyProperty initializer must always set a value. Keep the
+            // exception pending for the caller and fall back to no colors.
+            scope.release();
+            init.set(JSFunction::create(init.vm, init.owner, utilInspectStylizeWithNoColorCodeGenerator(init.vm), init.owner));
         });
 
     m_utilInspectStylizeNoColorFunction.initLater(

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2350,9 +2350,11 @@ void GlobalObject::finishCreation(VM& vm)
                 if (returnedException) [[unlikely]] {
                     throwException(init.owner, scope, returnedException.get());
                 }
-                if (!scope.exception() && result) [[likely]] {
-                    init.set(uncheckedDowncast<JSFunction>(result));
-                    return;
+                if (!scope.exception()) [[likely]] {
+                    if (auto* stylizeFunction = dynamicDowncast<JSFunction>(result)) [[likely]] {
+                        init.set(stylizeFunction);
+                        return;
+                    }
                 }
             }
             // LazyProperty initializers must always set a value; leave the exception pending for the caller.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2315,8 +2315,7 @@ void GlobalObject::finishCreation(VM& vm)
                     return;
                 }
             }
-            // A LazyProperty initializer must always set a value. Keep the
-            // exception pending for the caller and install a stub.
+            // LazyProperty initializers must always set a value; leave the exception pending for the caller.
             scope.release();
             init.set(JSFunction::create(init.vm, init.owner, 0, "inspect"_s, jsFunctionNotImplemented, ImplementationVisibility::Public));
         });
@@ -2353,8 +2352,7 @@ void GlobalObject::finishCreation(VM& vm)
                     return;
                 }
             }
-            // A LazyProperty initializer must always set a value. Keep the
-            // exception pending for the caller and fall back to no colors.
+            // LazyProperty initializers must always set a value; leave the exception pending for the caller.
             scope.release();
             init.set(JSFunction::create(init.vm, init.owner, utilInspectStylizeWithNoColorCodeGenerator(init.vm), init.owner));
         });

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2311,8 +2311,11 @@ void GlobalObject::finishCreation(VM& vm)
                 RELEASE_ASSERT(nodeUtilValue.isObject());
                 auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
                 if (!scope.exception() && prop) [[likely]] {
-                    init.set(uncheckedDowncast<JSFunction>(prop));
-                    return;
+                    // User code can replace util.inspect with a non-function.
+                    if (auto* inspectFunction = dynamicDowncast<JSFunction>(prop)) [[likely]] {
+                        init.set(inspectFunction);
+                        return;
+                    }
                 }
             }
             // LazyProperty initializers must always set a value; leave the exception pending for the caller.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6811,6 +6811,7 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
     // Get the util.inspect function from the global object
     auto* bunGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     JSC::JSValue inspectFn = bunGlobal->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
 
     if (!inspectFn || !inspectFn.isCallable()) {
         // Fallback to toString if util.inspect is not available

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -956,5 +956,6 @@ it("keeps walking properties when a lazy property initializer throws", async () 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe(["archive: true", "zstd: true", "sql: TypeError", ""].join("\n"));
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,33 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+it("keeps walking properties when a lazy property initializer throws", async () => {
+  // Clobbering Symbol makes the module evaluation behind lazy Bun properties
+  // (Bun.$, Bun.sql) throw while inspect materializes them. The walk has to
+  // clear that exception and continue instead of silently dropping every
+  // later property (and tripping an exception-scope assert in debug builds).
+  const fixture = `
+    globalThis.Symbol = NaN;
+    const out = Bun.inspect(Bun);
+    console.log("archive:", out.includes("Archive"));
+    console.log("zstd:", out.includes("zstdCompress"));
+    try {
+      Bun.sql;
+      console.log("sql: no throw");
+    } catch (e) {
+      console.log("sql:", e.constructor.name);
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe(["archive: true", "zstd: true", "sql: TypeError", ""].join("\n"));
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -936,9 +936,13 @@ it("keeps walking properties when a lazy property initializer throws", async () 
   // later property (and tripping an exception-scope assert in debug builds).
   const fixture = `
     globalThis.Symbol = NaN;
-    const out = Bun.inspect(Bun);
-    console.log("archive:", out.includes("Archive"));
-    console.log("zstd:", out.includes("zstdCompress"));
+    try {
+      const out = Bun.inspect(Bun);
+      console.log("archive:", out.includes("Archive"));
+      console.log("zstd:", out.includes("zstdCompress"));
+    } catch (e) {
+      console.log("inspect threw:", e.constructor.name);
+    }
     try {
       Bun.sql;
       console.log("sql: no throw");
@@ -955,7 +959,42 @@ it("keeps walking properties when a lazy property initializer throws", async () 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toBe(["archive: true", "zstd: true", "sql: TypeError", ""].join("\n"));
+  // On Windows process.env is a Proxy, so the walk reaches the custom inspect
+  // path, which needs node:util; its evaluation throws with the clobbered
+  // Symbol and that error propagates out of Bun.inspect.
+  const expected = isWindows
+    ? ["inspect threw: TypeError", "sql: TypeError", ""]
+    : ["archive: true", "zstd: true", "sql: TypeError", ""];
+  expect(stdout).toBe(expected.join("\n"));
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+it("throws instead of crashing when util.inspect cannot load for a custom inspect hook", async () => {
+  // The util.inspect lazy property is initialized on first use; if node:util
+  // fails to evaluate (clobbered Symbol), the initializer still has to set a
+  // value or LazyProperty aborts the process.
+  const fixture = `
+    const custom = Symbol.for("nodejs.util.inspect.custom");
+    const obj = { [custom]() { return "custom!"; } };
+    globalThis.Symbol = NaN;
+    try {
+      Bun.inspect(obj);
+      console.log("no throw");
+    } catch (e) {
+      console.log("threw:", e.constructor.name);
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("threw: TypeError\n");
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -970,6 +970,27 @@ it("keeps walking properties when a lazy property initializer throws", async () 
   expect(exitCode).toBe(0);
 });
 
+it("tolerates util.inspect being replaced with a non-function", async () => {
+  const fixture = `
+    require("node:util").inspect = 42;
+    const custom = Symbol.for("nodejs.util.inspect.custom");
+    const obj = { [custom]() { return "custom!"; } };
+    console.log(Bun.inspect(obj));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("custom!\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it("throws instead of crashing when util.inspect cannot load for a custom inspect hook", async () => {
   // The util.inspect lazy property is initialized on first use; if node:util
   // fails to evaluate (clobbered Symbol), the initializer still has to set a

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -991,31 +991,35 @@ it("tolerates util.inspect being replaced with a non-function", async () => {
   expect(exitCode).toBe(0);
 });
 
-it("throws instead of crashing when util.inspect cannot load for a custom inspect hook", async () => {
-  // The util.inspect lazy property is initialized on first use; if node:util
-  // fails to evaluate (clobbered Symbol), the initializer still has to set a
-  // value or LazyProperty aborts the process.
-  const fixture = `
-    const custom = Symbol.for("nodejs.util.inspect.custom");
-    const obj = { [custom]() { return "custom!"; } };
-    globalThis.Symbol = NaN;
-    try {
-      Bun.inspect(obj);
-      console.log("no throw");
-    } catch (e) {
-      console.log("threw:", e.constructor.name);
-    }
-  `;
+it.each([false, true])(
+  "throws instead of crashing when util.inspect cannot load for a custom inspect hook (colors: %p)",
+  async colors => {
+    // The util.inspect lazy property is initialized on first use; if node:util
+    // fails to evaluate (clobbered Symbol), the initializer still has to set a
+    // value or LazyProperty aborts the process. The colors variant initializes
+    // the color stylize lazy property first, covering its fallback too.
+    const fixture = `
+      const custom = Symbol.for("nodejs.util.inspect.custom");
+      const obj = { [custom]() { return "custom!"; } };
+      globalThis.Symbol = NaN;
+      try {
+        Bun.inspect(obj${colors ? ", { colors: true }" : ""});
+        console.log("no throw");
+      } catch (e) {
+        console.log("threw:", e.constructor.name);
+      }
+    `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toBe("threw: TypeError\n");
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-});
+    expect(stdout).toBe("threw: TypeError\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found abort in debug builds and a property-dropping bug in release builds when formatting an object whose lazy property initializer throws.

`Bun.inspect` and `console.log` walk properties through `JSC__JSValue__forEachPropertyImpl`. JSC reifies static `PropertyCallback` properties during `getPropertySlot`, and when the initializer throws it reports the slot as not found with the exception left pending. The loop then hit `continue` before its `CLEAR_IF_EXCEPTION`, so the exception stayed pending for the rest of the walk. In debug builds the next lookup that re-enters JS trips `ExceptionScope::releaseAssertNoException`:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Symbol is not a function. (In 'Symbol("cwd")', 'Symbol' is NaN)
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

In release builds every remaining property silently vanishes from the output, because `Lookup.cpp` reports static slots as missing whenever an exception is pending:

```js
globalThis.Symbol = NaN;         // makes the shell.ts builtin behind Bun.$ throw
Bun.inspect(Bun);                // output ends at $, Archive/zstd/etc are gone
```

The fuzzer hit this by clobbering `Symbol` and then triggering a failing `expect()` whose error message formats the `Bun` object (`Symbol("cwd")` is the first statement the lazy shell module evaluates).

The fix moves the existing `CLEAR_IF_EXCEPTION` above the not-found `continue`, which is exactly what `JSC__JSValue__forEachPropertyOrdered` already does a few lines below.

While verifying, direct `Bun.sql` access in the same state aborted in debug builds through a second path: the `#if BUN_DEBUG` blocks in the SQL lazy getters called `reportUncaughtExceptionAtEventLoop` with the exception still pending, re-entering JS in that state. Property lookups made during the report then reify static properties (transitioning the structure) while `Lookup.cpp` reports them as not found due to the pending exception, and the inlined prototype walk asserts on a stale `Structure*`. The `RETURN_IF_EXCEPTION` immediately after already propagates the error to the caller, the same way `Bun.$` handles it, so those blocks are removed.

### Follow-ups found while verifying

Windows CI exposed a third member of the family: the `util.inspect` lazy property initializers in `ZigGlobalObject.cpp` (`utilInspectFunction`, `utilInspectStylizeColorFunction`) could return without calling `init.set()` when `node:util` fails to evaluate, and `LazyProperty::callFunc` hits a `RELEASE_ASSERT` in that case, so release builds crash outright. On Windows this is reachable just by inspecting `Bun` (`process.env` is a Proxy there, and formatting it goes through the custom inspect path); on any platform it is reachable by registering a custom inspect hook before clobbering `Symbol`. The initializers now always set a value (a stub that throws, or the no-color stylize) and leave the exception pending, which the existing checks in `callCustomInspectFunction` propagate as a catchable TypeError.

Review feedback led to two more hardenings in the same code: `util.inspect` is validated with `dynamicDowncast` before being cached (user code can replace it with a non-function; the old `uncheckedDowncast` panics the current canary), and `Bun__REPL__formatValue` now checks for the pending exception after `utilInspectFunction()` like the other call sites.

Two other `initLater` callbacks (`ImportMetaObject::requireProperty` and the `JSMockFunction` mock object) share the return-without-set shape, but they can only throw on allocation failure, where a controlled crash is the intended outcome, so they are intentionally left alone.

### How did you verify your code works?

- Four regression tests in `test/js/bun/util/inspect.test.js`, each verified to fail on the unfixed build (`USE_SYSTEM_BUN=1`, two of them as outright panics) and pass with `bun bd test`.
- Reran the fuzzer crash script and the minimized repros against rebuilt debug and fuzzilli builds: clean exits, proper TypeError propagation for direct `Bun.$` / `Bun.sql` access, colors and no-colors stylize paths.
- `bun bd test` on inspect, console, node util inspect, and expect-extend suites, plus a `Bun.SQL` sqlite smoke test for the touched getters.
- Built the branch on Windows x64 and ran the full `inspect.test.js` there (the Proxy-env path is Windows-specific).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
