### PR TITLE
Throw ERR_STRING_TOO_LONG instead of aborting for 2 GiB to 4 GiB strings

### DIFF
--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -336,9 +336,8 @@ impl String {
         s
     }
 
-    /// Max `WTF::StringImpl` length (in characters, not bytes): the
-    /// process-wide [`STRING_ALLOCATION_LIMIT`] test knob clamped to
-    /// [`WTF_STRING_MAX_LENGTH`].
+    /// Max `WTF::StringImpl` length (in characters, not bytes):
+    /// [`STRING_ALLOCATION_LIMIT`] clamped to [`WTF_STRING_MAX_LENGTH`].
     #[inline]
     pub fn max_length() -> usize {
         STRING_ALLOCATION_LIMIT
@@ -2104,12 +2103,8 @@ pub mod lexer_tables {
 #[unsafe(export_name = "Bun__stringSyntheticAllocationLimit")]
 pub static STRING_ALLOCATION_LIMIT: AtomicUsize = AtomicUsize::new(u32::MAX as usize);
 
-/// Mirror of `WTF::StringImpl::MaxLength` (`INT32_MAX`): the hard cap on WTF
-/// string character count, enforced by `RELEASE_ASSERT` in the
-/// `StringImplShape` constructors. [`STRING_ALLOCATION_LIMIT`] alone defaults
-/// to `u32::MAX`, so guards that only consult it let lengths in
-/// `2^31..2^32` through to an uncatchable abort; [`String::max_length`]
-/// clamps to this.
+/// Mirror of `WTF::StringImpl::MaxLength` (`INT32_MAX`), which C++ enforces
+/// with `RELEASE_ASSERT` in the `StringImplShape` constructors.
 pub const WTF_STRING_MAX_LENGTH: usize = i32::MAX as usize;
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -274,7 +274,7 @@ impl String {
     /// that calls `callback(ctx, buffer, len)` when the impl is destroyed.
     ///
     /// External strings are WTF strings whose bytes live elsewhere; `bytes` is
-    /// borrowed (not copied). If `bytes.len() >= max_length()`, `callback` is
+    /// borrowed (not copied). If `bytes.len() > max_length()`, `callback` is
     /// invoked immediately and a `dead` string is returned.
     ///
     /// `Ctx` must be a pointer-sized type (raw pointer or `&T`); enforced by
@@ -299,7 +299,7 @@ impl String {
         }
         let () = AssertPtrSized::<Ctx>::OK;
         debug_assert!(!bytes.is_empty());
-        if bytes.len() >= Self::max_length() {
+        if bytes.len() > Self::max_length() {
             callback(ctx, bytes.as_ptr().cast_mut().cast::<c_void>(), bytes.len());
             return Self::DEAD;
         }
@@ -336,11 +336,14 @@ impl String {
         s
     }
 
-    /// Max `WTF::StringImpl` length (in characters, not bytes).
-    /// Reads the process-wide [`STRING_ALLOCATION_LIMIT`] data slot.
+    /// Max `WTF::StringImpl` length (in characters, not bytes): the
+    /// process-wide [`STRING_ALLOCATION_LIMIT`] test knob clamped to
+    /// [`WTF_STRING_MAX_LENGTH`].
     #[inline]
     pub fn max_length() -> usize {
-        STRING_ALLOCATION_LIMIT.load(Ordering::Relaxed)
+        STRING_ALLOCATION_LIMIT
+            .load(Ordering::Relaxed)
+            .min(WTF_STRING_MAX_LENGTH)
     }
 
     /// `bun.String.createStaticExternal` — wraps `bytes` in a
@@ -405,7 +408,7 @@ impl String {
         if bytes.is_empty() {
             return Self::EMPTY;
         }
-        if bytes.len() >= Self::max_length() {
+        if bytes.len() > Self::max_length() {
             return Self::DEAD;
         }
         // Do NOT call `into_boxed_slice()` — when `len < capacity` it issues a
@@ -424,7 +427,7 @@ impl String {
         if bytes.is_empty() {
             return Self::EMPTY;
         }
-        if bytes.len() >= Self::max_length() {
+        if bytes.len() > Self::max_length() {
             return Self::DEAD;
         }
         // See `create_external_globally_allocated_latin1` — avoid the
@@ -2100,6 +2103,14 @@ pub mod lexer_tables {
 /// `setSyntheticAllocationLimitForTesting` hook.
 #[unsafe(export_name = "Bun__stringSyntheticAllocationLimit")]
 pub static STRING_ALLOCATION_LIMIT: AtomicUsize = AtomicUsize::new(u32::MAX as usize);
+
+/// Mirror of `WTF::StringImpl::MaxLength` (`INT32_MAX`): the hard cap on WTF
+/// string character count, enforced by `RELEASE_ASSERT` in the
+/// `StringImplShape` constructors. [`STRING_ALLOCATION_LIMIT`] alone defaults
+/// to `u32::MAX`, so guards that only consult it let lengths in
+/// `2^31..2^32` through to an uncatchable abort; [`String::max_length`]
+/// clamps to this.
+pub const WTF_STRING_MAX_LENGTH: usize = i32::MAX as usize;
 
 // ──────────────────────────────────────────────────────────────────────────
 // move-in: printer (MOVE_DOWN ← `bun_js_printer`)

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -322,7 +322,7 @@ impl String {
                 ExternalStringImplFreeFunction<Ctx>,
                 extern "C" fn(*mut c_void, *mut c_void, usize),
             >(callback) });
-        // SAFETY: bytes describes a valid slice; len < max_length checked.
+        // SAFETY: bytes describes a valid slice; len <= max_length checked.
         let s = unsafe {
             BunString__createExternal(
                 bytes.as_ptr(),

--- a/src/jsc/ZigString.rs
+++ b/src/jsc/ZigString.rs
@@ -43,7 +43,7 @@ pub unsafe fn to_external_u16(ptr: *const u16, len: usize, global: &JSGlobalObje
         let _ = global
             .err(
                 crate::ErrorCode::STRING_TOO_LONG,
-                format_args!("Cannot create a string longer than 2^32-1 characters"),
+                format_args!("Cannot create a string longer than 2147483647 characters"),
             )
             .throw();
         return JSValue::ZERO;

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -94,6 +94,9 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue BunString__createUT
         return JSValue::encode(jsEmptyString(vm));
     }
     if (simdutf::validate_ascii(ptr, length)) {
+        if (length > WTF::String::MaxLength) [[unlikely]] {
+            return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
+        }
         return JSValue::encode(jsString(vm, WTF::String(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(ptr), length))));
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2530,8 +2530,8 @@ extern "C" JSC::EncodedJSValue ZigString__toJSONObject(const ZigString* strPtr, 
     if (str.isNull()) {
         // isNull() will be true for empty strings and for strings which are too long.
         // So we need to check the length is plausibly due to a long string.
-        if (strPtr->len > Bun__stringSyntheticAllocationLimit) {
-            scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_STRING_TOO_LONG, "Cannot parse a JSON string longer than 2^32-1 characters"_s));
+        if (strPtr->len > Bun__stringSyntheticAllocationLimit || strPtr->len > WTF::String::MaxLength) {
+            scope.throwException(globalObject, Bun::createError(globalObject, Bun::ErrorCode::ERR_STRING_TOO_LONG, "Cannot parse a JSON string longer than 2147483647 characters"_s));
             return {};
         }
     }

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1649,7 +1649,7 @@ impl ZigStringJsc for bun_core::ZigString {
             let _ = global
                 .err(
                     crate::ErrorCode::STRING_TOO_LONG,
-                    format_args!("Cannot create a string longer than 2^32-1 characters"),
+                    format_args!("Cannot create a string longer than 2147483647 characters"),
                 )
                 .throw();
             return JSValue::ZERO;
@@ -1684,7 +1684,7 @@ impl ZigStringJsc for bun_core::ZigString {
             let _ = global
                 .err(
                     crate::ErrorCode::STRING_TOO_LONG,
-                    format_args!("Cannot create a string longer than 2^32-1 characters"),
+                    format_args!("Cannot create a string longer than 2147483647 characters"),
                 )
                 .throw();
             return JSValue::ZERO;

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -1,6 +1,6 @@
 import { memfd_create, setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { closeSync, readFileSync, writeFileSync, writeSync } from "fs";
+import { closeSync, readFileSync, truncateSync, writeFileSync, writeSync } from "fs";
 import { bunEnv, bunExe, isASAN, isLinux, isPosix, tempDir } from "harness";
 import { join } from "path";
 setSyntheticAllocationLimitForTesting(128 * 1024 * 1024);
@@ -47,6 +47,63 @@ if (isLinux) {
     });
   });
 }
+
+// Files in [2^31, 2^32) bytes used to abort the process when decoded to a
+// string: the guards in front of WTF string construction only checked the
+// synthetic allocation limit (2^32 - 1 by default) and missed
+// WTF::StringImpl::MaxLength (2^31 - 1), tripping a RELEASE_ASSERT in
+// StringImplShape. The fs layer reports the dead string as ENOMEM (it speaks
+// errno), matching the existing >= 2^32 and /dev/zero behavior above.
+// 2^31 - 1 is the largest length WTF accepts and must keep working. The file
+// is sparse so only the in-memory read costs 2 GiB; each case runs in a
+// subprocess to keep the peak away from the test runner.
+describe("readFileSync at the 2 GiB string limit", () => {
+  const spawnRead = async (size: number) => {
+    using dir = tempDir("readfile-2gib", {});
+    const file = join(String(dir), "big.txt");
+    writeFileSync(file, "x");
+    truncateSync(file, size);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        try {
+          const s = require("fs").readFileSync(${JSON.stringify(file)}, "utf8");
+          console.log(JSON.stringify({ length: s.length }));
+        } catch (e) {
+          console.log(JSON.stringify({ name: e.name, code: e.code }));
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { result: JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode })), exitCode };
+  };
+
+  test(
+    "2^31 bytes throws ENOMEM instead of aborting",
+    async () => {
+      const { result, exitCode } = await spawnRead(2 ** 31);
+      expect(result).toEqual({ name: "Error", code: "ENOMEM" });
+      expect(exitCode).toBe(0);
+    },
+    180_000,
+  );
+
+  test(
+    "2^31 - 1 bytes still decodes",
+    async () => {
+      const { result, exitCode } = await spawnRead(2 ** 31 - 1);
+      expect(result).toEqual({ length: 2 ** 31 - 1 });
+      expect(exitCode).toBe(0);
+    },
+    180_000,
+  );
+});
 
 // The UTF-8 -> UTF-16 converters behind `fs.readFile*(.., "utf8")`,
 // `Buffer.prototype.toString("utf8")` and `TextDecoder.decode` must surface a

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -84,25 +84,17 @@ describe("readFileSync at the 2 GiB string limit", () => {
     return { result: JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode })), exitCode };
   };
 
-  test(
-    "2^31 bytes throws ENOMEM instead of aborting",
-    async () => {
-      const { result, exitCode } = await spawnRead(2 ** 31);
-      expect(result).toEqual({ name: "Error", code: "ENOMEM" });
-      expect(exitCode).toBe(0);
-    },
-    180_000,
-  );
+  test("2^31 bytes throws ENOMEM instead of aborting", async () => {
+    const { result, exitCode } = await spawnRead(2 ** 31);
+    expect(result).toEqual({ name: "Error", code: "ENOMEM" });
+    expect(exitCode).toBe(0);
+  }, 180_000);
 
-  test(
-    "2^31 - 1 bytes still decodes",
-    async () => {
-      const { result, exitCode } = await spawnRead(2 ** 31 - 1);
-      expect(result).toEqual({ length: 2 ** 31 - 1 });
-      expect(exitCode).toBe(0);
-    },
-    180_000,
-  );
+  test("2^31 - 1 bytes still decodes", async () => {
+    const { result, exitCode } = await spawnRead(2 ** 31 - 1);
+    expect(result).toEqual({ length: 2 ** 31 - 1 });
+    expect(exitCode).toBe(0);
+  }, 180_000);
 });
 
 // The UTF-8 -> UTF-16 converters behind `fs.readFile*(.., "utf8")`,

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -2,6 +2,7 @@ import { memfd_create, setSyntheticAllocationLimitForTesting } from "bun:interna
 import { describe, expect, test } from "bun:test";
 import { closeSync, readFileSync, truncateSync, writeFileSync, writeSync } from "fs";
 import { bunEnv, bunExe, isASAN, isLinux, isPosix, tempDir } from "harness";
+import os from "node:os";
 import { join } from "path";
 setSyntheticAllocationLimitForTesting(128 * 1024 * 1024);
 
@@ -56,8 +57,9 @@ if (isLinux) {
 // errno), matching the existing >= 2^32 and /dev/zero behavior above.
 // 2^31 - 1 is the largest length WTF accepts and must keep working. The file
 // is sparse so only the in-memory read costs 2 GiB; each case runs in a
-// subprocess to keep the peak away from the test runner.
-describe("readFileSync at the 2 GiB string limit", () => {
+// subprocess to keep the peak away from the test runner, and the block skips
+// on small machines (same gate as buffer.test.js's 4 GiB case).
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("readFileSync at the 2 GiB string limit", () => {
   const spawnRead = async (size: number) => {
     using dir = tempDir("readfile-2gib", {});
     const file = join(String(dir), "big.txt");

--- a/test/js/node/fs/fs-oom.test.ts
+++ b/test/js/node/fs/fs-oom.test.ts
@@ -90,13 +90,13 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("readFileSync at the 2 GiB strin
     const { result, exitCode } = await spawnRead(2 ** 31);
     expect(result).toEqual({ name: "Error", code: "ENOMEM" });
     expect(exitCode).toBe(0);
-  }, 180_000);
+  });
 
   test("2^31 - 1 bytes still decodes", async () => {
     const { result, exitCode } = await spawnRead(2 ** 31 - 1);
     expect(result).toEqual({ length: 2 ** 31 - 1 });
     expect(exitCode).toBe(0);
-  }, 180_000);
+  });
 });
 
 // The UTF-8 -> UTF-16 converters behind `fs.readFile*(.., "utf8")`,

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -188,7 +188,7 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
       },
     ]);
     expect(exitCode).toBe(0);
-  }, 180_000);
+  });
 
   test("Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting", async () => {
     using dir = tempDir("blob-2gib", {});
@@ -220,5 +220,5 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
       },
     ]);
     expect(exitCode).toBe(0);
-  }, 180_000);
+  });
 });

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -26,7 +26,9 @@ describe("Memory", () => {
 
     test(".text() should throw an OOM without crashing the process.", () => {
       const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
-      expect(async () => await new Blob(array).text()).toThrow("Cannot create a string longer than 2147483647 characters");
+      expect(async () => await new Blob(array).text()).toThrow(
+        "Cannot create a string longer than 2147483647 characters",
+      );
     });
 
     test(".bytes() should throw an OOM without crashing the process.", () => {
@@ -152,14 +154,12 @@ describe("Bun.file", () => {
 // 2 GiB, so each case runs in a subprocess to keep the peak away from the
 // test runner.
 describe("byte sources at the 2 GiB string limit", () => {
-  test(
-    "Blob.text() and Blob.json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting",
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
+  test("Blob.text() and Blob.json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
           const results = [];
           const report = e => ({ name: e.name, code: e.code, message: e.message });
           const blob = new Blob([new Uint8Array(2 ** 31)]);
@@ -167,62 +167,56 @@ describe("byte sources at the 2 GiB string limit", () => {
           await blob.json().then(() => results.push("JSON_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
           console.log(JSON.stringify(results));
           `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
-        {
-          name: "Error",
-          code: "ERR_STRING_TOO_LONG",
-          message: "Cannot create a string longer than 2147483647 characters",
-        },
-        {
-          name: "Error",
-          code: "ERR_STRING_TOO_LONG",
-          message: "Cannot parse a JSON string longer than 2147483647 characters",
-        },
-      ]);
-      expect(exitCode).toBe(0);
-    },
-    180_000,
-  );
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+      {
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot create a string longer than 2147483647 characters",
+      },
+      {
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot parse a JSON string longer than 2147483647 characters",
+      },
+    ]);
+    expect(exitCode).toBe(0);
+  }, 180_000);
 
-  test(
-    "Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting",
-    async () => {
-      using dir = tempDir("blob-2gib", {});
-      const file = path.join(String(dir), "big.txt");
-      // Sparse where the filesystem supports it; reads back as 'x' + NUL bytes.
-      writeFileSync(file, "x");
-      truncateSync(file, 2 ** 31);
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
+  test("Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting", async () => {
+    using dir = tempDir("blob-2gib", {});
+    const file = path.join(String(dir), "big.txt");
+    // Sparse where the filesystem supports it; reads back as 'x' + NUL bytes.
+    writeFileSync(file, "x");
+    truncateSync(file, 2 ** 31);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
           const results = [];
           const report = e => ({ name: e.name, code: e.code, message: e.message });
           await Bun.file(${JSON.stringify(file)}).text().then(() => results.push("UNEXPECTED_SUCCESS"), e => results.push(report(e)));
           console.log(JSON.stringify(results));
           `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
-        {
-          name: "Error",
-          code: "ERR_STRING_TOO_LONG",
-          message: "Cannot create a string longer than 2147483647 characters",
-        },
-      ]);
-      expect(exitCode).toBe(0);
-    },
-    180_000,
-  );
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+      {
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot create a string longer than 2147483647 characters",
+      },
+    ]);
+    expect(exitCode).toBe(0);
+  }, 180_000);
 });

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -2,6 +2,7 @@ import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing"
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { truncateSync, unlinkSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import os from "node:os";
 import path from "path";
 describe("Memory", () => {
   beforeAll(() => {
@@ -152,8 +153,9 @@ describe("Bun.file", () => {
 // "ASSERTION FAILED: data.size() <= MaxLength" / a RELEASE_ASSERT in
 // StringImplShape. Lengths >= 2^32 were already caught. These allocate a real
 // 2 GiB, so each case runs in a subprocess to keep the peak away from the
-// test runner.
-describe("byte sources at the 2 GiB string limit", () => {
+// test runner, and the block skips on small machines (same gate as
+// buffer.test.js's 4 GiB case).
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB string limit", () => {
   test("Blob.text() and Blob.json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -1,7 +1,7 @@
 import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { unlinkSync } from "fs";
-import { tempDirWithFiles } from "harness";
+import { truncateSync, unlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 describe("Memory", () => {
   beforeAll(() => {
@@ -20,13 +20,13 @@ describe("Memory", () => {
     test(".json() should throw an OOM without crashing the process.", () => {
       const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
       expect(async () => await new Blob(array).json()).toThrow(
-        "Cannot parse a JSON string longer than 2^32-1 characters",
+        "Cannot parse a JSON string longer than 2147483647 characters",
       );
     });
 
     test(".text() should throw an OOM without crashing the process.", () => {
       const array = [buf, buf, buf, buf, buf, buf, buf, buf, buf];
-      expect(async () => await new Blob(array).text()).toThrow("Cannot create a string longer than 2^32-1 characters");
+      expect(async () => await new Blob(array).text()).toThrow("Cannot create a string longer than 2147483647 characters");
     });
 
     test(".bytes() should throw an OOM without crashing the process.", () => {
@@ -52,7 +52,7 @@ describe("Memory", () => {
 
     test(".text() should throw an OOM without crashing the process.", () => {
       expect(async () => await new Response(blob).text()).toThrow(
-        "Cannot create a string longer than 2^32-1 characters",
+        "Cannot create a string longer than 2147483647 characters",
       );
     });
 
@@ -66,7 +66,7 @@ describe("Memory", () => {
 
     test(".json() should throw an OOM without crashing the process.", async () => {
       expect(async () => await new Response(blob).json()).toThrow(
-        "Cannot parse a JSON string longer than 2^32-1 characters",
+        "Cannot parse a JSON string longer than 2147483647 characters",
       );
     });
   });
@@ -83,7 +83,7 @@ describe("Memory", () => {
 
     test(".text() should throw an OOM without crashing the process.", () => {
       expect(async () => await new Request("http://localhost:3000", { body: blob }).text()).toThrow(
-        "Cannot create a string longer than 2^32-1 characters",
+        "Cannot create a string longer than 2147483647 characters",
       );
     });
 
@@ -97,7 +97,7 @@ describe("Memory", () => {
 
     test(".json() should throw an OOM without crashing the process.", async () => {
       expect(async () => await new Request("http://localhost:3000", { body: blob }).json()).toThrow(
-        "Cannot parse a JSON string longer than 2^32-1 characters",
+        "Cannot parse a JSON string longer than 2147483647 characters",
       );
     });
   });
@@ -141,4 +141,88 @@ describe("Bun.file", () => {
   test("arrayBuffer() should NOT throw an OOM.", () => {
     expect(async () => await Bun.file(tmpFile).arrayBuffer()).not.toThrow();
   });
+});
+
+// Byte lengths in [2^31, 2^32) used to abort the process instead of throwing:
+// the Rust-side guards in front of WTF string construction only checked the
+// synthetic allocation limit (2^32 - 1 by default) and missed
+// WTF::StringImpl::MaxLength (2^31 - 1), tripping
+// "ASSERTION FAILED: data.size() <= MaxLength" / a RELEASE_ASSERT in
+// StringImplShape. Lengths >= 2^32 were already caught. These allocate a real
+// 2 GiB, so each case runs in a subprocess to keep the peak away from the
+// test runner.
+describe("byte sources at the 2 GiB string limit", () => {
+  test(
+    "Blob.text() and Blob.json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const results = [];
+          const report = e => ({ name: e.name, code: e.code, message: e.message });
+          const blob = new Blob([new Uint8Array(2 ** 31)]);
+          await blob.text().then(() => results.push("TEXT_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+          await blob.json().then(() => results.push("JSON_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+          console.log(JSON.stringify(results));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+        {
+          name: "Error",
+          code: "ERR_STRING_TOO_LONG",
+          message: "Cannot create a string longer than 2147483647 characters",
+        },
+        {
+          name: "Error",
+          code: "ERR_STRING_TOO_LONG",
+          message: "Cannot parse a JSON string longer than 2147483647 characters",
+        },
+      ]);
+      expect(exitCode).toBe(0);
+    },
+    180_000,
+  );
+
+  test(
+    "Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting",
+    async () => {
+      using dir = tempDir("blob-2gib", {});
+      const file = path.join(String(dir), "big.txt");
+      // Sparse where the filesystem supports it; reads back as 'x' + NUL bytes.
+      writeFileSync(file, "x");
+      truncateSync(file, 2 ** 31);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const results = [];
+          const report = e => ({ name: e.name, code: e.code, message: e.message });
+          await Bun.file(${JSON.stringify(file)}).text().then(() => results.push("UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+          console.log(JSON.stringify(results));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+        {
+          name: "Error",
+          code: "ERR_STRING_TOO_LONG",
+          message: "Cannot create a string longer than 2147483647 characters",
+        },
+      ]);
+      expect(exitCode).toBe(0);
+    },
+    180_000,
+  );
 });


### PR DESCRIPTION
### Problem

`await new Blob([new Uint8Array(2 ** 31)]).text()` aborts the process. Same for `Bun.file(path).text()` and `fs.readFileSync(path, "utf8")` when the file is between 2 GiB and 4 GiB - 1 bytes (a sparse `truncate -s 2G big.txt` reproduces it). Release builds die with a silent SIGABRT; debug builds fail with:

```
ASSERTION FAILED: data.size() <= MaxLength
WTF/wtf/text/StringImpl.h(891) StringImplShape(uint32_t, std::span<const Latin1Character>, unsigned)
```

Sizes of 4 GiB and above already threw catchable errors, and 2^31 - 1 worked, so only the [2^31, 2^32) range crashed.

### Cause

The Rust-side guards in front of WTF string construction (`bun_core::String::max_length()`) only consult `Bun__stringSyntheticAllocationLimit`, which defaults to 2^32 - 1. The hard cap enforced by `RELEASE_ASSERT` in the `StringImplShape` constructors is `WTF::StringImpl::MaxLength` = 2^31 - 1. The C++ conversions in `helpers.h` already clamp (`len > Bun__stringSyntheticAllocationLimit || len > WTF::String::MaxLength`); the Rust side missed the second half, so external-string creation for lengths in [2^31, 2^32) passed the guard and tripped the assert.

### Fix

- `String::max_length()` clamps the synthetic limit to `WTF::StringImpl::MaxLength` (2^31 - 1).
- The `create_external*` guards compare with `>` instead of `>=`, so 2^31 - 1, the largest valid WTF length, still works.
- `ZigString__toJSONObject` also checks `WTF::String::MaxLength`, so `Blob.json()` at these sizes reports `ERR_STRING_TOO_LONG` instead of falling through to `JSONParse` on a null string.
- `BunString__createUTF8ForJS` rejects oversized all-ASCII input with `ERR_STRING_TOO_LONG` instead of asserting.
- Error messages report the real limit (2147483647, matching the C++ `ErrorCode.cpp` text) instead of "2^32-1".

`Blob.text()` / `Bun.file().text()` now throw `ERR_STRING_TOO_LONG`; `fs.readFileSync(path, "utf8")` reports `ENOMEM` like the existing >= 4 GiB and `/dev/zero` paths (the fs layer speaks errno). `Buffer.prototype.toString` already threw `ERR_STRING_TOO_LONG` for these sizes via its own `WTF::String::MaxLength` check in `JSBuffer.cpp`.

### Verification

- `test/js/web/fetch/blob-oom.test.ts`: subprocess tests for `Blob.text()`, `Blob.json()` and `Bun.file().text()` at 2^31 bytes (abort before, catchable error after), plus the existing synthetic-limit assertions updated to the corrected message.
- `test/js/node/fs/fs-oom.test.ts`: `readFileSync(file, "utf8")` at 2^31 bytes throws `ENOMEM`; at 2^31 - 1 bytes still decodes to a 2147483647-length string. The fixture files are sparse so only the in-memory read costs 2 GiB, and each case runs in a subprocess.
- Manually verified 4 GiB inputs still produce the same catchable errors as before, and 2^31 - 1 still succeeds on all three faces.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-oom.test.ts

<!-- robobun:evidence:end -->