### PR TITLE
Startup snapshots: a Bun.serve() created before the snapshot listens again on restore

### DIFF
--- a/docs/bundler/startup-snapshots.mdx
+++ b/docs/bundler/startup-snapshots.mdx
@@ -68,6 +68,22 @@ Bun.startupSnapshot.take({
 
 `process.on("restore")` is available in both modes. Its listeners run before anything else in a restored launch, so state that must be recomputed per machine can be recomputed there; `main()` functions run after them.
 
+### Servers
+
+`Bun.serve()` (and `node:http`, which listens through it) needs no adjustment. A server created before the snapshot does not bind on the build machine — a socket opened there could not exist in a restored launch anyway. Instead it keeps its options, and every restored launch binds it again, in creation order, before `"restore"` listeners run; a launch whose bind fails exits reporting the error, just as the program would have at startup. Calling `server.stop()` before the snapshot is taken means no launch binds it.
+
+```ts server.ts icon="/icons/typescript.svg"
+import { app } from "./app"; // the expensive part ends up in the snapshot
+
+const server = Bun.serve({ port: 3000, fetch: app.fetch });
+
+process.on("restore", () => {
+  console.log(`listening on ${server.url}`); // bound again by the time this runs
+});
+```
+
+Because the server binds per launch, `server.port` and `server.url` have no value while the snapshot is being built: `port` is `undefined` and `url` throws. Code that needs them at startup belongs in a `"restore"` listener or `Bun.startupSnapshot.main()`, which run in every launch that has them.
+
 ## What a restored launch gets from its environment
 
 The runtime refreshes what it owns before your code runs again: `process.argv`, `process.env`, the working directory, `process.pid`, the clocks (`performance.now()`, `process.uptime()`), the time zone, every source of randomness, timers, the DNS cache, its own threads, standard input and output, which are the launcher's, the IPC channel to a parent that spawned the launch with one (`process.send`), and the defaults it derives from the environment, such as the default S3 client and TLS verification. Files and sockets that were open when the snapshot was taken are gone; the program receives hangups for them after `"restore"`.
@@ -84,7 +100,7 @@ When the snapshot is written, the build prints which environment variables were 
 
 ## What the build may do
 
-While the snapshot is being taken, operations whose result would be frozen into every launch are refused: `fetch()` and other network use, `node:fs`, subprocesses, DNS and sockets throw an error saying so. If the program fails because of that, or never becomes quiet, no snapshot is taken and the build fails, saying what happened; the executable it built is left in place, so it can still be used or the step re-run with different settings.
+While the snapshot is being taken, operations whose result would be frozen into every launch are refused: `fetch()` and other network use, `node:fs`, subprocesses, DNS and sockets throw an error saying so. (`Bun.serve()` is not one of them — it defers its bind to the restored launch, as described above.) If the program fails because of that, or never becomes quiet, no snapshot is taken and the build fails, saying what happened; the executable it built is left in place, so it can still be used or the step re-run with different settings.
 
 Programs that legitimately read their own files or run helpers while starting up can be allowed to:
 

--- a/src/jsc/bindings/StartupSnapshot.cpp
+++ b/src/jsc/bindings/StartupSnapshot.cpp
@@ -21,6 +21,7 @@
 #include <wtf/RefCounted.h>
 #include <JavaScriptCore/VMInlines.h>
 #include <JavaScriptCore/StackAlignment.h>
+#include <JavaScriptCore/DeferGC.h>
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/HeapIterationScope.h>
@@ -223,8 +224,8 @@ static bool snapshotEnvIsSet()
 static void reexecWithoutASLRIfSlid()
 {
     // The re-exec'd generation is tagged in argv[0] so it never re-execs again even if disabling ASLR silently failed; the tag is
-    // cut off again right here, before anything (Bun's argv capture, ps) can see it.
-    static constexpr const char* kReexecTag = " [snapshot-reexec]";
+    // cut off again right here, before anything (Bun's argv capture, ps) can see it. Only Darwin tags (Linux re-execs via personality()).
+    [[maybe_unused]] static constexpr const char* kReexecTag = " [snapshot-reexec]";
 #if OS(DARWIN)
     bool alreadyReexeced = false;
     if (char* argv0 = (*_NSGetArgv())[0]) {
@@ -540,6 +541,7 @@ extern "C" bool Bun__startupSnapshotDumpNow(JSC::VM* vm, const char* path)
 }
 extern "C" uint32_t Bun__standaloneStartupSnapshotBuildFlags();
 extern "C" void Bun__startupSnapshotRunMain(JSC::JSGlobalObject*);
+extern "C" void Bun__startupSnapshotBindPendingServers(JSC::JSGlobalObject*);
 extern "C" bool Bun__startupSnapshotHasMain();
 // `bun build --snapshot` marks the payload (Flags::TAKE_STARTUP_SNAPSHOT…); a marked run writes `<own path>.snapshot` instead of starting the app. Translated here into the runtime's internal variables, so the app's own env/argv are never involved.
 static void applySnapshotBuildMarking()
@@ -1206,22 +1208,29 @@ static bool snapshotDump(JSC::VM& vm, const char* path)
     }
     size_t settledStrings = 0;
     { // Error objects keep raw StackFrames (CodeBlock pointers) until .stack is first read; resolve them now so nothing in the snapshot points at code we drop or re-link
-        JSC::HeapIterationScope scope(vm.heap);
-        vm.heap.objectSpace().forEachLiveCell(scope, [&](JSC::HeapCell* heapCell, JSC::HeapCell::Kind kind) {
-            if (isJSCellKind(kind)) {
-                JSC::JSCell* cell = static_cast<JSC::JSCell*>(heapCell);
-                if (auto* error = dynamicDowncast<JSC::ErrorInstance>(cell)) error->materializeErrorInfoIfNeeded(vm);
-                // Lazy one-time StringImpl header writes (hash, did-report-cost) would otherwise dirty snapshot pages the first time a string is used after restore.
-                if (auto* str = dynamicDowncast<JSC::JSString>(cell)) {
-                    if (!str->isRope())
-                        if (auto* impl = str->tryGetValueImpl()) {
-                            impl->settleLazyHeaderWritesForStartupSnapshot();
-                            settledStrings++;
-                        }
+        WTF::Vector<JSC::ErrorInstance*, 16> errors;
+        {
+            JSC::HeapIterationScope scope(vm.heap);
+            vm.heap.objectSpace().forEachLiveCell(scope, [&](JSC::HeapCell* heapCell, JSC::HeapCell::Kind kind) {
+                if (isJSCellKind(kind)) {
+                    JSC::JSCell* cell = static_cast<JSC::JSCell*>(heapCell);
+                    if (auto* error = dynamicDowncast<JSC::ErrorInstance>(cell)) errors.append(error);
+                    // Lazy one-time StringImpl header writes (hash, did-report-cost) would otherwise dirty snapshot pages the first time a string is used after restore.
+                    if (auto* str = dynamicDowncast<JSC::JSString>(cell)) {
+                        if (!str->isRope())
+                            if (auto* impl = str->tryGetValueImpl()) {
+                                impl->settleLazyHeaderWritesForStartupSnapshot();
+                                settledStrings++;
+                            }
+                    }
                 }
-            }
-            return IterationStatus::Continue;
-        });
+                return IterationStatus::Continue;
+            });
+        }
+        // Materializing allocates (the stack string, structure transitions), which must not happen while the heap is being iterated; DeferGC keeps the collected pointers valid through those allocations.
+        JSC::DeferGC deferGC(vm);
+        for (auto* error : errors)
+            error->materializeErrorInfoIfNeeded(vm);
     }
     if (auto* table = vm.atomStringTable())
         for (auto& packed : table->table())
@@ -1954,6 +1963,7 @@ static void snapshotRestoreAndRun(const char* path)
         JSC::JSLockHolder lock(*vm);
         NakedPtr<JSC::Exception> exception;
         globalObject->weakRandom().setSeed(WTF::cryptographicallyRandomNumber<unsigned>()); // Math.random's stream came from the builder
+        Bun__startupSnapshotBindPendingServers(globalObject); // servers created before the snapshot listen again, before 'restore' listeners run
         // chdir('.') refreshes libc's cached cwd; after the app's post-restore burst settles, one full GC plus a reclean hands back what it only touched transiently.
         JSC::evaluate(globalObject, JSC::makeSource("try { process.chdir('.'); } catch {} process.emit('restore');"_s, JSC::SourceOrigin {}, JSC::SourceTaintedOrigin::Untainted), JSC::JSValue(), exception);
         if (exception) { // reported before main() runs: main() may end the process, and a listener's failure is the likelier cause of main()'s

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1574,8 +1574,18 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
             }
             // SAFETY: `init` returned a live heap-allocated server pointer.
             let server_ref: &mut $ServerType = unsafe { &mut *server };
-            // SAFETY: `server` is the live heap-allocated server returned by `init`.
-            let route_list_object = <$ServerType>::listen(server);
+            // Building a startup snapshot (strict I/O): don't bind — this
+            // launch's socket could not exist in a restored one. The server is
+            // queued instead, and every restored launch binds it before its
+            // `"restore"` listeners run; the route list is built then too.
+            let snapshot_deferred = crate::server::startup_snapshot_defers_listen();
+            let route_list_object = if snapshot_deferred {
+                <$ServerType>::defer_listen_until_snapshot_restore(server);
+                JSValue::ZERO
+            } else {
+                // SAFETY: `server` is the live heap-allocated server returned by `init`.
+                <$ServerType>::listen(server)
+            };
             if global_object.has_exception() {
                 return Ok(JSValue::ZERO);
             }
@@ -1632,33 +1642,39 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
             // local `config` is defaulted from here on — read `allow_hot`
             // and `id` from the server's own config or the registration is
             // keyed on the wrong (empty) id.
-            if server_ref.config.allow_hot {
-                // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
-                // borrow was released by the `hot_map()` arm above.
-                if let Some(hot) = global_object.bun_vm().as_mut().hot_map() {
-                    hot.insert_raw(
-                        &server_ref.config.id,
-                        HotMapEntry {
-                            tag: $tag as u8,
-                            ptr: server.cast::<()>(),
-                        },
-                    );
+            // A snapshot-deferred server skips the hot map (a second serve()
+            // with the same id would try to reload routes on the not-yet-bound
+            // app) and the inspector notification (there is no address to
+            // report until a launch binds it).
+            if !snapshot_deferred {
+                if server_ref.config.allow_hot {
+                    // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
+                    // borrow was released by the `hot_map()` arm above.
+                    if let Some(hot) = global_object.bun_vm().as_mut().hot_map() {
+                        hot.insert_raw(
+                            &server_ref.config.id,
+                            HotMapEntry {
+                                tag: $tag as u8,
+                                ptr: server.cast::<()>(),
+                            },
+                        );
+                    }
                 }
-            }
 
-            // SAFETY: bun_vm() returns the live thread-local VM.
-            if let Some(debugger) = global_object.bun_vm().as_mut().debugger.as_deref_mut() {
-                let any = AnyServer::from(server.cast_const());
-                crate::server::http_server_agent::notify_server_started(
-                    &mut debugger.http_server_agent,
-                    any,
-                );
-                bun_core::handle_oom(
-                    crate::server::http_server_agent::notify_server_routes_updated(
+                // SAFETY: bun_vm() returns the live thread-local VM.
+                if let Some(debugger) = global_object.bun_vm().as_mut().debugger.as_deref_mut() {
+                    let any = AnyServer::from(server.cast_const());
+                    crate::server::http_server_agent::notify_server_started(
                         &mut debugger.http_server_agent,
                         any,
-                    ),
-                );
+                    );
+                    bun_core::handle_oom(
+                        crate::server::http_server_agent::notify_server_routes_updated(
+                            &mut debugger.http_server_agent,
+                            any,
+                        ),
+                    );
+                }
             }
 
             Ok(obj)

--- a/src/runtime/api/StartupSnapshotObject.rs
+++ b/src/runtime/api/StartupSnapshotObject.rs
@@ -156,6 +156,20 @@ pub extern "C" fn Bun__startupSnapshotRunMain(global: &JSGlobalObject) {
     }
 }
 
+/// Called by the restore sequence before `'restore'` is emitted: servers
+/// created before the snapshot (`Bun.serve()` at module scope) bind now, in
+/// creation order, so `'restore'` listeners already see them listening. A bind
+/// failure ends the launch the way the same failure would end a normal boot.
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__startupSnapshotBindPendingServers(global: &JSGlobalObject) {
+    if let Err(err) = crate::server::bind_pending_snapshot_servers(global) {
+        let vm = VirtualMachine::get().as_mut();
+        let exception = global.take_exception(err);
+        vm.run_error_handler(exception, None);
+        crate::cli::run_command::exit_with_unhandled_note(vm);
+    }
+}
+
 /// Asked by the snapshot writer: a snapshot taken with a `main()` registered is valid for any invocation.
 #[unsafe(no_mangle)]
 pub extern "C" fn Bun__startupSnapshotHasMain() -> bool {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1682,6 +1682,12 @@ fn record_passthrough_offset(passthrough: &[Box<[u8]>]) {
 
 /// Under BUN_STARTUP_SNAPSHOT_IO=local, everything the app touched on this machine before the freeze — the results are in the snapshot.
 fn print_local_io_audit() {
+    let servers = crate::server::pending_snapshot_server_count();
+    if servers > 0 {
+        bun_core::Output::print_errorln(format_args!(
+            "snapshot: {servers} server(s) were created before the freeze; every launch binds them at restore, before 'restore' listeners run"
+        ));
+    }
     let stdio = bun_core::startup_snapshot::take_stdio_notes();
     if !stdio.is_empty() {
         bun_core::Output::print_errorln(format_args!(

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -325,6 +325,14 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// `JSValue::ZERO` when unset; written by `server_set_on_connection`.
     pub(crate) on_connection: JSValue,
 
+    /// uws-app parser flags (`set_flags` arguments) that arrived while a
+    /// snapshot-pending server had no app — node:http pushes them right after
+    /// `Bun.serve()` returns; applied by [`Self::bind_snapshot_pending`].
+    pub(crate) deferred_app_flags: Option<(bool, bool, u8, bool)>,
+
+    /// Same deferral for `set_max_http_header_size`.
+    pub(crate) deferred_max_http_header_size: Option<u64>,
+
     pub(crate) inspector_server_id: jsc::DebuggerId,
 }
 
@@ -1692,6 +1700,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 lenient_http_flags,
                 http_allow_half_open,
             );
+        } else if self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            // No app to accept them yet; the restore-time bind applies them.
+            self.deferred_app_flags = Some((
+                require_host_header,
+                use_strict_method_validation,
+                lenient_http_flags,
+                http_allow_half_open,
+            ));
         }
     }
 
@@ -1699,6 +1715,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if let Some(app) = self.app {
             // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
             bun_opaque::opaque_deref_mut(app).set_max_http_header_size(max_header_size);
+        } else if self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            // No app to accept it yet; the restore-time bind applies it.
+            self.deferred_max_http_header_size = Some(max_header_size);
         }
     }
 
@@ -2253,6 +2272,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             user_routes: Vec::new(),
             on_clienterror: JSValue::ZERO,
             on_connection: JSValue::ZERO,
+            deferred_app_flags: None,
+            deferred_max_http_header_size: None,
             inspector_server_id: jsc::DebuggerId::init(0),
         }));
 
@@ -2856,13 +2877,40 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if global.has_exception() {
             return Err(bun_jsc::JsError::Thrown);
         }
-        // SAFETY: `listen()` succeeded, so `this` was not freed; no other
-        // borrow is live.
-        let this_ref = unsafe { &mut *this };
-        this_ref.flags.remove(ServerFlags::SNAPSHOT_PENDING);
+        let (wrapper, needs_client_error, needs_connection) = {
+            // SAFETY: `listen()` succeeded, so `this` was not freed; the
+            // borrow ends with this block (the register_* calls below
+            // re-derive from the raw pointer).
+            let this_ref = unsafe { &mut *this };
+            this_ref.flags.remove(ServerFlags::SNAPSHOT_PENDING);
+            // node:http pushed its custom options right after `Bun.serve()`
+            // returned, when there was no app to accept them; apply what the
+            // server held onto.
+            if let Some((require_host, strict_method, lenient, half_open)) =
+                this_ref.deferred_app_flags.take()
+            {
+                this_ref.set_flags(require_host, strict_method, lenient, half_open);
+            }
+            if let Some(max) = this_ref.deferred_max_http_header_size.take() {
+                this_ref.set_max_http_header_size(max);
+            }
+            (
+                this_ref.js_value.try_get(),
+                !this_ref.on_clienterror.is_empty(),
+                !this_ref.on_connection.is_empty(),
+            )
+        };
+        // The callbacks were stored (and GC-rooted) by the setters during the
+        // build; only the uws registration was waiting for the app.
+        if needs_client_error {
+            Self::register_client_error_thunk(this);
+        }
+        if needs_connection {
+            Self::register_connection_thunk(this);
+        }
         // The wrapper was created when the build run called `Bun.serve()` and
         // `js_value` has kept it alive since.
-        if let Some(obj) = this_ref.js_value.try_get() {
+        if let Some(obj) = wrapper {
             if route_list != JSValue::ZERO {
                 // Root the fresh RouteList in the wrapper's cached-value slot
                 // exactly as `serve_with!` does.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -221,6 +221,11 @@ bitflags::bitflags! {
         const DEINIT_SCHEDULED            = 1 << 0;
         const TERMINATED                  = 1 << 1;
         const HAS_HANDLED_ALL_CLOSED_PROMISE = 1 << 2;
+        /// Created while a startup snapshot was being built: nothing is bound
+        /// (`app`/`listener` are `None`) until a restored launch binds it via
+        /// [`NewServer::bind_snapshot_pending`]. JS-reachable paths must
+        /// tolerate the missing uws app while this is set.
+        const SNAPSHOT_PENDING            = 1 << 3;
     }
 }
 
@@ -645,6 +650,75 @@ pub(crate) fn wrap_handler_slot(
     };
     set(server_js, global, v);
     *shadow = v;
+}
+
+// ─── startup-snapshot pending servers ────────────────────────────────────────
+/// Servers created while a startup snapshot was being built, in creation
+/// order. They hold no OS socket; every launch that restores the snapshot
+/// binds them (via [`bind_pending_snapshot_servers`]) before `"restore"`
+/// listeners run. A static (not VM state) so it sits in the data segment the
+/// snapshot captures; stored as `(tag, address)` because `AnyServer`'s
+/// `*mut ()` is not `Send`.
+static PENDING_SNAPSHOT_SERVERS: std::sync::Mutex<Vec<(AnyServerTag, usize)>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// `Bun.serve()` in the run that builds a snapshot (strict I/O policy, main
+/// thread): create the server but bind at restore instead of refusing — the
+/// socket would not exist in a restored launch anyway, and deferring captures
+/// nothing machine-specific. Under `--snapshot-io=local`/`network` the bind
+/// stays immediate (the build opted into real I/O, e.g. to warm caches against
+/// its own server); on a worker thread the strict refusal stays (workers do
+/// not survive a snapshot, so there is no launch that could bind the server).
+pub(crate) fn startup_snapshot_defers_listen() -> bool {
+    bun_core::startup_snapshot::building()
+        && !bun_core::startup_snapshot::io_allowed("Bun.serve")
+        && jsc::VirtualMachine::get().as_mut().is_main_thread
+}
+
+/// Servers currently waiting to bind at restore (for the snapshot writer's report).
+pub(crate) fn pending_snapshot_server_count() -> usize {
+    PENDING_SNAPSHOT_SERVERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .len()
+}
+
+/// Restore sequence, before `process.emit('restore')`: bind every server
+/// created before the snapshot, in creation order. Stops at the first failure
+/// with that bind's exception left on `global` (the caller reports it the way
+/// a throw at startup is reported and ends the launch).
+pub(crate) fn bind_pending_snapshot_servers(
+    global: &JSGlobalObject,
+) -> Result<(), bun_jsc::JsError> {
+    loop {
+        let next = {
+            let mut pending = PENDING_SNAPSHOT_SERVERS
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if pending.is_empty() {
+                None
+            } else {
+                Some(pending.remove(0))
+            }
+        };
+        let Some((tag, addr)) = next else {
+            return Ok(());
+        };
+        match tag {
+            AnyServerTag::HTTPServer => {
+                HTTPServer::bind_snapshot_pending(addr as *mut HTTPServer, global)?;
+            }
+            AnyServerTag::HTTPSServer => {
+                HTTPSServer::bind_snapshot_pending(addr as *mut HTTPSServer, global)?;
+            }
+            AnyServerTag::DebugHTTPServer => {
+                DebugHTTPServer::bind_snapshot_pending(addr as *mut DebugHTTPServer, global)?;
+            }
+            AnyServerTag::DebugHTTPSServer => {
+                DebugHTTPSServer::bind_snapshot_pending(addr as *mut DebugHTTPSServer, global)?;
+            }
+        }
+    }
 }
 
 impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
@@ -1775,6 +1849,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     }
 
     pub(crate) fn stop(&mut self, abrupt: bool) {
+        // A pending snapshot server never bound; stopping it before the
+        // snapshot means no launch binds it either.
+        self.drop_pending_snapshot_entry();
         if self.config.allow_hot && !self.config.id.is_empty() {
             // `hot_map()` is reached via the thread-local VM singleton (raw ptr
             // deref) and does not borrow `self`, so it cannot overlap with the
@@ -1931,19 +2008,22 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // scheduleDeinit can be called inside a finalizer.
             // Therefore, we split it into two tasks.
             self.flags.insert(ServerFlags::TERMINATED);
-            let app = self.app.unwrap();
-            // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine`
-            // (non-null for the server's lifetime); single-threaded JS
-            // context, `&mut` scoped to this call.
-            unsafe {
-                (*self.vm_mut()).enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
-                    app,
-                    |app| {
-                        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                        bun_opaque::opaque_deref_mut(app).close();
-                        Ok(())
-                    },
-                ));
+            // `None` only for a snapshot-pending server stopped before it ever
+            // bound (listen() never ran, so there is no app to close).
+            if let Some(app) = self.app {
+                // SAFETY: `vm_mut()` is the process-static `*mut VirtualMachine`
+                // (non-null for the server's lifetime); single-threaded JS
+                // context, `&mut` scoped to this call.
+                unsafe {
+                    (*self.vm_mut()).enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
+                        app,
+                        |app| {
+                            // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                            bun_opaque::opaque_deref_mut(app).close();
+                            Ok(())
+                        },
+                    ));
+                }
             }
         }
 
@@ -2103,6 +2183,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // This should've already been handled in stop_listening; however, when
         // the JS VM terminates, it hypothetically might not call stop_listening.
         server.notify_inspector_server_stopped();
+        // Same story for a snapshot-pending entry `stop()` would have dropped.
+        server.drop_pending_snapshot_entry();
         if let Some(handles) = crate::jsc_hooks::active_handles() {
             handles.swap_remove(&crate::jsc_hooks::ActiveHandle::Server(AnyServer::from(
                 this.cast_const(),
@@ -2726,11 +2808,92 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         route_list_value
     }
 
+    // ─── startup-snapshot deferred listen ────────────────────────────────────
+    /// `Bun.serve()` in the run that builds a startup snapshot: skip `listen()`
+    /// entirely — this launch's socket could not exist in a restored one — and
+    /// queue the server so every restored launch binds it (creation order,
+    /// before `"restore"` listeners). `server.stop()` before the snapshot
+    /// drops the entry again. The server holds no event-loop ref while
+    /// pending, so an auto-mode build still drains.
+    /// # Safety contract
+    /// `this` must be the live heap-allocated server from [`Self::init`].
+    pub(crate) fn defer_listen_until_snapshot_restore(this: *mut Self) {
+        // SAFETY: caller contract — `this` is the live boxed server from `init()`.
+        unsafe { (*this).flags.insert(ServerFlags::SNAPSHOT_PENDING) };
+        let any = AnyServer::from(this.cast_const());
+        PENDING_SNAPSHOT_SERVERS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push((any.tag, this as usize));
+    }
+
+    /// Drop this server's pending-bind entry (no-op unless `SNAPSHOT_PENDING`).
+    fn drop_pending_snapshot_entry(&mut self) {
+        if !self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            return;
+        }
+        self.flags.remove(ServerFlags::SNAPSHOT_PENDING);
+        let addr = core::ptr::from_ref(self) as usize;
+        PENDING_SNAPSHOT_SERVERS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .retain(|&(_, a)| a != addr);
+    }
+
+    /// Restored launch: run the `listen()` this server skipped while the
+    /// snapshot was built. On failure the bind exception is left on `global`
+    /// and the server is NOT freed — the JS wrapper from the build run still
+    /// owns it, and the caller ends the launch the way a throw at startup
+    /// would.
+    pub(crate) fn bind_snapshot_pending(
+        this: *mut Self,
+        global: &JSGlobalObject,
+    ) -> Result<(), bun_jsc::JsError>
+    where
+        Self: ServerPools<SSL, DEBUG>,
+    {
+        let route_list = Self::listen(this);
+        if global.has_exception() {
+            return Err(bun_jsc::JsError::Thrown);
+        }
+        // SAFETY: `listen()` succeeded, so `this` was not freed; no other
+        // borrow is live.
+        let this_ref = unsafe { &mut *this };
+        this_ref.flags.remove(ServerFlags::SNAPSHOT_PENDING);
+        // The wrapper was created when the build run called `Bun.serve()` and
+        // `js_value` has kept it alive since.
+        if let Some(obj) = this_ref.js_value.try_get() {
+            if route_list != JSValue::ZERO {
+                // Root the fresh RouteList in the wrapper's cached-value slot
+                // exactly as `serve_with!` does.
+                Self::js_gc_route_list_set(obj, global, route_list);
+            }
+            // `server.address` read during the build cached `null` (nothing was
+            // bound); un-cache it so the getter recomputes from the live listener.
+            Self::js_gc_address_set(obj, global, JSValue::ZERO);
+        }
+        Ok(())
+    }
+
+    /// Failure cleanup for `listen()`: frees the server, except when this is a
+    /// snapshot-pending bind at restore — there the JS wrapper from the build
+    /// run still owns the allocation, and the caller reports the error and
+    /// ends the launch, so freeing here would leave the wrapper's finalizer a
+    /// dangling pointer.
+    fn deinit_on_listen_failure(this: *mut Self) {
+        // SAFETY: caller contract — `this` is the live boxed server from `init()`.
+        if unsafe { (*this).flags.contains(ServerFlags::SNAPSHOT_PENDING) } {
+            return;
+        }
+        Self::deinit(this);
+    }
+
     // ─── listen ──────────────────────────────────────────────────────────────
     /// Create the uws `App<SSL>` (and optional H3 app), register routes via
     /// `set_routes()`, and bind the listen socket. On any failure the server
-    /// is `deinit()`ed synchronously and `.zero` is returned with an exception
-    /// pending on `global_this`.
+    /// is `deinit()`ed synchronously (unless a snapshot-pending restore bind —
+    /// see [`Self::deinit_on_listen_failure`]) and `.zero` is returned with an
+    /// exception pending on `global_this`.
     /// # Safety
     /// `this` must point to the live heap-allocated `NewServer` returned by
     /// [`Self::init`], with no other `&`/`&mut` borrow live for the duration
@@ -2766,7 +2929,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             .is_err()
         {
             // SAFETY: caller contract — `this` is the live boxed server from `init()`; freed here like every other failure below.
-            Self::deinit(this);
+            Self::deinit_on_listen_failure(this);
             return JSValue::ZERO; // thrown; every server (node:http included) listens through here
         }
 
@@ -2782,7 +2945,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     "Failed to create HTTPS server: missing tls config"
                 ));
                 // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                Self::deinit(this);
+                Self::deinit_on_listen_failure(this);
                 return JSValue::ZERO;
             };
 
@@ -2795,7 +2958,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     // SAFETY: `this` is the live boxed server from `init()`; no other borrow is live.
                     unsafe { (*this).app = None };
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
             };
@@ -2811,7 +2974,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             let _ = global.throw(format_args!("Failed to create HTTP/3 server"));
                         }
                         // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                        Self::deinit(this);
+                        Self::deinit_on_listen_failure(this);
                         return JSValue::ZERO;
                     }
                 };
@@ -2855,12 +3018,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         ));
                     }
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
 
@@ -2870,7 +3033,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 bun_opaque::opaque_deref_mut(app).domain(z);
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
 
@@ -2921,7 +3084,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 ));
                             }
                             // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                            Self::deinit(this);
+                            Self::deinit_on_listen_failure(this);
                             return JSValue::ZERO;
                         }
                     }
@@ -2938,14 +3101,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         ));
                     }
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                 bun_opaque::opaque_deref_mut(app).domain(z);
                 if throw_ssl_error_if_necessary(global) {
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
                 // SAFETY: `this` is the live boxed server from `init()`; no
@@ -2961,7 +3124,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         let _ = global.throw(format_args!("Failed to create HTTP server"));
                     }
                     // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-                    Self::deinit(this);
+                    Self::deinit_on_listen_failure(this);
                     return JSValue::ZERO;
                 }
             };
@@ -3150,7 +3313,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if global.has_exception() {
             // SAFETY: caller contract — `this` is the live boxed server from `init()`.
-            Self::deinit(this);
+            Self::deinit_on_listen_failure(this);
             return JSValue::ZERO;
         }
 
@@ -3195,7 +3358,8 @@ mod cached_values {
         ($ty:literal) => {
             bun_jsc::codegen_cached_accessors!(
                 $ty; routeList, onRequest, onError, onNodeHTTPRequest, onClientError, onConnection,
-                wsOnOpen, wsOnMessage, wsOnClose, wsOnDrain, wsOnError, wsOnPing, wsOnPong
+                wsOnOpen, wsOnMessage, wsOnClose, wsOnDrain, wsOnError, wsOnPing, wsOnPong,
+                address
             );
         };
     }
@@ -3255,6 +3419,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     slot_setter!(js_gc_ws_on_error_set, ws_on_error_set_cached);
     slot_setter!(js_gc_ws_on_ping_set, ws_on_ping_set_cached);
     slot_setter!(js_gc_ws_on_pong_set, ws_on_pong_set_cached);
+    // `server.address` is a `cache: true` getter; ZERO un-caches it (the
+    // generated getter treats an empty slot as never-computed).
+    slot_setter!(js_gc_address_set, address_set_cached);
 
     /// Mirror all 7 `Handler.on_*` shadows into the wrapper's `m_wsOn*`
     /// WriteBarrier slots, applying the async-context wrap (deferred from

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -226,6 +226,11 @@ bitflags::bitflags! {
         /// [`NewServer::bind_snapshot_pending`]. JS-reachable paths must
         /// tolerate the missing uws app while this is set.
         const SNAPSHOT_PENDING            = 1 << 3;
+        /// `server.unref()` was called while `SNAPSHOT_PENDING`. The keep-alive
+        /// is a plain active/inactive flag that `listen()` activates, so the
+        /// intent has to be carried separately and re-applied after the
+        /// restore-time bind; `server.ref()` while pending clears it.
+        const SNAPSHOT_PENDING_UNREF      = 1 << 4;
     }
 }
 
@@ -2893,6 +2898,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
             if let Some(max) = this_ref.deferred_max_http_header_size.take() {
                 this_ref.set_max_http_header_size(max);
+            }
+            // `listen()` just activated the keep-alive; a build-time
+            // `server.unref()` asked for it not to be.
+            if this_ref.flags.contains(ServerFlags::SNAPSHOT_PENDING_UNREF) {
+                this_ref.flags.remove(ServerFlags::SNAPSHOT_PENDING_UNREF);
+                this_ref.unref();
             }
             (
                 this_ref.js_value.try_get(),

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1468,7 +1468,9 @@ where
 
         let topic = topic_value.to_slice(global)?;
 
-        if topic.slice().is_empty() {
+        if topic.slice().is_empty() || self.app.is_none() {
+            // `app` is `None` only for a snapshot-pending server, which cannot
+            // have subscribers: nothing is bound yet.
             return Ok(JSValue::js_number(0.0));
         }
 
@@ -1662,7 +1664,12 @@ where
             return Ok(JSValue::js_number(0.0));
         }
 
-        let app = self.app.unwrap().cast::<c_void>();
+        // `None` only for a snapshot-pending server: nothing is bound, so
+        // there is no subscriber to deliver to.
+        let Some(app) = self.app else {
+            return Ok(JSValue::js_number(0.0));
+        };
+        let app = app.cast::<c_void>();
 
         if topic.len == 0 {
             httplog!("publish() topic invalid");
@@ -2254,12 +2261,17 @@ where
     ) {
         httplog!("onReload");
 
-        // SAFETY: `on_reload` is only reachable while the server is running
-        // (`self.app` set in `listen()`).
-        self.app_mut().clear_routes();
-        if Self::HAS_H3 {
-            if let Some(h3a) = self.h3_app {
-                bun_opaque::opaque_deref_mut(h3a).clear_routes();
+        // `app` is `None` only for a snapshot-pending server (reload() during
+        // a snapshot build): adopt the new config below as usual, and skip the
+        // route (re-)registration — the restore-time bind runs `set_routes()`
+        // against whatever the config holds by then.
+        let has_app = self.app.is_some();
+        if has_app {
+            self.app_mut().clear_routes();
+            if Self::HAS_H3 {
+                if let Some(h3a) = self.h3_app {
+                    bun_opaque::opaque_deref_mut(h3a).clear_routes();
+                }
             }
         }
 
@@ -2343,9 +2355,11 @@ where
             self.user_routes.clear();
         }
 
-        let route_list_value = self.set_routes();
-        if new_config.had_routes_object {
-            Self::js_gc_route_list_set(server_js, global, route_list_value);
+        if has_app {
+            let route_list_value = self.set_routes();
+            if new_config.had_routes_object {
+                Self::js_gc_route_list_set(server_js, global, route_list_value);
+            }
         }
 
         if self.inspector_server_id.get() != 0 {
@@ -2627,7 +2641,10 @@ where
         // `!deinit_running`: a `server.stop()` reached from a close callback
         // that an outer `stop()`'s drain fired would re-enter `stop_listening`
         // with a fresh `&mut self` under the outer frame's borrow.
+        // `SNAPSHOT_PENDING`: no listener exists, but a graceful stop() must
+        // still run so the pending bind-at-restore entry is dropped.
         if self.has_listener()
+            || self.flags.contains(ServerFlags::SNAPSHOT_PENDING)
             || (abrupt
                 && !self.flags.contains(ServerFlags::TERMINATED)
                 && !self.deinit_running.get())
@@ -2649,6 +2666,12 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_port(&self, _: &JSGlobalObject) -> JSValue {
+        if self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            // Building a snapshot: the port is only known once a launch binds.
+            // `undefined` rather than a throw so code that reads it
+            // incidentally (node:http's listen path does) keeps working.
+            return JSValue::UNDEFINED;
+        }
         let config_port = match &self.config.address {
             server_config::Address::Unix(_) => return JSValue::UNDEFINED,
             server_config::Address::Tcp { port, .. } => *port,
@@ -2744,6 +2767,13 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_url(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        if self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            // A URL built now would freeze this build's address into every
+            // launch; throw so the read moves to where the server is bound.
+            return Err(global.throw(format_args!(
+                "server.url is not available while building a snapshot: the server binds again in each restored launch, so the address is only known then. Read it after restore (process.on('restore') or Bun.startupSnapshot.main())"
+            )));
+        }
         let mut url = self
             .get_url_as_string()
             .map_err(|_| global.throw_out_of_memory())?;
@@ -2830,7 +2860,11 @@ where
     }
 
     pub(crate) fn get_all_closed_promise(&mut self, global: &JSGlobalObject) -> JSValue {
-        if !self.has_listener()
+        // A snapshot-pending server has no listener yet but is not "closed":
+        // it binds when a launch restores. Hand out the lazy promise so e.g.
+        // node:http's close tracking does not see an already-settled one.
+        if !self.flags.contains(ServerFlags::SNAPSHOT_PENDING)
+            && !self.has_listener()
             && self.pending_requests.get() == 0
             && !self.has_active_connections()
             && !self.has_active_web_sockets()

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2927,6 +2927,13 @@ where
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let this_value = callframe.this();
+        if self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            // Nothing is bound, so there is nothing to hold the build's loop
+            // open with (doing so would keep an auto-mode build from ever
+            // draining); the restore-time bind refs like a fresh listen().
+            self.flags.remove(ServerFlags::SNAPSHOT_PENDING_UNREF);
+            return Ok(this_value);
+        }
         self.ref_();
         Ok(this_value)
     }
@@ -2938,6 +2945,12 @@ where
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let this_value = callframe.this();
+        if self.flags.contains(ServerFlags::SNAPSHOT_PENDING) {
+            // The keep-alive is not active yet, so `unref()` alone would be a
+            // no-op; remember the intent for the restore-time bind.
+            self.flags.insert(ServerFlags::SNAPSHOT_PENDING_UNREF);
+            return Ok(this_value);
+        }
         self.unref();
         Ok(this_value)
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3691,6 +3691,80 @@ where
         resp.end(&json_string, resp.should_close_connection());
     }
 
+    /// uws_sys::App::on_client_error takes the raw C-ABI handler shape; this
+    /// thunk slices raw_packet and forwards to [`Self::on_client_error_callback`].
+    extern "C" fn client_error_thunk(
+        user_data: *mut c_void,
+        _ssl: c_int,
+        socket: *mut uws_sys::us_socket_t,
+        error_code: u8,
+        raw_packet: *mut u8,
+        raw_packet_len: c_int,
+    ) {
+        // SAFETY: user_data is the `*mut Self` registered in
+        // `register_client_error_thunk`; socket is a live uWS socket;
+        // raw_packet/raw_packet_len describe a valid (possibly empty) buffer.
+        // Shared — the callback re-enters JS.
+        let this = unsafe { &*user_data.cast::<Self>() };
+        let packet: &[u8] = if raw_packet_len > 0 {
+            // SAFETY: uWS guarantees `raw_packet` points to `raw_packet_len`
+            // readable bytes when `raw_packet_len > 0`.
+            unsafe { bun_core::ffi::slice(raw_packet, raw_packet_len as usize) }
+        } else {
+            &[]
+        };
+        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
+        this.on_client_error_callback(bun_opaque::opaque_deref_mut(socket), error_code, packet);
+    }
+
+    /// Register the uws client-error handler for the stored `on_clienterror`
+    /// callback; a no-op while the app does not exist yet (snapshot-pending).
+    /// Split from `server_set_on_client_error` so the restore-time bind can
+    /// register what node:http set while nothing was bound.
+    /// # Safety contract
+    /// `this` must be a live server pointer with no `&mut` borrow live.
+    pub(crate) fn register_client_error_thunk(this: *mut Self) {
+        // SAFETY: caller contract — `this` is live; borrow scoped to this statement.
+        let Some(app) = (unsafe { &*this }).app else {
+            return;
+        };
+        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+        bun_opaque::opaque_deref_mut(app)
+            .on_client_error(Self::client_error_thunk, this.cast::<c_void>());
+    }
+
+    /// uws filters fire with `1` when an HTTP connection is opened (for TLS,
+    /// when its handshake completes) and `-1` on close; only the open
+    /// notification is forwarded to JS.
+    extern "C" fn connection_filter_thunk(
+        socket: *mut uws_sys::us_socket_t,
+        opened: i32,
+        user_data: *mut c_void,
+    ) {
+        if opened != 1 {
+            return;
+        }
+        // SAFETY: user_data is the `*mut Self` registered in
+        // `register_connection_thunk`; socket is a live uWS socket for this
+        // server's group. Shared — the callback re-enters JS.
+        let this = unsafe { &*user_data.cast::<Self>() };
+        this.on_connection_callback(socket.cast::<c_void>());
+    }
+
+    /// Register the uws connection filter for the stored `on_connection`
+    /// callback; a no-op while the app does not exist yet (snapshot-pending).
+    /// # Safety contract
+    /// `this` must be a live server pointer with no `&mut` borrow live.
+    pub(crate) fn register_connection_thunk(this: *mut Self) {
+        // SAFETY: caller contract — `this` is live; borrow scoped to this statement.
+        let Some(app) = (unsafe { &*this }).app else {
+            return;
+        };
+        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+        bun_opaque::opaque_deref_mut(app)
+            .filter(Self::connection_filter_thunk, this.cast::<c_void>());
+    }
+
     pub(crate) fn on_client_error_callback(
         &self,
         socket: &mut uws::Socket,
@@ -3866,49 +3940,18 @@ fn server_set_on_client_error(
             if let Some(this_ptr) = server.as_::<$T>() {
                 // SAFETY: as_ returned a non-null *mut to a live server; nothing
                 // here re-enters through it, so each scoped access is exclusive.
-                if let Some(app) = unsafe { (*this_ptr).app } {
-                    // SAFETY: see above — `&mut` scoped to this statement.
-                    unsafe {
-                        (*this_ptr).on_clienterror = callback;
-                        super::wrap_handler_slot(
-                            &mut (*this_ptr).on_clienterror,
-                            server,
-                            global,
-                            <$T>::js_gc_on_client_error_set,
-                        );
-                    }
-                    // uws_sys::App::on_client_error takes the raw C-ABI handler shape;
-                    // wrap our typed callback in an extern "C" thunk that slices raw_packet.
-                    extern "C" fn thunk(
-                        user_data: *mut c_void,
-                        _ssl: c_int,
-                        socket: *mut uws_sys::us_socket_t,
-                        error_code: u8,
-                        raw_packet: *mut u8,
-                        raw_packet_len: c_int,
-                    ) {
-                        // SAFETY: user_data is the `*mut Self` registered below; socket is a live
-                        // uWS socket; raw_packet/raw_packet_len describe a valid (possibly empty)
-                        // buffer. Shared — the callback re-enters JS.
-                        let this = unsafe { &*user_data.cast::<$T>() };
-                        let packet: &[u8] = if raw_packet_len > 0 {
-                            // SAFETY: uWS guarantees `raw_packet` points to `raw_packet_len`
-                            // readable bytes when `raw_packet_len > 0`.
-                            unsafe { bun_core::ffi::slice(raw_packet, raw_packet_len as usize) }
-                        } else {
-                            &[]
-                        };
-                        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
-                        this.on_client_error_callback(
-                            bun_opaque::opaque_deref_mut(socket),
-                            error_code,
-                            packet,
-                        );
-                    }
-                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app)
-                        .on_client_error(thunk, this_ptr.cast::<c_void>());
+                // The store + GC-root run even when the app does not exist yet
+                // (snapshot-pending): the restore-time bind registers the thunk.
+                unsafe {
+                    (*this_ptr).on_clienterror = callback;
+                    super::wrap_handler_slot(
+                        &mut (*this_ptr).on_clienterror,
+                        server,
+                        global,
+                        <$T>::js_gc_on_client_error_set,
+                    );
                 }
+                <$T>::register_client_error_thunk(this_ptr);
                 return Ok(JSValue::UNDEFINED);
             }
         };
@@ -3943,37 +3986,18 @@ fn server_set_on_connection(
             if let Some(this_ptr) = server.as_::<$T>() {
                 // SAFETY: as_ returned a non-null *mut to a live server; nothing
                 // here re-enters through it, so each scoped access is exclusive.
-                if let Some(app) = unsafe { (*this_ptr).app } {
-                    // SAFETY: see above — `&mut` scoped to this statement.
-                    unsafe {
-                        (*this_ptr).on_connection = callback;
-                        super::wrap_handler_slot(
-                            &mut (*this_ptr).on_connection,
-                            server,
-                            global,
-                            <$T>::js_gc_on_connection_set,
-                        );
-                    }
-                    // uws filters fire with `1` when an HTTP connection is opened
-                    // (for TLS, when its handshake completes) and `-1` on close;
-                    // only the open notification is forwarded to JS.
-                    extern "C" fn thunk(
-                        socket: *mut uws_sys::us_socket_t,
-                        opened: i32,
-                        user_data: *mut c_void,
-                    ) {
-                        if opened != 1 {
-                            return;
-                        }
-                        // SAFETY: user_data is the `*mut Self` registered below;
-                        // socket is a live uWS socket for this server's group.
-                        // Shared — the callback re-enters JS.
-                        let this = unsafe { &*user_data.cast::<$T>() };
-                        this.on_connection_callback(socket.cast::<c_void>());
-                    }
-                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app).filter(thunk, this_ptr.cast::<c_void>());
+                // The store + GC-root run even when the app does not exist yet
+                // (snapshot-pending): the restore-time bind registers the filter.
+                unsafe {
+                    (*this_ptr).on_connection = callback;
+                    super::wrap_handler_slot(
+                        &mut (*this_ptr).on_connection,
+                        server,
+                        global,
+                        <$T>::js_gc_on_connection_set,
+                    );
                 }
+                <$T>::register_connection_thunk(this_ptr);
                 return Ok(JSValue::UNDEFINED);
             }
         };

--- a/test/js/bun/startup-snapshot/serve-pending-auto-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-auto-fixture.js
@@ -1,0 +1,10 @@
+// The shape the deferred bind exists for: Bun.serve() at module scope, auto mode, no snapshot code
+// beyond the 'restore' listener. The pending server holds no event-loop ref, so startup drains.
+const server = Bun.serve({ port: 0, fetch: () => new Response("auto server ok") });
+process.on("restore", async () => {
+  const res = await fetch(`http://localhost:${server.port}/`);
+  console.log("[js] auto serve ->", await res.text());
+  server.stop(true);
+  process.exit(0);
+});
+console.log("[js] module evaluated");

--- a/test/js/bun/startup-snapshot/serve-pending-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-fixture.js
@@ -1,0 +1,37 @@
+// Bun.serve() at module scope while a snapshot is built: nothing binds on the build machine;
+// every restored launch binds the server again, before its 'restore' listeners run.
+const server = Bun.serve({
+  port: 0,
+  websocket: { message() {} },
+  fetch(req) {
+    return new Response(`first handler ${new URL(req.url).pathname}`);
+  },
+});
+process.on("restore", async () => {
+  // The bind happened before this listener ran, so the port is already real.
+  console.log("[js] restore port type:", typeof server.port);
+  console.log("[js] restore url:", server.url.protocol);
+  const res = await fetch(`http://localhost:${server.port}/abc`);
+  console.log("[js] fetch ->", res.status, await res.text());
+  server.stop(true);
+  process.exit(0);
+});
+if (Bun.startupSnapshot.isBuildingSnapshot()) {
+  console.log("[js] building port:", String(server.port)); // per-launch, so unavailable: undefined
+  try {
+    void server.url;
+    console.log("[js] building url: readable");
+  } catch {
+    console.log("[js] building url: throws");
+  }
+  console.log("[js] building publish:", server.publish("topic", "x")); // nothing is bound: 0
+  console.log("[js] building subscriberCount:", server.subscriberCount("topic")); // 0
+  // reload() before the snapshot updates the config the restore-time bind uses.
+  server.reload({
+    port: 0,
+    fetch(req) {
+      return new Response(`reloaded handler ${new URL(req.url).pathname}`);
+    },
+  });
+  Bun.startupSnapshot.take({ timers: "cancel" });
+}

--- a/test/js/bun/startup-snapshot/serve-pending-node-http-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-node-http-fixture.js
@@ -1,0 +1,21 @@
+// node:http listens through Bun.serve, so a server created before the snapshot defers its bind too.
+const http = require("node:http");
+const server = http.createServer((req, res) => {
+  res.end("node ok");
+});
+server.listen(0, "127.0.0.1");
+process.on("restore", async () => {
+  const address = server.address();
+  console.log("[js] restore address port type:", typeof address?.port);
+  const res = await fetch(`http://127.0.0.1:${address.port}/`);
+  console.log("[js] node fetch ->", await res.text());
+  server.close(() => process.exit(0));
+});
+if (Bun.startupSnapshot.isBuildingSnapshot()) {
+  // listen() ran but nothing is bound; give the JS listen machinery (next-tick
+  // 'listening' emit, which reads the still-undefined port) a turn first.
+  setTimeout(() => {
+    console.log("[js] building address:", JSON.stringify(server.address()));
+    Bun.startupSnapshot.take({ timers: "cancel" });
+  }, 50);
+}

--- a/test/js/bun/startup-snapshot/serve-pending-node-http-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-node-http-fixture.js
@@ -1,15 +1,34 @@
 // node:http listens through Bun.serve, so a server created before the snapshot defers its bind too.
+// That includes the custom options node pushes right after listen() returns (parser flags,
+// maxHeaderSize, clientError/connection callbacks): nothing was bound to accept them, so the
+// restore-time bind has to apply them.
 const http = require("node:http");
-const server = http.createServer((req, res) => {
+const net = require("node:net");
+const server = http.createServer({ maxHeaderSize: 1024 }, (req, res) => {
   res.end("node ok");
+});
+let connections = 0;
+server.on("connection", () => connections++);
+server.on("clientError", (err, socket) => {
+  console.log("[js] clientError:", err.code);
+  socket.destroy();
 });
 server.listen(0, "127.0.0.1");
 process.on("restore", async () => {
   const address = server.address();
   console.log("[js] restore address port type:", typeof address?.port);
   const res = await fetch(`http://127.0.0.1:${address.port}/`);
-  console.log("[js] node fetch ->", await res.text());
-  server.close(() => process.exit(0));
+  console.log("[js] node fetch ->", await res.text(), "connection seen:", connections > 0);
+  // maxHeaderSize (1024) survived into the restored bind: an oversized header trips the
+  // parser limit, whose report also proves the clientError callback reached the new app.
+  await fetch(`http://127.0.0.1:${address.port}/`, {
+    headers: { "x-big": Buffer.alloc(4096, "a").toString() },
+  }).then(
+    r => console.log("[js] big header unexpectedly answered:", r.status),
+    () => console.log("[js] big header rejected"),
+  );
+  const sock = net.connect(address.port, "127.0.0.1", () => sock.write("NOT A VALID REQUEST\r\n\r\n"));
+  sock.on("close", () => server.close(() => process.exit(0)));
 });
 if (Bun.startupSnapshot.isBuildingSnapshot()) {
   // listen() ran but nothing is bound; give the JS listen machinery (next-tick

--- a/test/js/bun/startup-snapshot/serve-pending-stop-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-stop-fixture.js
@@ -1,0 +1,12 @@
+// server.stop() before the snapshot drops the pending entry: only the kept server binds at restore.
+const kept = Bun.serve({ port: 0, fetch: () => new Response("kept") });
+const dropped = Bun.serve({ port: 0, fetch: () => new Response("dropped") });
+dropped.stop(); // graceful: still drops the never-bound entry
+process.on("restore", async () => {
+  const res = await fetch(`http://localhost:${kept.port}/`);
+  console.log("[js] kept ->", await res.text());
+  console.log("[js] dropped port:", String(dropped.port)); // never bound: the configured port (0)
+  kept.stop(true);
+  process.exit(0);
+});
+if (Bun.startupSnapshot.isBuildingSnapshot()) Bun.startupSnapshot.take({ timers: "cancel" });

--- a/test/js/bun/startup-snapshot/serve-pending-unix-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-unix-fixture.js
@@ -1,0 +1,9 @@
+// Two pending servers on the same unix socket path: at restore the first binds, the second
+// fails the way it would at startup, ending the launch before 'restore' listeners run.
+const path = process.env.UNIX_PATH;
+Bun.serve({ unix: path, fetch: () => new Response("a") });
+Bun.serve({ unix: path, fetch: () => new Response("b") });
+process.on("restore", () => {
+  console.log("[js] restore ran"); // must not print: the duplicate bind fails first
+});
+if (Bun.startupSnapshot.isBuildingSnapshot()) Bun.startupSnapshot.take({ timers: "cancel" });

--- a/test/js/bun/startup-snapshot/serve-pending-unref-fixture.js
+++ b/test/js/bun/startup-snapshot/serve-pending-unref-fixture.js
@@ -1,0 +1,16 @@
+// server.ref()/unref() before the snapshot decide whether the server keeps a restored launch alive,
+// exactly as they would after a normal listen. Nothing is bound while building, so the calls have
+// to be carried over to the restore-time bind. The mode is read once, in the build, like the calls.
+const reref = process.env.SERVE_REF_MODE === "reref";
+const server = Bun.serve({ port: 0, fetch: () => new Response("x") });
+server.unref();
+if (reref) server.ref(); // the last call wins, as after a normal listen
+process.on("restore", () => {
+  console.log("[js] restore port type:", typeof server.port); // bound before this listener ran
+  // An unref'd timer only fires if something else keeps the loop alive: with the server unref'd
+  // the process exits before it fires; with the server ref'd it fires and reports that.
+  setTimeout(() => {
+    console.log("[js] loop held open by the server");
+    process.exit(reref ? 0 : 3);
+  }, 50).unref();
+});

--- a/test/js/bun/startup-snapshot/startup-snapshot.test.ts
+++ b/test/js/bun/startup-snapshot/startup-snapshot.test.ts
@@ -791,7 +791,10 @@ snapshotTest("a node:http server created before the snapshot listens again at re
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout, stderr.slice(-600)).toContain("[js] restore address port type: number");
-  expect(stdout).toContain("[js] node fetch -> node ok");
+  expect(stdout).toContain("[js] node fetch -> node ok connection seen: true"); // connection filter re-registered at bind
+  expect(stdout).toContain("[js] big header rejected"); // maxHeaderSize applied to the restored app
+  expect(stdout).toContain("[js] clientError: HPE_HEADER_OVERFLOW"); // clientError callback re-registered at bind
+  expect(stdout).toContain("[js] clientError: HPE_INVALID_CONSTANT");
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/startup-snapshot/startup-snapshot.test.ts
+++ b/test/js/bun/startup-snapshot/startup-snapshot.test.ts
@@ -823,33 +823,36 @@ snapshotTest("auto mode: Bun.serve() at module scope snapshots with no code chan
 });
 
 for (const mode of ["unref", "reref"] as const) {
-  snapshotTest(`server.${mode === "unref" ? "unref()" : "unref() then ref()"} before the snapshot applies to the restored bind`, async () => {
-    using dir = tempDir(`bun-snapshot-serve-${mode}`, {});
-    const img = join(String(dir), "s.snapshot");
-    const fixture = join(import.meta.dir, "serve-pending-unref-fixture.js");
-    await using build = Bun.spawn({
-      cmd: [bunExe(), fixture],
-      env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img, BUN_STARTUP_SNAPSHOT_AUTO: "1", SERVE_REF_MODE: mode },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [, buildErr] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(buildErr).toContain("[snapshot] wrote"); // neither call held the build's loop open: auto mode still drained
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), fixture],
-      env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout, stderr.slice(-600)).toContain("[js] restore port type: number");
-    if (mode === "unref") {
-      expect(stdout).not.toContain("loop held open"); // exited on its own: the bound server does not hold the loop
-    } else {
-      expect(stdout).toContain("[js] loop held open by the server");
-    }
-    expect(exitCode).toBe(0);
-  });
+  snapshotTest(
+    `server.${mode === "unref" ? "unref()" : "unref() then ref()"} before the snapshot applies to the restored bind`,
+    async () => {
+      using dir = tempDir(`bun-snapshot-serve-${mode}`, {});
+      const img = join(String(dir), "s.snapshot");
+      const fixture = join(import.meta.dir, "serve-pending-unref-fixture.js");
+      await using build = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img, BUN_STARTUP_SNAPSHOT_AUTO: "1", SERVE_REF_MODE: mode },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, buildErr] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      expect(buildErr).toContain("[snapshot] wrote"); // neither call held the build's loop open: auto mode still drained
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout, stderr.slice(-600)).toContain("[js] restore port type: number");
+      if (mode === "unref") {
+        expect(stdout).not.toContain("loop held open"); // exited on its own: the bound server does not hold the loop
+      } else {
+        expect(stdout).toContain("[js] loop held open by the server");
+      }
+      expect(exitCode).toBe(0);
+    },
+  );
 }
 
 snapshotTest("Bun.enableANSIColors reified during a piped build is re-derived for a launch on a terminal", async () => {

--- a/test/js/bun/startup-snapshot/startup-snapshot.test.ts
+++ b/test/js/bun/startup-snapshot/startup-snapshot.test.ts
@@ -652,7 +652,7 @@ snapshotTest("a snapshot is refused while a worker thread is running, and says s
   expect(code).toBe(70); // the runtime's "did not become quiet" exit
 });
 
-snapshotTest("a strict build refuses servers and UDP sockets, not just listen/connect", async () => {
+snapshotTest("a strict build refuses UDP sockets and fs, while Bun.serve defers its bind", async () => {
   using dir = tempDir("bun-snapshot-strict-servers", {});
   await using p = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "strict-servers-fixture.js")],
@@ -665,7 +665,7 @@ snapshotTest("a strict build refuses servers and UDP sockets, not just listen/co
     stderr: "pipe",
   });
   const [out] = await Promise.all([p.stdout.text(), p.stderr.text(), p.exited]);
-  expect(out).toContain("[js] serve refused");
+  expect(out).toContain("[js] serve created"); // deferred to bind at restore, not refused
   expect(out).toContain("[js] udp refused");
   for (const op of [
     "readdir",
@@ -689,6 +689,134 @@ snapshotTest("a strict build refuses servers and UDP sockets, not just listen/co
   ])
     expect(out).toContain(`[js] ${op} refused`); // hand-written node:fs bindings
   for (const op of ["stdout-write", "stdin-access"]) expect(out).toContain(`[js] ${op} created`); // stdio is exempt from the gate
+});
+
+snapshotTest("Bun.serve() before the snapshot binds again at restore, before 'restore' listeners run", async () => {
+  using dir = tempDir("bun-snapshot-serve-pending", {});
+  const img = join(String(dir), "s.snapshot");
+  const fixture = join(import.meta.dir, "serve-pending-fixture.js");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), fixture],
+    env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const buildOut = build.stdout.toString();
+  expect(buildOut).toContain("[js] building port: undefined"); // only known per launch
+  expect(buildOut).toContain("[js] building url: throws");
+  expect(buildOut).toContain("[js] building publish: 0"); // nothing bound, nothing subscribed
+  expect(buildOut).toContain("[js] building subscriberCount: 0");
+  expect(build.stderr.toString()).toContain("server(s) were created before the freeze");
+  expect(build.stderr.toString()).toContain("[snapshot] wrote");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("[snapshot] restored");
+  expect(stdout).toContain("[js] restore port type: number"); // already bound when the listener ran
+  expect(stdout).toContain("[js] restore url: http:");
+  expect(stdout).toContain("[js] fetch -> 200 reloaded handler /abc"); // reload() during the build carried into the restored bind
+  expect(exitCode).toBe(0);
+});
+
+snapshotTest("server.stop() before the snapshot drops the pending bind", async () => {
+  using dir = tempDir("bun-snapshot-serve-stop", {});
+  const img = join(String(dir), "s.snapshot");
+  const fixture = join(import.meta.dir, "serve-pending-stop-fixture.js");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), fixture],
+    env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  expect(build.stderr.toString()).toContain("[snapshot] wrote");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr.slice(-600)).toContain("[js] kept ->"); // wait for the fetch line before the others
+  expect(stdout).toContain("[js] kept -> kept");
+  expect(stdout).toContain("[js] dropped port: 0"); // never bound in the restored launch
+  expect(exitCode).toBe(0);
+});
+
+snapshotTest("a bind that fails at restore ends the launch like a startup throw", async () => {
+  using dir = tempDir("bun-snapshot-serve-unix", {});
+  const img = join(String(dir), "s.snapshot");
+  const fixture = join(import.meta.dir, "serve-pending-unix-fixture.js");
+  const unixPath = join(String(dir), "s.sock");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), fixture],
+    env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img, UNIX_PATH: unixPath },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  expect(build.stderr.toString()).toContain("[snapshot] wrote"); // two pending servers on one path: fine until a launch binds
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toMatch(/EADDRINUSE|Failed to listen on unix socket/); // the second server's path is taken by the first
+  expect(stdout).not.toContain("[js] restore ran"); // the launch ended before 'restore' listeners
+  expect(exitCode).not.toBe(0);
+});
+
+snapshotTest("a node:http server created before the snapshot listens again at restore", async () => {
+  using dir = tempDir("bun-snapshot-serve-node", {});
+  const img = join(String(dir), "s.snapshot");
+  const fixture = join(import.meta.dir, "serve-pending-node-http-fixture.js");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), fixture],
+    env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  expect(build.stdout.toString()).toContain("[js] building address: null"); // not bound while building
+  expect(build.stderr.toString()).toContain("[snapshot] wrote");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr.slice(-600)).toContain("[js] restore address port type: number");
+  expect(stdout).toContain("[js] node fetch -> node ok");
+  expect(exitCode).toBe(0);
+});
+
+snapshotTest("auto mode: Bun.serve() at module scope snapshots with no code changes", async () => {
+  using dir = tempDir("bun-snapshot-serve-auto", {});
+  const img = join(String(dir), "s.snapshot");
+  const fixture = join(import.meta.dir, "serve-pending-auto-fixture.js");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), fixture],
+    env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img, BUN_STARTUP_SNAPSHOT_AUTO: "1" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  expect(build.stdout.toString()).toContain("[js] module evaluated");
+  // the pending server holds no event-loop ref, so startup drains and auto mode takes the snapshot
+  expect(build.stderr.toString()).toContain("[snapshot] wrote");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout, stderr.slice(-600)).toContain("[js] auto serve -> auto server ok");
+  expect(exitCode).toBe(0);
 });
 
 snapshotTest("Bun.enableANSIColors reified during a piped build is re-derived for a launch on a terminal", async () => {

--- a/test/js/bun/startup-snapshot/startup-snapshot.test.ts
+++ b/test/js/bun/startup-snapshot/startup-snapshot.test.ts
@@ -822,6 +822,36 @@ snapshotTest("auto mode: Bun.serve() at module scope snapshots with no code chan
   expect(exitCode).toBe(0);
 });
 
+for (const mode of ["unref", "reref"] as const) {
+  snapshotTest(`server.${mode === "unref" ? "unref()" : "unref() then ref()"} before the snapshot applies to the restored bind`, async () => {
+    using dir = tempDir(`bun-snapshot-serve-${mode}`, {});
+    const img = join(String(dir), "s.snapshot");
+    const fixture = join(import.meta.dir, "serve-pending-unref-fixture.js");
+    await using build = Bun.spawn({
+      cmd: [bunExe(), fixture],
+      env: { ...buildEnv, BUN_STARTUP_SNAPSHOT_OUT: img, BUN_STARTUP_SNAPSHOT_AUTO: "1", SERVE_REF_MODE: mode },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, buildErr] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildErr).toContain("[snapshot] wrote"); // neither call held the build's loop open: auto mode still drained
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture],
+      env: { ...restoreEnv, BUN_STARTUP_SNAPSHOT_IN: img },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout, stderr.slice(-600)).toContain("[js] restore port type: number");
+    if (mode === "unref") {
+      expect(stdout).not.toContain("loop held open"); // exited on its own: the bound server does not hold the loop
+    } else {
+      expect(stdout).toContain("[js] loop held open by the server");
+    }
+    expect(exitCode).toBe(0);
+  });
+}
+
 snapshotTest("Bun.enableANSIColors reified during a piped build is re-derived for a launch on a terminal", async () => {
   using dir = tempDir("bun-snapshot-colors", {});
   const img = join(String(dir), "s.snapshot");

--- a/test/js/bun/startup-snapshot/strict-servers-fixture.js
+++ b/test/js/bun/startup-snapshot/strict-servers-fixture.js
@@ -1,4 +1,5 @@
-// A strict build must refuse anything that would freeze an OS socket into the snapshot: servers and UDP sockets included.
+// A strict build must refuse anything that would freeze an OS socket into the snapshot: UDP sockets included.
+// Bun.serve() is the exception: it defers its bind to restore instead (serve-pending-fixture.js), so it "creates".
 async function attempt(name, make) {
   try {
     let s = make();


### PR DESCRIPTION
Closes #37322. Stacked on #37261 (`claude/startup-snapshot-build`).

### What changes

`Bun.serve()` at module scope now snapshots as-is, in auto mode, with no code changes. Since every server (node:http included) listens through the same path, node:http servers get this for free.

| Step | Behavior |
|---|---|
| `Bun.serve()` while a snapshot is built (strict policy) | Does not bind. The server keeps its resolved config and is queued as pending; this replaces the strict refusal. It holds no event-loop ref, so an auto-mode build still drains. |
| At restore | Every pending server binds, in creation order, before `process.on("restore")` listeners run. A bind failure is reported through the regular error handler and ends the launch with exit 1, as the same failure would end a normal boot. |
| `server.port` / `server.url` during the build | `port` is `undefined` (not a throw, because node:http's listen path reads it incidentally); `url` throws with a message pointing at `"restore"`/`main()`. |
| `server.stop()` before the snapshot | Drops the pending entry; no launch binds it. Graceful and abrupt both work. |
| `server.unref()` / `ref()`, and node:http's custom options (parser flags, `maxHeaderSize`, `clientError`/`connection`) before the snapshot | Recorded on the server and applied by the restore-time bind, so the restored server behaves as if the calls had followed a normal listen. |
| `--snapshot-io=local` / `network` | Unchanged: the bind stays immediate (the build opted into real I/O, e.g. dns-fixture warms caches against its own server). |
| Workers | Unchanged strict refusal; a worker cannot survive a snapshot, so no launch could bind its server. |

### Implementation

- `ServerFlags::SNAPSHOT_PENDING` + a process-static pending list (data segment, so the restored process sees the builder's list). `serve()` skips `listen()` when deferring; `Bun__startupSnapshotBindPendingServers` runs `listen()` for each entry from the restore sequence, right before `'restore'` is emitted.
- A pending server is the first JS-reachable server whose uws `app` is `None`, so the paths reachable in that state now tolerate it: `publish`/`subscriberCount` return 0, `reload()` adopts config without touching routes (the restore-time bind builds them), `scheduleDeinit` skips the app-close task, and the stop()/close promise is no longer born settled (node:http's close tracking saw a spuriously resolved one).
- State that JS pushes onto a server right after `Bun.serve()` returns used to be applied straight to the app, so on a pending server it was lost. It is now kept on the server and applied after the bind: the `clientError`/`connection` callbacks are stored and GC-rooted regardless and their uws registration is a helper the bind calls; `set_flags`/`set_max_http_header_size` park their values; `unref()` sets `SNAPSHOT_PENDING_UNREF`, which the bind applies after `listen()` has ref'd (the keep-alive is a plain active flag, so an early `unref()` recorded nothing), and `ref()` clears it instead of activating a keep-alive inside the build process.
- `server.address` is a `cache: true` getter; a build-time read caches `null`, so the restore-time bind un-caches it (`addressSetCachedValue` with an empty value).
- On a failed restore bind, `listen()` must not free the server: the JS wrapper from the build run still owns it, and the launch exits right after reporting.
- The snapshot writer reports pending servers: `snapshot: N server(s) were created before the freeze; every launch binds them at restore, before 'restore' listeners run`.

Two small fixes in the stack's code that this work exposed:

- The dump settled `ErrorInstance`s by materializing their stacks inside a `HeapIterationScope`; materializing allocates, which asserts in debug WebKit (`!m_directory->markedSpace().isIterating()`) the moment any live Error exists at dump time. The errors are now collected during iteration and materialized after it, under `DeferGC`.
- `kReexecTag` is only used on Darwin and failed `-Werror=unused` on Linux no-asan builds.

### Verification

New fixtures + tests in `test/js/bun/startup-snapshot/` (they self-skip where snapshots are unsupported, including ASAN builds, like the rest of the suite):

- `serve-pending-fixture.js`: module scope serve; during build `port` is `undefined`, `url` throws, `publish`/`subscriberCount` are 0, and a `reload()` during the build carries into the restored bind; at restore the port is live before the `'restore'` listener runs and a fetch round-trips.
- `serve-pending-stop-fixture.js`: `stop()` during the build; the kept server binds at restore, the stopped one never does.
- `serve-pending-unix-fixture.js`: two pending servers on one unix path; at restore the second bind fails with `EADDRINUSE: address already in use, listen '<path>'`, the launch exits non-zero, and `'restore'` never runs.
- `serve-pending-node-http-fixture.js`: `http.createServer({ maxHeaderSize: 1024 }).listen(0)` at module scope; `address()` is `null` during the build, and after restore `'connection'` fires, an oversized header yields `clientError` `HPE_HEADER_OVERFLOW`, and garbage bytes yield `HPE_INVALID_CONSTANT`, matching a normal boot.
- `serve-pending-unref-fixture.js` (two modes, built in auto mode): `unref()` before the snapshot leaves a bound server that lets the restored launch exit on its own (it exited 3 before the fix, held open by the server); `unref()` then `ref()` holds it open.
- `serve-pending-auto-fixture.js`: auto mode; the entry drains despite the module-scope server and the restored launch serves.
- `strict-servers-fixture.js` updated: serve now "creates" (deferred) while UDP and fs stay refused.

All 42 tests in `startup-snapshot.test.ts` pass on a Linux release build of the current branch (1 skip as before); `serve.test.ts`, the `Bun.serve().unref()` tests in `bun-server.test.ts`, and the node:http close/max-header-size tests are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/startup-snapshot/startup-snapshot.test.ts

<!-- robobun:evidence:end -->
