### PR TITLE
node:wasi: implement lifecycle and import object APIs

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -567,6 +567,7 @@ declare function $ERR_BUFFER_TOO_LARGE(len: number): RangeError;
 declare function $ERR_BROTLI_INVALID_PARAM(p: number): RangeError;
 declare function $ERR_TLS_CERT_ALTNAME_INVALID(reason: string, host: string, cert): Error;
 declare function $ERR_USE_AFTER_CLOSE(name: string): Error;
+declare function $ERR_WASI_ALREADY_STARTED(): Error;
 declare function $ERR_HTTP2_INVALID_HEADER_VALUE(value: string, name: string): TypeError;
 declare function $ERR_INVALID_HANDLE_TYPE(): TypeError;
 declare function $ERR_INVALID_HTTP_TOKEN(name: string, value: string): TypeError;

--- a/src/js/internal/validators.ts
+++ b/src/js/internal/validators.ts
@@ -85,6 +85,10 @@ function validateBoolean(value, name) {
   if (typeof value !== "boolean") throw $ERR_INVALID_ARG_TYPE(name, "boolean", value);
 }
 
+function validateUndefined(value, name) {
+  if (value !== undefined) throw $ERR_INVALID_ARG_TYPE(name, "undefined", value);
+}
+
 /** Validate a string-or-URL path and return it resolved to an absolute path string. */
 function getValidatedPath(p: any) {
   if (p instanceof URL) return Bun.fileURLToPath(p as URL);
@@ -122,7 +126,7 @@ function getValidatedFsPath(p: any, propName: string = "path") {
 }
 
 hideFromStack(validateLinkHeaderValue);
-hideFromStack(validateString, validateFunction, validateBoolean);
+hideFromStack(validateString, validateFunction, validateBoolean, validateUndefined);
 hideFromStack(getValidatedPath, getValidatedFsPath, throwIfNullBytesInFileName);
 
 export default {
@@ -144,6 +148,8 @@ export default {
   validateFunction,
   /** `(value, name)` */
   validateBoolean,
+  /** `(value, name)` */
+  validateUndefined,
   /** `(port, name = 'Port', allowZero = true)` */
   validatePort: $newCppFunction("NodeValidator.cpp", "jsFunction_validatePort", 0),
   /** `(signal, name)` */

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -8,6 +8,22 @@
 
 const nodeFsConstants = $processBindingConstants.fs;
 
+const {
+  validateArray,
+  validateBoolean,
+  validateFunction,
+  validateInt32,
+  validateObject,
+  validateString,
+  validateUndefined,
+} = require("internal/validators");
+
+const kEmptyObject = Object.freeze({ __proto__: null });
+const kExitCode = Symbol("kExitCode");
+const kStarted = Symbol("kStarted");
+const kInstance = Symbol("kInstance");
+const kBindingName = Symbol("kBindingName");
+
 var __getOwnPropNames = Object.getOwnPropertyNames;
 
 var __commonJS = (cb, mod: typeof module | undefined = undefined) =>
@@ -571,17 +587,59 @@ var require_wasi = __commonJS({
     }
 
     var WASI = class WASI {
-      constructor(wasiConfig = {}) {
+      constructor(wasiConfig = kEmptyObject) {
+        validateObject(wasiConfig, "options");
+        validateString(wasiConfig.version, "options.version");
+
+        switch (wasiConfig.version) {
+          case "unstable":
+            this[kBindingName] = "wasi_unstable";
+            break;
+          case "preview1":
+            this[kBindingName] = "wasi_snapshot_preview1";
+            break;
+          default:
+            throw $ERR_INVALID_ARG_VALUE("options.version", wasiConfig.version, "unsupported WASI version");
+        }
+
+        const {
+          args: configuredArgs,
+          env: configuredEnv,
+          preopens: configuredPreopens,
+          returnOnExit: configuredReturnOnExit,
+        } = wasiConfig;
+        if (configuredArgs !== undefined) validateArray(configuredArgs, "options.args");
+        const args = $Array.prototype.map.$call(configuredArgs || [], String);
+
+        if (configuredEnv !== undefined) validateObject(configuredEnv, "options.env");
+        if (configuredPreopens !== undefined) validateObject(configuredPreopens, "options.preopens");
+
+        const { stdin = 0, stdout = 1, stderr = 2 } = wasiConfig;
+        validateInt32(stdin, "options.stdin", 0);
+        validateInt32(stdout, "options.stdout", 0);
+        validateInt32(stderr, "options.stderr", 0);
+
+        let returnOnExit = true;
+        if (configuredReturnOnExit !== undefined) {
+          validateBoolean(configuredReturnOnExit, "options.returnOnExit");
+          returnOnExit = configuredReturnOnExit;
+        }
+
         const defaultConfig = getDefaults();
         this.lastStdin = 0;
         this.sleep = wasiConfig.sleep || defaultConfig.sleep;
         this.getStdin = wasiConfig.getStdin;
         this.sendStdout = wasiConfig.sendStdout;
         this.sendStderr = wasiConfig.sendStderr;
-        let preopens = wasiConfig.preopens ?? defaultConfig.preopens;
-        this.env = wasiConfig.env ?? defaultConfig.env;
+        const preopens = { __proto__: null };
+        for (const [key, value] of Object.entries(configuredPreopens ?? defaultConfig.preopens)) {
+          preopens[`${key}`] = `${value}`;
+        }
+        this.env = { __proto__: null };
+        for (const [key, value] of Object.entries(configuredEnv ?? defaultConfig.env)) {
+          if (value !== undefined) this.env[`${key}`] = `${value}`;
+        }
 
-        const args = wasiConfig.args ?? defaultConfig.args;
         this.memory = void 0;
         this.view = void 0;
         this.bindings = wasiConfig.bindings || defaultConfig.bindings;
@@ -591,7 +649,7 @@ var require_wasi = __commonJS({
           [
             constants_1.WASI_STDIN_FILENO,
             {
-              real: 0,
+              real: stdin,
               filetype: constants_1.WASI_FILETYPE_CHARACTER_DEVICE,
               rights: {
                 base: STDIN_DEFAULT_RIGHTS,
@@ -603,7 +661,7 @@ var require_wasi = __commonJS({
           [
             constants_1.WASI_STDOUT_FILENO,
             {
-              real: 1,
+              real: stdout,
               filetype: constants_1.WASI_FILETYPE_CHARACTER_DEVICE,
               rights: {
                 base: STDOUT_DEFAULT_RIGHTS,
@@ -615,7 +673,7 @@ var require_wasi = __commonJS({
           [
             constants_1.WASI_STDERR_FILENO,
             {
-              real: 2,
+              real: stderr,
               filetype: constants_1.WASI_FILETYPE_CHARACTER_DEVICE,
               rights: {
                 base: STDERR_DEFAULT_RIGHTS,
@@ -1625,6 +1683,9 @@ var require_wasi = __commonJS({
           sched_yield() {
             return constants_1.WASI_ESUCCESS;
           },
+          sock_accept() {
+            return constants_1.WASI_ENOSYS;
+          },
           sock_recv() {
             return constants_1.WASI_ENOSYS;
           },
@@ -1641,6 +1702,15 @@ var require_wasi = __commonJS({
             return constants_1.WASI_ENOSYS;
           },
         };
+        if (returnOnExit) {
+          this.wasiImport.proc_exit = rval => {
+            this[kExitCode] = rval;
+            throw kExitCode;
+          };
+        }
+        this[kStarted] = false;
+        this[kExitCode] = 0;
+        this[kInstance] = void 0;
       }
       getState() {
         return { env: this.env, FD_MAP: this.FD_MAP, bindings: bindings };
@@ -1704,22 +1774,44 @@ var require_wasi = __commonJS({
       }
       setMemory(memory) {
         this.memory = memory;
+        this.view = void 0;
       }
-      start(instance, memory) {
-        const exports2 = instance.exports;
-        if (exports2 === null || typeof exports2 !== "object") {
-          throw new Error(`instance.exports must be an Object. Received ${exports2}.`);
+      finalizeBindings(instance, { memory = instance?.exports?.memory } = kEmptyObject) {
+        if (this[kStarted]) {
+          throw $ERR_WASI_ALREADY_STARTED();
         }
-        if (memory == null) {
-          memory = exports2.memory;
-          if (!(memory instanceof WebAssembly.Memory)) {
-            throw new Error(`instance.exports.memory must be a WebAssembly.Memory. Recceived ${memory}.`);
-          }
+        validateObject(instance, "instance");
+        validateObject(instance.exports, "instance.exports");
+        if (!(memory instanceof WebAssembly.Memory)) {
+          throw $ERR_INVALID_ARG_TYPE("instance.exports.memory", "WebAssembly.Memory", memory);
         }
         this.setMemory(memory);
-        if (exports2._start) {
-          exports2._start();
+        this[kInstance] = instance;
+        this[kStarted] = true;
+      }
+      start(instance) {
+        this.finalizeBindings(instance);
+        const { _start, _initialize } = this[kInstance].exports;
+        validateFunction(_start, "instance.exports._start");
+        validateUndefined(_initialize, "instance.exports._initialize");
+        try {
+          _start();
+        } catch (err) {
+          if (err !== kExitCode) throw err;
         }
+        return this[kExitCode];
+      }
+      initialize(instance) {
+        this.finalizeBindings(instance);
+        const { _start, _initialize } = this[kInstance].exports;
+        validateUndefined(_start, "instance.exports._start");
+        if (_initialize !== undefined) {
+          validateFunction(_initialize, "instance.exports._initialize");
+          _initialize();
+        }
+      }
+      getImportObject() {
+        return { [this[kBindingName]]: this.wasiImport };
       }
       getImports(module2) {
         let namespace: string | null = null;

--- a/src/js/wasi-runner.js
+++ b/src/js/wasi-runner.js
@@ -25,8 +25,10 @@ if (WASM_ENV_STR?.length) {
 }
 
 const wasi = new WASI({
+  version: "preview1",
   args: process.argv.slice(1),
   env,
+  returnOnExit: false,
   preopens: {
     ".": WASM_CWD || process.cwd(),
     "/": WASM_ROOT_DIR || "/",
@@ -46,6 +48,10 @@ const instance = !Number(WASM_USE_ASYNC_INIT)
   ? new WebAssembly.Instance(wasm, wasi.getImports(wasm))
   : await WebAssembly.instantiate(wasm, wasi.getImports(wasm));
 
-wasi.start(instance);
+if (typeof instance.exports._start === "function") {
+  wasi.start(instance);
+} else {
+  wasi.initialize(instance);
+}
 
 process.reallyExit(0);

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -275,6 +275,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_UNKNOWN_SIGNAL", TypeError],
   ["ERR_ZSTD_INVALID_PARAM", RangeError],
   ["ERR_USE_AFTER_CLOSE", Error],
+  ["ERR_WASI_ALREADY_STARTED", Error],
   ["ERR_WASI_NOT_STARTED", Error],
   ["ERR_WEBASSEMBLY_RESPONSE", TypeError],
   ["ERR_WORKER_INIT_FAILED", Error],

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -28,7 +28,7 @@ it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {
   using dir = tempDir("wasi-set-rights", {
     "inside.txt": "inside",
   });
-  const wasi = new WASI({ preopens: { "/": String(dir) } });
+  const wasi = new WASI({ version: "preview1", preopens: { "/": String(dir) } });
   wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
 
   const WASI_ESUCCESS = 0;
@@ -48,7 +48,7 @@ it("fd_fdstat_set_rights only narrows the rights of a descriptor", () => {
 });
 
 it("random_get fills only the requested window", () => {
-  const wasi = new WASI({});
+  const wasi = new WASI({ version: "preview1" });
   wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
 
   const WASI_ESUCCESS = 0;
@@ -76,7 +76,7 @@ it("path_open reports the host errno to the guest when the open fails", () => {
   using dir = tempDir("wasi-path-open-errno", {
     "exists.txt": "x",
   });
-  const wasi = new WASI({ preopens: { "/": String(dir) } });
+  const wasi = new WASI({ version: "preview1", preopens: { "/": String(dir) } });
   wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
   const memory = Buffer.from(wasi.memory.buffer);
   const view = new DataView(wasi.memory.buffer);
@@ -122,7 +122,7 @@ it("path_* syscalls cannot escape the preopened directory", () => {
     fs.symlinkSync(path.join("..", "secret.txt"), path.join(sandbox, "escape"));
   }
 
-  const wasi = new WASI({ preopens: { "/": sandbox } });
+  const wasi = new WASI({ version: "preview1", preopens: { "/": sandbox } });
   wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
   const memory = Buffer.from(wasi.memory.buffer);
 
@@ -162,4 +162,104 @@ it("path_* syscalls cannot escape the preopened directory", () => {
     WASI_ESUCCESS,
   );
   expect(wasi.FD_MAP.has(4)).toBe(true);
+});
+
+it("implements the Node WASI lifecycle and import-object contract", () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const wasi = new WASI({ version: "preview1", stdin: 4, stdout: 5, stderr: 6 });
+
+  expect(wasi.getImportObject()).toEqual({ wasi_snapshot_preview1: wasi.wasiImport });
+  expect(wasi.FD_MAP.get(0).real).toBe(4);
+  expect(wasi.FD_MAP.get(1).real).toBe(5);
+  expect(wasi.FD_MAP.get(2).real).toBe(6);
+
+  let startCalls = 0;
+  const command = { exports: { memory, _start: () => startCalls++ } };
+  expect(wasi.start(command)).toBe(0);
+  expect(startCalls).toBe(1);
+  expect(() => wasi.start(command)).toThrow(expect.objectContaining({ code: "ERR_WASI_ALREADY_STARTED" }));
+});
+
+it("starts an unstable WASI module through getImportObject()", async () => {
+  using dir = tempDir("wasi-start", {});
+  const outputPath = path.join(String(dir), "output.txt");
+  const outputFd = fs.openSync(outputPath, "w");
+
+  try {
+    const wasi = new WASI({ version: "unstable", stdout: outputFd });
+    const wasm = await WebAssembly.compile(fs.readFileSync(import.meta.dir + "/hello-wasi.wasm"));
+    const instance = await WebAssembly.instantiate(wasm, wasi.getImportObject());
+    expect(wasi.start(instance)).toBe(0);
+  } finally {
+    fs.closeSync(outputFd);
+  }
+
+  expect(fs.readFileSync(outputPath, "utf8")).toBe("hello world\n");
+});
+
+it("returns a WASI proc_exit code from start()", () => {
+  const wasi = new WASI({ version: "preview1" });
+  const command = {
+    exports: {
+      memory: new WebAssembly.Memory({ initial: 1 }),
+      _start: () => wasi.wasiImport.proc_exit(7),
+    },
+  };
+
+  expect(wasi.start(command)).toBe(7);
+});
+
+it("initializes reactor modules and rejects command modules", () => {
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const wasi = new WASI({ version: "preview1" });
+  let initializeCalls = 0;
+  const reactor = { exports: { memory, _initialize: () => initializeCalls++ } };
+
+  expect(wasi.initialize(reactor)).toBeUndefined();
+  expect(initializeCalls).toBe(1);
+  expect(() => wasi.initialize(reactor)).toThrow(expect.objectContaining({ code: "ERR_WASI_ALREADY_STARTED" }));
+
+  const command = {
+    exports: {
+      memory: new WebAssembly.Memory({ initial: 1 }),
+      _start() {},
+    },
+  };
+  expect(() => new WASI({ version: "preview1" }).initialize(command)).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
+});
+
+it("validates the WASI version option", () => {
+  expect(() => new WASI()).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+  expect(() => new WASI({ version: "unsupported" })).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+  );
+
+  const unstable = new WASI({ version: "unstable" });
+  expect(unstable.getImportObject()).toEqual({ wasi_unstable: unstable.wasiImport });
+});
+
+it("validates and normalizes WASI constructor options", () => {
+  expect(() => new WASI({ version: "preview1", args: "args" })).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
+  expect(() => new WASI({ version: "preview1", env: "env" })).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
+  expect(() => new WASI({ version: "preview1", preopens: "preopens" })).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
+  expect(() => new WASI({ version: "preview1", stdout: -1 })).toThrow(
+    expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+  );
+  expect(() => new WASI({ version: "preview1", returnOnExit: 1 })).toThrow(
+    expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+  );
+
+  const wasi = new WASI({ version: "preview1", args: [42, true] });
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  wasi.initialize({ exports: { memory } });
+  wasi.wasiImport.args_sizes_get(0, 4);
+  expect(new DataView(memory.buffer).getUint32(0, true)).toBe(2);
 });


### PR DESCRIPTION
## Summary

Bun's `node:wasi` implementation was missing several documented Node-compatible lifecycle APIs and did not honor the configured stdio descriptors.

This PR:

- validates the WASI version and constructor options;
- implements `getImportObject()`, `finalizeBindings()`, and `initialize()`;
- makes `start()` one-shot, validates command modules, and returns `proc_exit` codes;
- wires `stdin`, `stdout`, and `stderr` options into the WASI descriptor map;
- keeps the existing `getImports()` path and CLI WASI runner compatibility.

## Testing

- `bun run lint` — passed
- Focused WASI lifecycle, import-object, validation, exit-code, reactor, and `wasi_unstable` tests — passed with `bun bd test`
- `USE_SYSTEM_BUN=1 bun test test/js/bun/wasm/wasi.test.js` — fails on the new API coverage as expected, confirming the test distinguishes the system Bun from this change
- Full `bun bd test test/js/bun/wasm/wasi.test.js` — 10 passed, 1 pre-existing CLI smoke test failed because this container cannot set WebKit scheduling policy and emits that error on stderr
