### PR TITLE
Throw instead of aborting when stream text() consumers accumulate more than 2^31-1 bytes

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -327,9 +327,8 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
         RETURN_IF_EXCEPTION(scope, false);
         if (size_t byteLength = utf8ByteLengthWithReplacement(string)) {
             size_t oldSize = bytes.size();
-            // tryGrow/tryAppend: UTF-8 expansion can push the total past the estimate that
-            // sized the vector, and growing past the Vector capacity limit must surface as
-            // a catchable out-of-memory error, not a CRASH() in allocateBuffer.
+            // UTF-8 expansion can overshoot the reserve, and Vector CRASH()es past
+            // INT32_MAX capacity; the try-variants keep both catchable.
             if (!bytes.tryGrow(oldSize + byteLength)) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return false;
@@ -721,11 +720,8 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
             return rope.substring(1);
         return rope;
     }
-    // The UTF-8 re-encode below only grows the estimate (binary bytes are exact, string
-    // chunks count UTF-16 code units), so an estimate past the string limit is final.
-    // Throw before touching the Vector: its capacity CRASH()es past INT32_MAX, so an
-    // estimate in [2^31, 2^32) would abort in reserveInitialCapacity before the
-    // exceedsStringLimit() throw below is ever reached.
+    // estimatedLength only undercounts the result (binary sizes are exact, strings count
+    // UTF-16 units), so over the limit is final; Vector CRASH()es past INT32_MAX capacity.
     const double estimatedLength = accumulator.estimatedLength;
     if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
         || exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -283,6 +283,23 @@ static size_t writeUTF8(const WTF::String& string, std::span<uint8_t> destinatio
     return Bun__encoding__writeUTF16(string.span16().data(), string.span16().size(), destination.data(), destination.size(), utf8);
 }
 
+bool appendUTF8WithinStringLimit(const WTF::String& string, WTF::Vector<uint8_t>& bytes)
+{
+    size_t byteLength = utf8ByteLengthWithReplacement(string);
+    if (!byteLength)
+        return true;
+    size_t oldSize = bytes.size();
+    // UTF-8 expansion can exceed any reserve taken from the code-unit estimate.
+    if (exceedsStringLimit(oldSize + byteLength) || !bytes.tryGrow(oldSize + byteLength)) [[unlikely]]
+        return false;
+    size_t written = writeUTF8(string, bytes.mutableSpan().subspan(oldSize));
+    // The sizer and writer must agree; never expose ungrown (uninitialized) bytes.
+    ASSERT(written == byteLength);
+    if (written < byteLength) [[unlikely]]
+        bytes.shrink(oldSize + written);
+    return true;
+}
+
 // `obj[name](...args)` with `this` = obj.
 static JSValue invokeMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* object, const Identifier& name, const MarkedArgumentBuffer& args)
 {
@@ -325,18 +342,9 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
     if (chunk.isString()) {
         WTF::String string = asString(chunk)->value(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
-        if (size_t byteLength = utf8ByteLengthWithReplacement(string)) {
-            size_t oldSize = bytes.size();
-            // UTF-8 expansion can exceed the reserved estimate.
-            if (!bytes.tryGrow(oldSize + byteLength)) [[unlikely]] {
-                throwOutOfMemoryError(globalObject, scope);
-                return false;
-            }
-            size_t written = writeUTF8(string, bytes.mutableSpan().subspan(oldSize));
-            // The sizer and writer must agree; never expose ungrown (uninitialized) bytes.
-            ASSERT(written == byteLength);
-            if (written < byteLength) [[unlikely]]
-                bytes.shrink(oldSize + written);
+        if (!appendUTF8WithinStringLimit(string, bytes)) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return false;
         }
         return true;
     }
@@ -747,8 +755,7 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
         WTF::String rope = accumulator.rope.toString();
         if (rope[0] == 0xFEFF)
             rope = rope.substring(1);
-        WTF::CString utf8 = rope.utf8();
-        if (!bytes.tryAppend(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() })) [[unlikely]] {
+        if (!appendUTF8WithinStringLimit(rope, bytes)) [[unlikely]] {
             releaseAccumulated();
             throwOutOfMemoryError(globalObject, scope);
             return WTF::String();

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -327,8 +327,7 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
         RETURN_IF_EXCEPTION(scope, false);
         if (size_t byteLength = utf8ByteLengthWithReplacement(string)) {
             size_t oldSize = bytes.size();
-            // UTF-8 expansion can overshoot the reserve, and Vector CRASH()es past
-            // INT32_MAX capacity; the try-variants keep both catchable.
+            // UTF-8 expansion can exceed the reserved estimate.
             if (!bytes.tryGrow(oldSize + byteLength)) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 return false;
@@ -720,8 +719,7 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
             return rope.substring(1);
         return rope;
     }
-    // estimatedLength only undercounts the result (binary sizes are exact, strings count
-    // UTF-16 units), so over the limit is final; Vector CRASH()es past INT32_MAX capacity.
+    // estimatedLength never overcounts the bytes, so an estimate past the limit is final.
     const double estimatedLength = accumulator.estimatedLength;
     if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
         || exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -738,9 +738,10 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
         if (!value)
             continue;
         bool appended = appendChunkBytes(vm, globalObject, value, bytes);
-        RETURN_IF_EXCEPTION(scope, WTF::String());
-        if (!appended)
+        if (scope.exception() || !appended) [[unlikely]] {
+            releaseAccumulated();
             return WTF::String();
+        }
     }
     if (accumulator.rope.length()) {
         WTF::String rope = accumulator.rope.toString();

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -327,7 +327,13 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
         RETURN_IF_EXCEPTION(scope, false);
         if (size_t byteLength = utf8ByteLengthWithReplacement(string)) {
             size_t oldSize = bytes.size();
-            bytes.grow(oldSize + byteLength);
+            // tryGrow/tryAppend: UTF-8 expansion can push the total past the estimate that
+            // sized the vector, and growing past the Vector capacity limit must surface as
+            // a catchable out-of-memory error, not a CRASH() in allocateBuffer.
+            if (!bytes.tryGrow(oldSize + byteLength)) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return false;
+            }
             size_t written = writeUTF8(string, bytes.mutableSpan().subspan(oldSize));
             // The sizer and writer must agree; never expose ungrown (uninitialized) bytes.
             ASSERT(written == byteLength);
@@ -337,13 +343,19 @@ static bool appendChunkBytes(JSC::VM& vm, JSGlobalObject* globalObject, JSValue 
         return true;
     }
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
-        if (!view->isDetached())
-            bytes.append(view->span());
+        if (!view->isDetached() && !bytes.tryAppend(view->span())) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return false;
+        }
         return true;
     }
     if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
-        if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-            bytes.append(impl->span());
+        if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached()) {
+            if (!bytes.tryAppend(impl->span())) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return false;
+            }
+        }
         return true;
     }
     throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
@@ -709,10 +721,24 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
             return rope.substring(1);
         return rope;
     }
-    WTF::Vector<uint8_t> bytes;
+    // The UTF-8 re-encode below only grows the estimate (binary bytes are exact, string
+    // chunks count UTF-16 code units), so an estimate past the string limit is final.
+    // Throw before touching the Vector: its capacity CRASH()es past INT32_MAX, so an
+    // estimate in [2^31, 2^32) would abort in reserveInitialCapacity before the
+    // exceedsStringLimit() throw below is ever reached.
     const double estimatedLength = accumulator.estimatedLength;
-    if (estimatedLength > 0 && estimatedLength < static_cast<double>(std::numeric_limits<uint32_t>::max()))
-        bytes.reserveInitialCapacity(static_cast<size_t>(estimatedLength));
+    if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
+        || exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {
+        releaseAccumulated();
+        throwOutOfMemoryError(globalObject, scope);
+        return WTF::String();
+    }
+    WTF::Vector<uint8_t> bytes;
+    if (estimatedLength > 0 && !bytes.tryReserveInitialCapacity(static_cast<size_t>(estimatedLength))) [[unlikely]] {
+        releaseAccumulated();
+        throwOutOfMemoryError(globalObject, scope);
+        return WTF::String();
+    }
     for (auto& piece : accumulator.pieces) {
         JSValue value = piece.get();
         if (!value)
@@ -727,7 +753,11 @@ static WTF::String finishTextAccumulator(JSC::VM& vm, JSGlobalObject* globalObje
         if (rope[0] == 0xFEFF)
             rope = rope.substring(1);
         WTF::CString utf8 = rope.utf8();
-        bytes.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() });
+        if (!bytes.tryAppend(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() })) [[unlikely]] {
+            releaseAccumulated();
+            throwOutOfMemoryError(globalObject, scope);
+            return WTF::String();
+        }
     }
     releaseAccumulated();
     if (exceedsStringLimit(bytes.size())) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -271,11 +271,8 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         return rope;
     }
 
-    // The UTF-8 re-encode below only grows the estimate (binary bytes are exact, string
-    // chunks count UTF-16 code units), so an estimate past the string limit is final.
-    // Throw before appending anything: Vector's capacity CRASH()es past INT32_MAX, so a
-    // >2GB accumulation would abort in append before the exceedsStringLimit() throw
-    // below is ever reached.
+    // estimatedLength only undercounts the result (binary sizes are exact, strings count
+    // UTF-16 units), so over the limit is final; Vector CRASH()es past INT32_MAX capacity.
     const double estimatedLength = accumulator.estimatedLength;
     if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
         || Bun::WebStreams::exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -271,8 +271,7 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         return rope;
     }
 
-    // estimatedLength only undercounts the result (binary sizes are exact, strings count
-    // UTF-16 units), so over the limit is final; Vector CRASH()es past INT32_MAX capacity.
+    // estimatedLength never overcounts the bytes, so an estimate past the limit is final.
     const double estimatedLength = accumulator.estimatedLength;
     if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
         || Bun::WebStreams::exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -271,7 +271,8 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         return rope;
     }
 
-    // estimatedLength never overcounts the bytes, so an estimate past the limit is final.
+    // Sizes are taken at write() time, so a buffer detached before end() can make this
+    // overcount; rejecting such an over-limit write set is still the right outcome.
     const double estimatedLength = accumulator.estimatedLength;
     if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
         || Bun::WebStreams::exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -271,21 +271,41 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         return rope;
     }
 
+    // The UTF-8 re-encode below only grows the estimate (binary bytes are exact, string
+    // chunks count UTF-16 code units), so an estimate past the string limit is final.
+    // Throw before appending anything: Vector's capacity CRASH()es past INT32_MAX, so a
+    // >2GB accumulation would abort in append before the exceedsStringLimit() throw
+    // below is ever reached.
+    const double estimatedLength = accumulator.estimatedLength;
+    if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
+        || Bun::WebStreams::exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return String();
+    }
     Vector<uint8_t> bytes;
+    if (estimatedLength > 0 && !bytes.tryReserveInitialCapacity(static_cast<size_t>(estimatedLength))) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return String();
+    }
     for (auto& piece : accumulator.pieces) {
         JSValue value = piece.get();
+        bool appended = true;
         if (value.isString()) {
             String string = asString(value)->value(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             auto utf8 = string.utf8();
-            bytes.append(std::span { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() });
+            appended = bytes.tryAppend(std::span { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() });
         } else if (auto* view = dynamicDowncast<JSArrayBufferView>(value)) {
             if (!view->isDetached())
-                bytes.append(view->span());
+                appended = bytes.tryAppend(view->span());
         } else if (auto* buffer = dynamicDowncast<JSArrayBuffer>(value)) {
             auto* impl = buffer->impl();
             if (impl && !impl->isDetached())
-                bytes.append(impl->span());
+                appended = bytes.tryAppend(impl->span());
+        }
+        if (!appended) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return String();
         }
     }
     if (!accumulator.rope.isEmpty()) {
@@ -293,7 +313,10 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         if (rope[0] == 0xFEFF)
             rope = rope.substring(1);
         auto utf8 = rope.utf8();
-        bytes.append(std::span { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() });
+        if (!bytes.tryAppend(std::span { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() })) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return String();
+        }
     }
     if (Bun::WebStreams::exceedsStringLimit(bytes.size())) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -271,8 +271,7 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         return rope;
     }
 
-    // Sizes are taken at write() time, so a buffer detached before end() can make this
-    // overcount; rejecting such an over-limit write set is still the right outcome.
+    // Sizes are recorded at write() time; rejecting even if buffers were detached later is intended.
     const double estimatedLength = accumulator.estimatedLength;
     if (estimatedLength > static_cast<double>(WTF::StringImpl::MaxLength)
         || Bun::WebStreams::exceedsStringLimit(static_cast<size_t>(estimatedLength))) [[unlikely]] {

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -289,8 +289,7 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         if (value.isString()) {
             String string = asString(value)->value(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
-            auto utf8 = string.utf8();
-            appended = bytes.tryAppend(std::span { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() });
+            appended = Bun::WebStreams::appendUTF8WithinStringLimit(string, bytes);
         } else if (auto* view = dynamicDowncast<JSArrayBufferView>(value)) {
             if (!view->isDetached())
                 appended = bytes.tryAppend(view->span());
@@ -308,8 +307,7 @@ static String finishTextSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
         String rope = accumulator.rope.toString();
         if (rope[0] == 0xFEFF)
             rope = rope.substring(1);
-        auto utf8 = rope.utf8();
-        if (!bytes.tryAppend(std::span { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() })) [[unlikely]] {
+        if (!Bun::WebStreams::appendUTF8WithinStringLimit(rope, bytes)) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return String();
         }

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -597,9 +597,7 @@ JSC::JSValue readableStreamIntoText(JSC::JSGlobalObject*, JSReadableStream*); //
 JSC::JSValue readableStreamIntoArray(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp
 // Drop ONE leading U+FEFF, and only on the generic toText path.
 WTF::String withoutUTF8BOM(const WTF::String&); // userJS: no — BunStreamConsumers.cpp
-// Appends `string` UTF-8 encoded (lone surrogates become U+FFFD, matching the chunk
-// appenders). Returns false when the result would pass the string limit or the allocation
-// fails; WTF's String::utf8() is avoided because its conversion caps abort instead.
+// Appends `string` UTF-8 encoded (lone surrogates become U+FFFD); false = over the string limit or allocation failed.
 bool appendUTF8WithinStringLimit(const WTF::String&, WTF::Vector<uint8_t>& bytes); // userJS: no — BunStreamConsumers.cpp
 
 // The three *Direct conversion paths.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -597,6 +597,10 @@ JSC::JSValue readableStreamIntoText(JSC::JSGlobalObject*, JSReadableStream*); //
 JSC::JSValue readableStreamIntoArray(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp
 // Drop ONE leading U+FEFF, and only on the generic toText path.
 WTF::String withoutUTF8BOM(const WTF::String&); // userJS: no — BunStreamConsumers.cpp
+// Appends `string` UTF-8 encoded (lone surrogates become U+FFFD, matching the chunk
+// appenders). Returns false when the result would pass the string limit or the allocation
+// fails; WTF's String::utf8() is avoided because its conversion caps abort instead.
+bool appendUTF8WithinStringLimit(const WTF::String&, WTF::Vector<uint8_t>& bytes); // userJS: no — BunStreamConsumers.cpp
 
 // The three *Direct conversion paths.
 JSC::JSValue readableStreamToTextDirect(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -135,6 +135,7 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
         pull(c) {
           c.write(new Uint8Array(ab));
           ab.resize(2400000000);
+          console.log("resized", ab.byteLength);
           c.end();
         },
       });
@@ -145,6 +146,10 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
         console.log("threw", e.name, e.message);
       }
     `);
-    expect(result).toEqual(threw);
+    expect(result).toEqual({
+      stdout: "resized 2400000000\nthrew RangeError Out of memory\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -123,4 +123,28 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
       `);
     expect(result).toEqual(threw);
   }, 60_000);
+
+  // The direct sink records sizes at write() time and reads the spans at end(), so a
+  // resizable ArrayBuffer grown in between bypasses the up-front estimate check; the
+  // append itself must reject the oversized span.
+  test("direct stream with a buffer grown past the limit after write() rejects", async () => {
+    const result = await run(`
+      const ab = new ArrayBuffer(8, { maxByteLength: 2400000000 });
+      const rs = new ReadableStream({
+        type: "direct",
+        pull(c) {
+          c.write(new Uint8Array(ab));
+          ab.resize(2400000000);
+          c.end();
+        },
+      });
+      try {
+        const text = await Bun.readableStreamToText(rs);
+        console.log("resolved", text.length);
+      } catch (e) {
+        console.log("threw", e.name, e.message);
+      }
+    `);
+    expect(result).toEqual(threw);
+  });
 });

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { totalmem } from "node:os";
+
+// Consuming a stream as text must reject with a catchable error when the accumulated
+// chunks exceed the maximum string length (2^31-1 bytes), instead of aborting the
+// process in WTF::Vector's capacity check. Each child commits ~2.2GB.
+const enoughMemory = totalmem() >= 8 * 1024 * 1024 * 1024;
+
+// 3 chunks of n bytes sum to 2^31+1: each chunk fits comfortably, the total does not.
+function consumeToText(streamSource: string): string {
+  return `
+    const n = 715827883;
+    const rs = ${streamSource};
+    try {
+      const text = await Bun.readableStreamToText(rs);
+      console.log("resolved", text.length);
+    } catch (e) {
+      console.log("threw", e.name, e.message);
+    }
+  `;
+}
+
+async function run(script: string): Promise<{ stdout: string; exitCode: number }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  return { stdout, exitCode };
+}
+
+describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past 2^31-1", () => {
+  test("queue-backed ReadableStream", async () => {
+    const { stdout, exitCode } = await run(
+      consumeToText(`new ReadableStream({
+        start(c) {
+          for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));
+          c.close();
+        },
+      })`),
+    );
+    expect(stdout).toBe("threw RangeError Out of memory\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("direct ReadableStream", async () => {
+    const { stdout, exitCode } = await run(
+      consumeToText(`new ReadableStream({
+        type: "direct",
+        pull(c) {
+          for (let i = 0; i < 3; i++) c.write(new Uint8Array(n));
+          c.end();
+        },
+      })`),
+    );
+    expect(stdout).toBe("threw RangeError Out of memory\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Response(stream).text()", async () => {
+    const { stdout, exitCode } = await run(`
+      const n = 715827883;
+      const rs = new ReadableStream({
+        start(c) {
+          for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));
+          c.close();
+        },
+      });
+      try {
+        const text = await new Response(rs).text();
+        console.log("resolved", text.length);
+      } catch (e) {
+        console.log("threw", e.name, e.message);
+      }
+    `);
+    expect(stdout).toBe("threw RangeError Out of memory\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -78,4 +78,57 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
     `);
     expect(result).toEqual(threw);
   });
+
+  // WTF::String::utf8() aborts once its conversion needs more than INT32_MAX bytes of
+  // scratch (2x the length for 8-bit strings), so a mixed stream with a near-limit string
+  // chunk crashed in the encode even when the real UTF-8 total fit. The consumers now size
+  // and write through simdutf instead.
+  test(
+    "mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits",
+    async () => {
+      const result = await run(`
+        const big = Buffer.alloc(1200000000, "a").toString();
+        const rs = new ReadableStream({
+          start(c) {
+            c.enqueue(new Uint8Array([65]));
+            c.enqueue(big);
+            c.close();
+          },
+        });
+        try {
+          const text = await Bun.readableStreamToText(rs);
+          console.log("resolved", text.length);
+        } catch (e) {
+          console.log("threw", e.name, e.message);
+        }
+      `);
+      expect(result).toEqual({ stdout: "resolved 1200000001\n", stderr: "", exitCode: 0 });
+    },
+    60_000,
+  );
+
+  test(
+    "mixed chunks whose UTF-8 expansion passes the limit reject",
+    async () => {
+      const result = await run(`
+        // 1.2e9 U+00E9 chars: a Latin1 string whose UTF-8 form is 2.4e9 bytes.
+        const big = Buffer.alloc(1200000000, 233).toString("latin1");
+        const rs = new ReadableStream({
+          start(c) {
+            c.enqueue(new Uint8Array([65]));
+            c.enqueue(big);
+            c.close();
+          },
+        });
+        try {
+          const text = await Bun.readableStreamToText(rs);
+          console.log("resolved", text.length);
+        } catch (e) {
+          console.log("threw", e.name, e.message);
+        }
+      `);
+      expect(result).toEqual(threw);
+    },
+    60_000,
+  );
 });

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -83,10 +83,8 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
   // scratch (2x the length for 8-bit strings), so a mixed stream with a near-limit string
   // chunk crashed in the encode even when the real UTF-8 total fit. The consumers now size
   // and write through simdutf instead.
-  test(
-    "mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits",
-    async () => {
-      const result = await run(`
+  test("mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits", async () => {
+    const result = await run(`
         const big = Buffer.alloc(1200000000, "a").toString();
         const rs = new ReadableStream({
           start(c) {
@@ -102,15 +100,11 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
           console.log("threw", e.name, e.message);
         }
       `);
-      expect(result).toEqual({ stdout: "resolved 1200000001\n", stderr: "", exitCode: 0 });
-    },
-    60_000,
-  );
+    expect(result).toEqual({ stdout: "resolved 1200000001\n", stderr: "", exitCode: 0 });
+  }, 60_000);
 
-  test(
-    "mixed chunks whose UTF-8 expansion passes the limit reject",
-    async () => {
-      const result = await run(`
+  test("mixed chunks whose UTF-8 expansion passes the limit reject", async () => {
+    const result = await run(`
         // 1.2e9 U+00E9 chars: a Latin1 string whose UTF-8 form is 2.4e9 bytes.
         const big = Buffer.alloc(1200000000, 233).toString("latin1");
         const rs = new ReadableStream({
@@ -127,8 +121,6 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
           console.log("threw", e.name, e.message);
         }
       `);
-      expect(result).toEqual(threw);
-    },
-    60_000,
-  );
+    expect(result).toEqual(threw);
+  }, 60_000);
 });

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -21,20 +21,22 @@ function consumeToText(streamSource: string): string {
   `;
 }
 
-async function run(script: string): Promise<{ stdout: string; exitCode: number }> {
+async function run(script: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  return { stdout, exitCode };
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
 }
+
+const threw = { stdout: "threw RangeError Out of memory\n", stderr: "", exitCode: 0 };
 
 describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past 2^31-1", () => {
   test("queue-backed ReadableStream", async () => {
-    const { stdout, exitCode } = await run(
+    const result = await run(
       consumeToText(`new ReadableStream({
         start(c) {
           for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));
@@ -42,12 +44,11 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
         },
       })`),
     );
-    expect(stdout).toBe("threw RangeError Out of memory\n");
-    expect(exitCode).toBe(0);
+    expect(result).toEqual(threw);
   });
 
   test("direct ReadableStream", async () => {
-    const { stdout, exitCode } = await run(
+    const result = await run(
       consumeToText(`new ReadableStream({
         type: "direct",
         pull(c) {
@@ -56,12 +57,11 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
         },
       })`),
     );
-    expect(stdout).toBe("threw RangeError Out of memory\n");
-    expect(exitCode).toBe(0);
+    expect(result).toEqual(threw);
   });
 
   test("Response(stream).text()", async () => {
-    const { stdout, exitCode } = await run(`
+    const result = await run(`
       const n = 715827883;
       const rs = new ReadableStream({
         start(c) {
@@ -76,7 +76,6 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
         console.log("threw", e.name, e.message);
       }
     `);
-    expect(stdout).toBe("threw RangeError Out of memory\n");
-    expect(exitCode).toBe(0);
+    expect(result).toEqual(threw);
   });
 });


### PR DESCRIPTION
### Problem

`Bun.readableStreamToText(rs)` and `new Response(rs).text()` abort the process (uncatchable SIGABRT, `panic(main thread): abort() called`) when the stream's binary chunks sum to more than 2^31-1 bytes, even though each individual chunk is well under the limit. The same abort happens for the direct-stream text sink (`type: "direct"`).

```js
const n = 715827883; // 3*n = 2^31+1
const rs = new ReadableStream({
  start(c) {
    for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));
    c.close();
  },
});
await Bun.readableStreamToText(rs); // rc 134, nothing catchable
```

Node's equivalent (`new Response(rs).text()`) throws a catchable error.

### Cause

Three distinct abort paths in the text consumers' finish arms:

- `finishTextAccumulator` (BunStreamConsumers.cpp) guarded its `reserveInitialCapacity` estimate with `estimatedLength < numeric_limits<uint32_t>::max()`, a check in the wrong width: `WTF::Vector<uint8_t>` caps capacity at INT32_MAX (`isValidCapacityForVector`) and `CRASH()`es above it in `WTF::VectorBufferBase<uint8_t>::allocateBuffer`, so totals in [2^31, 2^32) aborted in the reserve before the function's `exceedsStringLimit()` throw was reached.
- `finishTextSink` (JSDirectStreamController.cpp) had no size guard at all and hit the same `CRASH()` while growing the vector through incremental `append`.
- Both arms encoded string pieces and the trailing rope through `WTF::String::utf8()`, which `RELEASE_ASSERT`s once its conversion scratch passes INT32_MAX (2x the length for 8-bit strings, 3x for 16-bit strings containing lone surrogates). A mixed stream with a near-limit string chunk aborted in the encode even when the actual UTF-8 total fit the limit.

### Fix

In both finish arms:

- Check `estimatedLength` against `WTF::StringImpl::MaxLength` (via the existing `exceedsStringLimit`) before touching the vector. Sizes are recorded at write time (binary chunk sizes exact, string chunks as UTF-16 code units, which UTF-8 re-encoding never shrinks below), so an estimate past the limit is final and throwing early is correct. This also fails fast, before copying gigabytes.
- Use `tryReserveInitialCapacity` / `tryGrow` / `tryAppend` for every vector operation so capacity and allocation failures surface as catchable errors instead of `CRASH()`.
- Encode string pieces and the trailing rope through a new shared helper, `appendUTF8WithinStringLimit`: size with the simdutf sizer, reject past the string limit before allocating, then write straight into the byte vector. This removes the `String::utf8()` scratch-allocation aborts, and lone surrogates now consistently become U+FFFD on every mixed-path arm (string chunks already did).
- Release the accumulator on the chunk-append error path, which was the one error exit in `finishTextAccumulator` that skipped it.

The thrown error is the same `RangeError: Out of memory` these consumers already throw at the string limit (the synthetic-limit tests in `test/js/web/streams/streams.test.js` pin that contract).

### Verification

`test/js/web/streams/streams-string-limit.test.ts`, five subprocess tests (the file skips on machines with less than 8GB of RAM):

- queue-backed stream, direct stream, and `Response(stream).text()` with 3 binary chunks summing to 2^31+1 bytes: abort before, `threw RangeError Out of memory` with exit 0 after
- mixed chunks with a 1.2e9-char ASCII string chunk: aborted in the `String::utf8()` encode before even though the UTF-8 total fits, now resolves with the full 1200000001-char text
- mixed chunks whose UTF-8 expansion passes the limit (1.2e9 U+00E9 chars, 2.4e9 UTF-8 bytes): abort before, catchable rejection after

All verified to fail on the unfixed build (release 1.4.0 canary and debug+ASAN with the src changes stashed) and pass with the fix. Also green locally: `streams.test.js`, `body.test.ts`, `body-stream.test.ts`, `direct-readable-stream.test.tsx`, `utf8-bom.test.ts`, `blob-oom.test.ts`, `stream-fast-path.test.ts` (10k+ tests).

The sibling crash for `readableStreamToArrayBuffer`/`readableStreamToBytes` with mixed chunks (`concatenateChunks`, same file) is a separate consumer with different constraints (an ArrayBuffer result may legitimately exceed 2^31-1) and is handled in #37239.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/streams-string-limit.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/web/streams/streams-string-limit.test.ts:
42 |           for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));
43 |           c.close();
44 |         },
45 |       })`),
46 |     );
47 |     expect(result).toEqual(threw);
                        ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 134,
    "stderr": "",
-   "stdout": 
- "threw RangeError Out of memory
- "
- ,
+   "stdout": "",
  }

- Expected  - 5
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/streams/streams-string-limit.test.ts:47:20)
(fail) text consumers reject binary chunks summing past 2^31-1 > queue-backed ReadableStream [483.96ms]
55 |           for (let i = 0; i < 3; i++) c.write(new Uint8Array(n));
56 |           c.end();
57 |         },
58 |       })`),
59 |     );
60 |     expect(result).toEqual(threw);
                        ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 134,
    "
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/web/streams/streams-string-limit.test.ts:
42 |           for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));
43 |           c.close();
44 |         },
45 |       })`),
46 |     );
47 |     expect(result).toEqual(threw);
                        ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": 
- "threw RangeError Out of memory
+   "exitCode": 134,
+   "stderr": 
+ "============================================================
+ Bun Canary v1.4.0-canary.1 (8326d1bd3) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "-e" "\n    const n = 715827883;\n    const rs = new ReadableStream({\n        start(c) {\n          for (let i = 0; i < 3; i++) c.enqueue(new Uint8Array(n));\n          c.c"...
+ Features: bunfig jsc tsconfig 
+ Builtins: "bun:main" 
+ 
+ Elapsed: 5ms | User: 1ms | Sys: 5ms
+ RSS: 32.17 MB | Peak: 46.52 MB | Commit: 2.19 GB | Faults: 0 | Machine: 34.36 GB
+ 
+ panic(main thread): abort() called
+ oh no: Bun has crashed. This indicates a bug in Bun, not your code.
+ 
+ To send a re
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/streams/streams-string-limit.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/web/streams/streams-string-limit.test.ts:
(pass) text consumers reject binary chunks summing past 2^31-1 > queue-backed ReadableStream [329.73ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct ReadableStream [439.48ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > Response(stream).text() [306.04ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits [8137.48ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks whose UTF-8 expansion passes the limit reject [2418.01ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct stream with a buffer grown past the limit after write() rejects [457.06ms]

 6 pass
 0 fail
 6 expect() calls
Ran 6 tests across 1 file. [14.49s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 673ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp.o
[2/38] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[3/38] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp.o
[4/38] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[5/38] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[6/38] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.o
[7/38] cxx obj/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp.o
[8/38] cxx obj/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp.o
[9/38] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[10/38] cxx obj/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp.o
[11/38] cxx obj/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp.o
[12/38] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStream.cpp.o
[13/38] cxx obj/src/jsc/bindings/webcore/streams/JSReadRequest.cpp.o
[14/38] cxx obj/src/jsc/binding
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunStreamConsumers.cpp         |  70 +++++++---
 .../webcore/streams/JSDirectStreamController.cpp   |  29 +++-
 .../bindings/webcore/streams/WebStreamsInternals.h |   2 +
 test/js/web/streams/streams-string-limit.test.ts   | 155 +++++++++++++++++++++
 4 files changed, 231 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp       5      7      0
…c/bindings/webcore/streams/JSDirectStreamController.cpp      4      8      0
src/jsc/bindings/webcore/streams/WebStreamsInternals.h        2      3      0
test/js/web/streams/streams-string-limit.test.ts              5      7      0
```

</details>

<!-- robobun:evidence:end -->