### PR TITLE
fix(bun): fix debug-build abort when Bun.SQL is first accessed near stack overflow

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -257,3 +257,32 @@ describe("globalThis.gc", () => {
     });
   });
 });
+
+it("accessing Bun.SQL while unwinding from stack overflow does not crash", async () => {
+  // Touching a lazily-initialized Bun property when there is almost no stack
+  // left makes its module require throw mid-reification. The process must
+  // surface that as a catchable error, not abort.
+  const src = `
+    Error.stackTraceLimit = 0;
+    let probes = 200;
+    function F() {
+      if (!new.target) throw "must call with new";
+      try { new F(); } catch {}
+      if (probes > 0) {
+        probes--;
+        try { Bun.SQL; } catch {}
+      }
+    }
+    new F();
+    Bun.SQL;
+    console.log("survived");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("survived\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -265,24 +265,26 @@ it("accessing Bun.SQL while unwinding from stack overflow does not crash", async
   const src = `
     Error.stackTraceLimit = 0;
     let probes = 200;
+    let caught = 0;
     function F() {
       if (!new.target) throw "must call with new";
       try { new F(); } catch {}
       if (probes > 0) {
         probes--;
-        try { Bun.SQL; } catch {}
+        try { Bun.SQL; } catch { caught++; }
       }
     }
     new F();
     Bun.SQL;
-    console.log("survived");
+    console.log("survived, sawLazyInitFailure:", caught > 0);
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", src],
     env: bunEnv,
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout).toBe("survived\n");
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("survived, sawLazyInitFailure: true\n");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes a crash found by fuzzing (assertions with varying fingerprints, including `PropertySlot.h(226)` and `StructureInlinesLight.h(56)`, debug builds only).

### Repro

```js
function F() {
  if (!new.target) throw 'must call with new';
  try { new F(); } catch {}
  try { Bun.SQL; } catch {}
}
new F();
```

The fuzzer's original script reached the same state through `Bun.jest().expect(Bun).toEqual(...)`, whose failure diff walks the Bun object's properties and reifies `Bun.SQL` while unwinding from a stack overflow.

### Root cause

`constructBunSQLObject` and `defaultBunSQLObject` (the lazy `PropertyCallback` initializers for `Bun.SQL` and `Bun.sql`) contained a debug-only diagnostic:

```cpp
#if BUN_DEBUG
    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
#endif
```

When the internal `bun:sql` module require throws (reachable deterministically by touching the property with almost no stack left), this runs the whole uncaught exception machinery synchronously, with the exception still pending, from inside `JSC::reifyStaticProperty` mid `getPropertySlot`. The handler re-enters the VM: it performs property gets which reify further lazy static properties and transition structures while outer frames hold cached `Structure*` values. Depending on the interleaving this trips `Structure::storedPrototype` (`object->structure() == this`) or `PropertySlot::setValue` assertions and aborts the process. Captured stack:

```
Structure::storedPrototype
JSObject::getPropertySlot
JSObject::get
Bun__handleUncaughtException            <- re-entered with pending exception
Zig::GlobalObject::reportUncaughtExceptionAtEventLoop
Bun::constructBunSQLObject              <- the debug block
JSC::reifyStaticProperty
JSC::setUpStaticFunctionSlot
JSC::getStaticPropertySlotFromTable
JSObject::getPropertySlot
JSC__JSValue__forEachPropertyOrdered    <- expect() failure diff formatting
```

### Fix

Delete the two debug blocks. The surrounding protocol already handles a throwing lazy callback: it returns empty with the exception pending, `reifyStaticProperty` skips the put, and the error propagates to the property access as a catchable JS error. Release builds never compiled the block, so release behavior is unchanged.

### Tests

Added a regression test in `test/js/bun/globals.test.js` that probes `Bun.SQL` during the deepest 200 unwind levels of a stack overflow in a subprocess, then verifies a later access succeeds. On the unfixed debug build the child aborts on the assertion (reproduced 5 out of 5 runs); with the fix the file passes (21 tests). The bug is debug-build-only (`#if BUN_DEBUG`), so a release binary cannot exhibit it; fail-before was verified against an unfixed debug build at the same base commit.

The `PropertySlot.h(226)` fingerprint also appears in a separate, unrelated spyOn bug fixed in #37021; the two are independent.