### PR TITLE
webcore: remove dead TextEncoder export of global symbol c

### DIFF
--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -122,15 +122,6 @@ unsafe extern "C" fn TextEncoder__encode16(
     encode16_impl(global_this, slice)
 }
 
-/// # Safety
-/// `ptr` must be valid for reading `len` UTF-16 code units.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn c(global_this: &JSGlobalObject, ptr: *const u16, len: usize) -> JSValue {
-    // SAFETY: caller guarantees ptr[0..len] is valid UTF-16 data
-    let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
-    encode16_impl(global_this, slice)
-}
-
 // This is a fast path for copying a Rope string into a Uint8Array.
 // This keeps us from an extra string temporary allocation
 struct RopeStringEncoder<'a> {

--- a/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
+++ b/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
@@ -1,7 +1,7 @@
 // Guards against reintroduction of symbols removed as dead code from the
 // FFI declaration crates (mimalloc/cares/lsquic/zlib/libuv/brotli/boringssl/
-// libdeflate/windows_sys), bun_core, test_runner, webcore, and the built-in
-// JS/codegen sources. Each entry was verified to have zero references across src/,
+// libdeflate/windows_sys), bun_core, test_runner, and the built-in JS/codegen
+// sources. Each entry was verified to have zero references across src/,
 // scripts/, test/, and freshly regenerated build/debug/codegen/ output before
 // deletion, and the removal was validated by `cargo check` on all 10 CI
 // target triples plus a full `bun bd` build.
@@ -83,7 +83,7 @@ test("dead FFI declarations (sys crates) do not reappear", () => {
   expect(resurrected).toEqual([]);
 });
 
-test("dead Rust symbols (bun_core, jsc, test_runner, webcore) do not reappear", () => {
+test("dead Rust symbols (bun_core, jsc, test_runner) do not reappear", () => {
   const checks: Array<[string, RegExp]> = [
     // BuildTarget::Wasi was never constructed (BUILD_TARGET is Native or Wasm).
     ["src/bun_core/env.rs", /\bWasi\b/],
@@ -93,9 +93,6 @@ test("dead Rust symbols (bun_core, jsc, test_runner, webcore) do not reappear", 
     // throw2 + its carrier trait duplicated JSGlobalObject::throw_error.
     ["src/runtime/test_runner/mod.rs", /\btrait JSGlobalObjectTestExt\b/],
     ["src/runtime/test_runner/mod.rs", /\bfn throw2\b/],
-    // A no_mangle duplicate of TextEncoder__encode16 whose name was truncated
-    // to the bare global symbol `c`; nothing in C++ or Rust referenced it.
-    ["src/runtime/webcore/TextEncoder.rs", /\bfn c\(/],
   ];
   const resurrected = checks.filter(([file, re]) => re.test(src(file))).map(([file, re]) => `${file}: ${re.source}`);
   expect(resurrected).toEqual([]);

--- a/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
+++ b/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
@@ -1,7 +1,7 @@
 // Guards against reintroduction of symbols removed as dead code from the
 // FFI declaration crates (mimalloc/cares/lsquic/zlib/libuv/brotli/boringssl/
-// libdeflate/windows_sys), bun_core, test_runner, and the built-in JS/codegen
-// sources. Each entry was verified to have zero references across src/,
+// libdeflate/windows_sys), bun_core, test_runner, webcore, and the built-in
+// JS/codegen sources. Each entry was verified to have zero references across src/,
 // scripts/, test/, and freshly regenerated build/debug/codegen/ output before
 // deletion, and the removal was validated by `cargo check` on all 10 CI
 // target triples plus a full `bun bd` build.
@@ -83,7 +83,7 @@ test("dead FFI declarations (sys crates) do not reappear", () => {
   expect(resurrected).toEqual([]);
 });
 
-test("dead Rust symbols (bun_core, jsc, test_runner) do not reappear", () => {
+test("dead Rust symbols (bun_core, jsc, test_runner, webcore) do not reappear", () => {
   const checks: Array<[string, RegExp]> = [
     // BuildTarget::Wasi was never constructed (BUILD_TARGET is Native or Wasm).
     ["src/bun_core/env.rs", /\bWasi\b/],
@@ -93,6 +93,9 @@ test("dead Rust symbols (bun_core, jsc, test_runner) do not reappear", () => {
     // throw2 + its carrier trait duplicated JSGlobalObject::throw_error.
     ["src/runtime/test_runner/mod.rs", /\btrait JSGlobalObjectTestExt\b/],
     ["src/runtime/test_runner/mod.rs", /\bfn throw2\b/],
+    // A no_mangle duplicate of TextEncoder__encode16 whose name was truncated
+    // to the bare global symbol `c`; nothing in C++ or Rust referenced it.
+    ["src/runtime/webcore/TextEncoder.rs", /\bfn c\(/],
   ];
   const resurrected = checks.filter(([file, re]) => re.test(src(file))).map(([file, re]) => `${file}: ${re.source}`);
   expect(resurrected).toEqual([]);

--- a/test/internal/source-lints/no-mangle-short-names.test.ts
+++ b/test/internal/source-lints/no-mangle-short-names.test.ts
@@ -1,0 +1,72 @@
+// `#[no_mangle]` / `#[unsafe(no_mangle)]` exports a function under its bare
+// Rust name as a global C symbol in libbun_rust.a, where a one- or two-letter
+// name is a link-time collision hazard with any C/C++ object that defines the
+// same name, and no_mangle exempts the function from Rust's unused-code
+// analysis, so a dead one never gets flagged. This happened: TextEncoder.rs
+// carried a duplicate of TextEncoder__encode16 exported as the bare symbol `c`
+// through several dead-code sweeps before it was noticed.
+//
+// The shortest legitimate exports today are `main` and `zig_log`, so a
+// <= 3 character threshold needs no allowlist. Macro-metavariable functions
+// (`fn $name` inside macro_rules!) are skipped: their exported names are the
+// idents spelled at the macro call sites.
+//
+// This is a source-tree lint: it reads files from src/ and does not touch the
+// built binary, so it belongs in test/internal/source-lints/ per the README.
+//
+// Candidate files come from one `git grep` (tracked files, working-tree
+// contents), and each file is scanned with a single regex pass; per-line
+// JS loops over the whole tree are too slow under debug+ASAN builds.
+
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+// A no_mangle attribute at the start of a line, then the first `fn <ident>`
+// within the next 9 lines (more attributes, visibility, `unsafe extern "C"`
+// may sit in between). Group 1 is that in-between span, group 2 the name.
+const SITE = /^[ \t]*#\[(?:unsafe\()?no_mangle\)?\]((?:[^\n]*\n){0,9}?[^\n]*?)\bfn[ \t]+(\$?[A-Za-z_][A-Za-z0-9_]*)/gm;
+
+function countLines(s: string): number {
+  let n = 0;
+  for (let i = s.indexOf("\n"); i !== -1; i = s.indexOf("\n", i + 1)) n++;
+  return n;
+}
+
+test("no_mangle functions have names longer than 3 characters", () => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "grep", "-l", "no_mangle", "--", "src"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (r.exitCode !== 0) {
+    throw new Error(`git grep failed (exit ${r.exitCode}): ${r.stderr.toString()}`);
+  }
+  const files = r.stdout
+    .toString()
+    .split("\n")
+    .filter(f => f.endsWith(".rs"));
+  expect(files.length).toBeGreaterThan(0);
+
+  const violations: string[] = [];
+  for (const rel of files) {
+    const content = readFileSync(path.join(root, rel), "utf8");
+    for (const m of content.matchAll(SITE)) {
+      const name = m[2];
+      if (name.startsWith("$") || name.length > 3) continue;
+      // A `static`/`const` item between the attribute and a later, unrelated
+      // `fn` means the attribute belongs to the static (e.g. a no_mangle
+      // static followed by an ordinary function). `const` on the fn's own
+      // line is part of the signature (`pub const extern "C" fn`), so only
+      // the lines before the fn's line count.
+      const between = m[1];
+      const beforeFnLine = between.slice(0, between.lastIndexOf("\n") + 1);
+      if (/\b(?:static|const)\b/.test(beforeFnLine)) continue;
+      const line = 1 + countLines(content.slice(0, m.index)) + countLines(m[0]);
+      violations.push(`${rel}:${line}: #[no_mangle] fn ${name}`);
+    }
+  }
+  expect(violations).toEqual([]);
+});

--- a/test/internal/source-lints/no-mangle-short-names.test.ts
+++ b/test/internal/source-lints/no-mangle-short-names.test.ts
@@ -29,7 +29,8 @@ const root = path.resolve(import.meta.dir, "..", "..", "..");
 // within the next 9 lines (more attributes, doc comments, visibility,
 // `unsafe extern "C"` may sit in between). Group 1 is that in-between span,
 // group 2 the name.
-const SITE = /^[ \t]*#\[(?:unsafe\()?no_mangle\)?\]((?:[^\n]*\n){0,9}?[^\n]*?)\bfn[ \t]+(?:r#)?(\$?[A-Za-z_][A-Za-z0-9_]*)/gm;
+const SITE =
+  /^[ \t]*#\[(?:unsafe\()?no_mangle\)?\]((?:[^\n]*\n){0,9}?[^\n]*?)\bfn[ \t]+(?:r#)?(\$?[A-Za-z_][A-Za-z0-9_]*)/gm;
 
 function countLines(s: string): number {
   let n = 0;
@@ -101,9 +102,9 @@ test("the matcher handles the tricky attribute arrangements", () => {
 
   // A no_mangle static does not suppress a short no_mangle fn right after it,
   // and is not itself a violation (nor is the ordinary fn following it).
-  expect(
-    flag(`#[unsafe(no_mangle)]\nstatic X: u32 = 1;\n\n#[unsafe(no_mangle)]\nextern "C" fn ab() {}`),
-  ).toEqual(["f.rs:5: #[no_mangle] fn ab"]);
+  expect(flag(`#[unsafe(no_mangle)]\nstatic X: u32 = 1;\n\n#[unsafe(no_mangle)]\nextern "C" fn ab() {}`)).toEqual([
+    "f.rs:5: #[no_mangle] fn ab",
+  ]);
   expect(flag(`#[unsafe(no_mangle)]\nstatic X: u32 = 1;\n\nfn ab() {}`)).toEqual([]);
 
   // Raw identifiers export the symbol without `r#`; macro metavariables get

--- a/test/internal/source-lints/no-mangle-short-names.test.ts
+++ b/test/internal/source-lints/no-mangle-short-names.test.ts
@@ -9,7 +9,8 @@
 // The shortest legitimate exports today are `main` and `zig_log`, so a
 // <= 3 character threshold needs no allowlist. Macro-metavariable functions
 // (`fn $name` inside macro_rules!) are skipped: their exported names are the
-// idents spelled at the macro call sites.
+// idents spelled at the macro call sites. A raw identifier (`fn r#ab`) is
+// measured without the `r#`, which is what the exported symbol omits.
 //
 // This is a source-tree lint: it reads files from src/ and does not touch the
 // built binary, so it belongs in test/internal/source-lints/ per the README.
@@ -25,14 +26,45 @@ import path from "node:path";
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 
 // A no_mangle attribute at the start of a line, then the first `fn <ident>`
-// within the next 9 lines (more attributes, visibility, `unsafe extern "C"`
-// may sit in between). Group 1 is that in-between span, group 2 the name.
-const SITE = /^[ \t]*#\[(?:unsafe\()?no_mangle\)?\]((?:[^\n]*\n){0,9}?[^\n]*?)\bfn[ \t]+(\$?[A-Za-z_][A-Za-z0-9_]*)/gm;
+// within the next 9 lines (more attributes, doc comments, visibility,
+// `unsafe extern "C"` may sit in between). Group 1 is that in-between span,
+// group 2 the name.
+const SITE = /^[ \t]*#\[(?:unsafe\()?no_mangle\)?\]((?:[^\n]*\n){0,9}?[^\n]*?)\bfn[ \t]+(?:r#)?(\$?[A-Za-z_][A-Za-z0-9_]*)/gm;
 
 function countLines(s: string): number {
   let n = 0;
   for (let i = s.indexOf("\n"); i !== -1; i = s.indexOf("\n", i + 1)) n++;
   return n;
+}
+
+function scanFile(rel: string, source: string): string[] {
+  // Blank out full-line comments so prose like "this fn is exported" in a doc
+  // comment between the attribute and the signature cannot match as a
+  // function name (newlines are kept, so line numbers stay accurate).
+  const content = source.replace(/^[ \t]*\/\/.*$/gm, "");
+  const violations: string[] = [];
+  SITE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SITE.exec(content)) !== null) {
+    // A `static`/`const` item between the attribute and a later `fn` means
+    // the attribute belongs to the static, not the fn. Rescan from the line
+    // after the attribute instead of from the end of the match, so a
+    // no_mangle fn later in the window anchors on its own attribute. `const`
+    // on the fn's own line is part of the signature (`pub const extern "C"
+    // fn`), so only the lines before the fn's line count.
+    const between = m[1];
+    const beforeFnLine = between.slice(0, between.lastIndexOf("\n") + 1);
+    if (/\b(?:static|const)\b/.test(beforeFnLine)) {
+      const nl = m[0].indexOf("\n");
+      SITE.lastIndex = m.index + (nl === -1 ? m[0].length : nl + 1);
+      continue;
+    }
+    const name = m[2];
+    if (name.startsWith("$") || name.length > 3) continue;
+    const line = 1 + countLines(content.slice(0, m.index)) + countLines(m[0]);
+    violations.push(`${rel}:${line}: #[no_mangle] fn ${name}`);
+  }
+  return violations;
 }
 
 test("no_mangle functions have names longer than 3 characters", () => {
@@ -50,23 +82,33 @@ test("no_mangle functions have names longer than 3 characters", () => {
     .filter(f => f.endsWith(".rs"));
   expect(files.length).toBeGreaterThan(0);
 
-  const violations: string[] = [];
-  for (const rel of files) {
-    const content = readFileSync(path.join(root, rel), "utf8");
-    for (const m of content.matchAll(SITE)) {
-      const name = m[2];
-      if (name.startsWith("$") || name.length > 3) continue;
-      // A `static`/`const` item between the attribute and a later, unrelated
-      // `fn` means the attribute belongs to the static (e.g. a no_mangle
-      // static followed by an ordinary function). `const` on the fn's own
-      // line is part of the signature (`pub const extern "C" fn`), so only
-      // the lines before the fn's line count.
-      const between = m[1];
-      const beforeFnLine = between.slice(0, between.lastIndexOf("\n") + 1);
-      if (/\b(?:static|const)\b/.test(beforeFnLine)) continue;
-      const line = 1 + countLines(content.slice(0, m.index)) + countLines(m[0]);
-      violations.push(`${rel}:${line}: #[no_mangle] fn ${name}`);
-    }
-  }
+  const violations = files.flatMap(rel => scanFile(rel, readFileSync(path.join(root, rel), "utf8")));
   expect(violations).toEqual([]);
+});
+
+test("the matcher handles the tricky attribute arrangements", () => {
+  const flag = (src: string) => scanFile("f.rs", src);
+
+  // The motivating case, in both attribute spellings.
+  expect(flag(`#[no_mangle]\npub extern "C" fn c() {}`)).toEqual(["f.rs:2: #[no_mangle] fn c"]);
+  expect(flag(`#[unsafe(no_mangle)]\nunsafe extern "C" fn ab() {}`)).toEqual(["f.rs:2: #[no_mangle] fn ab"]);
+
+  // Prose in a doc comment between the attribute and the signature is not a
+  // function name.
+  expect(flag(`#[unsafe(no_mangle)]\n/// This fn is exported for C callers.\nextern "C" fn Mod__fine() {}`)).toEqual(
+    [],
+  );
+
+  // A no_mangle static does not suppress a short no_mangle fn right after it,
+  // and is not itself a violation (nor is the ordinary fn following it).
+  expect(
+    flag(`#[unsafe(no_mangle)]\nstatic X: u32 = 1;\n\n#[unsafe(no_mangle)]\nextern "C" fn ab() {}`),
+  ).toEqual(["f.rs:5: #[no_mangle] fn ab"]);
+  expect(flag(`#[unsafe(no_mangle)]\nstatic X: u32 = 1;\n\nfn ab() {}`)).toEqual([]);
+
+  // Raw identifiers export the symbol without `r#`; macro metavariables get
+  // their names from the call sites.
+  expect(flag(`#[no_mangle]\nextern "C" fn r#ab() {}`)).toEqual(["f.rs:2: #[no_mangle] fn ab"]);
+  expect(flag(`#[no_mangle]\nextern "C" fn r#match() {}`)).toEqual([]);
+  expect(flag(`#[no_mangle]\npub extern "C" fn $name() {}`)).toEqual([]);
 });


### PR DESCRIPTION
### What

`src/runtime/webcore/TextEncoder.rs` exported this function:

```rust
#[unsafe(no_mangle)]
unsafe extern "C" fn c(global_this: &JSGlobalObject, ptr: *const u16, len: usize) -> JSValue {
    // SAFETY: caller guarantees ptr[0..len] is valid UTF-16 data
    let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
    encode16_impl(global_this, slice)
}
```

It is a byte-for-byte duplicate of `TextEncoder__encode16` directly above it (both just call `encode16_impl`), exported under the bare one-letter symbol `c`.

### History

The duplicate first appeared in the Zig sources during #17093 (on main since March 2025), was moved by #18430, ported verbatim to Rust by #30412, and then survived several dead-code sweeps (#31254, #31385, #36184): `no_mangle` exempts a function from Rust's unused-code analysis, so nothing ever flagged it.

### Why remove it

Nothing references the symbol:

- the C++ bindings only declare and call `TextEncoder__encode16` (`src/jsc/bindings/webcore/JSTextEncoder.cpp`)
- no entry in `src/symbols.txt` or `src/symbols.dyn`
- no use in regenerated `build/debug/codegen` output
- the function is private, so no Rust code outside the file can call it, and nothing in the file does

Dead weight aside, `no_mangle` makes `c` a global symbol in `libbun_rust.a`, and a one-letter global C symbol is a link-time collision hazard with any C/C++ object that happens to define `c`.

### Test

Rather than pinning this one symbol, `test/internal/source-lints/no-mangle-short-names.test.ts` scans tracked `.rs` files under `src/` and fails on any `no_mangle` function whose exported name is 3 characters or fewer, so the next truncated export anywhere in the tree is caught too. The shortest legitimate exports are `main` and `zig_log`, so the threshold ships with no allowlist (383 no_mangle functions scanned today, zero violations). The lint fails on the pre-fix tree (`src/runtime/webcore/TextEncoder.rs:128: #[no_mangle] fn c`) and passes with the removal.

### Verification

- `bun bd` builds and links; `nm` shows no symbol `c` in the binary and `TextEncoder__encode16` still present
- `bun bd test test/js/web/encoding/text-encoder.test.js`: 42 pass, 0 fail
- `bun test test/internal/source-lints/`: 76 pass, 0 fail (includes the new lint; also passes under `bun bd test`)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/no-mangle-short-names.test.ts
bun test v1.4.0 (983850660)

test/internal/source-lints/no-mangle-short-names.test.ts:
82 |     .split("\n")
83 |     .filter(f => f.endsWith(".rs"));
84 |   expect(files.length).toBeGreaterThan(0);
85 | 
86 |   const violations = files.flatMap(rel => scanFile(rel, readFileSync(path.join(root, rel), "utf8")));
87 |   expect(violations).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/webcore/TextEncoder.rs:128: #[no_mangle] fn c",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/no-mangle-short-names.test.ts:87:22)
(fail) no_mangle functions have names longer than 3 characters [840.52ms]
(pass) the matcher handles the tricky attribute arrangements [9.10ms]

 1 pass
 1 fail
 10 expect() calls
Ran 2 tests across 1 file. [3.26s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (089d10675)

test/internal/source-lints/no-mangle-short-names.test.ts:
82 |     .split("\n")
83 |     .filter(f => f.endsWith(".rs"));
84 |   expect(files.length).toBeGreaterThan(0);
85 | 
86 |   const violations = files.flatMap(rel => scanFile(rel, readFileSync(path.join(root, rel), "utf8")));
87 |   expect(violations).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/webcore/TextEncoder.rs:128: #[no_mangle] fn c",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/no-mangle-short-names.test.ts:87:22)
(fail) no_mangle functions have names longer than 3 characters [83.31ms]
(pass) the matcher handles the tricky attribute arrangements [0.18ms]

 1 pass
 1 fail
 10 expect() calls
Ran 2 tests across 1 file. [238.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/no-mangle-short-names.test.ts
bun test v1.4.0 (983850660)

test/internal/source-lints/no-mangle-short-names.test.ts:
(pass) no_mangle functions have names longer than 3 characters [819.77ms]
(pass) the matcher handles the tricky attribute arrangements [12.09ms]

 2 pass
 0 fail
 10 expect() calls
Ran 2 tests across 1 file. [3.20s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 691ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_paths v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/TextEncoder.rs                 |   9 --
 .../source-lints/no-mangle-short-names.test.ts     | 115 +++++++++++++++++++++
 2 files changed, 115 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/webcore/TextEncoder.rs                            1      1      0
test/internal/source-lints/no-mangle-short-names.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->