### PR TITLE
worker: RSS comes back down after workers exit on macOS (test-worker-memory)

### DIFF
--- a/scripts/build/depVersionsHeader.ts
+++ b/scripts/build/depVersionsHeader.ts
@@ -31,11 +31,23 @@ function sourceIdentifier(source: Source): string | undefined {
     case "prebuilt":
       return source.identity;
     case "local":
+      // User-managed checkout: its git HEAD when it is a repository, else just "local", so
+      // consumers of BUN_VERSION_<macro> keep compiling and process.versions stays meaningful.
+      return localSourceIdentifier(source.path);
     case "in-tree":
-      // User-managed / in-tree — no pinned identifier independent of the
-      // bun commit. Callers that need a value use cfg.revision.
+      // In-tree — no pinned identifier independent of the bun commit. Callers that need a value
+      // use cfg.revision.
       return undefined;
   }
+}
+
+function localSourceIdentifier(path: string | undefined): string {
+  if (path) {
+    const proc = Bun.spawnSync({ cmd: ["git", "-C", path, "rev-parse", "HEAD"], stdout: "pipe", stderr: "ignore" });
+    const sha = proc.success ? proc.stdout.toString().trim() : "";
+    if (/^[0-9a-f]{40}$/.test(sha)) return sha + "-local";
+  }
+  return "local";
 }
 
 /**

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -18,11 +18,10 @@ export const mimalloc: Dependency = {
   name: "mimalloc",
   versionMacro: "MIMALLOC",
 
-  source: () => ({
-    kind: "github-archive",
-    repo: "oven-sh/mimalloc",
-    commit: MIMALLOC_COMMIT,
-  }),
+  source: () =>
+    process.env.BUN_MIMALLOC_PATH
+      ? { kind: "local", path: process.env.BUN_MIMALLOC_PATH }
+      : { kind: "github-archive", repo: "oven-sh/mimalloc", commit: MIMALLOC_COMMIT },
 
   build: cfg => {
     // ─── Override behavior (global malloc replacement) ───

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "1803341d6241d8fa4b3f65fa68cb13a32ad92f04";
+const MIMALLOC_COMMIT = "1176b6aab514580cc8734420abfe0571dac6cca3";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1050,6 +1050,10 @@ impl WebWorker {
         // http2 session on this thread allocated.
         Bun__freeSharedHeaderBufferForThreadExit();
         drop(arena.take());
+        // Everything this thread allocated is now free; hand it back to the OS before the parent
+        // learns the worker exited, rather than leaving it to a delayed purge that only runs when
+        // some later allocation elsewhere happens to trigger one.
+        bun_alloc::mimalloc::mi_collect(true);
         log!(
             "[{}] shutdown: thread state freed",
             self.execution_context_id

--- a/test/js/node/test/parallel/test-worker-memory.js
+++ b/test/js/node/test/parallel/test-worker-memory.js
@@ -1,0 +1,51 @@
+'use strict';
+const common = require('../common');
+if (common.isIBMi)
+  common.skip('On IBMi, the rss memory always returns zero');
+
+const assert = require('assert');
+const util = require('util');
+const { Worker } = require('worker_threads');
+
+let numWorkers = +process.env.JOBS || require('os').availableParallelism();
+if (numWorkers > 20) {
+  // Cap the number of workers at 20 (as an even divisor of 60 used as
+  // the total number of workers started) otherwise the test fails on
+  // machines with high core counts.
+  numWorkers = 20;
+}
+
+// Verify that a Worker's memory isn't kept in memory after the thread finishes.
+
+function run(n, done) {
+  console.log(`run() called with n=${n} (numWorkers=${numWorkers})`);
+  if (n <= 0)
+    return done();
+  const worker = new Worker(
+    'require(\'worker_threads\').parentPort.postMessage(2 + 2)',
+    { eval: true });
+  worker.on('message', common.mustCall((value) => {
+    assert.strictEqual(value, 4);
+  }));
+  worker.on('exit', common.mustCall(() => {
+    run(n - 1, done);
+  }));
+}
+
+const startStats = process.memoryUsage();
+let finished = 0;
+for (let i = 0; i < numWorkers; ++i) {
+  run(60 / numWorkers, common.mustCall(() => {
+    console.log(`done() called (finished=${finished})`);
+    if (++finished === numWorkers) {
+      const finishStats = process.memoryUsage();
+      // A typical value for this ratio would be ~1.15.
+      // 5 as a upper limit is generous, but the main point is that we
+      // don't have the memory of 50 Isolates/Node.js environments just lying
+      // around somewhere.
+      assert.ok(finishStats.rss / startStats.rss < 5,
+                'Unexpected memory overhead: ' +
+                util.inspect([startStats, finishStats]));
+    }
+  }));
+}


### PR DESCRIPTION
### What

`process.memoryUsage().rss` on macOS stayed pinned at its peak after a burst of worker threads exited. 60 short-lived `worker_threads` Workers, 16 at a time, left a ~24 MB process reporting ~215 MB indefinitely (Node on the same machine: back to ~77 MB), and Node's `test-worker-memory.js` (`finish rss / start rss < 5`) failed on every darwin CI runner. Linux was unaffected.

### Why

Nothing was leaked — `phys_footprint` was back to ~27 MB while `rss` said 215 MB. Two things kept `resident_size` (the `task_info` field both Bun and libuv report as `rss`) high:

1. **mimalloc purged freed arena memory with `MADV_FREE_REUSABLE` only.** On macOS that moves the pages to the task's *reusable* ledger: the footprint drops at once, but they stay counted in `resident_size` until the kernel reclaims them under pressure (and a later read simply faults the old contents back in). Measured with a standalone probe on macOS 26/arm64: REUSABLE leaves resident unchanged; REUSABLE + `mprotect(PROT_NONE)`, `munmap`, or a `MAP_FIXED` remap drop it; `MADV_FREE`/`MADV_DONTNEED` move neither counter. Fixed in the fork — oven-sh/mimalloc#14 — and pinned here: purge additionally drops the protection so the pages leave the resident set immediately, the reservation is kept, and the range is re-protected on reuse.
2. **A worker's freed memory was only purged by a later, *delayed* purge** that runs when some other thread happens to allocate — an idle parent never triggered it, so even with (1) the memory was still resident at the moment the last worker's `exit` fired. A worker now collects on its own thread once everything it allocated is free, right before the parent is told it exited.

### Result (release, macOS arm64)

| | before | after |
|---|---|---|
| 60 workers, 16 wide: rss at last `exit` / after settle | 215 MB / 215 MB (ratio ~9) | **54 MB / 51 MB (ratio ~2.1)**; peak 215 → 132 MB |
| 60 workers sequential: rss after | 53 MB | 39 MB |
| worker spawn throughput (200 workers, 8 wide) | 562–596/s | 587–608/s (noise) |
| alloc/purge churn loop (30 × 128 MB) | 186–198 ms | 182–190 ms (noise) |

`test/js/node/test/parallel/test-worker-memory.js` is vendored again and passes at `JOBS=16` and `JOBS=20`.

Also adds `BUN_MIMALLOC_PATH` (like `BUN_WEBKIT_PATH`) to build against a local checkout of the mimalloc fork; a local source reports its checkout's git HEAD as its version so `process.versions.mimalloc` stays defined.

Depends on oven-sh/mimalloc#14 (the pin points at that PR's commit so CI here exercises it).
