### PR TITLE
Expose totalAllocatedHeapBytes() in bun:jsc

### DIFF
--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -9,6 +9,19 @@ declare module "bun:jsc" {
   function edenGC(): number;
   function heapSize(): number;
   function heapStats(): HeapStats;
+  /**
+   * Cumulative bytes allocated in the JavaScriptCore GC heap since the
+   * process (or worker thread) started, regardless of how much has since
+   * been freed.
+   *
+   * JSC resets its internal allocation counter each GC cycle; this
+   * accumulates deltas across reads, so bytes allocated between your last
+   * call and a GC are not counted. It is a monotonic lower bound whose
+   * accuracy improves the more frequently it is called. Useful for
+   * computing allocation rates and for weighting profiler samples by
+   * allocated bytes.
+   */
+  function totalAllocatedHeapBytes(): number;
   function memoryUsage(): MemoryUsage;
   function getRandomSeed(): number;
   function setRandomSeed(value: number): void;

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -168,6 +168,12 @@ public:
     ALWAYS_INLINE bool scriptAllowed() const { return Bun__VmHandle__scriptAllowedInline(vmHandleState); }
     Bun::JSCTaskScheduler deferredWorkTimer;
 
+    // Accumulator for bun:jsc totalAllocatedHeapBytes(): JSC's per-cycle
+    // allocation counter resets at GC; these fold it into a monotonic
+    // per-VM total.
+    size_t lastCycleAllocatedBytes { 0 };
+    size_t totalAllocatedHeapBytes { 0 };
+
     // Linked list of StrongRootBlock cells backing bun_jsc::Strong handles
     // (see StrongRootBlock.h). Raw pointers into the GC heap: they are rooted
     // by a SimpleMarkingConstraint registered in JSVMClientData::create(), so

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -1,5 +1,6 @@
 #include "root.h"
 #include "_NativeModule.h"
+#include "BunClientData.h"
 
 #include "ExceptionOr.h"
 #include "JavaScriptCore/CallData.h"
@@ -209,17 +210,16 @@ JSC_DEFINE_HOST_FUNCTION(functionTotalAllocatedHeapBytes,
     // JSC's allocation counter resets each GC cycle, so accumulate deltas
     // across reads into a monotonic total. Bytes allocated between the last
     // read and a GC reset are lost, making this a lower bound whose accuracy
-    // improves with read frequency. One VM per thread, so thread_local state
-    // is per-VM.
-    static thread_local size_t lastCycleBytes = 0;
-    static thread_local size_t totalBytes = 0;
+    // improves with read frequency. State lives on the VM's client data so a
+    // VM created on a reused native thread starts from zero.
+    auto* clientData = WebCore::clientData(vm);
     size_t current = vm.heap.totalBytesAllocatedThisCycle();
-    if (current >= lastCycleBytes)
-        totalBytes += current - lastCycleBytes;
+    if (current >= clientData->lastCycleAllocatedBytes)
+        clientData->totalAllocatedHeapBytes += current - clientData->lastCycleAllocatedBytes;
     else
-        totalBytes += current;
-    lastCycleBytes = current;
-    return JSValue::encode(jsNumber(totalBytes));
+        clientData->totalAllocatedHeapBytes += current;
+    clientData->lastCycleAllocatedBytes = current;
+    return JSValue::encode(jsNumber(clientData->totalAllocatedHeapBytes));
 }
 
 JSC::Structure*

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -200,6 +200,28 @@ JSC_DEFINE_HOST_FUNCTION(functionHeapSize,
     return JSValue::encode(jsNumber(vm.heap.size()));
 }
 
+JSC_DECLARE_HOST_FUNCTION(functionTotalAllocatedHeapBytes);
+JSC_DEFINE_HOST_FUNCTION(functionTotalAllocatedHeapBytes,
+    (JSGlobalObject * globalObject, CallFrame*))
+{
+    VM& vm = globalObject->vm();
+    JSLockHolder lock(vm);
+    // JSC's allocation counter resets each GC cycle, so accumulate deltas
+    // across reads into a monotonic total. Bytes allocated between the last
+    // read and a GC reset are lost, making this a lower bound whose accuracy
+    // improves with read frequency. One VM per thread, so thread_local state
+    // is per-VM.
+    static thread_local size_t lastCycleBytes = 0;
+    static thread_local size_t totalBytes = 0;
+    size_t current = vm.heap.totalBytesAllocatedThisCycle();
+    if (current >= lastCycleBytes)
+        totalBytes += current - lastCycleBytes;
+    else
+        totalBytes += current;
+    lastCycleBytes = current;
+    return JSValue::encode(jsNumber(totalBytes));
+}
+
 JSC::Structure*
 createMemoryFootprintStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
@@ -989,6 +1011,7 @@ JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * 
     getRandomSeed                       functionGetRandomSeed                       Function    0
     heapSize                            functionHeapSize                            Function    0
     heapStats                           functionMemoryUsageStatistics               Function    0
+    totalAllocatedHeapBytes             functionTotalAllocatedHeapBytes             Function    0
     startSamplingProfiler               functionStartSamplingProfiler               Function    0
     samplingProfilerStackTraces         functionSamplingProfilerStackTraces         Function    0
     noInline                            functionNeverInlineFunction                 Function    0
@@ -1017,7 +1040,7 @@ JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * 
 namespace Zig {
 DEFINE_NATIVE_MODULE(BunJSC)
 {
-    INIT_NATIVE_MODULE(BunJSC, 36);
+    INIT_NATIVE_MODULE(BunJSC, 37);
 
     putNativeFn(Identifier::fromString(vm, "callerSourceOrigin"_s), functionCallerSourceOrigin);
     putNativeFn(Identifier::fromString(vm, "jscDescribe"_s), functionDescribe);
@@ -1029,6 +1052,7 @@ DEFINE_NATIVE_MODULE(BunJSC)
     putNativeFn(Identifier::fromString(vm, "getRandomSeed"_s), functionGetRandomSeed);
     putNativeFn(Identifier::fromString(vm, "heapSize"_s), functionHeapSize);
     putNativeFn(Identifier::fromString(vm, "heapStats"_s), functionMemoryUsageStatistics);
+    putNativeFn(Identifier::fromString(vm, "totalAllocatedHeapBytes"_s), functionTotalAllocatedHeapBytes);
     putNativeFn(Identifier::fromString(vm, "startSamplingProfiler"_s), functionStartSamplingProfiler);
     putNativeFn(Identifier::fromString(vm, "samplingProfilerStackTraces"_s), functionSamplingProfilerStackTraces);
     putNativeFn(Identifier::fromString(vm, "noInline"_s), functionNeverInlineFunction);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -21,6 +21,7 @@ import {
   serialize,
   setRandomSeed,
   setTimeZone,
+  totalAllocatedHeapBytes,
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
@@ -64,6 +65,24 @@ describe("bun:jsc", () => {
     const usage = memoryUsage();
     expect(usage.current).toBeGreaterThan(0);
     expect(usage.peak).toBeGreaterThan(0);
+  });
+  it("totalAllocatedHeapBytes", () => {
+    const before = totalAllocatedHeapBytes();
+    expect(before).toBeGreaterThanOrEqual(0);
+
+    // Allocate enough to guarantee the counter moves even if a GC cycle
+    // resets JSC's internal per-cycle counter mid-loop.
+    let sink: unknown[] = [];
+    for (let i = 0; i < 10_000; i++) {
+      sink.push({ i, arr: new Array(16).fill(i) });
+    }
+    const after = totalAllocatedHeapBytes();
+    expect(after).toBeGreaterThan(before);
+
+    // Monotonic: a full GC frees memory but must not decrease the total.
+    fullGC();
+    expect(totalAllocatedHeapBytes()).toBeGreaterThanOrEqual(after);
+    expect(sink.length).toBe(10_000);
   });
   it("getRandomSeed", () => {
     expect(getRandomSeed()).toBeDefined();

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -25,7 +25,8 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isWindows, tempDir } from "harness";
+import path from "node:path";
 
 describe("bun:jsc", () => {
   function count() {
@@ -83,6 +84,41 @@ describe("bun:jsc", () => {
     fullGC();
     expect(totalAllocatedHeapBytes()).toBeGreaterThanOrEqual(after);
     expect(sink.length).toBe(10_000);
+  });
+  it("totalAllocatedHeapBytes is per-VM in workers", async () => {
+    // Inflate the main-thread counter well past anything a fresh worker VM
+    // could plausibly allocate during startup.
+    let sink: unknown[] = [];
+    for (let i = 0; i < 50_000; i++) {
+      sink.push({ i, arr: new Array(16).fill(i) });
+    }
+    const mainBytes = totalAllocatedHeapBytes();
+    expect(sink.length).toBe(50_000);
+
+    using dir = tempDir("jsc-alloc-worker", {
+      "worker.ts": `
+        import { totalAllocatedHeapBytes } from "bun:jsc";
+        const first = totalAllocatedHeapBytes();
+        let sink = [];
+        for (let i = 0; i < 10_000; i++) {
+          sink.push({ i, arr: new Array(16).fill(i) });
+        }
+        const second = totalAllocatedHeapBytes();
+        postMessage({ first, second, sinkLength: sink.length });
+      `,
+    });
+    const worker = new Worker(path.join(String(dir), "worker.ts"));
+    const { promise, resolve, reject } = Promise.withResolvers<{ first: number; second: number; sinkLength: number }>();
+    worker.onmessage = event => resolve(event.data);
+    worker.onerror = event => reject(new Error(event.message));
+    const result = await promise;
+    worker.terminate();
+
+    // The worker's counter grows with its own allocations and is independent
+    // of the main thread's much larger accumulated total.
+    expect(result.sinkLength).toBe(10_000);
+    expect(result.second).toBeGreaterThan(result.first);
+    expect(result.first).toBeLessThan(mainBytes);
   });
   it("getRandomSeed", () => {
     expect(getRandomSeed()).toBeDefined();


### PR DESCRIPTION
# What does this PR do?

Adds `totalAllocatedHeapBytes()` to `bun:jsc`. This is a monotonic, cumulative count of bytes allocated in the JavaScriptCore GC heap since the process (or worker thread) started, regardless of how much has since been freed.

JSC already maintains perfect allocation accounting internally — it's how the GC schedules collections — but the counter resets every GC cycle and isn't exposed. This function reads it (see related PR [here](https://github.com/oven-sh/WebKit/pull/402)) and accumulates deltas across reads into a monotonic total.

This is to answer questions like "how many bytes is my code allocating" instead of _having_ to generate a heap snapshot. For example: 
* https://github.com/oven-sh/bun/issues/4290
* https://github.com/oven-sh/bun/issues/22474

This allows you to integrate with existing tools like Pyroscope, to generate nice flame graphs 🙂

### Limitations

1. This only tracks `alloc_space` so where the bytes originate, not `inuse_space`. So leak detection still would need a heap snapshot. But can make things slightly easier to debug
2. No allocation timeline 
3. `@grafana/pyroscope-nodejs` still will not work unfortunately, this is just a simple bridge in the meantime 
4. The counter is a lower bound: JSC resets its internal counter each GC cycle, so bytes allocated between your last read and a reset are not counted. Accuracy improves with read frequency (negligible at profiler tick rates). Documented in the JSDoc.

### Dependencies
Requires [oven-sh/WebKit#402](https://github.com/oven-sh/WebKit/pull/402) (makes the header-only inline accessor public) 

# How did you verify your code works?

Tested by adding new unit tests for this new code. Also tested locally by building from source, and using this dummy code:
```
/**
 * Proof-of-concept: continuous alloc_space profiling for Bun -> Pyroscope.
 *
 * Byte-weights JSC sampling-profiler stack traces per time window using
 * bun:jsc totalAllocatedHeapBytes(), folds them, and ships them to a local
 * Pyroscope via the /ingest folded-format API.
 */
import { samplingProfilerStackTraces, startSamplingProfiler, totalAllocatedHeapBytes } from "bun:jsc";

interface SamplingFrame {
  name: string;
  sourceURL: string;
}

interface SamplingTrace {
  timestamp: number;
  frames: SamplingFrame[];
}

interface SamplingTraces {
  interval: number;
  traces: SamplingTrace[];
}

const PYROSCOPE_URL = process.env.PYROSCOPE_URL ?? "http://localhost:4040";
const APP_NAME = "bun-demo.alloc_space";
const WINDOW_MS = 250;
const WINDOWS = 40;

/** Heavy allocator: many small objects with string churn. */
function allocateJsonBlobs({ count }: { count: number }): number {
  let total = 0;
  for (let i = 0; i < count; i++) {
    const blob = JSON.parse(
      JSON.stringify({ id: i, name: `item-${i}`, tags: ["a", "b", "c"], nested: { x: i, y: i * 2 } }),
    );
    total += blob.nested.y;
  }
  return total;
}

/** Medium allocator: typed-array backing stores. */
function allocateBuffers({ count }: { count: number }): number {
  let total = 0;
  for (let i = 0; i < count; i++) {
    const buf = new Float64Array(256);
    buf[0] = i;
    total += buf.length;
  }
  return total;
}

/** Nearly allocation-free: pure arithmetic. */
function computeOnly({ iterations }: { iterations: number }): number {
  let acc = 0;
  for (let i = 0; i < iterations; i++) {
    acc = (acc + i * 31) % 1_000_003;
  }
  return acc;
}

function foldTrace({ trace }: { trace: SamplingTrace }): string {
  const names: string[] = [];
  for (let i = trace.frames.length - 1; i >= 0; i--) {
    const name = trace.frames[i].name || "(anonymous)";
    names.push(name.replace(/[;\n]/g, "_"));
  }
  return names.join(";");
}

async function pushFolded({
  folded,
  fromSec,
  untilSec,
}: {
  folded: Map<string, number>;
  fromSec: number;
  untilSec: number;
}): Promise<void> {
  const body = Array.from(folded.entries())
    .map(([stack, bytes]) => `${stack} ${Math.round(bytes)}`)
    .join("\n");
  const params = new URLSearchParams({
    name: `${APP_NAME}{service=bun-demo}`,
    from: String(fromSec),
    until: String(untilSec),
    format: "folded",
    units: "bytes",
    aggregationType: "sum",
    sampleRate: "100",
  });
  const res = await fetch(`${PYROSCOPE_URL}/ingest?${params}`, { method: "POST", body });
  if (!res.ok) {
    throw new Error(`pyroscope ingest failed: ${res.status} ${await res.text()}`);
  }
}

async function main(): Promise<void> {
  startSamplingProfiler(undefined, 200);
  samplingProfilerStackTraces();
  totalAllocatedHeapBytes();

  const folded = new Map<string, number>();
  const startSec = Math.floor(Date.now() / 1000);
  let totalBytesSeen = 0;

  for (let window = 0; window < WINDOWS; window++) {
    const bytesBefore = totalAllocatedHeapBytes();
    const deadline = performance.now() + WINDOW_MS;
    while (performance.now() < deadline) {
      allocateJsonBlobs({ count: 2_000 });
      allocateBuffers({ count: 2_000 });
      computeOnly({ iterations: 2_000_000 });
    }
    const bytesDelta = totalAllocatedHeapBytes() - bytesBefore;
    totalBytesSeen += bytesDelta;

    const { traces } = samplingProfilerStackTraces() as SamplingTraces;
    if (traces.length === 0 || bytesDelta <= 0) continue;
    const bytesPerTrace = bytesDelta / traces.length;
    for (const trace of traces) {
      const stack = foldTrace({ trace });
      folded.set(stack, (folded.get(stack) ?? 0) + bytesPerTrace);
    }
  }

  const untilSec = Math.ceil(Date.now() / 1000);
  await pushFolded({ folded, fromSec: startSec, untilSec });

  console.log(`pushed ${folded.size} unique stacks, ${(totalBytesSeen / 1024 / 1024).toFixed(1)} MB attributed`);
  const top = Array.from(folded.entries())
    .sort((a, b) => b[1] - a[1])
    .slice(0, 5);
  for (const [stack, bytes] of top) {
    const leaf = stack.split(";").at(-1);
    console.log(`  ${(bytes / 1024 / 1024).toFixed(1).padStart(6)} MB  ${leaf}  [${stack}]`);
  }
}

await main();

```

Then spinning up a local grafana stack:
```
services:
  pyroscope:
    image: grafana/pyroscope:latest
    ports:
      - "4040:4040"
  grafana:
    image: grafana/grafana:latest
    environment:
      - GF_AUTH_ANONYMOUS_ENABLED=true
      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
      - GF_AUTH_DISABLE_LOGIN_FORM=true
      - GF_FEATURE_TOGGLES_ENABLE=flameGraph
    ports:
      - "3000:3000"
    volumes:
      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
    depends_on:
      - pyroscope
```
and
```
apiVersion: 1
datasources:
  - name: Pyroscope
    type: grafana-pyroscope-datasource
    access: proxy
    url: http://pyroscope:4040
    isDefault: true
```

And confirming the pyropscope data is viewable! 
<img width="2048" height="1971" alt="image" src="https://github.com/user-attachments/assets/835ac9e6-6106-45f9-92f2-3fba1280e405" />
