### PR TITLE
Fix clippy and source lint failures on main

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -1098,7 +1098,7 @@ pub(crate) fn run_scripts_with_filter(
         .handles
         .iter_mut()
         .filter(|handle| handle.remaining_dependencies == 0)
-        .map(|handle| std::ptr::from_mut(handle))
+        .map(std::ptr::from_mut)
         .collect();
     for handle in roots {
         // SAFETY: points into `state.handles`, which lives for the whole loop.

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -622,8 +622,7 @@ impl<'a> State<'a> {
             self.handles.iter_mut().map(std::ptr::from_mut).collect();
         for handle in handles {
             // SAFETY: points into `self.handles`, live for the whole run loop.
-            let handle = unsafe { &mut *handle };
-            if let Some(proc) = &mut handle.process {
+            if let Some(proc) = unsafe { (*handle).process.as_ref() } {
                 // if we get an error here we simply ignore it
                 // SAFETY: proc.ptr is a live `*mut Process` (set in start(); leaked
                 // until program exit per on_process_exit note).
@@ -632,7 +631,9 @@ impl<'a> State<'a> {
             // An already-exited handle may be waiting on pipes a grandchild
             // still holds; with `aborted` set this finishes it now. Killed
             // handles finish when their exit arrives.
-            let _ = self.maybe_finish(handle);
+            // SAFETY: same `self.handles` element as above; the exclusive
+            // reborrow is confined to this call.
+            let _ = self.maybe_finish(unsafe { &mut *handle });
         }
     }
 

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1258,7 +1258,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         .handles
         .iter_mut()
         .filter(|handle| handle.remaining_dependencies == 0)
-        .map(|handle| std::ptr::from_mut(handle))
+        .map(std::ptr::from_mut)
         .collect();
     for handle in roots {
         // SAFETY: points into `state.handles`, which lives for the whole loop.

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -540,8 +540,7 @@ impl<'a> State<'a> {
             self.handles.iter_mut().map(std::ptr::from_mut).collect();
         for handle in handles {
             // SAFETY: points into `self.handles`, live for the whole run loop.
-            let handle = unsafe { &mut *handle };
-            if let Some(proc) = &mut handle.process {
+            if let Some(proc) = unsafe { (*handle).process.as_ref() } {
                 if matches!(proc.status, Status::Running) {
                     // SAFETY: proc.ptr is a live intrusively-ref-counted Process
                     // allocated in `ProcessHandle::start`.
@@ -551,7 +550,9 @@ impl<'a> State<'a> {
             // An already-exited handle may be waiting on pipes a grandchild
             // still holds; with `aborted` set this finishes it now. Killed
             // handles finish when their exit arrives.
-            let _ = self.maybe_finish(handle);
+            // SAFETY: same `self.handles` element as above; the exclusive
+            // reborrow is confined to this call.
+            let _ = self.maybe_finish(unsafe { &mut *handle });
         }
     }
 

--- a/test/internal/source-lints/fn-long-mut-reborrow.test.ts
+++ b/test/internal/source-lints/fn-long-mut-reborrow.test.ts
@@ -77,8 +77,10 @@ for (const abs of rustSources) {
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
   const content = await file(abs).text();
-  // Strip full-line comments so prose mentions (including this file) don't count.
-  const stripped = content.replace(/^\s*\/\/.*$/gm, "");
+  // Strip full-line comments so prose mentions (including this file) don't
+  // count. `[ \t]*`, not `\s*`: `\s` crosses newlines, so a comment preceded
+  // by blank lines would swallow them and shift every reported line number.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
   for (const m of stripped.matchAll(BANNED)) {
     const line = stripped.slice(0, m.index).split("\n").length;
     counts[source] = (counts[source] ?? 0) + 1;


### PR DESCRIPTION
Main is red twice from #37206: the Clippy workflow and the Source lints workflow both fail.

**Clippy** (`-D warnings`): two `redundant_closure` errors.

```
error: redundant closure
    --> src/runtime/cli/filter_run.rs:1101:14
     |
1101 |         .map(|handle| std::ptr::from_mut(handle))
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `std::ptr::from_mut`
```

and the same at `src/runtime/cli/multi_run.rs:1261`. Replaced both closures with `std::ptr::from_mut` directly.

**Source lints**: `fn-long-mut-reborrow.test.ts` flags the new `State::abort` loops.

```
+   "src/runtime/cli/filter_run.rs:619: let handle = unsafe { &mut *handle };",
+   "src/runtime/cli/multi_run.rs:528: let handle = unsafe { &mut *handle };",
```

Replaced the fn-long reborrow with statement-scoped raw place access (`(*handle).process.as_ref()`) and a call-scoped reborrow for `maybe_finish`, the same shape the roots loop in each file already uses.

While fixing this, the lint's reported line numbers (619/528) did not match the actual lines (625/543): the comment-stripping regex uses `\s*`, which crosses newlines and swallows blank lines preceding a comment, shifting every subsequent line number. Changed it to `[ \t]*` so reported lines are exact.

Verification:
- `bun run rust:clippy` (full workspace): exits 0
- `bun test test/internal/source-lints/`: 75 pass, 0 fail (the fn-long test fails against unfixed sources, with exact line numbers)
- `test/cli/run/multi-run.test.ts` (120 pass) and `test/cli/run/filter-workspace.test.ts` (58 pass) with a debug build
- `cargo fmt --check`: clean

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/fn-long-mut-reborrow.test.ts
bun test v1.4.0 (f1e142de5)

test/internal/source-lints/fn-long-mut-reborrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.36ms]
 95 |   // nothing to scan, which would make the ban below pass vacuously.
 96 |   expect(scanned).toBeGreaterThan(0);
 97 | });
 98 | 
 99 | test("fn-long `&mut *<callback param>` reborrow is banned", () => {
100 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/cli/filter_run.rs:625: let handle = unsafe { &mut *handle };",
+   "src/runtime/cli/multi_run.rs:543: let handle = unsafe { &mut *handle };",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/internal/source-lints/fn-long-mut-reborrow.test.ts:100:21)
(fail) fn-long `&mut *<callback param>` reborrow is banned [4.57ms]
(pass) allowlisted files still carry exactly their documented count [1.92ms]

 2 pass
 1 fail
 2 expect() calls
Ran 3 tests across 1 file. [22.14s]
erro
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (45ee9556a)

test/internal/source-lints/fn-long-mut-reborrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.11ms]
 95 |   // nothing to scan, which would make the ban below pass vacuously.
 96 |   expect(scanned).toBeGreaterThan(0);
 97 | });
 98 | 
 99 | test("fn-long `&mut *<callback param>` reborrow is banned", () => {
100 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/cli/filter_run.rs:625: let handle = unsafe { &mut *handle };",
+   "src/runtime/cli/multi_run.rs:543: let handle = unsafe { &mut *handle };",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/internal/source-lints/fn-long-mut-reborrow.test.ts:100:21)
(fail) fn-long `&mut *<callback param>` reborrow is banned [0.25ms]
(pass) allowlisted files still carry exactly their documented count [0.09ms]

 2 pass
 1 fail
 2 expect() calls
Ran 3 tests across 1 file. [763.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/fn-long-mut-reborrow.test.ts
bun test v1.4.0 (f1e142de5)

test/internal/source-lints/fn-long-mut-reborrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [1.86ms]
(pass) fn-long `&mut *<callback param>` reborrow is banned [1.53ms]
(pass) allowlisted files still carry exactly their documented count [2.20ms]

 3 pass
 0 fail
 2 expect() calls
Ran 3 tests across 1 file. [22.18s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 651ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 05s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+f1e142de5
[build] done
bun test v1.4.0-canary.1 (f1e142de5)

test/internal/source-lints/fn-long-mut-reborrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.11ms]
(pass) fn-long `&mut *<callback param>` reborrow is banned [0.04ms]
(pass) allowlisted files still carry exactly their documented count [0.07ms]

 3 pass
 0 fail
 2 expect() calls
Ran 3 tests across 1 file. 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/filter_run.rs                           | 9 +++++----
 src/runtime/cli/multi_run.rs                            | 9 +++++----
 test/internal/source-lints/fn-long-mut-reborrow.test.ts | 6 ++++--
 3 files changed, 14 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/runtime/cli/filter_run.rs                                3      3      0
src/runtime/cli/multi_run.rs                                 3      3      0
test/internal/source-lints/fn-long-mut-reborrow.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->