### PR TITLE
install: don't let overrides displace workspace member links

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -693,8 +693,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             && (dependency.version.tag != dependency::version::Tag::Npm
                 || !dependency.version.npm().is_alias)
         {
-            if !links_workspace_member(this, &dependency.version, name, name_hash)
-                && let Some(new) = this.lockfile.overrides.get(name_hash)
+            if let Some(new) = this.lockfile.overrides.get(name_hash)
+                && !links_workspace_member(this, &dependency.version, name, name_hash)
             {
                 bun_output::scoped_log!(
                     PackageManager,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -688,18 +688,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         }
 
         // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>",
-        // is a workspaceOnly dependency, or links a present workspace member
+        // is a workspaceOnly dependency, or links a workspace member of this install
         if !dependency.behavior.is_workspace()
-            && !(dependency.version.tag == dependency::version::Tag::Workspace
-                && crate::lockfile::package_index::contains_workspace_package(
-                    &this.lockfile.package_index,
-                    this.lockfile.packages.items_resolution(),
-                    name_hash,
-                ))
             && (dependency.version.tag != dependency::version::Tag::Npm
                 || !dependency.version.npm().is_alias)
         {
-            if let Some(new) = this.lockfile.overrides.get(name_hash) {
+            if !links_workspace_member(this, &dependency.version, name, name_hash)
+                && let Some(new) = this.lockfile.overrides.get(name_hash)
+            {
                 bun_output::scoped_log!(
                     PackageManager,
                     "override: {} -> {}",
@@ -1912,6 +1908,60 @@ fn enqueue_local_tarball(
     let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
     // SAFETY: `get_init` just fully initialized the slot.
     unsafe { &raw mut (*task).threadpool_task }
+}
+
+/// Would this edge, absent overrides, resolve to a workspace member of the
+/// current install? Overrides skip such edges so they never displace a member
+/// link. Mirrors the linking rules: `Package::parse` rewrites satisfying npm
+/// ranges on versioned members to workspace links, and
+/// `get_or_put_resolved_package` links wildcard ranges through the root's
+/// workspace edges (`'resolve_from_workspace`). A `catalog:` edge links
+/// through whatever version the catalog materializes to. Ranges that do not
+/// link, and names whose member is missing from this run, stay overridable.
+fn links_workspace_member(
+    this: &PackageManager,
+    version: &dependency::Version,
+    name: SemverString,
+    name_hash: PackageNameHash,
+) -> bool {
+    let catalog_version;
+    let version = if version.tag == dependency::version::Tag::Catalog {
+        match this
+            .lockfile
+            .catalogs
+            .get(&this.lockfile, *version.catalog(), name)
+        {
+            Some(catalog_dep) => {
+                catalog_version = catalog_dep.version;
+                &catalog_version
+            }
+            None => return false,
+        }
+    } else {
+        version
+    };
+
+    match version.tag {
+        dependency::version::Tag::Workspace => this.lockfile.is_workspace_member_name(name_hash),
+        dependency::version::Tag::Npm => {
+            let npm = version.npm();
+            if npm.is_alias
+                || !this.options.link_workspace_packages
+                || !this.lockfile.is_workspace_member_name(name_hash)
+            {
+                return false;
+            }
+            if npm.version.is_star() {
+                return true;
+            }
+            let buf = this.lockfile.buffers.string_bytes.as_slice();
+            this.lockfile
+                .workspace_versions
+                .get(&name_hash)
+                .is_some_and(|workspace_version| npm.version.satisfies(*workspace_version, buf, buf))
+        }
+        _ => false,
+    }
 }
 
 fn update_name_and_name_hash_from_version_replacement(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -687,9 +687,16 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
         }
 
-        // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>" or
-        // if it's a workspaceOnly dependency
+        // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>",
+        // is a workspaceOnly dependency, or links a present workspace member (overrides never displace a workspace
+        // package; a `workspace:` dependency whose member is missing stays overridable)
         if !dependency.behavior.is_workspace()
+            && !(dependency.version.tag == dependency::version::Tag::Workspace
+                && crate::lockfile::package_index::contains_workspace_package(
+                    &this.lockfile.package_index,
+                    this.lockfile.packages.items_resolution(),
+                    name_hash,
+                ))
             && (dependency.version.tag != dependency::version::Tag::Npm
                 || !dependency.version.npm().is_alias)
         {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1958,7 +1958,9 @@ fn links_workspace_member(
             this.lockfile
                 .workspace_versions
                 .get(&name_hash)
-                .is_some_and(|workspace_version| npm.version.satisfies(*workspace_version, buf, buf))
+                .is_some_and(|workspace_version| {
+                    npm.version.satisfies(*workspace_version, buf, buf)
+                })
         }
         _ => false,
     }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -688,8 +688,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         }
 
         // allow overriding all dependencies unless the dependency is coming directly from an alias, "npm:<this dep>",
-        // is a workspaceOnly dependency, or links a present workspace member (overrides never displace a workspace
-        // package; a `workspace:` dependency whose member is missing stays overridable)
+        // is a workspaceOnly dependency, or links a present workspace member
         if !dependency.behavior.is_workspace()
             && !(dependency.version.tag == dependency::version::Tag::Workspace
                 && crate::lockfile::package_index::contains_workspace_package(

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2638,28 +2638,6 @@ pub mod package_index {
             Entry::Id(0)
         }
     }
-
-    /// Does a package with this name exist with a workspace resolution? Used
-    /// by the bun.lock loader, where the loaded lockfile is the member set
-    /// being reproduced; the fresh resolver keys the same exemption on the
-    /// current install's members (`Lockfile::is_workspace_member_name`).
-    pub(crate) fn contains_workspace_package(
-        map: &Map,
-        pkg_resolutions: &[Resolution],
-        name_hash: PackageNameHash,
-    ) -> bool {
-        let Some(entry) = map.get(&name_hash) else {
-            return false;
-        };
-        let ids: &[PackageID] = match entry {
-            Entry::Id(id) => core::slice::from_ref(id),
-            Entry::Ids(ids) => ids.as_slice(),
-        };
-        ids.iter().any(|&id| {
-            (id as usize) < pkg_resolutions.len()
-                && pkg_resolutions[id as usize].tag == ResolutionTag::Workspace
-        })
-    }
 }
 
 pub use package_index::Entry as PackageIndexEntry;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2623,9 +2623,8 @@ pub mod package_index {
     }
 
     /// Does a package with this name exist with a workspace resolution?
-    /// Unlike `Lockfile.workspace_paths` (which a `workspace:` dependency
-    /// also registers its name in, member or not), this only matches names
-    /// an actual workspace package resolved for.
+    /// `Lockfile.workspace_paths` is not equivalent: a `workspace:` dependency
+    /// registers its name there even when no member matches.
     pub(crate) fn contains_workspace_package(
         map: &Map,
         pkg_resolutions: &[Resolution],

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2621,6 +2621,28 @@ pub mod package_index {
             Entry::Id(0)
         }
     }
+
+    /// Does a package with this name exist with a workspace resolution?
+    /// Unlike `Lockfile.workspace_paths` (which a `workspace:` dependency
+    /// also registers its name in, member or not), this only matches names
+    /// an actual workspace package resolved for.
+    pub(crate) fn contains_workspace_package(
+        map: &Map,
+        pkg_resolutions: &[Resolution],
+        name_hash: PackageNameHash,
+    ) -> bool {
+        let Some(entry) = map.get(&name_hash) else {
+            return false;
+        };
+        let ids: &[PackageID] = match entry {
+            Entry::Id(id) => core::slice::from_ref(id),
+            Entry::Ids(ids) => ids.as_slice(),
+        };
+        ids.iter().any(|&id| {
+            (id as usize) < pkg_resolutions.len()
+                && pkg_resolutions[id as usize].tag == ResolutionTag::Workspace
+        })
+    }
 }
 
 pub use package_index::Entry as PackageIndexEntry;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -850,6 +850,23 @@ impl Lockfile {
         self.packages.items_dependencies()[0].contains(id)
     }
 
+    /// Is this name a workspace member of the current install, i.e. does the
+    /// root package carry an injected workspace edge for it? Unlike
+    /// `workspace_paths` (which a `workspace:` dependency with no matching
+    /// member also registers in) and `package_index` (which can still hold a
+    /// member a loaded lockfile resolved before the member directory was
+    /// removed), the root's workspace edges are rebuilt from package.json on
+    /// every install.
+    pub(crate) fn is_workspace_member_name(&self, name_hash: PackageNameHash) -> bool {
+        let Some(root) = self.root_package() else {
+            return false;
+        };
+        root.dependencies
+            .get(self.buffers.dependencies.as_slice())
+            .iter()
+            .any(|dep| dep.behavior.is_workspace() && dep.name_hash == name_hash)
+    }
+
     /// Is this a direct dependency of the workspace the install is taking place in?
     pub(crate) fn is_root_dependency(
         &self,
@@ -2622,9 +2639,10 @@ pub mod package_index {
         }
     }
 
-    /// Does a package with this name exist with a workspace resolution?
-    /// `Lockfile.workspace_paths` is not equivalent: a `workspace:` dependency
-    /// registers its name there even when no member matches.
+    /// Does a package with this name exist with a workspace resolution? Used
+    /// by the bun.lock loader, where the loaded lockfile is the member set
+    /// being reproduced; the fresh resolver keys the same exemption on the
+    /// current install's members (`Lockfile::is_workspace_member_name`).
     pub(crate) fn contains_workspace_package(
         map: &Map,
         pkg_resolutions: &[Resolution],

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3080,16 +3080,12 @@ fn resolve_peer_dep_version_based(
     // here would pick a version the override replaced. The printed tree
     // already reflects the overridden resolution, so overridden edges keep
     // the path walk. The exemptions mirror
-    // `enqueue_dependency_with_main_and_success_fn`: `npm:` aliases,
-    // workspace-only edges, and edges linking a present workspace member
-    // are never overridden.
+    // `enqueue_dependency_with_main_and_success_fn`: `npm:` aliases and
+    // workspace-only edges are never overridden. The fresh resolver's
+    // member-link exemption needs no clause here: a workspace-tagged edge
+    // falls through to `None` either way (`satisfies_dependency_version`
+    // and the kind fallback below never match the Workspace tag).
     let overridable = !dep.behavior.is_workspace()
-        && !(dep.version.tag == DependencyVersionTag::Workspace
-            && super::package_index::contains_workspace_package(
-                package_index,
-                pkg_resolutions,
-                name_hash,
-            ))
         && (dep.version.tag != DependencyVersionTag::Npm || !dep.version.npm().is_alias);
     if overridable && overrides.get(name_hash).is_some() {
         return None;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3080,9 +3080,16 @@ fn resolve_peer_dep_version_based(
     // here would pick a version the override replaced. The printed tree
     // already reflects the overridden resolution, so overridden edges keep
     // the path walk. The exemptions mirror
-    // `enqueue_dependency_with_main_and_success_fn`: `npm:` aliases and
-    // workspace-only edges are never overridden.
+    // `enqueue_dependency_with_main_and_success_fn`: `npm:` aliases,
+    // workspace-only edges, and edges linking a present workspace member
+    // are never overridden.
     let overridable = !dep.behavior.is_workspace()
+        && !(dep.version.tag == DependencyVersionTag::Workspace
+            && super::package_index::contains_workspace_package(
+                package_index,
+                pkg_resolutions,
+                name_hash,
+            ))
         && (dep.version.tag != DependencyVersionTag::Npm || !dep.version.npm().is_alias);
     if overridable && overrides.get(name_hash).is_some() {
         return None;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2189,6 +2189,236 @@ test.concurrent("override for a workspace member's name does not apply to a memb
   expect(await exited).toBe(0);
 });
 
+// Version-less members link through the resolver's wildcard rule instead of the
+// parse-time rewrite, so their edges stay npm-tagged; the override exemption must
+// cover that flavor too or the same DependencyLoop returns.
+test.concurrent("override for a version-less workspace member's name does not displace the member", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "*",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps" })),
+    write(
+      join(packageDir, "packages", "bar", "package.json"),
+      JSON.stringify({ name: "bar", version: "1.0.0", dependencies: { "no-deps": "*" } }),
+    ),
+  ]);
+
+  const proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderrText).not.toContain("dependency loop");
+  expect(exitCode).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+  });
+  expect(await exists(join(packageDir, "node_modules", "bar", "node_modules", "no-deps"))).toBe(false);
+});
+
+test.concurrent("override for a workspace member's name does not apply to a catalog: dependency", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        catalog: {
+          "no-deps": "^1.0.0",
+        },
+        dependencies: {
+          "no-deps": "catalog:",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  const proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderrText).not.toContain("dependency loop");
+  expect(exitCode).toBe(0);
+  // the catalog range links the member, so the override does not displace it
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+});
+
+// The exemption keys on the members of the current install, not on what the loaded
+// lockfile resolved: removing the member directory must hand the name back to the
+// override instead of failing on the stale workspace link forever.
+test.concurrent("removing the member migrates an exempted workspace: dependency to the override", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "workspace:*",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  let { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  let stderrText = await stderr.text();
+  expect(stderrText).not.toContain("dependency loop");
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+
+  await rm(join(packageDir, "packages", "m"), { recursive: true, force: true });
+
+  // the stale lockfile no longer matches: frozen installs report it instead of
+  // failing on the missing workspace
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).toContain("lockfile had changes");
+  expect(stderrText).not.toContain("Workspace dependency");
+  expect(await exited).toBe(1);
+
+  // a plain install migrates the name to the override
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).not.toContain("Workspace dependency");
+  expect(stderrText).toContain("Saved lockfile");
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "2.0.0",
+  });
+
+  // and converges
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).not.toContain("Saved lockfile");
+  expect(await exited).toBe(0);
+});
+
+test.concurrent("removing the member migrates an exempted npm-range dependency to the override", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "^1.0.0",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  let { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  let stderrText = await stderr.text();
+  expect(stderrText).not.toContain("dependency loop");
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+
+  await rm(join(packageDir, "packages", "m"), { recursive: true, force: true });
+
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).toContain("lockfile had changes");
+  expect(await exited).toBe(1);
+
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "2.0.0",
+  });
+});
+
 // A ranged `workspace:` dependency a present member cannot satisfy is rejected while
 // parsing package.json, before overrides are consulted, with or without this fix. The
 // override neither rescues it nor turns it into a resolution conflict.

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2412,11 +2412,25 @@ test.concurrent("removing the member migrates an exempted npm-range dependency t
     env,
   }));
   stderrText = await stderr.text();
+  expect(stderrText).not.toContain("Workspace dependency");
+  expect(stderrText).toContain("Saved lockfile");
   expect(await exited).toBe(0);
   expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
     name: "no-deps",
     version: "2.0.0",
   });
+
+  // and converges
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).not.toContain("Saved lockfile");
+  expect(await exited).toBe(0);
 });
 
 // A ranged `workspace:` dependency a present member cannot satisfy is rejected while

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1912,6 +1912,228 @@ test.concurrent("can override npm package with workspace package under a differe
   });
 });
 
+// An override for a name that is also a workspace member must not displace dependencies
+// that link to the member. Previously the override rewrote the workspace-linked edge back
+// to a registry range, leaving the root with two conflicting resolutions for the same name
+// and every install failed with "Package \"no-deps@2.0.0\" has a dependency loop (DependencyLoop)".
+test.concurrent("override for a workspace member's name does not displace the member", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "^1.0.0",
+          "one-dep": "1.0.0",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  let { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  let stderrText = await stderr.text();
+  expect(stderrText).not.toContain("dependency loop");
+  expect(stderrText).toContain("Saved lockfile");
+  expect(await exited).toBe(0);
+
+  // the satisfying range links the member; the override does not unlink it
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+  // the override still applies to registry edges with the same name
+  expect(
+    await file(join(packageDir, "node_modules", "one-dep", "node_modules", "no-deps", "package.json")).json(),
+  ).toEqual({
+    name: "no-deps",
+    version: "2.0.0",
+  });
+
+  // repeat install does not change the lockfile
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).not.toContain("Saved lockfile");
+  expect(await exited).toBe(0);
+
+  // --frozen-lockfile reinstalls from the lockfile
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install", "--frozen-lockfile"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).not.toContain("dependency loop");
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+});
+
+test.concurrent("override for a workspace member's name does not apply to workspace: dependencies", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "workspace:*",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await stderr.text()).not.toContain("dependency loop");
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+});
+
+test.concurrent("override for a workspace member's name does not apply to a sibling member's dependency", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+    write(
+      join(packageDir, "packages", "bar", "package.json"),
+      JSON.stringify({ name: "bar", version: "1.0.0", dependencies: { "no-deps": "^1.0.0" } }),
+    ),
+  ]);
+
+  const { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await stderr.text()).not.toContain("dependency loop");
+  expect(await exited).toBe(0);
+  // bar's satisfying range links the sibling member, so no overridden registry
+  // copy is nested under bar
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+  expect(await exists(join(packageDir, "node_modules", "bar", "node_modules", "no-deps"))).toBe(false);
+});
+
+test.concurrent("override still applies to a workspace: dependency with no matching member", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  // without the override this install fails with "Workspace dependency \"no-deps\" not found"
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "root",
+      workspaces: ["packages/*"],
+      dependencies: {
+        "no-deps": "workspace:*",
+      },
+      overrides: {
+        "no-deps": "2.0.0",
+      },
+    }),
+  );
+
+  const { exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await exited).toBe(0);
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "2.0.0",
+  });
+});
+
+test.concurrent("override still applies when the range does not link the member", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "^3.0.0",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  const { exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  expect(await exited).toBe(0);
+  // ^3.0.0 does not link the member, so the name resolves from the registry and
+  // the override picks the version
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "2.0.0",
+  });
+});
+
 describe("LinkWorkspacePackages", () => {
   // Shared setup previously done in a `beforeEach`: each test gets its own dir,
   // a root workspace package.json, and a `no-deps` workspace package.

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2138,6 +2138,57 @@ test.concurrent("override still applies when the range does not link the member"
   });
 });
 
+test.concurrent("override for a workspace member's name does not apply to a member's peer dependency", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+    write(
+      join(packageDir, "packages", "bar", "package.json"),
+      JSON.stringify({ name: "bar", version: "1.0.0", peerDependencies: { "no-deps": "^1.0.0" } }),
+    ),
+  ]);
+
+  let { exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  let stderrText = await stderr.text();
+  expect(stderrText).not.toContain("dependency loop");
+  expect(await exited).toBe(0);
+  // the peer binds to the member, not an overridden registry copy
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+  expect(await exists(join(packageDir, "node_modules", "bar", "node_modules", "no-deps"))).toBe(false);
+
+  // a reinstall from the written lockfile binds the same way and does not re-save
+  ({ exited, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  }));
+  stderrText = await stderr.text();
+  expect(stderrText).not.toContain("Saved lockfile");
+  expect(await exited).toBe(0);
+});
+
 // A ranged `workspace:` dependency a present member cannot satisfy is rejected while
 // parsing package.json, before overrides are consulted, with or without this fix. The
 // override neither rescues it nor turns it into a resolution conflict.

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2084,14 +2084,16 @@ test.concurrent("override still applies to a workspace: dependency with no match
     }),
   );
 
-  const { exited } = spawn({
+  const proc = spawn({
     cmd: [bunExe(), "install"],
     cwd: packageDir,
     stdout: "ignore",
     stderr: "pipe",
     env,
   });
-  expect(await exited).toBe(0);
+  const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderrText).not.toContain("error:");
+  expect(exitCode).toBe(0);
   expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
     name: "no-deps",
     version: "2.0.0",
@@ -2118,20 +2120,58 @@ test.concurrent("override still applies when the range does not link the member"
     write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
   ]);
 
-  const { exited } = spawn({
+  const proc = spawn({
     cmd: [bunExe(), "install"],
     cwd: packageDir,
     stdout: "ignore",
     stderr: "pipe",
     env,
   });
-  expect(await exited).toBe(0);
+  const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderrText).not.toContain("error:");
+  expect(exitCode).toBe(0);
   // ^3.0.0 does not link the member, so the name resolves from the registry and
   // the override picks the version
   expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
     name: "no-deps",
     version: "2.0.0",
   });
+});
+
+// A ranged `workspace:` dependency a present member cannot satisfy is rejected while
+// parsing package.json, before overrides are consulted, with or without this fix. The
+// override neither rescues it nor turns it into a resolution conflict.
+test.concurrent("override does not rescue a workspace: range the member does not satisfy", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "no-deps": "workspace:^3.0.0",
+        },
+        overrides: {
+          "no-deps": "2.0.0",
+        },
+      }),
+    ),
+    write(join(packageDir, "packages", "m", "package.json"), JSON.stringify({ name: "no-deps", version: "1.0.0" })),
+  ]);
+
+  const proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [stderrText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderrText).toContain('No matching version for workspace dependency "no-deps"');
+  expect(stderrText).not.toContain("dependency loop");
+  expect(exitCode).toBe(1);
 });
 
 describe("LinkWorkspacePackages", () => {


### PR DESCRIPTION
### Repro

```
# package.json
{ "name": "root", "workspaces": ["packages/*"],
  "dependencies": { "no-deps": "^1.0.0" },
  "overrides":    { "no-deps": "2.0.0" } }
# packages/m/package.json   { "name": "no-deps", "version": "1.0.0" }
```

```
$ bun install
error: Package "no-deps@2.0.0" has a dependency loop
  Resolution: "no-deps@workspace:packages/m"
  Dependency: "no-deps@^1.0.0"
error: An internal error occurred (DependencyLoop)
```

Every install fails the same way, including `--frozen-lockfile`; there is no working state. The same happens for every other dependency shape that links the member: an explicit `"no-deps": "workspace:*"`, a wildcard range on a version-less member, and a `"catalog:"` range the member satisfies. The member-declared flavor (a sibling member depending on `no-deps@^1.0.0`) silently nests an overridden registry copy under the sibling instead of linking it.

### Cause

Dependencies that accept a workspace member resolve to the member (the parse rewrite for satisfying ranges, the resolver's wildcard rule for version-less members, the catalog materialization feeding either), while the root keeps its injected workspace edge on the assumption that both edges resolve to the member. The override gate in `enqueue_dependency_with_main_and_success_fn` only exempts workspace-*behavior* edges (the injected ones), so the override rewrote the member-linking edge to a registry range. The root then carried two resolutions for one name, which the hoister reports as the misleading `DependencyLoop` internal error.

### Fix

Overrides now skip any edge that, absent the override, links a workspace member of the current install (`links_workspace_member` in PackageManagerEnqueue.rs): workspace-tagged edges, npm edges whose range is a wildcard or satisfies the member's version under `linkWorkspacePackages`, and `catalog:` edges through the version the catalog materializes to. The loader's peer-binding mirror of the gate (`resolve_peer_dep_version_based`) gets the matching exemption for the edge flavor that can reach it.

Two presence subtleties shape the member check:

- `workspace_paths` also holds names a `workspace:` dependency registered with no matching member, and an override is currently the only thing that makes such a dependency installable (it redirects it to the registry), so the check cannot key on that map.
- The lockfile's package index still holds a member a previous install resolved after the member directory is deleted, so keying on it would make the stale link permanent: every install would fail with `Workspace dependency "no-deps" not found` with no way out short of deleting bun.lock. The check keys on the root package's injected workspace edges instead, which are rebuilt from package.json on every install, so removing the member hands the name back to the override (one re-save; `--frozen-lockfile` reports the usual "lockfile had changes" until regenerated).

### Why this direction

npm rejects an override that conflicts with a workspace member outright (`EOVERRIDE: Override for no-deps@^1.0.0 conflicts with direct dependency`, verified with npm 11 against the same registry fixtures, and it errors even when only the workspace declares the name). Bun deliberately allows this configuration instead: #17417 established "overrides do not apply to workspaces" for the injected edges, and the real-world config behind it (ariakit overrides `@ariakit/react` to its own workspace folder) wants the member to stay linked. This PR completes that rule for the other edges that link a member. Overrides keep applying everywhere else with the member's name:

- registry packages' dependencies on the name (they resolve from the registry, so the overridden copy installs nested when the member holds the root slot, same as before)
- root/workspace ranges the member does not satisfy (they already resolve from the registry; the override picks the version)
- `workspace:` dependencies with no matching member, and names whose member directory was removed (the registry rescue above)

### Verification

Eleven tests in `test/cli/install/bun-workspaces.test.ts`. Seven fail on an unmodified build: the `DependencyLoop` shapes (satisfying range, `workspace:*`, version-less wildcard, `catalog:`), the sibling-member flavor that nested `no-deps@2.0.0` under the sibling, and both member-removal migration tests (their first install already loops). The other four pin boundaries that must keep working: registry rescue for a missing member, non-satisfying range + override, non-satisfying `workspace:` range still rejected at parse, and peer dependencies binding to the member across a lockfile reload. The main test also covers lockfile stability, `--frozen-lockfile` reinstall, and the override still applying to a registry package's dependency on the member's name in the same install.

Locally green: `bun-workspaces` (74), `overrides` (7), `catalogs` (18), `bun-install-registry` (229 + 5 todo), `isolated-install` (62), `bun-lock` (17), `bun-lockb` (6), `lockfile-only` (2), `lockfile-version-2` (10).

Lockfiles written by current bun for the member-declared shape (the only flavor that produced a lockfile at all) migrate on the next plain `bun install`: one re-save that links the member, stable from then on; checked by hand against a lockfile generated with 1.4.0-canary. A `--frozen-lockfile` install against such a stale lockfile reports the usual "lockfile had changes" error until it is regenerated.

Related but distinct: #37248 / #37249 / #37264 cover name collisions between npm deps and workspace members without `overrides` involved; this failure reproduces identically with those changes applied, and none of them touch the override gate.
