### PR TITLE
node:https: pool names digest TLS parts over 1 KiB instead of embedding them

### DIFF
--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -367,6 +367,21 @@ function Agent(options) {
 $toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = createConnection;
 
+// Unlike Node, TLS parts over 1 KiB (CA bundles, chains) go into the pool name as a digest; smaller parts keep Node's exact name.
+const kLargePoolKeyPart = 1024;
+const kPoolKeyDigestCacheSize = 8;
+const poolKeyDigests = new Map();
+function compactPoolKeyPart(value) {
+  const text = "" + value;
+  if (text.length <= kLargePoolKeyPart) return text;
+  let digest = poolKeyDigests.$get(text);
+  if (digest === undefined) {
+    if (poolKeyDigests.$size >= kPoolKeyDigestCacheSize) poolKeyDigests.$delete(poolKeyDigests.$keys().next().value);
+    poolKeyDigests.$set(text, (digest = "sha256:" + Bun.SHA256.hash(text, "base64")));
+  }
+  return digest;
+}
+
 /**
  * Gets a unique name for a set of options.
  */
@@ -398,10 +413,10 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   } = options;
 
   name += ":";
-  if (ca) name += ca;
+  if (ca) name += compactPoolKeyPart(ca);
 
   name += ":";
-  if (cert) name += cert;
+  if (cert) name += compactPoolKeyPart(cert);
 
   name += ":";
   if (clientCertEngine) name += clientCertEngine;
@@ -410,10 +425,10 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (ciphers) name += ciphers;
 
   name += ":";
-  if (key) name += key;
+  if (key) name += compactPoolKeyPart(key);
 
   name += ":";
-  if (pfx) name += pfx;
+  if (pfx) name += compactPoolKeyPart(pfx);
 
   name += ":";
   if (rejectUnauthorized !== undefined) name += rejectUnauthorized;
@@ -431,7 +446,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (secureProtocol) name += secureProtocol;
 
   name += ":";
-  if (crl) name += crl;
+  if (crl) name += compactPoolKeyPart(crl);
 
   name += ":";
   if (honorCipherOrder !== undefined) name += honorCipherOrder;
@@ -440,7 +455,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (ecdhCurve) name += ecdhCurve;
 
   name += ":";
-  if (dhparam) name += dhparam;
+  if (dhparam) name += compactPoolKeyPart(dhparam);
 
   name += ":";
   if (secureOptions !== undefined) name += secureOptions;

--- a/test/js/node/http/node-https-agent-pool-key.test.ts
+++ b/test/js/node/http/node-https-agent-pool-key.test.ts
@@ -1,0 +1,58 @@
+// Bun keys TLS parts over 1 KiB by digest in https.Agent#getName where Node embeds them verbatim. These tests are
+// therefore Bun-only, which node-http.test.ts's header rules out for that file, so they live here.
+import { describe, expect, test } from "bun:test";
+import https from "node:https";
+
+describe("https.Agent#getName with large TLS options", () => {
+  const bigCA = Buffer.alloc(2048, "A").toString();
+  const otherBigCA = Buffer.alloc(2048, "B").toString();
+  const opts = (ca: unknown) => ({ host: "localhost", port: 443, ca });
+  const expectDigested = (name: string) => {
+    expect(name).toContain(":sha256:");
+    expect(name.length).toBeLessThan(256);
+  };
+
+  test("large parts are keyed by digest; small parts and arrays keep Node's exact format", () => {
+    const agent = new https.Agent();
+    const a = agent.getName(opts(bigCA));
+    expectDigested(a);
+    expect(agent.getName(opts(bigCA))).toBe(a);
+    expect(agent.getName(opts(otherBigCA))).not.toBe(a);
+    expect(agent.getName(opts("small-ca"))).toContain(":small-ca:");
+    expect(agent.getName(opts(["a", undefined, null, "b"]))).toContain(":a,,,b:");
+  });
+
+  test("the same material as a string, a Buffer or an array element shares one key", () => {
+    const agent = new https.Agent();
+    const a = agent.getName(opts(bigCA));
+    expectDigested(a);
+    expect(agent.getName(opts(Buffer.from(bigCA)))).toBe(a);
+    expect(agent.getName(opts([bigCA]))).toBe(a);
+    expect(agent.getName(opts(Buffer.from(otherBigCA)))).not.toBe(a);
+  });
+
+  test("mutating an array or Buffer is reflected on the next call; order matters", () => {
+    const agent = new https.Agent();
+    const ca = [bigCA];
+    const one = agent.getName(opts(ca));
+    ca.push(otherBigCA);
+    const two = agent.getName(opts(ca));
+    expectDigested(two);
+    expect(two).not.toBe(one);
+    expect(agent.getName(opts([otherBigCA, bigCA]))).not.toBe(two);
+    const buf = Buffer.from(bigCA);
+    const before = agent.getName(opts(buf));
+    buf.fill("B");
+    expect(agent.getName(opts(buf))).toBe(agent.getName(opts(otherBigCA)));
+    expect(agent.getName(opts(buf))).not.toBe(before);
+  });
+
+  test("frozen agents, detached calls (agent-base subclasses) and dhparam", () => {
+    const agent = Object.freeze(new https.Agent());
+    const a = agent.getName(opts(bigCA));
+    expectDigested(a);
+    expect(https.Agent.prototype.getName.call({}, opts(bigCA))).toBe(a);
+    expect(https.Agent.prototype.getName.call(undefined, opts(bigCA))).toBe(a);
+    expectDigested(agent.getName({ host: "localhost", port: 443, dhparam: bigCA }));
+  });
+});


### PR DESCRIPTION
### What

`https.Agent#getName` appended `ca`/`cert`/`key`/`pfx`/`crl`/`dhparam` to the pool name verbatim. With a custom CA bundle (commonly 100–300 KB) that string was rebuilt for every request (`addRequest`, `createSocket`, `free`, `removeSocket` each call `getName`) and retained as the key of every `sockets`/`freeSockets`/`requests` bucket and every TLS session-cache entry.

| | before | after |
|---|---|---|
| part ≤ 1 KiB (the normal case) | Node's exact name | unchanged, byte for byte (verified against `node` for strings, arrays incl. holes/nullish, Buffers, custom `toString`) |
| part > 1 KiB | copied into the name | `sha256:<base64>` of the same text (`""+value`, i.e. the coercion `+=` did — so a string, a Buffer and a one-element array of the same material still share a pool) |
| per-request cost with a 180 KiB bundle | ~15–20 µs concat + a 180 KiB rope per call | one SHA-256 the first time a distinct part is seen (8-entry FIFO cache), then a map hit |

Digest rather than a fast hash because the pool key decides which trust settings a reused socket was verified against.

### Tests

`test/js/node/http/node-https-agent-pool-key.test.ts` — Bun-only by nature (Node embeds the material), which `node-http.test.ts`'s header rules out for that file, hence the separate file. Fails on unmodified bun (0/4), passes with the change (4/4).