### PR TITLE
bun run --parallel/--sequential: do not wait for pipe EOF after the script exits

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -212,37 +212,29 @@ impl<'a> ProcessHandle<'a> {
         Ok(())
     }
 
-    /// Called when the process has exited with pipes possibly still open. A
-    /// background child the script left behind can hold the write ends
-    /// forever, so EOF must not be waited for: read what is already buffered
-    /// (the exit notification can beat the last readable data), then
-    /// force-end any pipe still open. On Windows there is no synchronous
-    /// drain; data libuv has not delivered yet is dropped, as it was before
-    /// the EOF gate existed.
+    /// On process exit, read what the pipes already hold, then force-end any
+    /// pipe a leftover child still keeps open: its EOF may never come and
+    /// must not stall the finish. Windows has no synchronous drain, so only
+    /// the force-end applies there.
     ///
     /// # Safety
-    /// `this` is the live handle. Raw (not `&mut self`): the reader callbacks
-    /// re-enter `State::maybe_finish` with their own exclusive reborrow of
-    /// the handle, which must not run under a live receiver borrow.
+    /// `this` is the live handle; the reader callbacks re-enter
+    /// `State::maybe_finish` with their own exclusive reborrow of it, so no
+    /// receiver borrow may be live across these calls.
     unsafe fn drain_and_close_pipes(this: *mut Self) {
-        // SAFETY: caller contract; each raw-ptr reborrow ends before the
-        // dispatches inside `read`/`deinit` run.
+        // SAFETY: caller contract; raw-ptr reborrows end before each dispatch.
         unsafe {
             for reader in [&raw mut (*this).stdout, &raw mut (*this).stderr] {
-                // `is_done()` distinguishes a reader whose EOF was already
-                // counted out of `remaining_fds` from one still open (the
-                // shared-parent done callback cannot tell which pipe it was).
+                // `is_done()` = EOF already counted out of `remaining_fds`.
                 #[cfg(unix)]
                 if !(*reader).is_done() && (*reader).get_fd() != sys::Fd::INVALID {
-                    // Streams readable data through `on_read_chunk`; reaching
-                    // EOF dispatches `on_reader_done` (decrements the count).
                     BufferedReader::read(reader);
                 }
                 if !(*reader).is_done() {
-                    // Fires no callback; the counter is zeroed below.
                     (*reader).deinit();
                 }
             }
+            // `deinit` fires no callback; all pipes are over, record it here.
             (*this).remaining_fds = 0;
         }
     }
@@ -278,13 +270,11 @@ impl<'a> ProcessHandle<'a> {
 
 bun_spawn::link_impl_ProcessExit! {
     FilterRunHandle for ProcessHandle<'static> => |this| {
-        // The process itself is leaked: the whole program exits once every
-        // script is done.
+        // The Process is never freed; the program exits when all scripts finish.
         on_process_exit(_process, status, _rusage) => {
             (*this).process.as_mut().unwrap().status = status;
             (*this).end_time = Some(Instant::now());
-            // Aborted runs keep the old rule (exit alone finishes); pending
-            // output of a killed script is dropped, not drained.
+            // Aborted runs finish on exit alone; their pending output is dropped.
             if !(*(*this).state.as_ptr()).aborted {
                 ProcessHandle::drain_and_close_pipes(this);
             }
@@ -400,11 +390,9 @@ impl<'a> State<'a> {
     }
 
     /// A script is finished once its process has exited *and* both pipes have
-    /// ended: the exit notification can arrive before the last output has
-    /// been read, and finishing then would drop that output (or, for the last
-    /// script, exit before printing it). A pipe a background child still
-    /// holds open cannot stall this: the exit path drains and force-ends both
-    /// pipes (`drain_and_close_pipes`), and on abort exit alone suffices.
+    /// ended; finishing on exit alone can drop output the exit notification
+    /// beat. The exit path force-ends pipes a leftover child holds open
+    /// (`drain_and_close_pipes`); on abort, exit alone suffices.
     fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> crate::Result<()> {
         let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
         if handle.finished || !exited || (handle.remaining_fds != 0 && !self.aborted) {

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -212,6 +212,41 @@ impl<'a> ProcessHandle<'a> {
         Ok(())
     }
 
+    /// Called when the process has exited with pipes possibly still open. A
+    /// background child the script left behind can hold the write ends
+    /// forever, so EOF must not be waited for: read what is already buffered
+    /// (the exit notification can beat the last readable data), then
+    /// force-end any pipe still open. On Windows there is no synchronous
+    /// drain; data libuv has not delivered yet is dropped, as it was before
+    /// the EOF gate existed.
+    ///
+    /// # Safety
+    /// `this` is the live handle. Raw (not `&mut self`): the reader callbacks
+    /// re-enter `State::maybe_finish` with their own exclusive reborrow of
+    /// the handle, which must not run under a live receiver borrow.
+    unsafe fn drain_and_close_pipes(this: *mut Self) {
+        // SAFETY: caller contract; each raw-ptr reborrow ends before the
+        // dispatches inside `read`/`deinit` run.
+        unsafe {
+            for reader in [&raw mut (*this).stdout, &raw mut (*this).stderr] {
+                // `is_done()` distinguishes a reader whose EOF was already
+                // counted out of `remaining_fds` from one still open (the
+                // shared-parent done callback cannot tell which pipe it was).
+                #[cfg(unix)]
+                if !(*reader).is_done() && (*reader).get_fd() != sys::Fd::INVALID {
+                    // Streams readable data through `on_read_chunk`; reaching
+                    // EOF dispatches `on_reader_done` (decrements the count).
+                    BufferedReader::read(reader);
+                }
+                if !(*reader).is_done() {
+                    // Fires no callback; the counter is zeroed below.
+                    (*reader).deinit();
+                }
+            }
+            (*this).remaining_fds = 0;
+        }
+    }
+
     fn on_read_chunk(&mut self, chunk: &[u8], has_more: ReadState) -> bool {
         let _ = has_more;
         let mut state_ref = self.state;
@@ -243,23 +278,24 @@ impl<'a> ProcessHandle<'a> {
 
 bun_spawn::link_impl_ProcessExit! {
     FilterRunHandle for ProcessHandle<'static> => |this| {
-        on_process_exit(process, status, rusage) =>
-            (*this).on_process_exit(&mut *process, status, rusage),
+        // The process itself is leaked: the whole program exits once every
+        // script is done.
+        on_process_exit(_process, status, _rusage) => {
+            (*this).process.as_mut().unwrap().status = status;
+            (*this).end_time = Some(Instant::now());
+            // Aborted runs keep the old rule (exit alone finishes); pending
+            // output of a killed script is dropped, not drained.
+            if !(*(*this).state.as_ptr()).aborted {
+                ProcessHandle::drain_and_close_pipes(this);
+            }
+            let mut state_ref = (*this).state;
+            let state = state_ref.get_mut();
+            let _ = state.maybe_finish(&mut *this);
+        },
     }
 }
 
 impl<'a> ProcessHandle<'a> {
-    fn on_process_exit(&mut self, proc: &mut Process, status: Status, _: &Rusage) {
-        self.process.as_mut().unwrap().status = status;
-        self.end_time = Some(Instant::now());
-        // We just leak the process because we're going to exit anyway after all processes are done
-        let _ = proc;
-        let mut state_ref = self.state;
-        // SAFETY: state backref valid (see start()).
-        let state = unsafe { state_ref.get_mut() };
-        let _ = state.maybe_finish(self);
-    }
-
     fn loop_(&self) -> *mut bun_io::Loop {
         // SAFETY: state backref valid; event_loop is the live MiniEventLoop singleton.
         bun_io::uws_to_native(unsafe { (*self.state.event_loop).loop_ })
@@ -364,10 +400,11 @@ impl<'a> State<'a> {
     }
 
     /// A script is finished once its process has exited *and* both pipes have
-    /// reached EOF: the exit notification can arrive before the last output
-    /// has been read, and finishing then would drop that output (or, for the
-    /// last script, exit before printing it). On abort, exit alone suffices:
-    /// a leftover child holding the pipes must not keep the aborted run alive.
+    /// ended: the exit notification can arrive before the last output has
+    /// been read, and finishing then would drop that output (or, for the last
+    /// script, exit before printing it). A pipe a background child still
+    /// holds open cannot stall this: the exit path drains and force-ends both
+    /// pipes (`drain_and_close_pipes`), and on abort exit alone suffices.
     fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> crate::Result<()> {
         let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
         if handle.finished || !exited || (handle.remaining_fds != 0 && !self.aborted) {

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -283,6 +283,38 @@ impl<'a> ProcessHandle<'a> {
 
         Ok(())
     }
+
+    /// Called when the process has exited with pipes possibly still open. A
+    /// background child the script left behind can hold the write ends
+    /// forever, so EOF must not be waited for: read what is already buffered
+    /// (the exit notification can beat the last readable data), then
+    /// force-end any pipe still open. On Windows there is no synchronous
+    /// drain; data libuv has not delivered yet is dropped, as it was before
+    /// the EOF gate existed.
+    ///
+    /// # Safety
+    /// `this` is the live handle. Raw (not `&mut self`): the reader callbacks
+    /// re-enter `State::maybe_finish` with their own exclusive reborrow of
+    /// the handle, which must not run under a live receiver borrow.
+    unsafe fn drain_and_close_pipes(this: *mut Self) {
+        // SAFETY: caller contract; each raw-ptr reborrow ends before the
+        // dispatches inside `read`/`deinit` run.
+        unsafe {
+            for pipe in [&raw mut (*this).stdout_reader, &raw mut (*this).stderr_reader] {
+                #[cfg(unix)]
+                if !(*pipe).ended && (*pipe).reader.get_fd() != bun_sys::Fd::INVALID {
+                    // Streams readable data through `on_read_chunk`; reaching
+                    // EOF dispatches `on_reader_done` (which sets `ended`).
+                    BufferedReader::read(&raw mut (*pipe).reader);
+                }
+                if !(*pipe).ended {
+                    (*pipe).ended = true;
+                    // Fires no callback; the accounting is the line above.
+                    (*pipe).reader.deinit();
+                }
+            }
+        }
+    }
 }
 
 bun_spawn::link_impl_ProcessExit! {
@@ -290,6 +322,11 @@ bun_spawn::link_impl_ProcessExit! {
         on_process_exit(_process, status, _rusage) => {
             (*this).process.as_mut().unwrap().status = status;
             (*this).end_time = Instant::now().into();
+            // Aborted runs keep the old rule (exit alone finishes); pending
+            // output of a killed script is dropped, not drained.
+            if !(*(*this).state).aborted {
+                ProcessHandle::drain_and_close_pipes(this);
+            }
             let state = &mut *(*this).state.cast_mut();
             let _ = state.maybe_finish(&mut *this);
         },
@@ -403,10 +440,11 @@ impl<'a> State<'a> {
     }
 
     /// A script is finished once its process has exited *and* both pipes have
-    /// reached EOF: the exit notification can arrive before the last output
-    /// has been read, and finishing then would drop that output (or, for the
-    /// last script, exit before printing it). On abort, exit alone suffices:
-    /// a leftover child holding the pipes must not keep the aborted run alive.
+    /// ended: the exit notification can arrive before the last output has
+    /// been read, and finishing then would drop that output (or, for the last
+    /// script, exit before printing it). A pipe a background child still
+    /// holds open cannot stall this: the exit path drains and force-ends both
+    /// pipes (`drain_and_close_pipes`), and on abort exit alone suffices.
     fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
         let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
         let pipes_open = !handle.stdout_reader.ended || !handle.stderr_reader.ended;

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -284,21 +284,17 @@ impl<'a> ProcessHandle<'a> {
         Ok(())
     }
 
-    /// Called when the process has exited with pipes possibly still open. A
-    /// background child the script left behind can hold the write ends
-    /// forever, so EOF must not be waited for: read what is already buffered
-    /// (the exit notification can beat the last readable data), then
-    /// force-end any pipe still open. On Windows there is no synchronous
-    /// drain; data libuv has not delivered yet is dropped, as it was before
-    /// the EOF gate existed.
+    /// On process exit, read what the pipes already hold, then force-end any
+    /// pipe a leftover child still keeps open: its EOF may never come and
+    /// must not stall the finish. Windows has no synchronous drain, so only
+    /// the force-end applies there.
     ///
     /// # Safety
-    /// `this` is the live handle. Raw (not `&mut self`): the reader callbacks
-    /// re-enter `State::maybe_finish` with their own exclusive reborrow of
-    /// the handle, which must not run under a live receiver borrow.
+    /// `this` is the live handle; the reader callbacks re-enter
+    /// `State::maybe_finish` with their own exclusive reborrow of it, so no
+    /// receiver borrow may be live across these calls.
     unsafe fn drain_and_close_pipes(this: *mut Self) {
-        // SAFETY: caller contract; each raw-ptr reborrow ends before the
-        // dispatches inside `read`/`deinit` run.
+        // SAFETY: caller contract; raw-ptr reborrows end before each dispatch.
         unsafe {
             for pipe in [
                 &raw mut (*this).stdout_reader,
@@ -306,13 +302,12 @@ impl<'a> ProcessHandle<'a> {
             ] {
                 #[cfg(unix)]
                 if !(*pipe).ended && (*pipe).reader.get_fd() != bun_sys::Fd::INVALID {
-                    // Streams readable data through `on_read_chunk`; reaching
-                    // EOF dispatches `on_reader_done` (which sets `ended`).
+                    // EOF here dispatches `on_reader_done`, setting `ended`.
                     BufferedReader::read(&raw mut (*pipe).reader);
                 }
                 if !(*pipe).ended {
                     (*pipe).ended = true;
-                    // Fires no callback; the accounting is the line above.
+                    // `deinit` fires no callback; `ended` is the accounting.
                     (*pipe).reader.deinit();
                 }
             }
@@ -325,8 +320,7 @@ bun_spawn::link_impl_ProcessExit! {
         on_process_exit(_process, status, _rusage) => {
             (*this).process.as_mut().unwrap().status = status;
             (*this).end_time = Instant::now().into();
-            // Aborted runs keep the old rule (exit alone finishes); pending
-            // output of a killed script is dropped, not drained.
+            // Aborted runs finish on exit alone; their pending output is dropped.
             if !(*(*this).state).aborted {
                 ProcessHandle::drain_and_close_pipes(this);
             }
@@ -443,11 +437,9 @@ impl<'a> State<'a> {
     }
 
     /// A script is finished once its process has exited *and* both pipes have
-    /// ended: the exit notification can arrive before the last output has
-    /// been read, and finishing then would drop that output (or, for the last
-    /// script, exit before printing it). A pipe a background child still
-    /// holds open cannot stall this: the exit path drains and force-ends both
-    /// pipes (`drain_and_close_pipes`), and on abort exit alone suffices.
+    /// ended; finishing on exit alone can drop output the exit notification
+    /// beat. The exit path force-ends pipes a leftover child holds open
+    /// (`drain_and_close_pipes`); on abort, exit alone suffices.
     fn maybe_finish(&mut self, handle: &mut ProcessHandle<'a>) -> Result<(), Error> {
         let exited = matches!(&handle.process, Some(p) if !matches!(p.status, Status::Running));
         let pipes_open = !handle.stdout_reader.ended || !handle.stderr_reader.ended;

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -300,7 +300,10 @@ impl<'a> ProcessHandle<'a> {
         // SAFETY: caller contract; each raw-ptr reborrow ends before the
         // dispatches inside `read`/`deinit` run.
         unsafe {
-            for pipe in [&raw mut (*this).stdout_reader, &raw mut (*this).stderr_reader] {
+            for pipe in [
+                &raw mut (*this).stdout_reader,
+                &raw mut (*this).stderr_reader,
+            ] {
                 #[cfg(unix)]
                 if !(*pipe).ended && (*pipe).reader.get_fd() != bun_sys::Fd::INVALID {
                     // Streams readable data through `on_read_chunk`; reaching

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -774,10 +774,10 @@ describe.skipIf(!isWindows).each([
 });
 
 describe("output timing", () => {
-  // A script is finished when its process has exited AND its output has reached
-  // EOF; treating the exit alone as "finished" drops output that hasn't been
-  // read yet (here: written by a child the script left behind).
-  test("output written after the script's shell exits is not dropped", async () => {
+  // A script is finished when its process exits: output it already wrote is
+  // drained at that point, but a detached child still holding the pipe write
+  // ends must not keep the run alive waiting for an EOF that may never come.
+  test("a detached child holding the pipes does not delay the script's finish", async () => {
     using dir = tempDir("filter-late-output", {
       "package.json": JSON.stringify({
         name: "ws-late",
@@ -790,30 +790,39 @@ describe("output timing", () => {
         },
       }),
       "packages/late/late.js": `
-        Bun.spawn({
-          cmd: [process.execPath, "-e", "await Bun.sleep(300); console.log('late-line')"],
+        const child = Bun.spawn({
+          cmd: [process.execPath, "-e", "await Bun.sleep(30_000); console.log('late-line')"],
           stdio: ["ignore", "inherit", "inherit"],
           // Windows: keep the child out of this process's kill-on-close job.
           detached: true,
-        }).unref();
+        });
+        child.unref();
+        await Bun.write("pid.txt", String(child.pid));
         console.log("early-line");
       `,
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", "--filter", "pkg-late", "go"],
       // CI ASAN lanes set BUN_FEATURE_FLAG_NO_ORPHANS, which makes the script's
-      // bun SIGKILL the detached child on exit, defeating the late write.
+      // bun SIGKILL the detached child on exit; unset it so the child really
+      // keeps the pipes open.
       env: { ...bunEnv, BUN_FEATURE_FLAG_NO_ORPHANS: undefined },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Reap the pipe-holding child so nothing outlives the test. Guard the pid:
+    // kill(0) would signal this whole process group.
+    try {
+      const pid = Number(await Bun.file(join(String(dir), "packages", "late", "pid.txt")).text());
+      if (Number.isInteger(pid) && pid > 0) process.kill(pid, "SIGKILL");
+    } catch {}
     expect(stdout).toContain("early-line");
-    expect(stdout).toContain("late-line");
     expect(stdout).toContain("Exited with code 0");
-    // The exit status line is printed at finish, after the output has ended.
-    expect(stdout.indexOf("late-line")).toBeLessThan(stdout.indexOf("Exited with code 0"));
+    // The run ends when the script exits; the child's much later write goes to
+    // a closed pipe instead of delaying the run by 30s.
+    expect(stdout).not.toContain("late-line");
     expect(exitCode).toBe(0);
   });
 

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -961,18 +961,21 @@ describe.concurrent("timing edge cases", () => {
     expect(r.exitCode).toBe(0);
   });
 
-  // A script is finished when its process has exited AND its output has reached
-  // EOF; treating the exit alone as "finished" drops output that hasn't been
-  // read yet (here: written by a child the script left behind).
-  test("output written after the script's shell exits is not dropped", async () => {
+  // A script is finished when its process exits: output it already wrote is
+  // drained at that point, but a detached child still holding the pipe write
+  // ends must not keep the run alive waiting for an EOF that may never come
+  // (e.g. "dev": "server & watcher" style scripts).
+  test("a detached child holding the pipes does not delay the script's finish", async () => {
     using dir = tempDir("mr-late-output", {
       "late.js": `
-        Bun.spawn({
-          cmd: [process.execPath, "-e", "await Bun.sleep(300); console.log('late-line')"],
+        const child = Bun.spawn({
+          cmd: [process.execPath, "-e", "await Bun.sleep(30_000); console.log('late-line')"],
           stdio: ["ignore", "inherit", "inherit"],
           // Windows: keep the child out of this process's kill-on-close job.
           detached: true,
-        }).unref();
+        });
+        child.unref();
+        await Bun.write("pid.txt", String(child.pid));
         console.log("early-line");
       `,
       "package.json": JSON.stringify({
@@ -983,16 +986,48 @@ describe.concurrent("timing edge cases", () => {
       }),
     });
     // CI ASAN lanes set BUN_FEATURE_FLAG_NO_ORPHANS, which makes the script's
-    // bun SIGKILL the detached child on exit, defeating the late write.
+    // bun SIGKILL the detached child on exit; unset it so the child really
+    // keeps the pipes open.
     const r = await runMulti(["run", "--sequential", "late", "other"], String(dir), {
       BUN_FEATURE_FLAG_NO_ORPHANS: undefined,
     });
+    // Reap the pipe-holding child so nothing outlives the test. Guard the pid:
+    // kill(0) would signal this whole process group.
+    try {
+      const pid = Number(await Bun.file(path.join(String(dir), "pid.txt")).text());
+      if (Number.isInteger(pid) && pid > 0) process.kill(pid, "SIGKILL");
+    } catch {}
     expectPrefixed(r.stdout, "late", "early-line");
-    expectPrefixed(r.stdout, "late", "late-line");
     expectPrefixed(r.stdout, "other", "other-ran");
-    expect(r.stdout.indexOf("late-line")).toBeLessThan(r.stdout.indexOf("other-ran"));
+    // The run ends when the script exits; the child's much later write goes to
+    // a closed pipe instead of delaying `other` (and the whole run) by 30s.
+    expect(r.stdout).not.toContain("late-line");
     expectDone(r.stderr, "late");
     expectDone(r.stderr, "other");
+    expect(r.exitCode).toBe(0);
+  });
+
+  // Same shape, sh syntax: "orphan": "sleep 30 & echo ..." must not block
+  // --parallel completion until the backgrounded sleep exits.
+  test.skipIf(isWindows)("a backgrounded helper does not block --parallel completion", async () => {
+    using dir = tempDir("mr-bg-helper", {
+      "package.json": JSON.stringify({
+        scripts: {
+          orphan: `sleep 30 & echo orphan-started:$!`,
+          quick: `echo quick-done`,
+        },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "quick", "orphan"], String(dir));
+    // Reap the backgrounded sleep so nothing outlives the test.
+    try {
+      const pid = Number(/orphan-started:(\d+)/.exec(r.stdout)?.[1]);
+      if (Number.isInteger(pid) && pid > 0) process.kill(pid, "SIGKILL");
+    } catch {}
+    expectPrefixed(r.stdout, "orphan", "orphan-started");
+    expectPrefixed(r.stdout, "quick", "quick-done");
+    expectDone(r.stderr, "orphan");
+    expectDone(r.stderr, "quick");
     expect(r.exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### What does this PR do?

Fixes an unreleased regression from #37206 on main: a script that backgrounds a helper now blocks `bun run --parallel` (and every later `--sequential` script) until the helper exits.

```json
{ "scripts": {
    "orphan": "sleep 25 & echo orphan-parent-exits",
    "quick":  "echo quick-done" } }
```

```
bun run --parallel quick orphan    # main: prints output, then sits 25s before exiting
bun run --sequential orphan quick  # main: quick does not START for 25s
```

Plain `bun run orphan` returns in ~0.1s, and so did both flags before #37206. Any script that daemonizes something without redirecting its stdio hits this: `"db": "pg_ctl start &"`, `"dev": "server & watcher"`, ssh-agent/Xvfb-style helpers.

**Cause:** #37206 made a script finished only when its process has exited *and* both stdout/stderr pipes reach EOF (so output that the exit notification beats is not dropped). A backgrounded grandchild inherits the pipe write ends, so EOF never comes until it dies, and the runner waits. The abort path already special-cased this; the normal-exit path did not. `bun run --filter` (`filter_run.rs`) has the same code and the same hang.

**Fix:** on process exit (unless the run is aborted), drain what is already readable, then force-end any pipe still open:

- The drain (`BufferedReader::read`) preserves the #37206 guarantee: everything the script wrote before exiting is in the kernel pipe buffer at exit time, so it is read and printed before the script is marked done. The macOS already-exited-at-watch scenario that #37206 fixed still gets its full output.
- The force-end (`deinit`, which fires no callbacks) means a write end held by a leftover child no longer delays the run; the accounting is done directly (`ended` flag in `multi_run.rs`, `remaining_fds = 0` in `filter_run.rs`).
- Aborted runs are unchanged: exit alone finishes, pending output is dropped.
- On Windows there is no synchronous drain primitive for libuv pipes; data not yet delivered at exit is dropped, as it was before the EOF gate existed.

One behavioral consequence, reflected in the updated tests: output a detached child writes *after* the script's process has exited is no longer shown (the pipe is closed at exit). #37206 had introduced "keep reading until the last holder closes the pipe", and that is exactly the behavior that turns daemonizing scripts into hangs.

### How did you verify your code works?

On unfixed main (debug build), the repro above hangs until killed (`--parallel`: prints output then sits; `timeout 12` exits 124) and `--filter '*' orphan` does too. With this change all three finish in ~0.1s with full output, including the `orphan | Done` line that previously never printed.

Tests (all fail on the unfixed build by hanging into the test timeout, pass with the fix):

- `multi-run.test.ts`: "a detached child holding the pipes does not delay the script's finish" (rewritten from #37206's late-output test: early output still printed, the run no longer waits 30s for the child, `--sequential` starts the next script), and a new `sleep 30 & echo ...` test for `--parallel` completion.
- `filter-workspace.test.ts`: same reshape of the late-output test for `--filter`.

- `bun bd test test/cli/run/multi-run.test.ts`: 121 pass
- `bun bd test test/cli/run/filter-workspace.test.ts`: 58 pass
- `bun bd test test/cli/run/run-quote.test.ts`: 6 pass
- `bun bd test test/cli/install/bun-run.test.ts`: 292 pass
- `bun run rust:check-all`: 10 ok (all platform targets)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts test/cli/run/multi-run.test.ts

<!-- robobun:evidence:end -->