### PR TITLE
bun:sqlite: make index-like column names readable on row objects

### DIFF
--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -774,24 +774,35 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
         auto& globalObject = *lexicalGlobalObject;
 
         auto columnNames = castedThis->columnNames.get();
-        bool anyHoles = false;
+        bool needsSlowPath = false;
         for (int i = count - 1; i >= 0; i--) {
             const char* name = sqlite3_column_name(stmt, i);
 
             if (name == nullptr) {
-                anyHoles = true;
+                needsSlowPath = true;
                 break;
             }
 
             size_t len = strlen(name);
 
+            const auto identifier = len == 0
+                ? vm.propertyNames->emptyIdentifier
+                : Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len }));
+
+            // Structure::addPropertyTransition asserts !parseIndex() — a column
+            // aliased to "0", "2023", … must go through indexed storage or its
+            // value is unreachable by property access. Bail to the slow path,
+            // which stores it via putDirectMayBeIndex().
+            if (parseIndex(identifier)) {
+                needsSlowPath = true;
+                break;
+            }
+
             // When joining multiple tables, the same column names can appear multiple times
             // columnNames de-dupes property names internally
             // We can't have two properties with the same name, so we use validColumns to track this.
             auto preCount = columnNames->size();
-            columnNames->add(len == 0
-                    ? vm.propertyNames->emptyIdentifier
-                    : Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len })));
+            columnNames->add(identifier);
             auto curCount = columnNames->size();
 
             if (preCount != curCount) {
@@ -799,7 +810,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             }
         }
 
-        if (!anyHoles) [[likely]] {
+        if (!needsSlowPath) [[likely]] {
             PropertyOffset offset;
             JSObject* prototype = castedThis->userPrototype ? castedThis->userPrototype.get() : globalObject.objectPrototype();
             Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, prototype, columnNames->size());
@@ -817,7 +828,7 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             // We are done.
             return;
         } else {
-            // If for any reason we do not have column names, disable the fast path.
+            // Missing or index-like column names: reset and use the slow path.
             columnNames->releaseData();
             castedThis->columnNames.reset(new PropertyNameArrayBuilder(
                 castedThis->columnNames->vm(),
@@ -843,36 +854,28 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             ? vm.propertyNames->emptyIdentifier
             : Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len }));
 
-        JSC::JSValue primitive = JSC::jsUndefined();
-        auto decl = sqlite3_column_decltype(stmt, i);
-        if (decl != nullptr) {
-            switch (decl[0]) {
-            case 'F':
-            case 'D':
-            case 'I': {
-                primitive = jsNumber(0);
-                break;
-            }
-            case 'V':
-            case 'T': {
-                primitive = jsEmptyString(vm);
-                break;
-            }
-            }
-        }
-
         auto preCount = castedThis->columnNames->size();
         castedThis->columnNames->add(key);
         auto curCount = castedThis->columnNames->size();
 
-        // only put the property if it's not a duplicate
+        // only track the column if it's not a duplicate (the last occurrence wins)
         if (preCount != curCount) {
             castedThis->validColumns.set(i);
-            object->putDirect(vm, key, primitive, 0);
         }
     }
     // We iterated over the columns in reverse order so we need to reverse the columnNames here
     castedThis->columnNames->data()->propertyNameVector().reverse();
+
+    // Seed the template's named properties from the forward-ordered name list
+    // so rows enumerate in column order, matching the fast path. The template
+    // only donates its Structure to rows; every slot is rewritten per row in
+    // constructResultObject(). An index-like key ("0", "2023", …) cannot be a
+    // named Structure slot; constructResultObject() stores it per-row with
+    // putDirectMayBeIndex() instead.
+    for (const auto& propertyName : *castedThis->columnNames) {
+        if (!parseIndex(propertyName))
+            object->putDirect(vm, propertyName, JSC::jsUndefined(), 0);
+    }
     castedThis->_prototype.set(vm, castedThis, object);
 }
 
@@ -2073,7 +2076,8 @@ static inline JSC::JSValue constructResultObject(JSC::JSGlobalObject* lexicalGlo
             const auto& name = columnNames[j];
             auto value = toJS<useBigInt64>(vm, lexicalGlobalObject, stmt, i);
             RETURN_IF_EXCEPTION(scope, {});
-            result->putDirect(vm, name, value, 0);
+            result->putDirectMayBeIndex(lexicalGlobalObject, name, value);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2620,3 +2620,96 @@ it("exec/run with an embedded NUL byte in the SQL string does not hang", async (
     exitCode: 0,
   });
 });
+
+describe("column names that look like array indices", () => {
+  it("are reachable as own indexed properties", () => {
+    const db = new Database(":memory:");
+    db.run("CREATE TABLE sales (year INT, amt INT)");
+    db.run("INSERT INTO sales VALUES (2023, 5), (2024, 7)");
+
+    const row = db
+      .query(
+        `SELECT sum(CASE WHEN year=2023 THEN amt END) AS "2023",
+                sum(CASE WHEN year=2024 THEN amt END) AS "2024",
+                count(*) AS n FROM sales`,
+      )
+      .get();
+    expect(row["2023"]).toBe(5);
+    expect(row[2024]).toBe(7);
+    expect(row.n).toBe(2);
+    expect(JSON.parse(JSON.stringify(row))).toEqual({ "2023": 5, "2024": 7, n: 2 });
+
+    // writes go to the same property that reads and JSON see
+    row["2023"] = 99;
+    expect(row["2023"]).toBe(99);
+    expect(JSON.parse(JSON.stringify(row))).toEqual({ "2023": 99, "2024": 7, n: 2 });
+  });
+
+  it("support in, hasOwn, keys, and entries", () => {
+    const db = new Database(":memory:");
+    const s = db.query(`SELECT 10 AS "0", 'x' AS name`).get();
+    expect(Object.hasOwn(s, "0")).toBe(true);
+    expect("0" in s).toBe(true);
+    expect(0 in s).toBe(true);
+    expect(s[0]).toBe(10);
+    expect(s.name).toBe("x");
+    expect(Object.keys(s)).toEqual(["0", "name"]);
+    expect(Object.entries(s)).toEqual([
+      ["0", 10],
+      ["name", "x"],
+    ]);
+  });
+
+  it("treats non-index numeric-looking names as plain named properties", () => {
+    const db = new Database(":memory:");
+    // 4294967295 is not a valid array index; 4294967294 is the largest one
+    const t = db.query(`SELECT 1 AS "4294967295", 2 AS "01", 3 AS "-0", 4 AS "4294967294"`).get();
+    expect(t["4294967295"]).toBe(1);
+    expect(t["01"]).toBe(2);
+    expect(t["-0"]).toBe(3);
+    expect(t["4294967294"]).toBe(4);
+  });
+
+  it("work with all(), iterate(), and more than 64 columns", () => {
+    const db = new Database(":memory:");
+    const wide = Array.from({ length: 70 }, (_, i) => `${i + 100} AS "${i}"`).join(", ");
+    const rows = db.query(`SELECT ${wide}`).all();
+    expect(rows).toHaveLength(1);
+    for (let i = 0; i < 70; i++) {
+      expect(rows[0][i]).toBe(i + 100);
+    }
+
+    const [iterated] = Array.from(db.query(`SELECT 7 AS "3"`).iterate());
+    expect(iterated[3]).toBe(7);
+  });
+
+  it("keep last-wins semantics for duplicate names", () => {
+    const db = new Database(":memory:");
+    const r = db.query(`SELECT 1 AS "5", 2 AS "5"`).get();
+    expect(r[5]).toBe(2);
+    expect(Object.keys(r)).toEqual(["5"]);
+  });
+
+  it("keep column order for mixed named and index-like columns", () => {
+    const db = new Database(":memory:");
+    const r = db.query(`SELECT 1 AS a, 2 AS "0", 3 AS b`).get();
+    expect(r.a).toBe(1);
+    expect(r[0]).toBe(2);
+    expect(r.b).toBe(3);
+    // integer keys enumerate first, then named keys in column order
+    expect(Object.keys(r)).toEqual(["0", "a", "b"]);
+  });
+
+  it("are own properties on rows mapped with as(Class)", () => {
+    const db = new Database(":memory:");
+    class Row {
+      get 0() {
+        return "prototype getter";
+      }
+    }
+    const u = db.query(`SELECT 10 AS "0", 20 AS v`).as(Row).get();
+    expect(u).toBeInstanceOf(Row);
+    expect(u[0]).toBe(10);
+    expect(u.v).toBe(20);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes `bun:sqlite` rows whose column names look like array indices (`"0"`, `"2023"`, ... anything `parseIndex` accepts, i.e. `"0"` through `"4294967294"`). Those columns were stored as named Structure slots, which JSC's property lookup never consults for index-like keys, producing ghost properties: visible in `JSON.stringify` and `Object.keys`, but unreachable by property access.

```js
import { Database } from "bun:sqlite";
const db = new Database(":memory:");
db.run("create table sales(year int, amt int)");
db.run("insert into sales values (2023,5),(2024,7)");
const r = db.query(`select sum(case when year=2023 then amt end) as "2023",
                           sum(case when year=2024 then amt end) as "2024",
                           count(*) as n from sales`).get();
console.log(JSON.stringify(r)); // {"2023":5,"2024":7,"n":2}
console.log(r["2023"], r.n);    // undefined 2  (expected 5 2)
```

Writes (`r["2023"] = "x"`) created a second, indexed property alongside the ghost. Debug builds assert on the first lookup:

```
ASSERTION FAILED: !parseIndex(propertyName)  (JSObject.h getOwnNonIndexPropertySlot)
```

Both the <= 64 column Structure-cache path and the wider path were affected, as were `.as(Class)` rows. `.values()`/`.raw()` were fine.

### How did you fix it?

Same approach `NodeSqlite.cpp` already uses for `node:sqlite` rows:

- `initializeColumnNames()` bails out of the cached-Structure fast path when any column name parses as an array index (`Structure::addPropertyTransition` asserts `!parseIndex()`), so the common all-named case keeps its exact current fast path.
- The slow path of `constructResultObject()` stores each column with `putDirectMayBeIndex()`, which routes index-like keys to indexed storage and everything else to `putDirect`.
- The slow-path template object now seeds its named properties from the deduplicated, forward-ordered column name list instead of putting them while iterating columns in reverse. Rows only reuse the template's Structure and every slot is rewritten per row, so the seed values don't matter, but the property order does: previously the slow path enumerated named columns in reverse. That was unobservable before (the slow path only ran when sqlite3_column_name returned null) but becomes user-visible now.

Boundary behavior is unchanged where it should be: `"4294967295"`, `"01"`, and `"-0"` are not array indices and stay named properties.

### Tests

7 new cases in `test/js/bun/sqlite/sqlite.test.js` covering property reads/writes, `in`/`Object.hasOwn`/`Object.keys`/`Object.entries`, parseIndex boundary names, `all()`/`iterate()`, >64 columns, duplicate column names (last-wins), mixed named/index-like enumeration order, and `.as(Class)` rows shadowing prototype getters. All fail on the released 1.4.0 (`USE_SYSTEM_BUN=1`) and pass with this change; `test/js/bun/sqlite/` and `test/js/node/sqlite/` suites pass with the debug (ASAN) build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->