### PR TITLE
Bump WebKit to 447082ab6897: conservative scan accepts no past-the-end butterfly slack for non-butterfly cells (fixes napi.test.ts on darwin-x64)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "171babe26c3b330ac0263d1bed3550571908c838";
+export const WEBKIT_VERSION = "autobuild-preview-pr-398-6cb6d084";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-398-e501c5cb";
+export const WEBKIT_VERSION = "autobuild-preview-pr-398-9b999ae9";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-398-9b999ae9";
+export const WEBKIT_VERSION = "447082ab6897278727b44e1ba3c326ae6e1504c3";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-398-6cb6d084";
+export const WEBKIT_VERSION = "autobuild-preview-pr-398-e501c5cb";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### What does this PR do?

Bumps the WebKit pin to oven-sh/WebKit@447082ab6897, which is oven-sh/WebKit#398 merged onto the fork's main (the only other commit past the previous pin is oven-sh/WebKit#393, additive Temporal helpers).

**Why:** `test/napi/napi.test.ts › napi_reference_unref is blocked from finalizers in experimental modules` has failed on essentially every darwin-14-x64 run since #37075 (and once on debian-aarch64). Not flaky — deterministic for a given binary+env+argv, and #37075 didn't do anything wrong; it shifted startup allocations by one 16-byte slot.

Mechanism (from instrumented CI builds on #37214 — GC-debugging heap snapshot + in-binary probes with the child's argv/env byte-identical):
- The child does `arr = null; gc()` at top level of the `-e` entry script and expects the addon's three finalizable objects (held by a `JSArray`) to be finalized by that synchronous full GC. They survived it (and a second full GC right after), and only died once the entry script returned to the event loop.
- Snapshot: the array was live with no incoming edge and no root-reason entry → marked via the conservative-roots constraint. One registered thread; VM scratch/side-state roots empty; no register and no stack word equal to or inside the array.
- The single candidate: `stack[…] = arrayCell + 24`, sitting at `fp-0x20` of `CallableWrapper<Bun::commonJSModuleSyntheticSourceCode::$_0>::call` — the `push r12` in that function's prologue, i.e. `JSModuleLoader::makeModule`'s `r12` (the entry module's `SourceProvider*`, a live C++ object that happens to sit right after the array in memory) at the moment it invoked Bun's CommonJS entry generator. That frame lives for the whole entry script.
- The array is a 16-byte lower-tier `PreciseAllocation` (`addr ≡ 8 mod 16`), so `arrayCell + 24` is `end + 8`. `PreciseAllocation::contains()` accepts up to `end + sizeof(IndexingHeader)` so that a butterfly's end pointer still marks its storage — but it applied that slack to every cell kind, including a plain `JSArray` cell that can never be referenced that way. oven-sh/WebKit#398 keeps the slack for `Auxiliary`/`JSCellWithIndexingHeader` allocations and accepts only `[cell, end]` for the rest, and applies the same `mayHaveIndexingHeader(cellKind)` gate to the in‑MarkedBlock "previous cell" rule (matching the already-gated cross-block variant a few lines above it).

The test itself is unchanged. (The unrelated, low-rate wrapper race in the same test is #37227.)

### How did you verify your code works?

The diagnostics branch (#37214) forces `napi/napi.test.ts` 4× on every darwin-x64 shard and runs the byte-identical failing configuration with a pre-GC stack probe. Before: `NO-CRASH ×3` on cornbread/pretzel/matzo in every one of ~10 builds. Against this WebKit change (build 90812): cornbread and pretzel both `SIGABRT` at GC #1 in all 4 runs (finalizers ran, array collected), 0 `NO-CRASH` cells — while the probe shows the same `arrayCell + 24` word still on the stack in the same frame, so the only thing that changed is the scan rule. CI here builds bun against the new WebKit on all platforms; the previous run on the identical WebKit source (preview tag) was 195/196 with the one failure an unrelated `node-http2` test on darwin-aarch64.