### PR TITLE
TextDecoder: throw ERR_STRING_TOO_LONG instead of returning an empty string

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3367,15 +3367,19 @@ JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* globalObject,
 
     if (!clone) {
         for (size_t i = 0; i < initialCapacity; ++i) {
+            auto* value = Zig::toJSStringGC(values[i], globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
             object->putDirect(
                 vm, JSC::PropertyName(JSC::Identifier::fromString(vm, Zig::toString(keys[i]))),
-                Zig::toJSStringGC(values[i], globalObject), 0);
+                value, 0);
             RETURN_IF_EXCEPTION(scope, {});
         }
     } else {
         for (size_t i = 0; i < initialCapacity; ++i) {
+            auto* value = Zig::toJSStringGC(values[i], globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
             object->putDirect(vm, JSC::PropertyName(Zig::toIdentifier(keys[i], globalObject)),
-                Zig::toJSStringGC(values[i], globalObject), 0);
+                value, 0);
             RETURN_IF_EXCEPTION(scope, {});
         }
     }
@@ -3700,7 +3704,7 @@ __attribute__((__always_inline__)) VirtualMachine* JSC__JSGlobalObject__bunVM(JS
 
 JSC::EncodedJSValue ZigString__toValueGC(const ZigString* arg0, JSC::JSGlobalObject* arg1)
 {
-    return JSC::JSValue::encode(JSC::jsString(arg1->vm(), Zig::toStringCopy(*arg0)));
+    return JSC::JSValue::encode(Zig::toJSStringGC(*arg0, arg1));
 }
 
 void JSC__JSValue__toZigString(JSC::EncodedJSValue JSValue0, ZigString* arg1, JSC::JSGlobalObject* arg2)

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -28,8 +28,7 @@ extern "C" const char* Bun__errnoName(int);
 
 namespace Bun {
 namespace ERR {
-// Defined in ErrorCode.cpp; forward-declared here because ErrorCode.h cannot
-// be included from this header.
+// Forward declaration: ErrorCode.h transitively includes this header.
 JSC::EncodedJSValue STRING_TOO_LONG(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject);
 }
 }
@@ -260,12 +259,15 @@ static JSC::JSString* toJSStringGC(ZigString str, JSC::JSGlobalObject* global)
 {
     auto wtfString = toStringCopy(str);
     if (wtfString.isNull() && str.len > 0) [[unlikely]] {
-        // toStringCopy returns a null string when the input is over the string
-        // length limit or when allocation fails; surface an error instead of
-        // silently returning an empty string.
         auto scope = DECLARE_THROW_SCOPE(global->vm());
         size_t maxLength = std::min(Bun__stringSyntheticAllocationLimit, static_cast<size_t>(WTF::String::MaxLength));
-        if (str.len > maxLength) {
+        // For UTF-8 input `str.len` counts bytes, but the limit applies to the
+        // decoded UTF-16 length.
+        size_t decodedLength = str.len;
+        if (isTaggedUTF8Ptr(str.ptr) && str.len > maxLength) {
+            decodedLength = simdutf::utf16_length_from_utf8(reinterpret_cast<const char*>(untag(str.ptr)), str.len);
+        }
+        if (decodedLength > maxLength) {
             Bun::ERR::STRING_TOO_LONG(scope, global);
         } else {
             JSC::throwOutOfMemoryError(global, scope);

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -6,6 +6,7 @@
 
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/Exception.h>
+#include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSString.h>
@@ -24,6 +25,14 @@ class GlobalObject;
 
 extern "C" size_t Bun__stringSyntheticAllocationLimit;
 extern "C" const char* Bun__errnoName(int);
+
+namespace Bun {
+namespace ERR {
+// Defined in ErrorCode.cpp; forward-declared here because ErrorCode.h cannot
+// be included from this header.
+JSC::EncodedJSValue STRING_TOO_LONG(JSC::ThrowScope& throwScope, JSC::JSGlobalObject* globalObject);
+}
+}
 
 namespace Zig {
 
@@ -191,6 +200,11 @@ static const WTF::String toStringCopy(ZigString str)
         return WTF::String::fromUTF8ReplacingInvalidSequences(std::span { untag(str.ptr), str.len });
     }
 
+    // This will fail if the string is too long. Let's make it explicit instead of an ASSERT.
+    if (str.len > Bun__stringSyntheticAllocationLimit || str.len > WTF::String::MaxLength) [[unlikely]] {
+        return {};
+    }
+
     if (isTaggedUTF16Ptr(str.ptr)) {
         std::span<char16_t> out;
         auto impl = WTF::StringImpl::tryCreateUninitialized(str.len, out);
@@ -240,9 +254,25 @@ static const JSC::JSString* toJSString(ZigString str, JSC::JSGlobalObject* globa
     return JSC::jsOwnedString(global->vm(), toString(str));
 }
 
+// Copies `str` into a GC-managed JSString. Throws ERR_STRING_TOO_LONG (or an
+// out-of-memory error) and returns nullptr when the string cannot be created.
 static JSC::JSString* toJSStringGC(ZigString str, JSC::JSGlobalObject* global)
 {
-    return JSC::jsString(global->vm(), toStringCopy(str));
+    auto wtfString = toStringCopy(str);
+    if (wtfString.isNull() && str.len > 0) [[unlikely]] {
+        // toStringCopy returns a null string when the input is over the string
+        // length limit or when allocation fails; surface an error instead of
+        // silently returning an empty string.
+        auto scope = DECLARE_THROW_SCOPE(global->vm());
+        size_t maxLength = std::min(Bun__stringSyntheticAllocationLimit, static_cast<size_t>(WTF::String::MaxLength));
+        if (str.len > maxLength) {
+            Bun::ERR::STRING_TOO_LONG(scope, global);
+        } else {
+            JSC::throwOutOfMemoryError(global, scope);
+        }
+        return nullptr;
+    }
+    return JSC::jsString(global->vm(), WTF::move(wtfString));
 }
 
 static const ZigString ZigStringEmpty = ZigString { (unsigned char*)"", 0 };

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -947,3 +947,40 @@ it.each(["utf-16le", "utf-16be"])(
   },
   30_000,
 ); // 3072 decodes + repeated Bun.gc(true) take ~4s under ASAN.
+
+describe("TextDecoder.decode above the maximum string length", () => {
+  const expected = "threw:ERR_STRING_TOO_LONG:Cannot create a string longer than 2147483647 characters";
+  const script = size => `
+    try {
+      const s = new TextDecoder().decode(new Uint8Array(${size}));
+      console.log("returned:" + s.length);
+    } catch (e) {
+      console.log("threw:" + e.code + ":" + e.message);
+    }`;
+
+  // A zeroed input is all-ASCII, so the decoded string's length equals the
+  // input length. 2**31 exceeds WTF::StringImpl's maximum length (2^31-1);
+  // decode() used to return "" silently instead of throwing. The input is
+  // never written, so the 2 GiB Uint8Array stays untouched zero pages.
+  it("throws ERR_STRING_TOO_LONG for a 2**31 byte ASCII input", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script("2 ** 31")],
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe(expected);
+    expect(exitCode).toBe(0);
+  }, 30_000); // scans 2 GiB of input; slow under debug + ASAN.
+
+  // Same path, exercised cheaply via the synthetic allocation limit so the
+  // guard is covered without a 2 GiB allocation.
+  it("throws ERR_STRING_TOO_LONG above the synthetic allocation limit", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script("160 * 1024 * 1024")],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "134217728" },
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -961,16 +961,19 @@ describe("TextDecoder.decode above the maximum string length", () => {
   // A zeroed input is all-ASCII, so the decoded string's length equals the
   // input length. 2**31 exceeds WTF::StringImpl's maximum length (2^31-1);
   // decode() used to return "" silently instead of throwing. The input is
-  // never written, so the 2 GiB Uint8Array stays untouched zero pages.
+  // never written (untouched zero pages) and the throw happens before the
+  // output string is allocated, so this runs in about a second even under
+  // debug + ASAN.
   it("throws ERR_STRING_TOO_LONG for a 2**31 byte ASCII input", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script("2 ** 31")],
       env: bunEnv,
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout.trim()).toBe(expected);
     expect(exitCode).toBe(0);
-  }, 30_000); // scans 2 GiB of input; slow under debug + ASAN.
+  });
 
   // Same path, exercised cheaply via the synthetic allocation limit so the
   // guard is covered without a 2 GiB allocation.
@@ -978,8 +981,9 @@ describe("TextDecoder.decode above the maximum string length", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script("160 * 1024 * 1024")],
       env: { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: "134217728" },
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout.trim()).toBe(expected);
     expect(exitCode).toBe(0);
   });

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -9,6 +9,7 @@ import {
   tempDir,
   withoutAggressiveGC,
 } from "harness";
+import os from "node:os";
 
 const getByteLength = str => {
   // returns the byte length of an utf8 string
@@ -963,8 +964,9 @@ describe("TextDecoder.decode above the maximum string length", () => {
   // decode() used to return "" silently instead of throwing. The input is
   // never written (untouched zero pages) and the throw happens before the
   // output string is allocated, so this runs in about a second even under
-  // debug + ASAN.
-  it("throws ERR_STRING_TOO_LONG for a 2**31 byte ASCII input", async () => {
+  // debug + ASAN. Skipped on small machines where the 2 GiB reservation
+  // itself can fail (same gate as blob-oom.test.ts and fs-oom.test.ts).
+  it.skipIf(os.totalmem() < 10 * 1024 ** 3)("throws ERR_STRING_TOO_LONG for a 2**31 byte ASCII input", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script("2 ** 31")],
       env: bunEnv,


### PR DESCRIPTION
### Repro

```js
for (const n of [2 ** 31 - 1, 2 ** 31, 2 ** 31 + 5, 2 ** 32 - 1]) {
  try { console.log(n, '->', new TextDecoder().decode(new Uint8Array(n)).length); }
  catch (e) { console.log(n, '-> threw', String(e).slice(0, 80)); }
}
```

On 1.4.0-canary this prints `2147483647 -> 2147483647`, then `-> 0` for every larger size, with exit code 0: any decode whose output is 2^31 .. 2^32-1 characters silently returns the empty string. Node throws `ERR_STRING_TOO_LONG` for sizes over its limit.

### Cause

The all-ASCII decode path lands in `ZigString__toValueGC` (`ZigString.toJS`), where `Zig::toStringCopy` returns a null `WTF::String` when the length exceeds `WTF::StringImpl::MaxLength` (2^31-1) or allocation fails, and `jsString()` turns that null string into the empty string. No error was raised anywhere.

### Fix

- `Zig::toJSStringGC` (and with it `ZigString__toValueGC`, which now delegates to it) throws `ERR_STRING_TOO_LONG` when the input is over the length limit, and an out-of-memory error when the length was fine but allocation failed, instead of returning `""`. Its other caller, `Bun::toJS`'s `ZigString` arm, already returns nullptr-with-pending-exception for dead strings, so the contract is unchanged.
- The non-UTF-8 branches of the single-argument `Zig::toStringCopy` now check the synthetic allocation limit, matching the other helpers in `helpers.h`.
- `JSC__JSValue__fromEntries` materializes the value and checks for the exception before `putDirect` (a nullptr `JSString*` would have put an empty `JSValue`).

`decode(new Uint8Array(2 ** 31 - 1))` still returns a 2^31-1-length string.

This PR is scoped to the silent-empty-string path. The sibling bug on the external-string paths (lengths in 2^31 .. 2^32-1 aborting the process, e.g. `fs.readFileSync` of a >2 GiB file, #26323) is fixed separately in #37215, which caps `String::max_length()` at `WTF::StringImpl::MaxLength`; the two PRs no longer share any hunks and merge independently in either order.

### Verification

New tests in `test/js/web/encoding/text-decoder.test.js`: a 2^31-byte decode must throw `ERR_STRING_TOO_LONG` (the zeroed input is never written, so the 2 GiB stay untouched zero pages and the test runs in under a second), plus a cheap variant via `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT` that covers the same path with a 160 MB input. Both fail on current main (`returned:0` / `returned:167772160`) and pass with this change. The full `text-decoder.test.js` (127 tests) and `blob-oom.test.ts` pass with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-decoder.test.js
bun test v1.4.0 (bbf4670d7)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [2463.32ms]
(pass) TextDecoder > should decode ascii text [143.32ms]
(pass) TextDecoder > should decode unicode text [2795.90ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [3.06ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.46ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array [0.38ms]
(pass) TextDecoder > typedArrays > should decode Int8Array [0.29ms]
(pass) TextDecoder > typedArrays > should decode Int16Array [0.35ms]
(pass) TextDecoder > typedArrays > should decode Int32Array [0.37ms]
(pass) TextDecoder > typedArrays > should decode Float16Array [0.34ms]
(pass) TextDecoder > typedArrays > should decode Float32Array [0.43ms]
(pass) TextDecoder > typedArrays > should decode Float64Array [0.30ms]
(pass) TextDecoder > typedArrays > should decode DataView [0.35ms]
(pass) TextDecoder > typedArrays > should decode BigInt64Arra
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b70c1fc55)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [6.33ms]
(pass) TextDecoder > should decode ascii text [7.68ms]
(pass) TextDecoder > should decode unicode text [97.49ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [0.09ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array
(pass) TextDecoder > typedArrays > should decode Uint32Array
(pass) TextDecoder > typedArrays > should decode Int8Array
(pass) TextDecoder > typedArrays > should decode Int16Array
(pass) TextDecoder > typedArrays > should decode Int32Array
(pass) TextDecoder > typedArrays > should decode Float16Array
(pass) TextDecoder > typedArrays > should decode Float32Array
(pass) TextDecoder > typedArrays > should decode Float64Array
(pass) TextDecoder > typedArrays > should decode DataView
(pass) TextDecoder > typedArrays > should decode BigInt64Array
(pass) TextDecoder > typedArrays > should decode BigUint64Array
(pass) TextDecoder > typedArrays > DOMJIT call [25.86ms]
(pass) TextDecoder > should decode unicode text with multiple consecutive emoji [10.97ms]
(pass) TextDecoder > coerces the fatal fl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-decoder.test.js
bun test v1.4.0 (bbf4670d7)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [2480.51ms]
(pass) TextDecoder > should decode ascii text [143.63ms]
(pass) TextDecoder > should decode unicode text [2809.08ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [2.66ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.48ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array [0.35ms]
(pass) TextDecoder > typedArrays > should decode Int8Array [0.31ms]
(pass) TextDecoder > typedArrays > should decode Int16Array [0.32ms]
(pass) TextDecoder > typedArrays > should decode Int32Array [0.37ms]
(pass) TextDecoder > typedArrays > should decode Float16Array [0.32ms]
(pass) TextDecoder > typedArrays > should decode Float32Array [0.40ms]
(pass) TextDecoder > typedArrays > should decode Float64Array [0.32ms]
(pass) TextDecoder > typedArrays > should decode DataView [0.32ms]
(pass) TextDecoder > typedArrays > should decode BigInt64Arra
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 636ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen cpp.rs (cppbind)
[1/124] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp             | 10 ++++---
 src/jsc/bindings/helpers.h                | 34 +++++++++++++++++++++++-
 test/js/web/encoding/text-decoder.test.js | 43 +++++++++++++++++++++++++++++++
 3 files changed, 83 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/bindings.cpp                  4      7      0
src/jsc/bindings/helpers.h                     4      8      0
test/js/web/encoding/text-decoder.test.js      2      5      0
```

</details>

<!-- robobun:evidence:end -->