### PR TITLE
Fix crash when a lazy Bun property builder throws during inspect

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,12 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy static
+                // property builders, including when the slot was not found.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -953,7 +953,9 @@ it("tolerates lazy Bun property builders that throw during the walk", async () =
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // stderr is drained alongside stdout so an aborting child cannot fill the
+  // pipe buffer and stall before exiting.
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toBe(["inspect: true", "sql: TypeError", "SQL: TypeError", ""].join("\n"));
   expect(exitCode).toBe(0);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,33 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+it("tolerates lazy Bun property builders that throw during the walk", async () => {
+  // Clobbering the global Symbol makes lazily-loaded internal modules (the
+  // builders behind Bun.$, Bun.sql, ...) throw from module scope when the
+  // property walk materializes them. The walk used to continue with that
+  // exception still pending, entering the next lazy builder with it.
+  const fixture = `
+    Symbol = NaN;
+    const out = Bun.inspect(Bun);
+    console.log("inspect:", typeof out === "string" && out.length > 0);
+    try { Bun.sql; console.log("sql: no error"); } catch (e) { console.log("sql:", e.constructor.name); }
+    try { Bun.SQL; console.log("SQL: no error"); } catch (e) { console.log("SQL:", e.constructor.name); }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      // Skip symbolizing a failure report; symbolization of the debug
+      // binary takes longer than the test timeout.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe(["inspect: true", "sql: TypeError", "SQL: TypeError", ""].join("\n"));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes a deterministic Fuzzilli crash (fingerprint `e42c73f70c7e7925`, debug assertion abort).

### Repro

```js
Symbol = NaN;        // any tampering that breaks internal module evaluation
Bun.inspect(Bun);    // or anything that renders Bun in an error message
```

The fuzzer hit this through `new CompressionStream(globalThis)`: the invalid `format` error message inspects the received value, the walk reaches the `Bun` object, and materializing the lazy `$` property evaluates `shell.ts`, which throws `Symbol is not a function` at module scope.

### What was wrong

Two pending-exception bugs, both only observable as aborts in debug/ASAN builds:

1. `JSC__JSValue__forEachPropertyImpl` cleared getter exceptions only when `getPropertySlot` reported the slot as found. A throwing lazy static property builder makes `getPropertySlot` return false with the exception left pending, so the `continue` skipped the clear and the walk entered the next lazy builder (`Bun.Archive`) with a pending exception, failing `releaseAssertNoException`. `JSC__JSValue__forEachPropertyOrdered` already clears before its `continue`; this applies the same order to the unordered walk.

2. The `Bun.sql` / `Bun.SQL` builders called `reportUncaughtExceptionAtEventLoop` (debug builds only) while the module-load exception was still pending. That runs the uncaughtException machinery, and its `process._fatalException` lookup reifies static properties with a pending exception, which makes the lookup loop see a stale `Structure*` and fail the `object->structure() == this` assertion in `Structure::storedPrototype`. Reachable with just `Symbol = NaN; Bun.sql`. The report is gone; `RETURN_IF_EXCEPTION` propagates the real module error to whoever touched the property (PR #27308 fixed an earlier version of this but was closed after the repo restructure made it unmergeable).

### After the fix

- `Bun.inspect(Bun)` completes, skipping properties whose builder threw.
- `Bun.sql` / `Bun.SQL` throw the underlying module error instead of aborting.
- The original fuzzer script exits with a regular uncaught `TypeError`.

### Testing

Added a regression test in `test/js/bun/util/inspect.test.js` that spawns a child which clobbers `Symbol`, inspects `Bun`, and touches `Bun.sql` / `Bun.SQL`. It fails on an unfixed debug build (child dies with SIGABRT) and passes with this change. Release builds compile these assertions out, so the crash does not reproduce under `USE_SYSTEM_BUN=1`; the fail-before was verified against an unfixed debug binary.

Pre-existing local failures in `inspect-error.test.js` (extra `at require` stack frame) reproduce identically on an unfixed binary and are unrelated.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->