### PR TITLE
Throw instead of aborting when a string body's utf8 encoding exceeds 4 GiB

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -364,6 +364,8 @@ impl ArrayBuffer {
         value.as_array_buffer(ctx).unwrap()
     }
 
+    /// Ownership of `bytes` transfers to JSC either way: above
+    /// `MAX_ARRAY_BUFFER_SIZE` the C++ side frees them and throws a RangeError.
     pub fn from_default_allocator(
         global: &JSGlobalObject,
         typed_array_type: JSType,
@@ -372,7 +374,7 @@ impl ArrayBuffer {
         match typed_array_type {
             // SAFETY: FFI — `global` is a live opaque ZST handle (coerces to *const); `bytes` is
             // a mimalloc-backed buffer whose ownership transfers to JSC.
-            JSType::ArrayBuffer => Ok(unsafe {
+            JSType::ArrayBuffer => crate::call_zero_is_throw(global, || unsafe {
                 JSArrayBuffer__fromDefaultAllocator(global, bytes.as_mut_ptr(), bytes.len())
             }),
             // `JSUint8Array::from_bytes` takes `Box<[u8]>`; reconstruct

--- a/src/jsc/bindings/Uint8Array.cpp
+++ b/src/jsc/bindings/Uint8Array.cpp
@@ -2,41 +2,57 @@
 
 #include "JavaScriptCore/JSArrayBuffer.h"
 #include "JavaScriptCore/TypedArrayType.h"
+#include "JSBuffer.h"
 #include "MimallocWTFMalloc.h"
 
 namespace Bun {
 
+static void freeDefaultAllocatorBytes(void* bytes, void*)
+{
+    Bun::defaultAllocatorFree(bytes);
+}
+
 extern "C" JSC::EncodedJSValue JSUint8Array__fromDefaultAllocator(JSC::JSGlobalObject* lexicalGlobalObject, uint8_t* ptr, size_t length)
 {
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSUint8Array* uint8Array;
 
     if (length > 0) [[likely]] {
+        if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(lexicalGlobalObject, scope, ptr, length, freeDefaultAllocatorBytes, nullptr)) [[unlikely]]
+            return {};
+
         auto buffer = ArrayBuffer::createFromBytes({ ptr, length }, createSharedTask<void(void*)>([](void* p) {
-            Bun::defaultAllocatorFree(p);
+            freeDefaultAllocatorBytes(p, nullptr);
         }));
 
         uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, lexicalGlobalObject->typedArrayStructureWithTypedArrayType<JSC::TypeUint8>(), WTF::move(buffer), 0, length);
     } else {
         uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, lexicalGlobalObject->typedArrayStructureWithTypedArrayType<JSC::TypeUint8>(), 0);
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     return JSC::JSValue::encode(uint8Array);
 }
 
 extern "C" JSC::EncodedJSValue JSArrayBuffer__fromDefaultAllocator(JSC::JSGlobalObject* lexicalGlobalObject, uint8_t* ptr, size_t length)
 {
-
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     RefPtr<ArrayBuffer> buffer;
 
     if (length > 0) [[likely]] {
+        if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(lexicalGlobalObject, scope, ptr, length, freeDefaultAllocatorBytes, nullptr)) [[unlikely]]
+            return {};
+
         buffer = ArrayBuffer::createFromBytes({ ptr, length }, createSharedTask<void(void*)>([](void* p) {
-            Bun::defaultAllocatorFree(p);
+            freeDefaultAllocatorBytes(p, nullptr);
         }));
     } else {
         buffer = ArrayBuffer::create(0, 1);
     }
 
-    auto arrayBuffer = JSC::JSArrayBuffer::create(lexicalGlobalObject->vm(), lexicalGlobalObject->arrayBufferStructure(), WTF::move(buffer));
+    auto arrayBuffer = JSC::JSArrayBuffer::create(vm, lexicalGlobalObject->arrayBufferStructure(), WTF::move(buffer));
     return JSC::JSValue::encode(arrayBuffer);
 }
 

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -280,3 +280,45 @@ describe.skipIf(isWindows || os.totalmem() < 10 * 1024 ** 3)(
     }, 120_000);
   },
 );
+
+// A string body whose utf8 encoding exceeds the ArrayBuffer cap (2^32 bytes)
+// used to reach ArrayBuffer::createFromBytes, which RELEASE_ASSERTs above the
+// cap, so the process aborted. arrayBuffer() and bytes() adopt the bytes
+// through two different functions, so each gets a case. Each case encodes a
+// real 4 GiB in the child (about 30 seconds in a debug build), so it runs in a
+// subprocess with the same memory gate and timeout as the file cases above.
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("string bodies above the 4 GiB ArrayBuffer limit", () => {
+  async function consumeOversizedStringBody(method: "arrayBuffer" | "bytes") {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const s = "\\u20ac".repeat(1431655766); // 3 utf8 bytes each -> 2**32 + 2
+          const result = await new Response(s)[${JSON.stringify(method)}]().then(
+            buf => ({ unexpectedByteLength: buf.byteLength }),
+            e => ({ error: { name: e.name, message: e.message } }),
+          );
+          console.log(JSON.stringify(result));
+          `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode, signalCode: proc.signalCode }));
+  }
+
+  test("Response.arrayBuffer() rejects with a RangeError instead of aborting", async () => {
+    expect(await consumeOversizedStringBody("arrayBuffer")).toEqual({
+      error: { name: "RangeError", message: "Out of memory" },
+    });
+  }, 120_000);
+
+  test("Response.bytes() rejects with a RangeError instead of aborting", async () => {
+    expect(await consumeOversizedStringBody("bytes")).toEqual({
+      error: { name: "RangeError", message: "Out of memory" },
+    });
+  }, 120_000);
+});


### PR DESCRIPTION
### Problem

`Response`/`Request` `.arrayBuffer()` and `.bytes()` on a string body abort the process when the body's utf8 encoding exceeds 2^32 bytes. Release builds die with a silent SIGABRT. Debug builds fail with:

```
ASSERTION FAILED: m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE
ArrayBuffer.cpp(150) JSC::ArrayBufferContents::ArrayBufferContents(...)
```

```js
const s = "\u20ac".repeat(1431655766); // 3 utf8 bytes each -> 4294967298 = 2^32 + 2
await new Response(s).arrayBuffer();   // abort
```

- Cause: `Any::to_array_buffer_view` (Blob.rs) hands the bytes to `JSArrayBuffer__fromDefaultAllocator` / `JSUint8Array__fromDefaultAllocator` (Uint8Array.cpp). Those call `ArrayBuffer::createFromBytes`, which has no graceful size check, only the `RELEASE_ASSERT` above. Streamed bodies (`InternalBlob`) and `TextEncoderStream` (`JSUint8Array::from_bytes`) reach the same two functions.
- #39558 and #39564 added `Bun::rejectBytesNoCopyAboveArrayBufferLimit` and applied it to the other byte-adopting functions (file reads, `Bun.mmap`, the `Buffer` hand-offs, so `Buffer.from` already throws on main). #39558 left this pair to this PR.

### Fix

- `JSUint8Array__fromDefaultAllocator` and `JSArrayBuffer__fromDefaultAllocator` call `rejectBytesNoCopyAboveArrayBufferLimit` before `createFromBytes`. Above the cap the helper frees the bytes and throws the `RangeError: Out of memory` that `new ArrayBuffer(2 ** 32 + 1)` throws. The length is already known at this point, so this adds one comparison and no pass over the input.
- `ArrayBuffer::from_default_allocator` wraps the `ArrayBuffer` arm in `call_zero_is_throw`, so the throw reaches the Blob.rs callers as an `Err`. #40410 already did this for the `Uint8Array` arm through `JSUint8Array::from_bytes`.
- Results at or below 2^32 bytes are unchanged.

### Verification

- `test/js/web/fetch/blob-oom.test.ts`, "string bodies above the 4 GiB ArrayBuffer limit": one case per function. `Response.arrayBuffer()` and `Response.bytes()` on the string above reject with the RangeError. On main the child exits 134. With the fix, each case takes about 30 s in a debug build (it encodes a real 4 GiB), so each runs in a subprocess and uses the same 10 GiB memory gate and 120 s ceiling as the file cases above it.
- The same two calls pass with `BUN_JSC_validateExceptionChecks=1`.
- The whole file passes with the debug build (22 tests).

### Background

JSC stores an `ArrayBuffer` length as `size_t` but caps it at `MAX_ARRAY_BUFFER_SIZE` (2^32 on 64-bit). Its allocating constructors return null above the cap, and Bun turns that into `RangeError: Out of memory`, which is why `TextEncoder.encode` and `Blob.bytes()` already threw for this input. The adopting constructor `createFromBytes`, used for zero-copy hand-offs of bytes Bun already owns, asserts instead, so Bun has to check before the hand-off. `rejectBytesNoCopyAboveArrayBufferLimit` is that check. Because the caller has already given up the bytes, it runs the deallocator before it throws, the same way a collection would. `from_js_host_call` is the Rust wrapper for C++ functions that return a zero value exactly when they threw. It converts that into an `Err`.

<details>
<summary>Earlier shapes of this PR</summary>

The first version checked the size at three call sites before the shared helper existed. After #39558 and #39564 landed, it was rebased to use the helper at the two adopting functions, and also computed the utf8 length of the string ahead of encoding so the error path would not allocate the oversized encoding. That extra pass over the string was removed at review. The PR now only guards the hand-off.

A later rebase over #40410 (`JSUint8Array::from_bytes` now returns `JsResult`) removed the Blob.rs and JSUint8Array.rs changes, which main had made on its own. The conflict was in those two files plus the `ArrayBuffer` arm of `from_default_allocator`. The PR is now 3 files: the guard in Uint8Array.cpp, one wrapped arm in array_buffer.rs, and the test.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob-oom.test.ts

<!-- robobun:evidence:end -->
