### PR TITLE
test: strip seconds-formatted summary timings, run diffexample fixture from its own dir

### DIFF
--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -59,7 +59,7 @@ it("should link and unlink workspace package", async () => {
   );
   let { out, err } = await runBunInstall(env, link_dir);
   expect(err.split(/\r?\n/).slice(-2)).toEqual(["Saved lockfile", ""]);
-  expect(out.replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
+  expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
     "Done! Checked 3 packages (no changes)",
@@ -90,7 +90,7 @@ it("should link and unlink workspace package", async () => {
 
   err = await stderr.text();
   expect(err.split(/\r?\n/)).toEqual([""]);
-  expect((await stdout.text()).replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
+  expect((await stdout.text()).replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun link v1."),
     "",
     `installed moo@link:moo`,
@@ -143,7 +143,7 @@ it("should link and unlink workspace package", async () => {
 
   err = await stderr.text();
   expect(err.split(/\r?\n/)).toEqual([""]);
-  expect((await stdout.text()).replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
+  expect((await stdout.text()).replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun link v1."),
     "",
     `installed foo@link:foo`,
@@ -221,7 +221,7 @@ it("should link package", async () => {
   const err2 = await new Response(stderr2).text();
   expect(err2.split(/\r?\n/)).toEqual([""]);
   const out2 = await new Response(stdout2).text();
-  expect(out2.replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
+  expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun link v1."),
     "",
     `installed ${link_name}@link:${link_name}`,
@@ -314,7 +314,7 @@ it("should link scoped package", async () => {
   const err2 = await new Response(stderr2).text();
   expect(err2.split(/\r?\n/)).toEqual([""]);
   const out2 = await new Response(stdout2).text();
-  expect(out2.replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
+  expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun link v1."),
     "",
     `installed ${link_name}@link:${link_name}`,
@@ -404,7 +404,7 @@ it("should link dependency without crashing", async () => {
   const err2 = await new Response(stderr2).text();
   expect(err2.split(/\r?\n/).slice(-2)).toEqual(["Saved lockfile", ""]);
   const out2 = await new Response(stdout2).text();
-  expect(out2.replace(/\s*\[[0-9\.]+ms\]\s*$/, "").split(/\r?\n/)).toEqual([
+  expect(out2.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),
     "",
     `+ ${link_name}@link:${link_name}`,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1301,7 +1301,7 @@ describe("bun test", () => {
       stderr
         .replace(/bun-test-(.*)\.test\.ts/, "bun-test-*.test.ts")
         .trim()
-        .replace(/\[.*\ms\]/, "[xx ms]"),
+        .replace(/\[[\d.]+m?s\]/, "[xx ms]"),
     ).toMatchInlineSnapshot(`
       "bun-test-*.test.ts:
 
@@ -1422,7 +1422,7 @@ describe("bun test", () => {
     expect(
       stderr
         .replace(/bun-test-(.*)\.test\.ts/, "bun-test-*.test.ts")
-        .replace(/ \[[\d.]+ms\]/g, "") // Remove all timings
+        .replace(/ \[[\d.]+m?s\]/g, "") // Remove all timings
         .replace(/Ran \d+ tests across \d+ files?\.\s*$/, "Ran 2 tests across 1 file.") // Normalize test counts
         .trim(),
     ).toMatchInlineSnapshot(`

--- a/test/js/bun/test/printing/diffexample.test.ts
+++ b/test/js/bun/test/printing/diffexample.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe } from "harness";
 
 function cleanOutput(output: string) {
   return output
-    .replaceAll(/ \[[0-9\.]+ms\]/g, "")
+    .replaceAll(/ \[[0-9\.]+m?s\]/g, "")
     .replaceAll(/at <anonymous> \(.*\)/g, "at <anonymous> (FILE:LINE)")
     .replaceAll(
       "test\\js\\bun\\test\\printing\\diffexample.fixture.ts:",

--- a/test/js/bun/test/printing/diffexample.test.ts
+++ b/test/js/bun/test/printing/diffexample.test.ts
@@ -2,33 +2,34 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 function cleanOutput(output: string) {
-  return output
-    .replaceAll(/ \[[0-9\.]+m?s\]/g, "")
-    .replaceAll(/at <anonymous> \(.*\)/g, "at <anonymous> (FILE:LINE)")
-    .replaceAll(
-      "test\\js\\bun\\test\\printing\\diffexample.fixture.ts:",
-      "test/js/bun/test/printing/diffexample.fixture.ts:",
-    );
+  return output.replaceAll(/ \[[0-9\.]+m?s\]/g, "").replaceAll(/at <anonymous> \(.*\)/g, "at <anonymous> (FILE:LINE)");
 }
 function cleanAnsiEscapes(output: string) {
   return output.replaceAll(/\x1B\[[0-9;]*m/g, "");
 }
 
-test("no color", async () => {
-  const noColorSpawn = Bun.spawn({
+// cwd is pinned so the child does not load the repo bunfig.toml, whose test preload imports harness.ts.
+function runFixture() {
+  return Bun.spawn({
     cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
+    cwd: import.meta.dir,
     stdio: ["inherit", "pipe", "pipe"],
     env: {
       ...bunEnv,
       FORCE_COLOR: "0",
     },
   });
+}
+
+test("no color", async () => {
+  await using noColorSpawn = runFixture();
+  await using colorSpawn = runFixture();
   await noColorSpawn.exited;
   const noColorStderr = cleanOutput(await noColorSpawn.stderr.text());
   const noColorStdout = await noColorSpawn.stdout.text();
   expect(noColorStderr).toMatchInlineSnapshot(`
     "
-    test/js/bun/test/printing/diffexample.fixture.ts:
+    diffexample.fixture.ts:
     10 |     .replaceAll("\\\\", "/")
     11 |     .replaceAll(process.cwd(), "<cwd>");
     12 | }
@@ -725,14 +726,6 @@ test("no color", async () => {
   `);
   expect(noColorSpawn.exitCode).toBe(1);
 
-  const colorSpawn = Bun.spawn({
-    cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
-    stdio: ["inherit", "pipe", "pipe"],
-    env: {
-      ...bunEnv,
-      FORCE_COLOR: "0",
-    },
-  });
   await colorSpawn.exited;
   const colorStderr = cleanOutput(cleanAnsiEscapes(await colorSpawn.stderr.text()));
   const colorStdout = cleanAnsiEscapes(await colorSpawn.stdout.text());

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -32,7 +32,7 @@ describe("test.failing", () => {
       fail("Expected exit code to be non-zero\n\n" + stderr);
     }
     expect(stderr).toContain(" 2 fail\n");
-    expect(stderr.replaceAll(/ \[[\d.]+ms\]/g, "")).toMatchInlineSnapshot(`
+    expect(stderr.replaceAll(/ \[[\d.]+m?s\]/g, "")).toMatchInlineSnapshot(`
       "
       failing-test-passes.fixture.ts:
       (fail) This should fail but it doesnt

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -300,7 +300,7 @@ it("should return non-zero exit code for invalid syntax", async () => {
       env: bunEnv,
     });
     const err = (await stderr.text()).replaceAll("\\", "/");
-    expect(err.replaceAll(test_dir.replaceAll("\\", "/"), "<dir>").replaceAll(/\[(.*)\ms\]/g, "[xx ms]"))
+    expect(err.replaceAll(test_dir.replaceAll("\\", "/"), "<dir>").replaceAll(/\[[\d.]+m?s\]/g, "[xx ms]"))
       .toMatchInlineSnapshot(`
       "
       bad.test.js:

--- a/test/regression/issue/19850/19850.test.ts
+++ b/test/regression/issue/19850/19850.test.ts
@@ -17,7 +17,7 @@ describe("when beforeEach callback throws", () => {
     // the important part is not printing some gibberish in place of the second "test 1"
     err = err
       .replaceAll(import.meta.dir, "")
-      .replaceAll(/ \[[\d\.]+ms\]/g, "")
+      .replaceAll(/ \[[\d\.]+m?s\]/g, "")
       .replaceAll("\\", "/");
     expect(err).toBe(`
 err-in-hook-and-multiple-tests.ts:
@@ -56,11 +56,11 @@ Ran 2 tests across 1 file.
     const elapsed = Date.now() - start;
     expect(proc.exitCode).toBe(1);
     let err = await new Response(proc.stderr).text();
-    const matches = [...err.matchAll(/\[([\d\.]+)ms\]/g)];
+    const matches = [...err.matchAll(/\[([\d\.]+)(m?s)\]/g)];
     // 1 for test 0, 1 for the total
     expect(matches.length).toBe(2);
-    for (const match of matches) {
-      const ms = parseFloat(match[1]);
+    for (const [, value, unit] of matches) {
+      const ms = unit === "s" ? parseFloat(value) * 1000 : parseFloat(value);
       expect(ms).toBeGreaterThan(45); // should have slept for at least 50 ms
       expect(ms).toBeLessThan(2 * elapsed); // should not report a time vastly higher than what it actually took
     }


### PR DESCRIPTION
### Problem

`bun bd test test/js/bun/test/printing/diffexample.test.ts` fails the "no color" test on a debug (ASAN) build at current main, with no source changes. The only difference in the ~700 line inline snapshot is the summary line:

```
- Ran 19 tests across 1 file.
+ Ran 19 tests across 1 file. [2.41s]
```

### Cause

Two things combine here.

`Output::print_elapsed` (`src/bun_core/output.rs`) prints the total as `[N.NNms]` up to 1.5s and as `[N.NNs]` above that; the timer starts at process start. The test's `cleanOutput` only stripped `/ \[[0-9\.]+ms\]/`, so the snapshot and the later `colorStderr`/`noColorStderr` equality only hold while the child finishes in under 1.5s. Per-test timings are unaffected (`ElapsedFormatter` always prints `ms`); only the summary line switches units.

The reason this particular child takes ~2.5s on a debug build is mostly not the diffs: the test spawns `bun test` without a `cwd`, so the child inherits the repo root and loads the repo `bunfig.toml`, whose `[test] preload = "./test/preload.ts"` imports `harness.ts` into the child. On the debug build that import is ~1.8s of the ~2.5s (the same fixture run from its own directory prints `[~720ms]`; the 19 diffs themselves are under 0.5s). It also means the two sequential children in "no color" sit right at the test's 5s default timeout on a debug build (runs here landed between 4.9s and 5.0s), so widening the regex alone would only have traded the snapshot mismatch for an intermittent timeout in the same file.

The same `ms`-only strip is used against the same summary lines (from `bun test`, and from `bun install` / `bun link`, which share the formatter) in a few other files. Those files already spawn from a bunfig-free cwd, so they only cross 1.5s on a slow machine, but the normalizer has the same hole and is updated the same way:

- `test/regression/issue/19850/19850.test.ts` (the second test also counted `[..ms]` occurrences and expected the total to be one of them; it now accepts either unit and converts to ms)
- `test/js/bun/test/test-failing.test.ts`
- `test/js/bun/test/test-test.test.ts`
- `test/cli/test/bun-test.test.ts`
- `test/cli/install/bun-link.test.ts` (line 463 in the same file already accepted both units)

### Fix

- Accept both units in the normalizers (`m?s`), which is what `normalizeBunSnapshot` in `harness.ts` and the other install tests already do. The seconds format is intended output, so this is test-only.
- In `diffexample.test.ts`, run the fixture with `cwd: import.meta.dir`, as the other touched tests already do for their fixtures, and start both children before waiting on either. The snapshot header becomes the bare `diffexample.fixture.ts:`, which also makes the Windows backslash rewrite in `cleanOutput` unnecessary. No other snapshot content changes.

### Verification

- `bun bd test test/js/bun/test/printing/diffexample.test.ts`: failed before with the diff above; after, "no color" passes in 3 of 3 runs at 0.8s to 1.1s (it was 4.9s to 5.0s with only the regex change).
- `USE_SYSTEM_BUN=1 bun test` on the six files: all pass.
- `bun bd test` on the other five files: all touched tests pass. `bun-link.test.ts` "should link dependency without crashing" times out on the debug build with or without this change; that is a separate, pre-existing debug-only issue (the install failure path dumps a stack trace in debug builds) and is tracked separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->