### PR TITLE
Clear pending exception before continuing the property walk in forEachProperty

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,7 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-    // No load-failure reporting here: this runs inside a lazy property lookup,
-    // and reportUncaughtExceptionAtEventLoop runs JS, which is not safe
-    // mid-getPropertySlot. Propagating the exception is enough.
+    // Don't report the failure here: that runs JS inside a lazy property lookup.
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,7 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-    // Don't report the failure here: that runs JS inside a lazy property lookup.
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,9 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
+    // No load-failure reporting here: this runs inside a lazy property lookup,
+    // and reportUncaughtExceptionAtEventLoop runs JS, which is not safe
+    // mid-getPropertySlot. Propagating the exception is enough.
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +331,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5597,9 +5597,7 @@ restart:
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
                 bool hasProperty = object->getPropertySlot(globalObject, property, slot);
-                // Ignore exceptions from "Get" proxy traps and throwing lazy
-                // property initializers; leaving one pending would enter the
-                // next property's getter with an exception already set.
+                // Ignore exceptions from "Get" proxy traps and throwing lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
                 if (!hasProperty)
                     continue;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,13 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and throwing lazy
+                // property initializers; leaving one pending would enter the
+                // next property's getter with an exception already set.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -936,6 +936,12 @@ it("clears an exception thrown by a property get mid-walk", async () => {
   // pending aborted debug builds when the next lazy property's host callback
   // observed it.
   const fixture = `
+    // Warm lazy dependencies that cannot load once Symbol is clobbered, so the
+    // only failure left is the property-walk behavior this test covers:
+    // process.env (built by a JS builtin on Windows) and node:util (loaded on
+    // first use of the global util.inspect helper).
+    process.env.PATH;
+    require("node:util");
     globalThis.Symbol = 123;
     let thrown;
     try {
@@ -953,10 +959,9 @@ it("clears an exception thrown by a property get mid-walk", async () => {
     cmd: [bunExe(), "-e", fixture],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "ignore",
+    stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout).toBe("ok\n");
-  expect(exitCode).toBe(0);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,35 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+it("clears an exception thrown by a property get mid-walk", async () => {
+  // With the global Symbol clobbered, reifying Bun's lazy "$" property throws
+  // while the property walk is enumerating the Bun object. The exception must
+  // be cleared before the walk moves on to the next property; leaving it
+  // pending aborted debug builds when the next lazy property's host callback
+  // observed it.
+  const fixture = `
+    globalThis.Symbol = 123;
+    let thrown;
+    try {
+      Bun.$;
+    } catch (e) {
+      thrown = e;
+    }
+    if (!(thrown instanceof TypeError)) throw new Error("expected Bun.$ to throw, got: " + thrown);
+    const s = Bun.inspect(Bun);
+    if (!s.includes("Archive")) throw new Error("inspect(Bun) missing properties");
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes a Fuzzilli-found abort (fingerprint `33708478c5cd76b1`).

### Symptom

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Symbol is not a function. (In 'Symbol("cwd")', 'Symbol' is 3221225469)
!exception()
JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

Reproduces without the fuzzer:

```js
globalThis.Symbol = 123;
Bun.inspect(Bun); // SIGABRT in debug builds
```

or, the shape the fuzzer hit, where the value lands in an error message:

```js
globalThis.Symbol = 123;
new DecompressionStream(globalThis); // inspects the argument for ERR_INVALID_ARG_VALUE
```

### Cause

`JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect` and console formatting) did this in its slow path:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;               // skips the clear below
CLEAR_IF_EXCEPTION(scope);
```

When `getPropertySlot` returns false because a lazy static property's initializer threw (here: `Bun.$`'s builder runs `Symbol("cwd")` against the clobbered global), the `continue` skipped the clear and the walk entered the next property's host callback with the exception still pending. Debug builds abort on the host-callback exception scope assertion. Release builds silently drop every remaining property from the output, because `setUpStaticFunctionSlot` treats a successfully reified slot as not found while an exception is set. The fix clears before the early continue, matching what `JSC__JSValue__forEachPropertyOrdered` already does.

Continuing past the first throw then surfaced a second problem on the same path: the `Bun.sql` lazy builders had a debug-only `reportUncaughtExceptionAtEventLoop` call on module load failure. That runs the uncaught-exception machinery (which reads `process._fatalException` and can emit events, i.e. runs JS) from inside `getPropertySlot`, with the load error still pending, and tripped a stale-structure assertion in the prototype walk. Removed; the exception now just propagates to the property access, so `Bun.sql` throws the real load error.

### Test

Added to `test/js/bun/util/inspect.test.js`. Fails before the fix on both build types: debug builds abort, release builds return a truncated `Bun.inspect(Bun)` with the later properties missing. Verified the original fuzzer script no longer crashes, including replayed in a REPRL session with the `Symbol` clobber from a prior iteration, which is how the fuzzer originally triggered it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->