### PR TITLE
Bun.sql getters: do not report a still-pending exception as uncaught in debug builds

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12781,3 +12781,50 @@ test("data row that omits columns declared in the row description yields nulls f
   expect(filteredStderr).toBe("");
   expect(exitCode).toBe(0);
 }, 30_000);
+
+// Bun.sql / Bun.postgres / Bun.SQL are lazy properties whose getter loads the
+// bun:sql module on first access. If that load throws (here the stack is
+// already exhausted, so evaluating the module overflows it), the throw has to
+// reach the caller like any other exception and the property must stay lazy so
+// a later access works. Debug builds used to additionally report the pending
+// exception as uncaught from inside the getter, which aborted the process.
+// Runs in a subprocess because the property must not have been reified yet.
+test.concurrent.each(["sql", "postgres", "SQL"])("Bun.%s throwing under stack exhaustion is catchable", async name => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let first;
+        function recurse() {
+          try {
+            recurse();
+          } catch {}
+          if (first === undefined) {
+            try {
+              Bun.${name};
+            } catch (e) {
+              first = e;
+            }
+          }
+        }
+        recurse();
+        console.log(String(first));
+        console.log(typeof Bun.${name});
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const filteredStderr = stderr
+    .split(/\r?\n/)
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+
+  expect(stdout).toBe("RangeError: Maximum call stack size exceeded.\nfunction\n");
+  expect(filteredStderr).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12819,12 +12819,7 @@ test.concurrent.each(["sql", "postgres", "SQL"])("Bun.%s throwing under stack ex
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const filteredStderr = stderr
-    .split(/\r?\n/)
-    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-
   expect(stdout).toBe("RangeError: Maximum call stack size exceeded.\nfunction\n");
-  expect(filteredStderr).toBe("");
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a debug-build abort found by fuzzing. The first access of `Bun.sql`, `Bun.postgres` or `Bun.SQL` runs a lazy property builder (`defaultBunSQLObject` / `constructBunSQLObject` in `BunObject.cpp`) that loads the internal `bun:sql` module. If that load throws (the fuzzer case: the property is first touched from the bottom of a runaway recursion, so entering the module body throws `RangeError: Maximum call stack size exceeded`), the builder had a `#if BUN_DEBUG` block that called `reportUncaughtExceptionAtEventLoop` while the exception was still pending on the VM, and only then fell through to `RETURN_IF_EXCEPTION`.

Every other caller of that function clears the exception first. Running the uncaught exception machinery with one still set does a `process._fatalException` lookup and error printing on a VM that has an exception pending, which trips JSC's exception scope assertions. Depending on what state `process` is in at that point, the abort surfaces as `Structure::storedPrototype` (`object->structure() == this`, since `setUpStaticFunctionSlot` sees the pre-existing exception right after reifying `_fatalException`), as the `EXCEPTION_ASSERT` in `JSObject::get`, or as `assertNoExceptionExceptTermination` further down, which is why the fuzzer saw it as flaky. It also counted an error the user went on to catch as unhandled (exit code 1, or exit code 7 when it happened inside an `uncaughtException` handler).

The fix is removing the two debug-only blocks. The exception from `requireId` already propagates to the property access: `reifyStaticProperty` skips the `putDirect` when the builder returns empty and `setUpStaticFunctionSlot` reports the slot as missing, so the access throws the RangeError, the property stays lazy, and the next access loads the module normally. Release builds never had the extra report, so their behavior is unchanged.

### How did you verify your code works?

The fuzzer script (a constructor that recurses into itself and calls `Bun.postgres(this)` in a `try/catch` on the way back up) aborts on an unfixed debug build with the `storedPrototype` assertion, and exits 0 with this change.

Added three tests to `test/js/sql/sql.test.ts` that touch `Bun.sql`, `Bun.postgres` and `Bun.SQL` from an exhausted stack in a subprocess and check that the access throws the RangeError, that a later access returns the function, and that the process exits 0 with nothing on stderr. On an unfixed debug build the subprocess aborts and all three fail; with this change they pass. Since the removed code was debug-only, the tests also pass on a release build. Also ran the repro with `BUN_JSC_validateExceptionChecks=1`, which is clean.
