### PR TITLE
Fix quadratic backlog drain in bun test --parallel IPC

### DIFF
--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -108,9 +108,8 @@ pub type Socket = uws::NewSocketHandler<false>;
 #[cfg(not(windows))]
 pub struct PosixBackend {
     pub(crate) socket: Cell<Socket>,
-    /// Bytes at the front of `out` already written to the kernel. A cursor
-    /// rather than a per-write front-drain, which was quadratic in backlog
-    /// size (~90s for one 64MB frame over macOS's ~8KB socketpair buffers).
+    /// Bytes at the front of `out` already written to the kernel;
+    /// front-draining per partial write instead is quadratic in backlog size.
     out_head: Cell<usize>,
 }
 
@@ -469,8 +468,7 @@ impl<Owner: ChannelOwner> Channel<Owner> {
                     pending.clear();
                     head = 0;
                 } else if head >= pending.len() - head {
-                    // Sent prefix >= unsent tail: compacting now keeps the
-                    // total compaction cost linear in bytes sent.
+                    // Sent prefix caught up to the tail: compact (amortized linear).
                     pending.drain_front(head);
                     head = 0;
                 }

--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -108,6 +108,13 @@ pub type Socket = uws::NewSocketHandler<false>;
 #[cfg(not(windows))]
 pub struct PosixBackend {
     pub(crate) socket: Cell<Socket>,
+    /// Bytes at the front of `out` already accepted by the kernel. Tracking a
+    /// cursor instead of draining `out` after every partial write keeps the
+    /// backlog drain linear: the kernel accepts one send-buffer chunk per
+    /// writable event (8KB for macOS socketpairs), and a front-drain each time
+    /// would memmove the whole remaining backlog per chunk — quadratic, ~90s
+    /// of pure memmove for one 64MB frame on macOS x64.
+    out_head: Cell<usize>,
 }
 
 #[cfg(not(windows))]
@@ -115,6 +122,7 @@ impl Default for PosixBackend {
     fn default() -> Self {
         Self {
             socket: Cell::new(Socket::DETACHED),
+            out_head: Cell::new(0),
         }
     }
 }
@@ -448,13 +456,29 @@ impl<Owner: ChannelOwner> Channel<Owner> {
         {
             while !self.done.get() {
                 let mut pending = self.out.replace(Vec::new());
-                if pending.is_empty() {
+                let mut head = self.backend.out_head.get();
+                debug_assert!(head <= pending.len());
+                if pending.len() <= head {
+                    self.backend.out_head.set(0);
                     self.out.set(pending);
                     return;
                 }
-                let wrote = self.backend.socket.get().write(pending.as_slice());
-                let w = usize::try_from(wrote).unwrap_or(0).min(pending.len());
-                pending.drain_front(w);
+                let wrote = self.backend.socket.get().write(&pending[head..]);
+                let w = usize::try_from(wrote)
+                    .unwrap_or(0)
+                    .min(pending.len() - head);
+                head += w;
+                if head == pending.len() {
+                    pending.clear();
+                    head = 0;
+                } else if head >= pending.len() - head {
+                    // Compact only once the sent prefix is at least as large
+                    // as the unsent tail; each compaction is then charged to
+                    // the bytes it discards, keeping the total cost linear.
+                    pending.drain_front(head);
+                    head = 0;
+                }
+                self.backend.out_head.set(head);
                 self.out.with_mut(|cur| {
                     pending.extend_from_slice(cur);
                     *cur = pending;

--- a/src/runtime/cli/test/parallel/Channel.rs
+++ b/src/runtime/cli/test/parallel/Channel.rs
@@ -108,12 +108,9 @@ pub type Socket = uws::NewSocketHandler<false>;
 #[cfg(not(windows))]
 pub struct PosixBackend {
     pub(crate) socket: Cell<Socket>,
-    /// Bytes at the front of `out` already accepted by the kernel. Tracking a
-    /// cursor instead of draining `out` after every partial write keeps the
-    /// backlog drain linear: the kernel accepts one send-buffer chunk per
-    /// writable event (8KB for macOS socketpairs), and a front-drain each time
-    /// would memmove the whole remaining backlog per chunk — quadratic, ~90s
-    /// of pure memmove for one 64MB frame on macOS x64.
+    /// Bytes at the front of `out` already written to the kernel. A cursor
+    /// rather than a per-write front-drain, which was quadratic in backlog
+    /// size (~90s for one 64MB frame over macOS's ~8KB socketpair buffers).
     out_head: Cell<usize>,
 }
 
@@ -472,9 +469,8 @@ impl<Owner: ChannelOwner> Channel<Owner> {
                     pending.clear();
                     head = 0;
                 } else if head >= pending.len() - head {
-                    // Compact only once the sent prefix is at least as large
-                    // as the unsent tail; each compaction is then charged to
-                    // the bytes it discards, keeping the total cost linear.
+                    // Sent prefix >= unsent tail: compacting now keeps the
+                    // total compaction cost linear in bytes sent.
                     pending.drain_front(head);
                     head = 0;
                 }

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -876,6 +876,45 @@ test("--parallel: a test producing a >64MB result line is truncated, not treated
   expect(exitCode).toBe(1);
 }, 90_000);
 
+test("--parallel: back-to-back huge result lines drain in linear time without corrupting the channel", async () => {
+  // Two tests whose status lines each come in just under the 64MB IPC frame
+  // cap, from the same worker. The second frame is queued while the first
+  // backlog is still draining, so this exercises the write cursor, the
+  // amortized compaction, and appends to a partially-sent backlog. The 60s
+  // kill is the regression signal: draining the backlog by memmoving the
+  // whole remainder after every partial write is quadratic in frame size,
+  // and on macOS (~8KB socketpair buffers) one 64MB frame alone took ~90s
+  // of memmove.
+  using dir = tempDir("parallel-huge-backlog", {
+    "huge.test.js": `import {test,expect} from "bun:test";
+      test("A".repeat(60_000_000), () => expect(1).toBe(2));
+      test("B".repeat(60_000_000), () => expect(1).toBe(2));`,
+    "ok.test.js": `import {test,expect} from "bun:test"; test("ok",()=>expect(1).toBe(1));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+    timeout: 60_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  // Both huge tests failed normally: the channel survived both frames (no
+  // worker "crashed"), both 60MB status lines arrived intact (each stays
+  // just under the 64MB frame cap, so no truncation), and ok.test.js's pass
+  // survived on the other worker.
+  expect(stderr).not.toContain("crashed");
+  expect(stderr).toContain("A".repeat(10_000));
+  expect(stderr).toContain("B".repeat(10_000));
+  expect(stderr).toContain("1 pass");
+  expect(stderr).toContain("2 fail");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(1);
+}, 90_000);
+
 test("--parallel: a test writing garbage to fd 3 does not hang the coordinator", async () => {
   using dir = tempDir("parallel-hostile-fd3", {
     "ok.test.js": `import {test,expect} from "bun:test"; test("ok",()=>expect(1).toBe(1));`,

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -885,10 +885,11 @@ test("--parallel: back-to-back huge result lines drain in linear time without co
   // whole remainder after every partial write is quadratic in frame size,
   // and on macOS (~8KB socketpair buffers) one 64MB frame alone took ~90s
   // of memmove.
+  const TITLE_LENGTH = 60_000_000;
   using dir = tempDir("parallel-huge-backlog", {
     "huge.test.js": `import {test,expect} from "bun:test";
-      test("A".repeat(60_000_000), () => expect(1).toBe(2));
-      test("B".repeat(60_000_000), () => expect(1).toBe(2));`,
+      test(Buffer.alloc(${TITLE_LENGTH}, "A").toString(), () => expect(1).toBe(2));
+      test(Buffer.alloc(${TITLE_LENGTH}, "B").toString(), () => expect(1).toBe(2));`,
     "ok.test.js": `import {test,expect} from "bun:test"; test("ok",()=>expect(1).toBe(1));`,
   });
   await using proc = Bun.spawn({
@@ -907,8 +908,17 @@ test("--parallel: back-to-back huge result lines drain in linear time without co
   // just under the 64MB frame cap, so no truncation), and ok.test.js's pass
   // survived on the other worker.
   expect(stderr).not.toContain("crashed");
-  expect(stderr).toContain("A".repeat(10_000));
-  expect(stderr).toContain("B".repeat(10_000));
+  // Each title must arrive as one contiguous run of exactly TITLE_LENGTH
+  // characters: a shorter run (dropped bytes) leaves indexOf at -1, and a
+  // longer run (duplicated bytes) puts the title's letter right after the
+  // first match. Checked via index math so a failure doesn't dump 60MB
+  // strings into the log.
+  for (const letter of ["A", "B"]) {
+    const title = Buffer.alloc(TITLE_LENGTH, letter).toString();
+    const start = stderr.indexOf(title);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(stderr[start + TITLE_LENGTH]).not.toBe(letter);
+  }
   expect(stderr).toContain("1 pass");
   expect(stderr).toContain("2 fail");
   expect(proc.signalCode).toBeNull();


### PR DESCRIPTION
## Problem

`test/cli/test/parallel.test.ts > --parallel: a test producing a >64MB result line is truncated, not treated as a crash` is one of the most frequent flakes in CI right now: 19 failures across 17 branches in the last 400 builds, every one on the macOS x64 test lane, spread over six different agents. Signature:

```
867 |   expect(result).not.toBe("TIMEOUT");
error: expect(received).not.toBe(expected)
Expected: not "TIMEOUT"
```

The spawned `bun test --parallel=2` run blows past the test's 60s deadline. Reproduced on an idle macOS 14 x64 CI host with a current canary: the two-file repro takes **89 seconds**, CPU-bound (92s user time). `sample` shows 5294 of 5317 samples in `_platform_memmove` under the IPC flush path.

## Cause

`Channel::flush` (the fd-3 IPC channel used by `bun test --parallel`) drained the outgoing backlog like this: write once, then `drain_front(w)`, i.e. memmove the entire unsent remainder to the front of the buffer, once per writable event.

The kernel accepts one send-buffer chunk per event, and macOS socketpairs default to roughly 8KB (the extra-fd socketpair gets no buffer-size bump, unlike stdio fds 0-2). For the 64MB `TestDone` frame this test generates, that is ~8200 writable events, each memmoving ~64MB: about **512GB of memmove for one frame**, which is the 89 seconds. Linux socket buffers are ~26x larger, so the same quadratic stays near a second there and never trips the deadline, which is why the flake is exclusive to darwin x64 (darwin arm64 has the memory bandwidth to squeak under 60s).

## Fix

Track a cursor (`out_head`) of bytes already accepted by the kernel instead of draining the front after every partial write, and compact only once the sent prefix is at least as large as the unsent tail. Each compaction is charged to the bytes it discards, so total compaction cost is linear in bytes sent. No protocol or behavior change; Windows uses the `uv_write` path and is unaffected.

## Verification

- Linux debug build with the extra-fd socketpair buffers temporarily forced to 8KB (local-only patch) to mimic macOS: the 68MB-frame repro goes from **9.2s unfixed to 1.4s fixed** under identical conditions, with identical output (1 pass, 1 fail, truncation marker present).
- New test: two back-to-back 60MB status lines from the same worker, which exercises the cursor, the amortized compaction, and appending to a partially-sent backlog. Asserts both 60MB names arrive byte-intact, no worker is marked "crashed", and the run beats a 60s kill. On unfixed macOS x64 the drain alone exceeds the kill; passes in ~6s fixed (debug, Linux). Also ran the whole suite with the 8KB-buffer build so every frame goes through the chunked path: no new failures.
- `bun bd test test/cli/test/parallel.test.ts`: failure set identical to the unfixed baseline on this machine (two scheduling-sensitive tests that already fail locally under debug ASAN, unrelated).

Note for review: the quadratic is only observable with small socket buffers, so on Linux both the existing test and the new one pass with or without the fix; the lanes that prove the fix are the darwin x64 ones, where the existing `>64MB result line` test stops flaking.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->