### PR TITLE
Fix console async iterator lock handoff

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -12,11 +12,16 @@ export function asyncIterator(this: Console) {
   var value: Uint8Array[];
   var value_len: number;
   var pendingChunk: Uint8Array | undefined;
+  var activeIterator: AsyncGenerator<string> | undefined;
 
-  async function* ConsoleAsyncIterator() {
-    var reader = stream.getReader();
-    var deferredError: Error | undefined;
+  async function* readLines(session: { iterator: AsyncGenerator<string> | undefined }) {
+    var reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    var deferredError: unknown;
+    var hasDeferredError = false;
     try {
+      // ConsoleAsyncIterator consumes this so the generator always enters this try/finally before user code receives it.
+      yield "";
+      reader = stream.getReader();
       if (i !== -1) {
         last = i + 1;
         i = indexOf(actualChunk, last);
@@ -99,15 +104,30 @@ export function asyncIterator(this: Console) {
         actualChunk = undefined!;
       }
     } catch (e) {
-      deferredError = e as Error;
+      deferredError = e;
+      hasDeferredError = true;
     } finally {
-      reader.releaseLock();
+      try {
+        if (reader) reader.releaseLock();
+      } finally {
+        if (activeIterator === session.iterator) activeIterator = undefined;
+      }
     }
 
-    if (deferredError) {
+    if (hasDeferredError) {
       // eslint-disable-next-line no-throw-literal
       throw deferredError;
     }
+  }
+
+  function ConsoleAsyncIterator() {
+    if (activeIterator) return activeIterator;
+    var session: { iterator: AsyncGenerator<string> | undefined } = { iterator: undefined };
+    var iterator = readLines(session);
+    session.iterator = iterator;
+    activeIterator = iterator;
+    $asyncGeneratorPrototypeNext.$call(iterator);
+    return iterator;
   }
 
   const symbol = globalThis.Symbol.asyncIterator;

--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -74,3 +74,93 @@ it("can use the console iterator more than once", async () => {
   expect(await stdout.text()).toBe('["hello","world"]["another"]');
   proc.kill(0);
 });
+
+// https://github.com/oven-sh/bun/issues/7541
+async function runConsoleIterator(script: string, input: string) {
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", script],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  proc.stdin.write(input);
+  await proc.stdin.end();
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+it.concurrent("continues the console iterator after reading one line with next()", async () => {
+  expect(
+    await runConsoleIterator(
+      `const iterator = console[Symbol.asyncIterator]();
+const first = await iterator.next();
+const lines = [first.value];
+for await (const line of console) lines.push(line);
+console.write(JSON.stringify(lines));`,
+      "first\nsecond",
+    ),
+  ).toEqual({
+    stdout: '["first","second"]',
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+it.concurrent("shares stdin between console iterators created before reading", async () => {
+  expect(
+    await runConsoleIterator(
+      `const first = console[Symbol.asyncIterator]();
+const second = console[Symbol.asyncIterator]();
+const lines = [(await first.next()).value, (await second.next()).value];
+for await (const line of console) lines.push(line);
+console.write(JSON.stringify(lines));`,
+      "first\nsecond\nthird",
+    ),
+  ).toEqual({
+    stdout: '["first","second","third"]',
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+for (const [operation, cleanup] of [
+  [
+    "return()",
+    `const result = await console[Symbol.asyncIterator]().return();
+if (!result.done) throw new Error("Expected return() to close the iterator");`,
+  ],
+  [
+    "throw()",
+    `const reason = undefined;
+try {
+  await console[Symbol.asyncIterator]().throw(reason);
+  throw new Error("Expected throw() to reject");
+} catch (error) {
+  if (error !== reason) throw error;
+}`,
+  ],
+]) {
+  it.concurrent(`releases the console iterator after ${operation} before next()`, async () => {
+    expect(
+      await runConsoleIterator(
+        `${cleanup}
+const iterator = console[Symbol.asyncIterator]();
+const first = await iterator.next();
+const lines = [first.value];
+for await (const line of console) lines.push(line);
+console.write(JSON.stringify(lines));`,
+        "first\nsecond",
+      ),
+    ).toEqual({
+      stdout: '["first","second"]',
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+}

--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -128,7 +128,7 @@ console.write(JSON.stringify(lines));`,
   });
 });
 
-for (const [operation, cleanup] of [
+describe.each([
   [
     "return()",
     `const result = await iterator.return();
@@ -144,8 +144,8 @@ try {
   if (error !== reason) throw error;
 }`,
   ],
-]) {
-  it.concurrent(`releases the console iterator after ${operation} before next()`, async () => {
+])("%s", (_operation, cleanup) => {
+  it.concurrent("releases the console iterator before next()", async () => {
     expect(
       await runConsoleIterator(
         `const iterator = console[Symbol.asyncIterator]();
@@ -165,7 +165,7 @@ console.write(JSON.stringify(lines));`,
     });
   });
 
-  it.concurrent(`releases the console iterator after ${operation} following next()`, async () => {
+  it.concurrent("releases the console iterator following next()", async () => {
     expect(
       await runConsoleIterator(
         `const iterator = console[Symbol.asyncIterator]();
@@ -185,4 +185,4 @@ console.write(JSON.stringify(lines));`,
       signalCode: null,
     });
   });
-}
+});

--- a/test/js/bun/console/console-iterator.test.ts
+++ b/test/js/bun/console/console-iterator.test.ts
@@ -131,14 +131,14 @@ console.write(JSON.stringify(lines));`,
 for (const [operation, cleanup] of [
   [
     "return()",
-    `const result = await console[Symbol.asyncIterator]().return();
+    `const result = await iterator.return();
 if (!result.done) throw new Error("Expected return() to close the iterator");`,
   ],
   [
     "throw()",
     `const reason = undefined;
 try {
-  await console[Symbol.asyncIterator]().throw(reason);
+  await iterator.throw(reason);
   throw new Error("Expected throw() to reject");
 } catch (error) {
   if (error !== reason) throw error;
@@ -148,9 +148,10 @@ try {
   it.concurrent(`releases the console iterator after ${operation} before next()`, async () => {
     expect(
       await runConsoleIterator(
-        `${cleanup}
-const iterator = console[Symbol.asyncIterator]();
-const first = await iterator.next();
+        `const iterator = console[Symbol.asyncIterator]();
+${cleanup}
+const nextIterator = console[Symbol.asyncIterator]();
+const first = await nextIterator.next();
 const lines = [first.value];
 for await (const line of console) lines.push(line);
 console.write(JSON.stringify(lines));`,
@@ -158,6 +159,27 @@ console.write(JSON.stringify(lines));`,
       ),
     ).toEqual({
       stdout: '["first","second"]',
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  it.concurrent(`releases the console iterator after ${operation} following next()`, async () => {
+    expect(
+      await runConsoleIterator(
+        `const iterator = console[Symbol.asyncIterator]();
+const first = await iterator.next();
+if (first.done || first.value !== "first") throw new Error("Expected the first line");
+${cleanup}
+const nextIterator = console[Symbol.asyncIterator]();
+const lines = [];
+for await (const line of nextIterator) lines.push(line);
+console.write(JSON.stringify(lines));`,
+        "first\nsecond\n",
+      ),
+    ).toEqual({
+      stdout: '["second"]',
       stderr: "",
       exitCode: 0,
       signalCode: null,


### PR DESCRIPTION
### What does this PR do?

Fixes #7541.

`console[Symbol.asyncIterator]()` previously created a new async generator on every call. If a caller read one line with `.next()` and then acquired another iterator, the first generator retained stdin's reader and the second generator threw `ReadableStream is locked`.

This keeps one active console iterator, primes it into its cleanup region before returning it, and clears it after completion, `return()`, or `throw()`. An explicit error-presence flag preserves falsy throw reasons such as `undefined`.

The regression coverage exercises direct `.next()` handoff, multiple pre-read acquisitions, and cleanup through both `return()` and `throw()` before and after reader acquisition.

PR #33478 touches the same iterator for separate line-splitting and restart behavior; its current implementation still creates a new generator per call and does not address #7541.

### How did you verify your code works?

- `USE_SYSTEM_BUN=1 bun test test/js/bun/console/console-iterator.test.ts` (expected RED: 18 pass, 5 fail across the lock-handoff and falsy-throw paths)
- `bun bd --asan=off -j2 test test/js/bun/console/console-iterator.test.ts` (23 pass, 0 fail)
- `bun bd --asan=off -j2 test test/js/bun/console/console-iterator.test.ts --rerun-each=3` (69 pass, 0 fail)
- `bun run lint`
- `bun --bun ./node_modules/.bin/oxlint --config=oxlint.json --format=github test/js/bun/console/console-iterator.test.ts`
- `bun --bun ./node_modules/.bin/prettier --plugin=prettier-plugin-organize-imports --config .prettierrc --check src/js/builtins/ConsoleObject.ts test/js/bun/console/console-iterator.test.ts`
