### PR TITLE
webkit: validate oven-sh/WebKit#403 (restore ALWAYS_INLINE) on full CI

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "447082ab6897278727b44e1ba3c326ae6e1504c3";
+export const WEBKIT_VERSION = "autobuild-preview-pr-403-a9acfec7";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -12,6 +12,7 @@
 #include <JavaScriptCore/RegExpObject.h>
 #include <JavaScriptCore/JSSetIterator.h>
 #include <JavaScriptCore/ObjectPrototype.h>
+#include <JavaScriptCore/ObjectPrototypeInlines.h>
 #include <cmath>
 #include "JSEventTarget.h"
 #include "JavaScriptCore/TopExceptionScope.h"

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -91,4 +91,20 @@ describe("assert.partialDeepStrictEqual", () => {
     const arr = [[]];
     assert.partialDeepStrictEqual([arr], arr);
   });
+
+  test("objects with different Object.prototype.toString tags are never partially equal", () => {
+    assert.partialDeepStrictEqual(
+      { [Symbol.toStringTag]: "A", x: 1, y: 2 },
+      { [Symbol.toStringTag]: "A", x: 1 },
+    );
+    expect(() =>
+      assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1 }, { [Symbol.toStringTag]: "B", x: 1 }),
+    ).toThrow(assert.AssertionError);
+
+    // ArrayBuffer-family values compare tags through the same path.
+    assert.partialDeepStrictEqual(new ArrayBuffer(2), new ArrayBuffer(2));
+    expect(() => assert.partialDeepStrictEqual(new ArrayBuffer(2), new SharedArrayBuffer(2))).toThrow(
+      assert.AssertionError,
+    );
+  });
 });

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -91,17 +91,4 @@ describe("assert.partialDeepStrictEqual", () => {
     const arr = [[]];
     assert.partialDeepStrictEqual([arr], arr);
   });
-
-  test("objects with different Object.prototype.toString tags are never partially equal", () => {
-    assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1, y: 2 }, { [Symbol.toStringTag]: "A", x: 1 });
-    expect(() =>
-      assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1 }, { [Symbol.toStringTag]: "B", x: 1 }),
-    ).toThrow(assert.AssertionError);
-
-    // ArrayBuffer-family values compare tags through the same path.
-    assert.partialDeepStrictEqual(new ArrayBuffer(2), new ArrayBuffer(2));
-    expect(() => assert.partialDeepStrictEqual(new ArrayBuffer(2), new SharedArrayBuffer(2))).toThrow(
-      assert.AssertionError,
-    );
-  });
 });

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -93,10 +93,7 @@ describe("assert.partialDeepStrictEqual", () => {
   });
 
   test("objects with different Object.prototype.toString tags are never partially equal", () => {
-    assert.partialDeepStrictEqual(
-      { [Symbol.toStringTag]: "A", x: 1, y: 2 },
-      { [Symbol.toStringTag]: "A", x: 1 },
-    );
+    assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1, y: 2 }, { [Symbol.toStringTag]: "A", x: 1 });
     expect(() =>
       assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1 }, { [Symbol.toStringTag]: "B", x: 1 }),
     ).toThrow(assert.AssertionError);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -842,6 +842,27 @@ describe("detached ArrayBuffer", () => {
   });
 });
 
+describe("assert.partialDeepStrictEqual toString tags", () => {
+  // Exercises the Object.prototype.toString tag comparisons in the native
+  // partialDeepStrictEqual (the generic object branch and the ArrayBuffer
+  // branch). Expectations verified against node v26.3.0.
+  test("objects with different toString tags are never partially equal", () => {
+    expect(() =>
+      assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1 }, { [Symbol.toStringTag]: "B", x: 1 }),
+    ).toThrow(assert.AssertionError);
+    expect(() =>
+      assert.partialDeepStrictEqual({ [Symbol.toStringTag]: "A", x: 1, y: 2 }, { [Symbol.toStringTag]: "A", x: 1 }),
+    ).not.toThrow();
+  });
+
+  test("ArrayBuffer-family values compare tags through the same path", () => {
+    expect(() => assert.partialDeepStrictEqual(new ArrayBuffer(2), new SharedArrayBuffer(2))).toThrow(
+      assert.AssertionError,
+    );
+    expect(() => assert.partialDeepStrictEqual(new ArrayBuffer(2), new ArrayBuffer(2))).not.toThrow();
+  });
+});
+
 describe("AssertionError", () => {
   test("deepStrictEqual reports actual, expected and operator", () => {
     const error = caught(() => assert.deepStrictEqual({ a: 1 }, { a: 2 })) as any;


### PR DESCRIPTION
CI validation run for oven-sh/WebKit#403, which removes the December 2025 LTO de-inlining stopgap (restores `ALWAYS_INLINE` / `ALWAYS_INLINE_LAMBDA`, moves the GC liveness checks `Heap::isMarked` / `MarkedBlock::isMarked` / `MarkedBlock::Handle::isLive` back into their inline headers, and un-marks `Dependency::fence` / `loadAndFence` as `NEVER_INLINE`) now that the root cause is fixed (upstream 308243@main, `WTF::opaque()` asm missing `volatile`).

This pins `WEBKIT_VERSION` to the preview artifacts `autobuild-preview-pr-403-a9acfec7` so the full suite runs against them. The lanes that matter most are linux x64 musl release (LTO), where the original FinalizationRegistry miscompile appeared in December, plus the release lanes generally since that is where `__always_inline__` is active again.

### Findings

Build 91415 (first run): every release `build-bun` link failed with

```
undefined symbol: JSC::objectPrototypeToString(JSC::JSGlobalObject*, JSC::JSValue)
>>> referenced by NodeUtilTypesModule.cpp:712
```

`objectPrototypeToString` is defined `ALWAYS_INLINE` in `ObjectPrototypeInlines.h`; `NodeUtilTypesModule.cpp` only included `ObjectPrototype.h` (the declaration) and leaned on the out-of-line copy JSC happened to emit while `ALWAYS_INLINE` was demoted to plain `inline`. Fixed here by including the inlines header (1c25b30c19). That commit must ride along with whatever PR bumps `WEBKIT_VERSION` past oven-sh/WebKit#403; it is also harmless against current WebKit.

### Why the include fix has no fail-before test

The defect is a build-time link error in release builds, not a behavior change, so no runtime test can fail without the fix and pass with it:

- In debug builds NDEBUG is off, `ALWAYS_INLINE` degrades to plain `inline`, and JSC emits weak linkonce copies of the function: `nm` on the preview debug `libJavaScriptCore.a` shows three `W JSC::objectPrototypeToString(...)` entries. A debug build therefore links and behaves identically with or without the include.
- A prebuilt release binary was already linked, so the defect cannot be observed there either; it only manifests while linking a release bun against the post-#403 artifacts, which is exactly what the 13 failed `build-bun` lanes in build 91415 show (and what the release lanes in this PR's CI exercise with the fix applied).

`test/js/node/assert/deep-equal.test.ts` gained behavioral coverage for the `partialDeepStrictEqual` toString-tag branches (the two call sites at NodeUtilTypesModule.cpp:712/839, verified against node v26.3.0); the release links themselves are the regression test for the include, and every release lane in this PR runs it.

### Results (build 91420)

194 of 196 jobs green. All build lanes link on every platform. All test lanes pass except darwin 14 x64, whose two failing files are flagged pre-existing on main by the CI tooling. The linux musl release (ThinLTO) lanes, the configuration the December stopgap was chasing, are fully green including FinalizationRegistry coverage. binary-size is red by design: +2.3 to +3.8 MB per target is the cost of restoring always_inline, a maintainer tradeoff tracked on oven-sh/WebKit#403.

Draft on purpose: if oven-sh/WebKit#403 merges, this flips to the merged sha, or gets superseded by the regular WebKit bump (which must carry the NodeUtilTypesModule include fix).
