### PR TITLE
repl: recognize regex literals and comments in continuation detection

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2527,6 +2527,12 @@ fn is_incomplete_code(code: &[u8]) -> bool {
     let mut prev: u8 = 0;
     let mut word_start = 0usize;
     let mut word_end = 0usize;
+    // `obj.in` is a property access, not the `in` keyword.
+    let mut word_after_dot = false;
+    // Whether each open paren is an `if`/`for`/`while`/`with` head, so that a
+    // `/` right after its `)` reads as a regex, not division.
+    let mut paren_stack: Vec<bool> = Vec::new();
+    let mut last_paren_conditional = false;
 
     let mut i = 0usize;
     while i < code.len() {
@@ -2578,10 +2584,12 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             }
             // A `/` starts a regex literal when the previous significant token
             // cannot end an expression; otherwise it's division.
-            let after_keyword =
-                is_word_char(prev) && REGEX_KEYWORDS.contains(&&code[word_start..word_end]);
+            let after_keyword = is_word_char(prev)
+                && !word_after_dot
+                && REGEX_KEYWORDS.contains(&&code[word_start..word_end]);
             let starts_regex = prev == 0
                 || after_keyword
+                || (prev == b')' && last_paren_conditional)
                 || matches!(
                     prev,
                     b'(' | b'['
@@ -2598,6 +2606,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                         | b'+'
                         | b'-'
                         | b'*'
+                        | b'/'
                         | b'%'
                         | b'<'
                         | b'>'
@@ -2620,7 +2629,10 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                     }
                     i += 1;
                 }
-                prev = b'/';
+                // A regex literal ends an expression, so a following `/` is
+                // division; `)` (non-conditional) encodes that.
+                prev = b')';
+                last_paren_conditional = false;
                 i += 1;
                 continue;
             }
@@ -2629,10 +2641,10 @@ fn is_incomplete_code(code: &[u8]) -> bool {
         if is_word_char(ch) {
             if word_end != i {
                 word_start = i;
+                word_after_dot = prev == b'.';
             }
             word_end = i + 1;
         }
-        prev = ch;
 
         match ch {
             b'"' | b'\'' => in_string = ch,
@@ -2641,10 +2653,20 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             b'}' => brace_count -= 1,
             b'[' => bracket_count += 1,
             b']' => bracket_count -= 1,
-            b'(' => paren_count += 1,
-            b')' => paren_count -= 1,
+            b'(' => {
+                paren_count += 1;
+                paren_stack.push(
+                    is_word_char(prev)
+                        && matches!(&code[word_start..word_end], b"if" | b"for" | b"while" | b"with"),
+                );
+            }
+            b')' => {
+                paren_count -= 1;
+                last_paren_conditional = paren_stack.pop().unwrap_or(false);
+            }
             _ => {}
         }
+        prev = ch;
         i += 1;
     }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2608,8 +2608,22 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                     while j > 0 && is_word_char(code[j - 1]) {
                         j -= 1;
                     }
-                    (j > 0 && matches!(code[j - 1], b'.' | b'#'))
+                    if (j > 0 && matches!(code[j - 1], b'.' | b'#'))
                         || !REGEX_KEYWORDS.contains(&&code[j..end])
+                    {
+                        true
+                    } else {
+                        // `as void!` asserts a type, so the `!` is still postfix.
+                        let mut k = j;
+                        while k > 0 && matches!(code[k - 1], b' ' | b'\t') {
+                            k -= 1;
+                        }
+                        let kw_end = k;
+                        while k > 0 && is_word_char(code[k - 1]) {
+                            k -= 1;
+                        }
+                        matches!(&code[k..kw_end], b"as" | b"satisfies")
+                    }
                 } else {
                     false
                 }
@@ -2709,13 +2723,17 @@ fn is_incomplete_code(code: &[u8]) -> bool {
 
         if is_word_char(ch) {
             if word_end != i {
-                // `void` after `as`/`satisfies` is a type, not the void operator.
-                word_after_type_op = is_word_char(prev)
-                    && matches!(&code[word_start..word_end], b"as" | b"satisfies");
+                // `void` after `as`/`satisfies` (also across `|`/`&`) is a type.
+                word_after_type_op = (is_word_char(prev)
+                    && matches!(&code[word_start..word_end], b"as" | b"satisfies"))
+                    || (word_after_type_op && matches!(prev, b'|' | b'&'));
                 word_start = i;
                 word_after_dot = matches!(prev, b'.' | b'#');
             }
             word_end = i + 1;
+        } else if !matches!(ch, b'|' | b'&') {
+            // Any other significant token ends the type position.
+            word_after_type_op = false;
         }
 
         match ch {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2527,7 +2527,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
     let mut prev_idx = 0usize;
     let mut word_start = 0usize;
     let mut word_end = 0usize;
-    // `obj.in` is a property access, not the `in` keyword.
+    // `obj.in` / `this.#in` is a member access, not the `in` keyword.
     let mut word_after_dot = false;
     // Parens opened by `if`/`for`/`while`/`with`; a `/` after such a `)` is a regex.
     let mut paren_stack: Vec<bool> = Vec::new();
@@ -2659,7 +2659,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
         if is_word_char(ch) {
             if word_end != i {
                 word_start = i;
-                word_after_dot = prev == b'.';
+                word_after_dot = matches!(prev, b'.' | b'#');
             }
             word_end = i + 1;
         }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2634,8 +2634,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                     {
                         j -= 1;
                     }
-                    // `</tag>` closes a tag; `Map<K, V>` (word before `<`) closes a generic.
-                    // `a < b, c >` (no word before `<`) stays a comparison, so regex follows.
+                    // `</tag>` or `Map<K, V>` (word before `<`) ends an expression; `a < b` does not.
                     (j > 1 && code[j - 1] == b'/' && code[j - 2] == b'<')
                         || (j > 1 && code[j - 1] == b'<' && is_word_char(code[j - 2]))
                 } else {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2627,13 +2627,17 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 if j > 0 && code[j - 1] == b'/' {
                     true
                 } else if j > 0 && is_word_char(code[j - 1]) {
-                    // A tag/type name (dots/hyphens/colons ok) follows `<` or `/`; `a >` does not.
+                    // Walk a tag/type-argument run (`a.b`, `my-el`, `K, V`) back to its opener.
                     while j > 0
-                        && (is_word_char(code[j - 1]) || matches!(code[j - 1], b'.' | b'-' | b':'))
+                        && (is_word_char(code[j - 1])
+                            || matches!(code[j - 1], b'.' | b'-' | b':' | b',' | b' ' | b'\t'))
                     {
                         j -= 1;
                     }
-                    j > 0 && matches!(code[j - 1], b'<' | b'/')
+                    // `</tag>` closes a tag; `Map<K, V>` (word before `<`) closes a generic.
+                    // `a < b, c >` (no word before `<`) stays a comparison, so regex follows.
+                    (j > 1 && code[j - 1] == b'/' && code[j - 2] == b'<')
+                        || (j > 1 && code[j - 1] == b'<' && is_word_char(code[j - 2]))
                 } else {
                     false
                 }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2588,13 +2588,22 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             // A doubled `+`/`-` is postfix inc/dec, which ends an expression.
             let postfix_incdec =
                 matches!(prev, b'+' | b'-') && prev_idx > 0 && code[prev_idx - 1] == prev;
-            // `}` ends a statement block at top level, but an object literal inside `()`/`[]`.
-            let after_block = prev == b'}' && paren_count <= 0 && bracket_count <= 0;
+            // `x!` (TS non-null assertion) ends an expression; `!x` does not.
+            let postfix_bang = prev == b'!'
+                && prev_idx > 0
+                && (is_word_char(code[prev_idx - 1]) || matches!(code[prev_idx - 1], b')' | b']'));
+            // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
+            let jsx_close = prev == b'<' && prev_idx + 1 == i;
+            // `}` ends a statement block at top level, but an object literal inside a group.
+            let after_block =
+                prev == b'}' && paren_count <= 0 && bracket_count <= 0 && brace_count <= 0;
             let starts_regex = prev == 0
                 || after_keyword
                 || after_block
                 || (prev == b')' && last_paren_conditional)
                 || (!postfix_incdec
+                    && !postfix_bang
+                    && !jsx_close
                     && matches!(
                         prev,
                         b'(' | b'['
@@ -2659,6 +2668,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 paren_count += 1;
                 paren_stack.push(
                     is_word_char(prev)
+                        && !word_after_dot
                         && matches!(
                             &code[word_start..word_end],
                             b"if" | b"for" | b"while" | b"with"

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2591,10 +2591,14 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             // A doubled `+`/`-` is postfix inc/dec, which ends an expression.
             let postfix_incdec =
                 matches!(prev, b'+' | b'-') && prev_idx > 0 && code[prev_idx - 1] == prev;
-            // `x!` (TS non-null assertion) ends an expression; `!x` does not.
-            let postfix_bang = prev == b'!'
-                && prev_idx > 0
-                && (is_word_char(code[prev_idx - 1]) || matches!(code[prev_idx - 1], b')' | b']'));
+            // `x!` or `x!!` (TS non-null assertion) ends an expression; `!x` does not.
+            let postfix_bang = prev == b'!' && {
+                let mut j = prev_idx;
+                while j > 0 && code[j - 1] == b'!' {
+                    j -= 1;
+                }
+                j > 0 && (is_word_char(code[j - 1]) || matches!(code[j - 1], b')' | b']'))
+            };
             // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
             let jsx_close = prev == b'<' && prev_idx + 1 == i;
             // `}` ends an expression when it closes an object literal, not a block.

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2605,10 +2605,8 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                         | b'~'
                 );
             if starts_regex {
-                // Skip the regex body: quotes and brackets inside it are not
-                // code. A `/` inside a `[...]` class does not terminate it. A
-                // newline means the literal is unterminated (regexes cannot
-                // span lines); stop there and let evaluation report the error.
+                // Skip the regex body; a `/` inside a `[...]` class does not
+                // terminate it, and a newline does (regexes cannot span lines).
                 i += 1;
                 let mut in_class = false;
                 while i < code.len() && code[i] != b'\n' {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2601,6 +2601,10 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             };
             // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
             let jsx_close = prev == b'<' && prev_idx + 1 == i;
+            // `>` ending a JSX tag (`</a>`, `<a/>`, `</>`) ends an expression; `a > /re/` does not.
+            let jsx_end = prev == b'>'
+                && prev_idx > 0
+                && (code[prev_idx - 1] == b'/' || is_word_char(code[prev_idx - 1]));
             // A block's `}` resumes statement position unless it's inside `()`/`[]`.
             let after_block =
                 prev == b'}' && last_brace_block && paren_count <= 0 && bracket_count <= 0;
@@ -2611,6 +2615,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 || (!postfix_incdec
                     && !postfix_bang
                     && !jsx_close
+                    && !jsx_end
                     && matches!(
                         prev,
                         b'(' | b'['

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2529,6 +2529,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
     let mut word_end = 0usize;
     // `obj.in` / `this.#in` is a member access, not the `in` keyword.
     let mut word_after_dot = false;
+    let mut word_after_type_op = false;
     // Parens opened by `if`/`for`/`while`/`with`; a `/` after such a `)` is a regex.
     let mut paren_stack: Vec<bool> = Vec::new();
     let mut last_paren_conditional = false;
@@ -2587,6 +2588,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             // A `/` after a token that cannot end an expression starts a regex.
             let after_keyword = is_word_char(prev)
                 && !word_after_dot
+                && !word_after_type_op
                 && REGEX_KEYWORDS.contains(&&code[word_start..word_end]);
             // A doubled `+`/`-` is postfix inc/dec, which ends an expression.
             let postfix_incdec =
@@ -2699,6 +2701,9 @@ fn is_incomplete_code(code: &[u8]) -> bool {
 
         if is_word_char(ch) {
             if word_end != i {
+                // `void` after `as`/`satisfies` is a type, not the void operator.
+                word_after_type_op = is_word_char(prev)
+                    && matches!(&code[word_start..word_end], b"as" | b"satisfies");
                 word_start = i;
                 word_after_dot = matches!(prev, b'.' | b'#');
             }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2524,6 +2524,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
 
     // Regex-vs-division context: last significant byte, and the identifier ending at it.
     let mut prev: u8 = 0;
+    let mut prev_idx = 0usize;
     let mut word_start = 0usize;
     let mut word_end = 0usize;
     // `obj.in` is a property access, not the `in` keyword.
@@ -2584,32 +2585,38 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             let after_keyword = is_word_char(prev)
                 && !word_after_dot
                 && REGEX_KEYWORDS.contains(&&code[word_start..word_end]);
+            // A doubled `+`/`-` is postfix inc/dec, which ends an expression.
+            let postfix_incdec =
+                matches!(prev, b'+' | b'-') && prev_idx > 0 && code[prev_idx - 1] == prev;
+            // `}` ends a statement block at top level, but an object literal inside `()`/`[]`.
+            let after_block = prev == b'}' && paren_count <= 0 && bracket_count <= 0;
             let starts_regex = prev == 0
                 || after_keyword
+                || after_block
                 || (prev == b')' && last_paren_conditional)
-                || matches!(
-                    prev,
-                    b'(' | b'['
-                        | b'{'
-                        | b'}'
-                        | b','
-                        | b';'
-                        | b':'
-                        | b'='
-                        | b'!'
-                        | b'&'
-                        | b'|'
-                        | b'?'
-                        | b'+'
-                        | b'-'
-                        | b'*'
-                        | b'/'
-                        | b'%'
-                        | b'<'
-                        | b'>'
-                        | b'^'
-                        | b'~'
-                );
+                || (!postfix_incdec
+                    && matches!(
+                        prev,
+                        b'(' | b'['
+                            | b'{'
+                            | b','
+                            | b';'
+                            | b':'
+                            | b'='
+                            | b'!'
+                            | b'&'
+                            | b'|'
+                            | b'?'
+                            | b'+'
+                            | b'-'
+                            | b'*'
+                            | b'/'
+                            | b'%'
+                            | b'<'
+                            | b'>'
+                            | b'^'
+                            | b'~'
+                    ));
             if starts_regex {
                 // Skip the regex body; `/` in a `[...]` class doesn't end it, a newline does.
                 i += 1;
@@ -2665,6 +2672,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             _ => {}
         }
         prev = ch;
+        prev_idx = i;
         i += 1;
     }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2620,6 +2620,10 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 while j > 0 && matches!(code[j - 1], b' ' | b'\t') {
                     j -= 1;
                 }
+                // `>>` closing nested generics counts as one closer.
+                while j > 0 && code[j - 1] == b'>' {
+                    j -= 1;
+                }
                 if j > 0 && code[j - 1] == b'/' {
                     true
                 } else if j > 0 && is_word_char(code[j - 1]) {
@@ -2728,7 +2732,8 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                             | b'.'
                     ) || (is_word_char(prev)
                         && !word_after_dot
-                        && REGEX_KEYWORDS.contains(&&code[word_start..word_end])
+                        && (REGEX_KEYWORDS.contains(&&code[word_start..word_end])
+                            || matches!(&code[word_start..word_end], b"as" | b"satisfies"))
                         && !matches!(&code[word_start..word_end], b"do" | b"else")));
                 brace_stack.push(!expr_pos);
             }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2522,15 +2522,13 @@ fn is_incomplete_code(code: &[u8]) -> bool {
     let mut in_block_comment = false;
     let mut escaped = false;
 
-    // Last significant byte outside strings/comments (0 = none yet), and the
-    // identifier ending at it; both feed the regex-vs-division heuristic.
+    // Regex-vs-division context: last significant byte, and the identifier ending at it.
     let mut prev: u8 = 0;
     let mut word_start = 0usize;
     let mut word_end = 0usize;
     // `obj.in` is a property access, not the `in` keyword.
     let mut word_after_dot = false;
-    // Whether each open paren is an `if`/`for`/`while`/`with` head, so that a
-    // `/` right after its `)` reads as a regex, not division.
+    // Parens opened by `if`/`for`/`while`/`with`; a `/` after such a `)` is a regex.
     let mut paren_stack: Vec<bool> = Vec::new();
     let mut last_paren_conditional = false;
 
@@ -2582,8 +2580,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 }
                 _ => {}
             }
-            // A `/` starts a regex literal when the previous significant token
-            // cannot end an expression; otherwise it's division.
+            // A `/` after a token that cannot end an expression starts a regex.
             let after_keyword = is_word_char(prev)
                 && !word_after_dot
                 && REGEX_KEYWORDS.contains(&&code[word_start..word_end]);
@@ -2614,8 +2611,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                         | b'~'
                 );
             if starts_regex {
-                // Skip the regex body; a `/` inside a `[...]` class does not
-                // terminate it, and a newline does (regexes cannot span lines).
+                // Skip the regex body; `/` in a `[...]` class doesn't end it, a newline does.
                 i += 1;
                 let mut in_class = false;
                 while i < code.len() && code[i] != b'\n' {
@@ -2629,8 +2625,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                     }
                     i += 1;
                 }
-                // A regex literal ends an expression, so a following `/` is
-                // division; `)` (non-conditional) encodes that.
+                // A regex ends an expression; `)` (non-conditional) encodes that.
                 prev = b')';
                 last_paren_conditional = false;
                 i += 1;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2598,15 +2598,17 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 while j > 0 && matches!(code[j - 1], b'!' | b' ' | b'\t') {
                     j -= 1;
                 }
-                if j > 0 && matches!(code[j - 1], b')' | b']' | b'}') {
+                if j > 0 && matches!(code[j - 1], b')' | b']' | b'}' | b'"' | b'\'' | b'`') {
                     true
                 } else if j > 0 && is_word_char(code[j - 1]) {
-                    // `x !` is postfix; `return !` is a prefix after a keyword.
+                    // `x !` is postfix; `return !` is a prefix after a keyword,
+                    // unless the keyword lookalike is a member name (`o.in!`).
                     let end = j;
                     while j > 0 && is_word_char(code[j - 1]) {
                         j -= 1;
                     }
-                    !REGEX_KEYWORDS.contains(&&code[j..end])
+                    (j > 0 && matches!(code[j - 1], b'.' | b'#'))
+                        || !REGEX_KEYWORDS.contains(&&code[j..end])
                 } else {
                     false
                 }
@@ -2622,8 +2624,11 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 if j > 0 && code[j - 1] == b'/' {
                     true
                 } else if j > 0 && is_word_char(code[j - 1]) {
-                    // A tag/type name is one preceded by `<` or `/`; `a > /re/` is not.
-                    while j > 0 && is_word_char(code[j - 1]) {
+                    // A tag/type name (dotted, hyphenated, or namespaced) is one
+                    // preceded by `<` or `/`; `a > /re/` is not.
+                    while j > 0
+                        && (is_word_char(code[j - 1]) || matches!(code[j - 1], b'.' | b'-' | b':'))
+                    {
                         j -= 1;
                     }
                     j > 0 && matches!(code[j - 1], b'<' | b'/')

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2652,7 +2652,10 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 paren_count += 1;
                 paren_stack.push(
                     is_word_char(prev)
-                        && matches!(&code[word_start..word_end], b"if" | b"for" | b"while" | b"with"),
+                        && matches!(
+                            &code[word_start..word_end],
+                            b"if" | b"for" | b"while" | b"with"
+                        ),
                 );
             }
             b')' => {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2664,8 +2664,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             b'`' => in_template = true,
             b'{' => {
                 brace_count += 1;
-                // `=> {` opens a body; otherwise `{` after an operator, opener,
-                // or expression keyword (not `do`/`else`) is an object literal.
+                // `=> {` is a body; `{` after an operator/opener/expression keyword is an object.
                 let arrow = prev == b'>' && prev_idx > 0 && code[prev_idx - 1] == b'=';
                 let expr_pos = !arrow
                     && (matches!(

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2649,6 +2649,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                                     | b':'
                                     | b','
                                     | b'|'
+                                    | b'&'
                                     | b'['
                                     | b']'
                                     | b'>'

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2492,49 +2492,152 @@ extern "C" fn sigint_handler(_: c_int) {
 }
 
 fn is_incomplete_code(code: &[u8]) -> bool {
+    const fn is_word_char(ch: u8) -> bool {
+        ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'$'
+    }
+
+    /// Keywords after which a `/` starts a regex literal rather than division.
+    const REGEX_KEYWORDS: &[&[u8]] = &[
+        b"return",
+        b"typeof",
+        b"instanceof",
+        b"in",
+        b"of",
+        b"new",
+        b"delete",
+        b"void",
+        b"throw",
+        b"case",
+        b"do",
+        b"else",
+        b"yield",
+        b"await",
+    ];
+
     let mut brace_count: i32 = 0;
     let mut bracket_count: i32 = 0;
     let mut paren_count: i32 = 0;
     let mut in_string: u8 = 0;
     let mut in_template = false;
+    let mut in_block_comment = false;
     let mut escaped = false;
 
-    for &ch in code {
-        if escaped {
-            escaped = false;
-            continue;
-        }
+    // Last significant byte outside strings/comments (0 = none yet), and the
+    // identifier ending at it; both feed the regex-vs-division heuristic.
+    let mut prev: u8 = 0;
+    let mut word_start = 0usize;
+    let mut word_end = 0usize;
 
-        if ch == b'\\' {
-            escaped = true;
-            continue;
-        }
+    let mut i = 0usize;
+    while i < code.len() {
+        let ch = code[i];
 
-        // Handle strings
-        if in_string == 0 && !in_template {
-            if ch == b'"' || ch == b'\'' {
-                in_string = ch;
-                continue;
+        if in_block_comment {
+            if ch == b'*' && code.get(i + 1) == Some(&b'/') {
+                in_block_comment = false;
+                i += 2;
+            } else {
+                i += 1;
             }
-            if ch == b'`' {
-                in_template = true;
-                continue;
-            }
-        } else if in_string != 0 && ch == in_string {
-            in_string = 0;
-            continue;
-        } else if in_template && ch == b'`' {
-            in_template = false;
             continue;
         }
 
-        // Skip content inside strings
         if in_string != 0 || in_template {
+            if escaped {
+                escaped = false;
+            } else if ch == b'\\' {
+                escaped = true;
+            } else if in_string != 0 && ch == in_string {
+                in_string = 0;
+            } else if in_template && ch == b'`' {
+                in_template = false;
+            }
+            i += 1;
             continue;
         }
 
-        // Count brackets
+        if ch.is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        if ch == b'/' {
+            match code.get(i + 1) {
+                Some(b'/') => {
+                    while i < code.len() && code[i] != b'\n' {
+                        i += 1;
+                    }
+                    continue;
+                }
+                Some(b'*') => {
+                    in_block_comment = true;
+                    i += 2;
+                    continue;
+                }
+                _ => {}
+            }
+            // A `/` starts a regex literal when the previous significant token
+            // cannot end an expression; otherwise it's division.
+            let after_keyword =
+                is_word_char(prev) && REGEX_KEYWORDS.contains(&&code[word_start..word_end]);
+            let starts_regex = prev == 0
+                || after_keyword
+                || matches!(
+                    prev,
+                    b'(' | b'['
+                        | b'{'
+                        | b'}'
+                        | b','
+                        | b';'
+                        | b':'
+                        | b'='
+                        | b'!'
+                        | b'&'
+                        | b'|'
+                        | b'?'
+                        | b'+'
+                        | b'-'
+                        | b'*'
+                        | b'%'
+                        | b'<'
+                        | b'>'
+                        | b'^'
+                        | b'~'
+                );
+            if starts_regex {
+                // Skip the regex body: quotes and brackets inside it are not
+                // code. A `/` inside a `[...]` class does not terminate it. A
+                // newline means the literal is unterminated (regexes cannot
+                // span lines); stop there and let evaluation report the error.
+                i += 1;
+                let mut in_class = false;
+                while i < code.len() && code[i] != b'\n' {
+                    match code[i] {
+                        b'\\' => i += 1,
+                        b'[' => in_class = true,
+                        b']' => in_class = false,
+                        b'/' if !in_class => break,
+                        _ => {}
+                    }
+                    i += 1;
+                }
+                prev = b'/';
+                i += 1;
+                continue;
+            }
+        }
+
+        if is_word_char(ch) {
+            if word_end != i {
+                word_start = i;
+            }
+            word_end = i + 1;
+        }
+        prev = ch;
+
         match ch {
+            b'"' | b'\'' => in_string = ch,
+            b'`' => in_template = true,
             b'{' => brace_count += 1,
             b'}' => brace_count -= 1,
             b'[' => bracket_count += 1,
@@ -2543,10 +2646,16 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             b')' => paren_count -= 1,
             _ => {}
         }
+        i += 1;
     }
 
-    // Incomplete if any unclosed delimiters or unclosed strings
-    in_string != 0 || in_template || brace_count > 0 || bracket_count > 0 || paren_count > 0
+    // Incomplete if any unclosed delimiters, strings, or block comments
+    in_string != 0
+        || in_template
+        || in_block_comment
+        || brace_count > 0
+        || bracket_count > 0
+        || paren_count > 0
 }
 
 use crate::api::js_transpiler::is_likely_object_literal;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2597,7 +2597,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 while j > 0 && code[j - 1] == b'!' {
                     j -= 1;
                 }
-                j > 0 && (is_word_char(code[j - 1]) || matches!(code[j - 1], b')' | b']'))
+                j > 0 && (is_word_char(code[j - 1]) || matches!(code[j - 1], b')' | b']' | b'}'))
             };
             // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
             let jsx_close = prev == b'<' && prev_idx + 1 == i;
@@ -2696,6 +2696,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                             | b'>'
                             | b'^'
                             | b'~'
+                            | b'.'
                     ) || (is_word_char(prev)
                         && !word_after_dot
                         && REGEX_KEYWORDS.contains(&&code[word_start..word_end])
@@ -2710,14 +2711,29 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             b']' => bracket_count -= 1,
             b'(' => {
                 paren_count += 1;
-                paren_stack.push(
-                    is_word_char(prev)
-                        && !word_after_dot
-                        && matches!(
-                            &code[word_start..word_end],
-                            b"if" | b"for" | b"while" | b"with"
-                        ),
-                );
+                let mut head = is_word_char(prev)
+                    && !word_after_dot
+                    && matches!(
+                        &code[word_start..word_end],
+                        b"if" | b"for" | b"while" | b"with"
+                    );
+                // `for await (` is a conditional head; bare `await (` is a call-like use.
+                if !head
+                    && is_word_char(prev)
+                    && !word_after_dot
+                    && &code[word_start..word_end] == b"await"
+                {
+                    let mut j = word_start;
+                    while j > 0 && code[j - 1].is_ascii_whitespace() {
+                        j -= 1;
+                    }
+                    let end = j;
+                    while j > 0 && is_word_char(code[j - 1]) {
+                        j -= 1;
+                    }
+                    head = &code[j..end] == b"for";
+                }
+                paren_stack.push(head);
             }
             b')' => {
                 paren_count -= 1;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2613,7 +2613,8 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 let mut in_class = false;
                 while i < code.len() && code[i] != b'\n' {
                     match code[i] {
-                        b'\\' => i += 1,
+                        // A trailing escape must not consume the line break.
+                        b'\\' if code.get(i + 1).is_some_and(|&next| next != b'\n') => i += 1,
                         b'[' => in_class = true,
                         b']' => in_class = false,
                         b'/' if !in_class => break,

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2601,8 +2601,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 if j > 0 && matches!(code[j - 1], b')' | b']' | b'}' | b'"' | b'\'' | b'`') {
                     true
                 } else if j > 0 && is_word_char(code[j - 1]) {
-                    // `x !` is postfix; `return !` is a prefix after a keyword,
-                    // unless the keyword lookalike is a member name (`o.in!`).
+                    // `x !` and `o.in!` are postfix; `return !` is a prefix.
                     let end = j;
                     while j > 0 && is_word_char(code[j - 1]) {
                         j -= 1;
@@ -2624,8 +2623,7 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 if j > 0 && code[j - 1] == b'/' {
                     true
                 } else if j > 0 && is_word_char(code[j - 1]) {
-                    // A tag/type name (dotted, hyphenated, or namespaced) is one
-                    // preceded by `<` or `/`; `a > /re/` is not.
+                    // A tag/type name (dots/hyphens/colons ok) follows `<` or `/`; `a >` does not.
                     while j > 0
                         && (is_word_char(code[j - 1]) || matches!(code[j - 1], b'.' | b'-' | b':'))
                     {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2593,18 +2593,44 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 matches!(prev, b'+' | b'-') && prev_idx > 0 && code[prev_idx - 1] == prev;
             // `x!` or `x!!` (TS non-null assertion) ends an expression; `!x` does not.
             let postfix_bang = prev == b'!' && {
+                // Same-line whitespace is allowed before a postfix `!`; a newline is not.
                 let mut j = prev_idx;
-                while j > 0 && code[j - 1] == b'!' {
+                while j > 0 && matches!(code[j - 1], b'!' | b' ' | b'\t') {
                     j -= 1;
                 }
-                j > 0 && (is_word_char(code[j - 1]) || matches!(code[j - 1], b')' | b']' | b'}'))
+                if j > 0 && matches!(code[j - 1], b')' | b']' | b'}') {
+                    true
+                } else if j > 0 && is_word_char(code[j - 1]) {
+                    // `x !` is postfix; `return !` is a prefix after a keyword.
+                    let end = j;
+                    while j > 0 && is_word_char(code[j - 1]) {
+                        j -= 1;
+                    }
+                    !REGEX_KEYWORDS.contains(&&code[j..end])
+                } else {
+                    false
+                }
             };
             // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
             let jsx_close = prev == b'<' && prev_idx + 1 == i;
-            // `>` ending a JSX tag (`</a>`, `<a/>`, `</>`) ends an expression; `a > /re/` does not.
-            let jsx_end = prev == b'>'
-                && prev_idx > 0
-                && (code[prev_idx - 1] == b'/' || is_word_char(code[prev_idx - 1]));
+            // `>` ending a JSX tag or generic (`</a>`, `<a/>`, `<T>`) ends an expression.
+            let jsx_end = prev == b'>' && {
+                let mut j = prev_idx;
+                while j > 0 && matches!(code[j - 1], b' ' | b'\t') {
+                    j -= 1;
+                }
+                if j > 0 && code[j - 1] == b'/' {
+                    true
+                } else if j > 0 && is_word_char(code[j - 1]) {
+                    // A tag/type name is one preceded by `<` or `/`; `a > /re/` is not.
+                    while j > 0 && is_word_char(code[j - 1]) {
+                        j -= 1;
+                    }
+                    j > 0 && matches!(code[j - 1], b'<' | b'/')
+                } else {
+                    false
+                }
+            };
             // A block's `}` resumes statement position unless it's inside `()`/`[]`.
             let after_block =
                 prev == b'}' && last_brace_block && paren_count <= 0 && bracket_count <= 0;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2532,6 +2532,9 @@ fn is_incomplete_code(code: &[u8]) -> bool {
     // Parens opened by `if`/`for`/`while`/`with`; a `/` after such a `)` is a regex.
     let mut paren_stack: Vec<bool> = Vec::new();
     let mut last_paren_conditional = false;
+    // Braces opened in statement position (block) vs expression position (object literal).
+    let mut brace_stack: Vec<bool> = Vec::new();
+    let mut last_brace_block = true;
 
     let mut i = 0usize;
     while i < code.len() {
@@ -2594,9 +2597,8 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 && (is_word_char(code[prev_idx - 1]) || matches!(code[prev_idx - 1], b')' | b']'));
             // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
             let jsx_close = prev == b'<' && prev_idx + 1 == i;
-            // `}` ends a statement block at top level, but an object literal inside a group.
-            let after_block =
-                prev == b'}' && paren_count <= 0 && bracket_count <= 0 && brace_count <= 0;
+            // `}` ends an expression when it closes an object literal, not a block.
+            let after_block = prev == b'}' && last_brace_block;
             let starts_regex = prev == 0
                 || after_keyword
                 || after_block
@@ -2660,8 +2662,41 @@ fn is_incomplete_code(code: &[u8]) -> bool {
         match ch {
             b'"' | b'\'' => in_string = ch,
             b'`' => in_template = true,
-            b'{' => brace_count += 1,
-            b'}' => brace_count -= 1,
+            b'{' => {
+                brace_count += 1;
+                // `=> {` opens a body; otherwise `{` after an operator, opener,
+                // or expression keyword (not `do`/`else`) is an object literal.
+                let arrow = prev == b'>' && prev_idx > 0 && code[prev_idx - 1] == b'=';
+                let expr_pos = !arrow
+                    && (matches!(
+                        prev,
+                        b'(' | b'['
+                            | b','
+                            | b':'
+                            | b'='
+                            | b'!'
+                            | b'&'
+                            | b'|'
+                            | b'?'
+                            | b'+'
+                            | b'-'
+                            | b'*'
+                            | b'/'
+                            | b'%'
+                            | b'<'
+                            | b'>'
+                            | b'^'
+                            | b'~'
+                    ) || (is_word_char(prev)
+                        && !word_after_dot
+                        && REGEX_KEYWORDS.contains(&&code[word_start..word_end])
+                        && !matches!(&code[word_start..word_end], b"do" | b"else")));
+                brace_stack.push(!expr_pos);
+            }
+            b'}' => {
+                brace_count -= 1;
+                last_brace_block = brace_stack.pop().unwrap_or(true);
+            }
             b'[' => bracket_count += 1,
             b']' => bracket_count -= 1,
             b'(' => {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2622,17 +2622,25 @@ fn is_incomplete_code(code: &[u8]) -> bool {
                 while j > 0 && matches!(code[j - 1], b' ' | b'\t') {
                     j -= 1;
                 }
-                // `>>` closing nested generics counts as one closer.
-                while j > 0 && code[j - 1] == b'>' {
-                    j -= 1;
-                }
                 if j > 0 && code[j - 1] == b'/' {
                     true
-                } else if j > 0 && is_word_char(code[j - 1]) {
-                    // Walk a tag/type-argument run (`a.b`, `my-el`, `K, V`) back to its opener.
+                } else if j > 0 && (is_word_char(code[j - 1]) || matches!(code[j - 1], b'>' | b']'))
+                {
+                    // Walk the tag-name/type-argument run back to its opener.
                     while j > 0
                         && (is_word_char(code[j - 1])
-                            || matches!(code[j - 1], b'.' | b'-' | b':' | b',' | b' ' | b'\t'))
+                            || matches!(
+                                code[j - 1],
+                                b'.' | b'-'
+                                    | b':'
+                                    | b','
+                                    | b'|'
+                                    | b'['
+                                    | b']'
+                                    | b'>'
+                                    | b' '
+                                    | b'\t'
+                            ))
                     {
                         j -= 1;
                     }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -2601,8 +2601,9 @@ fn is_incomplete_code(code: &[u8]) -> bool {
             };
             // An adjacent `</` is a JSX closing tag, not `<` followed by a regex.
             let jsx_close = prev == b'<' && prev_idx + 1 == i;
-            // `}` ends an expression when it closes an object literal, not a block.
-            let after_block = prev == b'}' && last_brace_block;
+            // A block's `}` resumes statement position unless it's inside `()`/`[]`.
+            let after_block =
+                prev == b'}' && last_brace_block && paren_count <= 0 && bracket_count <= 0;
             let starts_regex = prev == 0
                 || after_keyword
                 || after_block

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -703,6 +703,59 @@ describe.concurrent("Bun REPL", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/37326
+  describe("regex literals and comments in continuation detection", () => {
+    test("regex containing a double quote evaluates on one line", async () => {
+      const { stdout, exitCode } = await runRepl(['x = /hello "world/;', "x.source", ".exit"]);
+      expect(stripAnsi(stdout)).toContain('hello "world');
+      expect(exitCode).toBe(0);
+    });
+
+    test("regex containing a backtick evaluates on one line", async () => {
+      const { stdout, exitCode } = await runRepl(["x = /hello `world/;", "x.source", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("hello `world");
+      expect(exitCode).toBe(0);
+    });
+
+    test("slash inside a regex character class does not end the regex", async () => {
+      const { stdout, exitCode } = await runRepl(['/[/"]/.test("/")', ".exit"]);
+      expect(stripAnsi(stdout)).toContain("true");
+      expect(exitCode).toBe(0);
+    });
+
+    test("invalid regex reports a syntax error instead of waiting for more input", async () => {
+      const { stdout, stderr, exitCode } = await runRepl(["x = /hello (world/;", "1 + 1", ".exit"]);
+      expect(stripAnsi(stdout + stderr)).toContain("SyntaxError");
+      // REPL recovered and evaluated the next line
+      expect(stripAnsi(stdout)).toContain("2");
+      expect(exitCode).toBe(0);
+    });
+
+    test("regex after the return keyword", async () => {
+      const { stdout, exitCode } = await runRepl(['function f() { return /ab"c/; }', "f()", ".exit"]);
+      expect(stripAnsi(stdout)).toContain('/ab"c/');
+      expect(exitCode).toBe(0);
+    });
+
+    test("division is not mistaken for a regex", async () => {
+      const { stdout, exitCode } = await runRepl(["x = 10 / 2 / 1; x", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("5");
+      expect(exitCode).toBe(0);
+    });
+
+    test("unbalanced bracket in a line comment is ignored", async () => {
+      const { stdout, exitCode } = await runRepl(["1 + 1 // unbalanced (", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("2");
+      expect(exitCode).toBe(0);
+    });
+
+    test("unterminated block comment continues to the next line", async () => {
+      const { stdout, exitCode } = await runRepl(["40 + 2 /* comment", "*/", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("async evaluation", () => {
     test("await expressions", async () => {
       const { stdout, exitCode } = await runRepl(["await Promise.resolve(42)", ".exit"]);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -846,6 +846,17 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(prefix.stdout)).toContain("true");
       expect(stripAnsi(prefix.stdout)).not.toContain("SyntaxError");
       expect(prefix.exitCode).toBe(0);
+
+      // A member named like a keyword is still postfix context.
+      const member = await runRepl(["q = ({ in: 84 }.in! / 2); q", ".exit"]);
+      expect(stripAnsi(member.stdout)).toContain("42");
+      expect(stripAnsi(member.stdout)).not.toContain("SyntaxError");
+      expect(member.exitCode).toBe(0);
+
+      const string = await runRepl(['q = ("x"! / 2); q', ".exit"]);
+      expect(stripAnsi(string.stdout)).toContain("NaN");
+      expect(stripAnsi(string.stdout)).not.toContain("SyntaxError");
+      expect(string.exitCode).toBe(0);
     });
 
     test("division after a spread object literal", async () => {
@@ -885,6 +896,14 @@ describe.concurrent("Bun REPL", () => {
       const spacedClose = await runRepl(["q = (<a></a > / 2)", "60 + 2", ".exit"]);
       expect(stripAnsi(spacedClose.stdout)).toContain("62");
       expect(spacedClose.exitCode).toBe(0);
+
+      const memberTag = await runRepl(["q = (<a.b></a.b> / 2)", "70 + 2", ".exit"]);
+      expect(stripAnsi(memberTag.stdout)).toContain("72");
+      expect(memberTag.exitCode).toBe(0);
+
+      const hyphenTag = await runRepl(["q = (<my-el></my-el> / 2)", "80 + 2", ".exit"]);
+      expect(stripAnsi(hyphenTag.stdout)).toContain("82");
+      expect(hyphenTag.exitCode).toBe(0);
     });
 
     test("a method named like a conditional keyword does not make its paren a regex context", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -880,6 +880,11 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(arraySuffix.stdout)).not.toContain("SyntaxError");
       expect(arraySuffix.exitCode).toBe(0);
 
+      const intersection = await runRepl(["q = (92 as unknown as Record<string, A & B> / 2); q", ".exit"]);
+      expect(stripAnsi(intersection.stdout)).toContain("46");
+      expect(stripAnsi(intersection.stdout)).not.toContain("SyntaxError");
+      expect(intersection.exitCode).toBe(0);
+
       // A comma-separated comparison is not a generic, so the `/` starts a regex.
       const comparison = await runRepl(["q = (1 < 2, 3 > /\"/.test('\"')); q", ".exit"]);
       expect(stripAnsi(comparison.stdout)).toContain("true");

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -860,9 +860,9 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("division after a nested generic cast", async () => {
-      const { stdout, exitCode } = await runRepl(["q = (8 as unknown as Array<Array<number>> / 2); q", ".exit"]);
+      const { stdout, exitCode } = await runRepl(["q = (84 as unknown as Array<Array<number>> / 2); q", ".exit"]);
       const output = stripAnsi(stdout);
-      expect(output).toContain("4");
+      expect(output).toContain("42");
       expect(output).not.toContain("SyntaxError");
       expect(exitCode).toBe(0);
     });

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -835,6 +835,17 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(object.stdout)).toContain("NaN");
       expect(stripAnsi(object.stdout)).not.toContain("SyntaxError");
       expect(object.exitCode).toBe(0);
+
+      const spaced = await runRepl(["q = (88 ! / 2); q", ".exit"]);
+      expect(stripAnsi(spaced.stdout)).toContain("44");
+      expect(stripAnsi(spaced.stdout)).not.toContain("SyntaxError");
+      expect(spaced.exitCode).toBe(0);
+
+      // `return !` is a prefix, so the `/` still starts a regex.
+      const prefix = await runRepl(['function r(s) { return ! /"/.test(s) }; r("a")', ".exit"]);
+      expect(stripAnsi(prefix.stdout)).toContain("true");
+      expect(stripAnsi(prefix.stdout)).not.toContain("SyntaxError");
+      expect(prefix.exitCode).toBe(0);
     });
 
     test("division after a spread object literal", async () => {
@@ -870,6 +881,10 @@ describe.concurrent("Bun REPL", () => {
       const selfClosed = await runRepl(["q = [<a/> / 2]", "50 + 2", ".exit"]);
       expect(stripAnsi(selfClosed.stdout)).toContain("52");
       expect(selfClosed.exitCode).toBe(0);
+
+      const spacedClose = await runRepl(["q = (<a></a > / 2)", "60 + 2", ".exit"]);
+      expect(stripAnsi(spacedClose.stdout)).toContain("62");
+      expect(spacedClose.exitCode).toBe(0);
     });
 
     test("a method named like a conditional keyword does not make its paren a regex context", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -893,11 +893,27 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(cast.stdout)).not.toContain("SyntaxError");
       expect(cast.exitCode).toBe(0);
 
+      const union = await runRepl(["q = (86 as string | void / 2); q", ".exit"]);
+      expect(stripAnsi(union.stdout)).toContain("43");
+      expect(stripAnsi(union.stdout)).not.toContain("SyntaxError");
+      expect(union.exitCode).toBe(0);
+
+      const asserted = await runRepl(["q = (88 as void! / 2); q", ".exit"]);
+      expect(stripAnsi(asserted.stdout)).toContain("44");
+      expect(stripAnsi(asserted.stdout)).not.toContain("SyntaxError");
+      expect(asserted.exitCode).toBe(0);
+
       // The void operator still takes a regex operand.
       const operator = await runRepl(["q = void /\"/.test('\"'); q", ".exit"]);
       expect(stripAnsi(operator.stdout)).toContain("undefined");
       expect(stripAnsi(operator.stdout)).not.toContain("SyntaxError");
       expect(operator.exitCode).toBe(0);
+
+      // Bitwise-or of a void-operator expression is not a type union.
+      const bitwise = await runRepl(["q = (256 | void /\"/.test('\"')) + 1; q", ".exit"]);
+      expect(stripAnsi(bitwise.stdout)).toContain("257");
+      expect(stripAnsi(bitwise.stdout)).not.toContain("SyntaxError");
+      expect(bitwise.exitCode).toBe(0);
     });
 
     test("division after a cast to an inline type literal", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -859,6 +859,22 @@ describe.concurrent("Bun REPL", () => {
       expect(string.exitCode).toBe(0);
     });
 
+    test("division after a nested generic cast", async () => {
+      const { stdout, exitCode } = await runRepl(["q = (8 as unknown as Array<Array<number>> / 2); q", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("4");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
+    });
+
+    test("division after a cast to an inline type literal", async () => {
+      const { stdout, exitCode } = await runRepl(["function t(x) { return x as {a:number} / 2 }; t(84)", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
+    });
+
     test("division after a spread object literal", async () => {
       const { stdout, exitCode } = await runRepl(["x = { ...{} / 2 }; 40 + 2", ".exit"]);
       const output = stripAnsi(stdout);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -764,9 +764,27 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("division after postfix increment and decrement", async () => {
+      const inc = await runRepl(["i = 84; q = (i++ / 2)", "q", ".exit"]);
+      expect(stripAnsi(inc.stdout)).toContain("42");
+      expect(inc.exitCode).toBe(0);
+
+      const dec = await runRepl(["i = 86; q = (i-- / 2)", "q", ".exit"]);
+      expect(stripAnsi(dec.stdout)).toContain("43");
+      expect(dec.exitCode).toBe(0);
+    });
+
+    test("division after an object literal inside brackets", async () => {
+      const { stdout, exitCode } = await runRepl(["q = [{} / 1]", "q", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("NaN");
+      expect(exitCode).toBe(0);
+    });
+
     test("regex after a conditional's closing paren", async () => {
-      const { stdout, exitCode } = await runRepl(['if (true) x = /"/;', "x", ".exit"]);
-      expect(stripAnsi(stdout)).toContain('/"/');
+      const { stdout, exitCode } = await runRepl(['if (true) x = /"/; x', ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain('/"/');
+      expect(output).not.toContain("SyntaxError");
       expect(exitCode).toBe(0);
     });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -784,6 +784,18 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("division after a function expression body inside a group", async () => {
+      const fn = await runRepl(["q = (function () {} / 2); q", ".exit"]);
+      expect(stripAnsi(fn.stdout)).toContain("NaN");
+      expect(stripAnsi(fn.stdout)).not.toContain("SyntaxError");
+      expect(fn.exitCode).toBe(0);
+
+      const cls = await runRepl(["q = [class {} / 2]; q", ".exit"]);
+      expect(stripAnsi(cls.stdout)).toContain("NaN");
+      expect(stripAnsi(cls.stdout)).not.toContain("SyntaxError");
+      expect(cls.exitCode).toBe(0);
+    });
+
     test("division after an assigned object literal opens a continuation", async () => {
       const { stdout, exitCode } = await runRepl(["q = {} / ({", "valueOf: () => 2 }); q", ".exit"]);
       const output = stripAnsi(stdout);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -764,6 +764,26 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("regex after a conditional's closing paren", async () => {
+      const { stdout, exitCode } = await runRepl(['if (true) x = /"/;', "x", ".exit"]);
+      expect(stripAnsi(stdout)).toContain('/"/');
+      expect(exitCode).toBe(0);
+    });
+
+    test("regex as the right operand of a division", async () => {
+      const { stdout, exitCode } = await runRepl(['10 / /[(]/.test("(")', ".exit"]);
+      expect(stripAnsi(stdout)).toContain("10");
+      expect(exitCode).toBe(0);
+    });
+
+    test("a property named like a keyword does not start a regex", async () => {
+      // `x.in / {` must open a continuation, not be read as `x.in` followed
+      // by a regex starting at `/ {`.
+      const { stdout, exitCode } = await runRepl(["x = { in: 84 }; x.in / {", "valueOf: () => 2 }", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+
     test("unbalanced bracket in a line comment is ignored", async () => {
       const { stdout, exitCode } = await runRepl(["1 + 1 // unbalanced (", ".exit"]);
       expect(stripAnsi(stdout)).toContain("2");

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -723,6 +723,27 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("escaped slash inside a regex does not end the regex", async () => {
+      const { stdout, exitCode } = await runRepl(['/a\\/b/.test("a/b")', ".exit"]);
+      expect(stripAnsi(stdout)).toContain("true");
+      expect(exitCode).toBe(0);
+    });
+
+    test("unbalanced brace and paren inside a regex evaluate on one line", async () => {
+      const { stdout, exitCode } = await runRepl(["x = /a{b\\(/;", "x", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("/a{b\\(/");
+      expect(exitCode).toBe(0);
+    });
+
+    test("backslash before a newline does not continue a regex onto the next line", async () => {
+      // `/a\` at end of line is an unterminated regex; the `2]` on the next
+      // line must still balance the `[`, not be swallowed as regex body.
+      const { stdout, stderr, exitCode } = await runRepl(["x = [1, /a\\", "2]", "40 + 2", ".exit"]);
+      expect(stripAnsi(stdout + stderr)).toContain("SyntaxError");
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+
     test("invalid regex reports a syntax error instead of waiting for more input", async () => {
       const { stdout, stderr, exitCode } = await runRepl(["x = /hello (world/;", "1 + 1", ".exit"]);
       expect(stripAnsi(stdout + stderr)).toContain("SyntaxError");

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -830,6 +830,27 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(chained.stdout)).toContain("43");
       expect(stripAnsi(chained.stdout)).not.toContain("SyntaxError");
       expect(chained.exitCode).toBe(0);
+
+      const object = await runRepl(["q = ({ a: 1 }! / 2); q", ".exit"]);
+      expect(stripAnsi(object.stdout)).toContain("NaN");
+      expect(stripAnsi(object.stdout)).not.toContain("SyntaxError");
+      expect(object.exitCode).toBe(0);
+    });
+
+    test("division after a spread object literal", async () => {
+      const { stdout, exitCode } = await runRepl(["x = { ...{} / 2 }; 40 + 2", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
+    });
+
+    test("regex after a for-await head", async () => {
+      const { stdout, exitCode } = await runRepl(['for await (const x of []) /"/.test("x"); 40 + 2', ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
     });
 
     test("a JSX closing tag is not a regex start", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -809,11 +809,15 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("division after a non-null assertion", async () => {
-      const { stdout, exitCode } = await runRepl(["q = (84! / 2); q", ".exit"]);
-      const output = stripAnsi(stdout);
-      expect(output).toContain("42");
-      expect(output).not.toContain("SyntaxError");
-      expect(exitCode).toBe(0);
+      const single = await runRepl(["q = (84! / 2); q", ".exit"]);
+      expect(stripAnsi(single.stdout)).toContain("42");
+      expect(stripAnsi(single.stdout)).not.toContain("SyntaxError");
+      expect(single.exitCode).toBe(0);
+
+      const chained = await runRepl(["q = (86!! / 2); q", ".exit"]);
+      expect(stripAnsi(chained.stdout)).toContain("43");
+      expect(stripAnsi(chained.stdout)).not.toContain("SyntaxError");
+      expect(chained.exitCode).toBe(0);
     });
 
     test("a JSX closing tag is not a regex start", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -780,6 +780,32 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("division after an object literal inside a function body", async () => {
+      const { stdout, exitCode } = await runRepl(["function g() { return {valueOf: () => 84} / 2 }", "g()", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+
+    test("division after a non-null assertion", async () => {
+      const { stdout, exitCode } = await runRepl(["q = (84! / 2)", "q", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+
+    test("a JSX closing tag is not a regex start", async () => {
+      // Line 1 may fail at runtime (no JSX runtime configured), but it must
+      // evaluate as one line so line 2 still runs.
+      const { stdout, exitCode } = await runRepl(["q = (<a></a>)", "40 + 2", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+
+    test("a method named like a conditional keyword does not make its paren a regex context", async () => {
+      const { stdout, exitCode } = await runRepl(["o = { if: (n) => n }; q = (o.if(84) / 2)", "q", ".exit"]);
+      expect(stripAnsi(stdout)).toContain("42");
+      expect(exitCode).toBe(0);
+    });
+
     test("regex after a conditional's closing paren", async () => {
       const { stdout, exitCode } = await runRepl(['if (true) x = /"/; x', ".exit"]);
       const output = stripAnsi(stdout);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -765,30 +765,54 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("division after postfix increment and decrement", async () => {
-      const inc = await runRepl(["i = 84; q = (i++ / 2)", "q", ".exit"]);
+      const inc = await runRepl(["i = 84; q = (i++ / 2); q", ".exit"]);
       expect(stripAnsi(inc.stdout)).toContain("42");
+      expect(stripAnsi(inc.stdout)).not.toContain("SyntaxError");
       expect(inc.exitCode).toBe(0);
 
-      const dec = await runRepl(["i = 86; q = (i-- / 2)", "q", ".exit"]);
+      const dec = await runRepl(["i = 86; q = (i-- / 2); q", ".exit"]);
       expect(stripAnsi(dec.stdout)).toContain("43");
+      expect(stripAnsi(dec.stdout)).not.toContain("SyntaxError");
       expect(dec.exitCode).toBe(0);
     });
 
     test("division after an object literal inside brackets", async () => {
-      const { stdout, exitCode } = await runRepl(["q = [{} / 1]", "q", ".exit"]);
-      expect(stripAnsi(stdout)).toContain("NaN");
+      const { stdout, exitCode } = await runRepl(["q = [{} / 1]; q", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("NaN");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
+    });
+
+    test("division after an assigned object literal opens a continuation", async () => {
+      const { stdout, exitCode } = await runRepl(["q = {} / ({", "valueOf: () => 2 }); q", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("NaN");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
+    });
+
+    test("regex after a statement block", async () => {
+      const { stdout, exitCode } = await runRepl(['if (true) {} /"/.test(\'"\')', ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("true");
+      expect(output).not.toContain("SyntaxError");
       expect(exitCode).toBe(0);
     });
 
     test("division after an object literal inside a function body", async () => {
-      const { stdout, exitCode } = await runRepl(["function g() { return {valueOf: () => 84} / 2 }", "g()", ".exit"]);
-      expect(stripAnsi(stdout)).toContain("42");
+      const { stdout, exitCode } = await runRepl(["function g() { return {valueOf: () => 84} / 2 }; g()", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
       expect(exitCode).toBe(0);
     });
 
     test("division after a non-null assertion", async () => {
-      const { stdout, exitCode } = await runRepl(["q = (84! / 2)", "q", ".exit"]);
-      expect(stripAnsi(stdout)).toContain("42");
+      const { stdout, exitCode } = await runRepl(["q = (84! / 2); q", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
       expect(exitCode).toBe(0);
     });
 
@@ -801,8 +825,10 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("a method named like a conditional keyword does not make its paren a regex context", async () => {
-      const { stdout, exitCode } = await runRepl(["o = { if: (n) => n }; q = (o.if(84) / 2)", "q", ".exit"]);
-      expect(stripAnsi(stdout)).toContain("42");
+      const { stdout, exitCode } = await runRepl(["o = { if: (n) => n }; q = (o.if(84) / 2); q", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
       expect(exitCode).toBe(0);
     });
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -793,7 +793,7 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("regex after a statement block", async () => {
-      const { stdout, exitCode } = await runRepl(['if (true) {} /"/.test(\'"\')', ".exit"]);
+      const { stdout, exitCode } = await runRepl(["if (true) {} /\"/.test('\"')", ".exit"]);
       const output = stripAnsi(stdout);
       expect(output).toContain("true");
       expect(output).not.toContain("SyntaxError");

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -877,6 +877,19 @@ describe.concurrent("Bun REPL", () => {
       expect(comparison.exitCode).toBe(0);
     });
 
+    test("division after a cast to void", async () => {
+      const cast = await runRepl(["q = (84 as void / 2); q", ".exit"]);
+      expect(stripAnsi(cast.stdout)).toContain("42");
+      expect(stripAnsi(cast.stdout)).not.toContain("SyntaxError");
+      expect(cast.exitCode).toBe(0);
+
+      // The void operator still takes a regex operand.
+      const operator = await runRepl(["q = void /\"/.test('\"'); q", ".exit"]);
+      expect(stripAnsi(operator.stdout)).toContain("undefined");
+      expect(stripAnsi(operator.stdout)).not.toContain("SyntaxError");
+      expect(operator.exitCode).toBe(0);
+    });
+
     test("division after a cast to an inline type literal", async () => {
       const { stdout, exitCode } = await runRepl(["function t(x) { return x as {a:number} / 2 }; t(84)", ".exit"]);
       const output = stripAnsi(stdout);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -860,11 +860,21 @@ describe.concurrent("Bun REPL", () => {
     });
 
     test("division after a nested generic cast", async () => {
-      const { stdout, exitCode } = await runRepl(["q = (84 as unknown as Array<Array<number>> / 2); q", ".exit"]);
-      const output = stripAnsi(stdout);
-      expect(output).toContain("42");
-      expect(output).not.toContain("SyntaxError");
-      expect(exitCode).toBe(0);
+      const nested = await runRepl(["q = (84 as unknown as Array<Array<number>> / 2); q", ".exit"]);
+      expect(stripAnsi(nested.stdout)).toContain("42");
+      expect(stripAnsi(nested.stdout)).not.toContain("SyntaxError");
+      expect(nested.exitCode).toBe(0);
+
+      const multiArg = await runRepl(["q = (86 as unknown as Map<string, number> / 2); q", ".exit"]);
+      expect(stripAnsi(multiArg.stdout)).toContain("43");
+      expect(stripAnsi(multiArg.stdout)).not.toContain("SyntaxError");
+      expect(multiArg.exitCode).toBe(0);
+
+      // A comma-separated comparison is not a generic, so the `/` starts a regex.
+      const comparison = await runRepl(["q = (1 < 2, 3 > /\"/.test('\"')); q", ".exit"]);
+      expect(stripAnsi(comparison.stdout)).toContain("true");
+      expect(stripAnsi(comparison.stdout)).not.toContain("SyntaxError");
+      expect(comparison.exitCode).toBe(0);
     });
 
     test("division after a cast to an inline type literal", async () => {

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -840,6 +840,17 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("division after a JSX element", async () => {
+      // Line 1 may fail at runtime, but it must evaluate as one line so line 2 runs.
+      const closed = await runRepl(["q = (<a></a> / 2)", "40 + 2", ".exit"]);
+      expect(stripAnsi(closed.stdout)).toContain("42");
+      expect(closed.exitCode).toBe(0);
+
+      const selfClosed = await runRepl(["q = [<a/> / 2]", "50 + 2", ".exit"]);
+      expect(stripAnsi(selfClosed.stdout)).toContain("52");
+      expect(selfClosed.exitCode).toBe(0);
+    });
+
     test("a method named like a conditional keyword does not make its paren a regex context", async () => {
       const { stdout, exitCode } = await runRepl(["o = { if: (n) => n }; q = (o.if(84) / 2); q", ".exit"]);
       const output = stripAnsi(stdout);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -848,6 +848,14 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("a private field named like a keyword does not start a regex", async () => {
+      const { stdout, exitCode } = await runRepl(["class C { #in = 84; q = this.#in / 2 }; new C().q", ".exit"]);
+      const output = stripAnsi(stdout);
+      expect(output).toContain("42");
+      expect(output).not.toContain("SyntaxError");
+      expect(exitCode).toBe(0);
+    });
+
     test("regex after a conditional's closing paren", async () => {
       const { stdout, exitCode } = await runRepl(['if (true) x = /"/; x', ".exit"]);
       const output = stripAnsi(stdout);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -870,6 +870,16 @@ describe.concurrent("Bun REPL", () => {
       expect(stripAnsi(multiArg.stdout)).not.toContain("SyntaxError");
       expect(multiArg.exitCode).toBe(0);
 
+      const innerClose = await runRepl(["q = (88 as unknown as Map<Array<number>, string> / 2); q", ".exit"]);
+      expect(stripAnsi(innerClose.stdout)).toContain("44");
+      expect(stripAnsi(innerClose.stdout)).not.toContain("SyntaxError");
+      expect(innerClose.exitCode).toBe(0);
+
+      const arraySuffix = await runRepl(["q = (90 as unknown as Record<string, number[]> / 2); q", ".exit"]);
+      expect(stripAnsi(arraySuffix.stdout)).toContain("45");
+      expect(stripAnsi(arraySuffix.stdout)).not.toContain("SyntaxError");
+      expect(arraySuffix.exitCode).toBe(0);
+
       // A comma-separated comparison is not a generic, so the `/` starts a regex.
       const comparison = await runRepl(["q = (1 < 2, 3 > /\"/.test('\"')); q", ".exit"]);
       expect(stripAnsi(comparison.stdout)).toContain("true");


### PR DESCRIPTION
### Problem

Fixes #37326

The REPL decides whether input is complete with a quick scanner that tracks quote state and bracket depth. It had no notion of regex literals or comments, so any quote, backtick, or bracket inside a regex body was counted as if it were top-level code:

```
> x = /hello "world/
... "
SyntaxError: Unexpected EOF
```

The same happened with ``` ` ```, `(`, `[`, and `{` inside a regex, and a `(` inside a `//` comment also forced a bogus continuation prompt.

### Fix

`is_incomplete_code` in `src/runtime/cli/repl.rs` now:

- skips regex literal bodies, deciding regex vs. division from the previous significant token, with `\\` escapes and `[...]` character classes handled; a regex that hits end of line is treated as terminated so an invalid literal like `/hello (world/` reports its SyntaxError immediately
- skips `//` line comments and `/* */` block comments; an unclosed block comment continues to the next line instead of erroring
- classifies the token before a `/` with small context trackers added during review: conditional heads (`if`/`for`/`while`/`with`, including `for await`), block vs. object-literal braces, postfix `++`/`--`/`!`, member accesses named like keywords (`obj.in`, `this.#in`), JSX closing tags and tag ends (including `</a.b>`, `</my-el>`, spaced `</a >`), nested generic closers (`A<B<T>>`), and `as`/`satisfies` type positions

### Verification

`test/js/bun/repl/repl.test.ts` gained 30 tests covering each case above plus guards for the opposite direction (division stays division, `return ! /re/` stays a regex). Most fail on the current release (`USE_SYSTEM_BUN=1`) and all pass with this change; the full REPL test file (177 tests) passes.

### Known limitations

The scanner is a byte-level heuristic, not a parser. Two classes of input remain misclassified, both recoverable with `.break`/Ctrl+C and both flagged during review as needing parser-grade context (JSX depth, declaration vs. expression position) that is out of proportion here:

- `//` or `/*` inside JSX text content, e.g. `(<a>https://x</a>)`, reads as a comment and prompts for continuation
- dividing a function/class expression whose body is not inside `()`/`[]`, e.g. `q = function () {} / 2`, evaluates early instead of prompting

If a structural rewrite is preferred (asking the real parser whether the buffer is recoverable-incomplete, as Node's REPL does), that is a follow-up I am happy to take.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->