### PR TITLE
bun:test: throw the formatter's own error from snapshot matchers instead of "Failed to pretty format value: "

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1182,14 +1182,7 @@ impl Expect {
             }
         }
 
-        if value.jest_snapshot_pretty_format(pretty_value, global_this).is_err() {
-            let mut formatter = ConsoleObject::Formatter::new(global_this);
-            return Err(global_this.throw(format_args!(
-                "Failed to pretty format value: {}",
-                value.to_fmt(&mut formatter),
-            )));
-        }
-        Ok(())
+        value.jest_snapshot_pretty_format(pretty_value, global_this)
     }
 
     pub(crate) fn snapshot(

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -273,11 +273,10 @@ pub mod expect {
                 out,
                 fmt_options,
             )?;
-            // `FormatOptions.flush` is false, so the formatter does not flush
-            // internally; a buffered `out` would otherwise drop trailing
-            // snapshot bytes. Every `Err` out of this function has a JS
-            // exception pending (the formatter throws before failing), so the
-            // writer error is thrown here too and callers can simply `?` it.
+            // The formatter ignores the result of its own flush. Throw the
+            // writer error here so that, like the formatter's failures, every
+            // `Err` from this function has a JS exception pending and callers
+            // can simply `?` it.
             out.flush().map_err(|e| global.throw_error(e, "snapshot writer flush failed"))?;
             Ok(())
         }

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -275,9 +275,9 @@ pub mod expect {
             )?;
             // `FormatOptions.flush` is false, so the formatter does not flush
             // internally; a buffered `out` would otherwise drop trailing
-            // snapshot bytes. Propagate the writer error as a thrown JS error
-            // so the caller's `.is_err()` branch
-            // (expect.rs `to_match_snapshot_value_kind`) fires.
+            // snapshot bytes. Every `Err` out of this function has a JS
+            // exception pending (the formatter throws before failing), so the
+            // writer error is thrown here too and callers can simply `?` it.
             out.flush().map_err(|e| global.throw_error(e, "snapshot writer flush failed"))?;
             Ok(())
         }

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -273,10 +273,7 @@ pub mod expect {
                 out,
                 fmt_options,
             )?;
-            // The formatter ignores the result of its own flush. Throw the
-            // writer error here so that, like the formatter's failures, every
-            // `Err` from this function has a JS exception pending and callers
-            // can simply `?` it.
+            // The formatter ignores its own flush result; a writer error has to be thrown like any other failure.
             out.flush().map_err(|e| global.throw_error(e, "snapshot writer flush failed"))?;
             Ok(())
         }

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -61,4 +61,106 @@ describe("toMatchSnapshot errors", () => {
       expect({ a: 4 }).toMatchSnapshot({ a: expect.any("not a constructor") });
     }).toThrow();
   });
+
+  describe("when formatting the received value throws", () => {
+    // The snapshot formatter reads `$$typeof` off every object (React element
+    // detection), `size` off Maps and Sets, and JSON-stringifies Dates, so
+    // user code on any of those runs while the value is being formatted.
+    const received: [string, () => unknown][] = [
+      [
+        "$$typeof getter on the received value",
+        () => ({
+          get $$typeof(): unknown {
+            throw new Error("boom");
+          },
+        }),
+      ],
+      [
+        "$$typeof getter on a nested value",
+        () => ({
+          a: {
+            get $$typeof(): unknown {
+              throw new Error("boom");
+            },
+          },
+        }),
+      ],
+      [
+        "size getter on a Map",
+        () =>
+          Object.defineProperty(new Map(), "size", {
+            get() {
+              throw new Error("boom");
+            },
+          }),
+      ],
+      [
+        "size getter on a Set",
+        () =>
+          Object.defineProperty(new Set(), "size", {
+            get() {
+              throw new Error("boom");
+            },
+          }),
+      ],
+      [
+        "toJSON on a Date",
+        () =>
+          Object.assign(new Date(0), {
+            toJSON() {
+              throw new Error("boom");
+            },
+          }),
+      ],
+    ];
+
+    it.each(received)("toMatchSnapshot throws the error from the %s", (_, makeValue) => {
+      expect(() => expect(makeValue()).toMatchSnapshot()).toThrow("boom");
+    });
+
+    it.each(received)("toMatchInlineSnapshot throws the error from the %s", (_, makeValue) => {
+      // Passing the inline snapshot means a build that does not throw fails on
+      // the mismatch instead of writing into this file.
+      expect(() => expect(makeValue()).toMatchInlineSnapshot(`"never recorded"`)).toThrow("boom");
+    });
+
+    it("throws the exception itself rather than a wrapper", () => {
+      const error = new Error("boom");
+      const value = {
+        get $$typeof(): unknown {
+          throw error;
+        },
+      };
+
+      let thrown: unknown;
+      try {
+        expect(value).toMatchSnapshot();
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+
+      thrown = undefined;
+      try {
+        expect(value).toMatchInlineSnapshot(`"never recorded"`);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(error);
+    });
+
+    it("still throws the formatting error after the property matchers matched", () => {
+      // A fresh object per call: matching property matchers writes them into the received object.
+      const makeValue = () => ({
+        n: 1,
+        get $$typeof(): unknown {
+          throw new Error("boom");
+        },
+      });
+      expect(() => expect(makeValue()).toMatchSnapshot({ n: expect.any(Number) })).toThrow("boom");
+      expect(() => expect(makeValue()).toMatchInlineSnapshot({ n: expect.any(Number) }, `"never recorded"`)).toThrow(
+        "boom",
+      );
+    });
+  });
 });

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -76,6 +76,8 @@ describe("toMatchSnapshot errors", () => {
         }),
       ],
       [
+        // Keep this a single property: until #37331 lands, the property walk
+        // only surfaces an exception thrown while formatting the last key.
         "$$typeof getter on a nested value",
         () => ({
           a: {
@@ -150,7 +152,7 @@ describe("toMatchSnapshot errors", () => {
     });
 
     it("still throws the formatting error after the property matchers matched", () => {
-      // A fresh object per call: matching property matchers writes them into the received object.
+      // Fresh object per call: matched property matchers are written into the received object (#3521).
       const makeValue = () => ({
         n: 1,
         get $$typeof(): unknown {


### PR DESCRIPTION
### Repro

```ts
import { expect, test } from "bun:test";

test("x", () => {
  const value = { a: { get $$typeof() { throw new Error("boom"); } } };
  expect(value).toMatchSnapshot(); // same with toMatchInlineSnapshot()
});
```

Before (release and debug builds alike), the matcher throws an error that says nothing about what went wrong:

```
error: Failed to pretty format value: 
```

After, `Error: boom` with the getter's stack comes out of the matcher. The snapshot formatter reads `$$typeof` off every object it visits (React element detection), `size` off Maps and Sets, and JSON-stringifies Dates, so a throwing getter or `toJSON` on any of those reaches this path.

### Cause

`Expect::match_and_fmt_snapshot` (`src/runtime/test_runner/expect.rs`) ignored the `Err` from `jest_snapshot_pretty_format` and threw a fresh `Failed to pretty format value: {value}` error instead. At that point the getter's exception is still pending on the VM, so formatting `{value}` for the new message fails too (the console formatter bails when an exception is pending), and `create_error_instance` handles that by clearing the pending exception and throwing whatever prefix had been written. The user's error is lost, and the message is cut off after the colon.

The wrapper dates from the Zig version, where `jestSnapshotPrettyFormat` had an inferred error set that also carried plain writer errors with no JS exception behind them. The Rust port returns `JsResult<()>` and throws the flush error itself, so every `Err` it returns is one of:

- `Thrown`: the real exception is pending. Every `?` inside `pretty_format.rs` is on a throwing JSC call, and the four `write_format` branches (Response/Request/Blob/BuildArtifact) explicitly throw when nothing is pending.
- `OutOfMemory` / `Terminated`: the host function wrapper (`to_js_host_call`) turns these into an `OutOfMemoryError` / leaves the termination pending.

So there is nothing left for the wrapper to convert; it only ever replaced the real error with an empty one.

### Fix

Return the result of `jest_snapshot_pretty_format` directly, the same way the property matcher check a few lines above already propagates exceptions from `jest_deep_match`. All four snapshot matchers (`toMatchSnapshot`, `toMatchInlineSnapshot`, `toThrowErrorMatchingSnapshot`, `toThrowErrorMatchingInlineSnapshot`) go through this function. Formatting happens before the snapshot store is consulted, so nothing is written in either the old or the new behavior; the only change is which error is thrown.

This matches Jest, where an error thrown while pretty-format serializes the value propagates out of the matcher with its original message (plugin `test()` errors are rewrapped as `PrettyFormatPluginError`, keeping the message and stack).

The comment in `mod.rs` next to the flush error pointed at the removed branch, so it is replaced with a one-liner.

### Tests

`test/js/bun/test/snapshot-tests/bun-snapshots.test.ts`, new `describe("when formatting the received value throws")`:

- `toMatchSnapshot()` and `toMatchInlineSnapshot(...)` with a throwing `$$typeof` getter on the received value (the `Tag::get` call at the top of the formatter), on a nested value (the property walk), a throwing `size` getter on a Map and on a Set, and a throwing `toJSON` on a Date, each asserting the thrown message is the getter's
- the thrown value is the getter's own Error object, not a wrapper
- the error still propagates when property matchers were passed and matched first

The inline snapshot cases pass a snapshot argument, so a build that does not throw fails on the mismatch instead of writing into the test file. The 12 new cases fail on the released build and on a debug build without the `src/` change (all with `Received message: "Failed to pretty format value: "`) and pass with it, including under `BUN_JSC_validateExceptionChecks=1`. The rest of `test/js/bun/test/snapshot-tests/` and `ci-restrictions.test.ts` pass with the change.

Related: #37331 makes the ordered property walk stop at a throwing property; without it a throwing nested getter that does not sort last is dropped from the output before reaching this code, which is why the nested test case uses a single property. Its added test in this same file currently asserts the old `Failed to pretty format value` message, so whichever of the two lands second needs to update that assertion to the getter's message. The property matcher test builds a fresh object per call because matched matchers are written into the received object (#3521, being removed in #35452).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
bun test v1.4.0 (519f50961)

test/js/bun/test/snapshot-tests/bun-snapshots.test.ts:
(pass) it will create a snapshot file if it doesn't exist [35.62ms]
(pass) toMatchSnapshot errors > should throw if property matchers exist and received is not an object [5.55ms]
(pass) toMatchSnapshot errors > should throw if property matchers don't match [15.43ms]
(pass) toMatchSnapshot errors > should throw if arguments are in the wrong order [5.62ms]
(pass) toMatchSnapshot errors > should throw if expect.any() doesn't received a constructor [7.69ms]
115 |           }),
116 |       ],
117 |     ];
118 | 
119 |     it.each(received)("toMatchSnapshot throws the error from the %s", (_, makeValue) => {
120 |       expect(() => expect(makeValue()).toMatchSnapshot()).toThrow("boom");
                                                                ^
error: expect(received).toThrow(expected)

Expected substring: "boom"
Received message: "Failed to pretty format value: "

      at <anonymous> (/workspace/b
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a79f8cfd1)

test/js/bun/test/snapshot-tests/bun-snapshots.test.ts:
(pass) it will create a snapshot file if it doesn't exist [3.80ms]
(pass) toMatchSnapshot errors > should throw if property matchers exist and received is not an object [0.09ms]
(pass) toMatchSnapshot errors > should throw if property matchers don't match [1.44ms]
(pass) toMatchSnapshot errors > should throw if arguments are in the wrong order [0.05ms]
(pass) toMatchSnapshot errors > should throw if expect.any() doesn't received a constructor [0.06ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the $$typeof getter on the received value [0.06ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the $$typeof getter on a nested value [0.02ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the size getter on a Map [0.04ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the size getter on a Set [0.02ms]
(pass) toMatc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
bun test v1.4.0 (519f50961)

test/js/bun/test/snapshot-tests/bun-snapshots.test.ts:
(pass) it will create a snapshot file if it doesn't exist [28.37ms]
(pass) toMatchSnapshot errors > should throw if property matchers exist and received is not an object [6.96ms]
(pass) toMatchSnapshot errors > should throw if property matchers don't match [24.16ms]
(pass) toMatchSnapshot errors > should throw if arguments are in the wrong order [9.75ms]
(pass) toMatchSnapshot errors > should throw if expect.any() doesn't received a constructor [13.55ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the $$typeof getter on the received value [8.48ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the $$typeof getter on a nested value [4.84ms]
(pass) toMatchSnapshot errors > when formatting the received value throws > toMatchSnapshot throws the error from the size gette
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1214ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/28] gen JS modules (bundle-modules)
Preprocess modules (15509ms)
Bundle modules (249ms)
Postprocesss modules (878ms)
Bundle Functions (1878ms)
Generate Code (41ms)

[18.58s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/28] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_z
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect.rs                  |   9 +-
 src/runtime/test_runner/mod.rs                     |   6 +-
 .../bun/test/snapshot-tests/bun-snapshots.test.ts  | 104 +++++++++++++++++++++
 3 files changed, 106 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/test_runner/expect.rs                          1      1      0
src/runtime/test_runner/mod.rs                             3      3      0
test/js/bun/test/snapshot-tests/bun-snapshots.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->