### PR TITLE
worker_threads: test that a port stranded in an exited worker's inbox closes its peer

### DIFF
--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1223,6 +1223,36 @@ test("dropping a transferred port notifies its peer", async () => {
   port1.close();
 });
 
+// Same, across threads: a port transferred to a worker that exits before draining its
+// inbox goes down with that inbox. The surviving peer must get 'close' and release the
+// loop, or a parent with a 'message' listener on it never exits (the listener refs the
+// port, and nothing is left to unref it).
+test.concurrent("a port stranded in an exited worker's inbox closes its peer", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker, MessageChannel } = require("worker_threads");
+       const { port1, port2 } = new MessageChannel();
+       const w = new Worker("process.exit(0)", { eval: true });
+       w.postMessage({ port: port2 }, [port2]); // queued; the worker never reads it
+       port1.on("message", () => {}); // refs port1; a missed 'close' hangs the parent
+       port1.on("close", () => console.log("port1 closed"));
+       process.on("exit", () => console.log("parent exit"));`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // signalCode null => it exited on its own rather than hanging until killed.
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "port1 closed\nparent exit",
+    stderr,
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 // close() outside a dispatch drops whatever is queued; close() from inside a
 // 'message' handler lets the in-flight drain finish. Both are node's behaviour.
 test("close() drops queued messages unless it runs inside a dispatch", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1247,7 +1247,7 @@ test.concurrent("a port stranded in an exited worker's inbox closes its peer", a
   // signalCode null => it exited on its own rather than hanging until killed.
   expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: "port1 closed\nparent exit",
-    stderr,
+    stderr: "",
     exitCode: 0,
     signalCode: null,
   });


### PR DESCRIPTION
### Scenario

A MessagePort transferred to a worker that exits before draining its inbox goes down with that inbox. The surviving peer must receive `'close'` and release its event-loop ref. Before the worker lifetime rework (#37075) it did not:

```js
import { Worker, isMainThread } from "node:worker_threads";
if (isMainThread) {
  const { port1, port2 } = new MessageChannel();
  const w = new Worker(new URL(import.meta.url));
  w.postMessage({ port: port2 }, [port2]);   // queued; the worker never reads it
  port1.on("message", () => {});             // refs port1
  port1.on("close", () => console.log("close"));
} else {
  process.exit(0);                           // exit before touching parentPort
}
```

Node v26 fires `'close'` on `port1` and the parent exits. Bun canaries right before #37075 (52bf09cb1) never fired `'close'`, `port1.hasRef()` stayed true, and the parent hung forever at 0% CPU. Bun 1.3.14 had a different wrong shape: the parent exited abruptly with no `'close'` and without running its `process.on('exit')` handlers.

### What this PR does

#37075 fixed this (the stop phase closes ports still queued in a dead worker's inbox), but its tests only cover the same-thread drop ("dropping a transferred port notifies its peer") and the in-transit-to-a-live-worker direction. This adds the cross-thread regression test so the dead-worker-inbox case stays pinned: spawn a parent whose worker exits immediately, assert the surviving port gets `'close'`, the parent's exit handlers run, and the process exits 0 on its own (no signal).

### Verification

- fails on bun 1.3.14: stdout empty (no `'close'`, exit handlers skipped)
- pre-#37075 canary per 3/3 manual runs of the repro: parent hangs until killed
- passes with a debug build of current main (`bun bd test`), full file green (122 pass)

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/worker_threads/worker_threads.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (5c1be4825)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1885.78ms]
(pass) all worker_threads module properties are present [23.11ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.93ms]
(pass) all worker_threads worker instance properties are present [162.99ms]
(pass) threadId module and worker property is consistent [204.83ms]
(pass) receiveMessageOnPort works across threads [1796.99ms]
(pass) receiveMessageOnPort works as FIFO [14.13ms]
(pass) you can override globalThis.postMessage [1792.31ms]
(pass) support require in eval [1762.85ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1744.55ms]
(pass) support require in eval for a file that doesnt exist [1751.23ms]
(pass) support worker eval that throws [1813.04ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [6859.29ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [3435.16ms]
(pass) execArgv option > can specify an array of strings [3428.96ms]
(pass) eval does not leak source code [31711.76ms]
(pass) captured stdio backpressure > stdout write completion is withheld until the parent reads [1849.03ms]
(pass) captured stdio backpressure > large stdout survives writev batching and repeated acks [2012.14ms]
(pass) captured stdio backpressure > captured stdio that is never consumed does not prevent exit [2838.97ms]
(pass) worker event > is emitted on the next tick with the right value [15.83ms]
(pass) worker event > uses an overridden process.emit function [17.16ms]
(pass) worker event > throws if process.emit is not a function [3646.11ms]
(pass) terminate() of a running, idle worker resolves 1 like Node [1844.63ms]
(pass) environmentData
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/worker_threads/worker_threads.test.ts | 30 ++++++++++++++++++++++
 1 file changed, 30 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
test/js/node/worker_threads/worker_threads.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->