### PR TITLE
install: fix npm dependencies that share a workspace member's name

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2276,8 +2276,20 @@ impl<'a> PackageInstall<'a> {
             dest_name_buf[..dest.len()].copy_from_slice(dest);
             // SAFETY: zero-initialized; NUL at [dest.len()].
             let dest_z = ZStr::from_buf(&dest_name_buf, dest.len());
-            if let Err(err) = sys::symlinkat(target_z, dest_dir.fd(), dest_z) {
-                return InstallResult::fail(err.into(), Step::LinkingDependency, None);
+            if let Err(first_err) = sys::symlinkat(target_z, dest_dir.fd(), dest_z) {
+                // A stale entry can survive `skip_delete`: a workspace
+                // member's internal node_modules is not reset by wiping the
+                // root node_modules. Replace it and retry, like the Windows
+                // branch above.
+                let retry = first_err.get_errno() == sys::E::EEXIST;
+                let mut result = Err(first_err);
+                if retry {
+                    self.uninstall_before_install(destination_dir);
+                    result = sys::symlinkat(target_z, dest_dir.fd(), dest_z);
+                }
+                if let Err(err) = result {
+                    return InstallResult::fail(err.into(), Step::LinkingDependency, None);
+                }
             }
         }
 

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2277,10 +2277,9 @@ impl<'a> PackageInstall<'a> {
             // SAFETY: zero-initialized; NUL at [dest.len()].
             let dest_z = ZStr::from_buf(&dest_name_buf, dest.len());
             if let Err(first_err) = sys::symlinkat(target_z, dest_dir.fd(), dest_z) {
-                // A stale entry can survive `skip_delete`: a workspace
-                // member's internal node_modules is not reset by wiping the
-                // root node_modules. Replace it and retry, like the Windows
-                // branch above.
+                // A stale entry can survive `skip_delete` (a member's
+                // internal node_modules outlives a root node_modules wipe);
+                // replace it and retry, like the Windows branch above.
                 let retry = first_err.get_errno() == sys::E::EEXIST;
                 let mut result = Err(first_err);
                 if retry {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -534,6 +534,20 @@ impl<'a> Installer<'a> {
                 break 'state (node_id, CompleteState::Skipped);
             }
 
+            // Check the package resolution as well as the edge: a workspace
+            // package may be reachable only through ordinary `workspace:`
+            // edges when a root dependency replaced the member's implicit
+            // workspace dependency. Workspace store tasks re-run on every
+            // install (the entry loop skips the on-disk freshness check for
+            // them), so counting one as a success would report installs
+            // forever on an already-converged tree.
+            let pkg_id = nodes.items_pkg_id()[node_id.get() as usize];
+            if self.lockfile().packages.slice().items_resolution()[pkg_id as usize].tag
+                == ResolutionTag::Workspace
+            {
+                break 'state (node_id, CompleteState::Skipped);
+            }
+
             break 'state (node_id, state);
         };
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -534,13 +534,9 @@ impl<'a> Installer<'a> {
                 break 'state (node_id, CompleteState::Skipped);
             }
 
-            // Check the package resolution as well as the edge: a workspace
-            // package may be reachable only through ordinary `workspace:`
-            // edges when a root dependency replaced the member's implicit
-            // workspace dependency. Workspace store tasks re-run on every
-            // install (the entry loop skips the on-disk freshness check for
-            // them), so counting one as a success would report installs
-            // forever on an already-converged tree.
+            // A member displaced by a root dependency is reachable only
+            // through non-workspace edges, and workspace store tasks re-run
+            // every install, so a completed one is not an install.
             let pkg_id = nodes.items_pkg_id()[node_id.get() as usize];
             if self.lockfile().packages.slice().items_resolution()[pkg_id as usize].tag
                 == ResolutionTag::Workspace

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1758,9 +1758,8 @@ impl Package<u64> {
                                 .version
                                 .satisfies(workspace_version, buf, buf)
                         }
-                        // A member without a version can only be used by a
-                        // wildcard range (`get_or_put_resolved_package`
-                        // applies the same rule when resolving).
+                        // A versionless member is only linkable by a wildcard
+                        // range, matching `get_or_put_resolved_package`.
                         None => dependency_version.npm().version.is_star(),
                     };
                     if pm.options.link_workspace_packages && satisfies {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1750,31 +1750,40 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                if let Some(workspace_version) = workspace_version {
-                    let satisfies =
-                        dependency_version
+                if workspace_path.is_some() {
+                    let satisfies = match workspace_version {
+                        Some(workspace_version) => dependency_version
                             .npm()
                             .version
-                            .satisfies(workspace_version, buf, buf);
+                            .satisfies(workspace_version, buf, buf),
+                        // A member without a version can only be used by a
+                        // wildcard range (`get_or_put_resolved_package`
+                        // applies the same rule when resolving).
+                        None => dependency_version.npm().version.is_star(),
+                    };
                     if pm.options.link_workspace_packages && satisfies {
-                        // `String::sliced` takes `&'a self`; bind the unwrapped
-                        // value so the borrow outlives the parse call.
-                        let wp = workspace_path.unwrap();
-                        let path = wp.sliced(buf);
-                        if let Some(mut dep) = dependency::parse_with_tag(
-                            external_alias.value,
-                            Some(external_alias.hash),
-                            path.slice,
-                            dependency::version::Tag::Workspace,
-                            &path,
-                            Some(&mut *log),
-                            Some(&mut *pm),
-                        ) {
-                            // Whole-struct move so `Drop` frees the old npm
-                            // chain; keep the existing `literal`.
-                            dep.literal = dependency_version.literal;
-                            dependency_version = dep;
+                        if workspace_version.is_some() {
+                            // `String::sliced` takes `&'a self`; bind the unwrapped
+                            // value so the borrow outlives the parse call.
+                            let wp = workspace_path.unwrap();
+                            let path = wp.sliced(buf);
+                            if let Some(mut dep) = dependency::parse_with_tag(
+                                external_alias.value,
+                                Some(external_alias.hash),
+                                path.slice,
+                                dependency::version::Tag::Workspace,
+                                &path,
+                                Some(&mut *log),
+                                Some(&mut *pm),
+                            ) {
+                                // Whole-struct move so `Drop` frees the old npm
+                                // chain; keep the existing `literal`.
+                                dep.literal = dependency_version.literal;
+                                dependency_version = dep;
+                            }
                         }
+                        // For a versionless member the dependency stays as-is;
+                        // resolution links it to the workspace package.
                     } else {
                         // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
                         for dep in &mut package_dependencies[0..dependencies_count as usize] {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1752,10 +1752,12 @@ impl Package<u64> {
             dependency::version::Tag::Npm => {
                 if workspace_path.is_some() {
                     let satisfies = match workspace_version {
-                        Some(workspace_version) => dependency_version
-                            .npm()
-                            .version
-                            .satisfies(workspace_version, buf, buf),
+                        Some(workspace_version) => {
+                            dependency_version
+                                .npm()
+                                .version
+                                .satisfies(workspace_version, buf, buf)
+                        }
                         // A member without a version can only be used by a
                         // wildcard range (`get_or_put_resolved_package`
                         // applies the same rule when resolving).

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1750,7 +1750,7 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                if workspace_path.is_some() {
+                if let Some(wp) = workspace_path {
                     let satisfies = match workspace_version {
                         Some(workspace_version) => {
                             dependency_version
@@ -1764,9 +1764,6 @@ impl Package<u64> {
                     };
                     if pm.options.link_workspace_packages && satisfies {
                         if workspace_version.is_some() {
-                            // `String::sliced` takes `&'a self`; bind the unwrapped
-                            // value so the borrow outlives the parse call.
-                            let wp = workspace_path.unwrap();
                             let path = wp.sliced(buf);
                             if let Some(mut dep) = dependency::parse_with_tag(
                                 external_alias.value,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2022,6 +2022,20 @@ pub(crate) fn parse_into_binary_lockfile(
             return Err(ParseError::InvalidWorkspaceObject);
         };
 
+        // `insert` overwrites on the same name hash, which would silently
+        // drop one of the colliding members
+        if lockfile.workspace_paths.get(&name_hash).is_some() {
+            log.add_error_fmt(
+                source,
+                value_loc_of(source, name_expr.loc),
+                format_args!(
+                    "Duplicate workspace name: '{}'",
+                    bstr::BStr::new(name_expr.as_utf8_string_literal().unwrap_or_default()),
+                ),
+            );
+            return Err(ParseError::InvalidWorkspaceObject);
+        }
+
         lockfile
             .workspace_paths
             .insert(name_hash, sbuf!(lockfile).append(path)?);
@@ -2914,9 +2928,22 @@ pub(crate) fn parse_into_binary_lockfile(
                                     return Some(found);
                                 }
                             }
-                            match strings::last_index_of_char(prefix, b'/') {
-                                Some(i) => prefix = &prefix[..i as usize],
-                                None => return None,
+                            // strip one tree level; a scoped package name is
+                            // a single node, so never leave a bare "@scope"
+                            // segment as the tail
+                            let Some(i) = strings::last_index_of_char(prefix, b'/') else {
+                                return None;
+                            };
+                            let parent = &prefix[..i as usize];
+                            let tail_start = strings::last_index_of_char(parent, b'/')
+                                .map_or(0, |j| j as usize + 1);
+                            if parent.get(tail_start) == Some(&b'@') {
+                                if tail_start == 0 {
+                                    return None;
+                                }
+                                prefix = &parent[..tail_start - 1];
+                            } else {
+                                prefix = parent;
                             }
                         }
                     });

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2095,6 +2095,7 @@ pub(crate) fn parse_into_binary_lockfile(
             None
         };
 
+        let root_pkgs_expr = root.get(b"packages");
         let (off, len) = parse_append_dependencies::<false, true>(
             lockfile,
             &root_pkg_exr,
@@ -2104,6 +2105,7 @@ pub(crate) fn parse_into_binary_lockfile(
             None,
             None,
             Some(&workspaces_obj),
+            root_pkgs_expr.as_ref(),
             link_workspace_packages,
         )?;
 
@@ -2128,6 +2130,10 @@ pub(crate) fn parse_into_binary_lockfile(
 
     let workspace_pkgs_off: u32 = 1;
     let mut workspace_pkgs_len: u32 = 0;
+
+    // Workspace-name duplicate detection, decoupled from the conditional
+    // `pkg_map` claim below so it fires even for displaced members.
+    let mut seen_workspace_names: PkgPathSet = PkgPathSet::init();
 
     if lockfile_version != Version::V0 {
         // these are the `workspaceOnly` packages
@@ -2162,6 +2168,16 @@ pub(crate) fn parse_into_binary_lockfile(
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
 
+                if seen_workspace_names.contains(name) {
+                    log.add_error_fmt(
+                        source,
+                        row.key_loc,
+                        format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
+                    );
+                    return Err(ParseError::InvalidWorkspaceObject);
+                }
+                seen_workspace_names.put(name, ());
+
                 pkg.name = sbuf!(lockfile).append_with_hash(name, name_hash)?;
                 pkg.name_hash = name_hash;
 
@@ -2171,6 +2187,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     &mut *log,
                     source,
                     &mut optional_peers_buf,
+                    None,
                     None,
                     None,
                     None,
@@ -2192,26 +2209,24 @@ pub(crate) fn parse_into_binary_lockfile(
                 }
 
                 // there should be no duplicates
+                let pkgs_len_before = lockfile.packages.len();
                 let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
                 // A member displaced by a root dependency only appears
                 // nested; pre-claiming its name would falsely collide with
                 // the root `packages` key the other package owns.
-                if member_owns_packages_key(&pkgs_expr_for_claims, name, path) {
+                if member_owns_packages_key(pkgs_expr_for_claims.as_ref(), name, path) {
                     let entry = pkg_map.get_or_put(name)?;
-                    if entry.found_existing {
-                        log.add_error_fmt(
-                            source,
-                            row.key_loc,
-                            format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
-                        );
-                        return Err(ParseError::InvalidWorkspaceObject);
-                    }
-
+                    debug_assert!(!entry.found_existing, "caught by seen_workspace_names");
                     *entry.value_ptr = pkg_id;
                 }
 
-                workspace_pkgs_len += 1;
+                // `workspace_pkgs_len` sizes the 1..1+len package-id range
+                // resolved below; it must count appended packages, not loop
+                // iterations.
+                if lockfile.packages.len() > pkgs_len_before {
+                    workspace_pkgs_len += 1;
+                }
                 continue 'workspaces;
             }
         }
@@ -2274,6 +2289,11 @@ pub(crate) fn parse_into_binary_lockfile(
             }
             bundled_pkgs.put(pkg_path, ());
         }
+
+        // Workspace packages claimed under a `packages` key other than their
+        // name (nested under a dependent, or aliased). Their own dependency
+        // keys are written under that placement, e.g. "beta/member/dep".
+        let mut member_tree_keys: Vec<(PackageID, &[u8])> = Vec::new();
 
         'next_pkg_key: for row in object_rows(&pkgs_expr) {
             let key_loc = row.key_loc;
@@ -2466,6 +2486,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             //   "another-pkg1": "workspaces:packages/pkg1",
                             // },
                             *entry.value_ptr = workspace_pkg_id;
+                            member_tree_keys.push((workspace_pkg_id, pkg_path));
                             continue 'next_pkg_key;
                         }
                     }
@@ -2532,6 +2553,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             &mut optional_peers_buf,
                             Some(pkg_path),
                             Some(&bundled_pkgs),
+                            None,
                             None,
                             link_workspace_packages,
                         )?;
@@ -2866,6 +2888,25 @@ pub(crate) fn parse_into_binary_lockfile(
                     let dep = &mut dependencies[dep_id as usize];
                     let dep_name = dep.name.slice(string_buf);
 
+                    // A displaced member's node lives under its recorded
+                    // `packages` key (e.g. "beta/member"), so its own
+                    // dependency keys are "beta/member/dep", not
+                    // "member/dep".
+                    let nested_res_id = member_tree_keys.iter().find_map(|&(id, key)| {
+                        if id != pkg_id {
+                            return None;
+                        }
+                        let needed = key.len() + 1 + dep_name.len();
+                        let buf_slice = &mut path_buf[..];
+                        if needed > buf_slice.len() {
+                            return None;
+                        }
+                        buf_slice[..key.len()].copy_from_slice(key);
+                        buf_slice[key.len()] = b'/';
+                        buf_slice[key.len() + 1..needed].copy_from_slice(dep_name);
+                        pkg_map.get(&buf_slice[..needed]).copied()
+                    });
+
                     let workspace_node_modules = {
                         let buf_slice = &mut path_buf[..];
                         let needed = workspace_name.len() + 1 + dep_name.len();
@@ -2898,7 +2939,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     } else {
                         None
                     };
-                    let Some(res_id) = peer_res_id.or_else(|| {
+                    let Some(res_id) = peer_res_id.or(nested_res_id).or_else(|| {
                         pkg_map
                             .get(workspace_node_modules)
                             .or_else(|| pkg_map.get(dep_name))
@@ -3170,7 +3211,7 @@ fn map_dep_to_pkg(
 /// name. When a root dependency replaced the member's workspace dependency
 /// (`Package::parse_dependency`), that key holds the other package and the
 /// member only appears nested, so its name must not pre-claim the key.
-fn member_owns_packages_key(pkgs_expr: &Option<Expr>, name: &[u8], path: &[u8]) -> bool {
+fn member_owns_packages_key(pkgs_expr: Option<&Expr>, name: &[u8], path: &[u8]) -> bool {
     let Some(pkgs) = pkgs_expr else {
         return true;
     };
@@ -3254,6 +3295,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
     bundled_pkgs: Option<&PkgPathSet>,
     workspaces_obj: Option<&Expr>,
     // Only meaningful when `IS_ROOT`.
+    pkgs_expr: Option<&Expr>,
     link_workspace_packages: bool,
 ) -> Result<(u32, u32), ParseError> {
     // Clearing on entry is equivalent to clearing on every exit path for all
@@ -3404,28 +3446,38 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
 
-                // Mirror `Package::parse_dependency`: an npm range that
-                // cannot link this member replaced its workspace dependency,
-                // so the loaded root dependency list must match.
+                // A member whose root `packages` key is owned by another
+                // package had its workspace dependency replaced when the
+                // lockfile was written; honor that recorded shape rather
+                // than re-deriving it from the current config, so a
+                // `linkWorkspacePackages` flip re-resolves through the
+                // normal changes diff instead of binding a workspace edge
+                // to the npm package. The range scan mirrors
+                // `Package::parse_dependency` for aliased dependencies,
+                // whose root key is the alias.
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
-                    let member_version = lockfile.workspace_versions.get(&name_hash).copied();
-                    lockfile.buffers.dependencies.as_slice()[off..]
-                        .iter()
-                        .any(|dep| {
-                            if dep.version.tag != DependencyVersionTag::Npm {
-                                return false;
-                            }
-                            let npm = dep.version.npm();
-                            if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash {
-                                return false;
-                            }
-                            let satisfies = match member_version {
-                                Some(version) => npm.version.satisfies(version, bytes, bytes),
-                                None => npm.version.is_star(),
-                            };
-                            !(link_workspace_packages && satisfies)
-                        })
+                    !member_owns_packages_key(pkgs_expr, name, path) || {
+                        let member_version =
+                            lockfile.workspace_versions.get(&name_hash).copied();
+                        lockfile.buffers.dependencies.as_slice()[off..]
+                            .iter()
+                            .any(|dep| {
+                                if dep.version.tag != DependencyVersionTag::Npm {
+                                    return false;
+                                }
+                                let npm = dep.version.npm();
+                                if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash
+                                {
+                                    return false;
+                                }
+                                let satisfies = match member_version {
+                                    Some(version) => npm.version.satisfies(version, bytes, bytes),
+                                    None => npm.version.is_star(),
+                                };
+                                !(link_workspace_packages && satisfies)
+                            })
+                    }
                 };
                 if overridden {
                     continue 'workspaces;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3454,8 +3454,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
                     !member_owns_packages_key(pkgs_expr, name, path) || {
-                        let member_version =
-                            lockfile.workspace_versions.get(&name_hash).copied();
+                        let member_version = lockfile.workspace_versions.get(&name_hash).copied();
                         lockfile.buffers.dependencies.as_slice()[off..]
                             .iter()
                             .any(|dep| {
@@ -3463,8 +3462,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                                     return false;
                                 }
                                 let npm = dep.version.npm();
-                                if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash
-                                {
+                                if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash {
                                     return false;
                                 }
                                 let satisfies = match member_version {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3446,15 +3446,11 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
 
-                // A member whose root `packages` key is owned by another
-                // package had its workspace dependency replaced when the
-                // lockfile was written; honor that recorded shape rather
-                // than re-deriving it from the current config, so a
-                // `linkWorkspacePackages` flip re-resolves through the
-                // normal changes diff instead of binding a workspace edge
-                // to the npm package. The range scan mirrors
-                // `Package::parse_dependency` for aliased dependencies,
-                // whose root key is the alias.
+                // The key-ownership check honors the shape the lockfile was
+                // written in (a linkWorkspacePackages flip must re-resolve,
+                // not bind a workspace edge to the npm package); the range
+                // scan mirrors `Package::parse_dependency` for aliased
+                // dependencies, whose root key is the alias.
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
                     !member_owns_packages_key(pkgs_expr, name, path) || {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2931,9 +2931,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             // strip one tree level; a scoped package name is
                             // a single node, so never leave a bare "@scope"
                             // segment as the tail
-                            let Some(i) = strings::last_index_of_char(prefix, b'/') else {
-                                return None;
-                            };
+                            let i = strings::last_index_of_char(prefix, b'/')?;
                             let parent = &prefix[..i as usize];
                             let tail_start = strings::last_index_of_char(parent, b'/')
                                 .map_or(0, |j| j as usize + 1);

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1604,6 +1604,10 @@ pub(crate) fn parse_into_binary_lockfile(
 ) -> Result<(), ParseError> {
     lockfile.init_empty();
 
+    let link_workspace_packages = manager
+        .as_deref()
+        .is_none_or(|m| m.options.link_workspace_packages);
+
     let Some(lockfile_version_expr) = root.get(b"lockfileVersion") else {
         log.add_error(Some(source), root.loc, b"Missing lockfile version");
         return Err(ParseError::InvalidLockfileVersion);
@@ -2100,6 +2104,7 @@ pub(crate) fn parse_into_binary_lockfile(
             None,
             None,
             Some(&workspaces_obj),
+            link_workspace_packages,
         )?;
 
         let mut root_pkg = Package::default();
@@ -2126,6 +2131,7 @@ pub(crate) fn parse_into_binary_lockfile(
 
     if lockfile_version != Version::V0 {
         // these are the `workspaceOnly` packages
+        let pkgs_expr_for_claims = root.get(b"packages");
         // snapshot the workspace-path handles up front so the loop
         // body can take `&mut *lockfile` (`parse_append_dependencies`,
         // `append_package_dedupe`) without conflicting with the
@@ -2168,6 +2174,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     None,
                     None,
                     None,
+                    link_workspace_packages,
                 )?;
 
                 pkg.dependencies = DependencySlice::new(off, len);
@@ -2187,17 +2194,26 @@ pub(crate) fn parse_into_binary_lockfile(
                 // there should be no duplicates
                 let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
-                let entry = pkg_map.get_or_put(name)?;
-                if entry.found_existing {
-                    log.add_error_fmt(
-                        source,
-                        row.key_loc,
-                        format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
-                    );
-                    return Err(ParseError::InvalidWorkspaceObject);
-                }
+                // A root dependency that replaced this member's workspace
+                // dependency (`Package::parse_dependency`) owns the root
+                // `packages` key matching the member's name, and the member
+                // only appears nested under its dependents. Pre-claiming the
+                // name in `pkg_map` would falsely collide with that entry as
+                // a duplicate package path; the nested key still maps to this
+                // package through the resolution search further down.
+                if member_owns_packages_key(&pkgs_expr_for_claims, name, path) {
+                    let entry = pkg_map.get_or_put(name)?;
+                    if entry.found_existing {
+                        log.add_error_fmt(
+                            source,
+                            row.key_loc,
+                            format_args!("Duplicate workspace name: '{}'", bstr::BStr::new(name)),
+                        );
+                        return Err(ParseError::InvalidWorkspaceObject);
+                    }
 
-                *entry.value_ptr = pkg_id;
+                    *entry.value_ptr = pkg_id;
+                }
 
                 workspace_pkgs_len += 1;
                 continue 'workspaces;
@@ -2521,6 +2537,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             Some(pkg_path),
                             Some(&bundled_pkgs),
                             None,
+                            link_workspace_packages,
                         )?;
 
                         pkg.dependencies = DependencySlice::new(off, len);
@@ -3153,6 +3170,33 @@ fn map_dep_to_pkg(
     }
 }
 
+/// A workspace member normally owns the root `packages` key matching its
+/// name. When a root dependency replaced the member's workspace dependency
+/// (`Package::parse_dependency`), that key holds the other package and the
+/// member only appears nested, so its name must not pre-claim the key.
+fn member_owns_packages_key(pkgs_expr: &Option<Expr>, name: &[u8], path: &[u8]) -> bool {
+    let Some(pkgs) = pkgs_expr else {
+        return true;
+    };
+    let Some(value) = pkgs.get(name) else {
+        return true;
+    };
+    if !value.is_array() {
+        return true;
+    }
+    let Some(first) = array_items(&value).first().and_then(|item| item.as_str()) else {
+        return true;
+    };
+    // a member's own entry is written as "<name>@workspace:<path>"
+    let Some(rest) = first.get(name.len() + 1..) else {
+        return false;
+    };
+    strings::has_prefix(first, name)
+        && first[name.len()] == b'@'
+        && strings::has_prefix(rest, b"workspace:")
+        && strings::eql(&rest[b"workspace:".len()..], path)
+}
+
 fn dependency_resolution_failure(
     dep: &Dependency,
     pkg_path: Option<&[u8]>,
@@ -3213,6 +3257,8 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
     pkg_path: Option<&[u8]>,
     bundled_pkgs: Option<&PkgPathSet>,
     workspaces_obj: Option<&Expr>,
+    // Only meaningful when `IS_ROOT`.
+    link_workspace_packages: bool,
 ) -> Result<(u32, u32), ParseError> {
     // Clearing on entry is equivalent to clearing on every exit path for all
     // callers (none read the buf between calls) and also covers early-error exits.
@@ -3361,6 +3407,33 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .as_utf8_string_literal()
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
+
+                // A root dependency whose npm range cannot link this member
+                // replaced the member's workspace dependency when
+                // package.json was parsed (`Package::parse_dependency`);
+                // mirror it so the loaded lockfile produces the same root
+                // dependency list.
+                let overridden = {
+                    let bytes = lockfile.buffers.string_bytes.as_slice();
+                    let member_version = lockfile.workspace_versions.get(&name_hash).copied();
+                    lockfile.buffers.dependencies.as_slice()[off..].iter().any(|dep| {
+                        if dep.version.tag != DependencyVersionTag::Npm {
+                            return false;
+                        }
+                        let npm = dep.version.npm();
+                        if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash {
+                            return false;
+                        }
+                        let satisfies = match member_version {
+                            Some(version) => npm.version.satisfies(version, bytes, bytes),
+                            None => npm.version.is_star(),
+                        };
+                        !(link_workspace_packages && satisfies)
+                    })
+                };
+                if overridden {
+                    continue 'workspaces;
+                }
 
                 let dep = Dependency {
                     name: sbuf!(lockfile).append_with_hash(name, name_hash)?,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2882,6 +2882,11 @@ pub(crate) fn parse_into_binary_lockfile(
 
                 seen_deps.clear_retaining_capacity();
 
+                // `"<name>/<dep>"` keys belong to whichever package owns the
+                // root `<name>` entry; for a displaced member that is the
+                // npm package that replaced it.
+                let owns_name_node = pkg_map.get(workspace_name).copied() == Some(pkg_id);
+
                 let deps = pkg_deps[pkg_id as usize];
                 for _dep_id in deps.begin()..deps.end() {
                     let dep_id: DependencyID = _dep_id;
@@ -2889,22 +2894,31 @@ pub(crate) fn parse_into_binary_lockfile(
                     let dep_name = dep.name.slice(string_buf);
 
                     // A displaced member's node lives under its recorded
-                    // `packages` key (e.g. "beta/member"), so its own
-                    // dependency keys are "beta/member/dep", not
-                    // "member/dep".
+                    // `packages` key (e.g. "beta/member"). Walk that
+                    // placement up like hoisting would: "beta/member/dep",
+                    // then "beta/dep"; the bare "dep" probe below covers the
+                    // root level.
                     let nested_res_id = member_tree_keys.iter().find_map(|&(id, key)| {
                         if id != pkg_id {
                             return None;
                         }
-                        let needed = key.len() + 1 + dep_name.len();
-                        let buf_slice = &mut path_buf[..];
-                        if needed > buf_slice.len() {
-                            return None;
+                        let mut prefix = key;
+                        loop {
+                            let needed = prefix.len() + 1 + dep_name.len();
+                            let buf_slice = &mut path_buf[..];
+                            if needed <= buf_slice.len() {
+                                buf_slice[..prefix.len()].copy_from_slice(prefix);
+                                buf_slice[prefix.len()] = b'/';
+                                buf_slice[prefix.len() + 1..needed].copy_from_slice(dep_name);
+                                if let Some(&found) = pkg_map.get(&buf_slice[..needed]) {
+                                    return Some(found);
+                                }
+                            }
+                            match strings::last_index_of_char(prefix, b'/') {
+                                Some(i) => prefix = &prefix[..i as usize],
+                                None => return None,
+                            }
                         }
-                        buf_slice[..key.len()].copy_from_slice(key);
-                        buf_slice[key.len()] = b'/';
-                        buf_slice[key.len() + 1..needed].copy_from_slice(dep_name);
-                        pkg_map.get(&buf_slice[..needed]).copied()
                     });
 
                     let workspace_node_modules = {
@@ -2940,10 +2954,12 @@ pub(crate) fn parse_into_binary_lockfile(
                         None
                     };
                     let Some(res_id) = peer_res_id.or(nested_res_id).or_else(|| {
-                        pkg_map
-                            .get(workspace_node_modules)
-                            .or_else(|| pkg_map.get(dep_name))
-                            .copied()
+                        let by_name = if owns_name_node {
+                            pkg_map.get(workspace_node_modules)
+                        } else {
+                            None
+                        };
+                        by_name.or_else(|| pkg_map.get(dep_name)).copied()
                     }) else {
                         if dep.behavior.contains(Behavior::OPTIONAL) {
                             continue;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3416,20 +3416,22 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
                     let member_version = lockfile.workspace_versions.get(&name_hash).copied();
-                    lockfile.buffers.dependencies.as_slice()[off..].iter().any(|dep| {
-                        if dep.version.tag != DependencyVersionTag::Npm {
-                            return false;
-                        }
-                        let npm = dep.version.npm();
-                        if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash {
-                            return false;
-                        }
-                        let satisfies = match member_version {
-                            Some(version) => npm.version.satisfies(version, bytes, bytes),
-                            None => npm.version.is_star(),
-                        };
-                        !(link_workspace_packages && satisfies)
-                    })
+                    lockfile.buffers.dependencies.as_slice()[off..]
+                        .iter()
+                        .any(|dep| {
+                            if dep.version.tag != DependencyVersionTag::Npm {
+                                return false;
+                            }
+                            let npm = dep.version.npm();
+                            if StringBuilder::string_hash(npm.name.slice(bytes)) != name_hash {
+                                return false;
+                            }
+                            let satisfies = match member_version {
+                                Some(version) => npm.version.satisfies(version, bytes, bytes),
+                                None => npm.version.is_star(),
+                            };
+                            !(link_workspace_packages && satisfies)
+                        })
                 };
                 if overridden {
                     continue 'workspaces;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2194,13 +2194,9 @@ pub(crate) fn parse_into_binary_lockfile(
                 // there should be no duplicates
                 let pkg_id = lockfile.append_package_dedupe(&mut pkg)?;
 
-                // A root dependency that replaced this member's workspace
-                // dependency (`Package::parse_dependency`) owns the root
-                // `packages` key matching the member's name, and the member
-                // only appears nested under its dependents. Pre-claiming the
-                // name in `pkg_map` would falsely collide with that entry as
-                // a duplicate package path; the nested key still maps to this
-                // package through the resolution search further down.
+                // A member displaced by a root dependency only appears
+                // nested; pre-claiming its name would falsely collide with
+                // the root `packages` key the other package owns.
                 if member_owns_packages_key(&pkgs_expr_for_claims, name, path) {
                     let entry = pkg_map.get_or_put(name)?;
                     if entry.found_existing {
@@ -3408,11 +3404,9 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     .expect("infallible: is_string checked");
                 let name_hash = StringBuilder::string_hash(name);
 
-                // A root dependency whose npm range cannot link this member
-                // replaced the member's workspace dependency when
-                // package.json was parsed (`Package::parse_dependency`);
-                // mirror it so the loaded lockfile produces the same root
-                // dependency list.
+                // Mirror `Package::parse_dependency`: an npm range that
+                // cannot link this member replaced its workspace dependency,
+                // so the loaded root dependency list must match.
                 let overridden = {
                     let bytes = lockfile.buffers.string_bytes.as_slice();
                     let member_version = lockfile.workspace_versions.get(&name_hash).copied();

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -755,6 +755,47 @@ describe("workspace and npm dependency sharing a name", () => {
     await runBunInstall(env, packageDir, { frozenLockfile: true });
   });
 
+  test.concurrent("scoped displaced member round-trips and keeps scoped walk boundaries", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    // a scoped name is a single tree node: resolving the member's hoisted
+    // dependency must walk "beta/@types/is-number" straight to "beta",
+    // never probing "beta/@types/<dep>"
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "@types/is-number": "1.0.0", "no-deps": "2.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "tin", "package.json"),
+        JSON.stringify({ name: "@types/is-number", version: "9.0.0", dependencies: { "no-deps": "2.0.0" } }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "@types/is-number": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain(`"@types/is-number": ["@types/is-number@1.0.0"`);
+    expect(lockfile).toContain(`"beta/@types/is-number": ["@types/is-number@workspace:packages/tin"]`);
+    // the member's no-deps hoists to the root
+    expect(lockfile).not.toContain("beta/@types/is-number/no-deps");
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+    expect(await exists(join(packageDir, "packages", "tin", "node_modules", "no-deps"))).toBe(false);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
   test.concurrent("duplicate workspace keys in a hand-edited lockfile are rejected", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -347,10 +347,9 @@ describe("workspace and npm dependency sharing a name", () => {
       name: "no-deps",
     });
 
-    // this shape re-saves the lockfile on every install (a pre-existing
-    // quirk, not specific to the name collision), but the content must not
-    // move and a frozen install must accept it
-    await runBunInstall(env, packageDir);
+    // whether this shape re-saves on reinstall is tracked separately; here
+    // only the content and frozen acceptance matter
+    await runBunInstall(env, packageDir, { savesLockfile: false });
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
 
     await runBunInstall(env, packageDir, { frozenLockfile: true });
@@ -697,7 +696,7 @@ describe("workspace and npm dependency sharing a name", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Duplicate workspace name: 'member-a'");
     expect(exitCode).toBe(1);
   });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -542,6 +542,168 @@ describe("workspace and npm dependency sharing a name", () => {
 
     await runBunInstall(env, packageDir, { frozenLockfile: true });
   });
+
+  test.concurrent("flipping linkWorkspacePackages re-resolves instead of failing", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    const bunfig = (linkWorkspacePackages: boolean) =>
+      Bun.TOML.stringify({
+        install: {
+          cache: join(packageDir, ".bun-cache"),
+          linkWorkspacePackages,
+          registry: verdaccio.registryUrl(),
+        },
+      });
+    await Promise.all([
+      write(join(packageDir, "bunfig.toml"), bunfig(false)),
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "no-deps", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "no-deps": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain(`"no-deps": ["no-deps@1.0.0"`);
+
+    // the lockfile embodies linkWorkspacePackages = false; flipping the
+    // config must fail a frozen install loudly and re-resolve on a plain
+    // install, not error forever with an internal DependencyLoop
+    await write(join(packageDir, "bunfig.toml"), bunfig(true));
+    const frozen = await runBunInstall(env, packageDir, {
+      frozenLockfile: true,
+      allowErrors: true,
+      expectedExitCode: 1,
+    });
+    expect(frozen.err).toContain("lockfile had changes");
+    expect(frozen.err).not.toContain("DependencyLoop");
+
+    await runBunInstall(env, packageDir);
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain(
+      `"no-deps": ["no-deps@workspace:packages/no-deps"]`,
+    );
+    const stable = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(stable.err).not.toContain("Saved lockfile");
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+
+    // and back
+    await write(join(packageDir, "bunfig.toml"), bunfig(false));
+    const frozenBack = await runBunInstall(env, packageDir, {
+      frozenLockfile: true,
+      allowErrors: true,
+      expectedExitCode: 1,
+    });
+    expect(frozenBack.err).toContain("lockfile had changes");
+
+    await runBunInstall(env, packageDir);
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain(`"no-deps": ["no-deps@1.0.0"`);
+    const stableBack = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(stableBack.err).not.toContain("Saved lockfile");
+  });
+
+  test.concurrent("displaced member's own pinned dependency survives reload", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.2" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "no-deps", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "3.0.0", dependencies: { "a-dep": "1.0.1" } }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "no-deps": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain(`"beta/no-deps/a-dep": ["a-dep@1.0.1"`);
+
+    // a cold install from the lockfile must resolve the member's dependency
+    // under its nested key, not fall back to the root version
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await rm(join(packageDir, "packages", "no-deps", "node_modules"), { recursive: true, force: true });
+    await runBunInstall(env, packageDir, { savesLockfile: false });
+
+    expect(
+      await file(join(packageDir, "packages", "no-deps", "node_modules", "a-dep", "package.json")).json(),
+    ).toMatchObject({ name: "a-dep", version: "1.0.1" });
+    expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).toMatchObject({
+      name: "a-dep",
+      version: "1.0.2",
+    });
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+  });
+
+  test.concurrent("duplicate workspace keys in a hand-edited lockfile are rejected", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "nd", "package.json"),
+        JSON.stringify({ name: "member-a", version: "1.0.0" }),
+      ),
+      // duplicate workspace path keys with an npm package owning the first
+      // member name's root packages key; the duplicate must be rejected by
+      // the parser, not trip an out-of-bounds workspace package range
+      write(
+        join(packageDir, "bun.lock"),
+        `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "sandbox", "dependencies": { "no-deps": "1.0.0" } },
+    "packages/nd": { "name": "member-a", "version": "1.0.0" },
+    "packages/nd": { "name": "member-b", "version": "1.0.0" },
+    "packages/nd": { "name": "member-c", "version": "1.0.0" },
+  },
+  "packages": {
+    "member-a": ["member-a@1.0.0", "", {}, ""],
+  }
+}`,
+      ),
+    ]);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Duplicate workspace name: 'member-a'");
+    expect(exitCode).toBe(1);
+  });
 });
 
 test.concurrent("successfully installs workspace when path already exists in node_modules", async () => {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -655,6 +655,49 @@ describe("workspace and npm dependency sharing a name", () => {
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
   });
 
+  test.concurrent("displaced member's dependency hoisted to root stays on the root version", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    // registry two-range-deps@1.0.0 depends on no-deps@^1.0.0, which nests
+    // under it as "two-range-deps/no-deps" because the root pins
+    // no-deps@2.0.0; the member's own no-deps@2.0.0 hoists to the root.
+    // Reloading must not bind the member's dependency through the npm
+    // package's "two-range-deps/no-deps" key.
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "two-range-deps": "1.0.0", "no-deps": "2.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "two-range-deps", "package.json"),
+        JSON.stringify({ name: "two-range-deps", version: "9.0.0", dependencies: { "no-deps": "2.0.0" } }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "two-range-deps": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain(`"two-range-deps/no-deps": ["no-deps@1.`);
+    expect(lockfile).toContain(`"beta/two-range-deps": ["two-range-deps@workspace:packages/two-range-deps"]`);
+    expect(lockfile).not.toContain("beta/two-range-deps/no-deps");
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+    // hoisted to the root: the member must not get its own nested copy
+    expect(await exists(join(packageDir, "packages", "two-range-deps", "node_modules", "no-deps"))).toBe(false);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
   test.concurrent("duplicate workspace keys in a hand-edited lockfile are rejected", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -698,6 +698,57 @@ describe("workspace and npm dependency sharing a name", () => {
     await runBunInstall(env, packageDir, { frozenLockfile: true });
   });
 
+  test.concurrent("displaced member's dependency hoisted to an intermediate node binds there", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    // beta pins the same a-dep version as the member, so the member's
+    // dependency hoists to beta's node ("beta/a-dep") rather than nesting
+    // under "beta/no-deps/a-dep" or hoisting to the root; the reload walk
+    // must stop at that intermediate level
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.2" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "no-deps", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "3.0.0", dependencies: { "a-dep": "1.0.1" } }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({
+          name: "beta",
+          version: "1.0.0",
+          dependencies: { "no-deps": "workspace:*", "a-dep": "1.0.1" },
+        }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain(`"beta/a-dep": ["a-dep@1.0.1"`);
+    expect(lockfile).not.toContain("beta/no-deps/a-dep");
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await rm(join(packageDir, "packages", "no-deps", "node_modules"), { recursive: true, force: true });
+    await rm(join(packageDir, "packages", "beta", "node_modules"), { recursive: true, force: true });
+    await runBunInstall(env, packageDir, { savesLockfile: false });
+
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+    expect(
+      await file(join(packageDir, "packages", "beta", "node_modules", "a-dep", "package.json")).json(),
+    ).toMatchObject({ name: "a-dep", version: "1.0.1" });
+    // hoisted to beta's node: the member must not get its own nested copy
+    expect(await exists(join(packageDir, "packages", "no-deps", "node_modules", "a-dep"))).toBe(false);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
   test.concurrent("duplicate workspace keys in a hand-edited lockfile are rejected", async () => {
     using ctx = await setupTest();
     const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -445,9 +445,7 @@ describe("workspace and npm dependency sharing a name", () => {
     expect(lockfile.match(/"no-deps": \[/g)).toHaveLength(1);
     expect(lockfile).toContain(`"no-deps": ["no-deps@1.0.0"`);
     expect(lockfile).toContain(`"beta/no-deps": ["no-deps@workspace:packages/no-deps"]`);
-    expect(
-      await file(join(packageDir, "packages", "beta", "node_modules", "no-deps", "package.json")).json(),
-    ).toEqual({
+    expect(await file(join(packageDir, "packages", "beta", "node_modules", "no-deps", "package.json")).json()).toEqual({
       name: "no-deps",
       version: "3.0.0",
     });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -278,6 +278,274 @@ test("dependency on same name as workspace and dist-tag", async () => {
   ]);
 });
 
+describe("workspace and npm dependency sharing a name", () => {
+  // A root npm dependency whose range cannot link the same-named workspace
+  // member must replace the member's implicit workspace dependency, the way
+  // a version mismatch against a versioned member already does. A versionless
+  // member used to keep both dependencies and `bun install` died with
+  // `error: Package "alpha@1.0.0" has a dependency loop` /
+  // `error: An internal error occurred (DependencyLoop)`. A versioned member
+  // resolved correctly but reloading the saved lockfile failed with
+  // `error: Duplicate package path`, so every install re-resolved and
+  // `--frozen-lockfile` failed.
+
+  test.concurrent("range that cannot match a versionless member installs from the registry", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      write(join(packageDir, "packages", "no-deps", "package.json"), JSON.stringify({ name: "no-deps" })),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"no-deps": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"no-deps": ["no-deps@1.0.0"`);
+    expect(lockfile).not.toContain("no-deps@workspace:");
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("wildcard range still links a versionless member", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "*" },
+        }),
+      ),
+      write(join(packageDir, "packages", "no-deps", "package.json"), JSON.stringify({ name: "no-deps" })),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain(`"no-deps": ["no-deps@workspace:packages/no-deps"]`);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+    });
+
+    // this shape re-saves the lockfile on every install (a pre-existing
+    // quirk, not specific to the name collision), but the content must not
+    // move and a frozen install must accept it
+    await runBunInstall(env, packageDir);
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("displaced member stays reachable through workspace: and the lockfile round-trips", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "no-deps", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "3.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "no-deps": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    // the root node_modules/no-deps is the registry package; the member nests
+    // under beta instead of duplicating the root key
+    expect(lockfile.match(/"no-deps": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"no-deps": ["no-deps@1.0.0"`);
+    expect(lockfile).toContain(`"beta/no-deps": ["no-deps@workspace:packages/no-deps"]`);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+    expect(
+      await file(join(packageDir, "node_modules", "beta", "node_modules", "no-deps", "package.json")).json(),
+    ).toEqual({
+      name: "no-deps",
+      version: "3.0.0",
+    });
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(second.out).toContain("(no changes)");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("displaced member converges with the isolated linker", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({
+          install: {
+            cache: join(packageDir, ".bun-cache"),
+            linker: "isolated",
+            registry: verdaccio.registryUrl(),
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "no-deps", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "3.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "no-deps": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"no-deps": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"no-deps": ["no-deps@1.0.0"`);
+    expect(lockfile).toContain(`"beta/no-deps": ["no-deps@workspace:packages/no-deps"]`);
+    expect(
+      await file(join(packageDir, "packages", "beta", "node_modules", "no-deps", "package.json")).json(),
+    ).toEqual({
+      name: "no-deps",
+      version: "3.0.0",
+    });
+
+    // the member's symlink task re-runs by design; it must not be reported
+    // as an install on a converged tree
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(second.out).toContain("(no changes)");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("aliased npm dependency colliding with a member's name", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "my-alias": "npm:no-deps@1.0.0" },
+        }),
+      ),
+      write(join(packageDir, "packages", "no-deps", "package.json"), JSON.stringify({ name: "no-deps" })),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile).toContain(`"my-alias": ["no-deps@1.0.0"`);
+    expect(lockfile).not.toContain("no-deps@workspace:");
+    expect(await file(join(packageDir, "node_modules", "my-alias", "package.json")).json()).toEqual({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("linkWorkspacePackages = false round-trips a satisfied range", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({
+          install: {
+            cache: join(packageDir, ".bun-cache"),
+            linkWorkspacePackages: false,
+            registry: verdaccio.registryUrl(),
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "sandbox",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      ),
+      // the range satisfies the member's version, but linkWorkspacePackages
+      // is off, so the registry package must win; beta keeps the member in
+      // the lockfile so reloading it exercises the same decision
+      write(
+        join(packageDir, "packages", "no-deps", "package.json"),
+        JSON.stringify({ name: "no-deps", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "beta", "package.json"),
+        JSON.stringify({ name: "beta", version: "1.0.0", dependencies: { "no-deps": "workspace:*" } }),
+      ),
+    ]);
+
+    await runBunInstall(env, packageDir);
+
+    const lockfile = await file(join(packageDir, "bun.lock")).text();
+    expect(lockfile.match(/"no-deps": \[/g)).toHaveLength(1);
+    expect(lockfile).toContain(`"no-deps": ["no-deps@1.0.0"`);
+    expect(lockfile).toContain(`"beta/no-deps": ["no-deps@workspace:packages/no-deps"]`);
+
+    const second = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(second.err).not.toContain("Saved lockfile");
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+});
+
 test.concurrent("successfully installs workspace when path already exists in node_modules", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -643,7 +643,8 @@ describe("workspace and npm dependency sharing a name", () => {
     // under its nested key, not fall back to the root version
     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
     await rm(join(packageDir, "packages", "no-deps", "node_modules"), { recursive: true, force: true });
-    await runBunInstall(env, packageDir, { savesLockfile: false });
+    const reload = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(reload.err).not.toContain("Saved lockfile");
 
     expect(
       await file(join(packageDir, "packages", "no-deps", "node_modules", "a-dep", "package.json")).json(),
@@ -694,6 +695,10 @@ describe("workspace and npm dependency sharing a name", () => {
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
     // hoisted to the root: the member must not get its own nested copy
     expect(await exists(join(packageDir, "packages", "two-range-deps", "node_modules", "no-deps"))).toBe(false);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "2.0.0",
+    });
 
     await runBunInstall(env, packageDir, { frozenLockfile: true });
   });
@@ -737,7 +742,8 @@ describe("workspace and npm dependency sharing a name", () => {
     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
     await rm(join(packageDir, "packages", "no-deps", "node_modules"), { recursive: true, force: true });
     await rm(join(packageDir, "packages", "beta", "node_modules"), { recursive: true, force: true });
-    await runBunInstall(env, packageDir, { savesLockfile: false });
+    const reload = await runBunInstall(env, packageDir, { savesLockfile: false });
+    expect(reload.err).not.toContain("Saved lockfile");
 
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockfile);
     expect(
@@ -793,6 +799,33 @@ describe("workspace and npm dependency sharing a name", () => {
     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Duplicate workspace name: 'member-a'");
     expect(exitCode).toBe(1);
+
+    // the same name at two different paths must also be rejected instead of
+    // silently keeping only the last path
+    await write(
+      join(packageDir, "bun.lock"),
+      `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "sandbox", "dependencies": { "no-deps": "1.0.0" } },
+    "packages/nd": { "name": "member-a", "version": "1.0.0" },
+    "packages/nd2": { "name": "member-a", "version": "1.0.0" },
+  },
+  "packages": {
+    "member-a": ["member-a@workspace:packages/nd"],
+  }
+}`,
+    );
+    await using proc2 = Bun.spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+    expect(stderr2).toContain("Duplicate workspace name: 'member-a'");
+    expect(exitCode2).toBe(1);
   });
 });
 

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -669,10 +669,7 @@ describe("workspace and npm dependency sharing a name", () => {
           dependencies: { "no-deps": "1.0.0" },
         }),
       ),
-      write(
-        join(packageDir, "packages", "nd", "package.json"),
-        JSON.stringify({ name: "member-a", version: "1.0.0" }),
-      ),
+      write(join(packageDir, "packages", "nd", "package.json"), JSON.stringify({ name: "member-a", version: "1.0.0" })),
       // duplicate workspace path keys with an npm package owning the first
       // member name's root packages key; the duplicate must be rejected by
       // the parser, not trip an out-of-bounds workspace package range


### PR DESCRIPTION
### Repro

Shape 1, versionless member:

```
# package.json
{ "name": "sandbox", "workspaces": ["packages/*"],
  "dependencies": { "alpha": "1.0.0" } }
# packages/alpha/package.json   { "name": "alpha" }        (no version field)
```

```
$ bun install
error: Package "alpha@1.0.0" has a dependency loop
  Resolution: "alpha@workspace:packages/alpha"
  Dependency: "alpha@1.0.0"
error: An internal error occurred (DependencyLoop)
```

Shape 2, versioned member the range does not satisfy, kept alive by another member:

```
# packages/alpha/package.json   { "name": "alpha", "version": "3.0.0" }
# packages/beta/package.json    { "name": "beta", "version": "1.0.0",
                                  "dependencies": { "alpha": "workspace:*" } }
```

```
$ bun install        # works: root gets registry alpha@1.0.0, member nests as "beta/alpha"
$ bun install
error: Duplicate package path
    at bun.lock:24:5
InvalidLockfile: failed to parse lockfile: 'bun.lock'
warn: Ignoring lockfile
$ bun install --frozen-lockfile
error: lockfile had changes, but lockfile is frozen
```

Every install after the first ignores the lockfile and re-resolves, and frozen installs (CI) are permanently broken. npm installs both shapes.

### Cause

Three gaps around one state: a root npm dependency replacing a member's implicit workspace dependency (the existing "Override the workspace with the other dependency" rule in `Package::parse_dependency`).

1. The Npm arm only ran its link-or-override decision when the member has a version. A versionless member left both same-name dependencies in the root list, and the hoist conflict surfaced as the misleading `DependencyLoop` internal error. Resolution already has a rule for this member (`get_or_put_resolved_package`, #10899: a versionless member is linkable only by a wildcard range); parsing never mirrored it.
2. Reloading bun.lock pre-claimed every member's name as a root `packages` key. When the override gave that key to the npm package and the member only appears nested (`"beta/alpha"`), parsing failed with `Duplicate package path` on a key that appears once.
3. `parse_append_dependencies` unconditionally injected every member's workspace dependency into the loaded root dependency list, so it never matched a fresh package.json parse and the install re-resolved and re-saved forever.

One follow-on in the isolated linker: workspace store tasks re-run on every install by design (no on-disk freshness check) and are excluded from the install summary only when the dependency edge carries workspace behavior. A displaced member is reachable only through ordinary `workspace:` edges, so every install of an already-converged tree reported `+ alpha@workspace:packages/alpha` and a nonzero install count, never "no changes".

Review of the first revision found three more problems in the newly loadable state, all reproduced before fixing:

4. Flipping `linkWorkspacePackages` after the lockfile was written bricked `bun install` permanently: the injection decision read the current config while the `packages`-key ownership embodied the old one, so the injected workspace dependency bound to the npm package and every install (plain and frozen) died with the `DependencyLoop` internal error until `bun.lock` was deleted.
5. A displaced member's own pinned dependency was keyed `"beta/alpha/dep"` by the writer, but the reload resolver only tried `"alpha/dep"` and `"dep"`, so a cold install silently bound the member's dependency to the root version. Review of that fix found the complementary hole: the `"alpha/dep"` probe belongs to the npm package that owns the root `alpha` key, so a member dependency that dedup-hoisted to the root bound to the npm package's nested copy of the same name.
6. The reload duplicate-workspace-name guard lived inside the now-conditional `packages`-key claim, so a hand-edited lockfile with duplicate workspace keys could over-count the workspace package range and fail with an index-out-of-bounds crash instead of a parse error. Review also pointed out that duplicate names at different paths silently kept only the last path (the name map overwrites on insert); the workspaces scan now rejects those too.

And one pre-existing gap this state exposes: linking a workspace symlink on POSIX failed with `EEXIST: failed linking dependency/workspace to node_modules` when the destination survived inside a member's own node_modules (a root `rm -rf node_modules` does not reset `packages/*/node_modules`, and `skip_delete` assumes a fresh tree). The Windows branch already replaces and retries.

### Fix

- `Package.rs`: the Npm arm runs whenever a member shares the dependency's real name. Satisfaction for a versionless member is `is_star()`, matching resolution. Wildcard plus versionless keeps today's behavior (the dependency stays as-is and resolution links the member); any other unsatisfied case takes the existing override branch, the same as a versioned mismatch.
- `bun.lock.rs`:
  - a member only pre-claims its root `packages` key when the lockfile assigns that key `<name>@workspace:<path>` (`member_owns_packages_key`);
  - the root injection loop first honors the recorded shape (another package owning the member's key means the member was displaced at write time, whatever the current config says), then falls back to mirroring the Npm-arm decision for aliased dependencies, whose root key is the alias. A config flip therefore loads the old shape, fails `--frozen-lockfile` with the normal "lockfile had changes" error, and re-resolves on a plain install;
  - duplicate workspace names are detected by a dedicated seen-name set, and the workspace package-id range counts appended packages, independent of key claiming;
  - workspace packages claimed under a different `packages` key (displaced or aliased) resolve their own dependencies by walking that placement upward the way hoisting does (`"beta/alpha/dep"`, then `"beta/dep"`, then the root), treating a scoped package name as a single node, and the name-based `"alpha/dep"` probe only runs when the member owns its root name entry.
- `isolated_install/Installer.rs`: `on_task_complete` also skips completions whose package resolution is a workspace, so the re-run symlink task stops being counted as an install.
- `PackageInstall.rs`: on POSIX, `install_from_link` replaces an existing destination and retries once on `EEXIST`, matching the Windows branch.

The `file:` cousin of this collision is #37245 (open); `member_owns_packages_key` here is the same code, so whichever PR lands second rebases that hunk away. The dist-tag flavor is #35468.

### Verification

Eleven tests in `test/cli/install/bun-workspaces.test.ts` under `workspace and npm dependency sharing a name`:

- the two repros above: single `"no-deps"` key, correct registry/nested placement, stable reinstall, `--frozen-lockfile` passes
- the second shape under the isolated linker, converging to "(no changes)"
- an aliased `npm:` dependency colliding with a member's name
- `linkWorkspacePackages = false` round-tripping a satisfied range
- flipping `linkWorkspacePackages` in both directions: loud frozen failure, plain install re-resolves and converges
- a displaced member's pinned dependency surviving a cold install from the lockfile (root gets `a-dep@1.0.2`, member keeps `a-dep@1.0.1`)
- a displaced member's dependency that hoists to the root staying on the root version instead of binding through the npm package's nested copy (`two-range-deps/no-deps`)
- a displaced member's dependency that hoists to an intermediate node (the dependent pins the same version) binding at that level on reload
- a hand-edited lockfile with duplicate workspace keys rejected with `Duplicate workspace name`, no crash
- a wildcard-range guard (still links the versionless member; passes on an unmodified build by design)

Ten of eleven fail on an unmodified build with the errors quoted above (only the wildcard guard passes there by design). `bun-workspaces` (72), `isolated-install` (62), `bun-lock`/`lockfile-only`/`lockfile-version-2`/`bun-lockb`/`migrate-bun-lockb-v2`/`migration/migrate`/`bun-add` (112), and `bun-install-registry` (234) pass locally; `migration/complex-workspace` fails only on gitlab/bitbucket network access and `bun-link`'s "link dependency without crashing" times out locally, both identically without this diff.
