### PR TITLE
node:http2: arm the dispatch guard around the streamStart callback

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5354,6 +5354,10 @@ impl H2FrameParser {
         if global.has_exception() {
             return Some(stream);
         }
+        // The callback runs arbitrary JS while `stream` is held (here and by every caller):
+        // arm the dispatch guard so a reentrant read() cannot drain
+        // pending_engine_stream_closes at depth 0 and free the box under us.
+        let _dispatch = self.enter_dispatch();
         match callback.call(
             &global,
             ctx_value,
@@ -5363,12 +5367,21 @@ impl H2FrameParser {
             Ok(returned) => {
                 // streamStart returns the JS stream it created; storing it here saves the
                 // setStreamContext host call the JS layer used to make per stream.
-                if returned.is_object() {
+                // Skip if the callback closed the stream (free_resources queued its id and
+                // dropped its sctx root): re-rooting it would pin the dead JS stream until
+                // the session dies.
+                if returned.is_object()
+                    && !self
+                        .pending_engine_stream_closes
+                        .get()
+                        .contains(&stream_identifier)
+                {
                     self.sctx.with_mut(|m| {
                         m.insert(stream_identifier, StrongOptional::create(returned, &global));
                     });
                     // SAFETY: stream is *mut Stream from self.streams; valid while the map
-                    // entry exists
+                    // entry exists — the armed dispatch guard deferred the only free path
+                    // (rewrite_read's pending close drain) while the callback ran.
                     unsafe { (*stream).set_context(returned, &global) };
                 }
             }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5354,12 +5354,10 @@ impl H2FrameParser {
         if global.has_exception() {
             return Some(stream);
         }
-        // The callback runs arbitrary JS while `stream` is held (here and by every caller):
-        // arm the dispatch guard so a reentrant read() cannot drain
-        // pending_engine_stream_closes at depth 0 and free the box under us.
-        // Deliberately not enter_stream_dispatch: no `&mut Stream` may live across the
-        // call — the streamStart handler's refused-stream path re-enters rst_stream,
-        // which forms its own `&mut` to this stream.
+        // The callback runs arbitrary JS while `stream` is held (here and by every
+        // caller): arm the dispatch guard so a reentrant read() cannot free the box at
+        // depth 0. Bare guard, not enter_stream_dispatch — rst_stream reached from the
+        // callback takes its own `&mut` to this stream, so ours must wait for the return.
         let _dispatch = self.enter_dispatch();
         match callback.call(
             &global,
@@ -5370,9 +5368,8 @@ impl H2FrameParser {
             Ok(returned) => {
                 // streamStart returns the JS stream it created; storing it here saves the
                 // setStreamContext host call the JS layer used to make per stream.
-                // Skip if the callback closed the stream (free_resources queued its id and
-                // dropped its sctx root): re-rooting it would pin the dead JS stream until
-                // the session dies.
+                // Skipped when the callback closed the stream: free_resources dropped its
+                // sctx root, and re-rooting would pin the dead JS stream until session death.
                 if returned.is_object()
                     && !self
                         .pending_engine_stream_closes
@@ -5382,10 +5379,7 @@ impl H2FrameParser {
                     self.sctx.with_mut(|m| {
                         m.insert(stream_identifier, StrongOptional::create(returned, &global));
                     });
-                    // SAFETY: stream is *mut Stream from self.streams; valid while the map
-                    // entry exists — the armed dispatch guard deferred the only free path
-                    // (rewrite_read's pending close drain) while the callback ran.
-                    unsafe { (*stream).set_context(returned, &global) };
+                    self.enter_stream_dispatch(stream).set_context(returned, &global);
                 }
             }
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5379,7 +5379,8 @@ impl H2FrameParser {
                     self.sctx.with_mut(|m| {
                         m.insert(stream_identifier, StrongOptional::create(returned, &global));
                     });
-                    self.enter_stream_dispatch(stream).set_context(returned, &global);
+                    self.enter_stream_dispatch(stream)
+                        .set_context(returned, &global);
                 }
             }
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5357,6 +5357,9 @@ impl H2FrameParser {
         // The callback runs arbitrary JS while `stream` is held (here and by every caller):
         // arm the dispatch guard so a reentrant read() cannot drain
         // pending_engine_stream_closes at depth 0 and free the box under us.
+        // Deliberately not enter_stream_dispatch: no `&mut Stream` may live across the
+        // call — the streamStart handler's refused-stream path re-enters rst_stream,
+        // which forms its own `&mut` to this stream.
         let _dispatch = self.enter_dispatch();
         match callback.call(
             &global,

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -105,6 +105,75 @@ test(
   10_000 * ASAN_MULTIPLIER,
 );
 
+// handle_received_stream_id invoked the JS streamStart callback without arming the
+// dispatch guard while holding the just-created *Stream. JS reached from inside that
+// callback (here: EventEmitter.prototype.on, called by the Http2Stream constructor)
+// could close the stream and then re-enter parser.read() at dispatch depth 0, where
+// the deferred-close drain frees the Stream box; the native caller then wrote the
+// stream context through the dangling pointer (ASAN: heap-use-after-free in
+// Stream::set_context). The parser is driven directly because the hook must observe
+// the window inside the native callback, before setStreamContext runs.
+test(
+  "closing the new stream and re-entering read() inside the streamStart callback does not UAF",
+  async () => {
+    const script = /* js */ `
+    const http2 = require("node:http2");
+    const { Duplex } = require("node:stream");
+    const EE = require("node:events");
+
+    const socket = new Duplex({
+      write(chunk, enc, cb) {
+        cb();
+      },
+      read() {},
+    });
+
+    const session = http2.performServerHandshake(socket);
+    const parser = session[Symbol.for("::bunhttp2native::")];
+
+    const origOn = EE.prototype.on;
+    let hooked = false;
+    let armed = false;
+    EE.prototype.on = function (ev, fn) {
+      // Http2Stream's constructor calls this.on("pause", ...) from inside the
+      // native onStreamStart callback for the stream getNextStream() allocates.
+      if (armed && ev === "pause") {
+        armed = false;
+        hooked = true;
+        parser.rstStream(2, 8 /* NGHTTP2_CANCEL */); // queue the new stream's deferred close
+        parser.read(Buffer.from("PRI * HTTP/2.0\\r\\n\\r\\nSM\\r\\n\\r\\n")); // depth-0 read used to drain it
+      }
+      return origOn.call(this, ev, fn);
+    };
+
+    armed = true;
+    const id = parser.getNextStream();
+    EE.prototype.on = origOn;
+    if (!hooked) {
+      console.error("hook was never invoked");
+      process.exit(1);
+    }
+    if (id !== 2) {
+      console.error("unexpected stream id: " + id);
+      process.exit(1);
+    }
+    session.destroy();
+    console.log("OK");
+    process.exit(0);
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
+  },
+  10_000 * ASAN_MULTIPLIER,
+);
+
 test("http2 client write callback that opens new streams during flushQueue does not UAF", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rehash.fixture.js")],

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -178,6 +178,10 @@ test(
     try {
       parser.getStreamContext(2);
     } catch (e) {
+      if (e.message !== "Invalid stream id") {
+        console.error("unexpected getStreamContext error: " + e.message);
+        process.exit(1);
+      }
       drained = true;
     }
     if (!drained) {

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -157,6 +157,33 @@ test(
       console.error("unexpected stream id: " + id);
       process.exit(1);
     }
+    // The close must have been deferred, not drained inside the callback: the native
+    // entry is still alive (pre-fix this throws "Invalid stream id" on every build
+    // tier because the drain freed it), and no context may have been installed for
+    // the closed stream (a guard-only fix would return the Http2Stream here).
+    let ctx;
+    try {
+      ctx = parser.getStreamContext(2);
+    } catch (e) {
+      console.error("getStreamContext threw: " + e.message);
+      process.exit(1);
+    }
+    if (ctx !== undefined) {
+      console.error("context installed for closed stream");
+      process.exit(1);
+    }
+    // One depth-0 read runs the deferred drain; the entry must actually go away.
+    parser.read(Buffer.alloc(0));
+    let drained = false;
+    try {
+      parser.getStreamContext(2);
+    } catch (e) {
+      drained = true;
+    }
+    if (!drained) {
+      console.error("deferred close never drained");
+      process.exit(1);
+    }
     session.destroy();
     console.log("OK");
     process.exit(0);


### PR DESCRIPTION
### Problem

`H2FrameParser::handle_received_stream_id` creates a `Stream` box, inserts it into the stream map, and then invokes the JS `streamStart` callback directly via `callback.call` without arming the `DispatchGuard`, while still holding the raw `*mut Stream`. Every other JS dispatch site in the parser arms the guard, because `rewrite_read` frees streams queued in `pending_engine_stream_closes` only at dispatch depth 0.

JS reached from inside that callback (the `Http2Stream` constructor calls `this.on("pause", ...)`, so a patched `EventEmitter.prototype.on` runs there; the handler also calls back into native `rstStream` for refused streams) can close the just-created stream, queueing its deferred free, and then re-enter `parser.read()` at depth 0. The drain frees the box, and the callback return path writes the stream context through the dangling pointer:

```
==ERROR: AddressSanitizer: heap-use-after-free ...
    #1 <bun_runtime::api::h2_frame_parser_body::Stream>::set_context src/runtime/api/bun/h2_frame_parser.rs:2110
    #2 <...H2FrameParser>::handle_received_stream_id src/runtime/api/bun/h2_frame_parser.rs:5372
    #3 <...H2FrameParser>::get_next_stream src/runtime/api/bun/h2_frame_parser.rs:8335
freed by:
   #12 <...H2FrameParser>::rewrite_read::{closure#3} src/runtime/api/bun/h2_frame_parser.rs:5804
```

The callers that keep dereferencing the returned pointer (`request()`, `get_next_stream`, the engine HEADERS path) were exposed to the same freed box.

### Fix

Arm `enter_dispatch` across the callback, matching the invariant documented on `enter_dispatch` (every section that holds a `Stream` pointer while user JS can run must arm the guard). With the guard armed, the deferred-close drain cannot run while the callback executes, so the pointer stays valid for `set_context` and for the callers.

Also skip the context install when the callback closed the stream: `free_resources` already dropped its `sctx` root, and re-inserting one afterwards would pin the dead JS stream object until the session dies.

This is the guard-arming fix for the pre-existing issue flagged during review of #37272 (that PR only removes dead code around it).

### Verification

New test in `test/js/node/http2/node-http2-streams-rehash.test.ts` (the file covering this class of reentrancy bugs) reproduces the exact sequence: close the new stream and re-enter `read()` from inside the `streamStart` callback. Without the fix it fails on every build tier: heap-use-after-free under the ASAN debug build, and on release builds `getStreamContext(2)` throws "Invalid stream id" because the drain already freed the entry inside the callback. With the fix the entry survives the callback with no context installed (covering the skip-install branch), and a follow-up depth-0 `read()` asserts the deferred close then actually drains. Existing http2 suites (`node-http2.test.js`, `h2-conformance.test.ts`, the staged h2 tests, node's server-push parallel tests) pass with the change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2-streams-rehash.test.ts"
bun test v1.4.0 (8f7956273)

test/js/node/http2/node-http2-streams-rehash.test.ts:
(pass) session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash [3284.09ms]
(pass) http2 client request() does not hold *Stream across user-controlled options getters [6184.76ms]
198 |       env: bunEnv,
199 |       stdout: "pipe",
200 |       stderr: "pipe",
201 |     });
202 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
203 |     expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
                                                              ^
error: expect(received).toMatchObject(expected)

  {
-   "exitCode": 0,
-   "stdout": "OK",
+   "exitCode": 1,
+   "stderr": 
+ "=================================================================
+ ==101685==ERROR: AddressSanitizer: heap-use-after-free on address 0x79be9bb005c0 at pc 0x00000e7ec22e bp 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7725ac871)

test/js/node/http2/node-http2-streams-rehash.test.ts:
(pass) session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash [163.99ms]
(pass) http2 client request() does not hold *Stream across user-controlled options getters [78.42ms]
(pass) closing the new stream and re-entering read() inside the streamStart callback does not UAF [31.29ms]
(pass) http2 client write callback that opens new streams during flushQueue does not UAF [49.40ms]
(pass) DeferredTaskQueue::run tolerates an on_auto_flush callback that unregisters itself and returns true [46.51ms]

 5 pass
 0 fail
 5 expect() calls
Ran 5 tests across 1 file. [513.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2-streams-rehash.test.ts"
bun test v1.4.0 (8f7956273)

test/js/node/http2/node-http2-streams-rehash.test.ts:
(pass) session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash [3278.34ms]
(pass) http2 client request() does not hold *Stream across user-controlled options getters [6171.66ms]
(pass) closing the new stream and re-entering read() inside the streamStart callback does not UAF [1906.06ms]
(pass) http2 client write callback that opens new streams during flushQueue does not UAF [2819.28ms]
(pass) DeferredTaskQueue::run tolerates an on_auto_flush callback that unregisters itself and returns true [2618.43ms]

 5 pass
 0 fail
 5 expect() calls
Ran 5 tests across 1 file. [19.19s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 689ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs             |  19 +++-
 .../node/http2/node-http2-streams-rehash.test.ts   | 100 +++++++++++++++++++++
 2 files changed, 115 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs                   10      4      0
test/js/node/http2/node-http2-streams-rehash.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->