### PR TITLE
install: fix duplicate bun.lock keys when a file: dependency shares a workspace member's name

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -111,6 +111,28 @@ pub(crate) fn value_loc_of(source: &bun_ast::Source, key_loc: bun_ast::Loc) -> b
     crate::bun_json::property_value_loc(&source.contents, key_loc).unwrap_or(key_loc)
 }
 
+/// A folder dependency and the workspace member sharing its name are the same
+/// package only when the dependency's path names the member's directory.
+/// `folder` is a folder path relative to the workspace root (either
+/// platform's separators); `workspace_path` is the member's registered
+/// posix-relative path.
+pub(crate) fn folder_path_is_workspace_path(folder: &[u8], workspace_path: &[u8]) -> bool {
+    let mut buf = path::path_buffer_pool::get();
+    let normalized = resolve_path::join_string_buf::<path::platform::Auto>(&mut buf[..], &[folder]);
+    if normalized.len() != workspace_path.len() {
+        return false;
+    }
+    if cfg!(windows) {
+        for (&a, &b) in normalized.iter().zip(workspace_path) {
+            if a != b && !(a == b'\\' && b == b'/') {
+                return false;
+            }
+        }
+        return true;
+    }
+    strings::eql(normalized, workspace_path)
+}
+
 #[cold]
 fn invalid_trusted_dependencies(
     log: &mut bun_ast::Log,
@@ -1748,6 +1770,29 @@ impl Package<u64> {
                 // if relative is empty, we are linking the package to itself
                 dependency_version.value.folder = string_builder
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
+
+                // A folder dependency pointing anywhere but the same-named
+                // workspace member's directory can never resolve to that
+                // member. Keep the explicitly declared dependency and drop
+                // the member's workspace dependency, like the Npm arm below
+                // does on a version mismatch. Without this, both place into
+                // the root node_modules and bun.lock gets a duplicate
+                // package key its own parser rejects.
+                if let Some(workspace_path) = workspace_path {
+                    if !folder_path_is_workspace_path(relative, workspace_path.slice(buf)) {
+                        for dep in &mut package_dependencies[0..dependencies_count as usize] {
+                            if dep.name_hash == name_hash && dep.behavior.is_workspace() {
+                                *dep = Dependency {
+                                    behavior: group.behavior,
+                                    name: external_alias.value,
+                                    name_hash: external_alias.hash,
+                                    version: dependency_version,
+                                };
+                                return Ok(None);
+                            }
+                        }
+                    }
+                }
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -111,11 +111,9 @@ pub(crate) fn value_loc_of(source: &bun_ast::Source, key_loc: bun_ast::Loc) -> b
     crate::bun_json::property_value_loc(&source.contents, key_loc).unwrap_or(key_loc)
 }
 
-/// A folder dependency and the workspace member sharing its name are the same
-/// package only when the dependency's path names the member's directory.
-/// `folder` is a folder path relative to the workspace root (either
-/// platform's separators); `workspace_path` is the member's registered
-/// posix-relative path.
+/// True when `folder`, a folder-dependency path relative to the workspace
+/// root (either platform's separators), names the directory of the member
+/// registered at `workspace_path` (posix).
 pub(crate) fn folder_path_is_workspace_path(folder: &[u8], workspace_path: &[u8]) -> bool {
     let mut buf = path::path_buffer_pool::get();
     let normalized = resolve_path::join_string_buf::<path::platform::Auto>(&mut buf[..], &[folder]);
@@ -1771,13 +1769,10 @@ impl Package<u64> {
                 dependency_version.value.folder = string_builder
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
 
-                // A folder dependency pointing anywhere but the same-named
-                // workspace member's directory can never resolve to that
-                // member. Keep the explicitly declared dependency and drop
-                // the member's workspace dependency, like the Npm arm below
-                // does on a version mismatch. Without this, both place into
-                // the root node_modules and bun.lock gets a duplicate
-                // package key its own parser rejects.
+                // A folder dependency that does not name the member's
+                // directory cannot resolve to it: the explicit dependency
+                // replaces the member's workspace dependency, like the Npm
+                // arm below on a version mismatch.
                 if let Some(workspace_path) = workspace_path {
                     if !folder_path_is_workspace_path(relative, workspace_path.slice(buf)) {
                         for dep in &mut package_dependencies[0..dependencies_count as usize] {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -114,7 +114,7 @@ pub(crate) fn value_loc_of(source: &bun_ast::Source, key_loc: bun_ast::Loc) -> b
 /// True when `folder`, a folder-dependency path relative to the workspace
 /// root (either platform's separators), names the directory of the member
 /// registered at `workspace_path` (posix).
-pub(crate) fn folder_path_is_workspace_path(folder: &[u8], workspace_path: &[u8]) -> bool {
+fn folder_path_is_workspace_path(folder: &[u8], workspace_path: &[u8]) -> bool {
     let mut buf = path::path_buffer_pool::get();
     let normalized = resolve_path::join_string_buf::<path::platform::Auto>(&mut buf[..], &[folder]);
     if normalized.len() != workspace_path.len() {
@@ -1769,22 +1769,32 @@ impl Package<u64> {
                 dependency_version.value.folder = string_builder
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
 
-                // A folder dependency that does not name the member's
-                // directory cannot resolve to it: the explicit dependency
-                // replaces the member's workspace dependency, like the Npm
-                // arm below on a version mismatch.
+                // The root package's dependencies share one node_modules
+                // entry per name with the workspace members, so a root folder
+                // dependency colliding with a member resolves to the member,
+                // as in npm. Both placed side by side would serialize the
+                // same bun.lock key twice.
                 if let Some(workspace_path) = workspace_path {
-                    if !folder_path_is_workspace_path(relative, workspace_path.slice(buf)) {
-                        for dep in &mut package_dependencies[0..dependencies_count as usize] {
-                            if dep.name_hash == name_hash && dep.behavior.is_workspace() {
-                                *dep = Dependency {
-                                    behavior: group.behavior,
-                                    name: external_alias.value,
-                                    name_hash: external_alias.hash,
-                                    version: dependency_version,
-                                };
-                                return Ok(None);
-                            }
+                    let collides = package_dependencies[0..dependencies_count as usize]
+                        .iter()
+                        .any(|dep| dep.name_hash == name_hash && dep.behavior.is_workspace());
+                    if collides
+                        && !folder_path_is_workspace_path(relative, workspace_path.slice(buf))
+                    {
+                        let path = workspace_path.sliced(buf);
+                        if let Some(mut dep) = dependency::parse_with_tag(
+                            external_alias.value,
+                            Some(external_alias.hash),
+                            path.slice,
+                            dependency::version::Tag::Workspace,
+                            &path,
+                            Some(&mut *log),
+                            Some(&mut *pm),
+                        ) {
+                            // Whole-struct move so `Drop` frees the old
+                            // chain; keep the existing `literal`.
+                            dep.literal = dependency_version.literal;
+                            dependency_version = dep;
                         }
                     }
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -8,8 +8,6 @@ use bun_collections::{HashMap, StringHashMap};
 use bun_core::strings;
 use bun_core::{self};
 use bun_paths::PathBuffer;
-use bun_paths::resolve_path;
-use bun_resolver::fs::FileSystem;
 use bun_semver::semver_string::{
     Buf as StringBuf, Builder as StringBuilder, JsonFormatterOptions as JsonOpts,
 };
@@ -42,7 +40,7 @@ use bun_install_types::DependencyVersionTag;
 // this file is `crate::lockfile_real::bun_lock`; `super` is the
 // real `Lockfile` module, distinct from the `crate::lockfile` stub.
 use super::PackageIDSlice;
-use super::package::{Meta, PackageColumns as _, folder_path_is_workspace_path, value_loc_of};
+use super::package::{Meta, PackageColumns as _, value_loc_of};
 use super::{
     DependencySlice, LoadResult, Lockfile as BinaryLockfile, OverrideMap, Package,
     PackageIndexEntry, PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
@@ -2132,7 +2130,6 @@ pub(crate) fn parse_into_binary_lockfile(
         // body can take `&mut *lockfile` (`parse_append_dependencies`,
         // `append_package_dedupe`) without conflicting with the
         // `workspace_paths.values()` iterator borrow. `String` is `Copy`.
-        let pkgs_expr_for_claims = root.get(b"packages");
         let workspace_path_snapshot: Vec<String> = lockfile.workspace_paths.values().to_vec();
         'workspaces: for workspace_path in &workspace_path_snapshot {
             for row in object_rows(&workspaces_obj) {
@@ -2190,23 +2187,17 @@ pub(crate) fn parse_into_binary_lockfile(
                 // there should be no duplicates
                 let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
-                // When a root dependency replaced this member's workspace
-                // dependency, its name keys another package and claiming it
-                // would report a false duplicate; the member's nested key
-                // still maps to it through the resolution search below.
-                if member_owns_packages_key(&pkgs_expr_for_claims, name, path) {
-                    let entry = pkg_map.get_or_put(name)?;
-                    if entry.found_existing {
-                        log.add_error_fmt(
-                            source,
-                            row.key_loc,
-                            format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
-                        );
-                        return Err(ParseError::InvalidWorkspaceObject);
-                    }
-
-                    *entry.value_ptr = pkg_id;
+                let entry = pkg_map.get_or_put(name)?;
+                if entry.found_existing {
+                    log.add_error_fmt(
+                        source,
+                        row.key_loc,
+                        format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
+                    );
+                    return Err(ParseError::InvalidWorkspaceObject);
                 }
+
+                *entry.value_ptr = pkg_id;
 
                 workspace_pkgs_len += 1;
                 continue 'workspaces;
@@ -3162,32 +3153,6 @@ fn map_dep_to_pkg(
     }
 }
 
-/// Whether the root `packages` key matching a member's name is the member's
-/// own entry, rather than a package that replaced its workspace dependency
-/// (`Package::parse_dependency`).
-fn member_owns_packages_key(pkgs_expr: &Option<Expr>, name: &[u8], path: &[u8]) -> bool {
-    let Some(pkgs) = pkgs_expr else {
-        return true;
-    };
-    let Some(value) = pkgs.get(name) else {
-        return true;
-    };
-    if !value.is_array() {
-        return true;
-    }
-    let Some(first) = array_items(&value).first().and_then(|item| item.as_str()) else {
-        return true;
-    };
-    // a member's own entry is written as "<name>@workspace:<path>"
-    let Some(rest) = first.get(name.len() + 1..) else {
-        return false;
-    };
-    strings::has_prefix(first, name)
-        && first[name.len()] == b'@'
-        && strings::has_prefix(rest, b"workspace:")
-        && strings::eql(&rest[b"workspace:".len()..], path)
-}
-
 fn dependency_resolution_failure(
     dep: &Dependency,
     pkg_path: Option<&[u8]>,
@@ -3396,50 +3361,6 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .as_utf8_string_literal()
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
-
-                // Mirror `Package::parse_dependency`: a root dependency on a
-                // folder other than this member's directory replaced the
-                // member's workspace dependency. The stored dependency holds
-                // the raw `file:` literal (possibly absolute), so apply the
-                // same checked join + relativize it applied before comparing.
-                let mut overridden = false;
-                {
-                    let bytes = lockfile.buffers.string_bytes.as_slice();
-                    for dep in &lockfile.buffers.dependencies.as_slice()[off..] {
-                        if dep.name_hash != name_hash
-                            || dep.version.tag != DependencyVersionTag::Folder
-                        {
-                            continue;
-                        }
-                        let top = FileSystem::instance().top_level_dir();
-                        let mut abs_buf = bun_paths::path_buffer_pool::get();
-                        let Some(joined) = resolve_path::join_abs_string_buf_checked::<
-                            resolve_path::platform::Auto,
-                        >(
-                            top,
-                            &mut abs_buf[..],
-                            &[dep.version.folder().slice(bytes)],
-                        ) else {
-                            log.add_error_fmt(
-                                source,
-                                value_loc_of(source, row.key_loc),
-                                format_args!(
-                                    "Dependency \"{}\" has an unsafe folder path",
-                                    bstr::BStr::new(dep.name.slice(bytes)),
-                                ),
-                            );
-                            return Err(ParseError::InvalidPackageInfo);
-                        };
-                        let relative = resolve_path::relative(top, joined);
-                        if !folder_path_is_workspace_path(relative, path) {
-                            overridden = true;
-                            break;
-                        }
-                    }
-                }
-                if overridden {
-                    continue 'workspaces;
-                }
 
                 let dep = Dependency {
                     name: sbuf!(lockfile).append_with_hash(name, name_hash)?,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -40,7 +40,7 @@ use bun_install_types::DependencyVersionTag;
 // this file is `crate::lockfile_real::bun_lock`; `super` is the
 // real `Lockfile` module, distinct from the `crate::lockfile` stub.
 use super::PackageIDSlice;
-use super::package::{Meta, PackageColumns as _, value_loc_of};
+use super::package::{Meta, PackageColumns as _, folder_path_is_workspace_path, value_loc_of};
 use super::{
     DependencySlice, LoadResult, Lockfile as BinaryLockfile, OverrideMap, Package,
     PackageIndexEntry, PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
@@ -2130,6 +2130,7 @@ pub(crate) fn parse_into_binary_lockfile(
         // body can take `&mut *lockfile` (`parse_append_dependencies`,
         // `append_package_dedupe`) without conflicting with the
         // `workspace_paths.values()` iterator borrow. `String` is `Copy`.
+        let pkgs_expr_for_claims = root.get(b"packages");
         let workspace_path_snapshot: Vec<String> = lockfile.workspace_paths.values().to_vec();
         'workspaces: for workspace_path in &workspace_path_snapshot {
             for row in object_rows(&workspaces_obj) {
@@ -2187,17 +2188,26 @@ pub(crate) fn parse_into_binary_lockfile(
                 // there should be no duplicates
                 let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
-                let entry = pkg_map.get_or_put(name)?;
-                if entry.found_existing {
-                    log.add_error_fmt(
-                        source,
-                        row.key_loc,
-                        format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
-                    );
-                    return Err(ParseError::InvalidWorkspaceObject);
-                }
+                // A root dependency that replaced this member's workspace
+                // dependency (`Package::parse_dependency`) owns the root
+                // `packages` key matching the member's name, and the member
+                // only appears nested under its dependents. Pre-claiming the
+                // name in `pkg_map` would falsely collide with that entry as
+                // a duplicate package path; the nested key still maps to this
+                // package through the resolution search further down.
+                if member_owns_packages_key(&pkgs_expr_for_claims, name, path) {
+                    let entry = pkg_map.get_or_put(name)?;
+                    if entry.found_existing {
+                        log.add_error_fmt(
+                            source,
+                            row.key_loc,
+                            format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
+                        );
+                        return Err(ParseError::InvalidWorkspaceObject);
+                    }
 
-                *entry.value_ptr = pkg_id;
+                    *entry.value_ptr = pkg_id;
+                }
 
                 workspace_pkgs_len += 1;
                 continue 'workspaces;
@@ -3153,6 +3163,33 @@ fn map_dep_to_pkg(
     }
 }
 
+/// A workspace member normally owns the root `packages` key matching its
+/// name. When a root dependency replaced the member's workspace dependency
+/// (`Package::parse_dependency`), that key holds the other package and the
+/// member only appears nested, so its name must not pre-claim the key.
+fn member_owns_packages_key(pkgs_expr: &Option<Expr>, name: &[u8], path: &[u8]) -> bool {
+    let Some(pkgs) = pkgs_expr else {
+        return true;
+    };
+    let Some(value) = pkgs.get(name) else {
+        return true;
+    };
+    if !value.is_array() {
+        return true;
+    }
+    let Some(first) = array_items(&value).first().and_then(|item| item.as_str()) else {
+        return true;
+    };
+    // a member's own entry is written as "<name>@workspace:<path>"
+    let Some(rest) = first.get(name.len() + 1..) else {
+        return false;
+    };
+    strings::has_prefix(first, name)
+        && first[name.len()] == b'@'
+        && strings::has_prefix(rest, b"workspace:")
+        && strings::eql(&rest[b"workspace:".len()..], path)
+}
+
 fn dependency_resolution_failure(
     dep: &Dependency,
     pkg_path: Option<&[u8]>,
@@ -3361,6 +3398,23 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .as_utf8_string_literal()
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
+
+                // A root dependency on a folder other than this member's
+                // directory replaced the member's workspace dependency when
+                // package.json was parsed (`Package::parse_dependency`);
+                // mirror it so the loaded lockfile produces the same root
+                // dependency list.
+                let overridden = {
+                    let bytes = lockfile.buffers.string_bytes.as_slice();
+                    lockfile.buffers.dependencies.as_slice()[off..].iter().any(|dep| {
+                        dep.name_hash == name_hash
+                            && dep.version.tag == DependencyVersionTag::Folder
+                            && !folder_path_is_workspace_path(dep.version.folder().slice(bytes), path)
+                    })
+                };
+                if overridden {
+                    continue 'workspaces;
+                }
 
                 let dep = Dependency {
                     name: sbuf!(lockfile).append_with_hash(name, name_hash)?,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2188,13 +2188,10 @@ pub(crate) fn parse_into_binary_lockfile(
                 // there should be no duplicates
                 let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
-                // A root dependency that replaced this member's workspace
-                // dependency (`Package::parse_dependency`) owns the root
-                // `packages` key matching the member's name, and the member
-                // only appears nested under its dependents. Pre-claiming the
-                // name in `pkg_map` would falsely collide with that entry as
-                // a duplicate package path; the nested key still maps to this
-                // package through the resolution search further down.
+                // When a root dependency replaced this member's workspace
+                // dependency, its name keys another package and claiming it
+                // would report a false duplicate; the member's nested key
+                // still maps to it through the resolution search below.
                 if member_owns_packages_key(&pkgs_expr_for_claims, name, path) {
                     let entry = pkg_map.get_or_put(name)?;
                     if entry.found_existing {
@@ -3163,10 +3160,9 @@ fn map_dep_to_pkg(
     }
 }
 
-/// A workspace member normally owns the root `packages` key matching its
-/// name. When a root dependency replaced the member's workspace dependency
-/// (`Package::parse_dependency`), that key holds the other package and the
-/// member only appears nested, so its name must not pre-claim the key.
+/// Whether the root `packages` key matching a member's name is the member's
+/// own entry, rather than a package that replaced its workspace dependency
+/// (`Package::parse_dependency`).
 fn member_owns_packages_key(pkgs_expr: &Option<Expr>, name: &[u8], path: &[u8]) -> bool {
     let Some(pkgs) = pkgs_expr else {
         return true;
@@ -3399,11 +3395,9 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
 
-                // A root dependency on a folder other than this member's
-                // directory replaced the member's workspace dependency when
-                // package.json was parsed (`Package::parse_dependency`);
-                // mirror it so the loaded lockfile produces the same root
-                // dependency list.
+                // Mirror `Package::parse_dependency`: a root dependency on a
+                // folder other than this member's directory replaced the
+                // member's workspace dependency.
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
                     lockfile.buffers.dependencies.as_slice()[off..]

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3406,11 +3406,16 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                 // dependency list.
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
-                    lockfile.buffers.dependencies.as_slice()[off..].iter().any(|dep| {
-                        dep.name_hash == name_hash
-                            && dep.version.tag == DependencyVersionTag::Folder
-                            && !folder_path_is_workspace_path(dep.version.folder().slice(bytes), path)
-                    })
+                    lockfile.buffers.dependencies.as_slice()[off..]
+                        .iter()
+                        .any(|dep| {
+                            dep.name_hash == name_hash
+                                && dep.version.tag == DependencyVersionTag::Folder
+                                && !folder_path_is_workspace_path(
+                                    dep.version.folder().slice(bytes),
+                                    path,
+                                )
+                        })
                 };
                 if overridden {
                     continue 'workspaces;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3401,29 +3401,42 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                 // folder other than this member's directory replaced the
                 // member's workspace dependency. The stored dependency holds
                 // the raw `file:` literal (possibly absolute), so apply the
-                // same join + relativize it applied before comparing.
-                let overridden = {
+                // same checked join + relativize it applied before comparing.
+                let mut overridden = false;
+                {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
-                    lockfile.buffers.dependencies.as_slice()[off..]
-                        .iter()
-                        .any(|dep| {
-                            if dep.name_hash != name_hash
-                                || dep.version.tag != DependencyVersionTag::Folder
-                            {
-                                return false;
-                            }
-                            let top = FileSystem::instance().top_level_dir();
-                            let mut abs_buf = bun_paths::path_buffer_pool::get();
-                            let joined =
-                                resolve_path::join_abs_string_buf::<resolve_path::platform::Auto>(
-                                    top,
-                                    &mut abs_buf[..],
-                                    &[dep.version.folder().slice(bytes)],
-                                );
-                            let relative = resolve_path::relative(top, joined);
-                            !folder_path_is_workspace_path(relative, path)
-                        })
-                };
+                    for dep in &lockfile.buffers.dependencies.as_slice()[off..] {
+                        if dep.name_hash != name_hash
+                            || dep.version.tag != DependencyVersionTag::Folder
+                        {
+                            continue;
+                        }
+                        let top = FileSystem::instance().top_level_dir();
+                        let mut abs_buf = bun_paths::path_buffer_pool::get();
+                        let Some(joined) = resolve_path::join_abs_string_buf_checked::<
+                            resolve_path::platform::Auto,
+                        >(
+                            top,
+                            &mut abs_buf[..],
+                            &[dep.version.folder().slice(bytes)],
+                        ) else {
+                            log.add_error_fmt(
+                                source,
+                                value_loc_of(source, row.key_loc),
+                                format_args!(
+                                    "Dependency \"{}\" has an unsafe folder path",
+                                    bstr::BStr::new(dep.name.slice(bytes)),
+                                ),
+                            );
+                            return Err(ParseError::InvalidPackageInfo);
+                        };
+                        let relative = resolve_path::relative(top, joined);
+                        if !folder_path_is_workspace_path(relative, path) {
+                            overridden = true;
+                            break;
+                        }
+                    }
+                }
                 if overridden {
                     continue 'workspaces;
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -8,6 +8,8 @@ use bun_collections::{HashMap, StringHashMap};
 use bun_core::strings;
 use bun_core::{self};
 use bun_paths::PathBuffer;
+use bun_paths::resolve_path;
+use bun_resolver::fs::FileSystem;
 use bun_semver::semver_string::{
     Buf as StringBuf, Builder as StringBuilder, JsonFormatterOptions as JsonOpts,
 };
@@ -3397,18 +3399,29 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
 
                 // Mirror `Package::parse_dependency`: a root dependency on a
                 // folder other than this member's directory replaced the
-                // member's workspace dependency.
+                // member's workspace dependency. The stored dependency holds
+                // the raw `file:` literal (possibly absolute), so apply the
+                // same join + relativize it applied before comparing.
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
                     lockfile.buffers.dependencies.as_slice()[off..]
                         .iter()
                         .any(|dep| {
-                            dep.name_hash == name_hash
-                                && dep.version.tag == DependencyVersionTag::Folder
-                                && !folder_path_is_workspace_path(
-                                    dep.version.folder().slice(bytes),
-                                    path,
-                                )
+                            if dep.name_hash != name_hash
+                                || dep.version.tag != DependencyVersionTag::Folder
+                            {
+                                return false;
+                            }
+                            let top = FileSystem::instance().top_level_dir();
+                            let mut abs_buf = bun_paths::path_buffer_pool::get();
+                            let joined =
+                                resolve_path::join_abs_string_buf::<resolve_path::platform::Auto>(
+                                    top,
+                                    &mut abs_buf[..],
+                                    &[dep.version.folder().slice(bytes)],
+                                );
+                            let relative = resolve_path::relative(top, joined);
+                            !folder_path_is_workspace_path(relative, path)
                         })
                 };
                 if overridden {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -279,14 +279,10 @@ test("dependency on same name as workspace and dist-tag", async () => {
 });
 
 describe("workspace and file: dependency sharing a name", () => {
-  // A root `file:` dependency whose name matched a workspace member used to be
-  // placed next to the member in the root node_modules. bun.lock then
-  // contained the same "packages" key twice, every later install printed
-  // `Duplicate key "alpha" in object literal`, ignored the lockfile and
-  // re-resolved, and `--frozen-lockfile` always failed. The explicitly
-  // declared dependency now replaces the member's implicit workspace
-  // dependency, the same way an npm dependency overrides a same-name
-  // workspace on a version mismatch.
+  // An explicitly declared root `file:` dependency replaces a same-named
+  // workspace member's implicit workspace dependency (like the npm-range
+  // override on a version mismatch). Both used to be placed at the root,
+  // writing duplicate bun.lock keys that broke --frozen-lockfile.
 
   test.concurrent("root file: dependency wins and the lockfile round-trips", async () => {
     using ctx = await setupTest();

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -278,6 +278,214 @@ test("dependency on same name as workspace and dist-tag", async () => {
   ]);
 });
 
+describe("workspace and file: dependency sharing a name", () => {
+  // A root `file:` dependency whose name matched a workspace member used to be
+  // placed next to the member in the root node_modules. bun.lock then
+  // contained the same "packages" key twice, every later install printed
+  // `Duplicate key "alpha" in object literal`, ignored the lockfile and
+  // re-resolved, and `--frozen-lockfile` always failed. The explicitly
+  // declared dependency now replaces the member's implicit workspace
+  // dependency, the same way an npm dependency overrides a same-name
+  // workspace on a version mismatch.
+
+  test.concurrent("root file: dependency wins and the lockfile round-trips", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { alpha: "file:./vendor/alpha" },
+        }),
+      ),
+      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha" })),
+      write(
+        join(packageDir, "vendor", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "2.0.0" }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
+    expect(lockfile).not.toContain("alpha@workspace:");
+    expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
+      name: "alpha",
+      version: "2.0.0",
+    });
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("member referenced through workspace: still installs", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { alpha: "file:./vendor/alpha" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { alpha: "workspace:*" } }),
+      ),
+      write(
+        join(packageDir, "vendor", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "2.0.0" }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    // the root node_modules/alpha is the folder dependency; the member nests
+    // under beta instead of duplicating the root key
+    expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
+    expect(lockfile).toContain(`"beta/alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
+      name: "alpha",
+      version: "2.0.0",
+    });
+    expect(
+      await file(join(packageDir, "node_modules", "beta", "node_modules", "alpha", "package.json")).json(),
+    ).toEqual({
+      name: "alpha",
+      version: "1.0.0",
+    });
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("file: dependency folder depending back on the member", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { alpha: "file:./vendor/alpha" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "vendor", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "2.0.0", dependencies: { alpha: "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
+    expect(lockfile).toContain(`"alpha/alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(lockfile).not.toContain("alpha/alpha/alpha");
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("file: dependency naming the member's directory still links the member", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { alpha: "file:./packages/alpha" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "1.0.0" }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(lockfile).not.toContain("alpha@file:");
+    expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
+      name: "alpha",
+      version: "1.0.0",
+    });
+  });
+
+  test.concurrent("aliased file: dependency colliding with another member's name", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { beta: "file:./vendor/alpha" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "vendor", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "2.0.0" }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"beta": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"beta": ["alpha@file:vendor/alpha"`);
+    expect(lockfile).not.toContain("beta@workspace:");
+    expect(await file(join(packageDir, "node_modules", "beta", "package.json")).json()).toEqual({
+      name: "alpha",
+      version: "2.0.0",
+    });
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+});
+
 test.concurrent("successfully installs workspace when path already exists in node_modules", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -449,10 +449,7 @@ describe("workspace and file: dependency sharing a name", () => {
           dependencies: { alpha: "file:./vendor/alpha" },
         }),
       ),
-      write(
-        join(packageDir, "packages", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "1.0.0" }),
-      ),
+      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
       write(
         join(packageDir, "packages", "beta", "package.json"),
         JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { alpha: "workspace:*" } }),
@@ -465,7 +462,10 @@ describe("workspace and file: dependency sharing a name", () => {
     // corrupt the lockfile with a folder path too long to normalize
     const lockPath = join(packageDir, "bun.lock");
     const huge = `file:./${Buffer.alloc(70000, "a").toString()}`;
-    await write(lockPath, (await file(lockPath).text()).replace('"alpha": "file:./vendor/alpha"', `"alpha": "${huge}"`));
+    await write(
+      lockPath,
+      (await file(lockPath).text()).replace('"alpha": "file:./vendor/alpha"', `"alpha": "${huge}"`),
+    );
 
     const second = await runBunInstall(env, packageDir, { allowErrors: true, allowWarnings: true });
     expect(second.err).toContain("Ignoring lockfile");

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -279,12 +279,12 @@ test("dependency on same name as workspace and dist-tag", async () => {
 });
 
 describe("workspace and file: dependency sharing a name", () => {
-  // An explicitly declared root `file:` dependency replaces a same-named
-  // workspace member's implicit workspace dependency (like the npm-range
-  // override on a version mismatch). Both used to be placed at the root,
-  // writing duplicate bun.lock keys that broke --frozen-lockfile.
+  // A root `file:` dependency and a same-named workspace member share one
+  // root node_modules entry. The member wins and the dependency resolves to
+  // it, as in npm. Both used to be placed side by side, writing duplicate
+  // bun.lock keys that broke --frozen-lockfile.
 
-  test.concurrent("root file: dependency wins and the lockfile round-trips", async () => {
+  test.concurrent("resolves to the member and the lockfile round-trips", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;
     await Promise.all([
@@ -305,11 +305,10 @@ describe("workspace and file: dependency sharing a name", () => {
 
     const lockfile = await file(join(packageDir, "bun.lock")).text();
     expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
-    expect(lockfile).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
-    expect(lockfile).not.toContain("alpha@workspace:");
+    expect(lockfile).toContain(`"alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(lockfile).not.toContain("alpha@file:");
     expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
       name: "alpha",
-      version: "2.0.0",
     });
 
     const second = await runBunInstall(env, packageDir, { savesLockfile: false });
@@ -319,7 +318,7 @@ describe("workspace and file: dependency sharing a name", () => {
     await runBunInstall(env, packageDir, { frozenLockfile: true });
   });
 
-  test.concurrent("member referenced through workspace: still installs", async () => {
+  test.concurrent("member with its own dependencies still resolves them", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;
     await Promise.all([
@@ -332,31 +331,41 @@ describe("workspace and file: dependency sharing a name", () => {
           dependencies: { alpha: "file:./vendor/alpha" },
         }),
       ),
-      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
+      write(
+        join(packageDir, "packages", "alpha", "package.json"),
+        JSON.stringify({
+          name: "alpha",
+          version: "1.0.0",
+          dependencies: { "alpha-dep": "file:../../vendor/alpha-dep" },
+        }),
+      ),
       write(
         join(packageDir, "packages", "beta", "package.json"),
         JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { alpha: "workspace:*" } }),
       ),
       write(join(packageDir, "vendor", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "2.0.0" })),
+      write(
+        join(packageDir, "vendor", "alpha-dep", "package.json"),
+        JSON.stringify({ name: "alpha-dep", version: "3.0.0" }),
+      ),
     ]);
 
     await runBunInstall(env, packageDir);
 
     const lockfile = await file(join(packageDir, "bun.lock")).text();
-    // the root node_modules/alpha is the folder dependency; the member nests
-    // under beta instead of duplicating the root key
     expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
-    expect(lockfile).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
-    expect(lockfile).toContain(`"beta/alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(lockfile).toContain(`"alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(lockfile).not.toContain("alpha@file:");
     expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
       name: "alpha",
-      version: "2.0.0",
+      version: "1.0.0",
+      dependencies: { "alpha-dep": "file:../../vendor/alpha-dep" },
     });
     expect(
-      await file(join(packageDir, "node_modules", "beta", "node_modules", "alpha", "package.json")).json(),
+      await file(join(packageDir, "node_modules", "alpha", "node_modules", "alpha-dep", "package.json")).json(),
     ).toEqual({
-      name: "alpha",
-      version: "1.0.0",
+      name: "alpha-dep",
+      version: "3.0.0",
     });
 
     const second = await runBunInstall(env, packageDir, { savesLockfile: false });
@@ -390,9 +399,9 @@ describe("workspace and file: dependency sharing a name", () => {
 
     const lockfile = await file(join(packageDir, "bun.lock")).text();
     expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
-    expect(lockfile).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
-    expect(lockfile).toContain(`"alpha/alpha": ["alpha@workspace:packages/alpha"]`);
-    expect(lockfile).not.toContain("alpha/alpha/alpha");
+    expect(lockfile).toContain(`"alpha": ["alpha@workspace:packages/alpha"]`);
+    expect(lockfile).not.toContain("alpha@file:");
+    expect(lockfile).not.toContain("alpha/alpha");
 
     const second = await runBunInstall(env, packageDir, { savesLockfile: false });
     expect(second.err).not.toContain("Saved lockfile");
@@ -436,45 +445,6 @@ describe("workspace and file: dependency sharing a name", () => {
     },
   );
 
-  test.concurrent("oversized file: path in bun.lock is rejected without crashing", async () => {
-    using ctx = await setupTest();
-    const { packageDir, env } = ctx;
-    await Promise.all([
-      write(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "sandbox",
-          version: "1.0.0",
-          workspaces: ["packages/*"],
-          dependencies: { alpha: "file:./vendor/alpha" },
-        }),
-      ),
-      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
-      write(
-        join(packageDir, "packages", "beta", "package.json"),
-        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { alpha: "workspace:*" } }),
-      ),
-      write(join(packageDir, "vendor", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "2.0.0" })),
-    ]);
-
-    await runBunInstall(env, packageDir);
-
-    // corrupt the lockfile with a folder path too long to normalize
-    const lockPath = join(packageDir, "bun.lock");
-    const huge = `file:./${Buffer.alloc(70000, "a").toString()}`;
-    await write(
-      lockPath,
-      (await file(lockPath).text()).replace('"alpha": "file:./vendor/alpha"', `"alpha": "${huge}"`),
-    );
-
-    const second = await runBunInstall(env, packageDir, { allowErrors: true, allowWarnings: true });
-    expect(second.err).toContain("Ignoring lockfile");
-
-    const final = await file(lockPath).text();
-    expect(final).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
-    expect(final.match(/"alpha": \[/g)).toHaveLength(1);
-  });
-
   test.concurrent("aliased file: dependency colliding with another member's name", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;
@@ -496,11 +466,11 @@ describe("workspace and file: dependency sharing a name", () => {
 
     const lockfile = await file(join(packageDir, "bun.lock")).text();
     expect(lockfile.match(/"beta": \[/g)).toHaveLength(1);
-    expect(lockfile).toContain(`"beta": ["alpha@file:vendor/alpha"`);
-    expect(lockfile).not.toContain("beta@workspace:");
+    expect(lockfile).toContain(`"beta": ["beta@workspace:packages/beta"]`);
+    expect(lockfile).not.toContain("@file:");
     expect(await file(join(packageDir, "node_modules", "beta", "package.json")).json()).toEqual({
-      name: "alpha",
-      version: "2.0.0",
+      name: "beta",
+      version: "1.0.0",
     });
 
     await runBunInstall(env, packageDir, { frozenLockfile: true });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -401,33 +401,40 @@ describe("workspace and file: dependency sharing a name", () => {
     await runBunInstall(env, packageDir, { frozenLockfile: true });
   });
 
-  test.concurrent("file: dependency naming the member's directory still links the member", async () => {
-    using ctx = await setupTest();
-    const { packageDir, env } = ctx;
-    await Promise.all([
-      write(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "sandbox",
-          version: "1.0.0",
-          workspaces: ["packages/*"],
-          dependencies: { alpha: "file:./packages/alpha" },
-        }),
-      ),
-      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
-    ]);
+  test.concurrent.each(["relative", "absolute"])(
+    "%s file: dependency naming the member's directory still links the member",
+    async kind => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
+      const literal = kind === "absolute" ? `file:${join(packageDir, "packages", "alpha")}` : "file:./packages/alpha";
+      await Promise.all([
+        write(
+          join(packageDir, "package.json"),
+          JSON.stringify({
+            name: "sandbox",
+            version: "1.0.0",
+            workspaces: ["packages/*"],
+            dependencies: { alpha: literal },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "alpha", "package.json"),
+          JSON.stringify({ name: "alpha", version: "1.0.0" }),
+        ),
+      ]);
 
-    await runBunInstall(env, packageDir);
+      await runBunInstall(env, packageDir);
 
-    const lockfile = await file(join(packageDir, "bun.lock")).text();
-    expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
-    expect(lockfile).toContain(`"alpha": ["alpha@workspace:packages/alpha"]`);
-    expect(lockfile).not.toContain("alpha@file:");
-    expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
-      name: "alpha",
-      version: "1.0.0",
-    });
-  });
+      const lockfile = await file(join(packageDir, "bun.lock")).text();
+      expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
+      expect(lockfile).toContain(`"alpha": ["alpha@workspace:packages/alpha"]`);
+      expect(lockfile).not.toContain("alpha@file:");
+      expect(await file(join(packageDir, "node_modules", "alpha", "package.json")).json()).toEqual({
+        name: "alpha",
+        version: "1.0.0",
+      });
+    },
+  );
 
   test.concurrent("aliased file: dependency colliding with another member's name", async () => {
     using ctx = await setupTest();

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -436,6 +436,45 @@ describe("workspace and file: dependency sharing a name", () => {
     },
   );
 
+  test.concurrent("oversized file: path in bun.lock is rejected without crashing", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { alpha: "file:./vendor/alpha" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "alpha", "package.json"),
+        JSON.stringify({ name: "alpha", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { alpha: "workspace:*" } }),
+      ),
+      write(join(packageDir, "vendor", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "2.0.0" })),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    // corrupt the lockfile with a folder path too long to normalize
+    const lockPath = join(packageDir, "bun.lock");
+    const huge = `file:./${Buffer.alloc(70000, "a").toString()}`;
+    await write(lockPath, (await file(lockPath).text()).replace('"alpha": "file:./vendor/alpha"', `"alpha": "${huge}"`));
+
+    const second = await runBunInstall(env, packageDir, { allowErrors: true, allowWarnings: true });
+    expect(second.err).toContain("Ignoring lockfile");
+
+    const final = await file(lockPath).text();
+    expect(final).toContain(`"alpha": ["alpha@file:vendor/alpha"`);
+    expect(final.match(/"alpha": \[/g)).toHaveLength(1);
+  });
+
   test.concurrent("aliased file: dependency colliding with another member's name", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -298,10 +298,7 @@ describe("workspace and file: dependency sharing a name", () => {
         }),
       ),
       write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha" })),
-      write(
-        join(packageDir, "vendor", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "2.0.0" }),
-      ),
+      write(join(packageDir, "vendor", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "2.0.0" })),
     ]);
 
     await runBunInstall(env, packageDir);
@@ -335,18 +332,12 @@ describe("workspace and file: dependency sharing a name", () => {
           dependencies: { alpha: "file:./vendor/alpha" },
         }),
       ),
-      write(
-        join(packageDir, "packages", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "1.0.0" }),
-      ),
+      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
       write(
         join(packageDir, "packages", "beta", "package.json"),
         JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { alpha: "workspace:*" } }),
       ),
-      write(
-        join(packageDir, "vendor", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "2.0.0" }),
-      ),
+      write(join(packageDir, "vendor", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "2.0.0" })),
     ]);
 
     await runBunInstall(env, packageDir);
@@ -388,10 +379,7 @@ describe("workspace and file: dependency sharing a name", () => {
           dependencies: { alpha: "file:./vendor/alpha" },
         }),
       ),
-      write(
-        join(packageDir, "packages", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "1.0.0" }),
-      ),
+      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
       write(
         join(packageDir, "vendor", "alpha", "package.json"),
         JSON.stringify({ name: "alpha", version: "2.0.0", dependencies: { alpha: "workspace:*" } }),
@@ -426,10 +414,7 @@ describe("workspace and file: dependency sharing a name", () => {
           dependencies: { alpha: "file:./packages/alpha" },
         }),
       ),
-      write(
-        join(packageDir, "packages", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "1.0.0" }),
-      ),
+      write(join(packageDir, "packages", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "1.0.0" })),
     ]);
 
     await runBunInstall(env, packageDir);
@@ -457,14 +442,8 @@ describe("workspace and file: dependency sharing a name", () => {
           dependencies: { beta: "file:./vendor/alpha" },
         }),
       ),
-      write(
-        join(packageDir, "packages", "beta", "package.json"),
-        JSON.stringify({ name: "beta", version: "1.0.0" }),
-      ),
-      write(
-        join(packageDir, "vendor", "alpha", "package.json"),
-        JSON.stringify({ name: "alpha", version: "2.0.0" }),
-      ),
+      write(join(packageDir, "packages", "beta", "package.json"), JSON.stringify({ name: "beta", version: "1.0.0" })),
+      write(join(packageDir, "vendor", "alpha", "package.json"), JSON.stringify({ name: "alpha", version: "2.0.0" })),
     ]);
 
     await runBunInstall(env, packageDir);


### PR DESCRIPTION
### Repro

```
# package.json
{ "name": "sandbox", "workspaces": ["packages/*"],
  "dependencies": { "alpha": "file:./vendor/alpha" } }
# packages/alpha/package.json   { "name": "alpha" }
# vendor/alpha/package.json     { "name": "alpha", "version": "2.0.0" }
```

```
$ bun install        # exit 0, but bun.lock now contains
    "packages": {
      "alpha": ["alpha@workspace:packages/alpha"],
      "alpha": ["alpha@file:vendor/alpha", {}],
    }
$ bun install
warn: Duplicate key "alpha" in object literal
warn: Ignoring lockfile
$ bun install --frozen-lockfile
error: Duplicate package path
InvalidLockfile: failed to parse lockfile: 'bun.lock'
error: lockfile had changes, but lockfile is frozen
```

Every install ignores the lockfile and re-resolves, and frozen installs (CI) are permanently broken. The hoisted and isolated linkers also disagree on which package gets the root `node_modules/alpha`.

### Cause

Folder-resolved dependencies are placed into the tree without going through `hoist_dependency` (`Tree.rs`, `process_subtree`), which is where two same-name dependencies of one node would deduplicate. The root package's dependency list contains both the member's implicit workspace dependency and the explicit `file:` dependency, so both land in the root node and serialize as the same `"packages"` key twice.

### Fix

The root package's dependencies and the workspace members share one `node_modules` entry per name, so the collision has to have a single winner. The member wins and the `file:` dependency resolves to it, which is what npm does for this shape (npm links `node_modules/alpha -> packages/alpha` and never installs `vendor/alpha`; `npm ci` round-trips).

`Package::parse_dependency`'s `Tag::Folder` arm now rewrites a folder dependency to a workspace dependency when a same-named workspace dependency exists in the list being parsed (only the root package has those) and the folder path does not name the member's directory. A path that does name the member's directory is left alone: both dependencies already resolve to the same package through the folder cache. The rewrite mirrors the `Tag::Npm` arm's existing workspace rewrite a few lines below, keeping the original literal.

Nothing else changes. The member keeps its root `packages` key, so the lockfile writer and parser are untouched: on reload the `file:` dependency maps by name to the workspace package and normalizes to a workspace dependency (`map_dep_to_pkg`), which is exactly what a fresh parse now produces, so the diff is clean and `--frozen-lockfile` passes.

An earlier revision of this PR made the explicit dependency win instead, extending the npm-range version-mismatch override ("Override the workspace with the other dependency") and dropping the member's workspace dependency. Review showed that displacing a member to a nested lockfile key (for example `"beta/alpha"`) breaks consumers that assume a member owns its name-keyed root entry: the parser cannot resolve the member's own dependencies from the nested key (re-breaking `--frozen-lockfile`, the symptom this PR exists to fix), the differ stops noticing the member's package.json edits, and `bun add` run inside the member writes a mangled entry. A folder path also carries no version constraint, so the version-mismatch rationale behind that override does not apply; following npm avoids inventing a third behavior.

### Verification

Six tests in `test/cli/install/bun-workspaces.test.ts` under `workspace and file: dependency sharing a name`:

- the repro above: single `"alpha"` key resolving to the member, stable reinstall, `--frozen-lockfile` passes
- a member with its own `file:` dependency plus a `workspace:*` backref from a sibling: the member's dependency installs and the lockfile round-trips
- the `file:` folder depending back on the member terminates and round-trips
- a `file:` path naming the member's directory (relative and absolute spellings) keeps resolving to the workspace
- an aliased `file:` dependency colliding with another member's name resolves to that member

Four fail on an unmodified build with the duplicate-key output above; the two member-directory spellings pass on both by design. Also verified manually: member package.json edits are picked up, `bun add` inside the member writes the correct entry, and an `optionalDependencies` collision with the folder absent still installs the member (all matching release-build behavior before this bug).

`bun-workspaces` (69), `bun-lock` (17), `isolated-install` (62), `migrate` (21), `bun-add` (54), `bun-lockb` (6), `bun-pm` (18), and the `transitive file dependencies` registry tests pass locally on Linux. `bun-install.test.ts` shows only pre-existing network-dependent failures (bitbucket/gitlab), identical on an unmodified build.

Related open PRs in this area: #33156 routes folder placements through `hoist_dependency` for two deps naming one folder (different shape, compatible), #34688 breaks folder dependency cycles in the tree builder (no overlap). #33168 rewrites `file:` deps whose path names a member by path; this PR's rewrite is name-keyed and fires only on a root collision, so the two compose, but #33168's "a colliding name pointing at a non-workspace folder stays a folder dependency" test covers the root shape this PR changes and will need its expectation updated to the workspace resolution if it lands second.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (90f8a4bc2)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [2291.35ms]
(pass) allowing negative workspace patterns [201.53ms]
(pass) dependency on same name as workspace and dist-tag [203.34ms]
302 |     ]);
303 | 
304 |     await runBunInstall(env, packageDir);
305 | 
306 |     const lockfile = await file(join(packageDir, "bun.lock")).text();
307 |     expect(lockfile.match(/"alpha": \[/g)).toHaveLength(1);
                                                 ^
error: expect(received).toHaveLength(expected)

Expected length: 1
Received length: 2

      at <anonymous> (/workspace/bun/test/cli/install/bun-workspaces.test.ts:307:44)
(fail) workspace and file: dependency sharing a name > resolves to the member and the lockfile round-trips [257.56ms]
396 |     ]);
397 | 
398 |     await runBunInstall(env, packageDir);
399 | 
400 |     const lockfile = await file(join(packageDir, "bun.lock")).text();
401 |     expect(lockfile.match(
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (78a3bee55)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [81.64ms]
(pass) allowing negative workspace patterns [10.31ms]
(pass) dependency on same name as workspace and dist-tag [9.84ms]
(pass) workspace and file: dependency sharing a name > absolute file: dependency naming the member's directory still links the member [10.90ms]
Saved lockfile
(pass) successfully installs workspace when path already exists in node_modules [11.52ms]
(pass) adding workspace in workspace edits package.json with correct version (workspace:*) [12.29ms]
(pass) workspace and file: dependency sharing a name > relative file: dependency naming the member's directory still links the member [13.08ms]
(pass) workspace aliases > combination [13.23ms]
(pass) workspaces with invalid versions should still install [14.10ms]
(pass) workspace aliases > version range workspace:@org/b@latest and workspace with no version [14.36ms]
(pass) workspace aliases > version range workspace:@org/b@* and workspace with no version [14.49ms]
(pass) workspace and file: dependency sharing a name > aliased file: dependency colliding wit
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (90f8a4bc2)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [2276.61ms]
(pass) allowing negative workspace patterns [207.15ms]
(pass) dependency on same name as workspace and dist-tag [209.34ms]
(pass) workspace and file: dependency sharing a name > relative file: dependency naming the member's directory still links the member [262.45ms]
(pass) workspace and file: dependency sharing a name > absolute file: dependency naming the member's directory still links the member [267.96ms]
(pass) successfully installs workspace when path already exists in node_modules [174.91ms]
(pass) workspace and file: dependency sharing a name > resolves to the member and the lockfile round-trips [581.44ms]
(pass) workspace and file: dependency sharing a name > file: dependency folder depending back on the member [566.80ms]
(pass) workspace and file: dependency sharing a name > member with its own dependencies still resolves them [613.88ms]
Saved 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 676ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/lockfile/Package.rs         |  50 ++++++++
 test/cli/install/bun-workspaces.test.ts | 199 ++++++++++++++++++++++++++++++++
 2 files changed, 249 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/install/lockfile/Package.rs              6      9      0
test/cli/install/bun-workspaces.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->