### PR TITLE
install: don't double-count packages in the isolated install summary

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2663,6 +2663,10 @@ pub(crate) fn install_isolated_packages(
             }
 
             debug_assert!(done);
+
+            // `success` counts unique packages, in lock-step with the
+            // `installed` bitset the tree printer consumes.
+            assert!(installer.summary.success as usize == installer.installed.count());
         }
 
         let mut summary = core::mem::take(&mut installer.summary);

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2664,8 +2664,7 @@ pub(crate) fn install_isolated_packages(
 
             debug_assert!(done);
 
-            // `success` counts unique packages, in lock-step with the
-            // `installed` bitset the tree printer consumes.
+            // The summary line prints `success`; the tree printer lists the bitset.
             assert!(installer.summary.success as usize == installer.installed.count());
         }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2665,7 +2665,10 @@ pub(crate) fn install_isolated_packages(
             debug_assert!(done);
 
             // The summary line prints `success`; the tree printer lists the bitset.
-            assert!(installer.summary.success as usize == installer.installed.count());
+            assert_eq!(
+                installer.summary.success as usize,
+                installer.installed.count()
+            );
         }
 
         let mut summary = core::mem::take(&mut installer.summary);

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -539,8 +539,7 @@ impl<'a> Installer<'a> {
 
         match real_state {
             CompleteState::Success => {
-                // A package with multiple store entries (one per peer
-                // dependency variant) counts as one installed package.
+                // A package may have several store entries (peer variants); count it once.
                 let pkg_id = nodes.items_pkg_id()[node_id.get() as usize];
                 let is_duplicate = self.installed.is_set(pkg_id as usize);
                 self.summary.success += (!is_duplicate) as u32;

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -539,23 +539,20 @@ impl<'a> Installer<'a> {
 
         match real_state {
             CompleteState::Success => {
-                self.summary.success += 1;
+                // A package with multiple store entries (one per peer
+                // dependency variant) counts as one installed package.
+                let pkg_id = nodes.items_pkg_id()[node_id.get() as usize];
+                let is_duplicate = self.installed.is_set(pkg_id as usize);
+                self.summary.success += (!is_duplicate) as u32;
+                self.installed.set(pkg_id as usize);
             }
             CompleteState::Skipped => {
                 self.summary.skipped += 1;
-                return;
             }
             CompleteState::Fail => {
                 self.summary.fail += 1;
-                return;
             }
         }
-
-        let pkg_id = nodes.items_pkg_id()[node_id.get() as usize];
-
-        let is_duplicate = self.installed.is_set(pkg_id as usize);
-        self.summary.success += (!is_duplicate) as u32;
-        self.installed.set(pkg_id as usize);
     }
 
     // This function runs only on the main thread. The installer tasks threads

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1130,7 +1130,7 @@ it("should add dependency alongside workspaces", async () => {
     "installed baz@0.0.3 with binaries:",
     " - baz-run",
     "",
-    "2 packages installed",
+    "1 package installed",
   ]);
   expect(await exited).toBe(0);
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
@@ -2156,7 +2156,7 @@ it("should add dependencies to workspaces directly", async () => {
     "",
     `installed foo@${relative(package_dir, add_dir).replace(/\\/g, "/")}`,
     "",
-    "2 packages installed",
+    "1 package installed",
   ]);
   expect(await exited).toBe(0);
   expect(await readdirSorted(join(package_dir))).toEqual([

--- a/test/cli/install/config-version.test.ts
+++ b/test/cli/install/config-version.test.ts
@@ -94,7 +94,7 @@ describe.concurrent("configVersion", () => {
     expect(normalizeBunSnapshot(out, packageDir)).toMatchInlineSnapshot(`
       "bun install <version> (<revision>)
 
-      2 packages installed"
+      1 package installed"
     `);
     expect(exitCode).toBe(0);
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2687,3 +2687,65 @@ describe("hoist", () => {
     );
   });
 });
+
+// The isolated installer used to count every completed store entry on top of
+// every unique package, so a fresh install reported roughly double the number
+// of packages the hoisted linker reported for the same project.
+describe.concurrent("install summary", () => {
+  test("counts one install per package", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "summary-single-dep",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+
+    const { out } = await runBunInstall(bunEnv, packageDir);
+    expect(out).toContain("1 package installed");
+  });
+
+  test("peer variants of one package count once", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    // `peer-deps@1.0.0` declares `peerDependencies: { "no-deps": "*" }`, so
+    // each workspace gets its own store entry of `peer-deps`. Three unique
+    // packages install: peer-deps@1.0.0, no-deps@1.0.0, and no-deps@1.1.0.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "summary-peer-variants",
+        workspaces: ["packages/*"],
+      }),
+    );
+    await write(
+      join(packageDir, "packages", "pkg-a", "package.json"),
+      JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: {
+          "peer-deps": "1.0.0",
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+    await write(
+      join(packageDir, "packages", "pkg-b", "package.json"),
+      JSON.stringify({
+        name: "pkg-b",
+        version: "1.0.0",
+        dependencies: {
+          "peer-deps": "1.0.0",
+          "no-deps": "1.1.0",
+        },
+      }),
+    );
+
+    const { out } = await runBunInstall(bunEnv, packageDir);
+    expect(out).toContain("3 packages installed");
+  });
+});

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2706,7 +2706,7 @@ describe.concurrent("install summary", () => {
     );
 
     const { out } = await runBunInstall(bunEnv, packageDir);
-    expect(out).toContain("1 package installed");
+    expect(out).toMatch(/\b1 package installed\b/);
   });
 
   test("peer variants of one package count once", async () => {
@@ -2746,6 +2746,6 @@ describe.concurrent("install summary", () => {
     );
 
     const { out } = await runBunInstall(bunEnv, packageDir);
-    expect(out).toContain("3 packages installed");
+    expect(out).toMatch(/\b3 packages installed\b/);
   });
 });


### PR DESCRIPTION
### What

With the isolated linker, `bun install` reports roughly double the number of packages it actually installed:

```sh
echo '{"name":"x","dependencies":{"wordwrap":"1.0.0"}}' > package.json
bun install --linker isolated   # "2 packages installed"
rm -rf node_modules bun.lock
bun install --linker hoisted    # "1 package installed"
```

Projects with peer dependency variants over-report even more: two workspaces sharing `peer-deps` against different `no-deps` versions install 3 unique packages but print "7 packages installed" (4 store entries + 3 unique packages).

### Cause

`Installer::on_task_complete` in `src/install/isolated_install/Installer.rs` incremented `summary.success` twice on a successful store entry: once unconditionally per entry, and once more when the entry's package id had not been counted yet. A package's first store entry added 2, and each additional entry for the same package (one per peer variant) added 1.

The hoisted installer only has the deduplicated increment, so `success` means "unique packages installed" everywhere else: the summary line prints it as "N packages installed", and the tree printer lists one line per package from the same bitset.

### Fix

Keep the per-unique-package increment and drop the per-entry one, matching the hoisted installer. `skipped` and `fail` counting are unchanged.

Debug and CI-assert builds now assert that `summary.success` equals the popcount of the `installed` bitset before the summary is returned: the count line prints the former while the tree printer lists the latter, so drift between them is user-visible and is exactly what this bug was.

Three existing tests had the doubled counts baked into their expectations (`config-version.test.ts` monorepo snapshot, two `bun add --linker=isolated` assertions in `bun-add.test.ts`); they now expect the real counts.

### Verification

New tests in `test/cli/install/isolated-install.test.ts` cover both shapes: a single dependency must print "1 package installed", and the peer-variant workspace setup must print "3 packages installed". Both fail before this change ("2 packages installed" and "7 packages installed") and pass after.

Also ran the other install suites that assert summary counts (`bun-install-registry`, `bun-workspaces`, `bun-lock`, `bun-update`, `bun-add`, `config-version`, `bun-install-patch`, `bun-install-tarball-integrity`): green with the fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->