### PR TITLE
node:vm: make breakOnSigint interrupt a script parked in Atomics.wait

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -533,7 +533,15 @@ static void writeArrowHeaderStack(VM& vm, ErrorInstance* errorInstance, const St
 void consumeTermination(JSC::VM& vm)
 {
     vm.clearHasTerminationRequest();
+    // A parked thread services no traps, so stand down both traps this run's
+    // interrupt machinery can leave pending: the SIGINT watcher's
+    // NeedTermination, and NeedWatchdogCheck from a {timeout} watchdog that
+    // fired mid-park. A stale NeedWatchdogCheck otherwise reaches
+    // Watchdog::shouldTerminate after the time limit was already restored and
+    // trips the startTimer ASSERT(hasTimeLimit()); an outer timed run is
+    // unaffected because restoring its limit re-arms the timer.
     vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+    vm.traps().clearTrap(JSC::VMTraps::NeedWatchdogCheck);
 }
 
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope)

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -530,6 +530,12 @@ static void writeArrowHeaderStack(VM& vm, ErrorInstance* errorInstance, const St
     errorInstance->putDirect(vm, decoratedName, jsBoolean(true), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
 }
 
+void consumeTermination(JSC::VM& vm)
+{
+    vm.clearHasTerminationRequest();
+    vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+}
+
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope)
 {
     if (auto* errorInstance = dynamicDowncast<ErrorInstance>(exception->value())) {

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -8,6 +8,7 @@
 #include <JavaScriptCore/SourceProvider.h>
 
 #include "BunClientData.h"
+#include "JavaScriptCore/Watchdog.h"
 #include "NodeVM.h"
 #include "NodeVMScript.h"
 #include "NodeVMModule.h"
@@ -530,16 +531,18 @@ static void writeArrowHeaderStack(VM& vm, ErrorInstance* errorInstance, const St
     errorInstance->putDirect(vm, decoratedName, jsBoolean(true), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
 }
 
-bool consumeTermination(JSC::VM& vm)
+bool consumeTermination(JSC::VM& vm, bool armedWatchdog)
 {
     vm.clearHasTerminationRequest();
-    // A parked thread services no traps, so stand down both traps this run's
-    // interrupt machinery can leave pending: the SIGINT watcher's
-    // NeedTermination, and NeedWatchdogCheck from a {timeout} watchdog that
-    // fired mid-park (left stale, it trips Watchdog::startTimer's
-    // ASSERT(hasTimeLimit()); an outer timed run re-arms via its restore).
+    // A parked thread services no traps, so the SIGINT watcher's
+    // NeedTermination can still be pending here; same for NeedWatchdogCheck
+    // when this run armed a {timeout} watchdog that fired mid-park (left
+    // stale after the time-limit restore, it trips Watchdog::startTimer's
+    // ASSERT(hasTimeLimit())). An outer frame's pending watchdog check is not
+    // ours to clear: its limit is still armed and it must keep enforcing.
     vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
-    vm.traps().clearTrap(JSC::VMTraps::NeedWatchdogCheck);
+    if (armedWatchdog)
+        vm.traps().clearTrap(JSC::VMTraps::NeedWatchdogCheck);
     // worker.terminate() may have landed after the caller's scriptAllowed
     // check, and the clears above must not eat its trap: fireTrap and
     // clearTrap serialize on the trap-signaling lock, so a stop whose trap we
@@ -550,6 +553,11 @@ bool consumeTermination(JSC::VM& vm)
         return false;
     }
     return true;
+}
+
+bool outerWatchdogArmed(JSC::VM& vm)
+{
+    return vm.watchdog() && vm.watchdog()->hasTimeLimit();
 }
 
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope)

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -530,18 +530,26 @@ static void writeArrowHeaderStack(VM& vm, ErrorInstance* errorInstance, const St
     errorInstance->putDirect(vm, decoratedName, jsBoolean(true), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
 }
 
-void consumeTermination(JSC::VM& vm)
+bool consumeTermination(JSC::VM& vm)
 {
     vm.clearHasTerminationRequest();
     // A parked thread services no traps, so stand down both traps this run's
     // interrupt machinery can leave pending: the SIGINT watcher's
     // NeedTermination, and NeedWatchdogCheck from a {timeout} watchdog that
-    // fired mid-park. A stale NeedWatchdogCheck otherwise reaches
-    // Watchdog::shouldTerminate after the time limit was already restored and
-    // trips the startTimer ASSERT(hasTimeLimit()); an outer timed run is
-    // unaffected because restoring its limit re-arms the timer.
+    // fired mid-park (left stale, it trips Watchdog::startTimer's
+    // ASSERT(hasTimeLimit()); an outer timed run re-arms via its restore).
     vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
     vm.traps().clearTrap(JSC::VMTraps::NeedWatchdogCheck);
+    // worker.terminate() may have landed after the caller's scriptAllowed
+    // check, and the clears above must not eat its trap: fireTrap and
+    // clearTrap serialize on the trap-signaling lock, so a stop whose trap we
+    // cleared is visible to this re-check. Re-deliver it.
+    if (!Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)) [[unlikely]] {
+        vm.setHasTerminationRequest();
+        vm.notifyNeedTermination();
+        return false;
+    }
+    return true;
 }
 
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope)

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -30,6 +30,10 @@ bool extractCachedData(JSValue cachedDataValue, WTF::Vector<uint8_t>& outCachedD
 String stringifyAnonymousFunction(JSGlobalObject* globalObject, const ArgList& args, ThrowScope& scope, int* outOffset);
 JSC::EncodedJSValue createCachedData(JSGlobalObject* globalObject, const JSC::SourceCode& source);
 bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Exception> exception, ThrowScope& throwScope);
+// Clear a termination node:vm consumed (breakOnSigint/timeout). The request
+// flag alone is insufficient: a termination that interrupted Atomics.wait
+// never ran handleTraps, and the pending trap would re-terminate the VM.
+void consumeTermination(JSC::VM& vm);
 // `url` must be caller-resolved: `new Script` falls back to evalmachine.<anonymous>
 // when no filename was provided; compileFunction has no such default.
 void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* error, StringView sourceString, const String& url, const JSC::ParserError& parseError, OrdinalNumber lineOffset);

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -33,7 +33,10 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
 // Clear a termination node:vm consumed (breakOnSigint/timeout). The request
 // flag alone is insufficient: a termination that interrupted Atomics.wait
 // never ran handleTraps, and the pending trap would re-terminate the VM.
-void consumeTermination(JSC::VM& vm);
+// Returns false when the VM began stopping (worker.terminate()) while we
+// consumed: the stop was re-delivered and the caller must propagate the
+// termination instead of reporting ERR_SCRIPT_EXECUTION_*.
+[[nodiscard]] bool consumeTermination(JSC::VM& vm);
 // `url` must be caller-resolved: `new Script` falls back to evalmachine.<anonymous>
 // when no filename was provided; compileFunction has no such default.
 void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* error, StringView sourceString, const String& url, const JSC::ParserError& parseError, OrdinalNumber lineOffset);

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -33,10 +33,15 @@ bool handleException(JSGlobalObject* globalObject, VM& vm, NakedPtr<JSC::Excepti
 // Clear a termination node:vm consumed (breakOnSigint/timeout). The request
 // flag alone is insufficient: a termination that interrupted Atomics.wait
 // never ran handleTraps, and the pending trap would re-terminate the VM.
+// armedWatchdog: whether this run armed a {timeout} watchdog; only then is a
+// pending NeedWatchdogCheck this run's to stand down.
 // Returns false when the VM began stopping (worker.terminate()) while we
 // consumed: the stop was re-delivered and the caller must propagate the
 // termination instead of reporting ERR_SCRIPT_EXECUTION_*.
-[[nodiscard]] bool consumeTermination(JSC::VM& vm);
+[[nodiscard]] bool consumeTermination(JSC::VM& vm, bool armedWatchdog);
+// An enclosing vm frame's {timeout} watchdog still has a time limit armed, so
+// a termination that carries no SIGINT flag is its timeout, not a raced SIGINT.
+bool outerWatchdogArmed(JSC::VM& vm);
 // `url` must be caller-resolved: `new Script` falls back to evalmachine.<anonymous>
 // when no filename was provided; compileFunction has no such default.
 void decorateParseErrorStack(JSGlobalObject* globalObject, VM& vm, JSObject* error, StringView sourceString, const String& url, const JSC::ParserError& parseError, OrdinalNumber lineOffset);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -110,6 +110,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
                 vm.clearHasTerminationRequest();
+                // A termination that interrupted Atomics.wait bypassed
+                // handleTraps, leaving the NeedTermination trap pending;
+                // clear it so it can't re-terminate the surviving VM.
+                vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
                 if (getSigintReceived()) {
                     setSigintReceived(false);
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
@@ -256,6 +260,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
+        // A termination that interrupted Atomics.wait bypassed handleTraps,
+        // leaving the NeedTermination trap pending; clear it so it can't
+        // re-terminate the surviving VM.
+        vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -70,6 +70,39 @@ void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
     }
 }
 
+bool NodeVMModule::reportOwnedTermination(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMGlobalObject* nodeVmGlobalObject, uint32_t timeout, bool breakOnSigint)
+{
+    VM& vm = JSC::getVM(globalObject);
+    // Ours only if the VM is not being stopped and this evaluation armed an
+    // interrupt source; otherwise the termination belongs to VM teardown or
+    // an outer vm frame (nested runs share the VM).
+    bool owned = Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)
+        && (getSigintReceived() || timeout != 0 || breakOnSigint);
+    if (!owned) {
+        if (!vm.hasPendingTerminationException())
+            vm.throwTerminationException();
+        return false;
+    }
+    vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
+    if (vm.hasPendingTerminationException())
+        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
+    if (!NodeVM::consumeTermination(vm)) {
+        vm.throwTerminationException();
+        return false;
+    }
+    if (getSigintReceived()) {
+        setSigintReceived(false);
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    } else if (timeout != 0) {
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
+    } else {
+        // breakOnSigint was armed, but SIGINT raced the watcher registration
+        // or teardown past the sigintReceived flag. It is still an interrupt.
+        throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
+    }
+    return true;
+}
+
 JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, bool breakOnSigint)
 {
     VM& vm = globalObject->vm();
@@ -100,36 +133,8 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             // exception-check validator is satisfied before the TOP scope
             // below, then convert it to ERR_SCRIPT_EXECUTION_*.
             std::ignore = scope.exception();
-            if ((vm.hasTerminationRequest() || vm.hasPendingTerminationException()) && !Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)) {
-                // The VM itself is being stopped; not ours to consume. Propagate the termination.
-                if (!vm.hasPendingTerminationException())
-                    vm.throwTerminationException();
-                return {};
-            }
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-                // Not armed by this evaluation and not flagged for it: an
-                // outer vm frame's interrupt. Propagate the termination.
-                if (!getSigintReceived() && timeout == 0 && !breakOnSigint) {
-                    if (!vm.hasPendingTerminationException())
-                        vm.throwTerminationException();
-                    return {};
-                }
-                vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-                DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                if (!NodeVM::consumeTermination(vm)) {
-                    vm.throwTerminationException();
-                    return {};
-                }
-                if (getSigintReceived()) {
-                    setSigintReceived(false);
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                } else if (timeout != 0) {
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-                } else {
-                    // breakOnSigint was armed, but SIGINT raced the watcher
-                    // registration or teardown past the sigintReceived flag.
-                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                }
+                reportOwnedTermination(globalObject, scope, nodeVmGlobalObject, timeout, breakOnSigint);
                 return {};
             }
         }
@@ -260,36 +265,12 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     // termination one is converted to ERR_SCRIPT_EXECUTION_* here. Observe it
     // so the exception-check validator is satisfied before the TOP scope.
     std::ignore = scope.exception();
-    if ((vm.hasTerminationRequest() || vm.hasPendingTerminationException()) && !Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)) {
-        // The VM itself is being stopped; not ours to consume. Propagate the termination.
-        if (!vm.hasPendingTerminationException())
-            vm.throwTerminationException();
-        return {};
-    }
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
-        // Not armed by this evaluation and not flagged for it: an outer vm
-        // frame's interrupt. Propagate the termination.
-        if (!getSigintReceived() && timeout == 0 && !breakOnSigint) {
-            if (!vm.hasPendingTerminationException())
-                vm.throwTerminationException();
+        // A propagated termination must not mark the module Errored (the
+        // VM_RETURN_IF_EXCEPTION below would pin it as the module's
+        // evaluation exception forever); only owned ERR_* errors fall through.
+        if (!reportOwnedTermination(globalObject, scope, nodeVmGlobalObject, timeout, breakOnSigint))
             return {};
-        }
-        vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
-        DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        if (!NodeVM::consumeTermination(vm)) {
-            vm.throwTerminationException();
-            return {};
-        }
-        if (getSigintReceived()) {
-            setSigintReceived(false);
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        } else if (timeout != 0) {
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-        } else {
-            // breakOnSigint was armed, but SIGINT raced the watcher
-            // registration or teardown past the sigintReceived flag.
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-        }
     } else {
         setSigintReceived(false);
     }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -107,17 +107,27 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 return {};
             }
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+                // Not armed by this evaluation and not flagged for it: an
+                // outer vm frame's interrupt. Propagate the termination.
+                if (!getSigintReceived() && timeout == 0 && !breakOnSigint) {
+                    if (!vm.hasPendingTerminationException())
+                        vm.throwTerminationException();
+                    return {};
+                }
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                NodeVM::consumeTermination(vm);
+                if (!NodeVM::consumeTermination(vm)) {
+                    vm.throwTerminationException();
+                    return {};
+                }
                 if (getSigintReceived()) {
                     setSigintReceived(false);
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                } else if (timeout != 0 || !breakOnSigint) {
+                } else if (timeout != 0) {
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
                 } else {
-                    // SIGINT raced the watcher registration or teardown, setting
-                    // the request without the paired sigintReceived flag.
+                    // breakOnSigint was armed, but SIGINT raced the watcher
+                    // registration or teardown past the sigintReceived flag.
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
                 }
                 return {};
@@ -257,20 +267,28 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
         return {};
     }
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
+        // Not armed by this evaluation and not flagged for it: an outer vm
+        // frame's interrupt. Propagate the termination.
+        if (!getSigintReceived() && timeout == 0 && !breakOnSigint) {
+            if (!vm.hasPendingTerminationException())
+                vm.throwTerminationException();
+            return {};
+        }
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        NodeVM::consumeTermination(vm);
+        if (!NodeVM::consumeTermination(vm)) {
+            vm.throwTerminationException();
+            return {};
+        }
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else if (timeout != 0) {
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
-        } else if (breakOnSigint) {
-            // SIGINT raced the watcher registration or teardown, setting the
-            // request without the paired sigintReceived flag.
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
+            // breakOnSigint was armed, but SIGINT raced the watcher
+            // registration or teardown past the sigintReceived flag.
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         }
     } else {
         setSigintReceived(false);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -113,8 +113,12 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
                 if (getSigintReceived()) {
                     setSigintReceived(false);
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
-                } else {
+                } else if (timeout != 0 || !breakOnSigint) {
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
+                } else {
+                    // SIGINT raced the watcher registration or teardown, setting
+                    // the request without the paired sigintReceived flag.
+                    throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
                 }
                 return {};
             }
@@ -261,6 +265,10 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else if (timeout != 0) {
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, timeout, "ms"_s));
+        } else if (breakOnSigint) {
+            // SIGINT raced the watcher registration or teardown, setting the
+            // request without the paired sigintReceived flag.
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else {
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.SourceTextModule evaluation terminated due neither to SIGINT nor to timeout");
         }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -109,11 +109,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
                 vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
                 DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-                vm.clearHasTerminationRequest();
-                // A termination that interrupted Atomics.wait bypassed
-                // handleTraps, leaving the NeedTermination trap pending;
-                // clear it so it can't re-terminate the surviving VM.
-                vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+                NodeVM::consumeTermination(vm);
                 if (getSigintReceived()) {
                     setSigintReceived(false);
                     throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
@@ -259,11 +255,7 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
     if (vm.hasTerminationRequest() || vm.hasPendingTerminationException()) {
         vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        // A termination that interrupted Atomics.wait bypassed handleTraps,
-        // leaving the NeedTermination trap pending; clear it so it can't
-        // re-terminate the surviving VM.
-        vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+        NodeVM::consumeTermination(vm);
         if (getSigintReceived()) {
             setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -73,11 +73,12 @@ void NodeVMModule::reconcileEvaluationState(JSC::VM& vm)
 bool NodeVMModule::reportOwnedTermination(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMGlobalObject* nodeVmGlobalObject, uint32_t timeout, bool breakOnSigint)
 {
     VM& vm = JSC::getVM(globalObject);
-    // Ours only if the VM is not being stopped and this evaluation armed an
-    // interrupt source; otherwise the termination belongs to VM teardown or
-    // an outer vm frame (nested runs share the VM).
+    // Ours only if the VM is not being stopped and this evaluation can
+    // attribute the termination to its own arming: a flagged SIGINT, its own
+    // {timeout}, or breakOnSigint with no enclosing armed watchdog (an armed
+    // outer watchdog means this is the outer frame's timeout firing).
     bool owned = Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle)
-        && (getSigintReceived() || timeout != 0 || breakOnSigint);
+        && (getSigintReceived() || timeout != 0 || (breakOnSigint && !NodeVM::outerWatchdogArmed(vm)));
     if (!owned) {
         if (!vm.hasPendingTerminationException())
             vm.throwTerminationException();
@@ -86,7 +87,7 @@ bool NodeVMModule::reportOwnedTermination(JSC::JSGlobalObject* globalObject, JSC
     vm.drainMicrotasksForGlobalObject(nodeVmGlobalObject);
     if (vm.hasPendingTerminationException())
         DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-    if (!NodeVM::consumeTermination(vm)) {
+    if (!NodeVM::consumeTermination(vm, timeout != 0)) {
         vm.throwTerminationException();
         return false;
     }

--- a/src/jsc/bindings/NodeVMModule.h
+++ b/src/jsc/bindings/NodeVMModule.h
@@ -61,6 +61,12 @@ public:
 
     JSValue evaluate(JSGlobalObject* globalObject, uint32_t timeout, bool breakOnSigint);
 
+    // Consume a termination this evaluation owns and throw the matching
+    // ERR_SCRIPT_EXECUTION_* (returns true), or propagate one that is not
+    // ours: VM teardown, an outer vm frame's interrupt, or a worker stop
+    // that raced the consume (returns false, termination left pending).
+    bool reportOwnedTermination(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMGlobalObject* nodeVmGlobalObject, uint32_t timeout, bool breakOnSigint);
+
     // For top-level-await modules JSC finishes evaluation asynchronously
     // (record status EvaluatingAsync -> Evaluated); pull the final state into
     // m_status/m_evaluationException once the record has settled.

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -315,25 +315,29 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         // evaluate() caught like any other exception.
         if (!Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle))
             return false;
+        // Not armed by this run and not flagged for it: the interrupt belongs
+        // to an outer vm frame (nested runs share the VM), whose own
+        // checkForTermination reports it. Leave the request pending.
+        if (!script->getSigintReceived() && !timeout && !breakOnSigint)
+            return false;
         vm.drainMicrotasksForGlobalObject(globalObject);
         // The termination may have fired inside an afterEvaluate microtask
         // checkpoint, leaving the termination exception pending; clear it so
         // the ERR_SCRIPT_EXECUTION_* error below replaces it.
         if (vm.hasPendingTerminationException())
             DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        consumeTermination(vm);
+        if (!consumeTermination(vm))
+            return false;
         if (script->getSigintReceived()) {
             script->setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else if (timeout) {
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
-        } else if (breakOnSigint) {
-            // SIGINT raced the watcher registration or teardown: the watcher
-            // observed the global but not the script receiver, so the request
-            // was set without the paired sigintReceived flag.
-            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else {
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
+            // breakOnSigint was armed, but SIGINT raced the watcher
+            // registration or teardown, so the paired sigintReceived flag
+            // was not set. It is still an interrupt.
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         }
         return true;
     }

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -321,12 +321,7 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         // the ERR_SCRIPT_EXECUTION_* error below replaces it.
         if (vm.hasPendingTerminationException())
             DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        vm.clearHasTerminationRequest();
-        // If the termination interrupted Atomics.wait, the waiter observed
-        // hasTerminationRequest() directly and the NeedTermination trap was
-        // never serviced by handleTraps. Clear it so the next trap check
-        // doesn't re-terminate the VM we just revived.
-        vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
+        consumeTermination(vm);
         if (script->getSigintReceived()) {
             script->setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -326,8 +326,12 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         // the ERR_SCRIPT_EXECUTION_* error below replaces it.
         if (vm.hasPendingTerminationException())
             DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        if (!consumeTermination(vm))
+        if (!consumeTermination(vm)) {
+            // Deliver the re-armed worker stop right away; the caller's
+            // RETURN_IF_EXCEPTION propagates it.
+            vm.throwTerminationException();
             return false;
+        }
         if (script->getSigintReceived()) {
             script->setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -315,10 +315,12 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         // evaluate() caught like any other exception.
         if (!Bun__VmHandle__scriptAllowed(WebCore::clientData(vm)->vmHandle))
             return false;
-        // Not armed by this run and not flagged for it: the interrupt belongs
-        // to an outer vm frame (nested runs share the VM), whose own
-        // checkForTermination reports it. Leave the request pending.
-        if (!script->getSigintReceived() && !timeout && !breakOnSigint)
+        // Not attributable to this run: no SIGINT flag, no own timeout, and
+        // breakOnSigint alone cannot claim it while an enclosing frame's
+        // watchdog is armed (that is the outer timeout firing during this
+        // run). The owning frame's checkForTermination reports it; leave the
+        // request pending.
+        if (!script->getSigintReceived() && !timeout && (!breakOnSigint || outerWatchdogArmed(vm)))
             return false;
         vm.drainMicrotasksForGlobalObject(globalObject);
         // The termination may have fired inside an afterEvaluate microtask
@@ -326,7 +328,7 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         // the ERR_SCRIPT_EXECUTION_* error below replaces it.
         if (vm.hasPendingTerminationException())
             DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
-        if (!consumeTermination(vm)) {
+        if (!consumeTermination(vm, timeout.has_value())) {
             // Deliver the re-armed worker stop right away; the caller's
             // RETURN_IF_EXCEPTION propagates it.
             vm.throwTerminationException();

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -322,6 +322,11 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
         if (vm.hasPendingTerminationException())
             DECLARE_TOP_EXCEPTION_SCOPE(vm).clearException();
         vm.clearHasTerminationRequest();
+        // If the termination interrupted Atomics.wait, the waiter observed
+        // hasTerminationRequest() directly and the NeedTermination trap was
+        // never serviced by handleTraps. Clear it so the next trap check
+        // doesn't re-terminate the VM we just revived.
+        vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
         if (script->getSigintReceived()) {
             script->setSigintReceived(false);
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -307,7 +307,7 @@ void NodeVMScript::destroy(JSCell* cell)
     static_cast<NodeVMScript*>(cell)->NodeVMScript::~NodeVMScript();
 }
 
-static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout)
+static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, NodeVMScript* script, std::optional<double> timeout, bool breakOnSigint)
 {
     if (vm.hasTerminationRequest()) {
         // The whole VM is being stopped (worker terminate()/exit): that
@@ -327,6 +327,11 @@ static bool checkForTermination(JSC::VM& vm, JSC::JSGlobalObject* globalObject, 
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else if (timeout) {
             throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_TIMEOUT, makeString("Script execution timed out after "_s, *timeout, "ms"_s));
+        } else if (breakOnSigint) {
+            // SIGINT raced the watcher registration or teardown: the watcher
+            // observed the global but not the script receiver, so the request
+            // was set without the paired sigintReceived flag.
+            throwError(globalObject, scope, ErrorCode::ERR_SCRIPT_EXECUTION_INTERRUPTED, "Script execution was interrupted by `SIGINT`"_s);
         } else {
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("vm.Script terminated due neither to SIGINT nor to timeout");
         }
@@ -414,7 +419,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
         vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
     }
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, newLimit, options.breakOnSigint)) {
         return {};
     }
 
@@ -481,7 +486,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
         vm.watchdog()->setTimeLimit(WTF::Seconds::fromMilliseconds(*oldLimit));
     }
 
-    if (checkForTermination(vm, globalObject, scope, script, newLimit)) {
+    if (checkForTermination(vm, globalObject, scope, script, newLimit, options.breakOnSigint)) {
         return {};
     }
 

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -207,7 +207,15 @@ bool SigintWatcher::signalAll()
     }
 
     for (JSGlobalObject* globalObject : m_globalObjects) {
-        globalObject->vm().notifyNeedTermination();
+        JSC::VM& vm = globalObject->vm();
+        // The NeedTermination trap alone cannot interrupt a thread parked in
+        // Atomics.wait: VMTraps wakes vm.syncWaiter(), but the park loop in
+        // WaiterListManager::waitForSync only exits on hasTerminationRequest(),
+        // which is otherwise set at a safepoint the parked thread never
+        // reaches. Set it first so the woken waiter observes the interrupt
+        // instead of re-parking forever.
+        vm.setHasTerminationRequest();
+        vm.notifyNeedTermination();
     }
 
     return true;

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -1,6 +1,8 @@
 #include "NodeVM.h"
 #include "SigintWatcher.h"
 
+#include <JavaScriptCore/WaiterListManager.h>
+
 #if OS(WINDOWS)
 #include <windows.h>
 #endif
@@ -213,6 +215,12 @@ bool SigintWatcher::signalAll()
         // but is serviced only at safepoints, which a parked thread never reaches.
         vm.setHasTerminationRequest();
         vm.notifyNeedTermination();
+        // fireTrap only notifies the sync waiter on the first thread-stop
+        // request; if another async trap (a {timeout} watchdog fire) already
+        // requested one, the parked waiter would not be woken. POSIX hides
+        // this behind the trap SignalSender's retry loop, but that is
+        // compiled out on Windows and under usePollingTraps.
+        vm.syncWaiter()->condition().notifyOne();
     }
 
     return true;

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -208,12 +208,9 @@ bool SigintWatcher::signalAll()
 
     for (JSGlobalObject* globalObject : m_globalObjects) {
         JSC::VM& vm = globalObject->vm();
-        // The NeedTermination trap alone cannot interrupt a thread parked in
-        // Atomics.wait: VMTraps wakes vm.syncWaiter(), but the park loop in
-        // WaiterListManager::waitForSync only exits on hasTerminationRequest(),
-        // which is otherwise set at a safepoint the parked thread never
-        // reaches. Set it first so the woken waiter observes the interrupt
-        // instead of re-parking forever.
+        // Atomics.wait's park loop (WaiterListManager::waitForSync) only exits
+        // on hasTerminationRequest(); the NeedTermination trap wakes the waiter
+        // but is serviced only at safepoints, which a parked thread never reaches.
         vm.setHasTerminationRequest();
         vm.notifyNeedTermination();
     }

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1521,8 +1521,10 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
     return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   }
 
-  test.concurrent("script", async () => {
-    const fixture = `
+  test.concurrent(
+    "script",
+    async () => {
+      const fixture = `
       const vm = require("node:vm");
       const { Worker } = require("node:worker_threads");
       const sab = new SharedArrayBuffer(8);
@@ -1536,14 +1538,18 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
       }
       ${proveStillAlive}
     `;
-    const [stdout, stderr, exitCode] = await run(fixture);
-    expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-  }, 20_000);
+      const [stdout, stderr, exitCode] = await run(fixture);
+      expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    20_000,
+  );
 
-  test.concurrent("source text module", async () => {
-    const fixture = `
+  test.concurrent(
+    "source text module",
+    async () => {
+      const fixture = `
       const vm = require("node:vm");
       const { Worker } = require("node:worker_threads");
       const sab = new SharedArrayBuffer(8);
@@ -1559,9 +1565,11 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
       }
       ${proveStillAlive}
     `;
-    const [stdout, stderr, exitCode] = await run(fixture);
-    expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-  }, 20_000);
+      const [stdout, stderr, exitCode] = await run(fixture);
+      expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    20_000,
+  );
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1493,13 +1493,14 @@ test("node:vm Object.defineProperty on the context global when the sandbox is an
 // afterward so the surviving thread is not re-terminated at its next trap
 // check.
 describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
-  // Atomics.notify returning 1 proves the main thread is parked; the short
-  // wait lets it re-enter the park before SIGINT is sent.
+  // Each Atomics.notify returning 1 proves the guest thread is parked at that
+  // instant; the second spin observes the re-park after the first wake, so
+  // SIGINT is only sent against a provably parked (or just-woken) guest.
   const workerSource = `
     const { workerData } = require("node:worker_threads");
     const ia = new Int32Array(workerData);
     while (Atomics.notify(ia, 0, 1) === 0) {}
-    Atomics.wait(ia, 1, 0, 100);
+    while (Atomics.notify(ia, 0, 1) === 0) {}
     process.kill(process.pid, "SIGINT");
   `;
 
@@ -1608,10 +1609,10 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
         messages.push(m);
         if (m === "alive") aliveResolve();
       });
-      // Atomics.notify returning 1 proves the worker is parked inside the
-      // guest's Atomics.wait; then give it 100ms to re-enter the park.
+      // Each Atomics.notify returning 1 proves the worker is parked inside
+      // the guest's Atomics.wait; the second spin observes the re-park.
       while (Atomics.notify(ia, 0, 1) === 0) {}
-      Atomics.wait(ia, 1, 0, 100);
+      while (Atomics.notify(ia, 0, 1) === 0) {}
       process.kill(process.pid, "SIGINT");
       await alive;
       phase = "post";
@@ -1681,7 +1682,13 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
           \`const { workerData } = require("node:worker_threads");
            const ia = new Int32Array(workerData);
            while (Atomics.notify(ia, 0, 1) === 0) {}
+           // The 400ms wait is wall-clock ordering, not a park grace: the
+           // 200ms watchdog timer must fire (claiming the thread-stop
+           // request) before SIGINT arrives, or this test degenerates into
+           // the plain interrupt path. The final spin proves the guest is
+           // parked again when SIGINT is sent.
            Atomics.wait(ia, 1, 0, 400);
+           while (Atomics.notify(ia, 0, 1) === 0) {}
            process.kill(process.pid, "SIGINT");\`,
           { eval: true, workerData: sab },
         ).unref();

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1572,4 +1572,107 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
     },
     20_000,
   );
+
+  // The inverted topology the watcher's cross-thread machinery exists for:
+  // the guest runs inside a worker_threads Worker while the process-wide
+  // SIGINT arrives on the main thread. Also pins the listener semantics: a
+  // main-thread SIGINT listener must not fire while the watcher holds the
+  // signal, and must fire again once the breakOnSigint run is over.
+  test.concurrent(
+    "script hosted in a worker",
+    async () => {
+      const fixture = `
+      const { Worker } = require("node:worker_threads");
+      const sab = new SharedArrayBuffer(8);
+      const ia = new Int32Array(sab);
+      let phase = "hold";
+      let holdCount = 0;
+      const { promise: post, resolve: postResolve } = Promise.withResolvers();
+      process.on("SIGINT", () => (phase === "hold" ? holdCount++ : postResolve()));
+      const w = new Worker(
+        \`const { parentPort, workerData } = require("node:worker_threads");
+         const vm = require("node:vm");
+         globalThis.ia = new Int32Array(workerData);
+         try {
+           vm.runInThisContext("for(;;) Atomics.wait(ia, 0, 0);", { breakOnSigint: true });
+           parentPort.postMessage("returned");
+         } catch (e) {
+           parentPort.postMessage("caught " + e.code);
+         }
+         parentPort.postMessage("alive");\`,
+        { eval: true, workerData: sab },
+      );
+      const { promise: alive, resolve: aliveResolve } = Promise.withResolvers();
+      const messages = [];
+      w.on("message", m => {
+        messages.push(m);
+        if (m === "alive") aliveResolve();
+      });
+      // Atomics.notify returning 1 proves the worker is parked inside the
+      // guest's Atomics.wait; then give it 100ms to re-enter the park.
+      while (Atomics.notify(ia, 0, 1) === 0) {}
+      Atomics.wait(ia, 1, 0, 100);
+      process.kill(process.pid, "SIGINT");
+      await alive;
+      phase = "post";
+      process.kill(process.pid, "SIGINT");
+      await post;
+      console.log(JSON.stringify({ messages, holdCount }));
+      process.exit(0);
+    `;
+      const [stdout, stderr, exitCode] = await run(fixture);
+      expect(stdout.trim()).toBe(
+        JSON.stringify({ messages: ["caught ERR_SCRIPT_EXECUTION_INTERRUPTED", "alive"], holdCount: 0 }),
+      );
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    20_000,
+  );
+
+  // breakOnSigint composed with {timeout}: the watchdog's NeedWatchdogCheck
+  // fires first and claims the thread-stop request, so the SIGINT's own trap
+  // does not notify the parked waiter; the watcher's direct syncWaiter notify
+  // is what delivers the wake. Run under both trap configurations: polling
+  // traps has no signal-sender retry loop to paper over a missed notify
+  // (Windows always behaves like polling traps).
+  for (const usePollingTraps of [false, true]) {
+    test.concurrent(
+      `script with timeout armed${usePollingTraps ? " (polling traps)" : ""}`,
+      async () => {
+        const fixture = `
+        const vm = require("node:vm");
+        const { Worker } = require("node:worker_threads");
+        const sab = new SharedArrayBuffer(8);
+        globalThis.ia = new Int32Array(sab);
+        new Worker(
+          \`const { workerData } = require("node:worker_threads");
+           const ia = new Int32Array(workerData);
+           while (Atomics.notify(ia, 0, 1) === 0) {}
+           Atomics.wait(ia, 1, 0, 400);
+           process.kill(process.pid, "SIGINT");\`,
+          { eval: true, workerData: sab },
+        ).unref();
+        try {
+          vm.runInThisContext("for(;;) Atomics.wait(ia, 0, 0);", { breakOnSigint: true, timeout: 200 });
+          console.log("returned");
+        } catch (e) {
+          console.log("caught", e.code);
+        }
+        ${proveStillAlive}
+      `;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", fixture],
+          env: usePollingTraps ? { ...bunEnv, BUN_JSC_usePollingTraps: "1" } : bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+      },
+      20_000,
+    );
+  }
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1630,6 +1630,38 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
     20_000,
   );
 
+  // A nested plain run must not consume (or crash on) an interrupt that
+  // belongs to the outer breakOnSigint frame, and the guest's own try/catch
+  // must not observe the uncatchable termination; the outer frame reports it.
+  test.concurrent(
+    "nested plain run inside a breakOnSigint run",
+    async () => {
+      const fixture = `
+      const vm = require("node:vm");
+      const { Worker } = require("node:worker_threads");
+      const sab = new SharedArrayBuffer(8);
+      globalThis.ia = new Int32Array(sab);
+      globalThis.vm = vm;
+      new Worker(${JSON.stringify(workerSource)}, { eval: true, workerData: sab }).unref();
+      try {
+        vm.runInThisContext(
+          "try { vm.runInThisContext('for(;;) Atomics.wait(ia, 0, 0);'); } catch (e) { console.log('guest caught', String(e)); } console.log('guest after');",
+          { breakOnSigint: true },
+        );
+        console.log("returned");
+      } catch (e) {
+        console.log("caught", e.code);
+      }
+      ${proveStillAlive}
+    `;
+      const [stdout, stderr, exitCode] = await run(fixture);
+      expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    20_000,
+  );
+
   // breakOnSigint composed with {timeout}: the watchdog's NeedWatchdogCheck
   // fires first and claims the thread-stop request, so the SIGINT's own trap
   // does not notify the parked waiter; the watcher's direct syncWaiter notify
@@ -1676,3 +1708,34 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
     );
   }
 });
+
+// A nested vm run with no options observes the shared VM's termination
+// request when the outer frame's {timeout} watchdog fires; its cleanup used
+// to hit RELEASE_ASSERT_NOT_REACHED ("terminated due neither to SIGINT nor
+// to timeout"), a crash in release builds too. The inner run must leave the
+// request for the outer frame, which reports the timeout as node does.
+test.concurrent("nested vm run propagates the outer frame's termination", async () => {
+  const fixture = `
+    const vm = require("node:vm");
+    globalThis.vm = vm;
+    try {
+      vm.runInThisContext("vm.runInThisContext('for(;;);');", { timeout: 100 });
+      console.log("returned");
+    } catch (e) {
+      console.log("caught", e.code);
+    }
+    let n = 0;
+    for (let i = 0; i < 100000; i++) n++;
+    console.log("alive", n === 100000);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_TIMEOUT\nalive true\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}, 20_000);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1714,8 +1714,10 @@ describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
 // to hit RELEASE_ASSERT_NOT_REACHED ("terminated due neither to SIGINT nor
 // to timeout"), a crash in release builds too. The inner run must leave the
 // request for the outer frame, which reports the timeout as node does.
-test.concurrent("nested vm run propagates the outer frame's termination", async () => {
-  const fixture = `
+test.concurrent(
+  "nested vm run propagates the outer frame's termination",
+  async () => {
+    const fixture = `
     const vm = require("node:vm");
     globalThis.vm = vm;
     try {
@@ -1728,14 +1730,16 @@ test.concurrent("nested vm run propagates the outer frame's termination", async 
     for (let i = 0; i < 100000; i++) n++;
     console.log("alive", n === 100000);
   `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_TIMEOUT\nalive true\n");
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-}, 20_000);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_TIMEOUT\nalive true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1750,3 +1750,41 @@ test.concurrent(
   },
   20_000,
 );
+
+// An inner breakOnSigint-only run must not claim the outer frame's watchdog
+// termination as a SIGINT: the misattributed (and catchable) error would let
+// the guest swallow it and keep running with the outer's one-shot watchdog
+// already spent, silently bypassing the outer {timeout}. The termination must
+// propagate uncatchably to the outer frame, which reports the timeout.
+test.concurrent(
+  "outer timeout fires during a nested breakOnSigint run",
+  async () => {
+    const fixture = `
+    const vm = require("node:vm");
+    globalThis.vm = vm;
+    try {
+      vm.runInThisContext(
+        "try { vm.runInThisContext('for(;;);', { breakOnSigint: true }); } catch (e) { console.log('guest caught', e.code); } for(;;);",
+        { timeout: 100 },
+      );
+      console.log("returned");
+    } catch (e) {
+      console.log("caught", e.code);
+    }
+    let n = 0;
+    for (let i = 0; i < 100000; i++) n++;
+    console.log("alive", n === 100000);
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_TIMEOUT\nalive true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import {
   compileFunction,
   constants,
@@ -1483,4 +1483,85 @@ test("node:vm Object.defineProperty on the context global when the sandbox is an
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe(JSON.stringify({ result: 1, sandboxArray: 1 }));
   expect(exitCode).toBe(0);
+});
+
+// breakOnSigint must interrupt a guest parked in Atomics.wait. The SIGINT
+// watcher thread fires the NeedTermination trap, which wakes the VM's sync
+// waiter, but JSC's park loop re-parks unless vm.hasTerminationRequest() is
+// set, and no safepoint inside the futex wait ever sets it. The watcher now
+// sets the request itself, and the vm entry points clear the unserviced trap
+// afterward so the surviving thread is not re-terminated at its next trap
+// check.
+describe.skipIf(isWindows)("breakOnSigint interrupts Atomics.wait", () => {
+  // Atomics.notify returning 1 proves the main thread is parked; the short
+  // wait lets it re-enter the park before SIGINT is sent.
+  const workerSource = `
+    const { workerData } = require("node:worker_threads");
+    const ia = new Int32Array(workerData);
+    while (Atomics.notify(ia, 0, 1) === 0) {}
+    Atomics.wait(ia, 1, 0, 100);
+    process.kill(process.pid, "SIGINT");
+  `;
+
+  // The loop and call after catching are trap checks: they would rethrow the
+  // termination if the NeedTermination trap were left pending.
+  const proveStillAlive = `
+    let n = 0;
+    for (let i = 0; i < 100000; i++) n++;
+    (function alive() { console.log("alive", n === 100000); })();
+  `;
+
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  test.concurrent("script", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const { Worker } = require("node:worker_threads");
+      const sab = new SharedArrayBuffer(8);
+      globalThis.ia = new Int32Array(sab);
+      new Worker(${JSON.stringify(workerSource)}, { eval: true, workerData: sab }).unref();
+      try {
+        vm.runInThisContext("for(;;) Atomics.wait(ia, 0, 0);", { breakOnSigint: true });
+        console.log("returned");
+      } catch (e) {
+        console.log("caught", e.code);
+      }
+      ${proveStillAlive}
+    `;
+    const [stdout, stderr, exitCode] = await run(fixture);
+    expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }, 20_000);
+
+  test.concurrent("source text module", async () => {
+    const fixture = `
+      const vm = require("node:vm");
+      const { Worker } = require("node:worker_threads");
+      const sab = new SharedArrayBuffer(8);
+      const context = vm.createContext({ ia: new Int32Array(sab) });
+      new Worker(${JSON.stringify(workerSource)}, { eval: true, workerData: sab }).unref();
+      const mod = new vm.SourceTextModule("for(;;) Atomics.wait(ia, 0, 0);", { context });
+      await mod.link(() => { throw new Error("unexpected import"); });
+      try {
+        await mod.evaluate({ breakOnSigint: true });
+        console.log("returned");
+      } catch (e) {
+        console.log("caught", e.code);
+      }
+      ${proveStillAlive}
+    `;
+    const [stdout, stderr, exitCode] = await run(fixture);
+    expect(stdout).toBe("caught ERR_SCRIPT_EXECUTION_INTERRUPTED\nalive true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }, 20_000);
 });


### PR DESCRIPTION
### Problem

A `breakOnSigint` vm script parked in `Atomics.wait` ignores SIGINT forever:

```js
const vm = require("node:vm");
const { Worker } = require("worker_threads");
const sab = new SharedArrayBuffer(16);
globalThis.ia = new Int32Array(sab);
new Worker(
  `const { workerData } = require("worker_threads");
   const ia = new Int32Array(workerData);
   while (Atomics.notify(ia, 0, 1) === 0) {}   // proves the main thread is parked
   Atomics.wait(ia, 1, 0, 100);                 // let it re-park
   process.kill(process.pid, "SIGINT");`,
  { eval: true, workerData: sab },
).unref();
try {
  vm.runInThisContext("for(;;) Atomics.wait(ia, 0, 0);", { breakOnSigint: true });
} catch (e) { console.log("caught", e.code); }
```

Node (v26.3.0) prints `caught ERR_SCRIPT_EXECUTION_INTERRUPTED` and exits 0. Bun hangs forever.

### Cause

Several layers of the off-thread termination contract were missing in how node:vm delivers and consumes a SIGINT interrupt.

1. **The park loop never observes the interrupt.** `SigintWatcher::signalAll()` only called `vm.notifyNeedTermination()`, which fires the `NeedTermination` VM trap. The trap machinery wakes the VM's sync Atomics waiter, but the park loop in `WaiterListManager::waitForSync` only exits when `vm.hasTerminationRequest()` is set:

   ```cpp
   while (syncWaiter->isOnList() && time.now() < time && !vm.hasTerminationRequest())
       syncWaiter->condition().waitUntil(list->lock, ...);
   ```

   That flag is normally set by `VMTraps::handleTraps` at a JS safepoint, and a thread parked in a futex never reaches one, so the woken waiter re-parks forever. The watcher now sets the request itself before firing the trap.

2. **The trap bit outlives the run.** Once the request is set off-thread, the woken waiter throws the termination exception directly (`AtomicsObject.cpp`), bypassing `handleTraps`, so the `NeedTermination` trap bit is never consumed. It re-fires at the next trap check, which lands inside `checkForTermination`'s own `throwError`: `createError` is terminated mid-construction and returns an empty `JSValue`, and `ThrowScope::throwException` calls `isObject()` on it (empty reports `isCell() == true` with `asCell() == nullptr`). On debug builds this is a deterministic UBSan abort before the script's catch block ever runs:

   ```
   JSCJSValueCell.h:77:34: runtime error: member call on null pointer of type 'JSC::JSCell'
     #1 JSC::ThrowScope::throwException(JSC::JSGlobalObject*, JSC::JSValue) ThrowScope.cpp:84
     #2 Bun::throwError(...) ErrorCode.cpp:1811
     #3 Bun::checkForTermination(...) NodeVMScript.cpp:327
   ```

   The points that consume a SIGINT/timeout termination and revive the VM now stand the trap machinery down (`NodeVM::consumeTermination`).

3. **The wake is skipped when `{timeout}` is also armed.** `fireTrap` only notifies the sync waiter on the first thread-stop request. With `{ breakOnSigint: true, timeout }` the watchdog's `NeedWatchdogCheck` fires first (and is never serviced while parked), so the later SIGINT's trap does not notify at all. POSIX default config recovers through the trap SignalSender's retry loop, but that component does not exist on Windows or under `usePollingTraps` (the composed case hung there), and the stale `NeedWatchdogCheck` reaching `Watchdog::startTimer` after the time limit was restored aborted debug builds with `ASSERTION FAILED: hasTimeLimit()`. The watcher now notifies `vm.syncWaiter()` directly, and `consumeTermination` clears `NeedWatchdogCheck` alongside `NeedTermination` (an outer timed run is unaffected: restoring its limit re-arms the timer).

4. **A raced SIGINT could trip a RELEASE_ASSERT.** The watcher reads the receiver and global-object lists in two critical sections, and the holder registers/unregisters them in two as well, so a SIGINT landing mid-registration or mid-teardown can set the request without the paired `sigintReceived` flag. `checkForTermination` treated that state as unreachable. With `breakOnSigint` armed it is now reported as `ERR_SCRIPT_EXECUTION_INTERRUPTED` like any other SIGINT.

5. **Nested vm runs consumed (or crashed on) the outer frame's interrupt.** Nested runs share the VM, so an inner run observes the request set for an outer `breakOnSigint`/`timeout` frame. An optionless inner run hit the same `RELEASE_ASSERT_NOT_REACHED`, which needs no SIGINT and crashes released bun on main today:

   ```js
   globalThis.vm = require("node:vm");
   vm.runInThisContext("vm.runInThisContext('for(;;);');", { timeout: 100 });
   // main (1.4.0 canary): panic(main thread): abort() called
   // node: throws ERR_SCRIPT_EXECUTION_TIMEOUT
   ```

   And an inner run armed only with `breakOnSigint` would have claimed an outer `{timeout}`'s termination as a SIGINT: the mislabeled error is catchable, and since only the run that armed the watchdog re-arms it, a guest swallowing it would run past the outer timeout forever. Attribution is now explicit: a termination is this run's to consume only for a flagged SIGINT, its own `{timeout}`, or `breakOnSigint` with no enclosing watchdog still armed (`Watchdog::hasTimeLimit`). Anything else propagates (uncatchable by guest JS) to the frame that armed it, which reports `ERR_SCRIPT_EXECUTION_TIMEOUT`/`_INTERRUPTED` as node does, and `consumeTermination` only stands down `NeedWatchdogCheck` for the run that armed the watchdog.

6. **Consuming could race `worker.terminate()`.** The new trap clearing runs after the `scriptAllowed` check, so a terminate landing in between would have its `NeedTermination` trap silently discarded (before this PR the trap survived and re-fired at the next safepoint, so terminate self-healed). `consumeTermination` re-checks `scriptAllowed` after clearing: `fireTrap` and `clearTrap` serialize on the trap-signaling lock, so a stop whose trap was cleared is provably visible to the re-check, and it is re-delivered while the caller propagates the termination instead of reporting `ERR_SCRIPT_EXECUTION_*`.

### Fix

- `SigintWatcher::signalAll()`: set `hasTerminationRequest` before `notifyNeedTermination()`, then notify `vm.syncWaiter()` unconditionally.
- `NodeVM::consumeTermination()` (new, used by `checkForTermination` and both `NodeVMModule::evaluate` blocks): clear the request plus the `NeedTermination` and `NeedWatchdogCheck` traps, re-delivering a raced worker stop.
- The consume sites propagate a termination this run did not arm (nested frames, raced terminate) and fall back to `ERR_SCRIPT_EXECUTION_INTERRUPTED` when `breakOnSigint` was armed and the request arrived without the `sigintReceived` flag. The `RELEASE_ASSERT_NOT_REACHED` there is gone.

This is the SIGINT sibling of the `worker.terminate()` fix in #32802 (a terminated worker's VM never runs again, so no trap cleanup is needed there). The `timeout` option's own inability to interrupt `Atomics.wait` is a separate watchdog redesign, tracked in #33764; this change only makes SIGINT able to rescue a composed run and composes with both PRs.

One known, pre-existing attribution gap remains out of scope: an inner `{timeout}` run nested in an outer `{breakOnSigint}` frame claims the outer's SIGINT as its own timeout (mislabeled, catchable; the next Ctrl+C works since the outer's watcher hold stays registered). Attributing that correctly needs "did this run's watchdog deadline actually pass", which `JSC::Watchdog` does not expose; the per-evaluation deadline in #33764 can answer it, so it belongs in that follow-up. The available "enclosing watcher hold active" signal cannot be used instead: it would mislabel every legitimate inner timeout under an outer `breakOnSigint` as an interrupt.

A residual nanosecond window remains on configs without the SignalSender (Windows, `usePollingTraps`): a notify that lands between the waiter's predicate check and its park is lost, and the next Ctrl+C delivers the interrupt. Closing it fully would need a watcher-side retry loop; before this PR every Ctrl+C was lost on every platform.

### Verification

- The repro above matches node v26.3.0 output exactly; the process keeps executing JS afterwards (trap checks would rethrow a lingering termination) and exits 0. The nested-timeout repro also now matches node (`ERR_SCRIPT_EXECUTION_TIMEOUT` instead of a panic).
- Eight tests in `test/js/node/vm/vm.test.ts`: Script path, `SourceTextModule.evaluate`, the worker-hosted guest (also pins that a main-thread SIGINT listener stays silent during the hold and fires again after), a nested plain run inside a `breakOnSigint` frame (the guest's try/catch must not observe the termination), the composed `{breakOnSigint, timeout}` mode under default and polling traps, the nested-timeout crash (cross-platform, no SIGINT needed), and the outer-timeout-during-nested-breakOnSigint bypass. All fail on bun without the fix (hang or abort).
- Windows x64, manually with a real console `CTRL_C_EVENT` (`GenerateConsoleCtrlEvent` from a worker, isolated console): canary bun hangs; this build prints `caught ERR_SCRIPT_EXECUTION_INTERRUPTED` / `alive true` and exits 0 in both plain and composed modes. The automated tests skip Windows because `process.kill` cannot deliver a console Ctrl+C there.
- Without the trap-bit clearing, the UBSan null-member-call fires 3/3 on the debug ASAN build; with it, 0/3. Without the direct waiter notify, composed mode aborts (default traps) or hangs (polling traps) deterministically; with it, both pass.
- `test/js/node/vm/vm.test.ts` (219 pass), `sourcetextmodule-*.test.ts`, node's `test-vm-sigint.js`, `test-vm-sigint-existing-handler.js`, `test-vm-break-on-sigint.js`, and `test/js/node/worker_threads/worker_threads.test.ts` (121 pass) are green on the debug build.
