### PR TITLE
install: stop re-saving an unchanged lockfile for wildcard deps on versionless workspace members

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1750,12 +1750,8 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                // A versionless workspace member satisfies a wildcard range
-                // (the resolver links it; see the resolve-from-workspace rule
-                // in `get_or_put_resolved_package`). Apply the same rule here
-                // so re-parsing package.json yields the workspace-tagged
-                // dependency a loaded lockfile holds, instead of a mismatch
-                // that re-saves an unchanged lockfile on every install.
+                // A versionless member satisfies only a wildcard range, the
+                // same rule resolution applies in `get_or_put_resolved_package`.
                 let satisfies = match workspace_version {
                     Some(workspace_version) => {
                         dependency_version

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1757,13 +1757,13 @@ impl Package<u64> {
                 // dependency a loaded lockfile holds, instead of a mismatch
                 // that re-saves an unchanged lockfile on every install.
                 let satisfies = match workspace_version {
-                    Some(workspace_version) => dependency_version
-                        .npm()
-                        .version
-                        .satisfies(workspace_version, buf, buf),
-                    None => {
-                        workspace_path.is_some() && dependency_version.npm().version.is_star()
+                    Some(workspace_version) => {
+                        dependency_version
+                            .npm()
+                            .version
+                            .satisfies(workspace_version, buf, buf)
                     }
+                    None => workspace_path.is_some() && dependency_version.npm().version.is_star(),
                 };
                 if pm.options.link_workspace_packages && satisfies {
                     // `String::sliced` takes `&'a self`; bind the unwrapped

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1750,47 +1750,43 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                // A versionless member satisfies only a wildcard range, the
-                // same rule resolution applies in `get_or_put_resolved_package`.
-                let satisfies = match workspace_version {
-                    Some(workspace_version) => {
+                if let Some(workspace_version) = workspace_version {
+                    let satisfies =
                         dependency_version
                             .npm()
                             .version
-                            .satisfies(workspace_version, buf, buf)
-                    }
-                    None => workspace_path.is_some() && dependency_version.npm().version.is_star(),
-                };
-                if pm.options.link_workspace_packages && satisfies {
-                    // `String::sliced` takes `&'a self`; bind the unwrapped
-                    // value so the borrow outlives the parse call.
-                    let wp = workspace_path.unwrap();
-                    let path = wp.sliced(buf);
-                    if let Some(mut dep) = dependency::parse_with_tag(
-                        external_alias.value,
-                        Some(external_alias.hash),
-                        path.slice,
-                        dependency::version::Tag::Workspace,
-                        &path,
-                        Some(&mut *log),
-                        Some(&mut *pm),
-                    ) {
-                        // Whole-struct move so `Drop` frees the old npm
-                        // chain; keep the existing `literal`.
-                        dep.literal = dependency_version.literal;
-                        dependency_version = dep;
-                    }
-                } else if workspace_version.is_some() {
-                    // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
-                    for dep in &mut package_dependencies[0..dependencies_count as usize] {
-                        if dep.name_hash == name_hash && dep.behavior.is_workspace() {
-                            *dep = Dependency {
-                                behavior: group.behavior,
-                                name: external_alias.value,
-                                name_hash: external_alias.hash,
-                                version: dependency_version,
-                            };
-                            return Ok(None);
+                            .satisfies(workspace_version, buf, buf);
+                    if pm.options.link_workspace_packages && satisfies {
+                        // `String::sliced` takes `&'a self`; bind the unwrapped
+                        // value so the borrow outlives the parse call.
+                        let wp = workspace_path.unwrap();
+                        let path = wp.sliced(buf);
+                        if let Some(mut dep) = dependency::parse_with_tag(
+                            external_alias.value,
+                            Some(external_alias.hash),
+                            path.slice,
+                            dependency::version::Tag::Workspace,
+                            &path,
+                            Some(&mut *log),
+                            Some(&mut *pm),
+                        ) {
+                            // Whole-struct move so `Drop` frees the old npm
+                            // chain; keep the existing `literal`.
+                            dep.literal = dependency_version.literal;
+                            dependency_version = dep;
+                        }
+                    } else {
+                        // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
+                        for dep in &mut package_dependencies[0..dependencies_count as usize] {
+                            if dep.name_hash == name_hash && dep.behavior.is_workspace() {
+                                *dep = Dependency {
+                                    behavior: group.behavior,
+                                    name: external_alias.value,
+                                    name_hash: external_alias.hash,
+                                    version: dependency_version,
+                                };
+                                return Ok(None);
+                            }
                         }
                     }
                 }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1750,43 +1750,51 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                if let Some(workspace_version) = workspace_version {
-                    let satisfies =
-                        dependency_version
-                            .npm()
-                            .version
-                            .satisfies(workspace_version, buf, buf);
-                    if pm.options.link_workspace_packages && satisfies {
-                        // `String::sliced` takes `&'a self`; bind the unwrapped
-                        // value so the borrow outlives the parse call.
-                        let wp = workspace_path.unwrap();
-                        let path = wp.sliced(buf);
-                        if let Some(mut dep) = dependency::parse_with_tag(
-                            external_alias.value,
-                            Some(external_alias.hash),
-                            path.slice,
-                            dependency::version::Tag::Workspace,
-                            &path,
-                            Some(&mut *log),
-                            Some(&mut *pm),
-                        ) {
-                            // Whole-struct move so `Drop` frees the old npm
-                            // chain; keep the existing `literal`.
-                            dep.literal = dependency_version.literal;
-                            dependency_version = dep;
-                        }
-                    } else {
-                        // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
-                        for dep in &mut package_dependencies[0..dependencies_count as usize] {
-                            if dep.name_hash == name_hash && dep.behavior.is_workspace() {
-                                *dep = Dependency {
-                                    behavior: group.behavior,
-                                    name: external_alias.value,
-                                    name_hash: external_alias.hash,
-                                    version: dependency_version,
-                                };
-                                return Ok(None);
-                            }
+                // A versionless workspace member satisfies a wildcard range
+                // (the resolver links it; see the resolve-from-workspace rule
+                // in `get_or_put_resolved_package`). Apply the same rule here
+                // so re-parsing package.json yields the workspace-tagged
+                // dependency a loaded lockfile holds, instead of a mismatch
+                // that re-saves an unchanged lockfile on every install.
+                let satisfies = match workspace_version {
+                    Some(workspace_version) => dependency_version
+                        .npm()
+                        .version
+                        .satisfies(workspace_version, buf, buf),
+                    None => {
+                        workspace_path.is_some() && dependency_version.npm().version.is_star()
+                    }
+                };
+                if pm.options.link_workspace_packages && satisfies {
+                    // `String::sliced` takes `&'a self`; bind the unwrapped
+                    // value so the borrow outlives the parse call.
+                    let wp = workspace_path.unwrap();
+                    let path = wp.sliced(buf);
+                    if let Some(mut dep) = dependency::parse_with_tag(
+                        external_alias.value,
+                        Some(external_alias.hash),
+                        path.slice,
+                        dependency::version::Tag::Workspace,
+                        &path,
+                        Some(&mut *log),
+                        Some(&mut *pm),
+                    ) {
+                        // Whole-struct move so `Drop` frees the old npm
+                        // chain; keep the existing `literal`.
+                        dep.literal = dependency_version.literal;
+                        dependency_version = dep;
+                    }
+                } else if workspace_version.is_some() {
+                    // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
+                    for dep in &mut package_dependencies[0..dependencies_count as usize] {
+                        if dep.name_hash == name_hash && dep.behavior.is_workspace() {
+                            *dep = Dependency {
+                                behavior: group.behavior,
+                                name: external_alias.value,
+                                name_hash: external_alias.hash,
+                                version: dependency_version,
+                            };
+                            return Ok(None);
                         }
                     }
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1604,6 +1604,10 @@ pub(crate) fn parse_into_binary_lockfile(
 ) -> Result<(), ParseError> {
     lockfile.init_empty();
 
+    let link_workspace_packages = manager
+        .as_deref()
+        .is_none_or(|m| m.options.link_workspace_packages);
+
     let Some(lockfile_version_expr) = root.get(b"lockfileVersion") else {
         log.add_error(Some(source), root.loc, b"Missing lockfile version");
         return Err(ParseError::InvalidLockfileVersion);
@@ -2774,6 +2778,7 @@ pub(crate) fn parse_into_binary_lockfile(
         // tree path (see `resolve_peer_dep_version_based`).
         let package_index = &lockfile.package_index;
         let overrides = &lockfile.overrides;
+        let workspace_versions = &lockfile.workspace_versions;
 
         // Disjoint-field split of `lockfile.buffers` so each loop body can hold
         // `&mut dependencies[i]` and `&mut resolutions[i]` together with a shared
@@ -2833,6 +2838,9 @@ pub(crate) fn parse_into_binary_lockfile(
                     resolutions,
                     lockfile_version,
                     pkg_resolutions,
+                    string_buf,
+                    workspace_versions,
+                    link_workspace_packages,
                 );
             }
         }
@@ -2917,6 +2925,9 @@ pub(crate) fn parse_into_binary_lockfile(
                         resolutions,
                         lockfile_version,
                         pkg_resolutions,
+                        string_buf,
+                        workspace_versions,
+                        link_workspace_packages,
                     );
                 }
             }
@@ -2989,6 +3000,9 @@ pub(crate) fn parse_into_binary_lockfile(
                     resolutions,
                     lockfile_version,
                     pkg_resolutions,
+                    string_buf,
+                    workspace_versions,
+                    link_workspace_packages,
                 );
             }
         }
@@ -3133,12 +3147,33 @@ fn map_dep_to_pkg(
     resolutions: &mut [PackageID],
     text_lockfile_version: Version,
     pkg_resolutions: &[Resolution],
+    string_buf: &[u8],
+    workspace_versions: &VersionHashMap,
+    link_workspace_packages: bool,
 ) {
     resolutions[dep_id as usize] = pkg_id;
 
     if text_lockfile_version != Version::V0 {
         let res = &pkg_resolutions[pkg_id as usize];
         if res.tag == ResolutionTag::Workspace {
+            // Rewrite the dependency only into the shape `Package::parse_dependency`
+            // would produce for it: an npm range becomes a workspace dependency
+            // only for a member version the range satisfies. A dependency the
+            // parser keeps npm-tagged (a wildcard on a versionless member) must
+            // keep its parsed tag here too, or every install diffs the loaded
+            // lockfile against the fresh parse and re-saves it unchanged.
+            if dep.version.tag == DependencyVersionTag::Npm {
+                let npm = dep.version.npm();
+                let parse_would_rewrite = link_workspace_packages
+                    && workspace_versions
+                        .get(&StringBuilder::string_hash(npm.name.slice(string_buf)))
+                        .is_some_and(|version| {
+                            npm.version.satisfies(*version, string_buf, string_buf)
+                        });
+                if !parse_would_rewrite {
+                    return;
+                }
+            }
             // Whole-struct assign so `DependencyVersion::Drop` frees any prior
             // npm chain. SAFETY: `res.tag == Workspace` checked above.
             let literal = dep.version.literal;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3159,15 +3159,15 @@ fn map_dep_to_pkg(
             // Only rewrite into the shape `Package::parse_dependency` would
             // produce (a member version the range satisfies); otherwise the
             // loaded root never matches a fresh parse and every install
-            // re-saves the unchanged lockfile.
-            if dep.version.tag == DependencyVersionTag::Npm {
+            // re-saves the unchanged lockfile. With linking disabled, always
+            // rewrite so a stale workspace resolution diffs and re-resolves.
+            if dep.version.tag == DependencyVersionTag::Npm && link_workspace_packages {
                 let npm = dep.version.npm();
-                let parse_would_rewrite = link_workspace_packages
-                    && workspace_versions
-                        .get(&StringBuilder::string_hash(npm.name.slice(string_buf)))
-                        .is_some_and(|version| {
-                            npm.version.satisfies(*version, string_buf, string_buf)
-                        });
+                let parse_would_rewrite = workspace_versions
+                    .get(&StringBuilder::string_hash(npm.name.slice(string_buf)))
+                    .is_some_and(|version| {
+                        npm.version.satisfies(*version, string_buf, string_buf)
+                    });
                 if !parse_would_rewrite {
                     return;
                 }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3156,12 +3156,10 @@ fn map_dep_to_pkg(
     if text_lockfile_version != Version::V0 {
         let res = &pkg_resolutions[pkg_id as usize];
         if res.tag == ResolutionTag::Workspace {
-            // Rewrite the dependency only into the shape `Package::parse_dependency`
-            // would produce for it: an npm range becomes a workspace dependency
-            // only for a member version the range satisfies. A dependency the
-            // parser keeps npm-tagged (a wildcard on a versionless member) must
-            // keep its parsed tag here too, or every install diffs the loaded
-            // lockfile against the fresh parse and re-saves it unchanged.
+            // Only rewrite into the shape `Package::parse_dependency` would
+            // produce (a member version the range satisfies); otherwise the
+            // loaded root never matches a fresh parse and every install
+            // re-saves the unchanged lockfile.
             if dep.version.tag == DependencyVersionTag::Npm {
                 let npm = dep.version.npm();
                 let parse_would_rewrite = link_workspace_packages

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3165,9 +3165,7 @@ fn map_dep_to_pkg(
                 let npm = dep.version.npm();
                 let parse_would_rewrite = workspace_versions
                     .get(&StringBuilder::string_hash(npm.name.slice(string_buf)))
-                    .is_some_and(|version| {
-                        npm.version.satisfies(*version, string_buf, string_buf)
-                    });
+                    .is_some_and(|version| npm.version.satisfies(*version, string_buf, string_buf));
                 if !parse_would_rewrite {
                     return;
                 }

--- a/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-workspaces.test.ts.snap
@@ -50,7 +50,10 @@ exports[`dependency on workspace without version in package.json: version: * 1`]
     {
       "name": "no-deps",
       "literal": "*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -173,7 +176,10 @@ exports[`dependency on workspace without version in package.json: version: *.*.*
     {
       "name": "no-deps",
       "literal": "*.*.*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -296,7 +302,10 @@ exports[`dependency on workspace without version in package.json: version: =* 1`
     {
       "name": "no-deps",
       "literal": "=*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -542,7 +551,10 @@ exports[`dependency on workspace without version in package.json: version: *.1.*
     {
       "name": "no-deps",
       "literal": "*.1.*",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true
@@ -665,7 +677,10 @@ exports[`dependency on workspace without version in package.json: version: *-pre
     {
       "name": "no-deps",
       "literal": "*-pre",
-      "workspace": "packages/mono",
+      "npm": {
+        "name": "no-deps",
+        "version": ">=0.0.0"
+      },
       "package_id": 2,
       "behavior": {
         "prod": true

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -193,6 +193,69 @@ test("dependency on workspace without version in package.json", async () => {
   }
 });
 
+test.concurrent(
+  "repeat install does not re-save the lockfile for a wildcard dependency on a versionless workspace member",
+  async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["packages/*"],
+          dependencies: {
+            "no-deps": "*",
+          },
+        }),
+      ),
+      // no version field on purpose
+      write(join(packageDir, "packages", "no-deps", "package.json"), JSON.stringify({ name: "no-deps" })),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "no-deps": "*",
+          },
+        }),
+      ),
+    ]);
+
+    var { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    var err = await stderr.text();
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    const lockBefore = await file(join(packageDir, "bun.lock")).text();
+    // the wildcard dependencies resolve to the workspace member, not the registry
+    expect(lockBefore).toContain("no-deps@workspace:packages/no-deps");
+
+    ({ stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    }));
+
+    err = await stderr.text();
+    expect(err).not.toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockBefore);
+  },
+);
+
 test.concurrent("allowing negative workspace patterns", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -225,15 +225,15 @@ test.concurrent(
     var { stderr, exited } = spawn({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       env,
     });
 
-    var err = await stderr.text();
+    var [err, exitCode] = await Promise.all([stderr.text(), exited]);
     expect(err).toContain("Saved lockfile");
     expect(err).not.toContain("error:");
-    expect(await exited).toBe(0);
+    expect(exitCode).toBe(0);
 
     const lockBefore = await file(join(packageDir, "bun.lock")).text();
     // the wildcard dependencies resolve to the workspace member, not the registry
@@ -242,15 +242,15 @@ test.concurrent(
     ({ stderr, exited } = spawn({
       cmd: [bunExe(), "install"],
       cwd: packageDir,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       env,
     }));
 
-    err = await stderr.text();
+    [err, exitCode] = await Promise.all([stderr.text(), exited]);
     expect(err).not.toContain("Saved lockfile");
     expect(err).not.toContain("error:");
-    expect(await exited).toBe(0);
+    expect(exitCode).toBe(0);
 
     expect(await file(join(packageDir, "bun.lock")).text()).toBe(lockBefore);
   },


### PR DESCRIPTION
### Repro

```
# package.json
{ "name": "sandbox", "workspaces": ["packages/*"],
  "dependencies": { "pkg-x": "*" } }
# packages/member/package.json   { "name": "pkg-x" }     (no version field)
```

```
$ bun install
Saved lockfile
$ bun install
Saved lockfile        <- bun.lock is byte-identical, rewritten anyway

Done! Checked 2 packages (no changes)
```

Every install rewrites `bun.lock` forever, while `--frozen-lockfile` passes and the content never changes. Same loop when the wildcard dependency lives in another workspace member, including after a package-lock.json migration.

### Cause

A `*` range on a versionless workspace member is linkable only through the resolver's rule from #10899 (`get_or_put_resolved_package`: a versionless member satisfies a wildcard). `Package::parse_dependency` keeps such a dependency npm-tagged (it only rewrites to a workspace dependency for a member version the range satisfies), but loading `bun.lock` rewrote **every** dependency whose resolution is a workspace package to a workspace-tagged dependency (`map_dep_to_pkg`). The loaded and freshly parsed roots then never compare equal: `Version::eql` fails on the tag mismatch, the diff counts one update, `had_any_diffs` stays true, and the install re-saves an unchanged lockfile. Members with a version field don't loop because parse rewrites their satisfied ranges to the same shape the loader produces.

### Fix

Gate the loader's rewrite on the parser's rule: while `linkWorkspacePackages` is on, an npm-tagged dependency is rewritten to a workspace dependency only when the member has a version the range satisfies, i.e. exactly when re-parsing package.json would produce a workspace dependency for it. Dependencies the parser keeps npm-tagged (a wildcard on a versionless member) now load npm-tagged too, the dependency lists compare equal, and the re-save stops. The lookup uses the dependency's real npm name, matching the parser's alias handling, and non-npm tags (`workspace:` ranges and the injected member entries) keep the existing normalization.

With `linkWorkspacePackages` off the rewrite stays unconditional: a lockfile that previously linked a member must keep diffing against the fresh parse so flipping the setting re-resolves instead of silently keeping the stale link. Today that re-resolution surfaces the pre-existing name-collision error (`DependencyLoop`) for this shape, byte-identical to an unmodified build (#37248 is fixing that collision).

Resolution is unchanged: the dependency still maps to the workspace package on load, which is the same in-memory state a fresh install produces (the resolver links the wildcard to the member without retagging the dependency). The saved lockfile bytes are identical before and after, existing lockfiles load clean and stop being rewritten, and `lockfileVersion: 0` lockfiles take one migration save and then stabilize.

An earlier revision made the parser rewrite the dependency instead; CI caught it breaking package-lock.json migration (`migration/complex-workspace`): migrated lockfiles keep npm-tagged dependencies, so the parse-side rewrite made the differ discard affected members and re-resolve their dependencies, dropping npm's pins. Fixing the loader leaves parse, migration, and resolution untouched.

Known adjacent flavors, deliberately out of scope: a member with a **pre-release** version depended on via `*` still re-saves on every install (on an unmodified build too; the resolver's wildcard rule links it while the parser's override branch displaces it, the exact arm #37248 restructures), and the dist-tag fallback flavor sits in #35468's area. Neither overlaps this diff.

### Verification

New test in `test/cli/install/bun-workspaces.test.ts`: root and member wildcard dependencies on a versionless member, second install must not print "Saved lockfile" and `bun.lock` must be byte-identical, with the dependency still resolving to `no-deps@workspace:packages/no-deps`. Fails on an unmodified build (second install prints "Saved lockfile"), passes with the fix. Snapshot updates in the same file show the only in-memory change: the loaded wildcard dependency keeps its npm tag while still resolving to the member (`package_id` unchanged), and `toMatchNodeModulesAt` still passes.

Locally green: `bun-workspaces` (64), `isolated-install` (62), `bun-lock` (17), `lockfile-only`, `lockfile-version-2`, `bun-lockb`, `migrate-bun-lockb-v2`, `migration/migrate` (21), `bad-workspace`, `bun-add` (54), `bun-update` (6). Also checked by hand: hoisted and isolated linkers converge with a stable lockfile, a lockfile written by an older bun is accepted without a rewrite, `--frozen-lockfile` passes, a package-lock.json workspace migration produces the same lockfile as an unmodified build and then stays stable, and flipping `linkWorkspacePackages` off behaves identically to an unmodified build. `migration/complex-workspace` fails locally only on gitlab/bitbucket network access, identically without this diff.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (a368e5659)

test/cli/install/bun-workspaces.test.ts:
150 |     const { out } = await runBunInstall(env, packageDir);
151 |     const lockfile = parseLockfile(packageDir);
152 |     expect(lockfile).toMatchNodeModulesAt(packageDir);
153 |     expect(
154 |       JSON.stringify(lockfile, null, 2).replaceAll(/http:\/\/localhost:\d+/g, "http://localhost:1234"),
155 |     ).toMatchSnapshot(`version: ${version}`);
            ^
error: expect(received).toMatchSnapshot(expected)

@@ -46,14 +46,11 @@
        "id": 1
      },
      {
        "name": "no-deps",
        "literal": "*",
-       "npm": {
-         "name": "no-deps",
-         "version": ">=0.0.0"
-       },
+       "workspace": "packages/mono",
        "package_id": 2,
        "behavior": {
          "prod": true
        },
        "id": 2

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/install/bun-workspaces.test.ts:155:7)
(fail) dependency on workspace without version in package.json [306.78ms
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f20bf8144)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [92.94ms]
(pass) repeat install does not re-save the lockfile for a wildcard dependency on a versionless workspace member [6.54ms]
(pass) allowing negative workspace patterns [12.91ms]
(pass) dependency on same name as workspace and dist-tag [12.12ms]
Saved lockfile
(pass) workspace aliases > version range workspace:@org/b@1.0.0 and workspace with no version (should fail) [13.15ms]
(pass) workspaces with invalid versions should still install [14.40ms]
(pass) adding workspace in workspace edits package.json with correct version (workspace:*) [15.31ms]
(pass) workspace aliases > combination [14.82ms]
(pass) workspace aliases > version range workspace:@org/b@latest and workspace with no version [14.62ms]
(pass) workspace aliases > version range workspace:@org/b@* and workspace with no version [14.44ms]
(pass) successfully installs workspace when path already exists in node_modules [15.66ms]
(pass) workspace aliases > version range workspace:@org/b@ and workspace with no version [14.44ms]
(pass) workspace aliases > version range w
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-workspaces.test.ts
bun test v1.4.0 (a368e5659)

test/cli/install/bun-workspaces.test.ts:
(pass) dependency on workspace without version in package.json [2320.43ms]
(pass) allowing negative workspace patterns [215.09ms]
(pass) repeat install does not re-save the lockfile for a wildcard dependency on a versionless workspace member [323.68ms]
(pass) dependency on same name as workspace and dist-tag [204.84ms]
Saved lockfile
(pass) successfully installs workspace when path already exists in node_modules [317.10ms]
(pass) adding workspace in workspace edits package.json with correct version (workspace:*) [307.02ms]
(pass) workspaces with invalid versions should still install [294.69ms]
(pass) workspace aliases > version range workspace:@org/b@latest and workspace with no version [280.91ms]
(pass) workspace aliases > combination [298.18ms]
(pass) workspace aliases > version range workspace:@org/b@* and workspace with no version [192.02ms]
(pass) workspace aliases > version range workspace:@org/b@1 and workspace with no v
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 687ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/lockfile/bun.lock.rs                   | 31 +++++++++++
 .../__snapshots__/bun-workspaces.test.ts.snap      | 25 +++++++--
 test/cli/install/bun-workspaces.test.ts            | 63 ++++++++++++++++++++++
 3 files changed, 114 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/install/lockfile/bun.lock.rs                              5      7      0
…t/cli/install/__snapshots__/bun-workspaces.test.ts.snap      0      0      0
test/cli/install/bun-workspaces.test.ts                       5      3      0
```

</details>

<!-- robobun:evidence:end -->