### PR TITLE
node:dns: leave errno undefined on c-ares resolver errors

### DIFF
--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -8,6 +8,7 @@ use crate::{JSGlobalObject, JSPromise, JSValue};
 #[repr(C)]
 #[derive(Clone)]
 pub struct SystemError {
+    /// [`SystemError::NO_ERRNO`] = the JS error gets `errno: undefined`
     pub errno: c_int,
     /// label for errno
     pub code: bun_core::String,
@@ -80,6 +81,12 @@ unsafe extern "C" {
 }
 
 impl SystemError {
+    /// `errno` for an error that has no numeric system error code, only a
+    /// string `code`. Node reports such errors (a c-ares resolver failure, for
+    /// example) with an own `errno` property whose value is `undefined`, and
+    /// the C++ side (`systemErrorToErrorInstance`) emits exactly that.
+    pub const NO_ERRNO: c_int = c_int::MIN;
+
     /// Converts to a JS `Error`, consuming `self`. C++ only borrows the string
     /// fields; `Drop` releases them when `self` goes out of scope. `.clone()`
     /// first when two `Error`s are genuinely wanted.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2657,6 +2657,15 @@ JSC::EncodedJSValue JSGlobalObject__createOutOfMemoryError(JSC::JSGlobalObject* 
     return JSValue::encode(exception);
 }
 
+// `SystemError::NO_ERRNO` on the Rust side: the error has a string `code` but
+// no numeric errno, and Node reports those with `errno: undefined`.
+static JSC::JSValue systemErrorErrnoValue(const SystemError& err)
+{
+    if (err.errno_ == std::numeric_limits<int>::min())
+        return JSC::jsUndefined();
+    return JSC::jsNumber(err.errno_);
+}
+
 static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* globalObject, JSC::ErrorType errorType)
 {
     SystemError err = *arg0;
@@ -2725,7 +2734,7 @@ static JSC::EncodedJSValue systemErrorToErrorInstance(const SystemError* arg0, J
         }
     }
 
-    result->putDirect(vm, names.errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
+    result->putDirect(vm, names.errnoPublicName(), systemErrorErrnoValue(err), JSC::PropertyAttribute::DontDelete | 0);
 
     return JSC::JSValue::encode(result);
 }
@@ -2771,8 +2780,9 @@ JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError
     info->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, codeString), JSC::PropertyAttribute::DontDelete | 0);
     info->putDirect(vm, vm.propertyNames->message, jsString(vm, messageString), JSC::PropertyAttribute::DontDelete | 0);
 
-    info->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
-    result->putDirect(vm, clientData->builtinNames().errnoPublicName(), jsNumber(err.errno_), JSC::PropertyAttribute::DontDelete | 0);
+    JSC::JSValue errnoValue = systemErrorErrnoValue(err);
+    info->putDirect(vm, clientData->builtinNames().errnoPublicName(), errnoValue, JSC::PropertyAttribute::DontDelete | 0);
+    result->putDirect(vm, clientData->builtinNames().errnoPublicName(), errnoValue, JSC::PropertyAttribute::DontDelete | 0);
 
     return JSC::JSValue::encode(result);
 }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -160,6 +160,7 @@ public:
 static_assert(sizeof(ErrorableResolvedSource) == 144 && alignof(ErrorableResolvedSource) == 8, "ErrorableResolvedSource layout is mirrored in src/jsc/Errorable.rs");
 
 typedef struct SystemError {
+    /// MinInt (`SystemError::NO_ERRNO` in Rust) = the error gets `errno: undefined`
     int errno_;
     BunString code;
     BunString message;

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -641,10 +641,9 @@ fn any_reply_to_js(
 
 // ── Error ──────────────────────────────────────────────────────────────────
 
-/// Node's `dnsException` only assigns a numeric `errno` when libuv reported a
-/// numeric error (the getaddrinfo/getnameinfo family). c-ares resolver
-/// failures carry a string code, so Node leaves their `errno` undefined;
-/// overwrite the c-ares enum value `SystemError` put there.
+/// Node only sets a numeric `errno` on DNS errors when libuv reported a
+/// numeric code (getaddrinfo/getnameinfo); c-ares resolver failures carry a
+/// string code and leave `errno` undefined.
 fn clear_errno_for_resolver_syscall(
     instance: JSValue,
     global_this: &JSGlobalObject,

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -640,6 +640,21 @@ fn any_reply_to_js(
 }
 
 // ── Error ──────────────────────────────────────────────────────────────────
+
+/// Node's `dnsException` only assigns a numeric `errno` when libuv reported a
+/// numeric error (the getaddrinfo/getnameinfo family). c-ares resolver
+/// failures carry a string code, so Node leaves their `errno` undefined;
+/// overwrite the c-ares enum value `SystemError` put there.
+fn clear_errno_for_resolver_syscall(
+    instance: JSValue,
+    global_this: &JSGlobalObject,
+    syscall: &[u8],
+) {
+    if strings::has_prefix_comptime(syscall, b"query") || strings::eql(syscall, b"getHostByAddr") {
+        instance.put(global_this, b"errno", JSValue::UNDEFINED);
+    }
+}
+
 pub(crate) struct ErrorDeferred {
     pub errno: c_ares::Error,
     pub syscall: &'static [u8],
@@ -694,6 +709,7 @@ impl ErrorDeferred {
             b"name",
             bstr::String::static_(b"DNSException").to_js(global_this)?,
         );
+        clear_errno_for_resolver_syscall(instance, global_this, self.syscall);
 
         // `self` (and thus self.promise / self.hostname) drops at scope exit;
         // hostname was `take()`n above to avoid double-deref.
@@ -781,6 +797,7 @@ pub(crate) fn error_to_js_with_syscall(
         b"name",
         bstr::String::static_(b"DNSException").to_js(global_this)?,
     );
+    clear_errno_for_resolver_syscall(instance, global_this, syscall);
     Ok(instance)
 }
 
@@ -823,6 +840,7 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
         b"name",
         bstr::String::static_(b"DNSException").to_js(global_this)?,
     );
+    clear_errno_for_resolver_syscall(instance, global_this, syscall);
     Ok(instance)
 }
 

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -641,16 +641,14 @@ fn any_reply_to_js(
 
 // ── Error ──────────────────────────────────────────────────────────────────
 
-/// Node only sets a numeric `errno` on DNS errors when libuv reported a
-/// numeric code (getaddrinfo/getnameinfo); c-ares resolver failures carry a
-/// string code and leave `errno` undefined.
-fn clear_errno_for_resolver_syscall(
-    instance: JSValue,
-    global_this: &JSGlobalObject,
-    syscall: &[u8],
-) {
+/// Node only gives a DNS error a numeric `errno` when libuv reported one
+/// (`getaddrinfo`/`getnameinfo`). A c-ares resolver failure (`query*`,
+/// `getHostByAddr`) only has a string `code`, so its `errno` is undefined.
+fn errno_for_syscall(this: c_ares::Error, syscall: &[u8]) -> c_int {
     if strings::has_prefix_comptime(syscall, b"query") || strings::eql(syscall, b"getHostByAddr") {
-        instance.put(global_this, b"errno", JSValue::UNDEFINED);
+        SystemError::NO_ERRNO
+    } else {
+        this as c_int
     }
 }
 
@@ -693,7 +691,7 @@ impl ErrorDeferred {
             ))
         };
         let system_error = SystemError {
-            errno: self.errno as i32,
+            errno: errno_for_syscall(self.errno, self.syscall),
             code: bstr::String::static_(code),
             message,
             syscall: bstr::String::clone_utf8(self.syscall),
@@ -708,7 +706,6 @@ impl ErrorDeferred {
             b"name",
             bstr::String::static_(b"DNSException").to_js(global_this)?,
         );
-        clear_errno_for_resolver_syscall(instance, global_this, self.syscall);
 
         // `self` (and thus self.promise / self.hostname) drops at scope exit;
         // hostname was `take()`n above to avoid double-deref.
@@ -780,7 +777,7 @@ pub(crate) fn error_to_js_with_syscall(
 ) -> JsResult<JSValue> {
     let code = this.code();
     let instance = SystemError {
-        errno: this as i32,
+        errno: errno_for_syscall(this, syscall),
         code: bstr::String::static_(&code[4..]),
         syscall: bstr::String::static_(syscall),
         message: bstr::String::create_format(format_args!(
@@ -796,7 +793,6 @@ pub(crate) fn error_to_js_with_syscall(
         b"name",
         bstr::String::static_(b"DNSException").to_js(global_this)?,
     );
-    clear_errno_for_resolver_syscall(instance, global_this, syscall);
     Ok(instance)
 }
 
@@ -812,7 +808,7 @@ pub(crate) fn system_error_with_syscall_and_hostname(
 ) -> SystemError {
     let code = this.code();
     SystemError {
-        errno: this as i32,
+        errno: errno_for_syscall(this, syscall),
         code: bstr::String::static_(&code[4..]),
         message: bstr::String::create_format(format_args!(
             "{} {} {}",
@@ -839,7 +835,6 @@ pub(crate) fn error_to_js_with_syscall_and_hostname(
         b"name",
         bstr::String::static_(b"DNSException").to_js(global_this)?,
     );
-    clear_errno_for_resolver_syscall(instance, global_this, syscall);
     Ok(instance)
 }
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -178,13 +178,19 @@ test.skipIf(isWindows)("resolver query errors leave errno undefined", async () =
     const resolver = new dns.Resolver({ timeout: 1000, tries: 1 });
     resolver.setServers(["127.0.0.1:" + port]);
 
-    const queryErr = await new Promise(resolve => resolver.resolve4("invalid.invalid", err => resolve(err)));
+    const queryErr = await new Promise((resolve, reject) =>
+      resolver.resolve4("invalid.invalid", err =>
+        err ? resolve(err) : reject(new Error("expected resolve4 to fail")),
+      ),
+    );
     expect(queryErr.code).toBe("ENOTFOUND");
     expect(queryErr.syscall).toBe("queryA");
     expect(queryErr.hostname).toBe("invalid.invalid");
     expect(queryErr.errno).toBeUndefined();
 
-    const reverseErr = await new Promise(resolve => resolver.reverse("192.0.2.1", err => resolve(err)));
+    const reverseErr = await new Promise((resolve, reject) =>
+      resolver.reverse("192.0.2.1", err => (err ? resolve(err) : reject(new Error("expected reverse to fail")))),
+    );
     expect(reverseErr.code).toBe("ENOTFOUND");
     expect(reverseErr.syscall).toBe("getHostByAddr");
     expect(reverseErr.errno).toBeUndefined();

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -157,6 +157,42 @@ test.skipIf(isWindows)("dns.resolveSrv accepts compressed target in RDATA", asyn
   }
 });
 
+// Node only sets a numeric `errno` on DNS errors when libuv reported a
+// numeric error (getaddrinfo/getnameinfo). c-ares resolver failures carry a
+// string code and leave `errno` undefined. https://github.com/oven-sh/bun/issues/37320
+test.skipIf(isWindows)("resolver query errors leave errno undefined", async () => {
+  const socket = dgram.createSocket("udp4");
+  try {
+    socket.on("message", (query, rinfo) => {
+      // Reply NXDOMAIN to every query.
+      const res = Buffer.from(query);
+      res[2] = 0x81; // QR=1, RD=1
+      res[3] = 0x83; // RA=1, RCODE=3 (NXDOMAIN)
+      res.fill(0, 6, 12); // ANCOUNT/NSCOUNT/ARCOUNT = 0
+      socket.send(res, rinfo.port, rinfo.address);
+    });
+    socket.bind(0, "127.0.0.1");
+    await once(socket, "listening");
+    const { port } = socket.address();
+
+    const resolver = new dns.Resolver({ timeout: 1000, tries: 1 });
+    resolver.setServers(["127.0.0.1:" + port]);
+
+    const queryErr = await new Promise(resolve => resolver.resolve4("invalid.invalid", err => resolve(err)));
+    expect(queryErr.code).toBe("ENOTFOUND");
+    expect(queryErr.syscall).toBe("queryA");
+    expect(queryErr.hostname).toBe("invalid.invalid");
+    expect(queryErr.errno).toBeUndefined();
+
+    const reverseErr = await new Promise(resolve => resolver.reverse("192.0.2.1", err => resolve(err)));
+    expect(reverseErr.code).toBe("ENOTFOUND");
+    expect(reverseErr.syscall).toBe("getHostByAddr");
+    expect(reverseErr.errno).toBeUndefined();
+  } finally {
+    socket.close();
+  }
+});
+
 test("dns.resolveTxt (txt.socketify.dev)", () => {
   const { promise, resolve, reject } = Promise.withResolvers();
   dns.resolveTxt("txt.socketify.dev", (err, results) => {

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -160,7 +160,7 @@ test.skipIf(isWindows)("dns.resolveSrv accepts compressed target in RDATA", asyn
 // Node only sets a numeric `errno` on DNS errors when libuv reported a
 // numeric error (getaddrinfo/getnameinfo). c-ares resolver failures carry a
 // string code and leave `errno` undefined. https://github.com/oven-sh/bun/issues/37320
-test.skipIf(isWindows)("resolver query errors leave errno undefined", async () => {
+test.skipIf(isWindows)("resolver query errors leave errno undefined, lookup errors keep a number", async () => {
   const socket = dgram.createSocket("udp4");
   try {
     socket.on("message", (query, rinfo) => {
@@ -199,6 +199,9 @@ test.skipIf(isWindows)("resolver query errors leave errno undefined", async () =
       promisesResolve4: await promiseError(promisesResolver.resolve4("invalid.invalid")),
       promisesResolveAny: await promiseError(promisesResolver.resolveAny("invalid.invalid")),
       promisesReverse: await promiseError(promisesResolver.reverse("192.0.2.1")),
+      // dns.lookup() rejects a name with a NUL byte before it reaches a resolver
+      // backend, so this getaddrinfo failure does not need the network either.
+      lookup: await promiseError(dns.promises.lookup("invalid.invalid\0")),
     };
 
     // Node keeps `errno` as an own property of the error and only leaves its
@@ -236,6 +239,13 @@ test.skipIf(isWindows)("resolver query errors leave errno undefined", async () =
       promisesResolve4: query("queryA"),
       promisesResolveAny: query("queryAny"),
       promisesReverse: reverse,
+      lookup: {
+        code: "ENOTFOUND",
+        syscall: "getaddrinfo",
+        hostname: "invalid.invalid\0",
+        errno: expect.any(Number),
+        hasOwnErrno: true,
+      },
     });
   } finally {
     socket.close();

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -175,25 +175,68 @@ test.skipIf(isWindows)("resolver query errors leave errno undefined", async () =
     await once(socket, "listening");
     const { port } = socket.address();
 
+    const servers = ["127.0.0.1:" + port];
     const resolver = new dns.Resolver({ timeout: 1000, tries: 1 });
-    resolver.setServers(["127.0.0.1:" + port]);
+    resolver.setServers(servers);
+    const promisesResolver = new dns.promises.Resolver({ timeout: 1000, tries: 1 });
+    promisesResolver.setServers(servers);
 
-    const queryErr = await new Promise((resolve, reject) =>
-      resolver.resolve4("invalid.invalid", err =>
-        err ? resolve(err) : reject(new Error("expected resolve4 to fail")),
-      ),
-    );
-    expect(queryErr.code).toBe("ENOTFOUND");
-    expect(queryErr.syscall).toBe("queryA");
-    expect(queryErr.hostname).toBe("invalid.invalid");
-    expect(queryErr.errno).toBeUndefined();
+    const unexpectedSuccess = new Error("expected the query to fail");
+    const callbackError = query =>
+      new Promise((resolve, reject) => query(err => (err ? resolve(err) : reject(unexpectedSuccess))));
+    const promiseError = promise =>
+      promise.then(
+        () => {
+          throw unexpectedSuccess;
+        },
+        err => err,
+      );
 
-    const reverseErr = await new Promise((resolve, reject) =>
-      resolver.reverse("192.0.2.1", err => (err ? resolve(err) : reject(new Error("expected reverse to fail")))),
+    const errors = {
+      resolve4: await callbackError(cb => resolver.resolve4("invalid.invalid", cb)),
+      resolveAny: await callbackError(cb => resolver.resolveAny("invalid.invalid", cb)),
+      reverse: await callbackError(cb => resolver.reverse("192.0.2.1", cb)),
+      promisesResolve4: await promiseError(promisesResolver.resolve4("invalid.invalid")),
+      promisesResolveAny: await promiseError(promisesResolver.resolveAny("invalid.invalid")),
+      promisesReverse: await promiseError(promisesResolver.reverse("192.0.2.1")),
+    };
+
+    // Node keeps `errno` as an own property of the error and only leaves its
+    // value undefined, so check the property is still there.
+    const shapes = Object.fromEntries(
+      Object.entries(errors).map(([name, err]) => [
+        name,
+        {
+          code: err.code,
+          syscall: err.syscall,
+          hostname: err.hostname,
+          errno: err.errno,
+          hasOwnErrno: Object.hasOwn(err, "errno"),
+        },
+      ]),
     );
-    expect(reverseErr.code).toBe("ENOTFOUND");
-    expect(reverseErr.syscall).toBe("getHostByAddr");
-    expect(reverseErr.errno).toBeUndefined();
+    const query = syscall => ({
+      code: "ENOTFOUND",
+      syscall,
+      hostname: "invalid.invalid",
+      errno: undefined,
+      hasOwnErrno: true,
+    });
+    const reverse = {
+      code: "ENOTFOUND",
+      syscall: "getHostByAddr",
+      hostname: "192.0.2.1",
+      errno: undefined,
+      hasOwnErrno: true,
+    };
+    expect(shapes).toEqual({
+      resolve4: query("queryA"),
+      resolveAny: query("queryAny"),
+      reverse,
+      promisesResolve4: query("queryA"),
+      promisesResolveAny: query("queryAny"),
+      promisesReverse: reverse,
+    });
   } finally {
     socket.close();
   }
@@ -446,6 +489,8 @@ test("dns.lookup bad (qedjp3f4q4jgjh4d6vaf3fd2hbfhg6upt2bscrfe.com)", () => {
       expect(err).not.toBeNull();
       expect(err.syscall).toEqual("getaddrinfo");
       expect(err.code).toEqual("ENOTFOUND");
+      // Unlike resolver query errors, lookup errors keep a numeric errno in Node.
+      expect(err.errno).toBeNumber();
       expect(address).toBeUndefined();
       expect(family).toBeUndefined();
       resolve();


### PR DESCRIPTION
Fixes #37320

### Problem

- Resolver errors from `node:dns` (`resolve*`, `reverse`) expose the raw c-ares status enum as a numeric `errno`, for example `errno: 4` (ARES_ENOTFOUND). Node leaves `errno` as an own property with the value `undefined` on these errors.
- The cause: every c-ares error builder in `src/runtime/dns_jsc/cares_jsc.rs` stored the c-ares enum in `SystemError.errno`, and the C++ emitter always wrote it as a number.

### Fix

- Add `SystemError::NO_ERRNO` (`c_int::MIN`, the same sentinel the `fd` field already uses). The C++ emitter (`systemErrorToErrorInstance`) writes `errno: undefined` for it.
- The c-ares error builders set `NO_ERRNO` for resolver syscalls (`query*`, `getHostByAddr`). Lookup-family errors (`getaddrinfo`, `getnameinfo`) and the fetch/`Bun.connect` paths keep their numeric `errno`, matching Node's split: Node only assigns a numeric `errno` when libuv reported a numeric code.
- Verified: `test/js/node/dns/node-dns.test.js` runs a local UDP DNS server that answers NXDOMAIN and checks the full error shape (callback and promise APIs, `resolve4`, `resolveAny`, `reverse`, plus a hermetic `lookup` failure that keeps a numeric `errno`). It fails on the released bun and passes with this change.

### Background

- Node's `dnsException` (lib/internal/errors.js) receives either a numeric libuv code (getaddrinfo/getnameinfo) or a string code (c-ares query callbacks). It assigns `ex.errno = errno` where `errno` is only set in the numeric case, so resolver errors carry an own `errno: undefined`.
- `SystemError` is bun's `#[repr(C)]` error descriptor shared with C++. The Rust side fills the fields, `SystemError__toErrorInstance` builds the JS error.
- The c-ares enum values (positive small integers) do not match any Node constant: `dns.NOTFOUND` is the string `'ENOTFOUND'`, and libuv errnos are negative.

<details><summary>Notes</summary>

- First iteration overwrote `errno` with `undefined` on the JS object after construction. Review preferred deciding the value where the `SystemError` is built, which is the current shape.
- The test pins the lookup path with `dns.promises.lookup("invalid.invalid\0")`: a NUL byte is rejected before any resolver backend runs, so the getaddrinfo error needs no network. The pre-existing network-dependent `dns.lookup bad` test also asserts `errno` is a number now.
- Suites run locally: the new test (fails on release bun, passes with the fix), the full `test/js/node/dns/` local-fixture files, and `test/js/node/dns/node-dns.test.js` (remaining failures are the pre-existing network-dependent tests, identical with and without the fix).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->