### PR TITLE
Stop aborting when stream arrayBuffer/bytes consumers mix chunk types past 2 GiB

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -358,10 +358,9 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
     unsigned length = chunks->length();
 
     // ONE pass over the array: read each element exactly once, materialize each string
-    // exactly once, and size the output as we go. `values` roots every chunk across the
-    // string materializations; `measuredChunks` carries each chunk's measured byte size
-    // (plus the materialized string for string chunks) so the write pass below never
-    // re-reads the array or re-encodes.
+    // exactly once, and size the output as we go. `values` roots every chunk; `measuredChunks`
+    // carries each chunk's measured size (and each materialized string) so the write pass
+    // below never re-reads the array or re-encodes.
     MarkedArgumentBuffer values;
     WTF::Vector<std::pair<WTF::String, size_t>, 16> measuredChunks;
     bool anyString = false;
@@ -405,10 +404,9 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         throwOutOfMemoryError(globalObject, scope);
         return {};
     }
-    // Assemble directly into the result ArrayBuffer, like the all-binary arm above does.
-    // Staging through a WTF::Vector<uint8_t> would CRASH() past its INT32_MAX capacity
-    // cap, while a 64-bit ArrayBuffer legitimately holds up to MAX_ARRAY_BUFFER_SIZE
-    // bytes (and allocation failure here must throw, not abort).
+    // Assemble directly into the result ArrayBuffer: WTF::Vector<uint8_t> CRASH()es past
+    // its INT32_MAX capacity cap, while ArrayBuffer capacities are size_t and allocation
+    // failure throws instead of aborting.
     RefPtr<JSC::ArrayBuffer> resultBuffer = JSC::ArrayBuffer::tryCreateUninitialized(total.value(), 1);
     if (!resultBuffer) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
@@ -436,17 +434,16 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
             if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
                 span = impl->span();
         }
-        // Clamp to the measured size so a chunk that grew since the sizing pass (a
-        // growable SharedArrayBuffer can grow from another thread) cannot overrun the
-        // space sized for the chunks after it.
+        // Clamp to the measured size: a chunk grown since the sizing pass (a growable
+        // SharedArrayBuffer, from another thread) must not overrun the buffer.
         size_t copyLength = std::min(span.size(), measuredByteLength);
         if (copyLength)
             memcpy(bytes.data() + offset, span.data(), copyLength);
         offset += copyLength;
     }
     if (offset < bytes.size()) [[unlikely]] {
-        // A chunk shrank or detached after it was measured; re-create at the actual size
-        // rather than exposing the never-written (uninitialized) tail.
+        // A chunk shrank or detached after measurement: re-create at the actual size
+        // instead of exposing the uninitialized tail.
         RefPtr<JSC::ArrayBuffer> rightSized = JSC::ArrayBuffer::tryCreate(bytes.first(offset));
         if (!rightSized) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -357,10 +357,8 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned length = chunks->length();
 
-    // ONE pass over the array: read each element exactly once, materialize each string
-    // exactly once, and size the output as we go. `values` roots every chunk; `measuredChunks`
-    // carries each chunk's measured size (and each materialized string) so the write pass
-    // below never re-reads the array or re-encodes.
+    // One pass: read and measure each chunk exactly once (strings materialize into
+    // `measuredChunks`) so the write pass never re-reads or re-encodes; `values` roots the chunks.
     MarkedArgumentBuffer values;
     WTF::Vector<std::pair<WTF::String, size_t>, 16> measuredChunks;
     bool anyString = false;
@@ -405,8 +403,7 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         return {};
     }
     // Assemble directly into the result ArrayBuffer: WTF::Vector<uint8_t> CRASH()es past
-    // its INT32_MAX capacity cap, while ArrayBuffer capacities are size_t and allocation
-    // failure throws instead of aborting.
+    // its INT32_MAX capacity cap; ArrayBuffer capacities are size_t and fail by throwing.
     RefPtr<JSC::ArrayBuffer> resultBuffer = JSC::ArrayBuffer::tryCreateUninitialized(total.value(), 1);
     if (!resultBuffer) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -359,10 +359,11 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
 
     // ONE pass over the array: read each element exactly once, materialize each string
     // exactly once, and size the output as we go. `values` roots every chunk across the
-    // string materializations; `stringChunks` carries each string and its UTF-8 size so
-    // the write pass below never re-reads the array or re-encodes.
+    // string materializations; `measuredChunks` carries each chunk's measured byte size
+    // (plus the materialized string for string chunks) so the write pass below never
+    // re-reads the array or re-encodes.
     MarkedArgumentBuffer values;
-    WTF::Vector<std::pair<WTF::String, size_t>, 16> stringChunks;
+    WTF::Vector<std::pair<WTF::String, size_t>, 16> measuredChunks;
     bool anyString = false;
     WTF::CheckedSize total = 0;
     for (unsigned i = 0; i < length; i++) {
@@ -375,19 +376,21 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
             RETURN_IF_EXCEPTION(scope, {});
             size_t byteLength = utf8ByteLengthWithReplacement(string);
             total += byteLength;
-            stringChunks.append({ WTF::move(string), byteLength });
+            measuredChunks.append({ WTF::move(string), byteLength });
             continue;
         }
-        stringChunks.append({ WTF::String(), 0 });
+        size_t byteLength = 0;
         if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk))
-            total += view->isDetached() ? 0 : view->byteLength();
+            byteLength = view->isDetached() ? 0 : view->byteLength();
         else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
             auto* impl = jsBuffer->impl();
-            total += (impl && !impl->isDetached()) ? impl->byteLength() : 0;
+            byteLength = (impl && !impl->isDetached()) ? impl->byteLength() : 0;
         } else {
             throwTypeError(globalObject, scope, "Expected an ArrayBuffer, ArrayBufferView, or string chunk"_s);
             return {};
         }
+        total += byteLength;
+        measuredChunks.append({ WTF::String(), byteLength });
     }
     if (values.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
@@ -402,47 +405,62 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         throwOutOfMemoryError(globalObject, scope);
         return {};
     }
-    WTF::Vector<uint8_t> bytes;
-    bytes.reserveInitialCapacity(total.value());
+    // Assemble directly into the result ArrayBuffer, like the all-binary arm above does.
+    // Staging through a WTF::Vector<uint8_t> would CRASH() past its INT32_MAX capacity
+    // cap, while a 64-bit ArrayBuffer legitimately holds up to MAX_ARRAY_BUFFER_SIZE
+    // bytes (and allocation failure here must throw, not abort).
+    RefPtr<JSC::ArrayBuffer> resultBuffer = JSC::ArrayBuffer::tryCreateUninitialized(total.value(), 1);
+    if (!resultBuffer) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    std::span<uint8_t> bytes { static_cast<uint8_t*>(resultBuffer->data()), total.value() };
+    size_t offset = 0;
     for (unsigned i = 0; i < length; i++) {
-        auto& [string, stringByteLength] = stringChunks[i];
+        auto& [string, measuredByteLength] = measuredChunks[i];
         if (!string.isNull()) {
-            if (stringByteLength) {
-                size_t oldSize = bytes.size();
-                bytes.grow(oldSize + stringByteLength);
-                size_t written = writeUTF8(string, bytes.mutableSpan().subspan(oldSize));
-                // The sizer and writer must agree; never expose ungrown (uninitialized) bytes.
-                ASSERT(written == stringByteLength);
-                if (written < stringByteLength) [[unlikely]]
-                    bytes.shrink(oldSize + written);
+            if (measuredByteLength) {
+                size_t written = writeUTF8(string, bytes.subspan(offset, measuredByteLength));
+                // The sizer and writer must agree; never expose unwritten (uninitialized) bytes.
+                ASSERT(written == measuredByteLength);
+                offset += written;
             }
             continue;
         }
         JSValue chunk = values.at(i);
+        std::span<const uint8_t> span;
         if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(chunk)) {
             if (!view->isDetached())
-                bytes.append(view->span());
+                span = view->span();
         } else if (auto* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(chunk)) {
             if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
-                bytes.append(impl->span());
+                span = impl->span();
         }
+        // Clamp to the measured size so a chunk that grew since the sizing pass (a
+        // growable SharedArrayBuffer can grow from another thread) cannot overrun the
+        // space sized for the chunks after it.
+        size_t copyLength = std::min(span.size(), measuredByteLength);
+        if (copyLength)
+            memcpy(bytes.data() + offset, span.data(), copyLength);
+        offset += copyLength;
     }
-    if (asUint8Array) {
-        // Buffer-backed from birth: a later `.buffer` access never has to change modes.
-        RefPtr<JSC::ArrayBuffer> resultBuffer = JSC::ArrayBuffer::tryCreate(bytes.span());
-        if (!resultBuffer) [[unlikely]] {
+    if (offset < bytes.size()) [[unlikely]] {
+        // A chunk shrank or detached after it was measured; re-create at the actual size
+        // rather than exposing the never-written (uninitialized) tail.
+        RefPtr<JSC::ArrayBuffer> rightSized = JSC::ArrayBuffer::tryCreate(bytes.first(offset));
+        if (!rightSized) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return {};
         }
+        resultBuffer = WTF::move(rightSized);
+    }
+    size_t byteLength = resultBuffer->byteLength();
+    if (asUint8Array) {
+        // Buffer-backed from birth: a later `.buffer` access never has to change modes.
         auto* structure = globalObject->typedArrayStructureWithTypedArrayType<JSC::TypeUint8>();
-        RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(resultBuffer), 0, bytes.size()));
+        RELEASE_AND_RETURN(scope, JSC::JSUint8Array::create(globalObject, structure, WTF::move(resultBuffer), 0, byteLength));
     }
-    auto buffer = JSC::ArrayBuffer::tryCreate(bytes.span());
-    if (!buffer) [[unlikely]] {
-        throwOutOfMemoryError(globalObject, scope);
-        return {};
-    }
-    return JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(buffer));
+    return JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(resultBuffer));
 }
 
 static bool binaryChunkSpan(JSValue chunk, std::span<const uint8_t>& out)

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -416,9 +416,10 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
         if (!string.isNull()) {
             if (measuredByteLength) {
                 size_t written = writeUTF8(string, bytes.subspan(offset, measuredByteLength));
-                // The sizer and writer must agree; never expose unwritten (uninitialized) bytes.
-                ASSERT(written == measuredByteLength);
-                offset += written;
+                // The sizer/writer pair agrees by contract; the writer reports its count through
+                // a u32 (0 for an exactly-2^32-byte string), so advance by the measured size.
+                ASSERT_UNUSED(written, written == measuredByteLength || measuredByteLength == (1ull << 32));
+                offset += measuredByteLength;
             }
             continue;
         }
@@ -431,8 +432,8 @@ static JSValue concatenateChunks(JSC::VM& vm, JSGlobalObject* globalObject, JSAr
             if (auto* impl = jsBuffer->impl(); impl && !impl->isDetached())
                 span = impl->span();
         }
-        // Clamp to the measured size: a chunk grown since the sizing pass (a growable
-        // SharedArrayBuffer, from another thread) must not overrun the buffer.
+        // Clamp to the measured size: a chunk grown since the sizing pass (getter reentry
+        // during getIndex above, or a cross-thread SharedArrayBuffer grow) must not overrun.
         size_t copyLength = std::min(span.size(), measuredByteLength);
         if (copyLength)
             memcpy(bytes.data() + offset, span.data(), copyLength);

--- a/test/js/bun/util/readablestreamtoarraybuffer.test.ts
+++ b/test/js/bun/util/readablestreamtoarraybuffer.test.ts
@@ -99,10 +99,12 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
     expect(exitCode).toBe(0);
   });
 
-  test.skipIf(!hasEnoughMemory)(`${consumer} throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum`, async () => {
-    // The inputs are never touched (zero pages on Linux; Windows still commits them,
-    // hence the memory gate) and the oversized result allocation fails fast.
-    const script = `
+  test.skipIf(!hasEnoughMemory)(
+    `${consumer} throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum`,
+    async () => {
+      // The inputs are never touched (zero pages on Linux; Windows still commits them,
+      // hence the memory gate) and the oversized result allocation fails fast.
+      const script = `
       const n = 2200000000;
       let a, b;
       try {
@@ -127,18 +129,19 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
         console.log("THREW RangeError=" + (e instanceof RangeError));
       }
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    if (stdout.trim() === "SKIP") return;
-    expect(stdout.trim()).toBe("THREW RangeError=true");
-    expect(proc.signalCode).toBe(null);
-    expect(exitCode).toBe(0);
-  });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      if (stdout.trim() === "SKIP") return;
+      expect(stdout.trim()).toBe("THREW RangeError=true");
+      expect(proc.signalCode).toBe(null);
+      expect(exitCode).toBe(0);
+    },
+  );
 }
 
 // The string-encoding half of the mixed arm at scale: a single string chunk whose UTF-8

--- a/test/js/bun/util/readablestreamtoarraybuffer.test.ts
+++ b/test/js/bun/util/readablestreamtoarraybuffer.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import os from "node:os";
+
+// Same gate as blob-oom.test.ts / buffer.test.js 4 GiB cases: the multi-GiB tests below
+// need real memory (Windows commits allocations upfront; Linux would OOM-kill, not throw).
+const hasEnoughMemory = os.totalmem() >= 10 * 1024 ** 3;
 
 // The consumer's own promise plumbing must never route through user-patched
 // Promise.prototype.then. (A thenable returned by the user's own start() is
@@ -37,7 +42,8 @@ test("readableStreamToArrayBuffer does not call a patched Promise.prototype.then
 // should not live in the test runner. Each script prints SKIP if this machine cannot
 // allocate the inputs.
 for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"]) {
-  test(`${consumer} handles mixed string+binary chunks totaling over 2 GiB`, async () => {
+  test.skipIf(!hasEnoughMemory)(`${consumer} handles mixed string+binary chunks totaling over 2 GiB`, async () => {
+    // The trailing "!?" makes a string write land at an offset past 2^31, not just past 2^30.
     const script = `
       const GIB = 1073741824;
       let a, b;
@@ -58,6 +64,7 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
           c.enqueue(a);
           c.enqueue("xyz");
           c.enqueue(b);
+          c.enqueue("!?");
           c.close();
         },
       });
@@ -67,7 +74,7 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
         JSON.stringify({
           constructor: result.constructor.name,
           byteLength: result.byteLength,
-          markers: [r[0], r[GIB - 1], r[GIB], r[GIB + 1], r[GIB + 2], r[GIB + 3], r[2 * GIB + 2]],
+          markers: [r[0], r[GIB - 1], r[GIB], r[GIB + 1], r[GIB + 2], r[GIB + 3], r[2 * GIB + 2], r[2 * GIB + 3], r[2 * GIB + 4]],
         }),
       );
     `;
@@ -84,17 +91,17 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
     expect(stdout.trim()).toBe(
       JSON.stringify({
         constructor: consumer === "readableStreamToBytes" ? "Uint8Array" : "ArrayBuffer",
-        byteLength: 2 * 1073741824 + 3,
-        markers: [0xaa, 0xab, 0x78, 0x79, 0x7a, 0xba, 0xbb],
+        byteLength: 2 * 1073741824 + 5,
+        markers: [0xaa, 0xab, 0x78, 0x79, 0x7a, 0xba, 0xbb, 0x21, 0x3f],
       }),
     );
     expect(proc.signalCode).toBe(null);
     expect(exitCode).toBe(0);
   });
 
-  test(`${consumer} throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum`, async () => {
-    // The inputs are never touched, so they stay lazily-mapped zero pages and the
-    // oversized result allocation fails fast: this test is cheap despite the sizes.
+  test.skipIf(!hasEnoughMemory)(`${consumer} throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum`, async () => {
+    // The inputs are never touched (zero pages on Linux; Windows still commits them,
+    // hence the memory gate) and the oversized result allocation fails fast.
     const script = `
       const n = 2200000000;
       let a, b;
@@ -133,6 +140,135 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
     expect(exitCode).toBe(0);
   });
 }
+
+// The string-encoding half of the mixed arm at scale: a single string chunk whose UTF-8
+// size exceeds 2^31. UTF-16 source (U+0808 is 3 UTF-8 bytes: E0 A0 88) so the conversion
+// takes the simdutf path; the Latin-1 writer is a scalar loop that takes minutes in debug.
+test.skipIf(!hasEnoughMemory)(
+  "readableStreamToBytes handles a string chunk larger than 2 GiB",
+  async () => {
+    const script = `
+      const n = 716000000; // 3 * n = 2148000000 > 2^31
+      let s, marker;
+      try {
+        s = Buffer.alloc(2 * n, 0x08).toString("utf16le");
+        marker = new Uint8Array([1, 2, 3]);
+      } catch {
+        console.log("SKIP");
+        process.exit(0);
+      }
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(s);
+          c.enqueue(marker);
+          c.close();
+        },
+      });
+      const r = await Bun.readableStreamToBytes(stream);
+      console.log(
+        JSON.stringify({
+          byteLength: r.byteLength,
+          markers: [r[0], r[1], r[2], r[3 * n - 3], r[3 * n - 2], r[3 * n - 1], r[3 * n], r[3 * n + 1], r[3 * n + 2]],
+        }),
+      );
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    if (stdout.trim() === "SKIP") return;
+    expect(stdout.trim()).toBe(
+      JSON.stringify({
+        byteLength: 3 * 716000000 + 3,
+        markers: [0xe0, 0xa0, 0x88, 0xe0, 0xa0, 0x88, 1, 2, 3],
+      }),
+    );
+    expect(proc.signalCode).toBe(null);
+    expect(exitCode).toBe(0);
+  },
+  // ~18s under the debug+ASAN build: 3.5 GiB of string building plus a 2 GiB encode.
+  60_000,
+);
+
+// Array.prototype indexed accessors intercept the consumer's internal chunk-array pushes
+// (JSC havingABadTime), so a getter runs during the sizing pass and can resize, detach, or
+// grow an already-measured chunk before the write pass copies it. A grown chunk must be
+// clamped to its measured size (the result buffer is pre-sized; an unclamped copy would
+// overrun it) and a shrunken or detached chunk must yield a result of the actual bytes
+// written, never uninitialized memory.
+test("chunks mutated by Array.prototype accessor reentry during concatenation are clamped", async () => {
+  const script = `
+    let log = "";
+    let captured = {};
+    let mutate = () => {};
+    for (let i = 0; i < 2; i++) {
+      Object.defineProperty(Array.prototype, String(i), {
+        configurable: true,
+        set(v) {
+          log += "set" + i + ",";
+          captured[i] = v;
+        },
+        get() {
+          log += "get" + i + ",";
+          if (i === 1) mutate();
+          return captured[i];
+        },
+      });
+    }
+    // No array literals or pushes below (they would route through the accessors).
+    async function run(mutation) {
+      captured = {};
+      log = "";
+      const rab = new ArrayBuffer(64, { maxByteLength: 128 });
+      const view = new Uint8Array(rab);
+      view.fill(0x41);
+      mutate = () => {
+        if (mutation === "shrink") rab.resize(3);
+        else if (mutation === "transfer") rab.transfer();
+        else rab.resize(128);
+      };
+      let pulls = 0;
+      const stream = new ReadableStream(
+        {
+          async pull(c) {
+            pulls++;
+            if (pulls === 1) {
+              c.enqueue(view);
+            } else {
+              c.enqueue("x");
+              c.close();
+            }
+          },
+        },
+        { highWaterMark: 0 },
+      );
+      const r = new Uint8Array(await Bun.readableStreamToArrayBuffer(stream));
+      let allA = true;
+      for (let i = 0; i < r.length - 1; i++) allA = allA && r[i] === 0x41;
+      console.log(mutation + " " + log + " len=" + r.length + " allA=" + allA + " tail=" + r[r.length - 1]);
+    }
+    await run("shrink");
+    await run("transfer");
+    await run("grow");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim().split("\n")).toEqual([
+    "shrink set0,set1,get0,get1, len=4 allA=true tail=120",
+    "transfer set0,set1,get0,get1, len=1 allA=true tail=120",
+    "grow set0,set1,get0,get1, len=65 allA=true tail=120",
+  ]);
+  expect(proc.signalCode).toBe(null);
+  expect(exitCode).toBe(0);
+});
 
 test("an async start() promise is adopted observably, like Node", async () => {
   const originalThen = Promise.prototype.then;

--- a/test/js/bun/util/readablestreamtoarraybuffer.test.ts
+++ b/test/js/bun/util/readablestreamtoarraybuffer.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // The consumer's own promise plumbing must never route through user-patched
 // Promise.prototype.then. (A thenable returned by the user's own start() is
@@ -27,6 +28,107 @@ test("readableStreamToArrayBuffer does not call a patched Promise.prototype.then
     Promise.prototype.then = originalThen;
   }
 });
+
+// Mixed string+binary chunk arrays used to be concatenated through a WTF::Vector, whose
+// INT32_MAX capacity cap aborts the whole process once the total crosses 2 GiB. The
+// result must instead be assembled in an ArrayBuffer (fine up to 4 GiB on 64-bit), and
+// totals past the 4 GiB ArrayBuffer maximum must throw a catchable error.
+// Subprocess tests: the failure mode is a process abort, and the large allocations
+// should not live in the test runner. Each script prints SKIP if this machine cannot
+// allocate the inputs.
+for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"]) {
+  test(`${consumer} handles mixed string+binary chunks totaling over 2 GiB`, async () => {
+    const script = `
+      const GIB = 1073741824;
+      let a, b;
+      try {
+        a = new Uint8Array(GIB);
+        b = new ArrayBuffer(GIB);
+      } catch {
+        console.log("SKIP");
+        process.exit(0);
+      }
+      a[0] = 0xaa;
+      a[GIB - 1] = 0xab;
+      const bView = new Uint8Array(b);
+      bView[0] = 0xba;
+      bView[GIB - 1] = 0xbb;
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(a);
+          c.enqueue("xyz");
+          c.enqueue(b);
+          c.close();
+        },
+      });
+      const result = await Bun.${consumer}(stream);
+      const r = result instanceof Uint8Array ? result : new Uint8Array(result);
+      console.log(
+        JSON.stringify({
+          constructor: result.constructor.name,
+          byteLength: result.byteLength,
+          markers: [r[0], r[GIB - 1], r[GIB], r[GIB + 1], r[GIB + 2], r[GIB + 3], r[2 * GIB + 2]],
+        }),
+      );
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    if (stdout.trim() === "SKIP") return;
+    expect(JSON.parse(stdout)).toEqual({
+      constructor: consumer === "readableStreamToBytes" ? "Uint8Array" : "ArrayBuffer",
+      byteLength: 2 * 1073741824 + 3,
+      markers: [0xaa, 0xab, 0x78, 0x79, 0x7a, 0xba, 0xbb],
+    });
+    expect(proc.signalCode).toBe(null);
+    expect(exitCode).toBe(0);
+  });
+
+  test(`${consumer} throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum`, async () => {
+    // The inputs are never touched, so they stay lazily-mapped zero pages and the
+    // oversized result allocation fails fast: this test is cheap despite the sizes.
+    const script = `
+      const n = 2200000000;
+      let a, b;
+      try {
+        a = new Uint8Array(n);
+        b = new Uint8Array(n);
+      } catch {
+        console.log("SKIP");
+        process.exit(0);
+      }
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(a);
+          c.enqueue(b);
+          c.enqueue("x");
+          c.close();
+        },
+      });
+      try {
+        await Bun.${consumer}(stream);
+        console.log("NO_THROW");
+      } catch (e) {
+        console.log("THREW RangeError=" + (e instanceof RangeError));
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    if (stdout.trim() === "SKIP") return;
+    expect(stdout.trim()).toBe("THREW RangeError=true");
+    expect(proc.signalCode).toBe(null);
+    expect(exitCode).toBe(0);
+  });
+}
 
 test("an async start() promise is adopted observably, like Node", async () => {
   const originalThen = Promise.prototype.then;

--- a/test/js/bun/util/readablestreamtoarraybuffer.test.ts
+++ b/test/js/bun/util/readablestreamtoarraybuffer.test.ts
@@ -79,11 +79,15 @@ for (const consumer of ["readableStreamToArrayBuffer", "readableStreamToBytes"])
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     if (stdout.trim() === "SKIP") return;
-    expect(JSON.parse(stdout)).toEqual({
-      constructor: consumer === "readableStreamToBytes" ? "Uint8Array" : "ArrayBuffer",
-      byteLength: 2 * 1073741824 + 3,
-      markers: [0xaa, 0xab, 0x78, 0x79, 0x7a, 0xba, 0xbb],
-    });
+    // String comparison instead of JSON.parse: a crashed child diffs against "" here
+    // rather than failing with an unrelated parse error.
+    expect(stdout.trim()).toBe(
+      JSON.stringify({
+        constructor: consumer === "readableStreamToBytes" ? "Uint8Array" : "ArrayBuffer",
+        byteLength: 2 * 1073741824 + 3,
+        markers: [0xaa, 0xab, 0x78, 0x79, 0x7a, 0xba, 0xbb],
+      }),
+    );
     expect(proc.signalCode).toBe(null);
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
## What does this PR do?

Fixes an uncatchable process abort (`panic(main thread): abort() called`, exit 134) in `Bun.readableStreamToArrayBuffer` and `Bun.readableStreamToBytes` when the stream's chunks mix strings with binary data and their total size reaches 2 GiB:

```js
const n = 1100000000;
const rs = new ReadableStream({
  start(c) {
    c.enqueue(new Uint8Array(n));
    c.enqueue(new Uint8Array(n));
    c.enqueue("x"); // any string chunk forces the mixed path
    c.close();
  },
});
await Bun.readableStreamToArrayBuffer(rs); // aborted the whole process
```

### Cause

`concatenateChunks` (`src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp`) staged the mixed string+binary concatenation in a `WTF::Vector<uint8_t>`. It guarded the size sum with `CheckedSize` (which only catches 64-bit wraparound), then called `bytes.reserveInitialCapacity(total)`. `WTF::Vector` caps capacities at `INT32_MAX` and `CRASH()`es rather than failing (`isValidCapacityForVector` in `wtf/Vector.h`), so any total in [2^31, 2^64) aborted before a catchable out-of-memory path could run.

All-binary chunk arrays were unaffected: they take the `flattenArrayOfBuffersIntoArrayBufferOrUint8Array` arm, which already assembles into a `JSC::ArrayBuffer` and handles >2 GiB totals fine. Only adding a string chunk to the mix hit the Vector.

### Fix

Assemble the mixed arm directly into the result `JSC::ArrayBuffer` (`tryCreateUninitialized`), mirroring the all-binary arm:

- capacities are `size_t`, so results up to JSC's 4 GiB `MAX_ARRAY_BUFFER_SIZE` now work, matching what the all-binary arm already produces for the same data
- totals past 4 GiB make `tryCreateUninitialized` return null, which throws a catchable out-of-memory `RangeError` instead of aborting
- the final `Vector` to `ArrayBuffer` copy is gone (the bytes are written in place once)

The sizing pass now records each binary chunk's measured byte length, and the write pass clamps every copy to that measurement, so a chunk that changed size in between (e.g. a growable `SharedArrayBuffer` grown from a worker) can neither overrun the buffer nor leave uninitialized bytes exposed; if a chunk shrank or detached, the result is re-created at the actual written size, matching the previous Vector behavior.

The text consumers have the same crash shape in different functions; that is fixed separately in #37237. The Blob-side equivalents were fixed in #37215.

## How did you verify your code works?

- Reproduced the abort on `1.4.0-canary.1 (9d519e8ca)` for both consumers; both now return a 2200000001-byte result, and the all-binary arm is unchanged
- Added 4 subprocess tests to `test/js/bun/util/readablestreamtoarraybuffer.test.ts`: both consumers with mixed chunks totaling 2 GiB + 3 bytes (asserting byte markers across both chunk boundaries and the UTF-8 string bytes at offset 2^30), and both consumers with mixed totals past 4 GiB (asserting a catchable `RangeError` instead of an abort). All 4 fail on the released build (subprocess aborts) and pass with this change
- Verified small-input behavior is unchanged against the released build: chunk-type mix (view/ArrayBuffer/string), offset subarray views, multi-byte and lone-surrogate strings, empty chunks, detached buffers, and the TypeError for invalid chunk types
- `test/js/web/streams/streams.test.js`, `test/js/bun/stream/direct-readable-stream.test.tsx`, `test/js/web/fetch/stream-fast-path.test.ts`, `test/js/web/fetch/body-clone.test.ts`, `test/js/web/streams/compression.test.ts` all pass

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/readablestreamtoarraybuffer.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/util/readablestreamtoarraybuffer.test.ts:
(pass) readableStreamToArrayBuffer does not call a patched Promise.prototype.then [19.94ms]
86 |     });
87 |     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
88 |     if (stdout.trim() === "SKIP") return;
89 |     // String comparison instead of JSON.parse: a crashed child diffs against "" here
90 |     // rather than failing with an unrelated parse error.
91 |     expect(stdout.trim()).toBe(
                               ^
error: expect(received).toBe(expected)

Expected: "{"constructor":"ArrayBuffer","byteLength":2147483653,"markers":[170,171,120,121,122,186,187,33,63]}"
Received: ""

      at <anonymous> (/workspace/bun/test/js/bun/util/readablestreamtoarraybuffer.test.ts:91:27)
(fail) readableStreamToArrayBuffer handles mixed string+binary chunks totaling over 2 GiB [419.26ms]
135 |         stdout: "pipe",
136 |         stderr: "inherit",
137 |       });
138 | 
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/util/readablestreamtoarraybuffer.test.ts:
(pass) readableStreamToArrayBuffer does not call a patched Promise.prototype.then [0.27ms]
============================================================
Bun Canary v1.4.0-canary.1 (8326d1bd3) Linux x64
Linux Kernel v6.17.0 | glibc v2.41
CPU: sse42 popcnt avx avx2 avx512
Args: "/workspace/bun/build/release/bun" "-e" "\n      const GIB = 1073741824;\n      let a, b;\n      try {\n        a = new Uint8Array(GIB);\n        b = new ArrayBuffer(GIB);\n      } catch {\n        console.log("...
Features: bunfig jsc tsconfig 
Builtins: "bun:main" 

Elapsed: 5ms | User: 2ms | Sys: 3ms
RSS: 32.37 MB | Peak: 49.61 MB | Commit: 2.19 GB | Faults: 0 | Machine: 34.36 GB

panic(main thread): abort() called
oh no: Bun has crashed. This indicates a bug in Bun, not your code.

To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:

 https://bun.report/1.4.0/la28326d1bgCgkggC21klBq4635B_gpmpuDmsnhuDkvn4/Dotk1oEu3x86B8rlzoE2il1oEkst9lE2r00kEso10kE8/r9lE06w0kEs+8voEuj13tEottlwE8v5+6B0ji14CAa

curl: (22) The requested URL returned error: 403
86 |     });
87 | 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/readablestreamtoarraybuffer.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/util/readablestreamtoarraybuffer.test.ts:
(pass) readableStreamToArrayBuffer does not call a patched Promise.prototype.then [18.16ms]
(pass) readableStreamToArrayBuffer handles mixed string+binary chunks totaling over 2 GiB [1892.27ms]
(pass) readableStreamToArrayBuffer throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum [302.93ms]
(pass) readableStreamToBytes handles mixed string+binary chunks totaling over 2 GiB [1873.98ms]
(pass) readableStreamToBytes throws instead of aborting when mixed chunks exceed the 4 GiB ArrayBuffer maximum [294.42ms]
(pass) readableStreamToBytes handles a string chunk larger than 2 GiB [17616.50ms]
(pass) chunks mutated by Array.prototype accessor reentry during concatenation are clamped [321.76ms]
(pass) an async start() promise is adopted observably, like Node [11.75ms]

 8 pass
 0 fail
 22 expect() calls
Ran 8 tests across 1 file. [24.68s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c881f1ae3b
  features     baseline

22 deps, 120 codegen, 1175 objects in 641ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] gen ErrorCode+*.h
[2/1236] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 107 installs across 153 packages (no changes) [11.00ms]
[3/1236] gen bindgenv2
[4/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1236] fetch zlib
[zlib] up to date
[6/1236] fetch tinycc
[tinycc] up to date
[7/1235] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1235] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[9/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1235] gen .bind.ts → GeneratedBindings.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../webcore/streams/BunStreamConsumers.cpp         |  79 ++++---
 .../bun/util/readablestreamtoarraybuffer.test.ts   | 245 +++++++++++++++++++++
 2 files changed, 291 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp      0      0      0
test/js/bun/util/readablestreamtoarraybuffer.test.ts         0      0      0
```

</details>

<!-- robobun:evidence:end -->