### PR TITLE
Report UTF-16 to UTF-8 encode counts through size_t so exactly 2^32 written bytes doesn't wrap to 0

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -584,7 +584,7 @@ pub(crate) fn format_utf16_type_with_path_options(
             }
             write_bytes(writer, ptr)?;
         }
-        slice = &slice[result.read as usize..];
+        slice = &slice[result.read..];
     }
     Ok(())
 }

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -540,8 +540,8 @@ pub fn format_utf16_type(slice_: &[u16], writer: &mut impl fmt::Write) -> fmt::R
         if result.read == 0 || result.written == 0 {
             break;
         }
-        write_bytes(writer, &chunk[..result.written as usize])?;
-        slice = &slice[result.read as usize..];
+        write_bytes(writer, &chunk[..result.written])?;
+        slice = &slice[result.read..];
     }
     Ok(())
 }
@@ -562,7 +562,7 @@ pub(crate) fn format_utf16_type_with_path_options(
             break;
         }
 
-        let to_write = &chunk[..result.written as usize];
+        let to_write = &chunk[..result.written];
         if !opts.escape_backslashes && opts.path_sep == PathSep::Any {
             write_bytes(writer, to_write)?;
         } else {
@@ -1095,8 +1095,8 @@ pub fn format_latin1(slice_: &[u8], writer: &mut impl fmt::Write) -> fmt::Result
         if result.read == 0 || result.written == 0 {
             break;
         }
-        write_bytes(writer, &chunk[..result.written as usize])?;
-        slice = &slice[result.read as usize..];
+        write_bytes(writer, &chunk[..result.written])?;
+        slice = &slice[result.read..];
     }
 
     if !slice.is_empty() {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1682,13 +1682,10 @@ pub(crate) mod strings_impl {
     }
 
     /// Result of an encode-into-fixed-buffer operation. Port of `EncodeIntoResult`.
-    ///
-    /// `read`/`written` are `usize`: a UTF-16 source can encode to exactly
-    /// 2^32 UTF-8 bytes (JSC allows 2^32-byte ArrayBuffers), which a `u32`
-    /// count would silently wrap to 0.
-    ///
-    /// `repr(C)`: returned by value from `TextEncoder__encodeInto8/16`
-    /// (mirrored as `TextEncoderEncodeIntoResult` in `headers-handwritten.h`).
+    /// Counts are `usize` because `written` can be exactly 2^32 (JSC's max
+    /// ArrayBuffer size), which a `u32` would wrap to 0. `repr(C)` to return by
+    /// value from `TextEncoder__encodeInto8/16` (`TextEncoderEncodeIntoResult`
+    /// in `headers-handwritten.h`).
     #[repr(C)]
     #[derive(Clone, Copy, Default, Debug)]
     pub struct EncodeIntoResult {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1682,10 +1682,18 @@ pub(crate) mod strings_impl {
     }
 
     /// Result of an encode-into-fixed-buffer operation. Port of `EncodeIntoResult`.
+    ///
+    /// `read`/`written` are `usize`: a UTF-16 source can encode to exactly
+    /// 2^32 UTF-8 bytes (JSC allows 2^32-byte ArrayBuffers), which a `u32`
+    /// count would silently wrap to 0.
+    ///
+    /// `repr(C)`: returned by value from `TextEncoder__encodeInto8/16`
+    /// (mirrored as `TextEncoderEncodeIntoResult` in `headers-handwritten.h`).
+    #[repr(C)]
     #[derive(Clone, Copy, Default, Debug)]
     pub struct EncodeIntoResult {
-        pub read: u32,
-        pub written: u32,
+        pub read: usize,
+        pub written: usize,
     }
 
     /// Port of `elementLengthUTF16IntoUTF8`: the exact UTF-8 byte length of a
@@ -1741,8 +1749,8 @@ pub(crate) mod strings_impl {
             };
             if r.status == simdutf::Status::SUCCESS {
                 return EncodeIntoResult {
-                    read: utf16.len() as u32,
-                    written: r.count as u32,
+                    read: utf16.len(),
+                    written: r.count,
                 };
             }
         }
@@ -1760,10 +1768,7 @@ pub(crate) mod strings_impl {
             written += n;
             read += adv as usize;
         }
-        EncodeIntoResult {
-            read: read as u32,
-            written: written as u32,
-        }
+        EncodeIntoResult { read, written }
     }
 
     /// Port of `copyLatin1IntoUTF8` — encode Latin-1 into a fixed-size UTF-8 buffer.
@@ -1827,8 +1832,8 @@ pub(crate) mod strings_impl {
             debug_assert!(latin1_[read] >= 0x80);
             if STOP {
                 return EncodeIntoResult {
-                    written: u32::MAX,
-                    read: u32::MAX,
+                    written: usize::MAX,
+                    read: usize::MAX,
                 };
             }
             if buf_.len() - written < 2 {
@@ -1840,10 +1845,7 @@ pub(crate) mod strings_impl {
             read += 1;
         }
 
-        EncodeIntoResult {
-            written: written as u32,
-            read: read as u32,
-        }
+        EncodeIntoResult { written, read }
     }
 
     /// Null-terminated variant of `to_utf8_from_latin1`. Returns `ZBox` so

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -448,8 +448,8 @@ pub fn copy_cp1252_into_utf16(buf_: &mut [u16], latin1_: &[u8]) -> EncodeIntoRes
     }
 
     EncodeIntoResult {
-        read: (buf_total - buf.len()) as u32,
-        written: (latin1_total - latin1.len()) as u32,
+        read: buf_total - buf.len(),
+        written: latin1_total - latin1.len(),
     }
 }
 
@@ -459,7 +459,6 @@ pub fn copy_latin1_into_utf16(buf_: &mut [u16], latin1_: &[u8]) -> EncodeIntoRes
     for (out, &inp) in buf_[..len].iter_mut().zip(latin1_[..len].iter()) {
         *out = u16::from(inp);
     }
-    let len = len as u32;
     EncodeIntoResult {
         read: len,
         written: len,
@@ -1039,8 +1038,8 @@ fn copy_utf16_into_utf8_with_buffer_impl<const ALLOW_TRUNCATED_UTF8_SEQUENCE: bo
                 }
 
                 return EncodeIntoResult {
-                    read: utf16.len() as u32,
-                    written: result.count as u32,
+                    read: utf16.len(),
+                    written: result.count,
                 };
             }
         }
@@ -1140,8 +1139,8 @@ fn copy_utf16_into_utf8_with_buffer_impl<const ALLOW_TRUNCATED_UTF8_SEQUENCE: bo
     }
 
     EncodeIntoResult {
-        read: (utf16.len() - utf16_remaining.len()) as u32,
-        written: (buf_total - remaining.len()) as u32,
+        read: utf16.len() - utf16_remaining.len(),
+        written: buf_total - remaining.len(),
     }
 }
 

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -964,7 +964,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                 let content_byte_len: usize = strings::element_length_utf16_into_utf8(utf16);
                 let mut buf = vec![0u8; content_byte_len];
                 let encode_result = strings::copy_utf16_into_utf8(&mut buf, utf16);
-                buf.truncate(encode_result.written as usize);
+                buf.truncate(encode_result.written);
                 utf8_storage = buf;
                 &utf8_storage
             }
@@ -976,7 +976,7 @@ impl<const SSL: bool> WebSocket<SSL> {
                 } else {
                     let mut buf = vec![0u8; content_byte_len];
                     let encode_result = strings::copy_latin1_into_utf8(&mut buf, latin1);
-                    buf.truncate(encode_result.written as usize);
+                    buf.truncate(encode_result.written);
                     utf8_storage = buf;
                     &utf8_storage
                 }
@@ -1829,7 +1829,7 @@ fn encode_close_reason(reason: &ZigString, buf: &mut [u8; MAX_CONTROL_PAYLOAD]) 
     } else {
         // Latin-1 → UTF-8: raw Latin-1 bytes would fail `send_close_with_body`'s UTF-8 check.
         let result = strings::copy_latin1_into_utf8(cursor.get_mut(), reason.slice());
-        if (result.read as usize) < reason.slice().len() {
+        if result.read < reason.slice().len() {
             return None;
         }
         cursor.set_position(result.written as u64);
@@ -2341,20 +2341,20 @@ impl Copy<'_> {
         match self {
             Copy::Utf16(utf16) => {
                 let encoded = strings::copy_utf16_into_utf8_impl::<true>(parts.payload, utf16);
-                debug_assert_eq!(encoded.written as usize, content_byte_len);
-                debug_assert_eq!(encoded.read as usize, utf16.len());
+                debug_assert_eq!(encoded.written, content_byte_len);
+                debug_assert_eq!(encoded.read, utf16.len());
                 header
-                    .write_header(&mut parts.header, encoded.written as usize)
+                    .write_header(&mut parts.header, encoded.written)
                     .expect("unreachable");
                 Mask::fill_in_place(global_this, parts.mask, parts.payload);
             }
             Copy::Latin1(latin1) => {
                 let encoded = strings::copy_latin1_into_utf8(parts.payload, latin1);
-                debug_assert_eq!(encoded.written as usize, content_byte_len);
+                debug_assert_eq!(encoded.written, content_byte_len);
                 // latin1 can contain non-ascii
-                debug_assert_eq!(encoded.read as usize, latin1.len());
+                debug_assert_eq!(encoded.read, latin1.len());
                 header
-                    .write_header(&mut parts.header, encoded.written as usize)
+                    .write_header(&mut parts.header, encoded.written)
                     .expect("unreachable");
                 Mask::fill_in_place(global_this, parts.mask, parts.payload);
             }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -2200,7 +2200,7 @@ impl<'a> PackageInstall<'a> {
             }
 
             let res = strings::copy_utf16_into_utf8(&mut dest_buf[..], &wbuf[..i]);
-            let mut offset: usize = res.written as usize;
+            let mut offset: usize = res.written;
             if dest_buf[offset - 1] != bun_paths::SEP_WINDOWS {
                 dest_buf[offset] = bun_paths::SEP_WINDOWS;
                 offset += 1;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -396,9 +396,8 @@ extern "C" void ZigString__freeGlobal(const unsigned char* ptr, size_t len);
 extern "C" size_t Bun__encoding__writeLatin1(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 extern "C" size_t Bun__encoding__writeUTF16(const char16_t* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 
-// Mirrors `EncodeIntoResult` in bun_core (repr(C)). The counts are size_t
-// because `written` can be exactly 2^32 (a full 2^32-byte Uint8Array
-// destination), which would wrap a 32-bit count to 0.
+// Mirrors `EncodeIntoResult` in bun_core (repr(C)). size_t counts: `written`
+// can be exactly 2^32 (a full max-size Uint8Array), which would wrap a u32.
 typedef struct TextEncoderEncodeIntoResult {
     size_t read;
     size_t written;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -396,6 +396,16 @@ extern "C" void ZigString__freeGlobal(const unsigned char* ptr, size_t len);
 extern "C" size_t Bun__encoding__writeLatin1(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 extern "C" size_t Bun__encoding__writeUTF16(const char16_t* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 
+// Mirrors `EncodeIntoResult` in bun_core (repr(C)). The counts are size_t
+// because `written` can be exactly 2^32 (a full 2^32-byte Uint8Array
+// destination), which would wrap a 32-bit count to 0.
+typedef struct TextEncoderEncodeIntoResult {
+    size_t read;
+    size_t written;
+} TextEncoderEncodeIntoResult;
+extern "C" TextEncoderEncodeIntoResult TextEncoder__encodeInto8(const unsigned char* stringPtr, size_t stringLen, void* ptr, size_t len);
+extern "C" TextEncoderEncodeIntoResult TextEncoder__encodeInto16(const char16_t* stringPtr, size_t stringLen, void* ptr, size_t len);
+
 extern "C" size_t Bun__encoding__byteLengthLatin1AsUTF8(const unsigned char* ptr, size_t len);
 extern "C" size_t Bun__encoding__byteLengthUTF16AsUTF8(const char16_t* ptr, size_t len);
 

--- a/src/jsc/bindings/v8/V8String.cpp
+++ b/src/jsc/bindings/v8/V8String.cpp
@@ -2,6 +2,7 @@
 #include "V8HandleScope.h"
 #include "wtf/SIMDUTF.h"
 #include "v8_compatibility_assertions.h"
+#include "headers-handwritten.h"
 
 ASSERT_V8_TYPE_LAYOUT_MATCHES(v8::String)
 
@@ -149,9 +150,6 @@ bool String::IsExternalOneByte() const
     return !impl->isNull() && impl->impl()->isExternal() && impl->is8Bit();
 }
 
-extern "C" size_t TextEncoder__encodeInto8(const Latin1Character* stringPtr, size_t stringLen, void* ptr, size_t len);
-extern "C" size_t TextEncoder__encodeInto16(const char16_t* stringPtr, size_t stringLen, void* ptr, size_t len);
-
 int String::WriteUtf8(Isolate* isolate, char* buffer, int length, int* nchars_ref, int options) const
 {
     RELEASE_ASSERT(options == 0);
@@ -160,10 +158,11 @@ int String::WriteUtf8(Isolate* isolate, char* buffer, int length, int* nchars_re
 
     size_t unsigned_length = length < 0 ? static_cast<size_t>(std::numeric_limits<int>::max()) : static_cast<size_t>(length);
 
-    uint64_t result = string.is8Bit() ? TextEncoder__encodeInto8(string.span8().data(), string.span8().size(), buffer, unsigned_length)
-                                      : TextEncoder__encodeInto16(string.span16().data(), string.span16().size(), buffer, unsigned_length);
-    uint32_t read = static_cast<uint32_t>(result);
-    uint32_t written = static_cast<uint32_t>(result >> 32);
+    TextEncoderEncodeIntoResult result = string.is8Bit() ? TextEncoder__encodeInto8(string.span8().data(), string.span8().size(), buffer, unsigned_length)
+                                                         : TextEncoder__encodeInto16(string.span16().data(), string.span16().size(), buffer, unsigned_length);
+    // unsigned_length <= INT_MAX, so both counts fit in 32 bits here.
+    uint32_t read = static_cast<uint32_t>(result.read);
+    uint32_t written = static_cast<uint32_t>(result.written);
 
     if (written < length && read == string.length()) {
         buffer[written] = 0;
@@ -239,37 +238,15 @@ size_t String::WriteUtf8V2(Isolate* isolate, char* buffer, size_t capacity, int 
         // uses when kReplaceInvalidUtf8 is not set, so the result size matches either
         // way).
         if (str->is8Bit()) {
-            // Latin-1 expands at most 2x: 2 * (2^31 - 1) < 2^32, so the packed
-            // 32-bit counts cannot wrap.
             const auto span = str->span8();
-            uint64_t result = TextEncoder__encodeInto8(span.data(), span.size(), buffer, writableCapacity);
-            read = static_cast<uint32_t>(result);
-            written = static_cast<uint32_t>(result >> 32);
+            TextEncoderEncodeIntoResult result = TextEncoder__encodeInto8(span.data(), span.size(), buffer, writableCapacity);
+            read = result.read;
+            written = result.written;
         } else {
-            // UTF-16 expands up to 3x, which can exceed the 32-bit counts
-            // TextEncoder__encodeInto packs its result into (3 * (2^31 - 1) >
-            // 2^32). Encode in chunks small enough that each chunk's counts
-            // fit, accumulating in size_t.
             const auto span = str->span16();
-            const size_t total = span.size();
-            constexpr size_t maxChunk = static_cast<size_t>(1) << 30; // <= 3 GiB UTF-8 per chunk
-            while (read < total) {
-                size_t chunkLength = std::min(maxChunk, total - read);
-                // Never split a surrogate pair across chunks: the encoder
-                // would see two unpaired halves and write U+FFFD twice.
-                if (read + chunkLength < total && U16_IS_LEAD(span[read + chunkLength - 1])) {
-                    chunkLength--;
-                }
-                uint64_t result = TextEncoder__encodeInto16(span.data() + read, chunkLength, buffer + written, writableCapacity - written);
-                const uint32_t chunkRead = static_cast<uint32_t>(result);
-                const uint32_t chunkWritten = static_cast<uint32_t>(result >> 32);
-                read += chunkRead;
-                written += chunkWritten;
-                if (chunkRead < chunkLength) {
-                    // Ran out of output capacity.
-                    break;
-                }
-            }
+            TextEncoderEncodeIntoResult result = TextEncoder__encodeInto16(span.data(), span.size(), buffer, writableCapacity);
+            read = result.read;
+            written = result.written;
         }
     }
 

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -53,14 +53,13 @@
 #include "JSDOMOperation.h"
 #include "JSDOMWrapperCache.h"
 #include "BunClientData.h"
+#include "headers-handwritten.h"
 
 namespace WebCore {
 using namespace JSC;
 
 extern "C" JSC::EncodedJSValue TextEncoder__encode8(JSC::JSGlobalObject* global, const Latin1Character* stringPtr, size_t stringLen);
 extern "C" JSC::EncodedJSValue TextEncoder__encode16(JSC::JSGlobalObject* global, const char16_t* stringPtr, size_t stringLen);
-extern "C" size_t TextEncoder__encodeInto8(const Latin1Character* stringPtr, size_t stringLen, void* ptr, size_t len);
-extern "C" size_t TextEncoder__encodeInto16(const char16_t* stringPtr, size_t stringLen, void* ptr, size_t len);
 extern "C" JSC::EncodedJSValue TextEncoder__encodeRopeString(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSString* str);
 
 template<> TextEncoder::EncodeIntoResult convertDictionary<TextEncoder::EncodeIntoResult>(JSGlobalObject& lexicalGlobalObject, JSValue value)
@@ -345,7 +344,7 @@ static inline JSC::EncodedJSValue jsTextEncoderPrototypeFunction_encodeIntoBody(
         return {};
     }
 
-    size_t res = 0;
+    TextEncoderEncodeIntoResult res = {};
     if (!source->is8Bit()) {
         const auto span = source->span16();
         res = TextEncoder__encodeInto16(span.data(), span.size(), destination->vector(), destination->byteLength());
@@ -356,8 +355,8 @@ static inline JSC::EncodedJSValue jsTextEncoderPrototypeFunction_encodeIntoBody(
 
     Bun::GlobalScope* globalScope = reinterpret_cast<Bun::GlobalScope*>(lexicalGlobalObject);
     auto* result = JSC::constructEmptyObject(vm, globalScope->encodeIntoObjectStructure());
-    result->putDirectOffset(vm, 0, JSC::jsNumber(static_cast<uint32_t>(res)));
-    result->putDirectOffset(vm, 1, JSC::jsNumber(static_cast<uint32_t>(res >> 32)));
+    result->putDirectOffset(vm, 0, JSC::jsNumber(res.read));
+    result->putDirectOffset(vm, 1, JSC::jsNumber(res.written));
 
     return JSValue::encode(result);
 }

--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -69,7 +69,7 @@ pub fn from_w_path<'a>(buf: &'a mut [u8], utf16: &[u16]) -> &'a ZStr {
     let to_copy = strings::trim_prefix_comptime::<u16>(utf16, &windows::LONG_PATH_PREFIX);
     let last = buf.len() - 1;
     let encode_into_result = strings::copy_utf16_into_utf8(&mut buf[..last], to_copy);
-    let written = encode_into_result.written as usize;
+    let written = encode_into_result.written;
     debug_assert!(written < buf.len());
     buf[written] = 0;
     ZStr::from_buf(buf, written)

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -586,7 +586,7 @@ mod _impl {
         let mut buf1: Vec<u16> = vec![0u16; k.utf16_byte_length() + 1];
         let mut buf2: Vec<u16> = vec![0u16; v.utf16_byte_length() + 1];
         let len1: usize = if k.is_8bit() {
-            strings::copy_latin1_into_utf16(&mut buf1, k.latin1()).written as usize
+            strings::copy_latin1_into_utf16(&mut buf1, k.latin1()).written
         } else {
             buf1[0..k.length()].copy_from_slice(k.utf16());
             k.length()
@@ -600,7 +600,7 @@ mod _impl {
                     break 'str_ EMPTY_W.as_ptr();
                 }
                 let len2: usize = if v.is_8bit() {
-                    strings::copy_latin1_into_utf16(&mut buf2, v.latin1()).written as usize
+                    strings::copy_latin1_into_utf16(&mut buf2, v.latin1()).written
                 } else {
                     buf2[0..v.length()].copy_from_slice(v.utf16());
                     v.length()

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -309,7 +309,7 @@ impl TextDecoder {
                 Ok(unsafe {
                     jsc::zig_string::to_external_u16(
                         bun_core::heap::into_raw(bytes).cast::<u16>(),
-                        out.written as usize,
+                        out.written,
                         global_this,
                     )
                 })

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -44,8 +44,8 @@ unsafe extern "C" fn TextEncoder__encode8(
     };
     debug_assert!(array_buffer.len == utf8_len);
     let result = strings::copy_latin1_into_utf8(array_buffer.byte_slice_mut(), slice);
-    debug_assert!(result.written as usize == utf8_len);
-    debug_assert!(result.read as usize == slice.len());
+    debug_assert!(result.written == utf8_len);
+    debug_assert!(result.read == slice.len());
     uint8array
 }
 
@@ -69,8 +69,8 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
         if result.read == 0 || result.written == 0 {
             return replacement_char_uint8_array(global_this);
         }
-        let written = result.written as usize;
-        debug_assert!(result.read as usize == slice.len());
+        let written = result.written;
+        debug_assert!(result.read == slice.len());
         let Ok(uint8array) = create_uninitialized_uint8_array(global_this, written) else {
             return JSValue::ZERO;
         };
@@ -99,7 +99,7 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
     debug_assert!(array_buffer.len == need);
     let result =
         strings::copy_utf16_into_utf8_with_utf8_len(array_buffer.byte_slice_mut(), slice, need);
-    if result.written as usize == need && result.read as usize == slice.len() {
+    if result.written == need && result.read == slice.len() {
         return uint8array;
     }
 
@@ -177,11 +177,11 @@ impl<'a> RopeStringEncoder<'a> {
             &mut this.buf[this.tail..],
             src,
         );
-        if result.read == u32::MAX && result.written == u32::MAX {
+        if result.read == usize::MAX && result.written == usize::MAX {
             it.stop = 1;
             this.any_non_ascii = true;
         } else {
-            this.tail += result.written as usize;
+            this.tail += result.written;
         }
     }
 
@@ -199,7 +199,7 @@ impl<'a> RopeStringEncoder<'a> {
             &mut this.buf[offset as usize..],
             src,
         );
-        if result.read == u32::MAX && result.written == u32::MAX {
+        if result.read == usize::MAX && result.written == usize::MAX {
             it.stop = 1;
             this.any_non_ascii = true;
         }
@@ -267,17 +267,12 @@ unsafe extern "C" fn TextEncoder__encodeInto16(
     input_len: usize,
     buf_ptr: *mut u8,
     buf_len: usize,
-) -> u64 {
+) -> strings::EncodeIntoResult {
     // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid UTF-16 data
     let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
-    let result: strings::EncodeIntoResult = strings::copy_utf16_into_utf8(output, input);
-    // Pack `read` at byte offset 0 and `written` at offset 4 via native-endian bytes — no `unsafe`.
-    let mut b = [0u8; 8];
-    b[..4].copy_from_slice(&result.read.to_ne_bytes());
-    b[4..].copy_from_slice(&result.written.to_ne_bytes());
-    u64::from_ne_bytes(b)
+    strings::copy_utf16_into_utf8(output, input)
 }
 
 /// # Safety
@@ -289,15 +284,10 @@ unsafe extern "C" fn TextEncoder__encodeInto8(
     input_len: usize,
     buf_ptr: *mut u8,
     buf_len: usize,
-) -> u64 {
+) -> strings::EncodeIntoResult {
     // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
     let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
     // SAFETY: caller guarantees input_ptr[0..input_len] is valid Latin-1 data
     let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
-    let result: strings::EncodeIntoResult = strings::copy_latin1_into_utf8(output, input);
-    // Pack `read` at byte offset 0 and `written` at offset 4 via native-endian bytes — no `unsafe`.
-    let mut b = [0u8; 8];
-    b[..4].copy_from_slice(&result.read.to_ne_bytes());
-    b[4..].copy_from_slice(&result.written.to_ne_bytes());
-    u64::from_ne_bytes(b)
+    strings::copy_latin1_into_utf8(output, input)
 }

--- a/src/runtime/webcore/TextEncoderStreamEncoder.rs
+++ b/src/runtime/webcore/TextEncoderStreamEncoder.rs
@@ -69,10 +69,10 @@ impl TextEncoderStreamEncoder {
             let result = unsafe {
                 bun_core::vec::fill_spare(buffer, 0, |spare| {
                     let r = strings::copy_latin1_into_utf8(spare, remain);
-                    (r.written as usize, r)
+                    (r.written, r)
                 })
             };
-            remain = &remain[result.read as usize..];
+            remain = &remain[result.read..];
 
             if result.written == 0 && result.read == 0 {
                 buffer.reserve(2);

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -528,13 +528,13 @@ pub(crate) unsafe fn write_u8<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: boo
         }
         Encoding::Utf8 => {
             let r = strings::copy_latin1_into_utf8(to_slice, input_slice);
-            let mut written = r.written as usize;
+            let mut written = r.written;
             // `copy_latin1_into_utf8` stops at whole code points. Under
             // byte-level truncation, a Latin-1 char >= 0x80 whose 2-byte
             // sequence straddles the end still gets its lead byte.
-            if ALLOW_PARTIAL_WRITE && written < to_len && (r.read as usize) < len {
-                debug_assert!(input_slice[r.read as usize] >= 0x80);
-                to_slice[written] = 0xC0 | (input_slice[r.read as usize] >> 6);
+            if ALLOW_PARTIAL_WRITE && written < to_len && r.read < len {
+                debug_assert!(input_slice[r.read] >= 0x80);
+                to_slice[written] = 0xC0 | (input_slice[r.read] >> 6);
                 written += 1;
             }
             Ok(written)
@@ -550,7 +550,7 @@ pub(crate) unsafe fn write_u8<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: boo
                 0
             } else if (to_slice.as_ptr() as usize).is_multiple_of(core::mem::align_of::<u16>()) {
                 let output: &mut [u16] = bytemuck::cast_slice_mut(&mut to_slice[..out_units * 2]);
-                strings::copy_latin1_into_utf16(output, buf).written as usize * 2
+                strings::copy_latin1_into_utf16(output, buf).written * 2
             } else {
                 // Rust `&mut [u16]` requires natural alignment, so inline the
                 // (trivial) widen loop for the misaligned-dest case
@@ -643,7 +643,7 @@ pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bo
             };
             Ok(
                 strings::copy_utf16_into_utf8_impl::<ALLOW_PARTIAL_WRITE>(to_slice, input_slice)
-                    .written as usize,
+                    .written,
             )
         }
         Encoding::Latin1 | Encoding::Ascii | Encoding::Buffer => {

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -425,7 +425,7 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             let filename: &[u16] = event.filename.slice();
             let convert_res =
                 strings::copy_utf16_into_utf8(&mut this.platform.buf[base_idx..], filename);
-            let eventpath_len = base_idx + convert_res.written as usize;
+            let eventpath_len = base_idx + convert_res.written;
 
             bun_core::scoped_log!(
                 watcher,

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4695,3 +4695,49 @@ it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
     expect(exitCode).toBe(0);
   },
 );
+
+// The reported byte count itself can be exactly 2**32: a UTF-16 source whose
+// UTF-8 encoding fills a MAX_LENGTH buffer. Buffer.write/TextEncoder.encodeInto
+// used to round-trip that count through uint32, reporting 0 even though every
+// byte was written. Needs ~10 GiB RSS (4 GiB destination + UTF-16 source).
+it.skipIf(os.totalmem() < 16 * 1024 ** 3)(
+  "Buffer.write/TextEncoder.encodeInto report a byte count of exactly 2**32 without uint32 wrap",
+  async () => {
+    const script = `
+      const N = 2 ** 32;
+      // 1431655765 three-byte chars (U+0800 -> E0 A0 80) + one ASCII char
+      // encode to exactly N UTF-8 bytes.
+      const str = "\\u0800".repeat((N - 1) / 3) + "a";
+      const buf = Buffer.alloc(N);
+      const out = {};
+      out.byteLength = Buffer.byteLength(str, "utf8");
+      out.write_ret = buf.write(str, 0, N, "utf8");
+      // subarray instead of indexing: 2**32 - 1 is not a valid array index.
+      out.tail = Array.from(buf.subarray(N - 3));
+      const res = new TextEncoder().encodeInto(str, buf);
+      out.encode_read = res.read;
+      out.encode_written = res.written;
+      console.log(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr }).toEqual({
+      stdout: JSON.stringify({
+        byteLength: 4294967296,
+        write_ret: 4294967296,
+        tail: [0xa0, 0x80, 0x61],
+        encode_read: 1431655766,
+        encode_written: 4294967296,
+      }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+  // Two full 4.3 GB encode passes take ~1 min under a debug+ASAN build.
+  5 * 60 * 1000,
+);

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4696,12 +4696,9 @@ it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
   },
 );
 
-// The reported byte count itself can be exactly 2**32: a UTF-16 source whose
-// UTF-8 encoding fills a MAX_LENGTH buffer. Buffer.write/TextEncoder.encodeInto
-// used to round-trip that count through uint32, reporting 0 even though every
-// byte was written, and TextEncoder.encode aborted (the wrapped count failed
-// its completeness check and the fallback's ArrayBuffer length cast panics).
-// Needs ~10 GiB RSS per spawn (4 GiB destination + UTF-16 source).
+// A UTF-16 source can encode to exactly 2**32 UTF-8 bytes (a full MAX_LENGTH
+// buffer). Pre-fix, Buffer.write/encodeInto reported the u32-wrapped count (0)
+// and TextEncoder.encode aborted. Needs ~10 GiB RSS per spawn.
 it.skipIf(os.totalmem() < 16 * 1024 ** 3)(
   "Buffer.write/TextEncoder.encodeInto/TextEncoder.encode handle a byte count of exactly 2**32 without uint32 wrap",
   async () => {

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4699,9 +4699,11 @@ it.skipIf(os.totalmem() < 10 * 1024 ** 3)(
 // The reported byte count itself can be exactly 2**32: a UTF-16 source whose
 // UTF-8 encoding fills a MAX_LENGTH buffer. Buffer.write/TextEncoder.encodeInto
 // used to round-trip that count through uint32, reporting 0 even though every
-// byte was written. Needs ~10 GiB RSS (4 GiB destination + UTF-16 source).
+// byte was written, and TextEncoder.encode aborted (the wrapped count failed
+// its completeness check and the fallback's ArrayBuffer length cast panics).
+// Needs ~10 GiB RSS per spawn (4 GiB destination + UTF-16 source).
 it.skipIf(os.totalmem() < 16 * 1024 ** 3)(
-  "Buffer.write/TextEncoder.encodeInto report a byte count of exactly 2**32 without uint32 wrap",
+  "Buffer.write/TextEncoder.encodeInto/TextEncoder.encode handle a byte count of exactly 2**32 without uint32 wrap",
   async () => {
     const script = `
       const N = 2 ** 32;
@@ -4737,7 +4739,29 @@ it.skipIf(os.totalmem() < 16 * 1024 ** 3)(
       stderr: "",
     });
     expect(exitCode).toBe(0);
+
+    // TextEncoder.encode in a second spawn (sequential, so the ~10 GiB
+    // envelopes don't overlap): the count wrap made this abort, not miscount.
+    const encodeScript = `
+      const N = 2 ** 32;
+      const str = "\\u0800".repeat((N - 1) / 3) + "a";
+      const arr = new TextEncoder().encode(str);
+      console.log(JSON.stringify({ byteLength: arr.byteLength, tail: Array.from(arr.subarray(N - 3)) }));
+    `;
+    await using proc2 = Bun.spawn({
+      cmd: [bunExe(), "-e", encodeScript],
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout2, stderr2, exitCode2] = await Promise.all([proc2.stdout.text(), proc2.stderr.text(), proc2.exited]);
+    expect({ stdout: stdout2.trim(), stderr: stderr2 }).toEqual({
+      stdout: JSON.stringify({ byteLength: 4294967296, tail: [0xa0, 0x80, 0x61] }),
+      stderr: "",
+    });
+    expect(exitCode2).toBe(0);
   },
-  // Two full 4.3 GB encode passes take ~1 min under a debug+ASAN build.
-  5 * 60 * 1000,
+  // Each spawn does multiple full 4.3 GB encode passes; ~1 min per spawn
+  // under a debug+ASAN build.
+  10 * 60 * 1000,
 );


### PR DESCRIPTION
### Reproduction

Needs ~10 GiB RAM. A UTF-16 string whose UTF-8 encoding is exactly 2^32 bytes, written into a `MAX_LENGTH` (2^32) buffer:

```js
const str = "\u0800".repeat(1431655765) + "a"; // 3*1431655765 + 1 = 2**32 UTF-8 bytes
const buf = Buffer.alloc(4294967296);

buf.write(str, 0, buf.length, "utf8");        // bun: 0        expected: 4294967296
new TextEncoder().encodeInto(str, buf);       // bun: { read: 1431655766, written: 0 }
new TextEncoder().encode(str);                // bun: aborts (panic: int cast: TryFromIntError)
```

For `write`/`encodeInto`, every byte is actually written (the buffer contents are correct); only the reported count is wrong, so callers that trust it (advance offsets, slice results, loop on written) misbehave. `encode()` is worse: the wrapped count fails `encode16`'s completeness check, so the already-correct fast-path result is discarded and the 2^32-byte fallback hits the `u32::try_from(len).expect("int cast")` in `ArrayBuffer::from_bytes`, aborting the process.

### Cause

`EncodeIntoResult` in `bun_core` declared `read: u32, written: u32`, and every producer (`copy_utf16_into_utf8*`, `copy_latin1_into_utf8*`, `copy_latin1_into_utf16`, `copy_cp1252_into_utf16`) cast its `usize` count with `as u32`. The C ABI wrappers `Bun__encoding__writeUTF16`/`writeLatin1` take and return `size_t`, so the count silently truncated on the round-trip through the helper. Exactly 2^32 is reachable only for UTF-16 sources (Latin-1 caps at `2*(2^31-1) = 2^32-2`), and JSC permits ArrayBuffers of exactly 2^32 bytes.

`TextEncoder__encodeInto8/16` additionally packed `read`/`written` into two u32 halves of a u64 across the FFI, so `TextEncoder.encodeInto` (and the V8 `String::WriteUtf8V2` shim) could not receive 2^32 even with the helper fixed.

### Fix

- `EncodeIntoResult.read`/`written` are `usize` (now `repr(C)`), all producers return exact counts, all consumers updated (no behavior change below 2^32).
- `TextEncoder__encodeInto8/16` return the struct by value (declared as `TextEncoderEncodeIntoResult` in `headers-handwritten.h`) instead of the packed u64; `encodeInto`'s result object is built from the full counts (`jsNumber` yields 4294967296.0 as a double, which is exact).
- `V8String.cpp` `WriteUtf8V2` drops the chunked-encode workaround it carried specifically because the packed 32-bit counts could wrap; a single call now returns exact `size_t` counts.
- `TextEncoder.encode()` stops aborting at exactly 2^32 output bytes: with exact counts the completeness check passes and the fast path returns the already-filled array, so the panicking fallback is no longer reached for any input that fits in an ArrayBuffer.

This is the second layer of the bug family from #34274 (which carried `size_t` through `Buffer.toString`/`write` argument handling; the *returned* count still wrapped). The open #37239 works around this wrap in the stream consumer concatenation and can drop that once this lands.

Related but deliberately not included here: the pre-existing detached-destination case for `encodeInto` (null vector from a detached view) is fixed by the open #36531, which touches the same wrappers; and `ArrayBuffer::from_bytes`'s u32 length ceiling remains for its other callers (streams/Blob), tracked separately.

### Verification

New test in `test/js/node/buffer.test.js` next to the existing `MAX_LENGTH` test, gated on `os.totalmem() >= 16 GiB` (peak RSS ~10.5 GiB per spawn, two sequential spawns), covering `Buffer.write`, `TextEncoder.encodeInto`, `Buffer.byteLength`, buffer contents at the 2^32 boundary, and `TextEncoder.encode` (which aborted pre-fix).

- fails on unfixed bun: `write_ret: 0, encode_written: 0` (with correct buffer contents), and the `encode()` spawn aborts with the int-cast panic
- passes with this change: counts report `4294967296`, `encode()` returns a 4 GiB Uint8Array
- `bun run rust:check-all`: all 10 target/platform combos pass
- full `test/js/node/buffer.test.js` (618 tests), `test/js/web/encoding/` (197 tests), and `test/v8/v8.test.ts` (74 tests, exercising the `WriteUtf8V2` path) pass with the debug build

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 16 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (501e79610)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [90.37ms]
(pass) with native Buffer.write > #9120 alloc [69.34ms]
(pass) with native Buffer.write > isAscii [63.10ms]
(pass) with native Buffer.write > isUtf8 [65.67ms]
(pass) with native Buffer.write > Buffer global is settable [62.10ms]
(pass) with native Buffer.write > length overflow [63.22ms]
(pass) with native Buffer.write > truncate input values [189.39ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [68.47ms]
(pass) with native Buffer.write > Buffer.from() [68.39ms]
(pass) with native Buffer.write > offset properties [66.13ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [71.05ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [67.99ms]
(pass) with native Buffer.write > invalid encoding [77.48ms]
(pass) with native Buffer.write > create 0-length buffers [76.20ms]
(pass) with native Buffer.write > write() beyond end of buff
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f4df733b7)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [2.47ms]
(pass) with native Buffer.write > #9120 alloc [2.09ms]
(pass) with native Buffer.write > isAscii [2.07ms]
(pass) with native Buffer.write > isUtf8 [1.99ms]
(pass) with native Buffer.write > Buffer global is settable [2.00ms]
(pass) with native Buffer.write > length overflow [2.03ms]
(pass) with native Buffer.write > truncate input values [2.28ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [1.94ms]
(pass) with native Buffer.write > Buffer.from() [2.08ms]
(pass) with native Buffer.write > offset properties [1.87ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [2.23ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [2.15ms]
(pass) with native Buffer.write > invalid encoding [2.15ms]
(pass) with native Buffer.write > create 0-length buffers [2.10ms]
(pass) with native Buffer.write > write() beyond end of buffer [2.19ms]
(pass) with native Buffer.write > write BigInt beyond 64-bit range [2.34ms]
(pass) with native Buffer.write > write BigInt64 with insufficient buffer space
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (501e79610)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [95.84ms]
(pass) with native Buffer.write > #9120 alloc [73.40ms]
(pass) with native Buffer.write > isAscii [71.25ms]
(pass) with native Buffer.write > isUtf8 [76.18ms]
(pass) with native Buffer.write > Buffer global is settable [73.91ms]
(pass) with native Buffer.write > length overflow [76.24ms]
(pass) with native Buffer.write > truncate input values [229.90ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [70.29ms]
(pass) with native Buffer.write > Buffer.from() [65.38ms]
(pass) with native Buffer.write > offset properties [74.41ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [79.66ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [79.48ms]
(pass) with native Buffer.write > invalid encoding [79.98ms]
(pass) with native Buffer.write > create 0-length buffers [66.46ms]
(pass) with native Buffer.write > write() beyond end of buff
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 783ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[2/125] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/fmt.rs                             | 12 ++---
 src/bun_core/lib.rs                             | 27 +++++-----
 src/bun_core/string/immutable/unicode.rs        | 13 +++--
 src/http_jsc/websocket_client.rs                | 18 +++----
 src/install/PackageInstall.rs                   |  2 +-
 src/jsc/bindings/headers-handwritten.h          |  9 ++++
 src/jsc/bindings/v8/V8String.cpp                | 47 +++++------------
 src/jsc/bindings/webcore/JSTextEncoder.cpp      |  9 ++--
 src/paths/string_paths.rs                       |  2 +-
 src/runtime/node/node_process.rs                |  4 +-
 src/runtime/webcore/TextDecoder.rs              |  2 +-
 src/runtime/webcore/TextEncoder.rs              | 34 +++++--------
 src/runtime/webcore/TextEncoderStreamEncoder.rs |  4 +-
 src/runtime/webcore/encoding.rs                 | 12 ++---
 src/watcher/WindowsWatcher.rs                   |  2 +-
 test/js/node/buffer.test.js                     | 67 +++++++++++++++++++++++++
 16 files changed, 152 insertions(+), 112 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/bun_core/fmt.rs                                  1      2      0
src/bun_core/lib.rs                                  1      4      0
src/bun_core/string/immutable/unicode.rs             2      1      0
src/http_jsc/websocket_client.rs                     1      1      0
src/install/PackageInstall.rs                        1      2      0
src/jsc/bindings/headers-handwritten.h               1      3      0
src/jsc/bindings/v8/V8String.cpp                     1      3      0
src/jsc/bindings/webcore/JSTextEncoder.cpp           1      4      0
src/paths/string_paths.rs                            1      2      0
src/runtime/node/node_process.rs                     1      2      0
src/runtime/webcore/TextDecoder.rs                   1      2      0
src/runtime/webcore/TextEncoder.rs                   1      2      0
src/runtime/webcore/TextEncoderStreamEncoder.rs      1      2      0
src/runtime/webcore/encoding.rs                      1      1      0
src/watcher/WindowsWatcher.rs                        1      1      0
test/js/node/buffer.test.js                          1      3      0
```

</details>

<!-- robobun:evidence:end -->