### PR TITLE
error printer: fix infinite recursion when an error reaches itself through cause and errors

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3913,16 +3913,12 @@ pub mod formatter {
             writer_: &mut dyn bun_io::Write,
             value: JSValue,
         ) -> JsResult<()> {
-            // Deliberately left in the visited map: the printer re-enters
-            // this formatter for the error's `cause`/`errors` properties, and
-            // removing the value here let a self-referencing error recurse
-            // until stack overflow.
+            // The value stays in the visited map so re-entrant property
+            // formatting hits the `[Circular]` guard.
             let mut adapter = DynWriteAdapter::new(&mut *writer_);
             // SAFETY: per-thread VM.
             let vm = VirtualMachine::get().as_mut();
             vm.print_errorlike_object(value, None, None, self, adapter.interface(), C, false);
-            // `print_errorlike_object` returns unit; surface a pending
-            // exception as Err for `?`-chaining callers.
             if self.global_this.has_exception() {
                 return Err(jsc::JsError::Thrown);
             }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3913,29 +3913,22 @@ pub mod formatter {
             writer_: &mut dyn bun_io::Write,
             value: JSValue,
         ) -> JsResult<()> {
-            // Temporarily remove from the visited map to allow
-            // printErrorlikeObject to process it. The circular reference
-            // check is already done in print_as, so we know it's safe.
-            let was_in_map = if self.map_node.is_some() {
-                self.map.remove(&value).is_some()
-            } else {
-                false
-            };
-            let map_restore_ptr: *mut visited::Map = &raw mut self.map;
-            scopeguard::defer! {
-                // SAFETY: `self.map` outlives this guard; no other borrow is
-                // live at the drop point.
-                unsafe {
-                    if was_in_map {
-                        let _ = (*map_restore_ptr).insert(value, ());
-                    }
-                }
-            }
-
+            // The value must STAY in the visited map while the error printer
+            // runs: it re-enters this formatter for the error's properties
+            // (`cause` rendered inline, the `errors` array), and an error
+            // reachable from itself through those would otherwise recurse
+            // until the stack runs out (e.cause = e; e.errors = [e]).
             let mut adapter = DynWriteAdapter::new(&mut *writer_);
             // SAFETY: per-thread VM.
             let vm = VirtualMachine::get().as_mut();
             vm.print_errorlike_object(value, None, None, self, adapter.interface(), C, false);
+            // `print_errorlike_object` returns unit and can leave a pending
+            // exception (e.g. the AggregateError branch swallows `for_each`
+            // failures); restore the JsResult contract for `?`-chaining
+            // callers.
+            if self.global_this.has_exception() {
+                return Err(jsc::JsError::Thrown);
+            }
             Ok(())
         }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3913,19 +3913,16 @@ pub mod formatter {
             writer_: &mut dyn bun_io::Write,
             value: JSValue,
         ) -> JsResult<()> {
-            // The value must STAY in the visited map while the error printer
-            // runs: it re-enters this formatter for the error's properties
-            // (`cause` rendered inline, the `errors` array), and an error
-            // reachable from itself through those would otherwise recurse
-            // until the stack runs out (e.cause = e; e.errors = [e]).
+            // Deliberately left in the visited map: the printer re-enters
+            // this formatter for the error's `cause`/`errors` properties, and
+            // removing the value here let a self-referencing error recurse
+            // until stack overflow.
             let mut adapter = DynWriteAdapter::new(&mut *writer_);
             // SAFETY: per-thread VM.
             let vm = VirtualMachine::get().as_mut();
             vm.print_errorlike_object(value, None, None, self, adapter.interface(), C, false);
-            // `print_errorlike_object` returns unit and can leave a pending
-            // exception (e.g. the AggregateError branch swallows `for_each`
-            // failures); restore the JsResult contract for `?`-chaining
-            // callers.
+            // `print_errorlike_object` returns unit; surface a pending
+            // exception as Err for `?`-chaining callers.
             if self.global_this.has_exception() {
                 return Err(jsc::JsError::Thrown);
             }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6397,7 +6397,15 @@ impl VirtualMachine {
                         if global_ref.has_exception() {
                             global_ref.clear_exception();
                         }
-                    } else if global_ref.has_exception() || formatter.failed {
+                    } else if global_ref.has_exception() {
+                        // Propagate instead of returning Ok with the exception
+                        // still pending: `?`-chaining callers (console.log,
+                        // the worker error render) treat Ok as "nothing
+                        // pending", and a leaked exception trips
+                        // assertNoExceptionExceptTermination on the next
+                        // ExceptionScope in debug builds.
+                        return Err(crate::CrateError::JSError);
+                    } else if formatter.failed {
                         return Ok(());
                     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6398,9 +6398,6 @@ impl VirtualMachine {
                             global_ref.clear_exception();
                         }
                     } else if global_ref.has_exception() || formatter.failed {
-                        // Deliberate Ok with the exception left pending: Err
-                        // would get cleared upstream, and Bun.inspect rethrows
-                        // the pending overflow.
                         return Ok(());
                     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6398,13 +6398,9 @@ impl VirtualMachine {
                             global_ref.clear_exception();
                         }
                     } else if global_ref.has_exception() || formatter.failed {
-                        // Ok with the exception left pending, deliberately:
-                        // Err here would be cleared by
-                        // `print_error_from_maybe_private_data`, and callers
-                        // depend on the exception surviving (Bun.inspect
-                        // re-throws the stack-overflow RangeError;
-                        // `Formatter::print_error` converts it to Err(Thrown)
-                        // at the formatter boundary).
+                        // Deliberate Ok with the exception left pending: Err
+                        // would get cleared upstream, and Bun.inspect rethrows
+                        // the pending overflow.
                         return Ok(());
                     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6397,15 +6397,14 @@ impl VirtualMachine {
                         if global_ref.has_exception() {
                             global_ref.clear_exception();
                         }
-                    } else if global_ref.has_exception() {
-                        // Propagate instead of returning Ok with the exception
-                        // still pending: `?`-chaining callers (console.log,
-                        // the worker error render) treat Ok as "nothing
-                        // pending", and a leaked exception trips
-                        // assertNoExceptionExceptTermination on the next
-                        // ExceptionScope in debug builds.
-                        return Err(crate::CrateError::JSError);
-                    } else if formatter.failed {
+                    } else if global_ref.has_exception() || formatter.failed {
+                        // Ok with the exception left pending, deliberately:
+                        // Err here would be cleared by
+                        // `print_error_from_maybe_private_data`, and callers
+                        // depend on the exception surviving (Bun.inspect
+                        // re-throws the stack-overflow RangeError;
+                        // `Formatter::print_error` converts it to Err(Thrown)
+                        // at the formatter boundary).
                         return Ok(());
                     }
 

--- a/test/regression/issue/circular-error-stack.test.ts
+++ b/test/regression/issue/circular-error-stack.test.ts
@@ -82,3 +82,72 @@ test("error with circular reference in cause chain", async () => {
   expect(stdout).not.toContain("Maximum call stack");
   expect(stderr).not.toContain("Maximum call stack");
 });
+
+// A plain Error that is its own `cause` AND sits in its own `errors` array
+// used to alternate between the cause branch and the errors branch of the
+// printer, bypassing both cycle guards and crashing the process (SIGSEGV).
+test.concurrent("uncaught error that is its own cause and its own errors entry", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e;`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("error: cyc");
+  expect(stderr).toContain("[Circular]");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("console.log of error that is its own cause and its own errors entry", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const e = new Error('cyc'); e.cause = e; e.errors = [e]; console.log(e); console.log('after error print');`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("[Circular]");
+  expect(stdout).toContain("after error print");
+  expect(exitCode).toBe(0);
+});
+
+// Thrown inside a worker, the same cyclic error is rendered to build the
+// 'error' event payload. The render used to overflow, leaving the RangeError
+// pending across the dispatch (debug assert / aborted process), and the
+// serialization failure made the parent receive the rendered dump as
+// `message` instead of the real one.
+test.concurrent("worker uncaught cyclic error reaches the parent error event intact", async () => {
+  using dir = tempDir("worker-cyclic-error", {
+    "index.js": `
+      const { Worker } = require("node:worker_threads");
+      const src = "const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e";
+      const w = new Worker(src, { eval: true });
+      w.on("error", e => console.log("error-event", e.name, JSON.stringify(e.message)));
+      w.on("exit", c => console.log("worker-exit", c));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain('error-event Error "cyc"');
+  expect(stdout).toContain("worker-exit 1");
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/circular-error-stack.test.ts
+++ b/test/regression/issue/circular-error-stack.test.ts
@@ -136,10 +136,9 @@ test.concurrent("worker uncaught cyclic error reaches the parent error event int
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain('error-event Error "cyc"');
   expect(stdout).toContain("worker-exit 1");
-  expect(stderr).not.toContain("ASSERTION FAILED");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/circular-error-stack.test.ts
+++ b/test/regression/issue/circular-error-stack.test.ts
@@ -83,9 +83,6 @@ test("error with circular reference in cause chain", async () => {
   expect(stderr).not.toContain("Maximum call stack");
 });
 
-// A plain Error that is its own `cause` AND sits in its own `errors` array
-// used to alternate between the cause branch and the errors branch of the
-// printer, bypassing both cycle guards and crashing the process (SIGSEGV).
 test.concurrent("uncaught error that is its own cause and its own errors entry", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e;`],
@@ -94,7 +91,7 @@ test.concurrent("uncaught error that is its own cause and its own errors entry",
     stderr: "pipe",
   });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("error: cyc");
   expect(stderr).toContain("[Circular]");
@@ -113,18 +110,13 @@ test.concurrent("console.log of error that is its own cause and its own errors e
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout).toContain("[Circular]");
   expect(stdout).toContain("after error print");
   expect(exitCode).toBe(0);
 });
 
-// Thrown inside a worker, the same cyclic error is rendered to build the
-// 'error' event payload. The render used to overflow, leaving the RangeError
-// pending across the dispatch (debug assert / aborted process), and the
-// serialization failure made the parent receive the rendered dump as
-// `message` instead of the real one.
 test.concurrent("worker uncaught cyclic error reaches the parent error event intact", async () => {
   using dir = tempDir("worker-cyclic-error", {
     "index.js": `


### PR DESCRIPTION
A plain `Error` that is its own `cause` and also sits in its own `errors` array crashes the process when the error printer renders it. Found sweeping hostile uncaught-error shapes delivered to `worker.on('error')`.

### Repro

```js
const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e;
```

- Main thread: prints `error: cyc / cause: ... / errors: [ ...` alternating, then silent SIGSEGV (exit 139) on 1.4.0-canary and main.
- Thrown inside a `node:worker_threads` Worker: debug/ASAN builds abort the whole process with `ASSERTION FAILED: Unexpected exception observed ... Error Exception: Maximum call stack size exceeded ... assertNoExceptionExceptTermination - ExceptionScope.h(63)`. Release survives, but the parent's `'error'` event receives the printer's multi-line rendered dump as `err.message` instead of `"cyc"`.
- `console.log(e)` on the same shape kills the script (exit 1) instead of continuing.
- Controls: `e.cause = e` alone and `e.errors = [e, e]` alone were already handled.

Node prints `<ref *1> Error: cyc ... cause: [Circular *1], errors: [ [Circular *1] ]` and exits 1.

### Cause

`Formatter::print_error` (the `Tag::Error` arm) removed the value from the formatter's visited set before re-entering `printErrorlikeObject`, reasoning that `print_as` had already done the circular check. But the error printer re-enters the formatter for the error's own properties: `cause` rendered inline and the `errors` array. Alternating between those two paths re-entered `print_error` each cycle, so the value was never in the set when it mattered and the recursion was unbounded. The cause-chain guard in `print_error_instance_body` keys on the same set, so it was bypassed the same way.

The worker abort is a second contract bug surfaced by the same shape: `print_error_instance_body` returned `Ok` with the thrown stack-overflow `RangeError` still pending when side effects are disallowed, so the worker's error render (`format2`) reported success and the pending exception tripped the next `ExceptionScope` assert; the pending exception also made the error serialization fail, which is why the parent saw the rendered dump as `message`.

### Fix

- Keep the value in the visited set across the `print_error` re-entry; self-references through `cause`/`errors` now print `[Circular]` like every other cycle.
- Restore the error contract at the formatter boundary: `Formatter::print_error` converts an exception left pending by `print_errorlike_object` (which returns unit) into `Err` for its `?`-chaining callers instead of reporting success. The exception itself stays pending and is never cleared on this path, so `Bun.inspect` still re-throws a genuine stack overflow from a deep non-cyclic chain (pinned by `bun-inspect.test.ts`), while the worker render can no longer return success with an exception pending.

With the cycle bounded, the worker render no longer overflows, nothing is left pending, and the parent receives `name`/`message` intact (matches Node).

Related open PRs cover adjacent shapes in the same printer: self-referencing `AggregateError` (#35820, #35825) and depth-capping deep cause chains (#35288).

### Verification

Tests added to `test/regression/issue/circular-error-stack.test.ts` (the file from the original cycle-guard fix, #22863): uncaught throw, `console.log`, and the worker delivery. All three fail on the unfixed build (SIGSEGV / exit 1 / ASAN abort with mangled message) and pass with the fix; the existing six tests in the neighboring error-printing suites (`inspect.test.js`, `reportError.test.ts`, worker_threads suite, console suites) stay green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/regression/issue/circular-error-stack.test.ts
bun test v1.4.0 (8326d1bd3)

test/regression/issue/circular-error-stack.test.ts:
(pass) error with circular stack reference should not cause infinite recursion [326.67ms]
(pass) error with nested circular references should not cause infinite recursion [292.19ms]
(pass) error with circular reference in cause chain [294.84ms]
92 |   });
93 | 
94 |   const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
95 | 
96 |   expect(stderr).toContain("error: cyc");
97 |   expect(stderr).toContain("[Circular]");
                      ^
error: expect(received).toContain(expected)

Expected to contain: "[Circular]"
Received: "1 | const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e;\n                  ^\nerror: cyc\n errors: [\n  1 | const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e;\n                  ^\nerror: cyc\n  cause: 1 | const e = new Error('cyc'); e.cause = e; e.errors = [e]; throw e;\n                  ^\nerror: cyc
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3cdb45c93)

test/regression/issue/circular-error-stack.test.ts:
(pass) error with circular stack reference should not cause infinite recursion [8.68ms]
(pass) error with nested circular references should not cause infinite recursion [8.38ms]
(pass) error with circular reference in cause chain [7.51ms]
(pass) console.log of error that is its own cause and its own errors entry [5.48ms]
(pass) uncaught error that is its own cause and its own errors entry [6.14ms]
(pass) worker uncaught cyclic error reaches the parent error event intact [44.03ms]

 6 pass
 0 fail
 21 expect() calls
Ran 6 tests across 1 file. [223.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/regression/issue/circular-error-stack.test.ts
bun test v1.4.0 (8326d1bd3)

test/regression/issue/circular-error-stack.test.ts:
(pass) error with circular stack reference should not cause infinite recursion [332.90ms]
(pass) error with nested circular references should not cause infinite recursion [292.49ms]
(pass) error with circular reference in cause chain [287.39ms]
(pass) uncaught error that is its own cause and its own errors entry [284.26ms]
(pass) console.log of error that is its own cause and its own errors entry [293.47ms]
(pass) worker uncaught cyclic error reaches the parent error event intact [2621.07ms]

 6 pass
 0 fail
 21 expect() calls
Ran 6 tests across 1 file. [5.89s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 595ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                           | 24 ++-------
 test/regression/issue/circular-error-stack.test.ts | 60 ++++++++++++++++++++++
 2 files changed, 65 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/ConsoleObject.rs                                8      6      0
test/regression/issue/circular-error-stack.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->
