### PR TITLE
Add 2 GiB string-limit test for typed-array Response bodies

### DIFF
--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -190,6 +190,43 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
     expect(exitCode).toBe(0);
   });
 
+  // A typed-array body is stored as an InternalBlob (bytes copied into a Vec),
+  // which converts to a string through Internal::to_string_owned rather than
+  // the Blob store path above, so it exercises a different guard call site.
+  test("Response(typedArray).text() and .json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const results = [];
+          const report = e => ({ name: e.name, code: e.code, message: e.message });
+          const bytes = new Uint8Array(2 ** 31);
+          await new Response(bytes).text().then(() => results.push("TEXT_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+          await new Response(bytes).json().then(() => results.push("JSON_UNEXPECTED_SUCCESS"), e => results.push(report(e)));
+          console.log(JSON.stringify(results));
+          `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([
+      {
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot create a string longer than 2147483647 characters",
+      },
+      {
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot parse a JSON string longer than 2147483647 characters",
+      },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   test("Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting", async () => {
     using dir = tempDir("blob-2gib", {});
     const file = path.join(String(dir), "big.txt");


### PR DESCRIPTION
### What

Adds one test to the gated \`byte sources at the 2 GiB string limit\` block in \`test/js/web/fetch/blob-oom.test.ts\`: \`new Response(new Uint8Array(2 ** 31)).text()\` and \`.json()\` must reject with \`ERR_STRING_TOO_LONG\` instead of aborting the process.

### Why

Fuzzing hit this abort on a build that predates #37215:

\`\`\`
ASSERTION FAILED: data.size() <= MaxLength
wtf/text/StringImpl.h(891) : WTF::StringImplShape::StringImplShape(uint32_t, std::span<const Latin1Character>, unsigned int)
\`\`\`

repro: \`new Response(new Uint8Array(3221225471)).text()\` (release builds die with a silent SIGABRT via the RELEASE_ASSERT).

Current main already handles this correctly, the guards added in #37215 cover it. But the tests added there only exercise \`new Blob([...])\` and \`Bun.file()\`. A typed-array body takes a different path: it is stored as an InternalBlob (\`Body.rs\` copies the bytes into a Vec) and converts through \`Internal::to_string_owned\`, whose ASCII fast path goes through the \`to_external_value\` guard rather than the \`external\` guard the Blob store path uses. A regression in that path would abort the process again without any test catching it.

### Verification

- Fails on a pre-#37215 build (subprocess aborts with the StringImpl assertion): \`USE_SYSTEM_BUN=1 bun test test/js/web/fetch/blob-oom.test.ts -t typedArray\` on 1.4.0-canary.1+9d519e8ca
- Passes with a debug+ASAN build of current main: \`bun bd test test/js/web/fetch/blob-oom.test.ts\` (19 pass, 0 fail)

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/blob-oom.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/blob-oom.test.ts
bun test v1.4.0 (8233e6976)

test/js/web/fetch/blob-oom.test.ts:
(pass) Memory > Blob > .json() should throw an OOM without crashing the process. [471.42ms]
(pass) Memory > Blob > .text() should throw an OOM without crashing the process. [436.77ms]
(pass) Memory > Blob > .bytes() should throw an OOM without crashing the process. [369.01ms]
(pass) Memory > Blob > .arrayBuffer() should NOT throw an OOM. [684.64ms]
(pass) Memory > Response > .text() should throw an OOM without crashing the process. [98.74ms]
(pass) Memory > Response > .bytes() should throw an OOM without crashing the process. [30.94ms]
(pass) Memory > Response > .arrayBuffer() should NOT throw an OOM. [339.82ms]
(pass) Memory > Response > .json() should throw an OOM without crashing the process. [31.13ms]
(pass) Memory > Request > .text() should throw an OOM without crashing the process. [165.29ms]
(pass) Memory > Request > .bytes() should throw an OOM without crashing the process. [38.51ms]
(pass) Memory > Request > .arrayBuffer() should NOT throw an OOM. [375.36ms]
(pass) Memory > Request > .json() should throw an OOM without crashing the process. [34.03ms]
(pass) Bun.file > text() should throw an OOM without crashing the process. [25.89ms]
(pass) Bun.file > bytes() should throw an OOM without crashing the process. [16.30ms]
(pass) Bun.file > json() should throw an OOM without crashing the process. [17.34ms]
(pass) Bun.file > arrayBuffer() should NOT throw an OOM. [15.57ms]
(pass) byte sources at the 2 GiB string limit > Blob.text() and Blob.json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting [1954.44ms]
(pass) byte sources at the 2 GiB string limit > Response(typedArray).text() and .json() at 2^31 bytes throw ERR_STRING_TOO_LONG instead of aborting [3415.24ms]
(pass) byte sources at the 2 GiB string limit > Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/fetch/blob-oom.test.ts | 37 +++++++++++++++++++++++++++++++++++++
 1 file changed, 37 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
test/js/web/fetch/blob-oom.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->