### PR TITLE
Only reconstruct file-backed Blobs from in-process structured clones

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -393,7 +393,7 @@ JSC_DECLARE_CUSTOM_GETTER(js${typeName}Constructor);
       `extern JSC_CALLCONV JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${symbolName(
         typeName,
         "onStructuredCloneDeserialize",
-      )}(JSC::JSGlobalObject*, uint8_t**, const uint8_t*);` + "\n";
+      )}(JSC::JSGlobalObject*, uint8_t**, const uint8_t*, bool);` + "\n";
   }
   if (obj.finalize) {
     externs +=
@@ -2423,8 +2423,8 @@ function generateRust(
     }
     thunk(
       symbolName(typeName, "onStructuredCloneDeserialize"),
-      `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8) -> JSValue`,
-      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end))`,
+      `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8, is_from_untrusted_bytes: bool) -> JSValue`,
+      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end, is_from_untrusted_bytes))`,
     );
   }
 
@@ -2817,7 +2817,7 @@ class StructuredCloneableSerialize {
 
 class StructuredCloneableDeserialize {
   public:
-    static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*);
+    static std::optional<JSC::EncodedJSValue> fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject*, const uint8_t*&, const uint8_t*, bool isFromUntrustedBytes);
 };
 
 }
@@ -2845,7 +2845,7 @@ function writeCppSerializers() {
   function fromTagDeserializeForEachClass(klass) {
     return `
     if (tag == ${klass.structuredClone.tag}) {
-      return ${symbolName(klass.name, "onStructuredCloneDeserialize")}(globalObject, (uint8_t**)&ptr, end);
+      return ${symbolName(klass.name, "onStructuredCloneDeserialize")}(globalObject, (uint8_t**)&ptr, end, isFromUntrustedBytes);
     }
     `;
   }
@@ -2859,7 +2859,7 @@ function writeCppSerializers() {
   `;
 
   output += `
-  std::optional<JSC::EncodedJSValue> StructuredCloneableDeserialize::fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject* globalObject, const uint8_t*& ptr, const uint8_t* end)
+  std::optional<JSC::EncodedJSValue> StructuredCloneableDeserialize::fromTagDeserialize(uint8_t tag, JSC::JSGlobalObject* globalObject, const uint8_t*& ptr, const uint8_t* end, bool isFromUntrustedBytes)
   {
     ${structuredClonable.map(fromTagDeserializeForEachClass).join("\n").trim()}
     return std::nullopt;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3923,9 +3923,7 @@ private:
 
     JSGlobalObject* const m_globalObject;
     const bool m_isDOMGlobalObject;
-    // True when the wire bytes were supplied by the caller as a raw buffer
-    // (bun:jsc / node:v8 deserialize(), IPC) rather than produced by an
-    // in-process SerializedScriptValue::create().
+    // Wire bytes came from a caller-supplied buffer (deserialize()/IPC), not an in-process create().
     bool m_isFromUntrustedBytes { false };
     const uint8_t* m_ptr;
     const uint8_t* const m_end;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2260,7 +2260,8 @@ public:
         ,
         WasmModuleArray* wasmModules, WasmMemoryHandleArray* wasmMemoryHandles
 #endif
-    )
+        ,
+        bool isFromUntrustedBytes)
     {
         if (!buffer.size())
             return std::make_pair(jsNull(), SerializationReturnCode::UnspecifiedError);
@@ -2270,6 +2271,7 @@ public:
             wasmModules, wasmMemoryHandles
 #endif
         );
+        deserializer.m_isFromUntrustedBytes = isFromUntrustedBytes;
         if (!deserializer.isValid())
             return std::make_pair(JSValue(), SerializationReturnCode::ValidationError);
         return deserializer.deserialize();
@@ -3563,7 +3565,7 @@ private:
         //     return JSValue();
 
         // read bun types
-        if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end)) {
+        if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end, m_isFromUntrustedBytes)) {
             JSValue deserialized = JSValue::decode(value.value());
             if (deserialized.isEmpty()) {
                 fail();
@@ -3921,6 +3923,10 @@ private:
 
     JSGlobalObject* const m_globalObject;
     const bool m_isDOMGlobalObject;
+    // True when the wire bytes were supplied by the caller as a raw buffer
+    // (bun:jsc / node:v8 deserialize(), IPC) rather than produced by an
+    // in-process SerializedScriptValue::create().
+    bool m_isFromUntrustedBytes { false };
     const uint8_t* m_ptr;
     const uint8_t* const m_end;
     unsigned m_version;
@@ -4830,7 +4836,8 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
         ,
         nullptr, nullptr
 #endif
-    );
+        ,
+        /* isFromUntrustedBytes */ true);
 
     if (arrayBuffer->isShared()) {
         arrayBuffer->unpin();
@@ -5069,7 +5076,8 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                                                                ,
         m_wasmModulesArray.get(), m_wasmMemoryHandlesArray.get()
 #endif
-    );
+        ,
+        m_isFromUntrustedBytes);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;
     // Deserialize may throw an exception. Similar to serialize (SerializedScriptValue::create),

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5076,7 +5076,7 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
                                                                                ,
         m_wasmModulesArray.get(), m_wasmMemoryHandlesArray.get()
 #endif
-        ,
+                                      ,
         m_isFromUntrustedBytes);
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -188,8 +188,7 @@ private:
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
 
-    // Set by createFromWireBytes: deserialization rejects tags that would mint
-    // capabilities (file paths / fds) out of caller-supplied bytes.
+    // Set by createFromWireBytes so deserialization can refuse file-path/fd records from caller-supplied bytes.
     bool m_isFromUntrustedBytes { false };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -188,7 +188,7 @@ private:
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
 
-    // Set by createFromWireBytes so deserialization can refuse file-path/fd records from caller-supplied bytes.
+    // Set by createFromWireBytes so deserialization refuses file/fd/s3-backed Blob records; fromArrayBuffer passes the flag directly.
     bool m_isFromUntrustedBytes { false };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -140,7 +140,9 @@ public:
 
     static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&& data)
     {
-        return adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        auto value = adoptRef(*new SerializedScriptValue(WTF::move(data)));
+        value->m_isFromUntrustedBytes = true;
+        return value;
     }
     const Vector<uint8_t>& wireBytes() const { return m_data; }
 
@@ -185,6 +187,12 @@ private:
     String m_fastPathString;
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
+
+    // True when this value was reconstituted from a caller-supplied byte buffer
+    // (createFromWireBytes) rather than produced by an in-process create().
+    // Deserialization uses this to reject tags that would mint capabilities
+    // (file paths / file descriptors) straight out of the wire bytes.
+    bool m_isFromUntrustedBytes { false };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};
     // m_simpleArrayElements and m_arrayButterflyData/m_arrayLength are used exclusively:

--- a/src/jsc/bindings/webcore/SerializedScriptValue.h
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.h
@@ -188,10 +188,8 @@ private:
     FastPath m_fastPath { FastPath::None };
     size_t m_memoryCost { 0 };
 
-    // True when this value was reconstituted from a caller-supplied byte buffer
-    // (createFromWireBytes) rather than produced by an in-process create().
-    // Deserialization uses this to reject tags that would mint capabilities
-    // (file paths / file descriptors) straight out of the wire bytes.
+    // Set by createFromWireBytes: deserialization rejects tags that would mint
+    // capabilities (file paths / fds) out of caller-supplied bytes.
     bool m_isFromUntrustedBytes { false };
 
     FixedVector<SimpleInMemoryPropertyTableEntry> m_simpleInMemoryPropertyTable {};

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -208,6 +208,8 @@ pub enum Error {
     TooSmall,
     #[error("InvalidValue")]
     InvalidValue,
+    #[error("UntrustedFileBlob")]
+    UntrustedFileBlob,
     #[error("ConnectionFailed")]
     ConnectionFailed,
     #[error("InvalidOptions")]
@@ -683,6 +685,7 @@ impl Error {
             Self::EndOfStream => "EndOfStream",
             Self::TooSmall => "TooSmall",
             Self::InvalidValue => "InvalidValue",
+            Self::UntrustedFileBlob => "UntrustedFileBlob",
             Self::ConnectionFailed => "ConnectionFailed",
             Self::InvalidOptions => "InvalidOptions",
             Self::FailedToInitPipe => "FailedToInitPipe",

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -208,8 +208,6 @@ pub enum Error {
     TooSmall,
     #[error("InvalidValue")]
     InvalidValue,
-    #[error("UntrustedFileBlob")]
-    UntrustedFileBlob,
     #[error("ConnectionFailed")]
     ConnectionFailed,
     #[error("InvalidOptions")]
@@ -685,7 +683,6 @@ impl Error {
             Self::EndOfStream => "EndOfStream",
             Self::TooSmall => "TooSmall",
             Self::InvalidValue => "InvalidValue",
-            Self::UntrustedFileBlob => "UntrustedFileBlob",
             Self::ConnectionFailed => "ConnectionFailed",
             Self::InvalidOptions => "InvalidOptions",
             Self::FailedToInitPipe => "FailedToInitPipe",

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2006,8 +2006,7 @@ fn finish_decode(send_queue: &SendQueue, step: &DecodeStep) {
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
         DecodeStep::Fail(_) => {
-            // Closing the channel handles the bad frame; a decode exception
-            // left pending would surface as an unrelated uncaught error.
+            // A pending decode exception would surface as an unrelated uncaught error; closing the channel is the handling.
             send_queue
                 .get_global_this()
                 .clear_exception_except_termination();

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2000,9 +2000,19 @@ fn finish_decode(send_queue: &SendQueue, step: &DecodeStep) {
         }
         DecodeStep::Fail(IPCDecodeError::OutOfMemory) => {
             Output::print_errorln("IPC message is too long.");
+            send_queue
+                .get_global_this()
+                .clear_exception_except_termination();
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
         DecodeStep::Fail(_) => {
+            // The bad frame is fully handled here by closing the channel; a
+            // deserializer/JSONParse exception left pending on the VM would
+            // surface later as an unrelated uncaught error (and trips the
+            // exception-scope assert in debug builds).
+            send_queue
+                .get_global_this()
+                .clear_exception_except_termination();
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
     }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -1992,6 +1992,14 @@ enum DecodeStep {
     Fail(IPCDecodeError),
 }
 
+// A pending decode exception would surface as an unrelated uncaught error; closing the channel is the handling.
+fn close_after_decode_failure(send_queue: &SendQueue) {
+    send_queue
+        .get_global_this()
+        .clear_exception_except_termination();
+    send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
+}
+
 fn finish_decode(send_queue: &SendQueue, step: &DecodeStep) {
     match step {
         DecodeStep::Message(_) => unreachable!("caller dispatches Message"),
@@ -2000,17 +2008,10 @@ fn finish_decode(send_queue: &SendQueue, step: &DecodeStep) {
         }
         DecodeStep::Fail(IPCDecodeError::OutOfMemory) => {
             Output::print_errorln("IPC message is too long.");
-            send_queue
-                .get_global_this()
-                .clear_exception_except_termination();
-            send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
+            close_after_decode_failure(send_queue);
         }
         DecodeStep::Fail(_) => {
-            // A pending decode exception would surface as an unrelated uncaught error; closing the channel is the handling.
-            send_queue
-                .get_global_this()
-                .clear_exception_except_termination();
-            send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
+            close_after_decode_failure(send_queue);
         }
     }
 }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2006,10 +2006,8 @@ fn finish_decode(send_queue: &SendQueue, step: &DecodeStep) {
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
         DecodeStep::Fail(_) => {
-            // The bad frame is fully handled here by closing the channel; a
-            // deserializer/JSONParse exception left pending on the VM would
-            // surface later as an unrelated uncaught error (and trips the
-            // exception-scope assert in debug builds).
+            // Closing the channel handles the bad frame; a decode exception
+            // left pending would surface as an unrelated uncaught error.
             send_queue
                 .get_global_this()
                 .clear_exception_except_termination();

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -439,9 +439,8 @@ impl BlockList {
         global: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
-        // BlockList already validates wire bytes against the process-local
-        // `SERIALIZED_REFS` registry plus a per-instance nonce below, which
-        // rejects any payload that was not produced by this process.
+        // Unused: the `SERIALIZED_REFS` nonce check below already rejects
+        // payloads not produced by this process.
         _is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -439,6 +439,10 @@ impl BlockList {
         global: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        // BlockList already validates wire bytes against the process-local
+        // `SERIALIZED_REFS` registry plus a per-instance nonce below, which
+        // rejects any payload that was not produced by this process.
+        _is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the
         // caller (C++ SerializedScriptValue); `end >= *ptr`. `ptr` itself is a

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -439,8 +439,7 @@ impl BlockList {
         global: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
-        // Unused: the `SERIALIZED_REFS` nonce check below already rejects
-        // payloads not produced by this process.
+        // Unused: the `SERIALIZED_REFS` nonce check below already rejects foreign payloads.
         _is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2005,7 +2005,7 @@ impl BlobExt for Blob {
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
-        // `size` is untrusted (wire bytes, remote Content-Length): saturate instead of panicking the cast.
+        // `size` is a u64 bounded only by its writers; saturate so an unclamped value can never abort this cast.
         let size_i64 = i64::try_from(self.size.get()).unwrap_or(i64::MAX);
 
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -832,11 +832,6 @@ impl BlobExt for Blob {
             is_from_untrusted_bytes,
         ) {
             Ok(v) => v,
-            Err(crate::Error::UntrustedFileBlob) => {
-                return Err(global_this.throw(format_args!(
-                    "Cannot deserialize a file-backed Blob from serialized bytes; file references can only be cloned in-process via structuredClone or postMessage"
-                )));
-            }
             Err(e) if e.name() == "OutOfMemory" => {
                 return Err(global_this.throw_out_of_memory());
             }
@@ -4192,7 +4187,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
 
             // Raw buffers must not mint a handle to an arbitrary path, open fd, or s3:// key; only in-process clones may.
             if is_from_untrusted_bytes {
-                return Err(crate::Error::UntrustedFileBlob);
+                return Err(crate::Error::InvalidValue);
             }
 
             if version >= 4 {
@@ -4205,9 +4200,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
             match pathlike_tag {
                 PathOrFileDescriptorSerializeTag::Fd => {
                     let fd: Fd = reader.read_struct()?;
-                    // Wire bytes are untrusted: enforce the same range as `FdJsc::from_js_validated`
-                    // so a crafted record cannot materialize an fd no JS could construct (fd == -1
-                    // hits `Fd::as_borrowed_fd`'s `raw != -1` assert on posix and aborts).
+                    // Trusted-path defense in depth: mirror `FdJsc::from_js_validated` so an fd record can never reach `Fd::as_borrowed_fd`'s `raw != -1` assert.
                     #[cfg(not(windows))]
                     if fd.0 < 0 {
                         return Err(crate::Error::InvalidValue);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2005,9 +2005,8 @@ impl BlobExt for Blob {
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
-        // Saturate rather than abort: `size` is untrusted (it can come off the
-        // wire or from a remote Content-Length), so a value past i64::MAX must
-        // clamp instead of panicking the int cast.
+        // `size` is untrusted (wire bytes, remote Content-Length): saturate
+        // past i64::MAX instead of panicking the cast.
         let size_i64 = i64::try_from(self.size.get()).unwrap_or(i64::MAX);
 
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.
@@ -4192,10 +4191,9 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
 
-            // A path/fd-backed Blob reconstructed from caller-supplied bytes
-            // would grant access to an arbitrary file path, open descriptor,
-            // or `s3://` credential scope; only in-process serialized bytes
-            // may rebuild one.
+            // Caller-supplied bytes must not mint a handle to an arbitrary
+            // path, open fd, or s3:// key; only in-process clones may
+            // rebuild file-backed blobs.
             if is_from_untrusted_bytes {
                 return Err(crate::Error::UntrustedFileBlob);
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -183,6 +183,7 @@ pub trait BlobExt {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue>
     where
         Self: Sized;
@@ -812,6 +813,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
+        is_from_untrusted_bytes: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: codegen passes a live `*mut *mut u8` cursor (C++:
         // `(uint8_t**)&ptr`) and a one-past-the-end `*const u8`; both are
@@ -824,8 +826,17 @@ impl BlobExt for Blob {
         let mut buffer_stream =
             bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(start, total_length) });
 
-        let result = match on_structured_clone_deserialize(global_this, &mut buffer_stream) {
+        let result = match on_structured_clone_deserialize(
+            global_this,
+            &mut buffer_stream,
+            is_from_untrusted_bytes,
+        ) {
             Ok(v) => v,
+            Err(crate::Error::UntrustedFileBlob) => {
+                return Err(global_this.throw(format_args!(
+                    "Cannot deserialize a file-backed Blob from serialized bytes; file references can only be cloned in-process via structuredClone or postMessage"
+                )));
+            }
             Err(e) if e.name() == "OutOfMemory" => {
                 return Err(global_this.throw_out_of_memory());
             }
@@ -1994,10 +2005,15 @@ impl BlobExt for Blob {
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
+        // Saturate rather than abort: `size` is untrusted (it can come off the
+        // wire or from a remote Content-Length), so a value past i64::MAX must
+        // clamp instead of panicking the int cast.
+        let size_i64 = i64::try_from(self.size.get()).unwrap_or(i64::MAX);
+
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.
         let mut relative_start: i64 = 0;
         // If the optional end parameter is not used, let relativeEnd be size.
-        let mut relative_end: i64 = i64::try_from(self.size.get()).expect("int cast");
+        let mut relative_end: i64 = size_i64;
 
         // Mutate the fixed-3 args array in place to shift the string arg into [2].
         if args[0].is_string() {
@@ -2014,11 +2030,9 @@ impl BlobExt for Blob {
             if start_.is_number() {
                 let start = start_.to_int64();
                 if start < 0 {
-                    relative_start = (start
-                        .wrapping_add(i64::try_from(self.size.get()).expect("int cast")))
-                    .max(0);
+                    relative_start = (start.wrapping_add(size_i64)).max(0);
                 } else {
-                    relative_start = start.min(i64::try_from(self.size.get()).expect("int cast"));
+                    relative_start = start.min(size_i64);
                 }
             }
         }
@@ -2027,11 +2041,9 @@ impl BlobExt for Blob {
             if end_.is_number() {
                 let end = end_.to_int64();
                 if end < 0 {
-                    relative_end = (end
-                        .wrapping_add(i64::try_from(self.size.get()).expect("int cast")))
-                    .max(0);
+                    relative_end = (end.wrapping_add(size_i64)).max(0);
                 } else {
-                    relative_end = end.min(i64::try_from(self.size.get()).expect("int cast"));
+                    relative_end = end.min(size_i64);
                 }
             }
         }
@@ -4123,6 +4135,7 @@ fn read_slice<B: AsRef<[u8]>>(
 fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     global_this: &JSGlobalObject,
     reader: &mut bun_io::FixedBufferStream<B>,
+    is_from_untrusted_bytes: bool,
 ) -> crate::Result<JSValue> {
     let version = reader.read_int_le::<u8>()?;
     let offset = reader.read_int_le::<u64>()?;
@@ -4178,6 +4191,15 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         }
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
+
+            // A path/fd-backed Blob reconstructed from caller-supplied bytes
+            // would grant access to an arbitrary file path, open descriptor,
+            // or `s3://` credential scope; only in-process serialized bytes
+            // may rebuild one.
+            if is_from_untrusted_bytes {
+                return Err(crate::Error::UntrustedFileBlob);
+            }
+
             if version >= 4 {
                 file_size = Some(reader.read_int_le::<u64>()?);
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2005,8 +2005,7 @@ impl BlobExt for Blob {
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
-        // `size` is untrusted (wire bytes, remote Content-Length): saturate
-        // past i64::MAX instead of panicking the cast.
+        // `size` is untrusted (wire bytes, remote Content-Length): saturate instead of panicking the cast.
         let size_i64 = i64::try_from(self.size.get()).unwrap_or(i64::MAX);
 
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.
@@ -4191,9 +4190,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
 
-            // Caller-supplied bytes must not mint a handle to an arbitrary
-            // path, open fd, or s3:// key; only in-process clones may
-            // rebuild file-backed blobs.
+            // Raw buffers must not mint a handle to an arbitrary path, open fd, or s3:// key; only in-process clones may.
             if is_from_untrusted_bytes {
                 return Err(crate::Error::UntrustedFileBlob);
             }

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -795,7 +795,12 @@ describe("structuredClone with Blob and File", () => {
           `,
         });
         await using proc = Bun.spawn({
-          cmd: [bunExe(), join(String(dir), "parent.js"), join(String(dir), "child.js"), join(String(dir), "secret.txt")],
+          cmd: [
+            bunExe(),
+            join(String(dir), "parent.js"),
+            join(String(dir), "child.js"),
+            join(String(dir), "secret.txt"),
+          ],
           env: bunEnv,
           stdout: "pipe",
           stderr: "pipe",

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -478,8 +478,8 @@ describe("structuredClone with Blob and File", () => {
       // NUL payload below is that the rejection is a clean JS error and the
       // path never reaches the syscall layer where debug builds used to
       // abort in ZStr::as_cstr.
-      expect(() => deserialize(good)).toThrow();
-      expect(() => v8.deserialize(good)).toThrow();
+      expect(() => deserialize(good)).toThrow("Unable to deserialize data.");
+      expect(() => v8.deserialize(good)).toThrow("Unable to deserialize data.");
 
       const bad = Buffer.from(good);
       bad.set(Buffer.from("/e\0tc/host\0s____", "latin1"), at);
@@ -608,8 +608,8 @@ describe("structuredClone with Blob and File", () => {
 
       test("fd >= 0 is rejected from caller-supplied buffers too", () => {
         for (const fd of [0, 1, fdSentinel]) {
-          expect(() => deserialize(craftFd(fd))).toThrow();
-          expect(() => v8.deserialize(craftFd(fd))).toThrow();
+          expect(() => deserialize(craftFd(fd))).toThrow("Unable to deserialize data.");
+          expect(() => v8.deserialize(craftFd(fd))).toThrow("Unable to deserialize data.");
         }
       });
     });
@@ -630,8 +630,8 @@ describe("structuredClone with Blob and File", () => {
         // Serializing a path-backed Blob is still allowed; only reconstructing
         // one from the resulting raw bytes is not.
         const payload = serialize(Bun.file(join(String(dir), "secret.txt")));
-        expect(() => deserialize(payload)).toThrow();
-        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+        expect(() => deserialize(payload)).toThrow("Unable to deserialize data.");
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow("Unable to deserialize data.");
       });
 
       test("wire bytes naming a file descriptor are rejected", () => {
@@ -641,8 +641,8 @@ describe("structuredClone with Blob and File", () => {
         const fd = openSync(join(String(dir), "fd.txt"), "r");
         try {
           const payload = serialize(Bun.file(fd));
-          expect(() => deserialize(payload)).toThrow();
-          expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+          expect(() => deserialize(payload)).toThrow("Unable to deserialize data.");
+          expect(() => v8.deserialize(Buffer.from(payload))).toThrow("Unable to deserialize data.");
         } finally {
           closeSync(fd);
         }
@@ -658,8 +658,8 @@ describe("structuredClone with Blob and File", () => {
         const index = payload.indexOf(Buffer.from(placeholder));
         expect(index).toBeGreaterThan(-1);
         payload.set(Buffer.from(s3Path), index);
-        expect(() => deserialize(payload)).toThrow();
-        expect(() => v8.deserialize(payload)).toThrow();
+        expect(() => deserialize(payload)).toThrow("Unable to deserialize data.");
+        expect(() => v8.deserialize(payload)).toThrow("Unable to deserialize data.");
       });
 
       test("bytes-backed Blob and File still round-trip through deserialize", async () => {
@@ -720,10 +720,13 @@ describe("structuredClone with Blob and File", () => {
             let outcome;
             try {
               const blob = de(payload);
-              blob.slice(0, 10); // pre-fix: aborts on the unclamped size
+              // Pre-fix the record decoded and this aborted on the unclamped
+              // size; with the gate the catch below reports the rejection, and
+              // a gate regression surfaces as threw:false (or the abort).
+              blob.slice(0, 10);
               outcome = { threw: false, size: String(blob.size) };
             } catch (e) {
-              outcome = { threw: true };
+              outcome = { threw: true, message: String(e.message) };
             }
             process.stdout.write(JSON.stringify(outcome) + "\\n");
           }
@@ -736,7 +739,7 @@ describe("structuredClone with Blob and File", () => {
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-        const expected = { threw: true };
+        const expected = { threw: true, message: "Unable to deserialize data." };
         expect({
           stderr,
           outcomes: stdout

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,6 +1,8 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, rss } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, rss, tempDir } from "harness";
+import { closeSync, openSync } from "node:fs";
+import { join } from "node:path";
 import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
@@ -471,9 +473,13 @@ describe("structuredClone with Blob and File", () => {
       const good = Buffer.from(serialize(Bun.file(probe.toString("latin1"))));
       const at = good.indexOf(probe);
       expect(at).toBeGreaterThan(0);
-      // Sanity: both entry points accept the unmodified image.
-      expect(deserialize(good)).toBeInstanceOf(Blob);
-      expect(v8.deserialize(good)).toBeInstanceOf(Blob);
+      // File-backed records in caller-supplied buffers are rejected outright
+      // (NUL or not), so the unmodified image throws too. The point of the
+      // NUL payload below is that the rejection is a clean JS error and the
+      // path never reaches the syscall layer where debug builds used to
+      // abort in ZStr::as_cstr.
+      expect(() => deserialize(good)).toThrow();
+      expect(() => v8.deserialize(good)).toThrow();
 
       const bad = Buffer.from(good);
       bad.set(Buffer.from("/e\0tc/host\0s____", "latin1"), at);
@@ -536,11 +542,10 @@ describe("structuredClone with Blob and File", () => {
     });
 
     // The File-store variant of the Blob record carries a raw fd on the wire.
-    // `Bun.file(fd)` enforces `0 <= fd <= i32::MAX`; the deserializer must
-    // apply the same range so a crafted record cannot materialize a Blob over
-    // an fd that no JS could construct. On posix, fd == -1 reaches the
-    // `raw != -1` assert in `Fd::as_borrowed_fd` and aborts the process at
-    // the first `.size` / body-mixin touch.
+    // Caller-supplied buffers cannot rebuild an fd-backed Blob at all, and the
+    // rejection must be a clean JS error for every fd value: on posix,
+    // fd == -1 used to reach the `raw != -1` assert in `Fd::as_borrowed_fd`
+    // and abort the process at the first `.size` / body-mixin touch.
     describe.skipIf(isWindows)("crafted File blob fd (posix)", () => {
       // Robustness against header/framing changes: serialize a file-backed
       // blob over a distinctive sentinel fd, locate its 4-byte image in the
@@ -601,11 +606,214 @@ describe("structuredClone with Blob and File", () => {
         expect(exitCode).toBe(0);
       });
 
-      test("fd >= 0 still deserializes", () => {
+      test("fd >= 0 is rejected from caller-supplied buffers too", () => {
         for (const fd of [0, 1, fdSentinel]) {
-          expect(deserialize(craftFd(fd))).toBeInstanceOf(Blob);
-          expect(v8.deserialize(craftFd(fd))).toBeInstanceOf(Blob);
+          expect(() => deserialize(craftFd(fd))).toThrow();
+          expect(() => v8.deserialize(craftFd(fd))).toThrow();
         }
+      });
+    });
+
+    // The File store variant of the Blob record carries either a literal path
+    // or a raw fd number (s3:// keys ride the path form). Honoring either from
+    // a caller-supplied byte buffer (bun:jsc deserialize, node:v8 deserialize,
+    // child-process IPC) hands whoever crafted the buffer a live handle to an
+    // arbitrary file, an arbitrary open descriptor of the receiving process,
+    // or an S3 key resolved under the receiver's credentials. File-backed
+    // records only deserialize for byte streams produced by an in-process
+    // serialize (structuredClone / postMessage); raw buffers are rejected.
+    describe("file-backed stores in caller-supplied buffers", () => {
+      test("wire bytes naming a file path do not mint a readable file handle", () => {
+        using dir = tempDir("blob-deser-path", {
+          "secret.txt": "this is the secret file contents",
+        });
+        // Serializing a path-backed Blob is still allowed; only reconstructing
+        // one from the resulting raw bytes is not.
+        const payload = serialize(Bun.file(join(String(dir), "secret.txt")));
+        expect(() => deserialize(payload)).toThrow();
+        expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+      });
+
+      test("wire bytes naming a file descriptor are rejected", () => {
+        using dir = tempDir("blob-deser-fd", {
+          "fd.txt": "fd-backed contents",
+        });
+        const fd = openSync(join(String(dir), "fd.txt"), "r");
+        try {
+          const payload = serialize(Bun.file(fd));
+          expect(() => deserialize(payload)).toThrow();
+          expect(() => v8.deserialize(Buffer.from(payload))).toThrow();
+        } finally {
+          closeSync(fd);
+        }
+      });
+
+      test("wire bytes naming an s3:// path are rejected", () => {
+        // Patch the serialized path in-place to an `s3://` URL of the same
+        // length; an honored payload would mint an S3-credential-backed blob.
+        const placeholder = "/tmp/aaaaaaaaaa";
+        const s3Path = "s3://bucket/key";
+        expect(s3Path.length).toBe(placeholder.length);
+        const payload = Buffer.from(serialize(Bun.file(placeholder)));
+        const index = payload.indexOf(Buffer.from(placeholder));
+        expect(index).toBeGreaterThan(-1);
+        payload.set(Buffer.from(s3Path), index);
+        expect(() => deserialize(payload)).toThrow();
+        expect(() => v8.deserialize(payload)).toThrow();
+      });
+
+      test("bytes-backed Blob and File still round-trip through deserialize", async () => {
+        const blob = deserialize(serialize(new Blob(["hello"], { type: "text/plain" })));
+        expect(blob).toBeInstanceOf(Blob);
+        expect(await blob.text()).toBe("hello");
+
+        const file = v8.deserialize(v8.serialize(new File(["x"], "a.txt")));
+        expect(file).toBeInstanceOf(File);
+        expect(file.name).toBe("a.txt");
+        expect(await file.text()).toBe("x");
+      });
+
+      test("structuredClone of Bun.file still yields a readable file-backed blob", async () => {
+        using dir = tempDir("blob-clone-path", {
+          "data.txt": "in-process clone keeps the file reference",
+        });
+        const cloned = structuredClone(Bun.file(join(String(dir), "data.txt")));
+        expect(await cloned.text()).toBe("in-process clone keeps the file reference");
+      });
+
+      test("crafted size past i64::MAX cannot abort the receiver", async () => {
+        // Hand-built File record with size = 2^63. Pre-fix this deserialized
+        // into a Blob whose unclamped `size` made `.slice()` panic on the
+        // i64 cast (abort). The record must be rejected at deserialize; run
+        // in a child so a regression surfaces as a test failure instead of
+        // killing the runner.
+        const u32 = (n: number) => {
+          const b = Buffer.alloc(4);
+          b.writeUInt32LE(n);
+          return b;
+        };
+        const u64 = (n: bigint) => {
+          const b = Buffer.alloc(8);
+          b.writeBigUInt64LE(n);
+          return b;
+        };
+        const path = Buffer.from("/nonexistent");
+        const crafted = Buffer.concat([
+          Buffer.from(serialize(0)).subarray(0, 4), // outer serializer version header
+          Buffer.from([0xfe, 4]), // Blob tag 254, blob serialization version 4
+          u64(0n), // offset
+          u32(0), // content-type length
+          Buffer.from([0, 0]), // content_type_was_set, store tag = File
+          u64(1n << 63n), // size
+          Buffer.from([1]), // pathlike tag = Path
+          u32(path.length),
+          path,
+          Buffer.from([0]), // is_jsdom_file
+          Buffer.alloc(8), // lastModified
+        ]);
+
+        const childScript = `
+          const { deserialize } = require("bun:jsc");
+          const v8 = require("node:v8");
+          const payload = Buffer.from(process.argv[1], "base64");
+          for (const de of [deserialize, buf => v8.deserialize(Buffer.from(buf))]) {
+            let outcome;
+            try {
+              const blob = de(payload);
+              blob.slice(0, 10); // pre-fix: aborts on the unclamped size
+              outcome = { threw: false, size: String(blob.size) };
+            } catch (e) {
+              outcome = { threw: true };
+            }
+            process.stdout.write(JSON.stringify(outcome) + "\\n");
+          }
+        `;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", childScript, crafted.toString("base64")],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        const expected = { threw: true };
+        expect({
+          stderr,
+          outcomes: stdout
+            .split("\n")
+            .filter(Boolean)
+            .map(l => JSON.parse(l)),
+        }).toEqual({ stderr: "", outcomes: [expected, expected] });
+        expect(exitCode).toBe(0);
+      });
+
+      test.skipIf(isWindows)("a crafted IPC frame from a child does not mint a file handle in the parent", async () => {
+        // The confused-deputy shape: the child never receives a Blob from JS;
+        // it writes a raw advanced-serialization frame containing a
+        // path-backed Blob record straight onto the IPC pipe. The parent's
+        // decoder must reject the record (it closes the channel) rather than
+        // deliver a live file handle to the parent's message handler.
+        using dir = tempDir("ipc-blob-gate", {
+          "secret.txt": "ipc-secret-contents",
+          "parent.js": `
+            const childPath = process.argv[2];
+            const secretPath = process.argv[3];
+            const child = Bun.spawn({
+              cmd: [process.execPath, childPath, secretPath],
+              env: process.env,
+              serialization: "advanced",
+              stdout: "inherit",
+              stderr: "inherit",
+              ipc(message, c) {
+                console.log(JSON.stringify({ isBlob: message instanceof Blob, value: message instanceof Blob ? "<blob>" : String(message) }));
+                if (message === "hello") c.send("go");
+              },
+            });
+            await child.exited;
+            console.log(JSON.stringify({ done: true }));
+          `,
+          "child.js": `
+            const fs = require("node:fs");
+            const { serialize } = require("bun:jsc");
+            const secretPath = process.argv[2];
+            process.on("message", m => {
+              if (m !== "go") return;
+              // Receiving "go" proves the ordered IPC writer already flushed
+              // the handshake, so the raw frame below lands after it. The
+              // runtime consumes NODE_CHANNEL_FD before user code runs; with
+              // no extra fds in the spawn, the channel is always fd 3.
+              const payload = Buffer.from(serialize(Bun.file(secretPath)));
+              const frame = Buffer.alloc(5 + payload.byteLength);
+              frame[0] = 2; // SerializedMessage
+              frame.writeUInt32LE(payload.byteLength, 1);
+              payload.copy(frame, 5);
+              fs.writeSync(3, frame);
+              try { process.send("sentinel-after-frame"); } catch {}
+              process.exit(0);
+            });
+            process.send("hello");
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), join(String(dir), "parent.js"), join(String(dir), "child.js"), join(String(dir), "secret.txt")],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        const lines = stdout
+          .split("\n")
+          .filter(Boolean)
+          .map(l => JSON.parse(l));
+        // The handshake message arrives; the crafted frame must never surface
+        // as a message (let alone a Blob). The sentinel sent after the bad
+        // frame is allowed to be dropped with the closed channel.
+        expect(lines[0]).toEqual({ isBlob: false, value: "hello" });
+        expect(lines.some(l => l.isBlob)).toBe(false);
+        expect(lines.at(-1)).toEqual({ done: true });
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
       });
     });
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,5 +1,5 @@
 import { deserialize, serialize } from "bun:jsc";
-import { openSync } from "fs";
+import { closeSync, openSync } from "fs";
 import { bunEnv, bunExe, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
@@ -367,21 +367,64 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         const cloned = await structuredCloneFn(blob);
         await compareBlobs(blob, cloned);
       });
-      test("file from path", async () => {
-        const blob = Bun.file(join(import.meta.dir, "example.txt"));
-        const cloned = await structuredCloneFn(blob);
-        expect(cloned.lastModified).toBe(blob.lastModified);
-        expect(cloned.name).toBe(blob.name);
-        expect(cloned.size).toBe(blob.size);
-      });
-      test("file from fd", async () => {
-        const fd = openSync(join(import.meta.dir, "example.txt"), "r");
-        const blob = Bun.file(fd);
-        const cloned = await structuredCloneFn(blob);
-        expect(cloned.lastModified).toBe(blob.lastModified);
-        expect(cloned.name).toBe(blob.name);
-        expect(cloned.size).toBe(blob.size);
-      });
+      // Path/fd-backed Blobs only round-trip through the in-process
+      // structuredClone path. The two bun:jsc serialize/deserialize variants
+      // hand the deserializer a raw byte buffer, and reconstructing a file
+      // handle from caller-supplied bytes is rejected (the path/fd embedded in
+      // the payload cannot be trusted).
+      if (structuredCloneFn === structuredClone) {
+        test("file from path", async () => {
+          const blob = Bun.file(join(import.meta.dir, "example.txt"));
+          const cloned = await structuredCloneFn(blob);
+          expect(cloned.lastModified).toBe(blob.lastModified);
+          expect(cloned.name).toBe(blob.name);
+          expect(cloned.size).toBe(blob.size);
+        });
+        test("file from fd", async () => {
+          const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+          try {
+            const blob = Bun.file(fd);
+            const cloned = await structuredCloneFn(blob);
+            expect(cloned.lastModified).toBe(blob.lastModified);
+            expect(cloned.name).toBe(blob.name);
+            expect(cloned.size).toBe(blob.size);
+          } finally {
+            closeSync(fd);
+          }
+        });
+      } else if (structuredCloneFn === jscSerializeRoundtrip) {
+        test("file from path is rejected", () => {
+          const blob = Bun.file(join(import.meta.dir, "example.txt"));
+          expect(() => structuredCloneFn(blob)).toThrow();
+        });
+        test("file from fd is rejected", () => {
+          const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+          try {
+            const blob = Bun.file(fd);
+            expect(() => structuredCloneFn(blob)).toThrow();
+          } finally {
+            closeSync(fd);
+          }
+        });
+      } else {
+        // Cross-process: the child's deserialize() rejects the payload and
+        // dies with an uncaught error, which surfaces here as the
+        // child-exited error from the framing loop. The round trip never
+        // yields a file-backed Blob.
+        test("file from path is rejected", async () => {
+          const blob = Bun.file(join(import.meta.dir, "example.txt"));
+          await expect(jscSerializeRoundtripCrossProcess(blob)).rejects.toThrow(/child exited/);
+        });
+        test("file from fd is rejected", async () => {
+          const fd = openSync(join(import.meta.dir, "example.txt"), "r");
+          try {
+            const blob = Bun.file(fd);
+            await expect(jscSerializeRoundtripCrossProcess(blob)).rejects.toThrow(/child exited/);
+          } finally {
+            closeSync(fd);
+          }
+        });
+      }
       describe("dom file", async () => {
         test("without lastModified", async () => {
           const file = new File(["hi"], "example.txt", { type: "text/plain" });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -395,13 +395,13 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       } else if (structuredCloneFn === jscSerializeRoundtrip) {
         test("file from path is rejected", () => {
           const blob = Bun.file(join(import.meta.dir, "example.txt"));
-          expect(() => structuredCloneFn(blob)).toThrow();
+          expect(() => structuredCloneFn(blob)).toThrow("Unable to deserialize data.");
         });
         test("file from fd is rejected", () => {
           const fd = openSync(join(import.meta.dir, "example.txt"), "r");
           try {
             const blob = Bun.file(fd);
-            expect(() => structuredCloneFn(blob)).toThrow();
+            expect(() => structuredCloneFn(blob)).toThrow("Unable to deserialize data.");
           } finally {
             closeSync(fd);
           }

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -411,15 +411,19 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         // dies with an uncaught error, which surfaces here as the
         // child-exited error from the framing loop. The round trip never
         // yields a file-backed Blob.
+        // The child must die from the clean uncaught throw (exit 1, no
+        // signal) with the rejection on its stderr, which the framing loop
+        // embeds in the error it throws; a crash would surface a signal here.
+        const rejection = /child exited \(code 1, signal null\)[\s\S]*Unable to deserialize data\./;
         test("file from path is rejected", async () => {
           const blob = Bun.file(join(import.meta.dir, "example.txt"));
-          await expect(jscSerializeRoundtripCrossProcess(blob)).rejects.toThrow(/child exited/);
+          await expect(jscSerializeRoundtripCrossProcess(blob)).rejects.toThrow(rejection);
         });
         test("file from fd is rejected", async () => {
           const fd = openSync(join(import.meta.dir, "example.txt"), "r");
           try {
             const blob = Bun.file(fd);
-            await expect(jscSerializeRoundtripCrossProcess(blob)).rejects.toThrow(/child exited/);
+            await expect(jscSerializeRoundtripCrossProcess(blob)).rejects.toThrow(rejection);
           } finally {
             closeSync(fd);
           }

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -29,14 +29,10 @@ const testTypes = [
     name: "BunFile (cloneable, non-transferable)",
     createValue: () => Bun.file(import.meta.filename),
     isTransferable: false,
-    // A path-backed BunFile cannot be reconstructed from a raw byte buffer:
-    // the deserializer rejects file-backed stores whose bytes were supplied by
-    // the caller (they would mint a handle to an arbitrary path/fd). The child
-    // process's deserialize() throws, so the wire round trip yields nothing.
-    expectedAfterWireBytesRoundtrip: (original: any, cloned: any) => {
-      expect(original).toBeInstanceOf(Blob);
-      expect(cloned).not.toBeInstanceOf(Blob);
-    },
+    // A path-backed BunFile cannot be rebuilt from a raw byte buffer: the
+    // child's deserialize() dies with an uncaught error and the wire round
+    // trip yields nothing (asserted at the spawn site).
+    rejectsWireBytes: true,
     expectedAfterClone: (original: any, cloned: any, isTransfer: TransferMode, isStorage: boolean) => {
       expect(original).toBeInstanceOf(Blob);
       expect(original.name).toEqual(import.meta.filename);
@@ -95,12 +91,12 @@ describe("serialize & deserialize", () => {
         env: bunEnv,
         stdin: serialized,
         stdout: "pipe",
-        // Test types that declare expectedAfterWireBytesRoundtrip expect the
-        // child's deserialize() to die with an uncaught error; capture stderr
-        // for assertion instead of echoing the expected failure.
-        stderr: "expectedAfterWireBytesRoundtrip" in testType ? "pipe" : "inherit",
+        // rejectsWireBytes types expect the child's deserialize() to die with
+        // an uncaught error; capture stderr for assertion instead of echoing
+        // the expected failure.
+        stderr: "rejectsWireBytes" in testType ? "pipe" : "inherit",
       });
-      if ("expectedAfterWireBytesRoundtrip" in testType) {
+      if ("rejectsWireBytes" in testType) {
         // The child must reject the payload with a clean uncaught throw:
         // no signal (a crash here is the abort class this guards against),
         // nothing on stdout, and the rejection message on stderr.
@@ -110,7 +106,6 @@ describe("serialize & deserialize", () => {
           stdoutLength: result.stdout.length,
           stderrHasRejection: result.stderr.toString().includes("Unable to deserialize data."),
         }).toEqual({ signalCode: null, exitCode: 1, stdoutLength: 0, stderrHasRejection: true });
-        testType.expectedAfterWireBytesRoundtrip!(original, undefined);
       } else {
         const cloned = deserialize(result.stdout);
         testType.expectedAfterClone(original, cloned, TransferMode.no, true);

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -29,6 +29,14 @@ const testTypes = [
     name: "BunFile (cloneable, non-transferable)",
     createValue: () => Bun.file(import.meta.filename),
     isTransferable: false,
+    // A path-backed BunFile cannot be reconstructed from a raw byte buffer:
+    // the deserializer rejects file-backed stores whose bytes were supplied by
+    // the caller (they would mint a handle to an arbitrary path/fd). The child
+    // process's deserialize() throws, so the wire round trip yields nothing.
+    expectedAfterWireBytesRoundtrip: (original: any, cloned: any) => {
+      expect(original).toBeInstanceOf(Blob);
+      expect(cloned).not.toBeInstanceOf(Blob);
+    },
     expectedAfterClone: (original: any, cloned: any, isTransfer: TransferMode, isStorage: boolean) => {
       expect(original).toBeInstanceOf(Blob);
       expect(original.name).toEqual(import.meta.filename);
@@ -87,10 +95,17 @@ describe("serialize & deserialize", () => {
         env: bunEnv,
         stdin: serialized,
         stdout: "pipe",
-        stderr: "inherit",
+        // Test types that declare expectedAfterWireBytesRoundtrip expect the
+        // child's deserialize() to die with an uncaught error; don't echo that
+        // expected failure into the test runner's stderr.
+        stderr: "expectedAfterWireBytesRoundtrip" in testType ? "ignore" : "inherit",
       });
-      const cloned = deserialize(result.stdout);
-      testType.expectedAfterClone(original, cloned, TransferMode.no, true);
+      const cloned = result.stdout.length > 0 ? deserialize(result.stdout) : undefined;
+      if ("expectedAfterWireBytesRoundtrip" in testType) {
+        testType.expectedAfterWireBytesRoundtrip!(original, cloned);
+      } else {
+        testType.expectedAfterClone(original, cloned, TransferMode.no, true);
+      }
     });
   }
 });

--- a/test/js/web/workers/structuredClone-classes.test.ts
+++ b/test/js/web/workers/structuredClone-classes.test.ts
@@ -96,14 +96,23 @@ describe("serialize & deserialize", () => {
         stdin: serialized,
         stdout: "pipe",
         // Test types that declare expectedAfterWireBytesRoundtrip expect the
-        // child's deserialize() to die with an uncaught error; don't echo that
-        // expected failure into the test runner's stderr.
-        stderr: "expectedAfterWireBytesRoundtrip" in testType ? "ignore" : "inherit",
+        // child's deserialize() to die with an uncaught error; capture stderr
+        // for assertion instead of echoing the expected failure.
+        stderr: "expectedAfterWireBytesRoundtrip" in testType ? "pipe" : "inherit",
       });
-      const cloned = result.stdout.length > 0 ? deserialize(result.stdout) : undefined;
       if ("expectedAfterWireBytesRoundtrip" in testType) {
-        testType.expectedAfterWireBytesRoundtrip!(original, cloned);
+        // The child must reject the payload with a clean uncaught throw:
+        // no signal (a crash here is the abort class this guards against),
+        // nothing on stdout, and the rejection message on stderr.
+        expect({
+          signalCode: result.signalCode ?? null,
+          exitCode: result.exitCode,
+          stdoutLength: result.stdout.length,
+          stderrHasRejection: result.stderr.toString().includes("Unable to deserialize data."),
+        }).toEqual({ signalCode: null, exitCode: 1, stdoutLength: 0, stderrHasRejection: true });
+        testType.expectedAfterWireBytesRoundtrip!(original, undefined);
       } else {
+        const cloned = deserialize(result.stdout);
         testType.expectedAfterClone(original, cloned, TransferMode.no, true);
       }
     });


### PR DESCRIPTION
### Problem

The Blob structured-clone wire record (tag 254) stores a file-backed Blob as either a literal path, a raw file descriptor number, or an `s3://` key. The deserializer honored all three from any byte source, so `bun:jsc` / `node:v8` `deserialize()` and child-process IPC (advanced serialization) would mint a live `Bun.file(path)` / `Bun.file(fd)` / S3 blob straight out of caller-supplied bytes:

```js
import v8 from "node:v8";
const out = v8.deserialize(v8.serialize(Bun.file("/etc/hostname")));
await out.text(); // file contents; a hand-built buffer works the same
```

The fd form acts on the receiver's own open descriptors and needs no path permission, and a child process can write a hand-built 5-byte-header frame straight onto the IPC pipe to hand its parent a file reference the parent never asked for. The serializer already refuses to send Blob across processes (`process.send(Bun.file(p))` arrives as `{}` because Blob is not transferable), but the decoder had no matching gate.

Two adjacent hardening issues fixed in the same area:

- a crafted record whose `size` field is past `i64::MAX` deserialized into a Blob whose `.slice()` aborted the process (`panic: int cast: TryFromIntError(PosOverflow)`), because the wire size is kept unclamped while the file store's own size is still unknown and `get_slice` used `expect("int cast")`
- an IPC frame that fails to decode left the deserializer's JS exception pending on the VM, where it surfaced later as an unrelated uncaught error (and tripped the exception-scope assert in debug builds), so a peer could take down the receiving process with one bad frame

### Fix

Same approach as #31329, rebased onto current main:

- `SerializedScriptValue::fromArrayBuffer` and `createFromWireBytes` (the two entry points that reconstitute caller-supplied buffers: `bun:jsc`/`node:v8` `deserialize()` and IPC) mark the deserialization as coming from untrusted bytes; the flag threads through `CloneDeserializer` and the generated `fromTagDeserialize` dispatch into the per-class deserializers
- the Blob deserializer rejects the File store variant (path, fd, and s3 alike) when that flag is set, before reading any of the record's fields. Bytes-backed and empty Blob/File records round-trip through every entry point as before, and in-process clones (`structuredClone`, worker `postMessage`) of `Bun.file()` are unchanged
- `Blob.slice()` saturates the size cast instead of panicking
- IPC decode failures clear the pending exception before closing the channel, so a bad frame closes the channel and nothing else

`BlockList` (the only other tag in the dispatch) takes the new parameter and ignores it; it already validates wire bytes against a process-local registry.

Note `deserialize(serialize(Bun.file(p)))` in the same process now throws as well: serializing the reference is still allowed, but a raw buffer carries no provenance, so reconstruction is refused no matter who produced it. This matches Node, where `v8.serialize` of a Blob/File never round-trips a file handle.

### Tests

`test/js/web/structured-clone-blob-file.test.ts` gains coverage for path-, fd-, and s3-shaped records through both `deserialize` entry points, the hand-built oversized-`size` record (run in a child so the pre-fix abort fails cleanly), and a parent/child IPC case where the child writes a crafted frame directly onto the channel fd and the parent must reject it and survive. Existing tests that asserted the old byte-stream behavior (`fd >= 0 still deserializes`, the round-trip sanity checks, and the file-from-path/fd cases in `test/js/web/workers/structured-clone.test.ts` and `structuredClone-classes.test.ts`) now assert the rejection for raw-buffer entry points while keeping the in-process `structuredClone` assertions.

All touched suites pass with the debug build; the new and updated assertions fail on the unpatched binary (7 failures in the blob file, 4 in workers/structured-clone, 1 in structuredClone-classes).

Supersedes #31217 and #31329.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/structured-clone-blob-file.test.ts

<!-- robobun:evidence:end -->