### PR TITLE
ci: run hawk on PRs and fail on findings the PR introduces

### DIFF
--- a/.github/rust-matcher.json
+++ b/.github/rust-matcher.json
@@ -4,7 +4,7 @@
       "owner": "rust",
       "pattern": [
         {
-          "regexp": "^(error|warning)(\\[E\\d+\\])?: (.+)$",
+          "regexp": "^(error|warning)(\\[[^\\]]+\\])?: (.+)$",
           "severity": 1,
           "message": 3
         },

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -55,8 +55,9 @@ The workflow runs all three formatters simultaneously:
 
 1. Bump `channel` in `rust-toolchain.toml` (and `Dockerfile`/`bootstrap.sh` to match).
 2. Bump `RUSTUP_TOOLCHAIN` in the `Format Code` step's `env:` block in `format.yml` to the same value.
-3. Bump `RUSTUP_TOOLCHAIN` in the workflow-level `env:` block in `clippy.yml`, `miri.yml`, and `lolhtml.yml` to the same value.
+3. Bump `RUSTUP_TOOLCHAIN` in the workflow-level `env:` block in `clippy.yml`, `miri.yml`, `lolhtml.yml`, and `hawk.yml` to the same value.
 4. `cargo fmt` formatting can change between nightlies; run `cargo fmt --all` locally on the new toolchain and include the resulting diff in the same PR.
+5. `hawk.yml` builds `cargo-hawk` against the new nightly (it links rustc internals). Run `bun run rust:hawk install` locally on the new toolchain; if the build breaks, fix it on the `bun` branch of oven-sh/hawk and bump `HAWK_REV` in `scripts/rust-hawk.ts`.
 
 #### To update clang-format version:
 

--- a/.github/workflows/hawk.yml
+++ b/.github/workflows/hawk.yml
@@ -1,0 +1,125 @@
+name: Hawk
+
+# Cross-crate dead-code / over-visibility analysis of the Rust workspace
+# (tools/hawk/README.md). main is not hawk-clean, so the analysis runs on both
+# the base commit and the PR and only findings the PR introduces fail the job;
+# they are also surfaced as inline annotations and in the job summary.
+#
+# Each analysis is a full `cargo check` of the workspace for the 11 shipped
+# targets (hawk re-instruments every workspace crate per run; only third-party
+# deps are reused between the two runs), so this job takes a while. It is
+# advisory: it is not a required check, and nothing on main is gated on it.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**/*.rs"
+      - "src/**/Cargo.toml"
+      - "src/**/*.classes.ts"
+      - "src/codegen/**"
+      - "scripts/build/**"
+      - "scripts/build.ts"
+      - "scripts/rust-hawk.ts"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "hawk.toml"
+      - "tools/hawk/**"
+      - "rust-toolchain.toml"
+      - ".github/workflows/hawk.yml"
+      - ".github/actions/setup-bun/**"
+      - ".github/rust-matcher.json"
+
+env:
+  BUN_VERSION: "1.3.14"
+  LLVM_VERSION_MAJOR: "21"
+  # Keep in sync with `channel` in rust-toolchain.toml (same reasoning as
+  # clippy.yml: pinning here lets us install exactly the targets hawk.toml needs).
+  RUSTUP_TOOLCHAIN: nightly-2026-07-20
+
+jobs:
+  hawk:
+    name: cargo hawk check (new findings vs base)
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # HEAD is the PR merge commit; HEAD^1 (the base branch) is analyzed too.
+          fetch-depth: 2
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup system deps
+        # Same as clippy.yml: cmake/ninja for `--configure-only`, clang for
+        # toolchain detection during configure.
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${LLVM_VERSION_MAJOR} main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends cmake ninja-build clang-${LLVM_VERSION_MAJOR} lld-${LLVM_VERSION_MAJOR} llvm-${LLVM_VERSION_MAJOR}
+
+      - name: Setup Rust
+        # rustc-dev: cargo-hawk links against rustc internals, so it is built
+        # against the exact toolchain that then compiles the workspace. The
+        # target list mirrors `targets` in hawk.toml (the host is implicit).
+        run: |
+          rustup toolchain install "$RUSTUP_TOOLCHAIN" --profile minimal --component rustc-dev
+          rustup override set "$RUSTUP_TOOLCHAIN"
+          rustup target add \
+            aarch64-unknown-linux-gnu \
+            aarch64-unknown-linux-musl \
+            x86_64-unknown-linux-musl \
+            aarch64-linux-android \
+            x86_64-linux-android \
+            x86_64-unknown-freebsd \
+            aarch64-apple-darwin \
+            x86_64-apple-darwin \
+            aarch64-pc-windows-msvc \
+            x86_64-pc-windows-msvc
+
+      - name: Install cargo-hawk
+        # The PR's copy of the script drives both analyses (the base commit may
+        # predate it or have an older version); it operates on whatever is
+        # checked out in the working directory.
+        run: |
+          cp scripts/rust-hawk.ts "$RUNNER_TEMP/rust-hawk.ts"
+          bun "$RUNNER_TEMP/rust-hawk.ts" install
+
+      - name: Analyze base
+        # On pull_request HEAD is the merge commit, so HEAD^1 is the base
+        # branch as of this run. (On workflow_dispatch it is simply the parent
+        # commit, so the job reports what the tip commit introduces.)
+        run: |
+          echo "HEAD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          git checkout --quiet HEAD^1
+          bun install --frozen-lockfile
+          bun scripts/build.ts --configure-only
+          ninja -C build/debug codegen clone-lolhtml
+          bun "$RUNNER_TEMP/rust-hawk.ts" --output-format=json > "$RUNNER_TEMP/hawk-base.json"
+
+      - name: Analyze PR
+        run: |
+          git checkout --quiet "$HEAD_SHA"
+          bun install --frozen-lockfile
+          bun scripts/build.ts --configure-only
+          ninja -C build/debug codegen clone-lolhtml
+          bun "$RUNNER_TEMP/rust-hawk.ts" --output-format=json > "$RUNNER_TEMP/hawk-head.json"
+
+      - name: Report findings introduced by this PR
+        # The matcher is registered only here so annotations come from the
+        # diff, not from compiler output of either analysis.
+        run: |
+          echo "::add-matcher::.github/rust-matcher.json"
+          bun "$RUNNER_TEMP/rust-hawk.ts" diff "$RUNNER_TEMP/hawk-base.json" "$RUNNER_TEMP/hawk-head.json"

--- a/hawk.toml
+++ b/hawk.toml
@@ -454,54 +454,6 @@ reason = "external code table: weak-ref type numbering shared with JSC"
 
 [[override]]
 lint = "hawk::dead_public"
-crate = "bun_platform"
-item = "darwin::Category::PointsOfInterest"
-kind = "enum_variant"
-level = "expect"
-reason = "external code table: OSLog signpost category values"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "bun_platform"
-item = "darwin::Category::Dynamicity"
-kind = "enum_variant"
-level = "expect"
-reason = "external code table: OSLog signpost category values"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "bun_platform"
-item = "darwin::Category::SizeAndThroughput"
-kind = "enum_variant"
-level = "expect"
-reason = "external code table: OSLog signpost category values"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "bun_platform"
-item = "darwin::Category::TimeProfile"
-kind = "enum_variant"
-level = "expect"
-reason = "external code table: OSLog signpost category values"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "bun_platform"
-item = "darwin::Category::SystemReporting"
-kind = "enum_variant"
-level = "expect"
-reason = "external code table: OSLog signpost category values"
-
-[[override]]
-lint = "hawk::dead_public"
-crate = "bun_platform"
-item = "darwin::Category::UserCustom"
-kind = "enum_variant"
-level = "expect"
-reason = "external code table: OSLog signpost category values"
-
-[[override]]
-lint = "hawk::dead_public"
 crate = "bun_runtime"
 item = "bake::dev_server::serialized_failure::ErrorKind::JsError"
 kind = "enum_variant"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rust:check": "cargo check --workspace --keep-going",
     "rust:check-all": "bun scripts/rust-check-all.ts",
     "rust:clippy": "cargo clippy --workspace --no-deps --keep-going",
+    "rust:hawk": "bun scripts/rust-hawk.ts",
     "rust:miri": "bun scripts/rust-miri.ts",
     "rust:timings": "bun scripts/rust-timings.ts",
     "codegen:string-maps": "for f in src/**/*.string-map.ts; do bun src/codegen/generate-string-map.ts \"$f\" \"${f%.string-map.ts}.generated.rs\"; done",

--- a/scripts/rust-hawk.ts
+++ b/scripts/rust-hawk.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env bun
+/**
+ * Cross-crate dead-code analysis with hawk (see tools/hawk/README.md).
+ *
+ * `bun run rust:hawk [cargo hawk check args...]` scaffolds the throwaway
+ * analysis root in src/bun_bin, runs `cargo hawk check` (the 11 shipped
+ * targets unioned, per hawk.toml), then reverts the scaffolding.
+ * e.g. `bun run rust:hawk --only dead-public`.
+ *
+ * `bun run rust:hawk install` builds cargo-hawk from the pinned fork rev
+ * against the active toolchain (installs the `rustc-dev` component if needed).
+ *
+ * `bun run rust:hawk diff <base.json> <head.json>` compares two
+ * `--output-format=json` reports and fails on findings present only in head.
+ * main is not hawk-clean, so CI (.github/workflows/hawk.yml) runs the
+ * analysis on the PR's base and head and reports only what the PR adds.
+ *
+ * Operates on the checkout in the current directory (`bun run` sets it to the
+ * repo root) rather than the one containing this file: CI runs the PR's copy
+ * of this script against the base checkout too.
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+// oven-sh/hawk `bun` branch: upstream hawk (astral-sh/hawk) plus multi-target
+// analysis (astral-sh/hawk#150), per-profile cargo-profile/rustflags,
+// [[root-marker]] for codegen-scraped exports, and driver support for bun's
+// pinned nightly. The driver links rustc internals, so it must be BUILT with
+// the same toolchain that later compiles the workspace: after a
+// rust-toolchain.toml channel bump, `bun run rust:hawk install` again (and
+// bump this rev if the branch needed fixes for the new nightly).
+const HAWK_GIT = "https://github.com/oven-sh/hawk";
+const HAWK_REV = "c9ca301a72a99e089598af515af5f31f8ff610c3";
+
+const repoRoot = process.cwd();
+const cargoTomlPath = join(repoRoot, "src", "bun_bin", "Cargo.toml");
+const rootRsPath = join(repoRoot, "src", "bun_bin", "hawk_root.rs");
+const scaffoldPatch = join("tools", "hawk", "analysis-root.patch");
+
+function run(cmd: string[], opts: { env?: Record<string, string | undefined> } = {}): number {
+  const r = spawnSync(cmd[0], cmd.slice(1), {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: { ...process.env, ...opts.env },
+  });
+  return r.status ?? 1;
+}
+
+interface Diagnostic {
+  category: "finding" | "configuration";
+  code: string;
+  identity?: { crate: string; item: string; kind: string };
+  location?: { file: string; line: number; column: number };
+  reason?: string;
+  test_only?: boolean;
+}
+
+interface Report {
+  schema_version: number;
+  diagnostics: Diagnostic[];
+}
+
+function readReport(path: string): Report {
+  const report = JSON.parse(readFileSync(path, "utf8"));
+  if (!Array.isArray(report?.diagnostics)) throw new Error(`${path} is not a hawk JSON report`);
+  return report;
+}
+
+// Keyed on what the finding is about rather than hawk's `identity.id`, which
+// embeds file:line and so would report every finding in a file as new
+// whenever unrelated lines above it shift. An item compiled from several
+// cfg alternatives yields one entry per alternative, hence counting.
+function diagnosticKey(d: Diagnostic): string {
+  const subject = d.identity
+    ? `${d.identity.crate}|${d.identity.item}|${d.identity.kind}`
+    : `${d.location?.file ?? ""}|${d.reason ?? ""}`;
+  return `${d.code}|${subject}`;
+}
+
+const descriptions: Record<string, string> = {
+  "hawk::dead_public": "is pub but nothing reachable from the shipped binary uses it, on any target",
+  "hawk::unnecessary_public": "is pub but only used inside its own crate",
+  "hawk::unnecessary_restricted_visibility": "has a restricted visibility it does not need",
+};
+
+function describe(d: Diagnostic): string {
+  if (!d.identity) return d.reason ?? "configuration diagnostic";
+  const item = `\`${d.identity.crate}::${d.identity.item}\` (${d.identity.kind.replaceAll("_", " ")})`;
+  if (d.category === "configuration") return `hawk.toml entry for ${item}: ${d.code.replace("hawk::", "")}`;
+  const what = descriptions[d.code] ?? d.code.replace("hawk::", "").replaceAll("_", " ");
+  const testOnly = d.test_only ? " (used only by tests)" : "";
+  return `${item} ${what}${testOnly}`;
+}
+
+function diffReports(base: Report, head: Report): number {
+  if (base.schema_version !== head.schema_version) {
+    console.error(`[hawk] report schema mismatch: base ${base.schema_version}, head ${head.schema_version}`);
+    return 2;
+  }
+
+  const baseCounts = new Map<string, number>();
+  for (const d of base.diagnostics) {
+    const key = diagnosticKey(d);
+    baseCounts.set(key, (baseCounts.get(key) ?? 0) + 1);
+  }
+
+  const headByKey = new Map<string, Diagnostic[]>();
+  for (const d of head.diagnostics) {
+    const key = diagnosticKey(d);
+    const entries = headByKey.get(key);
+    if (entries) entries.push(d);
+    else headByKey.set(key, [d]);
+  }
+
+  const introduced: Diagnostic[] = [];
+  let fixed = 0;
+  for (const [key, count] of baseCounts) {
+    const remaining = headByKey.get(key)?.length ?? 0;
+    if (remaining < count) fixed += count - remaining;
+  }
+  for (const [key, entries] of headByKey) {
+    if (entries.length > (baseCounts.get(key) ?? 0)) introduced.push(...entries);
+  }
+  introduced.sort((a, b) => {
+    const fileOrder = (a.location?.file ?? "").localeCompare(b.location?.file ?? "");
+    return fileOrder || (a.location?.line ?? 0) - (b.location?.line ?? 0);
+  });
+
+  // rustc-style so .github/rust-matcher.json turns each one into an inline
+  // PR annotation.
+  for (const d of introduced) {
+    console.log(`error[${d.code}]: ${describe(d)}`);
+    if (d.location) console.log(`  --> ${d.location.file}:${d.location.line}:${d.location.column}\n`);
+  }
+  console.log(
+    `hawk: ${introduced.length} finding(s) introduced, ${fixed} fixed ` +
+      `(base ${base.diagnostics.length}, head ${head.diagnostics.length})`,
+  );
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const lines = [`### hawk: ${introduced.length} finding(s) introduced, ${fixed} fixed`, ""];
+    if (introduced.length > 0) {
+      lines.push(
+        "Items this PR makes dead or leaves more visible than needed (see tools/hawk/README.md).",
+        "",
+        ...introduced.map(d => {
+          const where = d.location ? ` at \`${d.location.file}:${d.location.line}\`` : "";
+          return `- \`${d.code}\`: ${describe(d)}${where}`;
+        }),
+      );
+    }
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n") + "\n");
+  }
+
+  return introduced.length > 0 ? 1 : 0;
+}
+
+const args = process.argv.slice(2);
+
+if (args[0] === "install") {
+  const components = spawnSync("rustup", ["component", "list", "--installed"], { encoding: "utf8" });
+  if (components.status === 0 && !components.stdout.includes("rustc-dev")) {
+    console.log("[hawk] installing rustc-dev component (needed to build cargo-hawk)");
+    if (run(["rustup", "component", "add", "rustc-dev"]) !== 0) process.exit(1);
+  }
+  process.exit(
+    run(["cargo", "install", "--locked", "--force", "--git", HAWK_GIT, "--rev", HAWK_REV, "cargo-hawk"], {
+      // Required because `cargo install` ignores the hawk repo's own cargo
+      // config that normally enables rustc_private.
+      env: { RUSTC_BOOTSTRAP: "1" },
+    }),
+  );
+}
+
+if (args[0] === "diff") {
+  if (args.length !== 3) {
+    console.error("usage: bun run rust:hawk diff <base.json> <head.json>");
+    process.exit(2);
+  }
+  process.exit(diffReports(readReport(args[1]), readReport(args[2])));
+}
+
+if (!existsSync(join(repoRoot, "hawk.toml"))) {
+  console.error(`[hawk] ${repoRoot} is not the repo root (no hawk.toml); run from the repo root`);
+  process.exit(1);
+}
+
+if (spawnSync("cargo-hawk", ["--version"], { stdio: "ignore" }).error) {
+  console.error("[hawk] cargo-hawk is not installed; run `bun run rust:hawk install` first");
+  process.exit(1);
+}
+
+// The workspace can't compile without the `include!`d codegen output and the
+// vendored lol_html path dependency.
+const codegenDir = resolve(process.env.BUN_CODEGEN_DIR ?? join(repoRoot, "build", "debug", "codegen"));
+if (
+  !existsSync(join(codegenDir, "generated_classes.rs")) ||
+  !existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml"))
+) {
+  console.error(`[hawk] missing codegen output or vendor/lolhtml; run:
+  bun scripts/build.ts --configure-only && ninja -C build/debug codegen clone-lolhtml`);
+  process.exit(1);
+}
+
+// Scaffold the analysis root (an rlib + throwaway [[bin]] in src/bun_bin;
+// kept out of the tree permanently because the extra crate-type would disable
+// fat LTO on the shipped staticlib). Revert only what this run applied, so a
+// manually scaffolded tree is left alone.
+const alreadyScaffolded = readFileSync(cargoTomlPath, "utf8").includes("bun_hawk_root");
+const createdRootRs = !existsSync(rootRsPath);
+if (!alreadyScaffolded && run(["git", "apply", scaffoldPatch]) !== 0) {
+  console.error(`[hawk] failed to apply ${scaffoldPatch}`);
+  process.exit(1);
+}
+if (createdRootRs) writeFileSync(rootRsPath, "fn main() {}\n");
+
+// Ctrl-C goes to cargo too; let it die and fall through to the revert below.
+process.on("SIGINT", () => {});
+let status = 1;
+try {
+  status = run(["cargo", "hawk", "check", ...args], { env: { BUN_CODEGEN_DIR: codegenDir } });
+} finally {
+  if (!alreadyScaffolded) run(["git", "apply", "--reverse", scaffoldPatch]);
+  if (createdRootRs) rmSync(rootRsPath, { force: true });
+}
+process.exit(status);

--- a/tools/hawk/README.md
+++ b/tools/hawk/README.md
@@ -9,18 +9,48 @@ The analysis config lives at the repo root: `hawk.toml` (release profile ×
 the 11 shipped targets, plus overrides for enum variants whose discriminants
 are external code tables).
 
+## Running it
+
+```sh
+bun scripts/build.ts --configure-only && ninja -C build/debug codegen clone-lolhtml
+bun run rust:hawk install          # builds cargo-hawk from the oven-sh/hawk rev pinned in scripts/rust-hawk.ts
+bun run rust:hawk                  # all current findings (main has thousands; see below)
+bun run rust:hawk --only dead-public --output-format=json > hawk-report.json
+```
+
+A full run compiles the workspace for all 11 targets, roughly 20 minutes on
+16 cores (the critical path is `bun_runtime`, so more cores do not help much)
+and about 4 GB of target dir.
+
+## CI
+
+`.github/workflows/hawk.yml` runs on PRs that touch Rust. `main` is not
+hawk-clean (#36184 narrowed visibility but left the dead-public deletions for
+later), so the job analyzes both the base commit and the PR and fails only on
+findings the PR introduces, listing them as inline annotations and in the job
+summary. The comparison (`bun run rust:hawk diff base.json head.json`) keys
+findings on lint + crate + item path + item kind, so unrelated line shifts do
+not count as new, but moving or renaming an already-flagged item does.
+
+When the job fails: delete the item, narrow its visibility, or, if it is dead
+on purpose (a code table, or an API a stacked follow-up PR is about to use),
+add an `[[override]]` to `hawk.toml` with a `reason`. Prefer
+`level = "expect"`: once the item gains a user, hawk reports
+`hawk::unfulfilled_expectation`, so the stale override gets removed too. The
+job is advisory, not a required check.
+
+Upstream hawk lacks the multi-target analysis and `[[root-marker]]` support
+this config uses, so the script builds from the `bun` branch of
+[oven-sh/hawk](https://github.com/oven-sh/hawk), against the workspace's
+pinned nightly (the driver links rustc internals and has to match the
+compiler that builds the workspace, so a toolchain bump means reinstalling).
+
 Hawk needs a `bin` product to root the analysis, but Bun's product crate
 (`src/bun_bin`) ships as a `staticlib` linked by the C++ build. Adding an
 `rlib`/`[[bin]]` permanently would disable fat LTO on the shipped staticlib,
-so the root is applied only for the duration of a run:
-
-```sh
-git apply tools/hawk/analysis-root.patch      # adds rlib + a throwaway [[bin]] to src/bun_bin
-printf 'fn main() {}\n' > src/bun_bin/hawk_root.rs
-export BUN_CODEGEN_DIR="$PWD/build/debug/codegen"   # run `bun bd --configure-only` + codegen first
-cargo hawk check --jobs "$(nproc)" --output-format=json > hawk-report.json
-git checkout -- src/bun_bin/Cargo.toml && rm -f src/bun_bin/hawk_root.rs   # revert the scaffolding
-```
+so `scripts/rust-hawk.ts` applies `analysis-root.patch` (rlib + a throwaway
+`[[bin]]` in `src/bun_bin`) plus an empty `hawk_root.rs` for the duration of
+the run and reverts them afterwards.
 
 The `#[no_mangle]` exports the C++ side calls are Hawk's real reachability
 roots; the empty `fn main() {}` is sufficient because Hawk treats every


### PR DESCRIPTION
### What

Runs the cross-crate dead-code analysis set up in #36184 ([hawk](https://github.com/astral-sh/hawk), `hawk.toml`) in GitHub Actions on every PR that touches Rust, so `pub` items a PR adds that nothing in the shipped binary reaches on any of the 11 targets (or that are more visible than needed) show up on the PR as a failed check with inline annotations, instead of waiting for the next manual sweep.

### Why a base/PR comparison

main is not hawk-clean. A full run on `827475e` reports 8784 diagnostics: 1222 `dead_public`, 855 `unnecessary_public`, 6701 `unnecessary_restricted_visibility`, plus 6 `unknown_item` config warnings (#36184 did the narrowing and left the dead-public deletions for later, and the tree has moved since). So `-D warnings` would be red on every PR. Instead the job analyzes the base commit (`HEAD^1` of the merge commit) and the PR, and fails only on findings present in the PR and not in the base.

The comparison keys a finding on lint + crate + item path + item kind (counted, since cfg alternatives of one item produce one entry each). hawk's own `identity.id` embeds file:line, which would flag every finding below an unrelated edit as new. Moving or renaming an already-flagged item does count as new; that seemed acceptable for an advisory check.

### Changes

- `.github/workflows/hawk.yml`: clippy.yml's setup, then builds `cargo-hawk`, analyzes base and PR, and runs the comparison. Not added to `merge_group`; this is an advisory check, not a required one, so a PR that intentionally adds code ahead of its caller (stacked PRs) still shows red but stays mergeable. For code that is dead on purpose, an `[[override]]` with `level = "expect"` in `hawk.toml` silences it and hawk later reports the override as unfulfilled once the code gains a user.
- `scripts/rust-hawk.ts` (`bun run rust:hawk`): the procedure from `tools/hawk/README.md` as a script, used locally and by CI. Applies `tools/hawk/analysis-root.patch` and an empty `hawk_root.rs` for the duration of the run and reverts them (the extra crate-type cannot live in the tree because it would disable fat LTO on the shipped staticlib). `install` builds `cargo-hawk`; `diff base.json head.json` does the comparison and prints new findings in rustc format. It operates on the current directory so CI can run the PR's copy of the script against the base checkout (which, for this PR, does not have the script yet).
- The pinned rev is the `bun` branch of oven-sh/hawk (`c9ca301`). `hawk.toml` uses `targets`, `cargo-profile` and `[[root-marker]]`, which upstream releases do not have (multi-target is astral-sh/hawk#150, still open), and the fork's one prebuilt release predates the last two. The driver links rustc internals, so the job builds it against the workspace's pinned nightly (`rustc-dev` component; about 15s). `.github/workflows/CLAUDE.md` gets the corresponding toolchain-bump step.
- `.github/rust-matcher.json`: the first pattern only accepted `error[E0xxx]:`; hawk's codes look like `error[hawk::dead_public]:`. Widened to any bracketed code; rustc and clippy lines match exactly as before. The matcher is registered only for the comparison step so annotations never come from compiler output of either analysis.
- `hawk.toml`: drops six overrides for `bun_platform` `darwin::Category` variants that #36833 deleted; hawk reports them as `hawk::unknown_item` today, and this job would have flagged the PR that added them.

### Cost

One analysis is a `cargo check` of the workspace per target, 11 targets, production and test surfaces: 21.5 min on a 16-core box at an average of only 2.7 cores busy (the critical path is `bun_runtime`), so `ubuntu-latest` should not be dramatically slower. hawk re-instruments every workspace crate on each run, so the PR analysis does not reuse the base one; expect roughly 45 min per job, running alongside the Buildkite pipeline. Target dir is about 4 GB. If that turns out to be too much, caching the base report keyed by base sha would roughly halve it; left out of this PR.

### Verification

- Base run on `827475e` (this branch's merge base): 8784 diagnostics, as above.
- Appended an unused `pub fn` to `src/csrf/lib.rs` and re-ran through the script (scaffolding applied and reverted cleanly, JSON on stdout parsed). `bun run rust:hawk diff` on the two reports:

  ```
  error[hawk::dead_public]: `bun_csrf::hawk_negative_test_probe` (function) is pub but nothing reachable from the shipped binary uses it, on any target
    --> src/csrf/lib.rs:267:1

  hawk: 1 finding(s) introduced, 6 fixed (base 8784, head 8779)
  ```

  exit code 1. The "6 fixed" are the stale overrides removed in this PR (the second run used the updated `hawk.toml`), which also exercises config diagnostics flowing through the comparison. Identical reports, and reports differing only in line numbers, produce `0 introduced` and exit 0.
- The `Hawk` workflow run on this PR exercises the job itself (`hawk.yml` is in its own trigger paths); it should finish with `0 finding(s) introduced, 6 fixed`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->