### PR TITLE
docs: replace stray control character in installation page Linux note

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -21,7 +21,7 @@ Bun ships as a single, dependency-free executable. Install it with the install s
 
     </CodeGroup>
     <Note>
-      **Linux users**  The `unzip` package is required to install Bun (`sudo apt install unzip`). Kernel version 5.6 or higher is recommended; Bun runs on kernels as old as 3.10 (RHEL 7) with graceful degradation of newer syscalls. Use `uname -r` to check your kernel version.
+      **Linux users:** The `unzip` package is required to install Bun (`sudo apt install unzip`). Kernel version 5.6 or higher is recommended; Bun runs on kernels as old as 3.10 (RHEL 7) with graceful degradation of newer syscalls. Use `uname -r` to check your kernel version.
       </Note>
 
   </Tab>


### PR DESCRIPTION
Fixes #37218

The "Linux users" note on https://bun.com/docs/installation contained a raw `\x14` control character as the separator after the bolded label, which browsers render as an invalid-character glyph ("Linux users  The `unzip` package...").

Replaced the control character with a colon: `**Linux users:** The ...`

Also scanned the rest of docs/ for other ASCII control characters; this was the only occurrence.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->