### PR TITLE
ci: annotate job-level timeouts in the pre-exit hook, with tart host state

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -6,11 +6,11 @@
 # `reported-$BUILDKITE_JOB_ID` via markBuildkiteStepReported() just before
 # exiting. Anything that kills the step before that marker is written (agent
 # command-hook failures such as a tart guest that never boots, artifact
-# download failures, `node` missing, the runner/build script itself crashing)
-# leaves the job red with nothing in the build's annotation list, so the
-# failure is only discoverable by opening the raw log. This repository pre-exit
-# hook posts a generic annotation for any such job so it shows up alongside
-# test/build failures.
+# download failures, `node` missing, the runner/build script itself crashing,
+# a job-level timeout killing a hung step) leaves the job red with nothing in
+# the build's annotation list, so the failure is only discoverable by opening
+# the raw log. This repository pre-exit hook posts a generic annotation for
+# any such job so it shows up alongside test/build failures.
 #
 # The marker is build meta-data, which is server-side and so remains visible
 # here even when the reporter ran inside an ephemeral VM (the darwin tart
@@ -23,21 +23,29 @@ status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
 [ "$status" = "0" ] && exit 0
 [ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
 
-# Skip canceled/timed-out jobs: on cancel the agent SIGTERMs then SIGKILLs the
-# command, so the reporter had no chance to set the marker, and a canceled
-# build annotating every running job is noise, not signal. The agent's
-# Executor.Cancel() sets BUILDKITE_JOB_CANCELLED=true in the shell env
-# (buildkite/agent@3ab8ab31, v3.94.0+), and additionally
-# BUILDKITE_JOB_TIMED_OUT=true when the cancel was a job-level timeout.
-if [ "${BUILDKITE_JOB_CANCELLED:-}" = "true" ]; then exit 0; fi
-# TODO(ci): the exit-code fallback below is only needed while agents older than
-# v3.94.0 remain in the fleet (as of 2026-07: the linux queue=ci image is still
-# on v3.87.0 and several bare-metal darwin boxes are on v3.87.0/v3.94.0;
-# scripts/bootstrap.sh already pins 3.114.0, those images just need rebaking).
-# -1 is the posix agent-killed code, 3221225786 is Windows STATUS_CONTROL_C_EXIT,
-# both observed on cancel in build 76127. Delete this `case` once every agent is
-# v3.94.0+.
-case "$status" in -1|3221225786) exit 0 ;; esac
+# The agent's Executor.Cancel() sets BUILDKITE_JOB_CANCELLED=true in the shell
+# env (buildkite/agent@3ab8ab31, v3.94.0+), and additionally
+# BUILDKITE_JOB_TIMED_OUT=true when the cancel came from the job's
+# timeout_in_minutes rather than a user. A job-level timeout is a real failure
+# the build surfaces with no annotation at all, so it proceeds to the
+# annotation below; a user/build cancel stays silent (a canceled build
+# annotating every running job is noise, not signal).
+timed_out=""
+if [ "${BUILDKITE_JOB_TIMED_OUT:-}" = "true" ]; then
+  timed_out=1
+else
+  if [ "${BUILDKITE_JOB_CANCELLED:-}" = "true" ]; then exit 0; fi
+  # The exit-code fallback below is only needed while agents older than
+  # v3.94.0 remain in the fleet (as of 2026-08: the linux queue=ci image and
+  # the darwin tart hosts sourdough/challah are on v3.87.0;
+  # scripts/bootstrap.sh already pins 3.114.0, those images just need
+  # rebaking). Those agents set neither variable above, so their job timeouts
+  # are indistinguishable from cancels and stay silent here. -1 is the posix
+  # agent-killed code, 3221225786 is Windows STATUS_CONTROL_C_EXIT, both
+  # observed on cancel in build 76127. Delete this `case` once every agent is
+  # v3.94.0+.
+  case "$status" in -1|3221225786) exit 0 ;; esac
+fi
 
 if buildkite-agent meta-data exists "reported-${BUILDKITE_JOB_ID}" 2>/dev/null; then
   exit 0
@@ -46,26 +54,64 @@ fi
 label="${BUILDKITE_LABEL:-${BUILDKITE_STEP_KEY:-job}}"
 job_url="${BUILDKITE_BUILD_URL:-}#${BUILDKITE_JOB_ID}"
 
+detail=""
+# $1 = section name, $2 = content; empty content adds nothing.
+append_detail() {
+  [ -n "$2" ] || return 0
+  detail+="${detail:+$'\n'}$1: $2"
+}
+
 # darwin tart agents redirect `tart run` to /tmp/{bk,sc}-<job-id>.log on the
 # host. A guest that booted and was cleanly stopped writes only
 # `Stopping VM...`; anything else is tart reporting why it exited.
-detail=""
+is_tart=""
 for log in "/tmp/bk-${BUILDKITE_JOB_ID}.log" "/tmp/sc-${BUILDKITE_JOB_ID}.log"; do
+  [ -e "$log" ] && is_tart=1
   [ -s "$log" ] || continue
   # Cap per-log output so a pathological tart dump cannot push the shared
   # `--append`ed annotation past Buildkite's 1 MiB body limit.
   body=$(grep -v '^Stopping VM\.\.\.' "$log" 2>/dev/null | head -c 2048 || true)
-  [ -n "$body" ] && detail+="${detail:+$'\n'}${log##*/}: ${body}"
+  append_detail "${log##*/}" "$body"
 done
+
+# A timed-out tart job is the wedge in issue #37246: the guest-command ssh
+# session goes silent (every observed case right at node_modules pre-warm) and
+# the job burns its whole timeout budget. The ssh denials PR #37220 root-caused
+# on the same hosts point at stale VMs squatting recycled vmnet addresses, so
+# capture the host's VM and address state at kill time while it still exists;
+# this snapshot is what identifies the squatter.
+if [ -n "$timed_out" ] && [ -n "$is_tart" ]; then
+  tart_bin=$(command -v tart || true)
+  [ -x "${tart_bin:-}" ] || tart_bin="/opt/homebrew/bin/tart"
+  if [ -x "$tart_bin" ]; then
+    append_detail "tart list" "$("$tart_bin" list 2>&1 | head -c 2048 || true)"
+  fi
+  leases="/var/db/dhcpd_leases"
+  if [ -r "$leases" ]; then
+    append_detail "$leases" "$(wc -l <"$leases" 2>/dev/null | tr -d ' ') lines, tail: $(tail -c 2048 "$leases" 2>/dev/null || true)"
+  fi
+  append_detail "arp -an" "$(arp -an 2>/dev/null | head -c 1024 || true)"
+fi
+
 [ -n "$detail" ] || detail="see the job log for output"
 
 # Match escapeCodeBlock() in scripts/runner.node.mjs: the body renders inside a
 # ```terminal fence, so only backticks need escaping.
 preview=$(printf '%s' "$detail" | sed 's/`/\\`/g')
 
-printf '<details><summary><a><code>step failed outside runner</code></a> - exit %s on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
-  "$status" "$job_url" "$label" "$preview" \
-  | buildkite-agent annotate --append --style error --context step-failed-outside-runner --priority 5 2>&1 \
+if [ -n "$timed_out" ]; then
+  # Name the agent: one sick host timing out every job it takes reads as
+  # unrelated PR failures until the annotations line up on the same name.
+  heading="job timed out${BUILDKITE_TIMEOUT:+ at ${BUILDKITE_TIMEOUT} minutes}${BUILDKITE_AGENT_NAME:+ on ${BUILDKITE_AGENT_NAME}}"
+  context="job-timed-out"
+else
+  heading="step failed outside runner - exit ${status}"
+  context="step-failed-outside-runner"
+fi
+
+printf '<details><summary><a><code>%s</code></a> on <a href="%s">%s</a></summary>\n\n```terminal\n%s\n```\n\n</details>\n\n' \
+  "$heading" "$job_url" "$label" "$preview" \
+  | buildkite-agent annotate --append --style error --context "$context" --priority 5 2>&1 \
   || echo "pre-exit: buildkite-agent annotate failed (non-fatal)"
 
 exit 0

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -24,12 +24,14 @@ status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
 [ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
 
 # The agent's Executor.Cancel() sets BUILDKITE_JOB_CANCELLED=true in the shell
-# env (buildkite/agent@3ab8ab31, v3.94.0+), and additionally
-# BUILDKITE_JOB_TIMED_OUT=true when the cancel came from the job's
-# timeout_in_minutes rather than a user. A job-level timeout is a real failure
-# the build surfaces with no annotation at all, so it proceeds to the
-# annotation below; a user/build cancel stays silent (a canceled build
-# annotating every running job is noise, not signal).
+# env (buildkite/agent@3ab8ab31, v3.94.0+), and since v3.127.0 (agent PR
+# #3871) additionally BUILDKITE_JOB_TIMED_OUT=true when the cancel came from
+# the job's timeout_in_minutes rather than a user. A job-level timeout is a
+# real failure the build surfaces with no annotation at all, so it proceeds to
+# the annotation below; a user/build cancel stays silent (a canceled build
+# annotating every running job is noise, not signal). On v3.94.0-v3.126.x
+# agents timeouts set only BUILDKITE_JOB_CANCELLED and remain silent here;
+# scripts/bootstrap.sh pins 3.127.1 so rebaked machines distinguish them.
 timed_out=""
 if [ "${BUILDKITE_JOB_TIMED_OUT:-}" = "true" ]; then
   timed_out=1
@@ -37,13 +39,10 @@ else
   if [ "${BUILDKITE_JOB_CANCELLED:-}" = "true" ]; then exit 0; fi
   # The exit-code fallback below is only needed while agents older than
   # v3.94.0 remain in the fleet (as of 2026-08: the linux queue=ci image and
-  # the darwin tart hosts sourdough/challah are on v3.87.0;
-  # scripts/bootstrap.sh already pins 3.114.0, those images just need
-  # rebaking). Those agents set neither variable above, so their job timeouts
-  # are indistinguishable from cancels and stay silent here. -1 is the posix
-  # agent-killed code, 3221225786 is Windows STATUS_CONTROL_C_EXIT, both
-  # observed on cancel in build 76127. Delete this `case` once every agent is
-  # v3.94.0+.
+  # the darwin tart hosts sourdough/challah are on v3.87.0). Those agents set
+  # neither variable above. -1 is the posix agent-killed code, 3221225786 is
+  # Windows STATUS_CONTROL_C_EXIT, both observed on cancel in build 76127.
+  # Delete this `case` once every agent is v3.94.0+.
   case "$status" in -1|3221225786) exit 0 ;; esac
 fi
 
@@ -55,10 +54,13 @@ label="${BUILDKITE_LABEL:-${BUILDKITE_STEP_KEY:-job}}"
 job_url="${BUILDKITE_BUILD_URL:-}#${BUILDKITE_JOB_ID}"
 
 detail=""
+# macOS ships bash 3.2, which parses $'\n' inside "${var:+...}" as the literal
+# five characters; hoisting it keeps the join portable.
+nl=$'\n'
 # $1 = section name, $2 = content; empty content adds nothing.
 append_detail() {
   [ -n "$2" ] || return 0
-  detail+="${detail:+$'\n'}$1: $2"
+  detail+="${detail:+$nl}$1: $2"
 }
 
 # darwin tart agents redirect `tart run` to /tmp/{bk,sc}-<job-id>.log on the
@@ -86,7 +88,9 @@ if [ -n "$timed_out" ] && [ -n "$is_tart" ]; then
   if [ -x "$tart_bin" ]; then
     append_detail "tart list" "$("$tart_bin" list 2>&1 | head -c 2048 || true)"
   fi
-  leases="/var/db/dhcpd_leases"
+  # Overridable so the tests can point it at a fixture; linux/windows CI has
+  # no real leases file and the darwin tart guests are DHCP clients, not hosts.
+  leases="${PRE_EXIT_DHCPD_LEASES_FILE:-/var/db/dhcpd_leases}"
   if [ -r "$leases" ]; then
     append_detail "$leases" "$(wc -l <"$leases" 2>/dev/null | tr -d ' ') lines, tail: $(tail -c 2048 "$leases" 2>/dev/null || true)"
   fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1907,7 +1907,10 @@ install_buildkite() {
 		return
 	fi
 
-	buildkite_version="3.114.0"
+	# 3.127.0 is the first release that sets BUILDKITE_JOB_TIMED_OUT (agent
+	# PR #3871), which .buildkite/hooks/pre-exit needs to annotate job-level
+	# timeouts; 3.127.1 is what the healthy darwin tart hosts already run.
+	buildkite_version="3.127.1"
 	case "$arch" in
 	aarch64)
 		buildkite_arch="arm64"

--- a/test/internal/pre-exit-hook.test.ts
+++ b/test/internal/pre-exit-hook.test.ts
@@ -5,9 +5,9 @@
 // These tests run the hook with a stubbed `buildkite-agent` and assert which
 // exits annotate and what the annotation carries.
 import { expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir } from "harness";
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, isWindows, tempDir } from "harness";
 
 // The hook is bash; on Windows CI it runs under Git Bash, but these tests
 // only need one posix lane to cover it. Each run is hermetic (own tempDir,

--- a/test/internal/pre-exit-hook.test.ts
+++ b/test/internal/pre-exit-hook.test.ts
@@ -25,7 +25,15 @@ interface HookRun {
 }
 
 async function runHook(env: Record<string, string>, opts?: { reported?: boolean }): Promise<HookRun> {
-  using dir = tempDir("pre-exit-hook", {});
+  using dir = tempDir("pre-exit-hook", {
+    // Stand-in for /var/db/dhcpd_leases; the hook reads it via
+    // PRE_EXIT_DHCPD_LEASES_FILE so the branch is reachable off-macOS.
+    "dhcpd_leases": Array.from(
+      { length: 2 },
+      (_, i) =>
+        `{\n\tname=bk-old-job-${i}\n\tip_address=192.168.64.${i + 2}\n\thw_address=1,aa:bb:cc:dd:ee:0${i}\n\tlease=0x69875a00\n}`,
+    ).join("\n"),
+  });
   const binDir = join(String(dir), "bin");
   const outDir = join(String(dir), "out");
   mkdirSync(binDir);
@@ -66,6 +74,7 @@ printf '? (192.168.64.2) at 11:22:33:44:55:66 on bridge101\\n'
     env: {
       ...bunEnv,
       PATH: `${binDir}:${process.env.PATH}`,
+      PRE_EXIT_DHCPD_LEASES_FILE: join(String(dir), "dhcpd_leases"),
       BUILDKITE_BUILD_URL: "https://buildkite.com/bun/bun/builds/12345",
       BUILDKITE_LABEL: ":darwin: 26 aarch64 - test-bun",
       ...env,
@@ -79,7 +88,7 @@ printf '? (192.168.64.2) at 11:22:33:44:55:66 on bridge101\\n'
   const annotateArgs: string[] = [];
   for (const name of readdirSync(outDir)) {
     const content = readFileSync(join(outDir, name), "utf8");
-    if (name.startsWith("annotation.")) annotations.push(content);
+    if (name.startsWith("annotation.")) annotations.push(content.replaceAll(String(dir), "<dir>"));
     if (name.startsWith("annotate-args.")) annotateArgs.push(content);
   }
   return { exitCode, stdout, stderr, annotations, annotateArgs };
@@ -96,9 +105,20 @@ t("job timeout posts an annotation", async () => {
     BUILDKITE_AGENT_NAME: "darwin-sourdough-arm64-tart-26",
   });
   expect(annotations).toHaveLength(1);
-  expect(annotations[0]).toContain("job timed out at 45 minutes on darwin-sourdough-arm64-tart-26");
-  expect(annotations[0]).toContain(`#${jobId}`);
-  expect(annotations[0]).toContain("see the job log for output");
+  // Pin the whole body: the <details> shell, the heading, the fence, and the
+  // fallback text, so a join or quoting regression cannot hide between
+  // substring checks.
+  expect(annotations[0].replaceAll(jobId, "<job-id>")).toMatchInlineSnapshot(`
+    "<details><summary><a><code>job timed out at 45 minutes on darwin-sourdough-arm64-tart-26</code></a> on <a href="https://buildkite.com/bun/bun/builds/12345#<job-id>">:darwin: 26 aarch64 - test-bun</a></summary>
+
+    \`\`\`terminal
+    see the job log for output
+    \`\`\`
+
+    </details>
+
+    "
+  `);
   expect(annotateArgs[0]).toContain("job-timed-out");
   expect(exitCode).toBe(0);
 });
@@ -106,7 +126,9 @@ t("job timeout posts an annotation", async () => {
 t("job timeout on a tart host captures guest logs and VM state", async () => {
   const jobId = `pre-exit-test-${crypto.randomUUID()}`;
   const guestLog = `/tmp/bk-${jobId}.log`;
-  writeFileSync(guestLog, "Stopping VM...\nvirtio-net: queue stalled\n");
+  // Backtick included: the body renders inside a ```terminal fence, so the
+  // hook must escape it.
+  writeFileSync(guestLog, "Stopping VM...\nvirtio-net: queue `stalled`\n");
   try {
     const { exitCode, annotations } = await runHook({
       BUILDKITE_COMMAND_EXIT_STATUS: "-1",
@@ -114,14 +136,37 @@ t("job timeout on a tart host captures guest logs and VM state", async () => {
       BUILDKITE_JOB_CANCELLED: "true",
       BUILDKITE_JOB_TIMED_OUT: "true",
       BUILDKITE_TIMEOUT: "45",
+      BUILDKITE_AGENT_NAME: "darwin-sourdough-arm64-tart-26",
     });
     expect(annotations).toHaveLength(1);
-    const body = annotations[0];
-    expect(body).toContain(`bk-${jobId}.log: virtio-net: queue stalled`);
-    expect(body).not.toContain("Stopping VM...");
-    expect(body).toContain("tart list: Source Name State");
-    expect(body).toContain("bk-stale-job running");
-    expect(body).toContain("arp -an: ? (192.168.64.2)");
+    // Every section in order, newline-separated, backtick escaped; the
+    // `Stopping VM...` boot noise is filtered out.
+    expect(annotations[0].replaceAll(jobId, "<job-id>")).toMatchInlineSnapshot(`
+      "<details><summary><a><code>job timed out at 45 minutes on darwin-sourdough-arm64-tart-26</code></a> on <a href="https://buildkite.com/bun/bun/builds/12345#<job-id>">:darwin: 26 aarch64 - test-bun</a></summary>
+
+      \`\`\`terminal
+      bk-<job-id>.log: virtio-net: queue \\\`stalled\\\`
+      tart list: Source Name State
+      local bk-stale-job running
+      <dir>/dhcpd_leases: 11 lines, tail: {
+      	name=bk-old-job-0
+      	ip_address=192.168.64.2
+      	hw_address=1,aa:bb:cc:dd:ee:00
+      	lease=0x69875a00
+      }
+      {
+      	name=bk-old-job-1
+      	ip_address=192.168.64.3
+      	hw_address=1,aa:bb:cc:dd:ee:01
+      	lease=0x69875a00
+      }
+      arp -an: ? (192.168.64.2) at 11:22:33:44:55:66 on bridge101
+      \`\`\`
+
+      </details>
+
+      "
+    `);
     expect(exitCode).toBe(0);
   } finally {
     rmSync(guestLog, { force: true });
@@ -156,11 +201,43 @@ t("step failure outside the runner still annotates", async () => {
     BUILDKITE_JOB_ID: jobId,
   });
   expect(annotations).toHaveLength(1);
-  expect(annotations[0]).toContain("step failed outside runner - exit 255");
-  // Not a timeout: no VM snapshot even though a `tart` stub is on PATH.
-  expect(annotations[0]).not.toContain("tart list");
+  expect(annotations[0].replaceAll(jobId, "<job-id>")).toMatchInlineSnapshot(`
+    "<details><summary><a><code>step failed outside runner - exit 255</code></a> on <a href="https://buildkite.com/bun/bun/builds/12345#<job-id>">:darwin: 26 aarch64 - test-bun</a></summary>
+
+    \`\`\`terminal
+    see the job log for output
+    \`\`\`
+
+    </details>
+
+    "
+  `);
   expect(annotateArgs[0]).toContain("step-failed-outside-runner");
   expect(exitCode).toBe(0);
+});
+
+t("non-timeout failure on a tart host includes guest logs but no VM snapshot", async () => {
+  const jobId = `pre-exit-test-${crypto.randomUUID()}`;
+  const guestLog = `/tmp/bk-${jobId}.log`;
+  writeFileSync(guestLog, "Stopping VM...\nguest never booted\n");
+  try {
+    const { exitCode, annotations } = await runHook({
+      BUILDKITE_COMMAND_EXIT_STATUS: "255",
+      BUILDKITE_JOB_ID: jobId,
+    });
+    expect(annotations).toHaveLength(1);
+    const body = annotations[0];
+    expect(body).toContain(`bk-${jobId}.log: guest never booted`);
+    expect(body).toContain("step failed outside runner - exit 255");
+    // The VM/DHCP/arp snapshot is timeout-only: a fast failure's annotation
+    // stays as small as it was before #37246.
+    expect(body).not.toContain("tart list");
+    expect(body).not.toContain("dhcpd_leases");
+    expect(body).not.toContain("arp -an");
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(guestLog, { force: true });
+  }
 });
 
 t("timeout after the reporter already annotated stays silent", async () => {

--- a/test/internal/pre-exit-hook.test.ts
+++ b/test/internal/pre-exit-hook.test.ts
@@ -1,0 +1,210 @@
+// .buildkite/hooks/pre-exit posts a fallback Buildkite annotation for jobs
+// that die before the runner/build reporter could post one: command-hook
+// failures and, since #37246, job-level timeouts (which previously produced a
+// red job with no annotation at all, hiding the darwin tart pre-warm hangs).
+// These tests run the hook with a stubbed `buildkite-agent` and assert which
+// exits annotate and what the annotation carries.
+import { expect, test } from "bun:test";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, isWindows, tempDir } from "harness";
+
+// The hook is bash; on Windows CI it runs under Git Bash, but these tests
+// only need one posix lane to cover it. Each run is hermetic (own tempDir,
+// unique job id), so they run concurrently.
+const t = isWindows ? test.skip : test.concurrent;
+
+const hookPath = join(import.meta.dir, "../../.buildkite/hooks/pre-exit");
+
+interface HookRun {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  annotations: string[];
+  annotateArgs: string[];
+}
+
+async function runHook(env: Record<string, string>, opts?: { reported?: boolean }): Promise<HookRun> {
+  using dir = tempDir("pre-exit-hook", {});
+  const binDir = join(String(dir), "bin");
+  const outDir = join(String(dir), "out");
+  mkdirSync(binDir);
+  mkdirSync(outDir);
+
+  // Stub buildkite-agent: `meta-data exists` reflects opts.reported, and
+  // `annotate` records its stdin and argv.
+  writeFileSync(
+    join(binDir, "buildkite-agent"),
+    `#!/usr/bin/env bash
+case "$1" in
+  meta-data) ${opts?.reported ? "exit 0" : "exit 1"} ;;
+  annotate) cat > "${outDir}/annotation.$$"; printf '%s\\n' "$@" > "${outDir}/annotate-args.$$"; exit 0 ;;
+  *) exit 2 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  // Stub tart so the timed-out tart branch is exercisable off-macOS.
+  writeFileSync(
+    join(binDir, "tart"),
+    `#!/usr/bin/env bash
+[ "$1" = "list" ] && printf 'Source Name State\\nlocal bk-stale-job running\\n'
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(binDir, "arp"),
+    `#!/usr/bin/env bash
+printf '? (192.168.64.2) at 11:22:33:44:55:66 on bridge101\\n'
+`,
+    { mode: 0o755 },
+  );
+
+  await using proc = Bun.spawn({
+    cmd: ["bash", hookPath],
+    env: {
+      ...bunEnv,
+      PATH: `${binDir}:${process.env.PATH}`,
+      BUILDKITE_BUILD_URL: "https://buildkite.com/bun/bun/builds/12345",
+      BUILDKITE_LABEL: ":darwin: 26 aarch64 - test-bun",
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const annotations: string[] = [];
+  const annotateArgs: string[] = [];
+  for (const name of readdirSync(outDir)) {
+    const content = readFileSync(join(outDir, name), "utf8");
+    if (name.startsWith("annotation.")) annotations.push(content);
+    if (name.startsWith("annotate-args.")) annotateArgs.push(content);
+  }
+  return { exitCode, stdout, stderr, annotations, annotateArgs };
+}
+
+t("job timeout posts an annotation", async () => {
+  const jobId = `pre-exit-test-${crypto.randomUUID()}`;
+  const { exitCode, annotations, annotateArgs } = await runHook({
+    BUILDKITE_COMMAND_EXIT_STATUS: "-1",
+    BUILDKITE_JOB_ID: jobId,
+    BUILDKITE_JOB_CANCELLED: "true",
+    BUILDKITE_JOB_TIMED_OUT: "true",
+    BUILDKITE_TIMEOUT: "45",
+    BUILDKITE_AGENT_NAME: "darwin-sourdough-arm64-tart-26",
+  });
+  expect(annotations).toHaveLength(1);
+  expect(annotations[0]).toContain("job timed out at 45 minutes on darwin-sourdough-arm64-tart-26");
+  expect(annotations[0]).toContain(`#${jobId}`);
+  expect(annotations[0]).toContain("see the job log for output");
+  expect(annotateArgs[0]).toContain("job-timed-out");
+  expect(exitCode).toBe(0);
+});
+
+t("job timeout on a tart host captures guest logs and VM state", async () => {
+  const jobId = `pre-exit-test-${crypto.randomUUID()}`;
+  const guestLog = `/tmp/bk-${jobId}.log`;
+  writeFileSync(guestLog, "Stopping VM...\nvirtio-net: queue stalled\n");
+  try {
+    const { exitCode, annotations } = await runHook({
+      BUILDKITE_COMMAND_EXIT_STATUS: "-1",
+      BUILDKITE_JOB_ID: jobId,
+      BUILDKITE_JOB_CANCELLED: "true",
+      BUILDKITE_JOB_TIMED_OUT: "true",
+      BUILDKITE_TIMEOUT: "45",
+    });
+    expect(annotations).toHaveLength(1);
+    const body = annotations[0];
+    expect(body).toContain(`bk-${jobId}.log: virtio-net: queue stalled`);
+    expect(body).not.toContain("Stopping VM...");
+    expect(body).toContain("tart list: Source Name State");
+    expect(body).toContain("bk-stale-job running");
+    expect(body).toContain("arp -an: ? (192.168.64.2)");
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(guestLog, { force: true });
+  }
+});
+
+t("user/build cancel stays silent", async () => {
+  const { exitCode, annotations } = await runHook({
+    BUILDKITE_COMMAND_EXIT_STATUS: "-1",
+    BUILDKITE_JOB_ID: `pre-exit-test-${crypto.randomUUID()}`,
+    BUILDKITE_JOB_CANCELLED: "true",
+  });
+  expect(annotations).toHaveLength(0);
+  expect(exitCode).toBe(0);
+});
+
+t("agent-killed exit codes without cancel vars stay silent", async () => {
+  for (const status of ["-1", "3221225786"]) {
+    const { exitCode, annotations } = await runHook({
+      BUILDKITE_COMMAND_EXIT_STATUS: status,
+      BUILDKITE_JOB_ID: `pre-exit-test-${crypto.randomUUID()}`,
+    });
+    expect(annotations).toHaveLength(0);
+    expect(exitCode).toBe(0);
+  }
+});
+
+t("step failure outside the runner still annotates", async () => {
+  const jobId = `pre-exit-test-${crypto.randomUUID()}`;
+  const { exitCode, annotations, annotateArgs } = await runHook({
+    BUILDKITE_COMMAND_EXIT_STATUS: "255",
+    BUILDKITE_JOB_ID: jobId,
+  });
+  expect(annotations).toHaveLength(1);
+  expect(annotations[0]).toContain("step failed outside runner - exit 255");
+  // Not a timeout: no VM snapshot even though a `tart` stub is on PATH.
+  expect(annotations[0]).not.toContain("tart list");
+  expect(annotateArgs[0]).toContain("step-failed-outside-runner");
+  expect(exitCode).toBe(0);
+});
+
+t("timeout after the reporter already annotated stays silent", async () => {
+  const { exitCode, annotations } = await runHook(
+    {
+      BUILDKITE_COMMAND_EXIT_STATUS: "-1",
+      BUILDKITE_JOB_ID: `pre-exit-test-${crypto.randomUUID()}`,
+      BUILDKITE_JOB_CANCELLED: "true",
+      BUILDKITE_JOB_TIMED_OUT: "true",
+    },
+    { reported: true },
+  );
+  expect(annotations).toHaveLength(0);
+  expect(exitCode).toBe(0);
+});
+
+t("successful job exits without touching buildkite-agent", async () => {
+  const { exitCode, annotations } = await runHook({
+    BUILDKITE_COMMAND_EXIT_STATUS: "0",
+    BUILDKITE_JOB_ID: `pre-exit-test-${crypto.randomUUID()}`,
+  });
+  expect(annotations).toHaveLength(0);
+  expect(exitCode).toBe(0);
+});
+
+// Keep the hook honest about never failing the job: unknown garbage env still
+// exits 0.
+t("never exits non-zero even when annotate fails", async () => {
+  using dir = tempDir("pre-exit-hook-fail", {});
+  const binDir = join(String(dir), "bin");
+  mkdirSync(binDir);
+  writeFileSync(join(binDir, "buildkite-agent"), `#!/usr/bin/env bash\nexit 1\n`, { mode: 0o755 });
+  await using proc = Bun.spawn({
+    cmd: ["bash", hookPath],
+    env: {
+      ...bunEnv,
+      PATH: `${binDir}:${process.env.PATH}`,
+      BUILDKITE_COMMAND_EXIT_STATUS: "255",
+      BUILDKITE_JOB_ID: `pre-exit-test-${crypto.randomUUID()}`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("pre-exit: buildkite-agent annotate failed (non-fatal)");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Repo-side piece of #37246.

## Problem

Darwin aarch64 tart jobs have been hanging at

```
[guest] pre-warming node_modules (native bun)
```

until `timeout_in_minutes: 45` kills them: state `timed_out`, exit 255, and **no failure annotation**, so every occurrence looks like an unexplained red job until someone opens the raw log. 16 such jobs across builds 90680-90830, all on the two hosts that #37246 shows have had zero passing jobs since Aug 8 (sourdough, challah). The pattern went unnoticed for a day and a half partly because timed-out jobs are invisible in the annotation list.

The pre-exit fallback hook (#34787) deliberately skips canceled jobs, and a job-level timeout arrives as a cancel, so these hangs hit the skip path. The host-side state that would identify the wedge (which VMs were running, the DHCP lease table, the arp table; #37220 proved stale VMs squat recycled addresses on these hosts) is destroyed when the job's VMs are reaped, so after the fact there is nothing to inspect.

## Fix

Agents distinguish a job timeout from a user/build cancel in the hook env: `Executor.Cancel()` sets `BUILDKITE_JOB_CANCELLED=true` (since v3.94.0, buildkite/agent@3ab8ab31) and `BUILDKITE_JOB_TIMED_OUT=true` when the cancel came from `timeout_in_minutes` (since v3.127.0, buildkite/agent#3871, via a marker file the job runner writes on timeout). The hook now:

- posts the fallback annotation for job-level timeouts (context `job-timed-out`), naming the timeout and the agent, so one sick host timing out every job it takes stops reading as unrelated PR failures;
- on darwin tart hosts (detected by the hook-written `/tmp/{bk,sc}-<job-id>.log` files), additionally captures `tart list`, the dhcpd leases line count and tail, and `arp -an` at kill time, size-capped, so the next hang documents the squatting-VM evidence instead of evaporating;
- leaves user/build cancels exactly as silent as before, including the exit-code fallback for pre-v3.94.0 agents. On v3.94.0-v3.126.x agents a timeout sets only `BUILDKITE_JOB_CANCELLED` and stays silent, which is why `scripts/bootstrap.sh`'s agent pin moves from 3.114.0 to 3.127.1 in this PR: rebaking at the old pin would produce machines that still cannot tell the two apart. The healthy darwin tart hosts already run 3.127.1, so the timeout path is live there as of this merge; the sick hosts run 3.87.0 and stay silent until the #37246 re-bake.

Portability fix while touching the hook: the section join's `$'\n'` is hoisted into a variable because bash 3.2 (macOS `/bin/bash`, which runs this hook on the darwin hosts) parses `$'\n'` inside `"${var:+...}"` as five literal characters.

The annotation summary was unified into the `<code>` heading for both paths; nothing parses the previous text (checked `scripts/`, `.buildkite/`, `test/`).

## Test

`test/internal/pre-exit-hook.test.ts` runs the hook with a stubbed `buildkite-agent` (plus `tart`/`arp` stubs and a dhcpd_leases fixture wired through `PRE_EXIT_DHCPD_LEASES_FILE`, so every capture branch is reachable on linux CI) and asserts:

- timeout with `BUILDKITE_JOB_TIMED_OUT=true` annotates with the `job-timed-out` context; the full annotation body is inline-snapshotted (HTML shell, heading with timeout and agent name, fence, fallback text);
- timeout on a tart host: full-body snapshot pinning section order and newline joins (guest log tail minus `Stopping VM...` noise, `tart list`, leases count+tail, `arp -an`) and backtick escaping inside the ```` ```terminal ```` fence;
- non-timeout failure with a guest log present keeps the log tail but gets no VM/DHCP/arp snapshot;
- user/build cancel, bare agent-killed exit codes (`-1`, `3221225786`), already-reported jobs, and successful jobs stay silent;
- non-cancel failures still annotate as `step failed outside runner` (full-body snapshot);
- the hook exits 0 even when `buildkite-agent annotate` fails.

Against the pre-#37247 hook, the timeout tests fail (no annotation is posted); all 9 pass with this change (`bun bd test test/internal/pre-exit-hook.test.ts`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->