### PR TITLE
perf(util): drop bound-function dispatch from primordials uncurryThis (up to 5x faster util.format)

### DIFF
--- a/bench/snippets/util-format.mjs
+++ b/bench/snippets/util-format.mjs
@@ -8,8 +8,8 @@ bench("util.format long message, 2 specifiers", () =>
 );
 bench("util.format 16-bit format string", () => util.format("café %s — número %d", "olé", 42));
 bench("util.format trailing args", () => util.format("plain", "join", "of", "strings", 123));
-bench('util.format("%j")', () => util.format("json: %j", { a: 1, b: "two" }));
-bench('util.format("%f %i %%")', () => util.format("%f%% done, batch %i", 85.5, 12));
+bench('util.format("json: %j")', () => util.format("json: %j", { a: 1, b: "two" }));
+bench('util.format("%f%% done, batch %i")', () => util.format("%f%% done, batch %i", 85.5, 12));
 
 const longFormat = `${"lorem ipsum dolor sit amet ".repeat(8)}%s ${"consectetur adipiscing elit ".repeat(8)}%d`;
 bench("util.format long format string", () => util.format(longFormat, "value", 42));

--- a/bench/snippets/util-format.mjs
+++ b/bench/snippets/util-format.mjs
@@ -11,9 +11,14 @@ bench("util.format trailing args", () => util.format("plain", "join", "of", "str
 bench('util.format("%j")', () => util.format("json: %j", { a: 1, b: "two" }));
 bench('util.format("%f %i %%")', () => util.format("%f%% done, batch %i", 85.5, 12));
 
+const longFormat = `${"lorem ipsum dolor sit amet ".repeat(8)}%s ${"consectetur adipiscing elit ".repeat(8)}%d`;
+bench("util.format long format string", () => util.format(longFormat, "value", 42));
+
 bench("util.inspect short string", () => util.inspect("hello world"));
-bench("util.inspect string with quotes", () => util.inspect("it's a \"quoted\" string\nwith a newline"));
+bench("util.inspect string with quotes", () => util.inspect('it\'s a "quoted" string\nwith a newline'));
 bench("util.inspect small object", () => util.inspect({ a: 1, b: "two", c: [1, 2, 3] }));
 bench("util.inspect array of numbers", () => util.inspect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+const longString = `line with 'quotes' and\ttabs\n`.repeat(40);
+bench("util.inspect long string with escapes", () => util.inspect(longString));
 
 await run();

--- a/bench/snippets/util-format.mjs
+++ b/bench/snippets/util-format.mjs
@@ -1,0 +1,19 @@
+import util from "node:util";
+import { bench, run } from "../runner.mjs";
+
+bench('util.format("hello %s number %d")', () => util.format("hello %s number %d", "world", 42));
+bench('util.format("%s:%s:%s")', () => util.format("%s:%s:%s", "GET", "/api/users", "200 OK"));
+bench("util.format long message, 2 specifiers", () =>
+  util.format("[worker %d] request completed with status %s after some time", 7, "success"),
+);
+bench("util.format 16-bit format string", () => util.format("café %s — número %d", "olé", 42));
+bench("util.format trailing args", () => util.format("plain", "join", "of", "strings", 123));
+bench('util.format("%j")', () => util.format("json: %j", { a: 1, b: "two" }));
+bench('util.format("%f %i %%")', () => util.format("%f%% done, batch %i", 85.5, 12));
+
+bench("util.inspect short string", () => util.inspect("hello world"));
+bench("util.inspect string with quotes", () => util.inspect("it's a \"quoted\" string\nwith a newline"));
+bench("util.inspect small object", () => util.inspect({ a: 1, b: "two", c: [1, 2, 3] }));
+bench("util.inspect array of numbers", () => util.inspect([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+
+await run();

--- a/src/js/internal/primordials.js
+++ b/src/js/internal/primordials.js
@@ -23,17 +23,18 @@ const createSafeIterator = (factory, next_) => {
   return SafeIterator;
 };
 
-// Intrinsics do not have `call` as a valid identifier, so this cannot be `Function.prototype.call.bind`.
-const FunctionPrototypeCall = $getByIdDirect(Function.prototype, "call");
-
 function getGetter(cls, getter) {
   // TODO: __lookupGetter__ is deprecated, but Object.getOwnPropertyDescriptor doesn't work on built-ins like Typed Arrays.
-  return FunctionPrototypeCall.bind(cls.prototype.__lookupGetter__(getter));
+  const fn = cls.prototype.__lookupGetter__(getter);
+  return obj => fn.$call(obj);
 }
 
 function uncurryThis(func) {
-  // Intrinsics do not have `call` as a valid identifier, so this cannot be `Function.prototype.call.bind`.
-  return FunctionPrototypeCall.bind(func);
+  // Not `Function.prototype.call.bind(func)`: JSC dispatches bound functions
+  // far slower than a direct call (~35ns vs ~1ns per call), and these wrappers
+  // sit in per-character loops of util.inspect/format. The `$apply` intrinsic
+  // keeps the dispatch tamper-proof, like internal/repl/node-primordials.js.
+  return (thisArg, ...args) => func.$apply(thisArg, args);
 }
 
 const copyProps = (src, dest) => {


### PR DESCRIPTION
## Summary

`internal/primordials.js` builds every uncurried helper with `Function.prototype.call.bind(fn)`. That pattern comes from Node, where V8 optimizes it away — but JSC dispatches bound functions much more slowly than direct calls, so every uncurried helper costs ~33ns per call instead of ~1ns. `internal/util/inspect.js` alone has 54 of these wrappers and calls them inside per-character scanning loops, so `util.format()`/`util.inspect()` pay the bound-call tax dozens of times per invocation — `util.format("hello %s number %d", ...)` runs ~6x slower than Node 22 on the same machine today.

This PR changes `uncurryThis` to forward through the tamper-proof `$apply` intrinsic instead:

```js
function uncurryThis(func) {
  return (thisArg, ...args) => func.$apply(thisArg, args);
}
```

`getGetter` gets the same treatment with a fixed-arity `$call` arrow, and the now-unused `FunctionPrototypeCall` capture is removed. This is the same dispatch pattern `internal/repl/node-primordials.js` already uses for the ported Node REPL sources.

Everything that consumes `internal/primordials` speeds up: `util.format`, `util.formatWithOptions`, `util.inspect`, `node:assert` error rendering, `node:v8` serdes helpers, quic, and the Safe* container internals.

## Why the wrappers are observably identical

- Rest + `$apply` forwards the exact argument list: absent arguments stay absent (a zero-extra-arg call still reaches the target with zero arguments), and variadic targets (`ArrayPrototypePush`) still see every argument.
- Wrapper `.length` stays `1` (`call.bind` produced length 1; a `(thisArg, ...rest)` arrow is also length 1).
- `$apply`/`$call` compile to JSC private names, so mutating `Function.prototype.apply` after module load cannot affect builtins — the same guarantee the bound `call` capture gave.
- No consumer reads `.name`/`.prototype` of an uncurried helper, calls `.bind`/`.call`/`.apply` on one, or constructs one with `new` (audited every `require("internal/primordials")` site under `src/js`). The only observable difference is the wrapper's own `.name` (`"bound call"` → `""`), which nothing reads.
- `SafeMap`/`SafeSet`/`SafeStringIterator`/`SafePromiseAll*` still behave the same with tampered prototypes (e.g. replacing `Map.prototype.entries` after module load does not affect `SafeMap` iteration).

## Microbenchmark (root cause)

Bun release, x64 — per-call cost of `s.charCodeAt(i)` through each dispatch style:

| dispatch style | ns/call |
|---|---|
| direct `s.charCodeAt(i)` | ~1 |
| `Function.prototype.call.bind(charCodeAt)` (current) | ~33 |
| `(t, ...a) => charCodeAt.$apply(t, a)` (this PR) | ~4 |

Node 22 on the same machine: bound ≈ arrow ≈ direct (~2ns) — V8 optimizes the `call.bind` pattern, JSC does not, so the pattern never transferred.

Every call shape gets faster, including with the JIT disabled (`BUN_JSC_useJIT=0`: 350ns → 174ns for the same loop), so there is no configuration where the per-call rest array makes the new wrapper slower than the old bound call.

## Benchmark

`bench/snippets/util-format.mjs` (added in this PR), two `bun run build:release` builds of this branch differing only in this diff, same machine (x64 Linux, AMD EPYC 7763, 4 cores):

| benchmark | before | after | speedup |
|---|---|---|---|
| `util.format("hello %s number %d")` | 694.52 ns | 177.90 ns | **3.9x** |
| `util.format("%s:%s:%s")` | 442.58 ns | 119.93 ns | **3.7x** |
| util.format long message, 2 specifiers | 2.05 µs | 444.42 ns | **4.6x** |
| util.format 16-bit format string | 721.98 ns | 184.93 ns | **3.9x** |
| util.format trailing args | 298.39 ns | 198.43 ns | 1.5x |
| `util.format("json: %j")` | 427.70 ns | 198.39 ns | 2.2x |
| `util.format("%f%% done, batch %i")` | 810.21 ns | 263.46 ns | 3.1x |
| util.format long format string | 13.67 µs | 2.63 µs | **5.2x** |
| util.inspect short string | 881.21 ns | 800.50 ns | 1.1x |
| util.inspect string with quotes | 3.06 µs | 1.89 µs | 1.6x |
| util.inspect small object | 4.23 µs | 3.67 µs | 1.2x |
| util.inspect array of numbers | 9.12 µs | 6.91 µs | 1.3x |
| util.inspect long string with escapes | 111.61 µs | 76.61 µs | 1.5x |

No measured case regresses. The snippet covers short/long and 8-bit/16-bit format strings, each specifier class, and `util.inspect` string/object/array cases.

## Test

No behavior change intended. `test/js/node/util/` + `test/js/node/assert/` against the patched release build: 983 pass, 0 fail (985 tests across 26 files). Wrapper-semantics parity (absent-vs-undefined arguments, variadic `push`, `.length`, tampered-prototype Safe* containers) was additionally verified against the `call.bind` version under the release JSC.
