### PR TITLE
Skip TS enum reverse mapping at runtime for string-valued members of unknown type

### DIFF
--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2196,6 +2196,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let name: &'a [u8] = value.name.slice();
 
             let mut has_string_value = false;
+            let mut value_may_be_string = false;
             if let Some(enum_value) = value.value {
                 next_numeric_value = None;
 
@@ -2230,8 +2231,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             .insert(value.ref_, js_ast::ts::Data::EnumString(str_));
                     }
                     _ => {
-                        if visited.known_primitive() == js_ast::expr::PrimitiveType::String {
-                            has_string_value = true;
+                        match visited.known_primitive() {
+                            js_ast::expr::PrimitiveType::String => has_string_value = true,
+                            js_ast::expr::PrimitiveType::Unknown
+                            | js_ast::expr::PrimitiveType::Mixed => value_may_be_string = true,
+                            _ => {}
                         }
 
                         if !p.expr_can_be_removed_if_unused(&visited) {
@@ -2296,6 +2300,70 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // String-valued enums do not form a two-way map
             if has_string_value {
                 value_exprs.push(assign_target);
+            } else if value_may_be_string {
+                // The value's type is not statically known (e.g. a member of an
+                // enum defined in another module). String members must not get
+                // a reverse mapping, so guard it at runtime:
+                // "typeof (Enum.Name = value) !== 'string' && (Enum[Enum.Name] = 'Name')"
+                let typeof_value = p.new_expr(
+                    E::Unary {
+                        op: js_ast::OpCode::UnTypeof,
+                        value: assign_target,
+                        flags: E::UnaryFlags::empty(),
+                    },
+                    value.loc,
+                );
+                let string_literal = p.new_expr(E::EString::from_static(b"string"), value.loc);
+                let is_not_string = p.new_expr(
+                    E::Binary {
+                        op: js_ast::OpCode::BinStrictNe,
+                        left: typeof_value,
+                        right: string_literal,
+                    },
+                    value.loc,
+                );
+                let read_back = if is_assign_target {
+                    p.new_expr(
+                        E::Dot {
+                            target: Expr::init_identifier(data.arg, value.loc),
+                            name: name.into(),
+                            name_loc: value.loc,
+                            ..Default::default()
+                        },
+                        value.loc,
+                    )
+                } else {
+                    let name_string = p.new_expr(value.name_as_e_string(p.arena), value.loc);
+                    p.new_expr(
+                        E::Index {
+                            target: Expr::init_identifier(data.arg, value.loc),
+                            index: name_string,
+                            optional_chain: None,
+                        },
+                        value.loc,
+                    )
+                };
+                p.record_usage(data.arg);
+                let reverse_mapping = Expr::assign(
+                    p.new_expr(
+                        E::Index {
+                            target: Expr::init_identifier(data.arg, value.loc),
+                            index: read_back,
+                            optional_chain: None,
+                        },
+                        value.loc,
+                    ),
+                    name_as_e_string.unwrap(),
+                );
+                p.record_usage(data.arg);
+                value_exprs.push(p.new_expr(
+                    E::Binary {
+                        op: js_ast::OpCode::BinLogicalAnd,
+                        left: is_not_string,
+                        right: reverse_mapping,
+                    },
+                    value.loc,
+                ));
             } else {
                 // "Enum[assignTarget] = 'Name'"
                 value_exprs.push(Expr::assign(

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -397,10 +397,18 @@ describe("bundler", () => {
       // make sure the minification trick "enum[enum.K=V]=K" is used, but `enum`
       assert(a.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.A=0]=["']A["']/), "should be using enum minification trick (1)");
       assert(a.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.B=1]=["']B["']/), "should be using enum minification trick (2)");
-      assert(a.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.C=[a-zA-Z$]]=["']C["']/), "should be using enum minification trick (3)");
+      // C's value is statically unknown, so the reverse mapping gets a runtime string check
+      assert(
+        a.match(/typeof\([a-zA-Z$]\.C=[a-zA-Z$]\)!=="string"&&\([a-zA-Z$]\[[a-zA-Z$]\.C]=["']C["']\)/),
+        "should be using enum minification trick (3)",
+      );
       assert(b.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.X=0]=["']X["']/), "should be using enum minification trick (4)");
       assert(b.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.Y=1]=["']Y["']/), "should be using enum minification trick (5)");
-      assert(b.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.Z=[a-zA-Z$]]=["']Z["']/), "should be using enum minification trick (6)");
+      // Z's value is statically unknown, so the reverse mapping gets a runtime string check
+      assert(
+        b.match(/typeof\([a-zA-Z$]\.Z=[a-zA-Z$]\)!=="string"&&\([a-zA-Z$]\[[a-zA-Z$]\.Z]=["']Z["']\)/),
+        "should be using enum minification trick (6)",
+      );
     },
     runtimeFiles: {
       "/test.js": /* js */ `
@@ -437,7 +445,11 @@ describe("bundler", () => {
       // make sure the minification trick "enum[enum.K=V]=K" is used, but `enum`
       assert(b.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.X=0]=["']X["']/), "should be using enum minification trick (4)");
       assert(b.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.Y=1]=["']Y["']/), "should be using enum minification trick (5)");
-      assert(b.match(/\b[a-zA-Z$]\[[a-zA-Z$]\.Z=[a-zA-Z$]]=["']Z["']/), "should be using enum minification trick (6)");
+      // Z's value is statically unknown, so the reverse mapping gets a runtime string check
+      assert(
+        b.match(/typeof\([a-zA-Z$]\.Z=[a-zA-Z$]\)!=="string"&&\([a-zA-Z$]\[[a-zA-Z$]\.Z]=["']Z["']\)/),
+        "should be using enum minification trick (6)",
+      );
     },
     runtimeFiles: {
       "/test.js": /* js */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -893,15 +893,15 @@ describe("Bun.Transpiler", () => {
       // A nested function establishes its own context, so these remain valid.
       exp(
         "function *f() { enum x { y = (function*() { yield 1 })() } }",
-        'function* f() {\n  let x;\n  ((x) => {\n    x[x["y"] = function* () {\n      yield 1;\n    }()] = "y";\n  })(x ||= {});\n}',
+        'function* f() {\n  let x;\n  ((x) => {\n    typeof (x["y"] = function* () {\n      yield 1;\n    }()) !== "string" && (x[x["y"]] = "y");\n  })(x ||= {});\n}',
       );
       exp(
         "async function f() { enum x { y = (async () => await 1)() } }",
-        'async function f() {\n  let x;\n  ((x) => {\n    x[x["y"] = (async () => await 1)()] = "y";\n  })(x ||= {});\n}',
+        'async function f() {\n  let x;\n  ((x) => {\n    typeof (x["y"] = (async () => await 1)()) !== "string" && (x[x["y"]] = "y");\n  })(x ||= {});\n}',
       );
       exp(
         "enum x { y = (function() { return this })() }",
-        'var x;\n((x) => {\n  x[x["y"] = function() {\n    return this;\n  }()] = "y";\n})(x ||= {})',
+        'var x;\n((x) => {\n  typeof (x["y"] = function() {\n    return this;\n  }()) !== "string" && (x[x["y"]] = "y");\n})(x ||= {})',
       );
       // The enclosing context is restored after the body: sibling statements
       // keep their yield/await/super permissions.
@@ -976,7 +976,7 @@ function foo() {}
       ).toMatchInlineSnapshot(`
         "var ABC;
         ((ABC) => {
-          ABC[ABC["A"] = () => {}] = "A";
+          typeof (ABC["A"] = () => {}) !== "string" && (ABC[ABC["A"]] = "A");
         })(ABC ||= {});
         function foo() {}
         "

--- a/test/bundler/transpiler/ts-enum-cross-module.test.ts
+++ b/test/bundler/transpiler/ts-enum-cross-module.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/37257
+// When an enum member's value is not statically known (e.g. it references an
+// enum from another transpile unit), the reverse mapping must be decided at
+// runtime: string members must not get one, numeric members must keep theirs.
+describe.concurrent("enum member referencing an enum from another module", () => {
+  test("string member gets no reverse mapping", async () => {
+    using dir = tempDir("enum-cross-module-string", {
+      "enum1.ts": `export enum Enum1 { K1 = "V" }`,
+      "main.ts": `
+        import { Enum1 } from "./enum1";
+        enum Enum2 { K2 = Enum1.K1 }
+        console.log(JSON.stringify({
+          entries: Object.entries(Enum2),
+          keys: Object.keys(Enum2),
+          values: Object.values(Enum2),
+        }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      entries: [["K2", "V"]],
+      keys: ["K2"],
+      values: ["V"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("numeric member keeps its reverse mapping", async () => {
+    using dir = tempDir("enum-cross-module-number", {
+      "enum1.ts": `export enum Enum1 { K1 = 7 }`,
+      "main.ts": `
+        import { Enum1 } from "./enum1";
+        enum Enum2 { K2 = Enum1.K1 }
+        console.log(JSON.stringify(Object.entries(Enum2)));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([
+      ["7", "K2"],
+      ["K2", 7],
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -751,6 +751,19 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(stdout)).toContain("test");
       expect(exitCode).toBe(0);
     });
+
+    // https://github.com/oven-sh/bun/issues/37257
+    test("string enum referencing an enum from a previous line gets no reverse mapping", async () => {
+      const { stdout, exitCode } = await runRepl([
+        'enum Enum1 { K1 = "V" }',
+        "enum Enum2 { K2 = Enum1.K1 }",
+        "console.log(JSON.stringify(Object.entries(Enum2)))",
+        ".exit",
+      ]);
+      expect(stripAnsi(stdout)).toContain('[["K2","V"]]');
+      expect(stripAnsi(stdout)).not.toContain('["V","K2"]');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("welcome message", () => {


### PR DESCRIPTION
Fixes #37257

### Repro

```ts
// enum1.ts
export enum Enum1 { K1 = "V" }

// main.ts
import { Enum1 } from "./enum1";
enum Enum2 { K2 = Enum1.K1 }
console.log(Object.entries(Enum2));
// before: [ [ "K2", "V" ], [ "V", "K2" ] ]
// after:  [ [ "K2", "V" ] ]
```

The issue reports this in the REPL (each line is its own transpile unit), but it also reproduces for any unbundled cross-file enum reference, as above.

### Cause

When lowering an enum, the transpiler only skips the numeric-style reverse mapping when it can statically prove the member value is a string. A reference to an enum from another transpile unit is an opaque identifier, so it fell into the numeric branch and unconditionally emitted `Enum2[Enum2["K2"] = Enum1.K1] = "K2"`, which at runtime assigns `Enum2["V"] = "K2"`.

### Fix

When the member value's type is statically unknown, emit the reverse mapping behind a runtime check:

```js
typeof (Enum2["K2"] = Enum1.K1) !== "string" && (Enum2[Enum2["K2"]] = "K2");
```

This matches tsc's semantics (tsc resolves cross-enum constants with type information, so string members never get a reverse mapping while computed numeric members do). Statically known values are unaffected: known strings still get no reverse mapping and no check, known numbers keep the unconditional reverse mapping, and same-unit or bundled enum references are still inlined as before.

### Tests

- `test/bundler/transpiler/ts-enum-cross-module.test.ts` (new): cross-file string member gets no reverse mapping, cross-file numeric member keeps its reverse mapping. The string case fails on current bun.
- `test/js/bun/repl/repl.test.ts`: the REPL repro from the issue.
- Updated expected output in `transpiler.test.js` and `esbuild/ts.test.ts` for members with statically unknown values (e.g. `Z = Foo` self-reference, function-valued members); their runtime-behavior assertions still pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->