### PR TITLE
ensureTerminationExceptionPending: acknowledge the termination it leaves pending (asan validator abort in worker tests)

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5173,18 +5173,26 @@ void JSC__VM__setExecutionForbidden(JSC::VM* arg0, bool arg1)
 // JS thread. Make the VM's stop concrete on this thread: after this a TerminationException is
 // pending (unless termination is currently deferred), whether or not the NeedTermination trap the
 // requester fired had been serviced yet. What RETURN_IF_EXCEPTION would have done at the next check.
+// The caller returns Err(Terminated) on the strength of it, so the exception this leaves behind is
+// a checked one: acknowledge it here rather than let the next scope constructed on this thread
+// (typically the module loader's) be the first to see it.
 [[ZIG_EXPORT(nothrow)]]
 void JSC__VM__ensureTerminationExceptionPending(JSC::VM* arg0)
 {
     JSC::VM& vm = *arg0;
-    if (vm.hasPendingTerminationException())
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    if (vm.hasPendingTerminationException()) {
+        EXCEPTION_ASSERT(scope.exception());
         return;
+    }
     if (!vm.hasTerminationRequest() && !vm.traps().needHandling(JSC::VMTraps::NeedTermination))
         vm.notifyNeedTermination();
     if (vm.hasTerminationRequest())
         vm.throwTerminationException();
     else
         vm.traps().handleTraps(JSC::VMTraps::NeedTermination);
+    // Pending now unless termination is deferred on this thread (then it lands when the deferral ends).
+    EXCEPTION_ASSERT(scope.exception() || !vm.hasPendingTerminationException());
 }
 
 // These may be called concurrently from another thread.


### PR DESCRIPTION
### What

The x64-asan lane aborted in `worker-transfer-list.test.ts` under exception-check validation:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: handleTraps @ VMTraps.cpp:443
    But the exception was unchecked as of this scope:
        JSC__JSModuleLoader__loadAndEvaluateModule @ bindings.cpp:3788   <- the DECLARE_TOP_EXCEPTION_SCOPE line
```

"Unchecked *as of this scope*" at a scope's declaration means the exception was already pending and unacknowledged when that scope was constructed — the module loader is the reporter, not the culprit.

### Why

`JSC__VM__ensureTerminationExceptionPending` makes a worker's stop concrete on its own thread (`throwTerminationException()` or `traps().handleTraps(NeedTermination)`) so its Rust caller — `wait_for_promise` seeing the gate closed, or a stream pull after script was forbidden — can return `Err(Terminated)` with an exception really pending. It did that with **no exception scope of its own**, so under validation the exception it produced was an unchecked one, and whichever scope was constructed next on that thread reported it. For a worker terminated while its preloads/entry were loading, that next scope is `JSC__JSModuleLoader__loadAndEvaluateModule`'s. It only surfaces when the terminate lands in that window, hence "flaky".

### Fix

`ensureTerminationExceptionPending` now owns a `TOP_EXCEPTION_SCOPE` and `EXCEPTION_ASSERT`s its postcondition (exception pending, unless termination is deferred on this thread). Reading `scope.exception()` acknowledges the throw where it is made; the caller's `Err(Terminated)` is the checked outcome. Nothing changes outside validation builds.

Only observable under `validateExceptionChecks` on the asan lane; relying on CI for the signal.
