### PR TITLE
Atomics.waitAsync: hand SharedArrayBuffer-death waiter cancellation to the owning VM

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "171babe26c3b330ac0263d1bed3550571908c838";
+export const WEBKIT_VERSION = "autobuild-preview-pr-399-01baacc2";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/atomics.test.ts
+++ b/test/js/web/atomics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("Atomics", () => {
   describe("basic operations", () => {
@@ -158,6 +159,59 @@ describe("Atomics", () => {
       } else {
         expect(typeof result.value).toBe("string");
       }
+    });
+
+    // GC of a SharedArrayBuffer on one thread must not cancel another thread's
+    // pending Atomics.waitAsync in place: whichever thread drops the last
+    // reference runs the SAB destructor, and the cancellation has to be handed
+    // to the VM that owns the waiter. Aborted with an assertion in
+    // JSC::DeferredWorkTimer::cancelPendingWork on assert-enabled builds.
+    test.concurrent("waitAsync survives cross-thread GC of the SharedArrayBuffer", async () => {
+      using dir = tempDir("atomics-waitasync-sab-gc", {
+        "waitasync-sab-gc-fixture.ts": `
+          import { Worker, isMainThread, parentPort } from "node:worker_threads";
+          if (!isMainThread) {
+            parentPort.on("message", m => {
+              // Pending forever; the waiter does not keep the SAB alive.
+              Atomics.waitAsync(new Int32Array(m.sab), 0, 0);
+              m = null;
+              // Let the handler frame return so the worker's GC sweeps its SAB
+              // wrapper and the main thread holds the last reference.
+              setTimeout(() => {
+                Bun.gc(true);
+                parentPort.postMessage("armed");
+              }, 5);
+            });
+          } else {
+            const w = new Worker(new URL(import.meta.url));
+            for (let i = 0; i < 20; i++) {
+              let sab = new SharedArrayBuffer(64);
+              w.postMessage({ sab });
+              await new Promise(r => w.once("message", r));
+              // Main now drops the last reference: the SAB destructor runs on
+              // this thread and tears down the worker's pending waiter.
+              sab = null;
+              Bun.gc(true);
+              await new Promise(r => setTimeout(r, 2));
+            }
+            console.log("done");
+            await w.terminate();
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "waitasync-sab-gc-fixture.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).not.toContain("ASSERTION FAILED");
+      expect(stdout).toBe("done\n");
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Problem

GC of a SharedArrayBuffer on one thread cancels another thread's pending `Atomics.waitAsync` ticket without that VM's lock. The SAB destructor runs on whichever thread drops the last reference; `WaiterListManager::unregister(uint8_t*, size_t)` then called the owning worker VM's `DeferredWorkTimer::cancelPendingWork` directly from that thread.

On assert-enabled builds (debug/ASAN):

```
ASSERTION FAILED: ticket.isCancelled() || ticket.vm().currentThreadIsHoldingAPILock() || (Thread::mayBeGCThread() && ticket.vm().heap.worldIsStopped())
DeferredWorkTimer.cpp(263) : bool JSC::DeferredWorkTimer::cancelPendingWork(Ticket&)
```

In release builds the same path mutates `Ticket` state and Bun's pending-ticket sets / event-loop keep-alive (`onCancelPendingWork`) concurrently with the owner thread.

Repro (aborts in under a second on a debug build):

```js
import { Worker, isMainThread, parentPort } from "node:worker_threads";
if (!isMainThread) {
  parentPort.on("message", m => {
    Atomics.waitAsync(new Int32Array(m.sab), 0, 0); // pending forever
    m = null;
    setTimeout(() => { Bun.gc(true); parentPort.postMessage("armed"); }, 5);
  });
} else {
  const w = new Worker(new URL(import.meta.url));
  for (let i = 0; i < 20; i++) {
    let sab = new SharedArrayBuffer(64);
    w.postMessage({ sab });
    await new Promise(r => w.once("message", r));
    sab = null; Bun.gc(true); // main drops the last ref, SAB destructor runs here
    await new Promise(r => setTimeout(r, 2));
  }
  console.log("done"); await w.terminate();
}
```

## Fix

WebKit side, oven-sh/WebKit#399: `DeferredWorkTimer::cancelPendingWorkCrossThread` hands the cancellation to the owning VM (via `onScheduleWorkSoon`, the same thread-safe channel that delivers cross-thread `Atomics.notify` resolutions), so `cancelPendingWork` only ever runs on the owner VM with its API lock held.

This PR pins WebKit to that PR's preview build (`autobuild-preview-pr-399-01baacc2`) and adds the regression test. Before merging, the pin should move to the final `autobuild-<sha>` once oven-sh/WebKit#399 lands on main.

## Verification

- Test fails against current pinned WebKit with the exact assertion above, at iteration 1 of the loop, consistently.
- Passes 10/10 with the fixed WebKit (built locally from the PR branch); `test/js/web/atomics.test.ts` (29 tests) and `test/js/web/workers/worker-terminate-funnels.test.ts` also pass.

Note: CI needs the WebKit preview build for PR 399 to finish publishing before it can download the pinned tarball; a retrigger may be needed if the first run races it.