### PR TITLE
fix(inspect): don't keep enumerating properties with an exception pending

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5671,7 +5672,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -467,6 +467,54 @@ describe("crash testing", () => {
   }
 });
 
+// An exception thrown while looking up a property (Proxy trap, lazily initialized
+// property) used to stay pending while the next property was looked up, and a
+// throwing getPrototypeOf trap crashed the walk up the prototype chain.
+// Run in a child so a regression fails this test instead of killing the runner.
+it("Bun.inspect ignores exceptions thrown while enumerating properties", async () => {
+  const code = `
+    {
+      const target = { a: 1, b: 2 };
+      const proto = new Proxy(target, {
+        get(t, key, receiver) {
+          if (key in target) throw new Error("get " + String(key));
+          return Reflect.get(t, key, receiver);
+        },
+      });
+      const obj = Object.create(proto);
+      obj.own = 1;
+      console.log(Bun.inspect(obj));
+    }
+    {
+      const proto = new Proxy({ fromProto: 2 }, {
+        getPrototypeOf() { throw new Error("getPrototypeOf"); },
+      });
+      const obj = Object.create(proto);
+      obj.own = 1;
+      console.log(Bun.inspect(obj));
+    }
+    {
+      // Several of Bun's lazily initialized properties (Bun.$ among them) call
+      // Symbol() when first accessed, so this makes their initializers throw.
+      globalThis.Symbol = undefined;
+      const out = Bun.inspect(Bun);
+      console.log(typeof out, out.includes("inspect"));
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "{\n  own: 1,\n}\n" + "{\n  own: 1,\n  fromProto: 2,\n}\n" + "string true\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 it("possibly formatted emojis log", () => {
   expect(Bun.inspect("✔")).toBe('"✔"');
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found debug assertion in `Bun.inspect` / `console.log` (`Unexpected exception observed ... releaseAssertNoException`) and, while tracking it down, a release-build segfault in the same loop.

`JSC__JSValue__forEachPropertyImpl` (`src/jsc/bindings/bindings.cpp`, the slow path used for objects with static tables, Proxies in the prototype chain, etc.) had two problems in its per-property loop:

1. When `getPropertySlot()` returned `false` because the lookup threw, it did `continue` before the `CLEAR_IF_EXCEPTION`, so the exception stayed pending while the next property was looked up. Lookups can throw through a Proxy `get` trap or through a lazily initialized static property whose initializer throws (the fuzzer's case: it had clobbered `globalThis.Symbol`, so the `Bun.$` initializer threw, and the next property, `Bun.Archive`, is a Rust lazy property callback whose host-call exception check aborts when it is entered with an exception pending). The fix is to move the `CLEAR_IF_EXCEPTION` above the `continue`, which is what `forEachPropertyOrdered` already does.
2. At the bottom of the loop, `iterating->getPrototype(globalObject).getObject()` dereferenced the empty `JSValue` that `ProxyObject::getPrototype` returns when it throws (either its own `getPrototypeOf` trap, or because of the stale exception from 1). In release builds this is `Segmentation fault at address 0x5`:

   ```js
   const target = { a: 1 };
   const proto = new Proxy(target, { get(t, k) { if (k in target) throw new Error("x"); return t[k]; } });
   console.log(Object.create(proto)); // segfaults in 1.4.0, prints {} with this PR
   ```

   Same with a `getPrototypeOf` trap that throws. The loop now clears the exception and stops walking the chain when `getPrototype()` comes back empty.

The `BunObject.cpp` hunk removes two `#if BUN_DEBUG` blocks in the `Bun.sql` / `Bun.SQL` initializers that called `reportUncaughtExceptionAtEventLoop()` while the exception was still pending on the VM (every other caller clears first). Once the walk above no longer aborts, `Bun.inspect(Bun)` with a broken global reaches these and trips `Structure::storedPrototype` (`object->structure() == this`) inside the uncaught exception handler, as does plain `Bun.sql` when the module fails to load; release builds just throw to the caller, which the `RETURN_IF_EXCEPTION` on the next line already does, so the blocks only made debug builds diverge.

`JSC__JSValue__forEachPropertyOrdered` (`{ sorted: true }`) has a related but different issue (it does not propagate exceptions thrown by the callback, see the TODO there); that is tracked separately and not changed here.

### How did you verify your code works?

Added `Bun.inspect ignores exceptions thrown while enumerating properties` to `test/js/bun/util/inspect.test.js`. It runs the three scenarios in a child process: Proxy prototype with a throwing `get` trap, Proxy prototype with a throwing `getPrototypeOf` trap, and `Bun.inspect(Bun)` with `globalThis.Symbol` removed. On an unfixed build the first two segfault in release (`exitCode: 139`, verified with `USE_SYSTEM_BUN=1`) and fail under the debug/sanitizer build (null member call in `JSValue::getObject`), and the third aborts with the assertion from the fuzzer report on the unfixed debug build (and with the `storedPrototype` assertion once only the `bindings.cpp` change is applied); with this PR the child prints the expected output and exits 0. `bun bd test test/js/bun/util/inspect.test.js` passes; the fuzzer's script (with the global state it depended on) runs to completion on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->