### PR TITLE
Stop the ordered property walk when the inspect callback throws

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5799,8 +5799,9 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
         ZigString key = toZigString(name);
 
         JSC::EnsureStillAliveScope ensureStillAliveScope(propertyValue);
-        // TODO: properly propagate exception upwards
         iter(globalObject, arg2, &key, JSC::JSValue::encode(propertyValue), property.isSymbol(), property.isPrivateName());
+        // Propagate exceptions from callbacks.
+        RETURN_IF_EXCEPTION(scope, void());
     }
     properties.releaseData();
 }

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -61,4 +61,35 @@ describe("toMatchSnapshot errors", () => {
       expect({ a: 4 }).toMatchSnapshot({ a: expect.any("not a constructor") });
     }).toThrow();
   });
+
+  it("should throw if formatting a nested value throws, instead of leaving that property out", () => {
+    // The snapshot formatter reads `$$typeof` off every object to detect React elements.
+    const reads: string[] = [];
+    const value = {
+      a: {
+        get $$typeof(): unknown {
+          reads.push("a");
+          throw new Error("boom");
+        },
+      },
+      b: {
+        get $$typeof(): unknown {
+          reads.push("b");
+          return undefined;
+        },
+      },
+    };
+
+    expect(() => {
+      // This is what used to get recorded: `a` dropped, the walk carried on with `b`.
+      expect(value).toMatchInlineSnapshot(`
+        {
+          "b": {
+            "$$typeof": [native code],
+          },
+        }
+      `);
+    }).toThrow();
+    expect(reads).toEqual(["a"]);
+  });
 });

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -80,6 +80,8 @@ describe("toMatchSnapshot errors", () => {
       },
     };
 
+    // The matcher reports formatting failures with its own message rather than
+    // rethrowing the getter's error.
     expect(() => {
       // This is what used to get recorded: `a` dropped, the walk carried on with `b`.
       expect(value).toMatchInlineSnapshot(`
@@ -89,7 +91,7 @@ describe("toMatchSnapshot errors", () => {
           },
         }
       `);
-    }).toThrow();
+    }).toThrow("Failed to pretty format value");
     expect(reads).toEqual(["a"]);
   });
 });

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -65,33 +65,43 @@ describe("toMatchSnapshot errors", () => {
   it("should throw if formatting a nested value throws, instead of leaving that property out", () => {
     // The snapshot formatter reads `$$typeof` off every object to detect React elements.
     const reads: string[] = [];
+    const formattable = (name: string) => ({
+      get $$typeof(): unknown {
+        reads.push(name);
+        return undefined;
+      },
+    });
     const value = {
-      a: {
-        get $$typeof(): unknown {
-          reads.push("a");
-          throw new Error("boom");
+      x: {
+        a: {
+          get $$typeof(): unknown {
+            reads.push("a");
+            throw new Error("boom");
+          },
         },
+        b: formattable("b"),
       },
-      b: {
-        get $$typeof(): unknown {
-          reads.push("b");
-          return undefined;
-        },
-      },
+      y: formattable("y"),
     };
 
     // The matcher reports formatting failures with its own message rather than
     // rethrowing the getter's error.
     expect(() => {
-      // This is what used to get recorded: `a` dropped, the walk carried on with `b`.
+      // This is what used to get recorded: `a` dropped, both walks carried on.
       expect(value).toMatchInlineSnapshot(`
         {
-          "b": {
+          "x": {
+            "b": {
+              "$$typeof": [native code],
+            },
+          },
+          "y": {
             "$$typeof": [native code],
           },
         }
       `);
     }).toThrow("Failed to pretty format value");
+    // Neither the rest of `x` nor the rest of `value` was formatted.
     expect(reads).toEqual(["a"]);
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,67 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("a nested value throws while formatting with { sorted: true }", () => {
+  const custom = Symbol.for("nodejs.util.inspect.custom");
+  const throwing = (visited, name) => ({
+    [custom]() {
+      visited.push(name);
+      throw new Error("boom");
+    },
+  });
+  const formattable = (visited, name) => ({
+    [custom]() {
+      visited.push(name);
+      return name;
+    },
+  });
+
+  it("throws and stops the walk at the throwing property, like the unsorted walk", () => {
+    const visited = [];
+    // `a` is neither first in insertion order nor last in sort order.
+    const obj = { c: formattable(visited, "c"), a: throwing(visited, "a"), b: formattable(visited, "b") };
+
+    expect(() => Bun.inspect(obj, { sorted: true })).toThrow("boom");
+    expect(visited).toEqual(["a"]);
+
+    visited.length = 0;
+    expect(() => Bun.inspect(obj)).toThrow("boom");
+    expect(visited).toEqual(["c", "a"]);
+  });
+
+  it("Bun.inspect.table", () => {
+    const visited = [];
+    const rows = [{ cell: { a: throwing(visited, "a"), b: formattable(visited, "b") } }];
+
+    expect(() => Bun.inspect.table(rows, { sorted: true })).toThrow("boom");
+    expect(visited).toEqual(["a"]);
+  });
+
+  it("does not read the following properties while the exception is pending", async () => {
+    // Most of the Bun object's properties are initialized lazily by a native
+    // callback the first time they are read. "A0" sorts right before one of them
+    // (Bun.Archive), so reading on with the exception from "A0" still pending
+    // trips the native callback's exception check in debug/ASAN builds.
+    const fixture = `
+      Bun.A0 = { [Symbol.for("nodejs.util.inspect.custom")]() { throw new Error("boom"); } };
+      try {
+        Bun.inspect(Bun, { sorted: true });
+        console.log("returned");
+      } catch (e) {
+        console.log("caught:", e.message);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("caught: boom\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -957,6 +957,17 @@ describe("a nested value throws while formatting with { sorted: true }", () => {
     expect(visited).toEqual(["c", "a"]);
   });
 
+  it("also stops the walks of the enclosing objects", () => {
+    const visited = [];
+    const obj = {
+      x: { a: throwing(visited, "a"), b: formattable(visited, "b") },
+      y: formattable(visited, "y"),
+    };
+
+    expect(() => Bun.inspect(obj, { sorted: true })).toThrow("boom");
+    expect(visited).toEqual(["a"]);
+  });
+
   it("Bun.inspect.table", () => {
     const visited = [];
     const rows = [{ cell: { a: throwing(visited, "a"), b: formattable(visited, "b") } }];


### PR DESCRIPTION
### Repro

```js
const custom = Symbol.for("nodejs.util.inspect.custom");
const obj = { a: { [custom]() { throw new Error("boom"); } }, b: 1 };

Bun.inspect(obj);                    // throws "boom"
Bun.inspect(obj, { sorted: true });  // returns "{\n  a: ,\n  b: 1,\n}"

// debug / ASAN build: aborts instead of returning
Bun.A0 = { [custom]() { throw new Error("boom"); } };
Bun.inspect(Bun, { sorted: true });
```

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: boom
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

The same walk is used for every object `bun test` formats for a snapshot, so on the unfixed build this records `{ "b": ... }` as the snapshot of an object whose `a` threw while being formatted (and `toMatchInlineSnapshot()` writes that into the test file), while the same getter on the property that happens to sort last fails the matcher.

### Cause

`JSC__JSValue__forEachPropertyOrdered` (`src/jsc/bindings/bindings.cpp`) called `iter(...)` for each key and just continued to the next one (there was a `// TODO: properly propagate exception upwards` above the call). With the callback's exception still pending, the loop called `getPropertySlot` for the next key. On the `Bun` object that key is a lazily initialized property backed by a native callback, whose exception check fires in debug/ASAN builds. In release builds the `tryClearException()` that guards the walk's own getter calls swallowed the callback's exception, so the result depended on the sort position of the throwing property: only an exception from the last key reached the caller.

### Fix

`RETURN_IF_EXCEPTION(scope, void())` after `iter(...)`, which is what the unordered `JSC__JSValue__forEachPropertyImpl` has done since #15985. Propagating is the contract the rest of the code already assumes: the function is exported as `check_slow`, `JSValue::for_each_property_ordered` checks the scope after the call, and both callers (`ConsoleObject` `print_object` and `pretty_format`) propagate the error. The ordered variant was the one place that did not honor it. Nothing else needed to change on the Rust side: both property callbacks already return with the exception pending, exactly like the unordered path.

### Tests

`test/js/bun/util/inspect.test.js`
- `sorted: true` throws and visits no further properties, same as the unsorted walk
- the throw inside a nested object also stops the enclosing object's walk (the exception crosses two levels of the function)
- `Bun.inspect.table(..., { sorted: true })`, the other caller of the ordered walk
- the `Bun` object case above, in a subprocess (aborts on an unfixed debug build, prints `returned` on an unfixed release build)

`test/js/bun/test/snapshot-tests/bun-snapshots.test.ts`
- a value two levels down whose `$$typeof` getter throws fails the snapshot matcher, and neither its siblings nor the outer object's remaining properties are formatted (this exercises the callback's `format()` error return as well as its `Tag::get` one); the inline snapshot argument is what the unfixed build used to record and match (`a` missing), so the test never writes anything on either build

All of these fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`. Also ran `bun-inspect-table.test.ts`, `console-table.test.ts` and `snapshot-tests/` against the debug build; the two failures there (`snapshots/snapshot.test.ts` "error snapshots" without a color TTY, and `pretty-format-overflow.test.ts` exiting 139 under ASAN) reproduce identically on a build without this change.

### Related, not changed here

- When formatting the received value of a failed `toEqual` throws, `DiffFormatter` goes on to format the expected value with the exception still pending and hits the same kind of assertion in debug builds. That is reachable today whenever the throwing property is the last one and is the subject of #28538 / #29784, so the new tests use snapshot matchers rather than `toEqual`.
- A formatting exception inside the snapshot matchers surfaces as `Failed to pretty format value: ` (the original error is dropped). This change makes that message consistent across properties; #37334 makes the matchers rethrow the original error instead. The two touch the same `describe` block in `bun-snapshots.test.ts`, and once #37334 is in, the new test here should expect `"boom"` instead of the wrapper message (whichever lands second picks that up).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->