### PR TITLE
test(napi): judge the experimental-finalizer wrapper on 'close', match markers on accumulated stderr

### DIFF
--- a/test/napi/napi-app/test_experimental_with_timeout.js
+++ b/test/napi/napi-app/test_experimental_with_timeout.js
@@ -36,15 +36,15 @@ proc.stdout.on('data', (data) => {
 proc.stderr.on('data', (data) => {
   stderr += data.toString();
   process.stderr.write(data);
-  
-  // Check if we've seen the expected crash messages
-  if (data.toString().includes('FATAL ERROR')) {
+
+  // Check the accumulated output: a marker can be split across two chunks.
+  if (stderr.includes('FATAL ERROR')) {
     sawFatalError = true;
   }
-  if (data.toString().includes('panic(main thread)')) {
+  if (stderr.includes('panic(main thread)')) {
     sawPanic = true;
   }
-  
+
   // If we've seen both messages, kill the process immediately
   // This avoids hanging on llvm-symbolizer
   if (sawFatalError && sawPanic) {
@@ -57,9 +57,11 @@ const timeout = setTimeout(() => {
   proc.kill('SIGKILL');
 }, 5000);
 
-proc.on('exit', (code, signal) => {
+// 'close', not 'exit': 'exit' can fire before the stdio pipes have been
+// drained, and the verdict below depends on everything the child wrote.
+proc.on('close', (code, signal) => {
   clearTimeout(timeout);
-  
+
   // Check if the test passed
   if (sawFatalError && sawPanic) {
     console.log('\n\nTEST PASSED: Process crashed as expected');

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1329,18 +1329,18 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
         bunProc.exited,
       ]);
 
-      // The wrapper script should exit with 0 if the test passed
-      expect(bunExitCode).toBe(0);
+      // Combined output first, so a failure shows what the wrapper and child wrote.
+      expect(bunStdout + "\n---- stderr ----\n" + bunStderr).toContain("TEST PASSED: Process crashed as expected");
       expect(bunStdout + bunStderr).toContain("Loading experimental module");
       expect(bunStdout + bunStderr).toContain("Created");
       expect(bunStderr).toContain("FATAL ERROR");
-      expect(bunStdout + bunStderr).toContain("TEST PASSED: Process crashed as expected");
 
       // The marker must NOT have actually been printed. Only check stdout: the
       // fixture prints the marker via console.log (stdout), while stderr contains
       // the debug-build panic report whose "Args:" line echoes the full -e script
       // source, including the literal "ERROR: Did not crash! Test failed!".
       expect(bunStdout).not.toContain("ERROR: Did not crash");
+      expect(bunExitCode).toBe(0);
     },
     25_000,
   );


### PR DESCRIPTION
### What does this PR do?

Fixes a low-rate flake in `test/napi/napi.test.ts › napi_reference_unref is blocked from finalizers in experimental modules` that is independent of the GC-side cause of that test's recent failures (that one is addressed by oven-sh/WebKit#398 and needs no test change).

`test_experimental_with_timeout.js` spawns a child that is expected to abort, and decides pass/fail from what the child printed. It did that in `proc.on('exit')` and looked for `FATAL ERROR` / `panic(main thread)` in each stderr *chunk*. `'exit'` may fire before the stdio pipes are drained, so on a busy host the wrapper sometimes judged before the tail of the crash report had arrived; and a marker split across two chunks was never matched. In both cases a child that crashed exactly as intended was reported as `TEST PASSED: Process terminated with code null signal SIGABRT` instead of `…crashed as expected`, and the outer assertion failed. Observed on darwin-x64 (build 90725): the captured stderr ended mid-report at `Args: "` with `FATAL ERROR` present and the panic line missing.

Changes: wait for `'close'` (stdio drained) instead of `'exit'`; test the accumulated stderr rather than the chunk; and in `napi.test.ts` assert on the captured stdout+stderr before the exit code so any future failure prints what the child wrote instead of `Expected: 0 Received: 1`.

### How did you verify your code works?

`bun bd test napi/napi.test.ts -t napi_reference_unref` → 2 pass. The race itself isn't reproducible on demand; the diagnosis is from the CI capture described above.