### PR TITLE
Blob file reads: a read its worker never completes releases its completion (funnel test LSan leak)

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -464,14 +464,12 @@ impl BlobExt for Blob {
 
             read_file::ReadFileUV::start::<Handler<'_, F>>(
                 // `bun_vm()` returns the live VM for this global; the event
-                // loop outlives any in-flight async fs request. `start<H>`
-                // takes the already-erased `*anyopaque` (caller casts); `H`
-                // (turbofish) supplies `Handler::run` for the callback.
+                // loop outlives any in-flight async fs request.
                 global.bun_vm().event_loop(),
                 self.store().expect("infallible: store present").clone(),
                 self.offset.get(),
                 self.size.get(),
-                handler.cast(),
+                handler,
             );
             return promise_value;
         }
@@ -482,7 +480,6 @@ impl BlobExt for Blob {
                 self.store().expect("infallible: store present").clone(),
                 self.offset.get(),
                 self.size.get(),
-                handler,
             )
             .unwrap_or_else(|e| bun_core::handle_oom(Err(e)));
             // Create the Promise only after the store has been ref()'d.
@@ -492,7 +489,11 @@ impl BlobExt for Blob {
             let promise_value = unsafe { (*handler).promise.value() };
             promise_value.ensure_still_alive();
 
-            read_file::ReadFile::schedule(file_read, global);
+            read_file::ReadFile::schedule(
+                file_read,
+                read_file::ReadFileCompletionFns::of(handler),
+                global,
+            );
 
             debug!("doReadFile: read_file_task scheduled");
             promise_value
@@ -535,6 +536,20 @@ impl BlobExt for Blob {
                     // SAFETY: `c` is the `*mut H` passed by the caller and kept alive
                     // across the async read by contract; exclusive borrow scoped to the call.
                     H::on_read_bytes(unsafe { &mut *c }, result);
+                }
+                fn cancel(c: *mut H) {
+                    // The caller owns `H` and waits for exactly one `on_read_bytes`.
+                    let err = jsc::SystemError {
+                        code: BunString::static_("ECANCELED").into(),
+                        message: BunString::static_(
+                            "The file read did not complete before its thread stopped",
+                        )
+                        .into(),
+                        syscall: BunString::static_("read").into(),
+                        ..Default::default()
+                    };
+                    // SAFETY: as for `call`.
+                    H::on_read_bytes(unsafe { &mut *c }, ReadBytesResult::Err(Box::new(err)));
                 }
             }
             self.do_read_file_internal::<H, Adapter<H>>(ctx, global);
@@ -674,21 +689,22 @@ impl BlobExt for Blob {
                 self.store().expect("infallible: store present").clone(),
                 self.offset.get(),
                 self.size.get(),
-                NewInternalReadFileHandler::<C, F>::run,
-                ctx.cast::<c_void>(),
+                NewInternalReadFileHandler::<C, F>::completion(ctx),
             );
         }
         #[cfg(not(windows))]
         {
-            let file_read = read_file::ReadFile::create_with_ctx(
+            let file_read = read_file::ReadFile::create(
                 self.store().expect("infallible: store present").clone(),
-                ctx.cast::<c_void>(),
-                NewInternalReadFileHandler::<C, F>::run,
                 self.offset.get(),
                 self.size.get(),
             )
             .unwrap_or_else(|e| bun_core::handle_oom(Err(e)));
-            read_file::ReadFile::schedule(file_read, global);
+            read_file::ReadFile::schedule(
+                file_read,
+                NewInternalReadFileHandler::<C, F>::completion(ctx),
+                global,
+            );
         }
     }
     fn get_content_type(&self) -> Option<ZigStringSlice> {
@@ -3809,6 +3825,8 @@ pub(crate) enum FormDataEntry<'a> {
 /// plain `fn(*mut c_void, ReadFileResultType)` thunk, monomorphized per `(C, F)`.
 pub trait InternalReadFileFn<C> {
     fn call(ctx: *mut C, bytes: read_file::ReadFileResultType);
+    /// The read will never complete (its VM stopped first): do with `ctx` what its owner needs.
+    fn cancel(ctx: *mut C);
 }
 
 pub(crate) struct NewInternalReadFileHandler<C, F>(core::marker::PhantomData<(C, F)>);
@@ -3817,12 +3835,22 @@ impl<C, F> NewInternalReadFileHandler<C, F>
 where
     F: InternalReadFileFn<C>,
 {
-    /// Type-erased thunk: `handler` is the `*mut C` ctx that was passed into
-    /// `ReadFile`/`ReadFileUV` cast to `*mut c_void`.
-    pub(crate) fn run(handler: *mut c_void, bytes: read_file::ReadFileResultType) {
-        // SAFETY: every call site passes a `*mut C` round-tripped
-        // through `*mut c_void`; this is the inverse pointer cast.
-        F::call(handler.cast::<C>(), bytes);
+    /// The erased `(ctx, run, cancel)` a `ReadFile`/`ReadFileUV` carries for this handler.
+    pub(crate) fn completion(ctx: *mut C) -> read_file::ReadFileCompletionFns {
+        fn run<C, F: InternalReadFileFn<C>>(
+            ctx: *mut c_void,
+            bytes: read_file::ReadFileResultType,
+        ) {
+            F::call(ctx.cast::<C>(), bytes);
+        }
+        fn cancel<C, F: InternalReadFileFn<C>>(ctx: *mut c_void) {
+            F::cancel(ctx.cast::<C>());
+        }
+        read_file::ReadFileCompletionFns {
+            ctx: ctx.cast::<c_void>(),
+            run: run::<C, F>,
+            cancel: cancel::<C, F>,
+        }
     }
 }
 

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -78,10 +78,9 @@ impl<'a, F: ReadFileToJs> NewReadFileHandler<'a, F> {
     }
 }
 
-/// Completion callback for a file read. Monomorphized per
-/// call-site type so the erased shim calls `C::run` directly and
-/// `on_complete_ctx` carries the **raw** `*mut C` — no heap wrapper, so any
-/// code introspecting `on_complete_ctx` sees the original context pointer.
+/// A typed receiver for a file read's bytes. [`ReadFileCompletionFns::of`] erases it to the
+/// `(ctx, run, cancel)` a `ReadFile` job carries as its JS side (or a `ReadFileUV` as a field): the
+/// shims call `C::run` / `C::cancel` directly and `ctx` is the raw `*mut C`, no extra heap wrapper.
 pub trait ReadFileCompletion {
     /// # Safety
     /// `ctx` must be a heap-allocated `Self` whose ownership is transferred to

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -87,6 +87,14 @@ pub trait ReadFileCompletion {
     /// `ctx` must be a heap-allocated `Self` whose ownership is transferred to
     /// this call (it is reclaimed via `bun_core::heap::take`).
     unsafe fn run(ctx: *mut Self, bytes: ReadFileResultType) -> jsc::JsTerminatedResult<()>;
+    /// The read will never complete (its VM stopped before it did): release `ctx`.
+    ///
+    /// # Safety
+    /// Same ownership transfer as `run`; exactly one of the two is called.
+    unsafe fn cancel(ctx: *mut Self) {
+        // SAFETY: per the trait contract `ctx` is the heap-allocated `Self` we now own.
+        drop(unsafe { bun_core::heap::take(ctx) });
+    }
 }
 
 impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
@@ -134,6 +142,52 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
 // ──────────────────────────────────────────────────────────────────────────
 
 type ReadFileOnReadFileCallback = fn(ctx: *mut c_void, bytes: ReadFileResultType);
+/// The read never completed; do with `ctx` what its owner needs (free it, or tell it).
+type ReadFileOnCancelCallback = fn(ctx: *mut c_void);
+
+/// What a `ReadFile`/`ReadFileUV` does with the bytes (or the lack of them): `run` on completion,
+/// `cancel` if it is dropped before completing. Exactly one of the two is invoked, once, on the JS
+/// thread — the ctx typically owns a promise and a Blob, so this is the job's JS side.
+pub struct ReadFileCompletionFns {
+    pub(crate) ctx: *mut c_void,
+    pub(crate) run: ReadFileOnReadFileCallback,
+    pub(crate) cancel: ReadFileOnCancelCallback,
+}
+
+impl ReadFileCompletionFns {
+    /// Erase a typed `ReadFileCompletion`.
+    pub(crate) fn of<C: ReadFileCompletion>(ctx: *mut C) -> Self {
+        fn run<C: ReadFileCompletion>(ctx: *mut c_void, bytes: ReadFileResultType) {
+            // The JsTerminated error is intentionally swallowed: the VM is stopping.
+            // SAFETY: `ctx` is the `*mut C` erased below; ownership transfers per the trait.
+            let _ = unsafe { C::run(ctx.cast::<C>(), bytes) };
+        }
+        fn cancel<C: ReadFileCompletion>(ctx: *mut c_void) {
+            // SAFETY: as for `run`.
+            unsafe { C::cancel(ctx.cast::<C>()) }
+        }
+        Self {
+            ctx: ctx.cast::<c_void>(),
+            run: run::<C>,
+            cancel: cancel::<C>,
+        }
+    }
+
+    fn complete(self, bytes: ReadFileResultType) {
+        let this = core::mem::ManuallyDrop::new(self);
+        (this.run)(this.ctx, bytes)
+    }
+}
+
+impl Drop for ReadFileCompletionFns {
+    fn drop(&mut self) {
+        (self.cancel)(self.ctx)
+    }
+}
+
+// SAFETY: the ctx holds JS-thread state (promise, Blob); it is only ever completed or cancelled on
+// the JS thread — as a Job's `Js` side, or inside the JS-thread-only ReadFileUV.
+unsafe impl bun_jsc::job::JsAffine for ReadFileCompletionFns {}
 
 pub struct ReadFileRead {
     /// Always a `Box::<[u8]>::into_raw` from the producer's read buffer
@@ -160,15 +214,16 @@ pub enum ReadFileResultType {
 /// The completion token a `ReadFile` keeps across its async I/O.
 pub type ReadFileTask = bun_jsc::Completion<ReadFile>;
 
-// SAFETY: file store / byte store / blob store ref (atomic), the read buffer,
-// io-loop registration state, and an opaque completion ctx that only the
-// JS-thread completion dereferences — nothing used off-thread is thread-affine.
+// SAFETY: file store / byte store / blob store ref (atomic), the read buffer and io-loop
+// registration state — nothing thread-affine. What the bytes are delivered to lives in the job's
+// JS side (`ReadFileCompletionFns`), never here.
 unsafe impl Send for ReadFile {}
 
 impl bun_jsc::JobContext for ReadFile {
     type OffThread = Self;
-    /// The completion is delivered through `on_complete_callback(ctx, ..)`.
-    type Js = ();
+    /// Where the bytes go: completed by `then`, or cancelled when the VM releases the JS sides of
+    /// its live jobs at teardown (a refused or unrun read then frees only this off-thread part).
+    type Js = ReadFileCompletionFns;
     fn run(
         this: &mut Self,
         _vm: &bun_jsc::vm_handle::Borrow,
@@ -178,16 +233,25 @@ impl bun_jsc::JobContext for ReadFile {
         this.run(done);
         None
     }
-    fn then(this: Self, _: (), cx: &bun_jsc::JsThread<'_>) -> jsc::JsResult<()> {
-        Ok(ReadFile::then(this, cx.global())?)
+    fn then(
+        this: Self,
+        completion: ReadFileCompletionFns,
+        cx: &bun_jsc::JsThread<'_>,
+    ) -> jsc::JsResult<()> {
+        Ok(ReadFile::then(this, completion, cx.global())?)
     }
 }
 
+#[cfg(not(windows))]
 impl ReadFile {
-    /// JS thread: hand a prepared `ReadFile` to the work pool (the job is
-    /// its one heap allocation).
-    pub fn schedule(this: ReadFile, global: &JSGlobalObject) {
-        bun_jsc::Job::<ReadFile>::schedule(&global.js_thread(), this, ());
+    /// JS thread: hand a prepared `ReadFile` and what to do with its bytes to the work pool (the
+    /// job is its one heap allocation).
+    pub(crate) fn schedule(
+        this: ReadFile,
+        completion: ReadFileCompletionFns,
+        global: &JSGlobalObject,
+    ) {
+        bun_jsc::Job::<ReadFile>::schedule(&global.js_thread(), this, completion);
     }
 }
 
@@ -216,8 +280,6 @@ pub struct ReadFile {
     pub task: WorkPoolTask,
     pub(crate) system_error: Option<SystemError>,
     pub(crate) errno: Option<Error>,
-    pub(crate) on_complete_ctx: *mut c_void,
-    pub(crate) on_complete_callback: ReadFileOnReadFileCallback,
     #[cfg(not(windows))]
     pub(crate) io_task: Option<ReadFileTask>,
     pub(crate) io_poll: io::Poll,
@@ -356,10 +418,8 @@ impl ReadFile {
 
     // Not for Windows; Windows callers use ReadFileUV.
     #[cfg(not(windows))]
-    pub(crate) fn create_with_ctx(
+    pub(crate) fn create(
         store: StoreRef,
-        on_read_file_context: *mut c_void,
-        on_complete_callback: ReadFileOnReadFileCallback,
         off: SizeType,
         max_len: SizeType,
     ) -> Result<ReadFile, Error> {
@@ -383,8 +443,6 @@ impl ReadFile {
             },
             system_error: None,
             errno: None,
-            on_complete_ctx: on_read_file_context,
-            on_complete_callback,
             io_task: None,
             io_poll: io::Poll::default(),
             io_request: io::Request {
@@ -397,33 +455,6 @@ impl ReadFile {
             state: AtomicU8::new(ClosingState::Running as u8),
         };
         Ok(read_file)
-    }
-
-    #[cfg(not(windows))]
-    pub(crate) fn create<C: ReadFileCompletion>(
-        store: StoreRef,
-        off: SizeType,
-        max_len: SizeType,
-        context: *mut C,
-    ) -> Result<ReadFile, Error> {
-        // `ReadFileCompletion`
-        // monomorphizes per `C`, so `handler_run::<C>` calls `C::run` directly
-        // and `on_complete_ctx` is the unwrapped `*mut C` — no extra heap box,
-        // nothing to leak on the `Err` path.
-        fn handler_run<C: ReadFileCompletion>(ctx: *mut c_void, bytes: ReadFileResultType) {
-            // The JsTerminated error is intentionally swallowed.
-            // TODO: propagate the exception.
-            // SAFETY: `ctx` is the `*mut C` passed unmodified through
-            // `on_complete_ctx`; ownership transfers per `ReadFileCompletion::run`.
-            let _ = unsafe { C::run(ctx.cast::<C>(), bytes) };
-        }
-        ReadFile::create_with_ctx(
-            store,
-            context.cast::<c_void>(),
-            handler_run::<C>,
-            off,
-            max_len,
-        )
     }
 
     #[cfg(not(windows))]
@@ -592,35 +623,32 @@ impl ReadFile {
         true
     }
 
-    pub(crate) fn then(this: Self, _: &JSGlobalObject) -> jsc::JsTerminatedResult<()> {
-        let cb = this.on_complete_callback;
-        let cb_ctx = this.on_complete_ctx;
+    pub(crate) fn then(
+        this: Self,
+        completion: ReadFileCompletionFns,
+        _: &JSGlobalObject,
+    ) -> jsc::JsTerminatedResult<()> {
+        let mut this = this;
 
         if this.store.is_none() && this.system_error.is_some() {
-            let mut this = this;
             let system_error = this.system_error.take().unwrap();
             drop(this);
-            cb(cb_ctx, ReadFileResultType::Err(system_error));
+            completion.complete(ReadFileResultType::Err(system_error));
             return Ok(());
         } else if this.store.is_none() {
             drop(this);
             if cfg!(debug_assertions) {
                 panic!("assertion failure - store should not be null");
             }
-            cb(
-                cb_ctx,
-                ReadFileResultType::Err(SystemError {
-                    code: BunString::static_("INTERNAL_ERROR").into(),
-                    message: BunString::static_("assertion failure - store should not be null")
-                        .into(),
-                    syscall: BunString::static_("read").into(),
-                    ..Default::default()
-                }),
-            );
+            completion.complete(ReadFileResultType::Err(SystemError {
+                code: BunString::static_("INTERNAL_ERROR").into(),
+                message: BunString::static_("assertion failure - store should not be null").into(),
+                syscall: BunString::static_("read").into(),
+                ..Default::default()
+            }));
             return Ok(());
         }
 
-        let mut this = this;
         let _store = this.store.take().unwrap();
         // reshaped for borrowck — take buffer out so it survives `drop(this)`.
         let buf = core::mem::take(&mut this.buffer);
@@ -630,18 +658,15 @@ impl ReadFile {
         drop(this);
 
         if let Some(err) = system_error {
-            cb(cb_ctx, ReadFileResultType::Err(err));
+            completion.complete(ReadFileResultType::Err(err));
             return Ok(());
         }
 
         // The receiver takes ownership. Normalize to `Box<[u8]>` so every
         // consumer can reclaim via `heap::take` with a matching layout.
-        cb(
-            cb_ctx,
-            ReadFileResultType::Result(ReadFileRead {
-                buf: bun_core::heap::into_raw(buf.into_boxed_slice()),
-            }),
-        );
+        completion.complete(ReadFileResultType::Result(ReadFileRead {
+            buf: bun_core::heap::into_raw(buf.into_boxed_slice()),
+        }));
         Ok(())
     }
 
@@ -964,8 +989,8 @@ pub struct ReadFileUV<'a> {
     pub(crate) buffer: Vec<u8>,
     pub(crate) system_error: Option<SystemError>,
     pub(crate) errno: Option<Error>,
-    pub(crate) on_complete_data: *mut c_void,
-    pub(crate) on_complete_fn: ReadFileOnReadFileCallback,
+    /// `Some` until the read completes; a `ReadFileUV` dropped before that cancels it.
+    pub(crate) completion: Option<ReadFileCompletionFns>,
     pub(crate) is_regular_file: bool,
 
     pub(crate) req: libuv::fs_t,
@@ -1047,47 +1072,22 @@ impl<'a> FileCloser for ReadFileUV<'a> {
     }
 }
 
-/// Handler for `ReadFileUV.start`: the
-/// implementor supplies the already-erased thunk.
-#[cfg(windows)]
-pub(crate) trait ReadFileUvHandler {
-    fn run(ctx: *mut c_void, bytes: ReadFileResultType);
-}
-
-/// Any `ReadFileCompletion` is usable as a `ReadFileUV` handler — the libuv
-/// path stores the same `(ctx, run)` pair, just without the JSTerminated
-/// return (the UV path's run thunk is `void`-returning by contract).
-#[cfg(windows)]
-impl<C: ReadFileCompletion> ReadFileUvHandler for C {
-    fn run(ctx: *mut c_void, bytes: ReadFileResultType) {
-        // SAFETY: `ctx` is the `*mut C` passed unmodified through
-        // `on_complete_data`; ownership transfers per `ReadFileCompletion::run`.
-        let _ = unsafe { <C as ReadFileCompletion>::run(ctx.cast::<C>(), bytes) };
-    }
-}
-
 #[cfg(windows)]
 impl<'a> ReadFileUV<'a> {
-    /// Typed entry: caller passes the already-erased
-    /// context pointer; `H` (via turbofish) supplies the run thunk through the
-    /// `ReadFileUvHandler` blanket impl.
-    pub(crate) fn start<H>(
+    /// Typed entry: `C` supplies run/cancel for the erased completion.
+    pub(crate) fn start<C: ReadFileCompletion>(
         event_loop: *mut EventLoop,
         store: StoreRef,
         off: SizeType,
         max_len: SizeType,
-        handler: *mut c_void,
-    ) where
-        H: ReadFileUvHandler,
-    {
+        handler: *mut C,
+    ) {
         Self::start_with_ctx(
             event_loop,
             store,
             off,
             max_len,
-            // Erase the typed handler to the C ABI cb.
-            H::run as ReadFileOnReadFileCallback,
-            handler,
+            ReadFileCompletionFns::of(handler),
         )
     }
 
@@ -1098,8 +1098,7 @@ impl<'a> ReadFileUV<'a> {
         store: StoreRef,
         off: SizeType,
         max_len: SizeType,
-        on_complete_fn: ReadFileOnReadFileCallback,
-        handler: *mut c_void,
+        completion: ReadFileCompletionFns,
     ) {
         log!("ReadFileUV.start");
         // SAFETY: `event_loop` is the per-thread `EventLoop` singleton owned by
@@ -1126,8 +1125,7 @@ impl<'a> ReadFileUV<'a> {
             buffer: Vec::new(),
             system_error: None,
             errno: None,
-            on_complete_data: handler,
-            on_complete_fn,
+            completion: Some(completion),
             is_regular_file: false,
             req: bun_core::ffi::zeroed(),
             open_callback: Self::on_file_open,
@@ -1147,8 +1145,10 @@ impl<'a> ReadFileUV<'a> {
         let mut this_box = unsafe { bun_core::heap::take(this) };
         let event_loop = this_box.event_loop;
 
-        let cb = this_box.on_complete_fn;
-        let cb_ctx = this_box.on_complete_data;
+        let completion = this_box
+            .completion
+            .take()
+            .expect("a ReadFileUV completes once");
 
         let result = if let Some(err) = this_box.system_error.take() {
             ReadFileResultType::Err(err)
@@ -1164,9 +1164,9 @@ impl<'a> ReadFileUV<'a> {
             })
         };
 
-        // cb() must run BEFORE the cleanup below (store deref / req.deinit /
-        // box drop / event_loop.unref) — cb may inspect store.
-        cb(cb_ctx, result);
+        // The completion must run BEFORE the cleanup below (store deref / req.deinit /
+        // box drop / event_loop.unref) — it may inspect store.
+        completion.complete(result);
 
         // store.deref runs via StoreRef's Drop when the Box drops.
         this_box.req.deinit();


### PR DESCRIPTION
### What

The x64-asan lane flagged `worker-terminate-funnels.test.ts` (`fs` family) as flaky. It isn't flaky — LSan caught a real leak the test exists to surface:

```
Direct leak of 392 byte(s) ... in Blob::do_read_file (NewReadFileHandler<ToStringWithBytesFn>)
Indirect leak of 320 byte(s) ...
```

`Bun.file(..).text()` (and every file-backed Blob read) boxed a completion handler holding the promise and a duped Blob, and handed `ReadFile` the erased `(ctx, run)` pair inside its **off-thread** payload, with `type Js = ()`. Only `run` — the completed-read path — reclaimed that box. A read whose worker stopped first (refused when the pool tried to complete it, or still queued when the loop stopped) freed the `ReadFile` and forgot the handler.

### Fix

The completion is JS-thread state, so on POSIX it is now the job's `Js` side — `ReadFileCompletionFns` (`ctx` + `run` + `cancel`, `JsAffine`, cancels on `Drop`):

- `then` completes it;
- at teardown the VM's job list releases it **on its own thread** (cancel → the handler and its promise/Blob are dropped where they may be);
- a refused read frees only the off-thread `ReadFile`.

That is the partition the `Job` machinery already enforces — no per-read "VM gone" code, nothing JS-affine reachable from the pool. `ReadFileUV` (Windows, JS thread throughout) keeps the same triple as a field and cancels it if dropped unfinished. `read_bytes_to_handler`'s *borrowed* context is told (`ECANCELED`) rather than freed, since its caller owns it and waits for exactly one callback.

### Verification

- `worker-refused-completion.test.ts` 15/15 — its `Bun.file().text()` row is what caught my first attempt (cancelling in place dropped a `Strong` off the JS thread; the debug assert fired), and passes with the JS-side design.
- `worker-terminate-funnels.test.ts` 10/10, `blob.test.ts` 46/46, `bun-file.test.ts`, `bun-write.test.js` 47/47; `rust:check-all` 10/10.
- The leak itself is only observable under LSan; the x64-asan lane's funnel `fs` row is the before/after signal.

`WriteFile` has the same `(ctx, run)` / `type Js = ()` shape and very likely the same latent leak on a stopped worker; not touched here (nothing has flagged it yet) — happy to follow up with the same treatment.
