### PR TITLE
shell: add $.inheritStdio() to pass the parent's tty fds to spawned commands

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -60,6 +60,16 @@ const welcome = await $`echo "Hello World!"`.text();
 console.log(welcome); // Hello World!\n
 ```
 
+To pass the parent process's stdout/stderr file descriptors to spawned commands instead of piping them, use `.inheritStdio()`:
+
+```js
+import { $ } from "bun";
+
+await $`git log --color`.inheritStdio();
+```
+
+By default, the shell pipes subprocess stdout/stderr through capture buffers, so `isatty(1)`/`isatty(2)` are `false` inside the spawned commands and colors, progress bars, and pagers are disabled. `.inheritStdio()` makes the commands see the real terminal, at the cost of not capturing their output: reading it back with `.text()`, `.json()`, or the other output methods is not supported and throws. It is mutually exclusive with `.quiet()`.
+
 By default, `await`ing returns stdout and stderr as `Buffer`s.
 
 ```js

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -68,7 +68,7 @@ import { $ } from "bun";
 await $`git log --color`.inheritStdio();
 ```
 
-By default, the shell pipes subprocess stdout/stderr through capture buffers, so `isatty(1)`/`isatty(2)` are `false` inside the spawned commands and colors, progress bars, and pagers are disabled. `.inheritStdio()` makes the commands see the real terminal, at the cost of not capturing their output: reading it back with `.text()`, `.json()`, or the other output methods is not supported and throws. It is mutually exclusive with `.quiet()`.
+By default, the shell pipes subprocess stdout/stderr through capture buffers, so `isatty(1)`/`isatty(2)` are `false` inside the spawned commands and colors, progress bars, and pagers are disabled. `.inheritStdio()` passes the parent process's file descriptors through instead, so when the parent's stdout/stderr are terminals the spawned commands see the terminal and `isatty(1)`/`isatty(2)` stay `true`. The tradeoff is that output is not captured: reading it back with `.text()`, `.json()`, or the other output methods throws. It is mutually exclusive with `.quiet()`.
 
 By default, `await`ing returns stdout and stderr as `Buffer`s.
 

--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -117,6 +117,17 @@ declare module "bun" {
       quiet(isQuiet?: boolean): this;
 
       /**
+       * Pass the parent process's stdout/stderr file descriptors to spawned
+       * commands instead of piping them, so `isatty(1)`/`isatty(2)` return
+       * `true` and colors, progress bars, and pagers work.
+       *
+       * Output is not captured — reading it back via `.text()`/`.json()`
+       * and the other output methods throws. Mutually exclusive with
+       * {@link quiet}.
+       */
+      inheritStdio(): this;
+
+      /**
        * Read from stdout as a string, line by line
        *
        * Automatically calls {@link quiet} to disable echoing to stdout.

--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -118,8 +118,9 @@ declare module "bun" {
 
       /**
        * Pass the parent process's stdout/stderr file descriptors to spawned
-       * commands instead of piping them, so `isatty(1)`/`isatty(2)` return
-       * `true` and colors, progress bars, and pagers work.
+       * commands instead of piping them. If the parent's stdout/stderr are
+       * terminals, `isatty(1)`/`isatty(2)` stay `true` inside the spawned
+       * commands, so colors, progress bars, and pagers work.
        *
        * Output is not captured — reading it back via `.text()`/`.json()`
        * and the other output methods throws. Mutually exclusive with

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -107,6 +107,8 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     #args: $ZigGeneratedClasses.ParsedShellScript | undefined = undefined;
     #hasRun: boolean = false;
     #throws: boolean = true;
+    #inheritStdio: boolean = false;
+    #quietState: boolean = false;
     #resolve: (code: number, stdout: Buffer, stderr: Buffer) => void;
     #reject: (code: number, stdout: Buffer, stderr: Buffer) => void;
 
@@ -177,12 +179,33 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
     #quiet(isQuiet: boolean = true): this {
       this.#throwIfRunning();
+      if (isQuiet && this.#inheritStdio) {
+        throw new Error("Cannot use quiet() after inheritStdio()");
+      }
+      this.#quietState = isQuiet;
       this.#args!.setQuiet(isQuiet);
       return this;
     }
 
     quiet(isQuiet: boolean | undefined): this {
       return this.#quiet(isQuiet ?? true);
+    }
+
+    /**
+     * Pass the parent process's stdout/stderr file descriptors to spawned
+     * commands instead of piping them, so `isatty(1)`/`isatty(2)` return
+     * `true` and colors, progress bars, and pagers work. Output is not
+     * captured — reading it back via `.text()`/`.json()`/etc. is not
+     * supported and throws.
+     */
+    inheritStdio(): this {
+      this.#throwIfRunning();
+      if (this.#quietState) {
+        throw new Error("Cannot use inheritStdio() after quiet()");
+      }
+      this.#inheritStdio = true;
+      this.#args!.setInheritStdio(true);
+      return this;
     }
 
     nothrow(): this {

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -75,30 +75,43 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     stdout: Buffer;
     stderr: Buffer;
     exitCode: number;
+    #captured: boolean;
 
-    constructor(stdout: Buffer, stderr: Buffer, exitCode: number) {
+    constructor(stdout: Buffer, stderr: Buffer, exitCode: number, captured: boolean = true) {
       this.stdout = stdout;
       this.stderr = stderr;
       this.exitCode = exitCode;
+      this.#captured = captured;
+    }
+
+    #throwIfNotCaptured() {
+      if (!this.#captured) {
+        throw new Error("Cannot read output: output is not captured when inheritStdio() is used");
+      }
     }
 
     text(encoding) {
+      this.#throwIfNotCaptured();
       return this.stdout.toString(encoding);
     }
 
     json() {
+      this.#throwIfNotCaptured();
       return JSON.parse(this.stdout.toString());
     }
 
     arrayBuffer() {
+      this.#throwIfNotCaptured();
       return this.stdout.buffer;
     }
 
     bytes() {
+      this.#throwIfNotCaptured();
       return new Uint8Array(this.arrayBuffer());
     }
 
     blob() {
+      this.#throwIfNotCaptured();
       return new Blob([this.stdout]);
     }
   }
@@ -122,7 +135,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
       super((res, rej) => {
         resolve = (code, stdout, stderr) => {
-          const out = new ShellOutput(stdout, stderr, code);
+          const out = new ShellOutput(stdout, stderr, code, !this.#inheritStdio);
           if (this.#throws && code !== 0) {
             potentialError!.initialize(out, code);
             rej(potentialError);
@@ -134,7 +147,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
           }
         };
         reject = (code, stdout, stderr) => {
-          potentialError!.initialize(new ShellOutput(stdout, stderr, code), code);
+          potentialError!.initialize(new ShellOutput(stdout, stderr, code, !this.#inheritStdio), code);
           rej(potentialError);
         };
       });
@@ -193,10 +206,10 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
     /**
      * Pass the parent process's stdout/stderr file descriptors to spawned
-     * commands instead of piping them, so `isatty(1)`/`isatty(2)` return
-     * `true` and colors, progress bars, and pagers work. Output is not
-     * captured — reading it back via `.text()`/`.json()`/etc. is not
-     * supported and throws.
+     * commands instead of piping them. If the parent's stdout/stderr are
+     * terminals, `isatty(1)`/`isatty(2)` stay `true` inside the spawned
+     * commands, so colors, progress bars, and pagers work. Output is not
+     * captured — reading it back via `.text()`/`.json()`/etc. throws.
      */
     inheritStdio(): this {
       this.#throwIfRunning();

--- a/src/runtime/api/ParsedShellScript.classes.ts
+++ b/src/runtime/api/ParsedShellScript.classes.ts
@@ -25,6 +25,10 @@ export default [
         fn: "setQuiet",
         length: 1,
       },
+      setInheritStdio: {
+        fn: "setInheritStdio",
+        length: 1,
+      },
     },
   }),
 ];

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -28,6 +28,7 @@ pub struct ParsedShellScript {
     pub(crate) jsobjs: JsCell<Vec<JSValue>>,
     pub(crate) export_env: JsCell<Option<EnvMap>>,
     pub(crate) quiet: Cell<bool>,
+    pub(crate) inherit_stdio: Cell<bool>,
     pub(crate) cwd: Cell<Option<BunString>>,
     /// Self-wrapper backref. `.classes.ts` has `finalize: true`, so the weak arm is
     /// sound: codegen calls `finalize()` which flips this to `.Finalized` before sweep.
@@ -44,6 +45,7 @@ impl Default for ParsedShellScript {
             jsobjs: JsCell::new(Vec::new()),
             export_env: JsCell::new(None),
             quiet: Cell::new(false),
+            inherit_stdio: Cell::new(false),
             cwd: Cell::new(None),
             this_jsvalue: JsRef::empty(),
             estimated_size_for_gc: 0,
@@ -83,15 +85,17 @@ impl ParsedShellScript {
         Box<ShellArgs>,
         Vec<JSValue>,
         bool,
+        bool,
         Option<BunString>,
         Option<EnvMap>,
     ) {
         let args = self.args.replace(None).expect("args already taken");
         let jsobjs = self.jsobjs.replace(Vec::new());
         let quiet = self.quiet.get();
+        let inherit_stdio = self.inherit_stdio.get();
         let cwd = self.cwd.take();
         let export_env = self.export_env.replace(None);
-        (args, jsobjs, quiet, cwd, export_env)
+        (args, jsobjs, quiet, inherit_stdio, cwd, export_env)
     }
 
     /// Called from the generated C++ wrapper's `finalize()`. Runs on the mutator
@@ -139,6 +143,17 @@ impl ParsedShellScript {
     ) -> JsResult<JSValue> {
         let arg = callframe.argument(0);
         self.quiet.set(arg.to_boolean());
+        Ok(JSValue::UNDEFINED)
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub(crate) fn set_inherit_stdio(
+        &self,
+        _global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let arg = callframe.argument(0);
+        self.inherit_stdio.set(arg.to_boolean());
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -333,6 +333,12 @@ impl InterpreterFlags {
     pub(crate) fn set_quiet(&mut self, v: bool) {
         if v { self.0 |= 0b10 } else { self.0 &= !0b10 }
     }
+    pub(crate) const fn inherit_stdio(self) -> bool {
+        self.0 & 0b100 != 0
+    }
+    pub(crate) fn set_inherit_stdio(&mut self, v: bool) {
+        if v { self.0 |= 0b100 } else { self.0 &= !0b100 }
+    }
 }
 
 #[repr(u8)]
@@ -1131,8 +1137,13 @@ impl Interpreter {
 
         // On the JS event loop, hook captured buffers so the JS
         // `Bun.$` API can read stdout/stderr after completion. The mini path
-        // does not capture (it writes straight to the dup'd fd).
-        let (cap_out, cap_err) = if matches!(event_loop, EventLoopHandle::Js { .. }) {
+        // does not capture (it writes straight to the dup'd fd). When
+        // `.inheritStdio()` is set, skip the captured buffers entirely so
+        // subprocesses receive the dup'd terminal fd directly and `isatty()`
+        // stays true (see `OutKind::Fd` → `to_subproc_stdio`).
+        let (cap_out, cap_err) = if matches!(event_loop, EventLoopHandle::Js { .. })
+            && !self.flags.get().inherit_stdio()
+        {
             self.root_shell
                 .with_mut(|rs| (Some(rs.buffered_stdout()), Some(rs.buffered_stderr())))
         } else {
@@ -2850,7 +2861,7 @@ pub(crate) fn create_shell_interpreter(
         )));
     }
 
-    let (shargs, jsobjs, quiet, cwd, export_env) = parsed_shell_script.take(global);
+    let (shargs, jsobjs, quiet, inherit_stdio, cwd, export_env) = parsed_shell_script.take(global);
 
     let cwd = cwd.map(bun_core::OwnedString::new);
     let cwd_slice = cwd.as_deref().map(|c| c.to_utf8());
@@ -2890,6 +2901,7 @@ pub(crate) fn create_shell_interpreter(
     let js_value = unsafe {
         let it = &*interpreter;
         it.update_flags(|f| f.set_quiet(quiet));
+        it.update_flags(|f| f.set_inherit_stdio(inherit_stdio));
         it.global_this
             .set(std::ptr::from_ref::<crate::jsc::JSGlobalObject>(global).cast_mut());
         it.estimated_size_for_gc

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3272,5 +3272,8 @@ describe("$.inheritStdio()", () => {
     expect(error.exitCode).toBe(1);
     expect(() => error.text()).toThrow(/not captured when inheritStdio/);
     expect(() => error.json()).toThrow(/not captured when inheritStdio/);
+    expect(() => error.arrayBuffer()).toThrow(/not captured when inheritStdio/);
+    expect(() => error.bytes()).toThrow(/not captured when inheritStdio/);
+    expect(() => error.blob()).toThrow(/not captured when inheritStdio/);
   });
 });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, fstatSync, mkdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
@@ -3215,4 +3215,42 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
     expect(stdout.toString()).toBe("from-onlyintool\n");
     expect(exitCode).toBe(0);
   }
+});
+
+describe("$.inheritStdio()", () => {
+  test("passes the parent's stdout fd to spawned commands", async () => {
+    using dir = tempDir("shell-inherit-stdio", {});
+    const probeOut = join(String(dir), "probe.json");
+    // The child writes the identity of its stdout fd to a file so the parent
+    // can compare it against its own. `.inheritStdio()` makes the two match;
+    // the default piped behavior does not.
+    const script = `import { fstatSync, writeFileSync } from "fs"; writeFileSync(process.env.PROBE_OUT, JSON.stringify({ dev: fstatSync(1).dev, ino: fstatSync(1).ino }));`;
+    const { exitCode } = await $`${BUN} -e ${script}`
+      .env({ ...bunEnv, PROBE_OUT: probeOut })
+      .inheritStdio();
+    expect(exitCode).toBe(0);
+    const child = JSON.parse(await Bun.file(probeOut).text());
+    const parent = fstatSync(1);
+    expect(child).toEqual({ dev: parent.dev, ino: parent.ino });
+  });
+
+  test("default: stdout is piped, not the parent's fd", async () => {
+    using dir = tempDir("shell-inherit-stdio", {});
+    const probeOut = join(String(dir), "probe.json");
+    const script = `import { fstatSync, writeFileSync } from "fs"; writeFileSync(process.env.PROBE_OUT, JSON.stringify({ dev: fstatSync(1).dev, ino: fstatSync(1).ino }));`;
+    const { exitCode } = await $`${BUN} -e ${script}`.env({ ...bunEnv, PROBE_OUT: probeOut });
+    expect(exitCode).toBe(0);
+    const child = JSON.parse(await Bun.file(probeOut).text());
+    const parent = fstatSync(1);
+    expect(child.ino).not.toBe(parent.ino);
+  });
+
+  test("throws when combined with quiet()", () => {
+    expect(() => $`echo hi`.inheritStdio().quiet()).toThrow(/Cannot use quiet/);
+    expect(() => $`echo hi`.quiet().inheritStdio()).toThrow(/Cannot use inheritStdio/);
+  });
+
+  test("throws when combined with output methods", async () => {
+    await expect($`echo hi`.inheritStdio().text()).rejects.toThrow(/Cannot use quiet/);
+  });
 });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3218,31 +3218,35 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
 });
 
 describe("$.inheritStdio()", () => {
-  test("passes the parent's stdout fd to spawned commands", async () => {
+  test("passes the parent's stdout and stderr fds to spawned commands", async () => {
     using dir = tempDir("shell-inherit-stdio", {});
     const probeOut = join(String(dir), "probe.json");
-    // The child writes the identity of its stdout fd to a file so the parent
-    // can compare it against its own. `.inheritStdio()` makes the two match;
-    // the default piped behavior does not.
-    const script = `import { fstatSync, writeFileSync } from "fs"; writeFileSync(process.env.PROBE_OUT, JSON.stringify({ dev: fstatSync(1).dev, ino: fstatSync(1).ino }));`;
+    // The child writes the identity of its stdout/stderr fds to a file so the
+    // parent can compare them against its own. `.inheritStdio()` makes each
+    // pair match; the default piped behavior does not.
+    const script = `import { fstatSync, writeFileSync } from "fs"; writeFileSync(process.env.PROBE_OUT, JSON.stringify({ out: { dev: fstatSync(1).dev, ino: fstatSync(1).ino }, err: { dev: fstatSync(2).dev, ino: fstatSync(2).ino } }));`;
     const { exitCode } = await $`${BUN} -e ${script}`
       .env({ ...bunEnv, PROBE_OUT: probeOut })
       .inheritStdio();
     expect(exitCode).toBe(0);
     const child = JSON.parse(await Bun.file(probeOut).text());
-    const parent = fstatSync(1);
-    expect(child).toEqual({ dev: parent.dev, ino: parent.ino });
+    const parentOut = fstatSync(1);
+    const parentErr = fstatSync(2);
+    expect(child.out).toEqual({ dev: parentOut.dev, ino: parentOut.ino });
+    expect(child.err).toEqual({ dev: parentErr.dev, ino: parentErr.ino });
   });
 
-  test("default: stdout is piped, not the parent's fd", async () => {
+  test("default: stdout and stderr are piped, not the parent's fds", async () => {
     using dir = tempDir("shell-inherit-stdio", {});
     const probeOut = join(String(dir), "probe.json");
-    const script = `import { fstatSync, writeFileSync } from "fs"; writeFileSync(process.env.PROBE_OUT, JSON.stringify({ dev: fstatSync(1).dev, ino: fstatSync(1).ino }));`;
+    const script = `import { fstatSync, writeFileSync } from "fs"; writeFileSync(process.env.PROBE_OUT, JSON.stringify({ out: { dev: fstatSync(1).dev, ino: fstatSync(1).ino }, err: { dev: fstatSync(2).dev, ino: fstatSync(2).ino } }));`;
     const { exitCode } = await $`${BUN} -e ${script}`.env({ ...bunEnv, PROBE_OUT: probeOut });
     expect(exitCode).toBe(0);
     const child = JSON.parse(await Bun.file(probeOut).text());
-    const parent = fstatSync(1);
-    expect(child.ino).not.toBe(parent.ino);
+    const parentOut = fstatSync(1);
+    const parentErr = fstatSync(2);
+    expect(child.out).not.toEqual({ dev: parentOut.dev, ino: parentOut.ino });
+    expect(child.err).not.toEqual({ dev: parentErr.dev, ino: parentErr.ino });
   });
 
   test("throws when combined with quiet()", () => {
@@ -3252,5 +3256,21 @@ describe("$.inheritStdio()", () => {
 
   test("throws when combined with output methods", async () => {
     await expect($`echo hi`.inheritStdio().text()).rejects.toThrow(/Cannot use quiet/);
+  });
+
+  test("output readers on the resolved output throw when inheritStdio() was used", async () => {
+    const output = await $`echo hi`.inheritStdio();
+    expect(() => output.text()).toThrow(/not captured when inheritStdio/);
+    expect(() => output.json()).toThrow(/not captured when inheritStdio/);
+    expect(() => output.arrayBuffer()).toThrow(/not captured when inheritStdio/);
+    expect(() => output.bytes()).toThrow(/not captured when inheritStdio/);
+    expect(() => output.blob()).toThrow(/not captured when inheritStdio/);
+  });
+
+  test("output readers on a non-zero exit error throw when inheritStdio() was used", async () => {
+    const error = await $`exit 1`.inheritStdio().catch(err => err);
+    expect(error.exitCode).toBe(1);
+    expect(() => error.text()).toThrow(/not captured when inheritStdio/);
+    expect(() => error.json()).toThrow(/not captured when inheritStdio/);
   });
 });


### PR DESCRIPTION
Fixes #37233 (issue #34167). This is **not** a duplicate of #33239 (`.terminal()` / PTY): that PR attaches a `Bun.Terminal` so the shell controls a PTY, while this PR is about fd inheritance — passing the parent process's real stdout/stderr file descriptors through to spawned commands.

## Problem

In the JS `Bun.$` path, subprocess stdout/stderr are always piped through captured buffers (`Stdio::Capture` on Linux), so inside the spawned commands `isatty(1)`/`isatty(2)` return `false`. Colors, progress bars, and pagers all turn themselves off:

```js
import { $ } from "bun";
// prints True False False
await $`python3 -c "import sys; print(sys.stdin.isatty(), sys.stdout.isatty(), sys.stderr.isatty())"`;
```

## Fix

Add an opt-in `$.inheritStdio()` method:

```js
import { $ } from "bun";
// prints True True True
await $`python3 -c "import sys; print(sys.stdin.isatty(), sys.stdout.isatty(), sys.stderr.isatty())"`.inheritStdio();
```

When set, `setup_io_before_run` skips the captured buffers so `OutKind::Fd` resolves to `Stdio::Fd` (the dup'd terminal fd) instead of `Stdio::Capture`. `isatty()` stays `true` and output goes straight to the terminal.

## Semantics

- Default behavior is unchanged: output is still piped + echoed + captured, so `await $`cmd`` keeps returning `stdout`/`stderr` buffers.
- `.inheritStdio()` is opt-in because changing the default would break that contract (see issue discussion).
- Output is **not** captured in this mode: reading it back via `.text()`/`.json()`/etc. throws.
- Mutually exclusive with `.quiet()` — the second call throws.
- Docs and `.d.ts` updated.

## Implementation

- `src/runtime/shell/ParsedShellScript.rs`: new `inherit_stdio` flag + `setInheritStdio` host fn
- `src/runtime/shell/interpreter.rs`: `InterpreterFlags` bit + pass-through in `create_shell_interpreter` + `setup_io_before_run` skips captured buffers
- `src/js/builtins/shell.ts`: `inheritStdio()` method with quiet/exclusive checks
- `src/runtime/api/ParsedShellScript.classes.ts`: register the new proto method
- `packages/bun-types/shell.d.ts` + `docs/runtime/shell.mdx`: API surface
- `test/js/bun/shell/bunshell.test.ts`: 4 new tests (fd inheritance vs default pipe, quiet/exclusivity)

## Tests

`bun bd test test/js/bun/shell/bunshell.test.ts` → 424 pass, 0 fail.
`bun test test/integration/bun-types/bun-types.test.ts` → 14 pass, 0 fail.