### PR TITLE
install: don't mark a placed peer optional when saving a migrated bun.lock

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -650,6 +650,7 @@ impl Stringifier {
 
             let mut tree_deps_sort_buf: Vec<DependencyID> = Vec::new();
             let mut pkg_deps_sort_buf: Vec<DependencyID> = Vec::new();
+            let mut entry_path_buf: Vec<u8> = Vec::new();
 
             Self::write_indent(writer, *indent)?;
             writer.write_all(b"\"packages\": {")?;
@@ -707,29 +708,27 @@ impl Stringifier {
                         Self::write_indent(writer, *indent)?;
                     }
 
-                    writer.write_byte(b'"')?;
-                    // relative_path is empty string for root resolutions
-                    write!(
-                        writer,
-                        "{}",
-                        bun_core::fmt::format_json_string_utf8(
-                            relative_path,
-                            bun_core::fmt::JSONFormatterUTF8Options { quote: false }
-                        ),
-                    )?;
-
-                    if *depth != 0 {
-                        writer.write_byte(b'/')?;
-                    }
-
                     let dep = &deps_buf[dep_id as usize];
                     let dep_name = dep.name.slice(buf);
 
+                    // The entry key is also the tree path this package's own
+                    // dependencies resolve from. `find_resolution` must walk up
+                    // from it (not from the parent node's `relative_path`), the
+                    // same way the parser binds this entry's dependencies.
+                    // relative_path is empty string for root resolutions.
+                    entry_path_buf.clear();
+                    entry_path_buf.extend_from_slice(relative_path);
+                    if *depth != 0 {
+                        entry_path_buf.push(b'/');
+                    }
+                    entry_path_buf.extend_from_slice(dep_name);
+                    let entry_path: &[u8] = entry_path_buf.as_slice();
+
                     write!(
                         writer,
-                        "{}\": ",
+                        "\"{}\": ",
                         bun_core::fmt::format_json_string_utf8(
-                            dep_name,
+                            entry_path,
                             bun_core::fmt::JSONFormatterUTF8Options { quote: false }
                         ),
                     )?;
@@ -826,7 +825,7 @@ impl Stringifier {
                                 &mut optional_peers_buf,
                                 extern_strings,
                                 &pkg_map,
-                                relative_path,
+                                entry_path,
                                 &mut path_buf,
                             )?;
 
@@ -851,7 +850,7 @@ impl Stringifier {
                                 &mut optional_peers_buf,
                                 extern_strings,
                                 &pkg_map,
-                                relative_path,
+                                entry_path,
                                 &mut path_buf,
                             )?;
 
@@ -881,7 +880,7 @@ impl Stringifier {
                                 &mut optional_peers_buf,
                                 extern_strings,
                                 &pkg_map,
-                                relative_path,
+                                entry_path,
                                 &mut path_buf,
                             )?;
 
@@ -910,7 +909,7 @@ impl Stringifier {
                                 &mut optional_peers_buf,
                                 extern_strings,
                                 &pkg_map,
-                                relative_path,
+                                entry_path,
                                 &mut path_buf,
                             )?;
 
@@ -957,7 +956,7 @@ impl Stringifier {
                                 &mut optional_peers_buf,
                                 extern_strings,
                                 &pkg_map,
-                                relative_path,
+                                entry_path,
                                 &mut path_buf,
                             )?;
 
@@ -1005,7 +1004,7 @@ impl Stringifier {
                                 &mut optional_peers_buf,
                                 extern_strings,
                                 &pkg_map,
-                                relative_path,
+                                entry_path,
                                 &mut path_buf,
                             )?;
 
@@ -1054,7 +1053,9 @@ impl Stringifier {
         optional_peers_buf: &mut Vec<String>,
         extern_strings: &[ExternalString],
         pkg_map: &PkgMap<()>,
-        relative_path: &[u8],
+        // The package's own tree path (its `packages` key), which its
+        // dependencies resolve relative to; see `PkgMap::find_resolution`.
+        pkg_path: &[u8],
         path_buf: &mut [u8],
     ) -> Result<(), WriteError> {
         // `optional_peers_buf` is cleared at the fn tail.
@@ -1109,7 +1110,7 @@ impl Stringifier {
                     && pkg_map.map.len() > 0
                 {
                     if pkg_map
-                        .find_resolution(relative_path, dep, buf, path_buf)
+                        .find_resolution(pkg_path, dep, buf, path_buf)
                         .is_err()
                     {
                         optional_peers_buf.push(dep.name);
@@ -1230,7 +1231,9 @@ impl Stringifier {
         workspace_versions: &VersionHashMap,
         optional_peers_buf: &mut Vec<String>,
         pkg_map: &PkgMap<()>,
-        relative_path: &[u8],
+        // The workspace package's own tree path ("" for the root package, the
+        // workspace name otherwise); its dependencies resolve relative to it.
+        pkg_path: &[u8],
         path_buf: &mut [u8],
     ) -> Result<(), WriteError> {
         // `optional_peers_buf` is cleared at the fn tail.
@@ -1351,7 +1354,7 @@ impl Stringifier {
                     && !dep.behavior.contains(Behavior::OPTIONAL)
                     && pkg_map.map.len() > 0
                 {
-                    if let Err(err) = pkg_map.find_resolution(relative_path, dep, buf, path_buf) {
+                    if let Err(err) = pkg_map.find_resolution(pkg_path, dep, buf, path_buf) {
                         if err == ResolveError::Unresolvable {
                             optional_peers_buf.push(dep.name);
                         }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -711,11 +711,9 @@ impl Stringifier {
                     let dep = &deps_buf[dep_id as usize];
                     let dep_name = dep.name.slice(buf);
 
-                    // The entry key is also the tree path this package's own
-                    // dependencies resolve from. `find_resolution` must walk up
-                    // from it (not from the parent node's `relative_path`), the
-                    // same way the parser binds this entry's dependencies.
-                    // relative_path is empty string for root resolutions.
+                    // The entry key ("" relative_path for root resolutions) is
+                    // also the tree path this entry's dependencies resolve
+                    // from; `find_resolution` walks up from it like the parser.
                     entry_path_buf.clear();
                     entry_path_buf.extend_from_slice(relative_path);
                     if *depth != 0 {
@@ -1053,8 +1051,7 @@ impl Stringifier {
         optional_peers_buf: &mut Vec<String>,
         extern_strings: &[ExternalString],
         pkg_map: &PkgMap<()>,
-        // The package's own tree path (its `packages` key), which its
-        // dependencies resolve relative to; see `PkgMap::find_resolution`.
+        // The package's own tree path (its `packages` key).
         pkg_path: &[u8],
         path_buf: &mut [u8],
     ) -> Result<(), WriteError> {
@@ -1231,8 +1228,7 @@ impl Stringifier {
         workspace_versions: &VersionHashMap,
         optional_peers_buf: &mut Vec<String>,
         pkg_map: &PkgMap<()>,
-        // The workspace package's own tree path ("" for the root package, the
-        // workspace name otherwise); its dependencies resolve relative to it.
+        // The workspace package's tree path ("" for the root package).
         pkg_path: &[u8],
         path_buf: &mut [u8],
     ) -> Result<(), WriteError> {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -711,9 +711,8 @@ impl Stringifier {
                     let dep = &deps_buf[dep_id as usize];
                     let dep_name = dep.name.slice(buf);
 
-                    // The entry key ("" relative_path for root resolutions) is
-                    // also the tree path this entry's dependencies resolve
-                    // from; `find_resolution` walks up from it like the parser.
+                    // The entry key is also the tree path this entry's dependencies
+                    // resolve from; `find_resolution` walks up from it like the parser.
                     entry_path_buf.clear();
                     entry_path_buf.extend_from_slice(relative_path);
                     if *depth != 0 {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -711,8 +711,7 @@ impl Stringifier {
                     let dep = &deps_buf[dep_id as usize];
                     let dep_name = dep.name.slice(buf);
 
-                    // The entry key is also the tree path this entry's dependencies
-                    // resolve from; `find_resolution` walks up from it like the parser.
+                    // The entry key doubles as the tree path this entry's dependencies resolve from.
                     entry_path_buf.clear();
                     entry_path_buf.extend_from_slice(relative_path);
                     if *depth != 0 {

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -487,13 +487,9 @@ test.concurrent.each([
 test.concurrent(
   "migrated bun.lock with a nested-placed peer of a file: dependency round-trips --frozen-lockfile",
   async () => {
-    // gamma (a file: dependency of the root) has a regular peer dependency on
-    // delta, and delta's only placement is nested (workspace ws-a's file:
-    // dependency), never hoisted to the root. The migration writer records the
-    // placement as "gamma/delta" and must not also list delta in gamma's
-    // "optionalPeers": reloading would then treat the peer as optional, re-derive
-    // its resolution slot, drop the entry, and fail --frozen-lockfile on an
-    // unchanged tree.
+    // delta is a regular peer of gamma with only a nested placement ("gamma/delta").
+    // The migration writer must not also list it in "optionalPeers", or reloading
+    // drops the entry and --frozen-lockfile fails on an unchanged tree.
     await using testDir = tempDir("migrate-nested-peer-fixed-point", {
       "package.json": JSON.stringify({
         name: "sandbox",

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -484,6 +484,76 @@ test.concurrent.each([
   },
 );
 
+test.concurrent("migrated bun.lock with a nested-placed peer of a file: dependency round-trips --frozen-lockfile", async () => {
+  // gamma (a file: dependency of the root) has a regular peer dependency on
+  // delta, and delta's only placement is nested (workspace ws-a's file:
+  // dependency), never hoisted to the root. The migration writer records the
+  // placement as "gamma/delta" and must not also list delta in gamma's
+  // "optionalPeers": reloading would then treat the peer as optional, re-derive
+  // its resolution slot, drop the entry, and fail --frozen-lockfile on an
+  // unchanged tree.
+  await using testDir = tempDir("migrate-nested-peer-fixed-point", {
+    "package.json": JSON.stringify({
+      name: "sandbox",
+      version: "1.0.0",
+      workspaces: ["packages/ws-a"],
+      dependencies: { gamma: "file:vendor/gamma" },
+    }),
+    "vendor/gamma/package.json": JSON.stringify({
+      name: "gamma",
+      version: "1.0.0",
+      peerDependencies: { delta: "*" },
+    }),
+    "vendor/delta/package.json": JSON.stringify({ name: "delta", version: "2.0.0" }),
+    "packages/ws-a/package.json": JSON.stringify({
+      name: "ws-a",
+      version: "0.1.0",
+      dependencies: { delta: "file:../../vendor/delta" },
+    }),
+    // What `npm install --package-lock-only` produces for this tree.
+    "package-lock.json": JSON.stringify({
+      name: "sandbox",
+      version: "1.0.0",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": {
+          name: "sandbox",
+          version: "1.0.0",
+          dependencies: { gamma: "file:vendor/gamma" },
+          workspaces: ["packages/ws-a"],
+        },
+        "node_modules/gamma": { resolved: "vendor/gamma", link: true },
+        "vendor/gamma": { name: "gamma", version: "1.0.0", peerDependencies: { delta: "*" } },
+        "node_modules/delta": { resolved: "vendor/delta", link: true },
+        "vendor/delta": { name: "delta", version: "2.0.0" },
+        "node_modules/ws-a": { resolved: "packages/ws-a", link: true },
+        "packages/ws-a": { name: "ws-a", version: "0.1.0", dependencies: { delta: "file:../../vendor/delta" } },
+      },
+    }),
+  });
+
+  const first = await install(testDir);
+  expect(first.stderr).toContain("migrated lockfile from package-lock.json");
+  expect(first.exitCode).toBe(0);
+
+  const lock = await Bun.file(join(testDir, "bun.lock")).text();
+  // The peer's resolution is recorded right below in the same lockfile, so the
+  // peer is not optional.
+  expect(lock).toContain('"gamma/delta"');
+  expect(lock).not.toContain("optionalPeers");
+
+  // An unchanged tree satisfies --frozen-lockfile...
+  const frozen = await install(testDir, "--frozen-lockfile");
+  expect(frozen.stderr).not.toContain("lockfile had changes");
+  expect(frozen.exitCode).toBe(0);
+
+  // ...and a plain re-install does not rewrite the lockfile.
+  const second = await install(testDir);
+  expect(second.exitCode).toBe(0);
+  expect(await Bun.file(join(testDir, "bun.lock")).text()).toBe(lock);
+});
+
 test.concurrent("package-lock.json migration does not platform-skip a regular file: tarball dependency", async () => {
   // Same divergence as the folder variant, for a `LocalTarball` resolution. npm records
   // the packed package's `os`/`cpu` arrays in its lockfile entry, and a fresh resolve of

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -484,75 +484,78 @@ test.concurrent.each([
   },
 );
 
-test.concurrent("migrated bun.lock with a nested-placed peer of a file: dependency round-trips --frozen-lockfile", async () => {
-  // gamma (a file: dependency of the root) has a regular peer dependency on
-  // delta, and delta's only placement is nested (workspace ws-a's file:
-  // dependency), never hoisted to the root. The migration writer records the
-  // placement as "gamma/delta" and must not also list delta in gamma's
-  // "optionalPeers": reloading would then treat the peer as optional, re-derive
-  // its resolution slot, drop the entry, and fail --frozen-lockfile on an
-  // unchanged tree.
-  await using testDir = tempDir("migrate-nested-peer-fixed-point", {
-    "package.json": JSON.stringify({
-      name: "sandbox",
-      version: "1.0.0",
-      workspaces: ["packages/ws-a"],
-      dependencies: { gamma: "file:vendor/gamma" },
-    }),
-    "vendor/gamma/package.json": JSON.stringify({
-      name: "gamma",
-      version: "1.0.0",
-      peerDependencies: { delta: "*" },
-    }),
-    "vendor/delta/package.json": JSON.stringify({ name: "delta", version: "2.0.0" }),
-    "packages/ws-a/package.json": JSON.stringify({
-      name: "ws-a",
-      version: "0.1.0",
-      dependencies: { delta: "file:../../vendor/delta" },
-    }),
-    // What `npm install --package-lock-only` produces for this tree.
-    "package-lock.json": JSON.stringify({
-      name: "sandbox",
-      version: "1.0.0",
-      lockfileVersion: 3,
-      requires: true,
-      packages: {
-        "": {
-          name: "sandbox",
-          version: "1.0.0",
-          dependencies: { gamma: "file:vendor/gamma" },
-          workspaces: ["packages/ws-a"],
+test.concurrent(
+  "migrated bun.lock with a nested-placed peer of a file: dependency round-trips --frozen-lockfile",
+  async () => {
+    // gamma (a file: dependency of the root) has a regular peer dependency on
+    // delta, and delta's only placement is nested (workspace ws-a's file:
+    // dependency), never hoisted to the root. The migration writer records the
+    // placement as "gamma/delta" and must not also list delta in gamma's
+    // "optionalPeers": reloading would then treat the peer as optional, re-derive
+    // its resolution slot, drop the entry, and fail --frozen-lockfile on an
+    // unchanged tree.
+    await using testDir = tempDir("migrate-nested-peer-fixed-point", {
+      "package.json": JSON.stringify({
+        name: "sandbox",
+        version: "1.0.0",
+        workspaces: ["packages/ws-a"],
+        dependencies: { gamma: "file:vendor/gamma" },
+      }),
+      "vendor/gamma/package.json": JSON.stringify({
+        name: "gamma",
+        version: "1.0.0",
+        peerDependencies: { delta: "*" },
+      }),
+      "vendor/delta/package.json": JSON.stringify({ name: "delta", version: "2.0.0" }),
+      "packages/ws-a/package.json": JSON.stringify({
+        name: "ws-a",
+        version: "0.1.0",
+        dependencies: { delta: "file:../../vendor/delta" },
+      }),
+      // What `npm install --package-lock-only` produces for this tree.
+      "package-lock.json": JSON.stringify({
+        name: "sandbox",
+        version: "1.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": {
+            name: "sandbox",
+            version: "1.0.0",
+            dependencies: { gamma: "file:vendor/gamma" },
+            workspaces: ["packages/ws-a"],
+          },
+          "node_modules/gamma": { resolved: "vendor/gamma", link: true },
+          "vendor/gamma": { name: "gamma", version: "1.0.0", peerDependencies: { delta: "*" } },
+          "node_modules/delta": { resolved: "vendor/delta", link: true },
+          "vendor/delta": { name: "delta", version: "2.0.0" },
+          "node_modules/ws-a": { resolved: "packages/ws-a", link: true },
+          "packages/ws-a": { name: "ws-a", version: "0.1.0", dependencies: { delta: "file:../../vendor/delta" } },
         },
-        "node_modules/gamma": { resolved: "vendor/gamma", link: true },
-        "vendor/gamma": { name: "gamma", version: "1.0.0", peerDependencies: { delta: "*" } },
-        "node_modules/delta": { resolved: "vendor/delta", link: true },
-        "vendor/delta": { name: "delta", version: "2.0.0" },
-        "node_modules/ws-a": { resolved: "packages/ws-a", link: true },
-        "packages/ws-a": { name: "ws-a", version: "0.1.0", dependencies: { delta: "file:../../vendor/delta" } },
-      },
-    }),
-  });
+      }),
+    });
 
-  const first = await install(testDir);
-  expect(first.stderr).toContain("migrated lockfile from package-lock.json");
-  expect(first.exitCode).toBe(0);
+    const first = await install(testDir);
+    expect(first.stderr).toContain("migrated lockfile from package-lock.json");
+    expect(first.exitCode).toBe(0);
 
-  const lock = await Bun.file(join(testDir, "bun.lock")).text();
-  // The peer's resolution is recorded right below in the same lockfile, so the
-  // peer is not optional.
-  expect(lock).toContain('"gamma/delta"');
-  expect(lock).not.toContain("optionalPeers");
+    const lock = await Bun.file(join(testDir, "bun.lock")).text();
+    // The peer's resolution is recorded right below in the same lockfile, so the
+    // peer is not optional.
+    expect(lock).toContain('"gamma/delta"');
+    expect(lock).not.toContain("optionalPeers");
 
-  // An unchanged tree satisfies --frozen-lockfile...
-  const frozen = await install(testDir, "--frozen-lockfile");
-  expect(frozen.stderr).not.toContain("lockfile had changes");
-  expect(frozen.exitCode).toBe(0);
+    // An unchanged tree satisfies --frozen-lockfile...
+    const frozen = await install(testDir, "--frozen-lockfile");
+    expect(frozen.stderr).not.toContain("lockfile had changes");
+    expect(frozen.exitCode).toBe(0);
 
-  // ...and a plain re-install does not rewrite the lockfile.
-  const second = await install(testDir);
-  expect(second.exitCode).toBe(0);
-  expect(await Bun.file(join(testDir, "bun.lock")).text()).toBe(lock);
-});
+    // ...and a plain re-install does not rewrite the lockfile.
+    const second = await install(testDir);
+    expect(second.exitCode).toBe(0);
+    expect(await Bun.file(join(testDir, "bun.lock")).text()).toBe(lock);
+  },
+);
 
 test.concurrent("package-lock.json migration does not platform-skip a regular file: tarball dependency", async () => {
   // Same divergence as the folder variant, for a `LocalTarball` resolution. npm records


### PR DESCRIPTION
### Repro

`bun install` right after a package-lock.json migration is not a fixed point: the very next `bun install --frozen-lockfile` on an unchanged tree fails, and a plain re-install rewrites bun.lock.

```sh
mkdir -p vendor/gamma vendor/delta packages/ws-a
echo '{"name":"gamma","version":"1.0.0","peerDependencies":{"delta":"*"}}' > vendor/gamma/package.json
echo '{"name":"delta","version":"2.0.0"}' > vendor/delta/package.json
echo '{"name":"ws-a","version":"0.1.0","dependencies":{"delta":"file:../../vendor/delta"}}' > packages/ws-a/package.json
echo '{"name":"sandbox","version":"1.0.0","workspaces":["packages/ws-a"],"dependencies":{"gamma":"file:vendor/gamma"}}' > package.json
npm install --package-lock-only

bun install                    # migrates, writes bun.lock
bun install --frozen-lockfile  # error: lockfile had changes, but lockfile is frozen
bun install                    # silently removes the "gamma/delta" entry from bun.lock
```

Any project migrated from package-lock.json with this shape (a peer dependency of a `file:` package whose resolution is only placed nested, never hoisted to the root) fails its next `--frozen-lockfile` CI run.

### Cause

When saving a lockfile loaded in the binary format (which includes the package-lock.json migration path), the writer checks every non-optional peer dependency for a resolution in the hoisted tree, and lists peers without one in `optionalPeers` so the saved file stays parseable. That lookup (`PkgMap::find_resolution`) walked up from the parent tree node's `relative_path` instead of from the package entry's own path. For the entry `"gamma"` it probed `"delta"` (root) instead of `"gamma/delta"` first, so a peer placed nested under the package itself was missed and marked optional, even though its resolution was written two lines below:

```json
"gamma": ["gamma@file:vendor/gamma", { "peerDependencies": { "delta": "*" }, "optionalPeers": ["delta"] }],
"gamma/delta": ["delta@file:vendor/delta", {}],
```

On reload the parser adds `Behavior::OPTIONAL` to anything in `optionalPeers`, and since bbe3f6a2629a (#35681) optional-peer resolution slots are re-derived from the rebuilt tree during cleaning instead of carried over. A nested-only placement is not visible from the dependent's position, so the re-derive leaves the slot empty and the `"gamma/delta"` entry is dropped: the frozen check fails, and a plain install rewrites the lockfile. Before #35681 the stale optional marking round-tripped unnoticed; #35681 exposed it.

### Fix

Pass the package entry's own tree path (its `packages` key) to `write_package_info_object`, the exact string the parser passes to `find_resolution` when binding that entry's dependencies, so writer and parser agree on which placements a peer can see. The new probe set is a superset of the old one (it checks one level deeper first), so a peer can only stop being marked optional, never start.

A non-optional peer with genuinely no placement anywhere is still marked `optionalPeers`, which keeps such lockfiles loadable, and that state round-trips stably.

### Verification

New test in `test/cli/install/migration/migrate.test.ts` covering the repro above: migration output must not mark the placed peer optional, `--frozen-lockfile` must pass on the unchanged tree, and a re-install must leave bun.lock byte-identical. Fails before this change (the lockfile contains `"optionalPeers": ["delta"]` and the frozen install exits 1), passes after.

Also ran `migrate.test.ts`, `bun-lock.test.ts` (including the #35681 optional-peer tests), `bun-lockb.test.ts`, `migrate-bun-lockb-v2.test.ts`, `pnpm-lock-migration.test.ts`, `yarn-lock-migration.test.ts`, `hoist.test.ts`, `bun-workspaces.test.ts`, `isolated-install.test.ts`, `overrides.test.ts`, `lockfile-only.test.ts`, and the peer/optional filters of `bun-install-registry.test.ts`: no failures.

There is a second, independent way to break the same `install && install --frozen-lockfile` invariant, via the optionalDependencies + peerDependenciesMeta idiom on a `file:` package (a duplicate same-name tree entry from the folder-dependency hoist shortcut). That one is already fixed by the `Tree.rs` dedupe hunk in #33156, so it is intentionally not duplicated here; details posted on that PR.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/migration/migrate.test.ts

<!-- robobun:evidence:end -->