### PR TITLE
install: link wildcard deps to prerelease workspace members in any position

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2290,12 +2290,13 @@ fn get_or_put_resolved_package(
                     let buf = this.lockfile.buffers.string_bytes.as_slice();
                     let npm_group = &version.npm().version;
                     if this.options.link_workspace_packages
-                        && ((workspace_version.is_some()
-                            && npm_group.satisfies(*workspace_version.unwrap(), buf, buf))
-                            // https://github.com/oven-sh/bun/pull/10899#issuecomment-2099609419
-                            // if the workspace doesn't have a version, it can still be used if
-                            // dependency version is wildcard
-                            || (workspace_path.is_some() && npm_group.is_star()))
+                        && dependency::npm_range_accepts_workspace_member(
+                            npm_group,
+                            workspace_version.copied(),
+                            workspace_path.is_some(),
+                            buf,
+                            buf,
+                        )
                     {
                         let Some(root_package) = this.lockfile.root_package() else {
                             break 'resolve_from_workspace;

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -586,6 +586,23 @@ pub(crate) fn is_safe_install_folder_name(name: &[u8]) -> bool {
     true
 }
 
+/// Whether an npm range accepts a same-name workspace member. Parse
+/// (`Package::parse_dependency`) and resolution
+/// (`get_or_put_resolved_package`) share this rule; if they disagree,
+/// link-vs-registry depends on which package declares the dependency.
+/// A wildcard accepts any present member, even versionless (#10899) or
+/// with a prerelease version the range does not otherwise satisfy.
+pub(crate) fn npm_range_accepts_workspace_member(
+    range: &Semver::query::Group,
+    workspace_version: Option<Semver::Version>,
+    has_workspace_path: bool,
+    range_buf: &[u8],
+    version_buf: &[u8],
+) -> bool {
+    workspace_version.is_some_and(|v| range.satisfies(v, range_buf, version_buf))
+        || (has_workspace_path && range.is_star())
+}
+
 /// assumes version is valid
 pub fn without_build_tag(version: &[u8]) -> &[u8] {
     if let Some(plus) = strings::index_of_char(version, b'+') {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1751,10 +1751,9 @@ impl Package<u64> {
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {
-                    // A wildcard accepts the member even when its version is a
-                    // prerelease the range does not satisfy, mirroring
-                    // `get_or_put_resolved_package` so the decision is the same
-                    // wherever the dependency is declared.
+                    // `is_star` mirrors `get_or_put_resolved_package`: a wildcard
+                    // accepts the member even when its version is a prerelease
+                    // the range does not satisfy.
                     let npm_version = &dependency_version.npm().version;
                     let satisfies =
                         npm_version.satisfies(workspace_version, buf, buf) || npm_version.is_star();

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1751,11 +1751,13 @@ impl Package<u64> {
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {
-                    let satisfies =
-                        dependency_version
-                            .npm()
-                            .version
-                            .satisfies(workspace_version, buf, buf);
+                    // A wildcard accepts the member even when its version is a
+                    // prerelease the range does not satisfy, mirroring
+                    // `get_or_put_resolved_package` so the decision is the same
+                    // wherever the dependency is declared.
+                    let npm_version = &dependency_version.npm().version;
+                    let satisfies = npm_version.satisfies(workspace_version, buf, buf)
+                        || npm_version.is_star();
                     if pm.options.link_workspace_packages && satisfies {
                         // `String::sliced` takes `&'a self`; bind the unwrapped
                         // value so the borrow outlives the parse call.

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1756,8 +1756,8 @@ impl Package<u64> {
                     // `get_or_put_resolved_package` so the decision is the same
                     // wherever the dependency is declared.
                     let npm_version = &dependency_version.npm().version;
-                    let satisfies = npm_version.satisfies(workspace_version, buf, buf)
-                        || npm_version.is_star();
+                    let satisfies =
+                        npm_version.satisfies(workspace_version, buf, buf) || npm_version.is_star();
                     if pm.options.link_workspace_packages && satisfies {
                         // `String::sliced` takes `&'a self`; bind the unwrapped
                         // value so the borrow outlives the parse call.

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1751,13 +1751,14 @@ impl Package<u64> {
             }
             dependency::version::Tag::Npm => {
                 if let Some(workspace_version) = workspace_version {
-                    // `is_star` mirrors `get_or_put_resolved_package`: a wildcard
-                    // accepts the member even when its version is a prerelease
-                    // the range does not satisfy.
-                    let npm_version = &dependency_version.npm().version;
-                    let satisfies =
-                        npm_version.satisfies(workspace_version, buf, buf) || npm_version.is_star();
-                    if pm.options.link_workspace_packages && satisfies {
+                    let accepts = dependency::npm_range_accepts_workspace_member(
+                        &dependency_version.npm().version,
+                        Some(workspace_version),
+                        true,
+                        buf,
+                        buf,
+                    );
+                    if pm.options.link_workspace_packages && accepts {
                         // `String::sliced` takes `&'a self`; bind the unwrapped
                         // value so the borrow outlives the parse call.
                         let wp = workspace_path.unwrap();

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -234,9 +234,7 @@ test.concurrent("root wildcard dependency on a prerelease workspace member links
   const lock = await file(join(packageDir, "bun.lock")).text();
   expect(lock).toContain("no-deps@workspace:packages/no-deps");
   expect(lock).not.toContain("no-deps@2.0.0");
-  expect((await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe(
-    "3.0.0-beta.1",
-  );
+  expect((await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe("3.0.0-beta.1");
 
   // repeat install converges: no re-save, identical lockfile
   {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -193,6 +193,200 @@ test("dependency on workspace without version in package.json", async () => {
   }
 });
 
+// A `*` range accepts a workspace member whose version is a prerelease even
+// though `*` does not satisfy prereleases under npm semver rules, and the
+// outcome must not depend on whether the root or another member declares the
+// dependency (`no-deps` also exists in the registry with 2.0.0 as latest).
+test.concurrent("root wildcard dependency on a prerelease workspace member links the workspace", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "*",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "no-deps", "package.json"),
+      JSON.stringify({ name: "no-deps", version: "3.0.0-beta.1" }),
+    ),
+  ]);
+
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  const lock = await file(join(packageDir, "bun.lock")).text();
+  expect(lock).toContain("no-deps@workspace:packages/no-deps");
+  expect(lock).not.toContain("no-deps@2.0.0");
+  expect((await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe(
+    "3.0.0-beta.1",
+  );
+
+  // repeat install converges: no re-save, identical lockfile
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(lock);
+
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+});
+
+test.concurrent("member wildcard dependency on a prerelease workspace member stays linked and stable", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["packages/*"],
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "no-deps", "package.json"),
+      JSON.stringify({ name: "no-deps", version: "3.0.0-beta.1" }),
+    ),
+    write(
+      join(packageDir, "packages", "pkg1", "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "*",
+        },
+      }),
+    ),
+  ]);
+
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  const lock = await file(join(packageDir, "bun.lock")).text();
+  expect(lock).toContain("no-deps@workspace:packages/no-deps");
+  expect(lock).not.toContain("no-deps@2.0.0");
+  const hoisted = join(packageDir, "node_modules", "no-deps", "package.json");
+  const nested = join(packageDir, "packages", "pkg1", "node_modules", "no-deps", "package.json");
+  const installedPkgJson = (await exists(nested)) ? nested : hoisted;
+  expect((await file(installedPkgJson).json()).version).toBe("3.0.0-beta.1");
+
+  // repeat install converges: no re-save, identical lockfile
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+  expect(await file(join(packageDir, "bun.lock")).text()).toBe(lock);
+
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--frozen-lockfile"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+});
+
+// Boundary guard: only a wildcard gets the prerelease exception. A range the
+// member's prerelease version does not satisfy keeps installing from the
+// registry. Passes on an unmodified build by design.
+test.concurrent("non-wildcard range on a prerelease workspace member still installs from the registry", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "^1.0.0",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, "packages", "no-deps", "package.json"),
+      JSON.stringify({ name: "no-deps", version: "3.0.0-beta.1" }),
+    ),
+  ]);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  const lock = await file(join(packageDir, "bun.lock")).text();
+  expect(lock).toContain("no-deps@1.1.0");
+  expect(lock).not.toContain("no-deps@workspace:packages/no-deps");
+  expect((await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe("1.1.0");
+});
+
 test.concurrent("allowing negative workspace patterns", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;


### PR DESCRIPTION
### Repro

Same member, same range, opposite outcomes depending on which package declares the dependency. No registry involvement needed; `pkg-x` is not a registry package.

Shape A, the root declares it:

```
# package.json
{ "name": "sandbox", "workspaces": ["packages/*"],
  "dependencies": { "pkg-x": "*" } }
# packages/m/package.json   { "name": "pkg-x", "version": "1.0.0-beta.1" }
```

```
$ bun install
error: GET https://registry.npmjs.org/pkg-x - 404
error: pkg-x@* failed to resolve
```

Shape B, another member declares it:

```
# package.json
{ "name": "sandbox", "workspaces": ["packages/*"] }
# packages/m/package.json     { "name": "pkg-x", "version": "1.0.0-beta.1" }
# packages/bar/package.json   { "name": "bar", "version": "1.0.0",
                                "dependencies": { "pkg-x": "*" } }
```

```
$ bun install        # links the workspace member, works offline
$ bun install
Saved lockfile       # and re-saves the unchanged lockfile on every install
```

npm installs both shapes by linking the workspace member.

### Cause

Two hand-copied versions of the same rule ("does this npm range accept this workspace member?") drifted:

- `Package::parse_dependency` (Npm arm) decided link-vs-override with `Group::satisfies(range, member_version)` alone. `*` does not satisfy `1.0.0-beta.1` under npm semver rules (a prerelease only satisfies a range that names a prerelease of the same version), so a root-declared wildcard took the override branch: the member's workspace dependency is displaced and the name resolves from the registry.
- `get_or_put_resolved_package` additionally accepts `npm_group.is_star()` for any present member (the #10899 rule), so a member-declared wildcard resolves to the workspace.

The disagreement also produced shape B's permanent re-save: resolution links the member and the bun.lock loader rewrites the loaded dependency to workspace-tagged (`map_dep_to_pkg`), but a fresh parse keeps it npm-tagged, so the loaded and re-parsed roots never compare equal and every install re-saves identical bytes (#37249 fixed the versionless flavor of this loop and listed this prerelease flavor as out of scope).

### Fix

Extract the rule into one shared predicate, `dependency::npm_range_accepts_workspace_member` (satisfies, or wildcard on any present member), and call it from both sites. Resolution behavior is unchanged (the helper is the resolver's exact expression); parse gains the wildcard disjunct, which is the fix. The versionless case is unchanged: the Npm arm still requires a member version, and wildcard-on-versionless stays with the resolver per #10899.

A wildcard therefore links the member wherever it is declared, matching npm's resolution for this shape, and the only registry fallback left for a member name is a non-wildcard range the member's version does not satisfy, which is bun's existing, deliberate divergence from npm and is untouched here (npm links the member for any range; bun's override rule lets e.g. `^2.0.0` fetch a registry copy of a name that is also a member, and several existing tests depend on that).

No loader change is needed: parse now produces the same workspace-tagged dependency `map_dep_to_pkg` produces on load, so lockfiles round-trip byte-stable and shape B's re-save loop stops. Lockfiles written by current bun for shape B load without a diff.

### Landing order: after #37248

Review of the first revision probed mixed declarations, where one package declares a range the member fails and another declares `*`, and found this PR must land after #37248 (same-name collision fixes). Details, all verified against a local registry:

- Root `^2.0.0` + sibling member `*` + member `1.0.0-beta.1`: with this PR alone, install 1 resolves per-declarer (root registry, sibling workspace), and that split is a state today's bun.lock writer emits but its parser rejects, so install 2 hits `Duplicate package path`, ignores the lockfile, and re-saves forever, with `--frozen-lockfile` failing. This is not a new failure mode: the identical loop exists on an unmodified build whenever the sibling's range satisfies (root `^2.0.0` + sibling `^1.0.0` + member `1.0.0`), because satisfying ranges have always linked per-declarer. The representation bug is exactly what #37248 fixes.
- On a merge of this branch with #37248's, both the satisfying and the wildcard/prerelease mixed shapes converge: one install, stable lockfile, `--frozen-lockfile` passes, and the combined test suites pass (78 tests in `bun-workspaces.test.ts`, including #37248's collision matrix). The merge reconciliation is mechanical because of the shared predicate: #37248's restructured Npm arm (its versionless `is_star` match is the helper's semantics) and its reload-mirror scan in `bun.lock.rs` both become calls to `npm_range_accepts_workspace_member`.
- Two adjacent shapes stay with their own fixes: a name declared in both `dependencies` and `devDependencies` of one package.json (bun already warns "duplicate dependency") goes from a hard `Duplicate package path` loop on an unmodified build to a quiet re-save under #37248, identically for satisfying and wildcard ranges; and a package.json `overrides` entry for a member's name already fails every install with a hard `DependencyLoop` error on an unmodified build when the range satisfies, which neither this PR nor #37248 addresses (tracked separately; after this PR the wildcard flavor joins that family instead of escaping to the registry).

#37249's loader gate mirrors the parse rule for versioned members and gains the same wildcard disjunct when both land; with the shared predicate that is a call-site change. The dist-tag flavor is #35468.

### Verification

Three tests in `test/cli/install/bun-workspaces.test.ts` (member `no-deps@3.0.0-beta.1` shadowing registry `no-deps`, latest 2.0.0):

- root-declared `*`: resolves to `no-deps@workspace:packages/no-deps`, not registry 2.0.0; repeat install does not re-save; `--frozen-lockfile` passes
- member-declared `*`: same resolution, and the second install no longer prints "Saved lockfile" (lockfile byte-identical)
- boundary guard: root-declared `^1.0.0` against the prerelease member still installs registry 1.1.0 (passes on an unmodified build by design)

The first two fail on an unmodified build (registry 2.0.0 wins; "Saved lockfile" on the second install).

Locally green: `bun-workspaces` (66), `bun-install-registry` (229 + 5 todo), `isolated-install` (62), `bun-lock` (17), `bun-lockb` (6), `lockfile-only`, `lockfile-version-2` (10), `migration/migrate` (21), `migrate-bun-lockb-v2` (2), `bun-add` (54). Checked by hand: both shapes install offline with no registry contact, and a package-lock.json written by npm 11 migrates to the workspace link and converges with a stable lockfile in both shapes.
