### PR TITLE
node:dns: treat null lookup option fields as unset

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -152,7 +152,7 @@ function setServersOn(servers, object) {
 }
 
 function validateFlagsOption(options) {
-  if (options.flags === undefined) {
+  if (options.flags == null) {
     return;
   }
 
@@ -188,14 +188,14 @@ function validateFamilyOption(options) {
 
 function validateAllOption(options) {
   const all = options.all;
-  if (all !== undefined) {
+  if (all != null) {
     validateBoolean(all);
   }
 }
 
 function validateVerbatimOption(options) {
   const verbatim = options.verbatim;
-  if (verbatim !== undefined) {
+  if (verbatim != null) {
     validateBoolean(verbatim);
   }
 }

--- a/src/runtime/dns_jsc/options_jsc.rs
+++ b/src/runtime/dns_jsc/options_jsc.rs
@@ -51,20 +51,22 @@ pub(crate) fn options_from_js(
         }
 
         if let Some(flags) = js(value.get(global, "flags"))? {
-            if !flags.is_number() {
-                return Err(FromJSError::InvalidFlags);
-            }
+            if !flags.is_null() {
+                if !flags.is_number() {
+                    return Err(FromJSError::InvalidFlags);
+                }
 
-            // Coerce to i32 and store/bit-test as u32.
-            let flags_int: i32 = js(flags.coerce::<i32>(global))?;
-            options.flags = flags_int;
+                // Coerce to i32 and store/bit-test as u32.
+                let flags_int: i32 = js(flags.coerce::<i32>(global))?;
+                options.flags = flags_int;
 
-            // hints & ~(AI_ADDRCONFIG | AI_ALL | AI_V4MAPPED)) !== 0
-            let filter: u32 =
-                !((bun_dns::AI_ALL | bun_dns::AI_ADDRCONFIG | bun_dns::AI_V4MAPPED) as u32);
-            let int: u32 = flags_int as u32;
-            if int & filter != 0 {
-                return Err(FromJSError::InvalidFlags);
+                // hints & ~(AI_ADDRCONFIG | AI_ALL | AI_V4MAPPED)) !== 0
+                let filter: u32 =
+                    !((bun_dns::AI_ALL | bun_dns::AI_ADDRCONFIG | bun_dns::AI_V4MAPPED) as u32);
+                let int: u32 = flags_int as u32;
+                if int & filter != 0 {
+                    return Err(FromJSError::InvalidFlags);
+                }
             }
         }
 

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -223,6 +223,16 @@ describe("dns", () => {
     expect(isIP(result[0].address)).toBeGreaterThan(0);
   });
 
+  test("lookup with null flags treats them as unset", async () => {
+    // `family: null` already meant unset; `flags: null` must too (node:dns
+    // forwards a null `hints` here). https://github.com/oven-sh/bun/issues/37318
+    // @ts-expect-error
+    const result = await dns.lookup("localhost", { flags: null });
+    expect(result).toBeArray();
+    expect(result.length).toBeGreaterThan(0);
+    expect(isIP(result[0].address)).toBeGreaterThan(0);
+  });
+
   describe("setServers", () => {
     test("triple with non-int32 family (double) throws TypeError", () => {
       // @ts-expect-error

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -701,6 +701,27 @@ describe("hostnames containing NUL bytes", () => {
   });
 });
 
+// Node treats a null option field the same as an absent one (its guards are
+// `!= null`), so e.g. `{ hints: null }` must not throw. https://github.com/oven-sh/bun/issues/37318
+describe("dns.lookup null option fields are treated as unset", () => {
+  const fields = ["hints", "all", "verbatim", "order", "family"];
+
+  it.each(fields)("dns.lookup with {%s: null} resolves", async field => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    dns.lookup("localhost", { [field]: null }, (err, address, family) => {
+      if (err) reject(err);
+      else resolve({ address, family });
+    });
+    const { address } = await promise;
+    expect(["127.0.0.1", "::1"]).toContain(address);
+  });
+
+  it.each(fields)("dns.promises.lookup with {%s: null} resolves", async field => {
+    const { address } = await dns_promises.lookup("localhost", { [field]: null });
+    expect(["127.0.0.1", "::1"]).toContain(address);
+  });
+});
+
 describe("dns.Resolver options validation", () => {
   describe.each([
     ["dns.Resolver", dns.Resolver],


### PR DESCRIPTION
Fixes #37318

### Repro

```js
const dns = require("node:dns");
dns.lookup("127.0.0.1", { hints: null }, (e, a, f) => console.log(e, a, f));
```

Node prints `null 127.0.0.1 4`. Bun threw synchronously:

```
TypeError: The "undefined" argument must be of type number. Received null
  code: "ERR_INVALID_ARG_TYPE"
```

`{ all: null }` and `{ verbatim: null }` threw the same way. Node treats a null option field the same as an absent one (its guards are `!= null`).

### Cause

In `src/js/node/dns.ts`, `validateFlagsOption`, `validateAllOption` and `validateVerbatimOption` only skipped `undefined`, so `null` fell through to `validateNumber`/`validateBoolean`. (`family` and `order` already handled null.)

Additionally, the native getaddrinfo options parser (`src/runtime/dns_jsc/options_jsc.rs`) rejected a null `flags` value while already treating null `family`, `socktype`, `protocol` and `backend` as unset, so a null `hints` forwarded by `node:dns` would have failed there next.

### Fix

- `dns.ts`: the three guards now skip null as well, matching Node's `!= null` checks. Non-null invalid values (`hints: "a"`, `all: 1`, `verbatim: 0`) still throw ERR_INVALID_ARG_TYPE.
- `options_jsc.rs`: a null `flags` is treated as unset, consistent with the other fields.

This overlaps with one bullet of #33516, which is a broader `lookup()` validation rework that has gone stale and now conflicts with main; this PR is just the null handling the issue reports.

### Verification

New tests in `test/js/node/dns/node-dns.test.js` cover `{hints|all|verbatim|order|family: null}` for both `dns.lookup` and `dns.promises.lookup` (6 of 10 fail on the released binary), and `test/js/bun/dns/resolve-dns.test.ts` covers `Bun.dns.lookup` with `flags: null` (fails on the released binary). All pass with this change, and both files report the same pre-existing pass/fail counts as main otherwise (the failures are network-bound tests that cannot resolve external domains in this sandbox).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/dns/resolve-dns.test.ts test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->