### PR TITLE
test: cover an undeserializable advanced-serialization IPC frame

### DIFF
--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test("child_process ipc", async () => {
   const output = await $`${bunExe()} ${import.meta.dir}/fixtures/ipc_fixture.js`.text();
@@ -12,4 +12,66 @@ test("child_process ipc", async () => {
     cb ERR_IPC_CHANNEL_CLOSED
     "
   `);
+});
+
+// The child writes a well-formed advanced-serialization frame header
+// (type=2 SerializedMessage, u32-LE length) with a body that is not a valid
+// structured-clone payload. The parent must surface that as its own
+// uncaughtException (Node raises one too: deserialize errors propagate out of
+// the channel read) and must not leave the exception pending on the VM, which
+// aborts ASSERT-enabled builds at the next microtask drain.
+// Writing raw bytes to the channel fd only reaches the decoder on POSIX
+// (Windows IPC is a named pipe); the decode path under test is shared.
+const badFrameFixture = `
+  import { fork } from "node:child_process";
+  import fs from "node:fs";
+  if (process.argv[2] === "child") {
+    process.on("disconnect", () => process.exit(0));
+    const frame = Buffer.concat([Buffer.from([2, 16, 0, 0, 0]), Buffer.alloc(16, 0x41)]);
+    fs.writeSync(3, frame); // fork() places the IPC channel at fd 3
+    setInterval(() => {}, 1000); // stay alive until the parent side closes the channel
+  } else {
+    if (process.argv[2] === "handler") {
+      process.on("uncaughtException", e => console.log("PARENT uncaughtException: " + e.message));
+    }
+    const c = fork(import.meta.filename, ["child"], { serialization: "advanced" });
+    c.on("exit", code => {
+      console.log("child exited " + code);
+      process.exit(0);
+    });
+  }
+`;
+
+describe.concurrent.skipIf(isWindows)("advanced serialization: undeserializable frame from peer", () => {
+  test("parent with an uncaughtException handler survives", async () => {
+    using dir = tempDir("ipc-bad-frame", { "bad-frame-fixture.mjs": badFrameFixture });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "bad-frame-fixture.mjs", "handler"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "PARENT uncaughtException: Unable to deserialize data.\nchild exited 0\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("parent without a handler dies from the uncaught exception", async () => {
+    using dir = tempDir("ipc-bad-frame", { "bad-frame-fixture.mjs": badFrameFixture });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "bad-frame-fixture.mjs", "nohandler"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Unable to deserialize data.");
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Test only. Adds regression coverage for `child_process` / `Bun.spawn` IPC with `serialization: "advanced"` receiving a frame whose header is well formed but whose body cannot be deserialized.

Until #37275 landed, the decode path closed the channel but left the `JSValue::deserialize` exception pending on the VM. Builds with assertions enabled aborted at the next microtask drain:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
!exception() || m_vm.hasPendingTerminationException()
JavaScriptCore/ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

Release builds happened to report the pending exception as an uncaughtException at drain time, so the user-visible behavior there was already right, just reached by accident.

#37275 fixed this as part of the exception-fold rework: `finish_decode` in `src/runtime/ipc.rs` now folds the `JSError` arm through `dispatch::fold`, which reports it as the receiving process's uncaughtException. Nothing on main exercises that path, so this PR adds the two cases:

- parent with an `uncaughtException` handler: logs `Unable to deserialize data.`, the channel closes, the child exits on `disconnect`, parent exits 0
- parent without a handler: dies with exit 1 and the error on stderr

Both pass against current main under `bun bd` (debug/ASAN) and both failed on the pre-#37275 main they were written against (exit 134 from the assertion above). POSIX only: the fixture writes raw bytes to the channel fd, which is a socket on POSIX and a named pipe on Windows; the decode path under test is shared.

### What Node does

Node raises an uncaughtException on the receiving process: deserialize errors escape `channel.onread` (`lib/internal/child_process/serialization.js`). Verified with Node v26.3.0 and a Node-framed bad message (4-byte big-endian length prefix + garbage):

```
PARENT uncaughtException: Unable to deserialize cloned data due to invalid or unsupported version.
```

One pre-existing divergence is not covered by this PR's assertions beyond what falls out of the child exiting on `disconnect`: Bun closes the channel on a decode error while Node leaves it connected.

This also supersedes #34883 (closed), which suppressed the error entirely. That PR's Node baseline was an artifact: its repro wrote Bun-framed bytes, which Node's big-endian length framing reads as an incomplete ~33MB frame, so Node never attempted to deserialize.

<details>
<summary>Earlier shape of this PR</summary>

Opened before #37275 merged, this PR also changed `finish_decode` to take the pending exception via `report_active_exception_as_unhandled` after closing the channel. #37275 removed that helper and made the same behavioral fix through the dispatcher fold, so the source change was dropped on rebase and only the tests remain.

</details>
