### PR TITLE
ci: collect darwin tart subnet diagnostics (do not merge)

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -20,12 +20,12 @@
 set -uo pipefail
 
 status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
-[ "$status" = "0" ] && exit 0
 [ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
 
 # Temporary diagnostic for the tart fleet's intermittent ssh misrouting into
-# freshly booted guests (auth denials and mid-job stalls): on any failure,
-# record the host-side network state the failing connection actually used.
+# freshly booted guests (auth denials and mid-job stalls). On every tart job,
+# record which VMs exist on the host with their MACs and DHCP leases; on
+# failures, additionally record the network state the failing connection used.
 # Read-only; bounded; runs before the cancel-skip so timed-out jobs report too.
 case "${BUILDKITE_AGENT_NAME:-}" in
   darwin-*-tart-*)
@@ -34,40 +34,44 @@ case "${BUILDKITE_AGENT_NAME:-}" in
       set +e
       tart_bin=$(command -v tart || echo /opt/homebrew/bin/tart)
       echo "[tart-host] agent=${BUILDKITE_AGENT_NAME} job=${BUILDKITE_JOB_ID} time=$(date -u +%FT%TZ)"
-      echo "[tart-host] interfaces (bridge/vmenet/inet):"
-      ifconfig -a 2>/dev/null | grep -E "^[a-z]|inet " | grep -B1 -E "inet |bridge|vmenet" | head -60
-      echo "[tart-host] inet routes touching 192.168.64:"
-      netstat -rn -f inet 2>/dev/null | grep -E "Destination|192\.168\.64" | head -50
-      echo "[tart-host] arp:"
-      arp -an 2>/dev/null | grep "192\.168\.64" | head -50
       echo "[tart-host] tart list:"
       "$tart_bin" list 2>&1 | head -20
       echo "[tart-host] tart run processes:"
       ps ax -o pid,lstart,command 2>/dev/null | grep "tart run" | grep -v grep | head -10
-      gip=$("$tart_bin" ip "bk-${BUILDKITE_JOB_ID}" 2>/dev/null)
-      sip=$("$tart_bin" ip "sc-${BUILDKITE_JOB_ID}" 2>/dev/null)
-      echo "[tart-host] tart ip: guest=${gip:-gone} sidecar=${sip:-gone}"
       echo "[tart-host] vm mac map:"
       for cfg in "$HOME"/.tart/vms/*/config.json; do
         [ -f "$cfg" ] || continue
         vm=${cfg%/config.json}; vm=${vm##*/}
         echo "  ${vm}: $(tr -d ' \n' < "$cfg" | grep -o '"macAddress":"[^"]*"' | head -1)"
       done
-      # One parallel keyscan of every address the host currently resolves on
-      # the vmnet bridge, plus this job's VM addresses: whoever answers ssh on
-      # a contested IP identifies itself by host key.
-      scan_ips=$( { arp -an 2>/dev/null | grep -o '192\.168\.64\.[0-9]*'; echo "${gip:-}"; echo "${sip:-}"; } | grep -v '\.255$' | sort -u | tr '\n' ' ')
-      echo "[tart-host] keyscan of ${scan_ips}:"
-      # shellcheck disable=SC2086
-      ssh-keyscan -T 3 -t ed25519 ${scan_ips} 2>/dev/null | sort
       echo "[tart-host] dhcpd_leases (head, newest first):"
       head -c 12000 /var/db/dhcpd_leases 2>/dev/null
-      for vmlog in "/tmp/bk-${BUILDKITE_JOB_ID}.log" "/tmp/sc-${BUILDKITE_JOB_ID}.log"; do
-        [ -s "$vmlog" ] && { echo "[tart-host] ${vmlog##*/}:"; grep -v '^Stopping VM\.\.\.' "$vmlog" | tail -12; }
-      done
+      if [ "$status" != "0" ]; then
+        echo "[tart-host] interfaces (bridge/vmenet/inet):"
+        ifconfig -a 2>/dev/null | grep -E "^[a-z]|inet " | grep -B1 -E "inet |bridge|vmenet" | head -60
+        echo "[tart-host] inet routes touching 192.168.64:"
+        netstat -rn -f inet 2>/dev/null | grep -E "Destination|192\.168\.64" | head -50
+        echo "[tart-host] arp:"
+        arp -an 2>/dev/null | grep "192\.168\.64" | head -50
+        gip=$("$tart_bin" ip "bk-${BUILDKITE_JOB_ID}" 2>/dev/null)
+        sip=$("$tart_bin" ip "sc-${BUILDKITE_JOB_ID}" 2>/dev/null)
+        echo "[tart-host] tart ip: guest=${gip:-gone} sidecar=${sip:-gone}"
+        # One parallel keyscan of every address the host currently resolves on
+        # the vmnet bridge, plus this job's VM addresses: whoever answers ssh
+        # on a contested IP identifies itself by host key.
+        scan_ips=$( { arp -an 2>/dev/null | grep -o '192\.168\.64\.[0-9]*'; echo "${gip:-}"; echo "${sip:-}"; } | grep -v '\.255$' | sort -u | tr '\n' ' ')
+        echo "[tart-host] keyscan of ${scan_ips}:"
+        # shellcheck disable=SC2086
+        ssh-keyscan -T 3 -t ed25519 ${scan_ips} 2>/dev/null | sort
+        for vmlog in "/tmp/bk-${BUILDKITE_JOB_ID}.log" "/tmp/sc-${BUILDKITE_JOB_ID}.log"; do
+          [ -s "$vmlog" ] && { echo "[tart-host] ${vmlog##*/}:"; grep -v '^Stopping VM\.\.\.' "$vmlog" | tail -12; }
+        done
+      fi
     ) 2>&1 | head -c 60000 || true
     ;;
 esac
+
+[ "$status" = "0" ] && exit 0
 
 # Skip canceled/timed-out jobs: on cancel the agent SIGTERMs then SIGKILLs the
 # command, so the reporter had no chance to set the marker, and a canceled

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -23,6 +23,43 @@ status="${BUILDKITE_COMMAND_EXIT_STATUS:-0}"
 [ "$status" = "0" ] && exit 0
 [ -n "${BUILDKITE_JOB_ID:-}" ] || exit 0
 
+# Temporary diagnostic for the tart fleet's intermittent ssh misrouting into
+# freshly booted guests (auth denials and mid-job stalls): on any failure,
+# record the host-side network state the failing connection actually used.
+# Read-only; bounded; runs before the cancel-skip so timed-out jobs report too.
+case "${BUILDKITE_AGENT_NAME:-}" in
+  darwin-*-tart-*)
+    echo "~~~ tart host network state (diagnostic, exit ${status})"
+    (
+      set +e
+      tart_bin=$(command -v tart || echo /opt/homebrew/bin/tart)
+      echo "[tart-host] agent=${BUILDKITE_AGENT_NAME} job=${BUILDKITE_JOB_ID} time=$(date -u +%FT%TZ)"
+      echo "[tart-host] interfaces (bridge/vmenet/inet):"
+      ifconfig -a 2>/dev/null | grep -E "^[a-z]|inet " | grep -B1 -E "inet |bridge|vmenet" | head -60
+      echo "[tart-host] inet routes touching 192.168.64:"
+      netstat -rn -f inet 2>/dev/null | grep -E "Destination|192\.168\.64" | head -50
+      echo "[tart-host] arp:"
+      arp -an 2>/dev/null | grep "192\.168\.64" | head -50
+      echo "[tart-host] tart list:"
+      "$tart_bin" list 2>&1 | head -20
+      echo "[tart-host] tart run processes:"
+      ps ax -o pid,lstart,command 2>/dev/null | grep "tart run" | grep -v grep | head -10
+      gip=$("$tart_bin" ip "bk-${BUILDKITE_JOB_ID}" 2>/dev/null)
+      sip=$("$tart_bin" ip "sc-${BUILDKITE_JOB_ID}" 2>/dev/null)
+      echo "[tart-host] tart ip: guest=${gip:-gone} sidecar=${sip:-gone}"
+      for ip in ${gip:-} ${sip:-} 192.168.64.1; do
+        echo "[tart-host] keyscan ${ip}:"
+        ssh-keyscan -T 2 -t ed25519 "$ip" 2>&1 | head -2
+      done
+      echo "[tart-host] dhcpd_leases (tail):"
+      tail -60 /var/db/dhcpd_leases 2>/dev/null
+      for vmlog in "/tmp/bk-${BUILDKITE_JOB_ID}.log" "/tmp/sc-${BUILDKITE_JOB_ID}.log"; do
+        [ -s "$vmlog" ] && { echo "[tart-host] ${vmlog##*/}:"; grep -v '^Stopping VM\.\.\.' "$vmlog" | tail -12; }
+      done
+    ) 2>&1 | head -c 60000 || true
+    ;;
+esac
+
 # Skip canceled/timed-out jobs: on cancel the agent SIGTERMs then SIGKILLs the
 # command, so the reporter had no chance to set the marker, and a canceled
 # build annotating every running job is noise, not signal. The agent's

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -47,12 +47,21 @@ case "${BUILDKITE_AGENT_NAME:-}" in
       gip=$("$tart_bin" ip "bk-${BUILDKITE_JOB_ID}" 2>/dev/null)
       sip=$("$tart_bin" ip "sc-${BUILDKITE_JOB_ID}" 2>/dev/null)
       echo "[tart-host] tart ip: guest=${gip:-gone} sidecar=${sip:-gone}"
-      for ip in ${gip:-} ${sip:-} 192.168.64.1; do
-        echo "[tart-host] keyscan ${ip}:"
-        ssh-keyscan -T 2 -t ed25519 "$ip" 2>&1 | head -2
+      echo "[tart-host] vm mac map:"
+      for cfg in "$HOME"/.tart/vms/*/config.json; do
+        [ -f "$cfg" ] || continue
+        vm=${cfg%/config.json}; vm=${vm##*/}
+        echo "  ${vm}: $(tr -d ' \n' < "$cfg" | grep -o '"macAddress":"[^"]*"' | head -1)"
       done
-      echo "[tart-host] dhcpd_leases (tail):"
-      tail -60 /var/db/dhcpd_leases 2>/dev/null
+      # One parallel keyscan of every address the host currently resolves on
+      # the vmnet bridge, plus this job's VM addresses: whoever answers ssh on
+      # a contested IP identifies itself by host key.
+      scan_ips=$( { arp -an 2>/dev/null | grep -o '192\.168\.64\.[0-9]*'; echo "${gip:-}"; echo "${sip:-}"; } | grep -v '\.255$' | sort -u | tr '\n' ' ')
+      echo "[tart-host] keyscan of ${scan_ips}:"
+      # shellcheck disable=SC2086
+      ssh-keyscan -T 3 -t ed25519 ${scan_ips} 2>/dev/null | sort
+      echo "[tart-host] dhcpd_leases (head, newest first):"
+      head -c 12000 /var/db/dhcpd_leases 2>/dev/null
       for vmlog in "/tmp/bk-${BUILDKITE_JOB_ID}.log" "/tmp/sc-${BUILDKITE_JOB_ID}.log"; do
         [ -s "$vmlog" ] && { echo "[tart-host] ${vmlog##*/}:"; grep -v '^Stopping VM\.\.\.' "$vmlog" | tail -12; }
       done

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -3358,6 +3358,88 @@ function escapeXml(str) {
     .replace(/'/g, "&apos;");
 }
 
+/**
+ * Temporary diagnostic for the darwin tart fleet's intermittent ssh
+ * "Permission denied" and mid-job stall failures (another VM answering the
+ * guest's IP). Prints the guest's view of the vmnet subnet: interface, DHCP
+ * lease, ARP table, and which neighbors answer ssh with a Linux banner.
+ * Only runs inside tart guests; bounded to 45s; never throws.
+ */
+async function printTartSubnetDiagnostics() {
+  if (process.platform !== "darwin" || !/^tcp:\/\/192\.168\.64\.1:\d+$/.test(process.env["DOCKER_HOST"] ?? "")) {
+    return;
+  }
+  const work = async () => {
+    const { default: net } = await import("node:net");
+    const sh = (...cmd) => {
+      try {
+        const { stdout, stderr } = spawnSync(cmd[0], cmd.slice(1), { encoding: "utf-8", timeout: 5_000 });
+        return ((stdout || "") + (stderr || "")).trim();
+      } catch (error) {
+        return `spawn error: ${error}`;
+      }
+    };
+    console.log("[tart-net] en0:", sh("ifconfig", "en0").replace(/\n\s*/g, " | "));
+    console.log("[tart-net] dhcp:", sh("ipconfig", "getpacket", "en0").replace(/\n\s*/g, " | "));
+    console.log("[tart-net] arp before sweep:", sh("arp", "-an").replace(/\n/g, " ; "));
+    const ips = [];
+    for (let i = 2; i <= 32; i++) ips.push(`192.168.64.${i}`);
+    const limit = pLimit(12);
+    const alive = [];
+    await Promise.all(
+      ips.map(ip =>
+        limit(async () => {
+          const ok = await new Promise(resolve => {
+            const child = spawn("ping", ["-c", "1", "-W", "600", "-t", "1", ip], { stdio: "ignore" });
+            child.on("close", code => resolve(code === 0));
+            child.on("error", () => resolve(false));
+          });
+          if (ok) alive.push(ip);
+        }),
+      ),
+    );
+    alive.sort((a, b) => Number(a.split(".")[3]) - Number(b.split(".")[3]));
+    console.log("[tart-net] alive:", alive.join(" "));
+    console.log("[tart-net] arp after sweep:", sh("arp", "-an").replace(/\n/g, " ; "));
+    await Promise.all(
+      alive.map(ip =>
+        limit(async () => {
+          const banner = await new Promise(resolve => {
+            const socket = net.connect({ host: ip, port: 22 });
+            const timer = setTimeout(() => {
+              socket.destroy();
+              resolve("(timeout)");
+            }, 2_000);
+            socket.once("data", data => {
+              clearTimeout(timer);
+              socket.destroy();
+              resolve(String(data).split("\n")[0].trim());
+            });
+            socket.once("error", error => {
+              clearTimeout(timer);
+              socket.destroy();
+              resolve(`(${error?.code ?? error})`);
+            });
+            socket.once("close", () => {
+              clearTimeout(timer);
+              resolve("(closed)");
+            });
+          });
+          console.log(`[tart-net] ssh ${ip}: ${banner}`);
+        }),
+      ),
+    );
+  };
+  try {
+    const result = await Promise.race([work(), setTimeoutPromise(45_000, "timeout")]);
+    if (result === "timeout") {
+      console.log("[tart-net] diagnostics timed out");
+    }
+  } catch (error) {
+    console.log(`[tart-net] diagnostics failed: ${error}`);
+  }
+}
+
 export async function main() {
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     process.on(signal, () => onExit(signal));
@@ -3366,6 +3448,8 @@ export async function main() {
   if (!isQuiet) {
     printEnvironment();
   }
+
+  await printTartSubnetDiagnostics();
 
   // FIXME: Some DNS tests hang unless we set the DNS server to 8.8.8.8
   // It also appears to hang on 1.1.1.1, which could explain this issue:

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -3366,7 +3366,11 @@ function escapeXml(str) {
  * Only runs inside tart guests; bounded to 45s; never throws.
  */
 async function printTartSubnetDiagnostics() {
-  if (process.platform !== "darwin" || !/^tcp:\/\/192\.168\.64\.1:\d+$/.test(process.env["DOCKER_HOST"] ?? "")) {
+  const isTartGuest =
+    process.platform === "darwin" &&
+    (/-tart-/.test(process.env["BUILDKITE_AGENT_NAME"] ?? "") ||
+      /^tcp:\/\/192\.168\.64\.1:\d+$/.test(process.env["DOCKER_HOST"] ?? ""));
+  if (!isTartGuest) {
     return;
   }
   const work = async () => {
@@ -3401,8 +3405,13 @@ async function printTartSubnetDiagnostics() {
     alive.sort((a, b) => Number(a.split(".")[3]) - Number(b.split(".")[3]));
     console.log("[tart-net] alive:", alive.join(" "));
     console.log("[tart-net] arp after sweep:", sh("arp", "-an").replace(/\n/g, " ; "));
+    // Deliberately probe ssh on addresses nothing should hold (plus the
+    // gateway). If a banner comes back from an unowned address, packets are
+    // being delivered by segment/route rather than destination IP, and the
+    // banner identifies which VM currently captures them.
+    const bannerTargets = [...new Set([...alive, "192.168.64.1", "192.168.64.199", "192.168.64.250"])];
     await Promise.all(
-      alive.map(ip =>
+      bannerTargets.map(ip =>
         limit(async () => {
           const banner = await new Promise(resolve => {
             const socket = net.connect({ host: ip, port: 22 });

--- a/test/internal/darwin-tart-net-probe.test.ts
+++ b/test/internal/darwin-tart-net-probe.test.ts
@@ -113,12 +113,7 @@ test.skipIf(!isTartGuest)(
       const version = await docker("/version");
       log("docker version:", JSON.stringify(version));
       const info = await docker("/info");
-      log(
-        "docker info: name=%s kernel=%s os=%s",
-        info?.Name,
-        info?.KernelVersion,
-        info?.OperatingSystem,
-      );
+      log("docker info: name=%s kernel=%s os=%s", info?.Name, info?.KernelVersion, info?.OperatingSystem);
       const images = (await docker("/images/json")) as any[];
       const tags = images.flatMap(i => i.RepoTags ?? []).filter(t => t && !t.startsWith("<none>"));
       log("sidecar images:", JSON.stringify(tags));
@@ -132,7 +127,7 @@ test.skipIf(!isTartGuest)(
       const script = [
         "echo HOSTNAME $(cat /proc/sys/kernel/hostname)",
         "echo UPTIME $(cat /proc/uptime)",
-        'for d in /sys/class/net/*; do echo IFACE $(basename $d) mac=$(cat $d/address 2>/dev/null) state=$(cat $d/operstate 2>/dev/null); done',
+        "for d in /sys/class/net/*; do echo IFACE $(basename $d) mac=$(cat $d/address 2>/dev/null) state=$(cat $d/operstate 2>/dev/null); done",
         'echo PROXY_ARP; for f in /proc/sys/net/ipv4/conf/*/proxy_arp; do echo "  $f=$(cat $f)"; done',
         "echo IP_FORWARD $(cat /proc/sys/net/ipv4/ip_forward)",
         "echo ADDRS; ip -4 addr show 2>/dev/null || cat /proc/net/fib_trie | head -80",

--- a/test/internal/darwin-tart-net-probe.test.ts
+++ b/test/internal/darwin-tart-net-probe.test.ts
@@ -1,0 +1,177 @@
+// Temporary diagnostic for the darwin tart fleet's intermittent
+// "Permission denied" ssh failures (something else answering the guest's IP).
+// Runs only inside a tart guest (detected via DOCKER_HOST pointing at the
+// vmnet gateway). Collects: guest ARP/interface state, an ssh banner census
+// of the subnet (macOS vs Linux sshd), DHCP lease info, and the sidecar VM's
+// network state via its Docker API. Always passes; output is the deliverable.
+// Do not merge.
+import { expect, test } from "bun:test";
+
+const DOCKER_HOST = process.env.DOCKER_HOST || "";
+const gw = DOCKER_HOST.match(/^tcp:\/\/(192\.168\.64\.1):(\d+)$/);
+const isTartGuest = process.platform === "darwin" && process.arch === "arm64" && gw !== null;
+
+const log = (...args: unknown[]) => console.log("[tart-probe]", ...args);
+
+async function run(cmd: string[], timeoutMs = 10_000): Promise<string> {
+  try {
+    const proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "pipe" });
+    const timer = setTimeout(() => proc.kill(), timeoutMs);
+    const [out, err] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+    clearTimeout(timer);
+    return out + (err ? `\n[stderr] ${err}` : "");
+  } catch (e) {
+    return `[spawn error] ${e}`;
+  }
+}
+
+async function ping(ip: string): Promise<boolean> {
+  const out = await run(["ping", "-c", "1", "-W", "700", "-t", "1", ip], 2_000);
+  return out.includes("1 packets received");
+}
+
+async function sshBanner(ip: string): Promise<string | null> {
+  return await new Promise(resolve => {
+    let settled = false;
+    const done = (v: string | null) => {
+      if (!settled) {
+        settled = true;
+        resolve(v);
+      }
+    };
+    const timer = setTimeout(() => done(null), 2_500);
+    Bun.connect({
+      hostname: ip,
+      port: 22,
+      socket: {
+        data(socket, data) {
+          clearTimeout(timer);
+          socket.end();
+          done(Buffer.from(data).toString("utf8").split("\n")[0].trim());
+        },
+        error() {
+          clearTimeout(timer);
+          done(null);
+        },
+        connectError() {
+          clearTimeout(timer);
+          done(null);
+        },
+        close() {
+          clearTimeout(timer);
+          done(null);
+        },
+      },
+    }).catch(() => {
+      clearTimeout(timer);
+      done(null);
+    });
+  });
+}
+
+async function docker(path: string, init?: RequestInit): Promise<any> {
+  const res = await fetch(`http://${gw![1]}:${gw![2]}${path}`, init);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+test.skipIf(!isTartGuest)(
+  "darwin tart subnet diagnostics",
+  async () => {
+    log("=== guest identity ===");
+    log("hostname:", (await run(["hostname"])).trim());
+    log("ifconfig en0:\n" + (await run(["ifconfig", "en0"])));
+    log("dhcp packet:\n" + (await run(["ipconfig", "getpacket", "en0"])));
+    log("routes:\n" + (await run(["netstat", "-rn", "-f", "inet"])));
+
+    log("=== subnet sweep (ping to populate arp, then banner census) ===");
+    const ips: string[] = [];
+    for (let i = 1; i <= 40; i++) ips.push(`192.168.64.${i}`);
+    for (let i = 240; i <= 254; i++) ips.push(`192.168.64.${i}`);
+    const alive = new Set<string>();
+    // bounded concurrency to keep this quick but not noisy
+    for (let i = 0; i < ips.length; i += 16) {
+      const batch = ips.slice(i, i + 16);
+      const results = await Promise.all(batch.map(ip => ping(ip)));
+      batch.forEach((ip, k) => {
+        if (results[k]) alive.add(ip);
+      });
+    }
+    log("alive:", [...alive].join(" "));
+    log("arp table after sweep:\n" + (await run(["arp", "-an"])));
+    for (const ip of alive) {
+      const banner = await sshBanner(ip);
+      log(`ssh banner ${ip}: ${banner ?? "(no banner/closed)"}`);
+    }
+
+    log("=== sidecar via docker api ===");
+    try {
+      const version = await docker("/version");
+      log("docker version:", JSON.stringify(version));
+      const info = await docker("/info");
+      log(
+        "docker info: name=%s kernel=%s os=%s",
+        info?.Name,
+        info?.KernelVersion,
+        info?.OperatingSystem,
+      );
+      const images = (await docker("/images/json")) as any[];
+      const tags = images.flatMap(i => i.RepoTags ?? []).filter(t => t && !t.startsWith("<none>"));
+      log("sidecar images:", JSON.stringify(tags));
+
+      let image = tags.find(t => /alpine|busybox/i.test(t)) ?? tags[0] ?? images[0]?.Id;
+      if (!image) {
+        log("no local images; attempting pull busybox:latest");
+        await docker("/images/create?fromImage=busybox&tag=latest", { method: "POST" });
+        image = "busybox:latest";
+      }
+      const script = [
+        "echo HOSTNAME $(cat /proc/sys/kernel/hostname)",
+        "echo UPTIME $(cat /proc/uptime)",
+        'for d in /sys/class/net/*; do echo IFACE $(basename $d) mac=$(cat $d/address 2>/dev/null) state=$(cat $d/operstate 2>/dev/null); done',
+        'echo PROXY_ARP; for f in /proc/sys/net/ipv4/conf/*/proxy_arp; do echo "  $f=$(cat $f)"; done',
+        "echo IP_FORWARD $(cat /proc/sys/net/ipv4/ip_forward)",
+        "echo ADDRS; ip -4 addr show 2>/dev/null || cat /proc/net/fib_trie | head -80",
+        "echo NEIGH; ip -4 neigh show 2>/dev/null || true",
+        "echo ARPTABLE; cat /proc/net/arp",
+      ].join("; ");
+      const create = await docker("/containers/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          Image: image,
+          Entrypoint: ["/bin/sh", "-c"],
+          Cmd: [script],
+          HostConfig: { Privileged: true, NetworkMode: "host", AutoRemove: false },
+        }),
+      });
+      const id = create?.Id;
+      log("probe container:", id ?? JSON.stringify(create));
+      if (id) {
+        await docker(`/containers/${id}/start`, { method: "POST" });
+        await docker(`/containers/${id}/wait`, { method: "POST" });
+        const res = await fetch(`http://${gw![1]}:${gw![2]}/containers/${id}/logs?stdout=1&stderr=1`);
+        const raw = Buffer.from(await res.arrayBuffer());
+        // strip docker stream multiplexing headers
+        let text = "";
+        let off = 0;
+        while (off + 8 <= raw.length) {
+          const len = raw.readUInt32BE(off + 4);
+          text += raw.subarray(off + 8, off + 8 + len).toString("utf8");
+          off += 8 + len;
+        }
+        log("sidecar state:\n" + (text || raw.toString("utf8")));
+        await docker(`/containers/${id}?force=true`, { method: "DELETE" });
+      }
+    } catch (e) {
+      log("docker probe failed:", e);
+    }
+
+    expect(true).toBe(true);
+  },
+  180_000,
+);


### PR DESCRIPTION
Darwin aarch64 tart lanes intermittently fail before running any test: the agent hook's ssh/rsync into the freshly booted guest is rejected with

```
admin@192.168.64.X: Permission denied (publickey,password,keyboard-interactive).
```

21 occurrences across builds 90367 to 90876 (Aug 8-9), on all five hosts and both agent slots per host. A related failure mode hangs at the checkout/pre-warm phase until the step times out (45 min). Log analysis shows the denied address is always the job's own guest IP, the denial begins 0-60 seconds after a Linux docker sidecar VM boots on the same host, and in several cases the same IP pair recurs roughly one DHCP lease after a canceled job held it. Every macOS guest clone accepts the credentials, so whatever answered those connections is not the guest; the auth method list in the error matches a Linux sshd. The behavior started between 00:10 and 00:51 UTC on Aug 8; the sidecar mechanism itself predates it by at least five days.

This PR adds temporary diagnostics, collected from inside the affected network:

- `scripts/runner.node.mjs` prints, at startup inside every tart guest (and nowhere else): the guest's interface and DHCP lease, the ARP table before and after a subnet ping sweep, and the ssh banner of every live neighbor (macOS vs Linux sshd per IP).
- `test/internal/darwin-tart-net-probe.test.ts` additionally inspects the sidecar VM through its Docker API: interfaces, proxy_arp/ip_forward sysctls, ARP table.

The output lands in the darwin test-bun job logs. Both pieces skip everywhere outside tart guests, are bounded in runtime, and cannot fail a lane. This exists to gather evidence for the fleet-side fix and will be closed without merging once the data is in.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->