### PR TITLE
bun test --parallel: do not hang when a test closes the worker IPC fd

### DIFF
--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -409,20 +409,6 @@ impl<Owner: ChannelOwner> Channel<Owner> {
         }
     }
 
-    /// True while the underlying socket/pipe is still open. When `done` is set
-    /// with the transport still attached, it was a protocol error (corrupt
-    /// frame), not a clean close.
-    pub(crate) fn is_attached(&self) -> bool {
-        #[cfg(windows)]
-        {
-            return !self.backend.pipe.get().is_null();
-        }
-        #[cfg(not(windows))]
-        {
-            !self.backend.socket.get().is_detached()
-        }
-    }
-
     /// True while any encoded bytes are still queued or in flight.
     pub(crate) fn has_pending_writes(&self) -> bool {
         if !self.out.get().is_empty() {

--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -650,9 +650,8 @@ impl<Owner: ChannelOwner> WindowsHandlers<Owner> {
         &mut buf[..]
     }
     fn on_error(self_: &Channel<Owner>, _err: bun_sys::E) {
-        // Mirror the POSIX on_close path: detach the transport before
-        // signalling done so the owner can tell EOF apart from a protocol
-        // error (where the pipe is still attached).
+        // Mirror the POSIX on_close path: detach and destroy the pipe before
+        // signalling done.
         let p = self_.backend.pipe.replace(core::ptr::null_mut());
         if !p.is_null() {
             // SAFETY: Box-allocated; close_and_destroy reclaims via heap::take.

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -515,6 +515,7 @@ impl<'a> Coordinator<'a> {
                     self.coverage_chunks.push(Box::<[u8]>::from(chunk));
                 }
             }
+            frame::Kind::Exiting => w.exiting = true,
             frame::Kind::Run | frame::Kind::Shutdown => {}
         }
     }

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -29,12 +29,11 @@ pub enum Kind {
     /// str lcov — this worker's coverage data, sent at exit; the coordinator
     /// merges every worker's into the one report it writes.
     CoverageChunk,
-    /// (empty) worker → coordinator: a deliberate exit is in progress
-    /// (`process.exit()`, or the normal end-of-run path). VM teardown closes
-    /// the channel before the process dies — long before it under
-    /// BUN_DESTRUCT_VM_ON_EXIT/ASAN — so without this announcement the
-    /// coordinator would see EOF from a live process and treat the worker as
-    /// lost (SIGKILL, clobbering the real exit status).
+    /// (empty) worker → coordinator: deliberate exit in progress. VM teardown
+    /// closes the channel before `_exit` (long before it under
+    /// BUN_DESTRUCT_VM_ON_EXIT), so EOF after this frame means the exit
+    /// status is on the way, while EOF without it means the worker lost its
+    /// channel and must be killed.
     Exiting,
 }
 

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -29,6 +29,13 @@ pub enum Kind {
     /// str lcov — this worker's coverage data, sent at exit; the coordinator
     /// merges every worker's into the one report it writes.
     CoverageChunk,
+    /// (empty) worker → coordinator: a deliberate exit is in progress
+    /// (`process.exit()`, or the normal end-of-run path). VM teardown closes
+    /// the channel before the process dies — long before it under
+    /// BUN_DESTRUCT_VM_ON_EXIT/ASAN — so without this announcement the
+    /// coordinator would see EOF from a live process and treat the worker as
+    /// lost (SIGKILL, clobbering the real exit status).
+    Exiting,
 }
 
 impl TryFrom<u8> for Kind {
@@ -45,6 +52,7 @@ impl TryFrom<u8> for Kind {
             6 => Kind::Shutdown,
             7 => Kind::JunitChunk,
             8 => Kind::CoverageChunk,
+            9 => Kind::Exiting,
             _ => return Err(()),
         })
     }

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -71,10 +71,8 @@ pub struct Worker {
     /// this and `ipc.done` so trailing IPC frames are decoded first.
     pub(crate) exit_status: Option<Status>,
     pub(crate) reap_pending: bool,
-    /// Worker announced a deliberate exit (`Kind::Exiting`). The EOF that
-    /// follows is its teardown closing the channel, not a lost worker: the
-    /// real exit status is on the way, and teardown (ASAN leak checks) must
-    /// be allowed to finish, so `on_channel_done` must not kill(9).
+    /// Worker sent `Kind::Exiting`: the EOF that follows is its own exit
+    /// path, not a lost channel, so `on_channel_done` must not kill it.
     pub(crate) exiting: bool,
 }
 
@@ -381,15 +379,10 @@ impl ChannelOwner for Worker {
     }
 
     fn on_channel_done(&mut self) {
-        // The channel is the worker's only command/result path, so a worker
-        // that outlives it can neither receive a file nor report one. Unless
-        // it announced a deliberate exit (`exiting`), a still-running worker
-        // here is lost — a corrupt frame, or its IPC fd died under it (e.g.
-        // a test closed fd 3, which the worker itself cannot detect: the fd
-        // silently left its poll set and it would wait for commands forever)
-        // — so kill it; onWorkerExit accounts for the in-flight file and the
-        // slot can respawn. A worker that already exited is an unreaped
-        // zombie here at most, for which kill(9) is a no-op.
+        // A live worker that didn't announce `Kind::Exiting` is lost with its
+        // channel (corrupt frame, or a test closed fd 3 — which the worker
+        // itself cannot detect): kill it so onWorkerExit accounts for the
+        // in-flight file and the slot can respawn.
         if !self.exiting {
             if let Some(p) = self.process {
                 // SAFETY: `p` is the live intrusive-refcounted *mut Process.

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -71,11 +71,17 @@ pub struct Worker {
     /// this and `ipc.done` so trailing IPC frames are decoded first.
     pub(crate) exit_status: Option<Status>,
     pub(crate) reap_pending: bool,
+    /// Worker announced a deliberate exit (`Kind::Exiting`). The EOF that
+    /// follows is its teardown closing the channel, not a lost worker: the
+    /// real exit status is on the way, and teardown (ASAN leak checks) must
+    /// be allowed to finish, so `on_channel_done` must not kill(9).
+    pub(crate) exiting: bool,
 }
 
 impl Worker {
     pub(crate) fn start(&mut self) -> crate::Result<()> {
         debug_assert!(!self.alive);
+        self.exiting = false;
         let coord_ptr = self.coord;
         // SAFETY: coord backref is valid for the worker's lifetime (Coordinator owns workers slice).
         let coord = unsafe { &*coord_ptr };
@@ -376,19 +382,21 @@ impl ChannelOwner for Worker {
 
     fn on_channel_done(&mut self) {
         // The channel is the worker's only command/result path, so a worker
-        // that outlives it can neither receive a file nor report one. That
-        // happens on a corrupt frame (transport still attached) and on EOF
-        // while the worker is still running — e.g. a test closed fd 3, which
-        // also leaves the worker unable to notice its channel died (the fd
-        // vanished from its poll set), so without this kill both sides wait
-        // forever. After a normal worker exit the EOF often arrives before
-        // the exit notification; the process is an unreaped zombie then and
-        // kill(9) is a no-op.
-        if let Some(p) = self.process {
-            // SAFETY: `p` is the live intrusive-refcounted *mut Process.
-            if unsafe { !(*p).has_exited() } {
-                // SAFETY: as above.
-                let _ = unsafe { (*p).kill(9) };
+        // that outlives it can neither receive a file nor report one. Unless
+        // it announced a deliberate exit (`exiting`), a still-running worker
+        // here is lost — a corrupt frame, or its IPC fd died under it (e.g.
+        // a test closed fd 3, which the worker itself cannot detect: the fd
+        // silently left its poll set and it would wait for commands forever)
+        // — so kill it; onWorkerExit accounts for the in-flight file and the
+        // slot can respawn. A worker that already exited is an unreaped
+        // zombie here at most, for which kill(9) is a no-op.
+        if !self.exiting {
+            if let Some(p) = self.process {
+                // SAFETY: `p` is the live intrusive-refcounted *mut Process.
+                if unsafe { !(*p).has_exited() } {
+                    // SAFETY: as above.
+                    let _ = unsafe { (*p).kill(9) };
+                }
             }
         }
         // SAFETY: coord backref valid; mutation — see `coord` field doc (provenance caveats).

--- a/src/runtime/cli/test/parallel/Worker.rs
+++ b/src/runtime/cli/test/parallel/Worker.rs
@@ -375,11 +375,19 @@ impl ChannelOwner for Worker {
     }
 
     fn on_channel_done(&mut self) {
-        if self.ipc.is_attached() {
-            // Corrupt frame path — kill the worker so onWorkerExit accounts for
-            // the in-flight file and the slot can respawn.
-            if let Some(p) = self.process {
-                // SAFETY: `p` is the live intrusive-refcounted *mut Process.
+        // The channel is the worker's only command/result path, so a worker
+        // that outlives it can neither receive a file nor report one. That
+        // happens on a corrupt frame (transport still attached) and on EOF
+        // while the worker is still running — e.g. a test closed fd 3, which
+        // also leaves the worker unable to notice its channel died (the fd
+        // vanished from its poll set), so without this kill both sides wait
+        // forever. After a normal worker exit the EOF often arrives before
+        // the exit notification; the process is an unreaped zombie then and
+        // kill(9) is a no-op.
+        if let Some(p) = self.process {
+            // SAFETY: `p` is the live intrusive-refcounted *mut Process.
+            if unsafe { !(*p).has_exited() } {
+                // SAFETY: as above.
                 let _ = unsafe { (*p).kill(9) };
             }
         }

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -532,10 +532,8 @@ impl<'a> WorkerLoop<'a> {
         unsafe {
             WORKER_CMDS.write(Some(&raw mut self.cmds));
         }
-        // `process.exit()` runs on_exit → cleanup hooks → VM teardown, and
-        // teardown closes this channel before the process dies. Announce the
-        // exit while the channel is still up so the coordinator lets the
-        // worker finish instead of treating the early EOF as a lost worker.
+        // `process.exit()` runs cleanup hooks before teardown closes this
+        // channel; see `Kind::Exiting`.
         let global = vm.global();
         vm.rare_data()
             .push_cleanup_hook(global, core::ptr::null_mut(), announce_deliberate_exit);
@@ -676,9 +674,7 @@ pub(crate) fn run_as_worker(
     vm_ref.run_with_api_lock(|| wloop.begin());
 
     worker_flush_aggregates(wloop.reporter, vm_ref, ctx, &mut wloop.cmds);
-    // This path bypasses on_exit (no cleanup hooks), so announce the exit
-    // here: global_exit's teardown closes the channel before the process
-    // dies, and the coordinator must not mistake that EOF for a lost worker.
+    // This path bypasses on_exit (no cleanup hooks); see `Kind::Exiting`.
     announce_deliberate_exit(core::ptr::null_mut());
     // Drain any backpressure-buffered frames before exit so the coordinator
     // sees repeat_bufs / junit_chunk / coverage_chunk.
@@ -753,10 +749,8 @@ static WORKER_CMDS: bun_core::RacyCell<Option<*mut WorkerCommands>> = bun_core::
 // Lifetime note: stores an 'a-bound pointer as 'static; sound because the
 // pointee outlives all callers (process exits before it's dropped).
 
-/// Tell the coordinator a deliberate exit is in progress (`Kind::Exiting`),
-/// so the EOF it is about to see is teardown closing the channel, not a lost
-/// worker to SIGKILL. Runs as a VM cleanup hook on the `process.exit()` path
-/// and is called directly from `run_as_worker`'s normal tail.
+/// Send `Kind::Exiting`. A VM cleanup hook on the `process.exit()` path;
+/// called directly from `run_as_worker`'s normal tail.
 extern "C" fn announce_deliberate_exit(_: *mut core::ffi::c_void) {
     // SAFETY: single-threaded worker; WORKER_CMDS only written/read on this thread.
     let Some(cmds_ptr) = (unsafe { WORKER_CMDS.read() }) else {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -136,6 +136,7 @@ pub(crate) fn run_as_coordinator(
             alive: false,
             exit_status: None,
             reap_pending: false,
+            exiting: false,
         });
         let w: *mut Worker = workers.last_mut().unwrap();
         // SAFETY: w points into workers; Vec will not reallocate (capacity == k)
@@ -531,6 +532,13 @@ impl<'a> WorkerLoop<'a> {
         unsafe {
             WORKER_CMDS.write(Some(&raw mut self.cmds));
         }
+        // `process.exit()` runs on_exit → cleanup hooks → VM teardown, and
+        // teardown closes this channel before the process dies. Announce the
+        // exit while the channel is still up so the coordinator lets the
+        // worker finish instead of treating the early EOF as a lost worker.
+        let global = vm.global();
+        vm.rare_data()
+            .push_cleanup_hook(global, core::ptr::null_mut(), announce_deliberate_exit);
 
         // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer
         let wf = unsafe { &mut *WORKER_FRAME.get() };
@@ -668,6 +676,10 @@ pub(crate) fn run_as_worker(
     vm_ref.run_with_api_lock(|| wloop.begin());
 
     worker_flush_aggregates(wloop.reporter, vm_ref, ctx, &mut wloop.cmds);
+    // This path bypasses on_exit (no cleanup hooks), so announce the exit
+    // here: global_exit's teardown closes the channel before the process
+    // dies, and the coordinator must not mistake that EOF for a lost worker.
+    announce_deliberate_exit(core::ptr::null_mut());
     // Drain any backpressure-buffered frames before exit so the coordinator
     // sees repeat_bufs / junit_chunk / coverage_chunk.
     while wloop.cmds.channel.has_pending_writes() && !wloop.cmds.channel.done.get() {
@@ -740,6 +752,25 @@ static WORKER_FRAME: bun_core::RacyCell<Frame> = bun_core::RacyCell::new(Frame::
 static WORKER_CMDS: bun_core::RacyCell<Option<*mut WorkerCommands>> = bun_core::RacyCell::new(None);
 // Lifetime note: stores an 'a-bound pointer as 'static; sound because the
 // pointee outlives all callers (process exits before it's dropped).
+
+/// Tell the coordinator a deliberate exit is in progress (`Kind::Exiting`),
+/// so the EOF it is about to see is teardown closing the channel, not a lost
+/// worker to SIGKILL. Runs as a VM cleanup hook on the `process.exit()` path
+/// and is called directly from `run_as_worker`'s normal tail.
+extern "C" fn announce_deliberate_exit(_: *mut core::ffi::c_void) {
+    // SAFETY: single-threaded worker; WORKER_CMDS only written/read on this thread.
+    let Some(cmds_ptr) = (unsafe { WORKER_CMDS.read() }) else {
+        return;
+    };
+    // SAFETY: cmds_ptr was set from &mut WorkerCommands in run_as_worker; pointee
+    // outlives all callers (process exits before it is dropped).
+    let cmds = unsafe { &mut *cmds_ptr };
+    // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer.
+    let wf = unsafe { &mut *WORKER_FRAME.get() };
+    wf.begin(frame::Kind::Exiting);
+    cmds.send(wf.finish());
+    cmds.channel.flush();
+}
 
 /// Called from `CommandLineReporter.handleTestCompleted` in the worker with the
 /// fully-formatted status line (✓/✗ + scopes + name + duration, including ANSI

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -127,6 +127,42 @@ test("--parallel marks a file whose worker exits mid-run as failed (no retry)", 
   expect(exitCode).toBe(1);
 });
 
+test(
+  "--parallel: a test closing the IPC fd fails that file and the run continues",
+  async () => {
+    // fd 3 is the worker's IPC channel. Closing it (fd-hygiene code, "close
+    // every fd >= 3" helpers) kills the channel from under both sides: the
+    // worker can't notice (the fd left its poll set) and used to spin
+    // forever while the coordinator waited for an exit that never came.
+    // The coordinator must treat EOF from a still-running worker as a lost
+    // worker: kill it, fail the file, keep going.
+    using dir = tempDir("parallel-fd3-close", {
+      "fd3.test.js": `import {test} from "bun:test"; import {closeSync} from "node:fs"; test("close fd 3", () => { closeSync(3); }); test("after", async () => { await Bun.sleep(200); });`,
+      "ok1.test.js": `import {test,expect} from "bun:test"; test("ok1",()=>expect(1).toBe(1));`,
+      "ok2.test.js": `import {test,expect} from "bun:test"; test("ok2",()=>expect(1).toBe(1));`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2"],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("PARALLEL");
+    expect(stderr).toContain("fd3.test.js");
+    expect(stderr).toContain("worker crashed");
+    // a lost channel is a per-file failure, not a run-aborting panic
+    expect(stderr).not.toContain("Aborting");
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("1 fail");
+    expect(stderr).toContain("Ran 3 tests across 3 files.");
+    expect(exitCode).toBe(1);
+  },
+  isASAN || isDebug ? 60_000 : 20_000,
+);
+
 // Concurrency is proven deterministically by the lazy-spawn PID-count tests
 // below; the timing-based "faster than serial" assertion was load-sensitive
 // and removed.


### PR DESCRIPTION
## Problem

Under `bun test --parallel`, a test file that closes fd 3 hangs the whole run forever, with the worker spinning at 100% CPU and `--timeout` never applying:

```js
// fd3close.test.js (plus any sibling test files)
import { test } from "bun:test";
import { closeSync } from "node:fs";
test("close fd 3", () => { closeSync(3); }); // e.g. a close-every-fd >= 3 hygiene helper
test("after", async () => { await Bun.sleep(200); });
```

`bun test --parallel=2 .` never finishes; serial `bun test` passes.

## Cause

fd 3 in a worker is its IPC socketpair end. `closeSync(3)` removes the fd from the worker's poll set without any callback, so the worker never learns the channel died: its frames go nowhere and it sits in the next-command loop forever. The coordinator does observe the resulting EOF on its end, but the clean-EOF path in `Worker::on_channel_done` assumed EOF means the worker process exited (the normal case) and only killed the worker on the corrupt-frame path (`is_attached()`). With the worker still alive, `try_reap` waits for an exit notification that never arrives and the run hangs.

## Fix

On channel-done, kill the worker whenever its process has not exited yet, not just on a corrupt frame. A worker that outlives its channel can neither receive a file nor report one, so it is lost either way. The in-flight file is accounted as `worker crashed: SIGKILL`, the slot respawns if files remain, and the run continues. `Channel::is_attached` lost its only caller and is removed.

One wrinkle: a worker doing a deliberate exit (`process.exit(7)` in a test, or the normal end-of-run path) closes its channel during VM teardown, before `_exit`. Under `BUN_DESTRUCT_VM_ON_EXIT` (set on CI's ASAN lanes) that teardown is long, so the coordinator would see EOF from a still-running process and the kill would clobber the real exit status (`worker crashed: SIGKILL` instead of `exit code 7`, caught by `test/regression/issue/30205.test.ts` in the first CI round). Workers therefore announce deliberate exits with a new `Exiting` IPC frame, sent while the channel is still up: a VM cleanup hook covers `process.exit`, and the worker loop's tail covers normal shutdown. The coordinator skips the kill for an announced exit and waits for the real status, which also lets ASAN leak checks in the worker finish. EOF with no announcement is a lost worker and is killed.

Fixed output for the repro above:

```
✗ fd3close.test.js (worker crashed: SIGKILL)
(pass) ok1
(pass) ok2
 2 pass
 1 fail
Ran 3 tests across 3 files.
```

## Verification

- New test in `test/cli/test/parallel.test.ts`: fails by timeout on an unfixed build, passes in ~2-4s on the fixed debug build.
- `test/regression/issue/30205.test.ts` (all 4 tests) passes with and without `BUN_DESTRUCT_VM_ON_EXIT=1`; the `process.exit(7)` fidelity failure from the first CI round reproduced locally with that env and is fixed by the exit announcement.
- Neighboring crash-path tests (worker `process.exit` mid-run, raw SIGABRT abort, garbage written to fd 3) pass in both env configurations.
- Three load-sensitive tests in `parallel.test.ts` (`lazily scales workers`, `partitions by directory`, `work-stealing balances`) fail identically with and without this change on a core-capped local machine; unrelated.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->