### PR TITLE
Check base64 output length before encoding and cover btoa, StringDecoder at the 2 GiB string limit

### DIFF
--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -444,9 +444,7 @@ fn encode_base64_to_bun_string(input: &[u8], url_safe: bool) -> BunString {
         bun_base64::encode_len(input)
     };
 
-    // An over-MaxLength output can never become a string; fail here instead of
-    // allocating and encoding `to_len` bytes first (the create_* constructors
-    // re-check, and callers surface Dead as ERR_STRING_TOO_LONG).
+    // Checked here so an over-MaxLength output fails before the allocate+encode, not after.
     if to_len > BunString::max_length() {
         return BunString::dead();
     }

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -444,6 +444,13 @@ fn encode_base64_to_bun_string(input: &[u8], url_safe: bool) -> BunString {
         bun_base64::encode_len(input)
     };
 
+    // An over-MaxLength output can never become a string; fail here instead of
+    // allocating and encoding `to_len` bytes first (the create_* constructors
+    // re-check, and callers surface Dead as ERR_STRING_TOO_LONG).
+    if to_len > BunString::max_length() {
+        return BunString::dead();
+    }
+
     if to_len < EXTERNAL_MIN_LEN {
         let (str, chars) = BunString::create_uninitialized_latin1(to_len);
         if str.is_dead() {

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, withoutAggressiveGC } from "harness";
+import os from "node:os";
 
 const RealStringDecoder = require("string_decoder").StringDecoder;
 
@@ -421,3 +422,47 @@ it(
   // Allocating a 2 GiB buffer under debug/ASAN is slow even when lazily committed.
   isDebug || isASAN ? 60_000 : undefined,
 );
+
+// Output lengths above WTF::StringImpl::MaxLength (2^31 - 1) used to trip a
+// RELEASE_ASSERT and abort the process instead of throwing. Runs in a
+// subprocess because of the multi-GiB peak; skips on small machines (same
+// gate as blob-oom.test.ts).
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("write() at the 2 GiB string limit", () => {
+  it(
+    "throws ERR_STRING_TOO_LONG for base64 and hex instead of aborting",
+    async () => {
+      const src = `
+        const { StringDecoder } = require("string_decoder");
+        const report = e => ({ name: e.name, code: e.code, message: e.message });
+        const results = [];
+        // 1610612736 = 3 * 2^29: base64 output is (len / 3) * 4 = 2147483648 = 2^31,
+        // hex output is len * 2 = 3221225472; both exceed 2^31 - 1.
+        const buf = Buffer.alloc(1610612736);
+        for (const encoding of ["base64", "hex"]) {
+          try {
+            results.push({ unexpectedLength: new StringDecoder(encoding).write(buf).length });
+          } catch (e) {
+            results.push(report(e));
+          }
+        }
+        console.log(JSON.stringify(results));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const tooLong = {
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot create a string longer than 2147483647 characters",
+      };
+      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual([tooLong, tooLong]);
+      expect(exitCode).toBe(0);
+    },
+    // Allocating multi-GiB buffers under debug/ASAN is slow.
+    isDebug || isASAN ? 60_000 : undefined,
+  );
+});

--- a/test/js/web/util/atob.test.js
+++ b/test/js/web/util/atob.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import os from "node:os";
 
 function expectInvalidCharacters(val) {
@@ -76,7 +76,7 @@ it("btoa", () => {
 // small machines (same gate as blob-oom.test.ts).
 describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("btoa at the 2 GiB string limit", () => {
   // Building and encoding multi-GiB strings is slow under debug/ASAN.
-  const timeout = 90_000;
+  const timeout = isDebug || isASAN ? 90_000 : undefined;
 
   it(
     "throws ERR_STRING_TOO_LONG when the output would exceed 2^31 - 1 characters",

--- a/test/js/web/util/atob.test.js
+++ b/test/js/web/util/atob.test.js
@@ -1,4 +1,6 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import os from "node:os";
 
 function expectInvalidCharacters(val) {
   expect(() => atob(val)).toThrow("The string contains invalid characters.");
@@ -66,4 +68,69 @@ it("btoa", () => {
   expect(btoa("🧐éé".substring("🧐".length))).toBe("6ek=");
   expect(btoa("\u0080\u0081")).toBe("gIE=");
   expect(btoa(Bun)).toBe(btoa("[object Bun]"));
+});
+
+// btoa output lengths above WTF::StringImpl::MaxLength (2^31 - 1) used to trip
+// a RELEASE_ASSERT and abort the process instead of throwing. These need real
+// multi-GiB peaks, so each case runs in a subprocess and the block skips on
+// small machines (same gate as blob-oom.test.ts).
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("btoa at the 2 GiB string limit", () => {
+  // Building and encoding multi-GiB strings is slow under debug/ASAN.
+  const timeout = 90_000;
+
+  it(
+    "throws ERR_STRING_TOO_LONG when the output would exceed 2^31 - 1 characters",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          // base64 output = ceil(1610612734 / 3) * 4 = 2147483648 = 2^31
+          const input = Buffer.alloc(1610612734, 0x61).toString();
+          try {
+            console.log(JSON.stringify({ unexpectedLength: btoa(input).length }));
+          } catch (e) {
+            console.log(JSON.stringify({ name: e.name, code: e.code, message: e.message }));
+          }
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual({
+        name: "Error",
+        code: "ERR_STRING_TOO_LONG",
+        message: "Cannot create a string longer than 2147483647 characters",
+      });
+      expect(exitCode).toBe(0);
+    },
+    timeout,
+  );
+
+  it(
+    "still encodes the largest input whose output fits",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          // base64 output = (1610612733 / 3) * 4 = 2147483644 <= 2^31 - 1
+          const input = Buffer.alloc(1610612733, 0x61).toString();
+          console.log(JSON.stringify({ length: btoa(input).length }));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual({ length: 2147483644 });
+      expect(exitCode).toBe(0);
+    },
+    timeout,
+  );
 });


### PR DESCRIPTION
### Problem

`btoa()` and `StringDecoder#write` with base64/hex used to abort the process (silent SIGABRT, ~4 GB RSS) when the encoded output reached 2^31 characters, while `Buffer#toString("base64")` on the same bytes threw `ERR_STRING_TOO_LONG` cleanly. Debug builds failed with:

```
ASSERTION FAILED: data.size() <= MaxLength
WTF/wtf/text/StringImpl.h(891) StringImplShape(uint32_t, span<const Latin1Character>)
```

Repro (rc 134 on 1.4.0 canary 5b98630ac, 3/3):

```js
import { StringDecoder } from "node:string_decoder";
btoa("a".repeat(1610612734));                           // output 2147483648 = 2^31
new StringDecoder("base64").write(Buffer.alloc(1610612736)); // same
Buffer.alloc(1610612736).toString("base64");            // control: ERR_STRING_TOO_LONG (ok)
```

### Cause

`functionBTOA` and `JSStringDecoder` call `Bun__encoding__toString` directly and skipped the output-size pre-checks that `JSBuffer.cpp`'s `toString` performs (`String::MaxLength`, hex x2, base64 4/3). The abort itself was fixed by #37215, which clamped `bun_core::String::max_length()` to `WTF::StringImpl::MaxLength`: the encoders now produce a Dead string that surfaces as `ERR_STRING_TOO_LONG`. Verified on current main that btoa and StringDecoder base64/hex/latin1/ascii/utf8 all throw instead of aborting. But none of these callers had test coverage, and the base64 encoder only discovered the overflow after allocating and encoding the full oversized output (2 GiB of doomed work on the btoa path).

### Fix

- `encode_base64_to_bun_string` checks the computed output length against `String::max_length()` before allocating, mirroring how the hex path fails fast in `create_uninitialized_latin1`. Same observable behavior (`ERR_STRING_TOO_LONG`), minus the 2 GiB allocate-encode-discard. With the check, the failing btoa case drops from ~7s to ~2s under a debug build.
- Tests for the callers #37215 did not cover, following the existing `blob-oom.test.ts` subprocess pattern (gated on `os.totalmem() >= 10 GiB`):
  - `test/js/web/util/atob.test.js`: btoa with output 2^31 throws `ERR_STRING_TOO_LONG`; the largest input whose output fits (2147483644 chars) still encodes.
  - `test/js/node/string_decoder/string-decoder.test.js`: `write()` with base64 and hex output over 2^31 - 1 throws `ERR_STRING_TOO_LONG`. This complements the existing test for oversized utf8 input: here the input buffers are well under the limit and only the encoded output crosses it.

### Verification

- Both new too-long tests fail against a pre-#37215 build (subprocess aborts) and pass with this branch.
- `bun bd test test/js/web/util/atob.test.js` and `bun bd test test/js/node/string_decoder/string-decoder.test.js`: all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/string_decoder/string-decoder.test.js test/js/web/util/atob.test.js
bun test v1.4.0 (5b738423f)

test/js/web/util/atob.test.js:
(pass) atob [31.80ms]
(pass) btoa [8.99ms]
(pass) btoa at the 2 GiB string limit > throws ERR_STRING_TOO_LONG when the output would exceed 2^31 - 1 characters [7359.35ms]
(pass) btoa at the 2 GiB string limit > still encodes the largest input whose output fits [7351.22ms]

test/js/node/string_decoder/string-decoder.test.js:
(pass) require('string_decoder') [4.93ms]
(pass) Bun.inspect(StringDecoder) [3.96ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8 [336.37ms]
(pass) FakeStringDecoderCall > StringDecoder-ucs-2 [240.07ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le [4.60ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8-additional [8.24ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le-additional [6.89ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64 testbuf [24.96ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64url testbuf [17.59ms]
(pass) FakeStrin
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (9d519e8ca)

test/js/web/util/atob.test.js:
(pass) atob [0.34ms]
(pass) btoa [0.10ms]
 98 |         env: bunEnv,
 99 |         stdout: "pipe",
100 |         stderr: "pipe",
101 |       });
102 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
103 |       expect(JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode }))).toEqual({
                                                                                              ^
error: expect(received).toEqual(expected)

  {
-   "code": "ERR_STRING_TOO_LONG",
-   "message": "Cannot create a string longer than 2147483647 characters",
-   "name": "Error",
+   "exitCode": 134,
+   "stderr": 
+ "============================================================
+ Bun Canary v1.4.0-canary.1 (9d519e8ca) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "-e" "\n          // base64 output = ceil(1610612734 / 3) * 4 = 2147483648 = 2^31\n          const input = Buffer.alloc(1610612734, 0x61).toString();\n          try {\n    "...
+ Features: bunfig jsc tsco
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/string_decoder/string-decoder.test.js test/js/web/util/atob.test.js
bun test v1.4.0 (5b738423f)

test/js/web/util/atob.test.js:
(pass) atob [31.92ms]
(pass) btoa [8.90ms]
(pass) btoa at the 2 GiB string limit > throws ERR_STRING_TOO_LONG when the output would exceed 2^31 - 1 characters [2409.04ms]
(pass) btoa at the 2 GiB string limit > still encodes the largest input whose output fits [7315.48ms]

test/js/node/string_decoder/string-decoder.test.js:
(pass) require('string_decoder') [4.77ms]
(pass) Bun.inspect(StringDecoder) [3.88ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8 [331.18ms]
(pass) FakeStringDecoderCall > StringDecoder-ucs-2 [240.35ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le [4.76ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8-additional [8.57ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le-additional [6.70ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64 testbuf [24.94ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64url testbuf [16.67ms]
(pass) FakeStrin
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 706ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/encoding.rs                    |  5 ++
 test/js/node/string_decoder/string-decoder.test.js | 45 ++++++++++++++
 test/js/web/util/atob.test.js                      | 69 +++++++++++++++++++++-
 3 files changed, 118 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/webcore/encoding.rs                         2      3      0
test/js/node/string_decoder/string-decoder.test.js      1      2      0
test/js/web/util/atob.test.js                           1      3      0
```

</details>

<!-- robobun:evidence:end -->