### PR TITLE
install: make the debug-build stack dump on package install failure opt-in

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -2197,7 +2197,9 @@ impl<'a> PackageInstaller<'a> {
                                 ),
                             ),
                         );
-                        // Opt-in: symbolizing the debug binary costs seconds per failed package.
+                        // Opt-in: these are ordinary user-facing failures, and this dump lands in
+                        // the install output on every platform (on Linux through llvm-symbolizer,
+                        // which also costs seconds per failed package).
                         #[cfg(bun_debug)]
                         if PackageInstaller.is_visible() {
                             bun_crash_handler::dump_stack_trace(

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -2197,10 +2197,13 @@ impl<'a> PackageInstaller<'a> {
                                 ),
                             ),
                         );
+                        // Opt-in: symbolizing the debug binary costs seconds per failed package.
                         #[cfg(bun_debug)]
-                        {
-                            let t = cause.debug_trace;
-                            bun_crash_handler::dump_stack_trace(&t.trace(), Default::default());
+                        if PackageInstaller.is_visible() {
+                            bun_crash_handler::dump_stack_trace(
+                                &cause.debug_trace.trace(),
+                                Default::default(),
+                            );
                         }
                         self.summary.fail += 1;
                     }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -2197,9 +2197,7 @@ impl<'a> PackageInstaller<'a> {
                                 ),
                             ),
                         );
-                        // Opt-in: these are ordinary user-facing failures, and this dump lands in
-                        // the install output on every platform (on Linux through llvm-symbolizer,
-                        // which also costs seconds per failed package).
+                        // Opt-in: ordinary failures; the dump would land in the install output.
                         #[cfg(bun_debug)]
                         if PackageInstaller.is_visible() {
                             bun_crash_handler::dump_stack_trace(

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -458,7 +458,12 @@ it("should link dependency without crashing", async () => {
     env,
   });
   const err4 = await new Response(stderr4).text();
-  expect(err4).toContain(`FileNotFound: failed linking dependency/workspace to node_modules for package ${link_name}`);
+  // Debug builds used to follow this line with a stack trace (stdout on Linux,
+  // stderr elsewhere); neither stream may carry it unless opted into.
+  expect(err4.split(/\r?\n/)).toEqual([
+    `FileNotFound: failed linking dependency/workspace to node_modules for package ${link_name}`,
+    "",
+  ]);
   const out4 = await new Response(stdout4).text();
   expect(out4.replace(/\[[0-9\.]+m?s\]/, "[]").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun install v1."),

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -458,8 +458,9 @@ it("should link dependency without crashing", async () => {
     env,
   });
   const err4 = await new Response(stderr4).text();
-  // Debug builds used to follow this line with a stack trace (stdout on Linux,
-  // stderr elsewhere); neither stream may carry it unless opted into.
+  // Debug builds used to follow this line with a stack trace (on stdout via
+  // llvm-symbolizer on Linux, on stderr elsewhere); neither stream may carry it
+  // unless BUN_DEBUG_PackageInstaller=1 is set.
   expect(err4.split(/\r?\n/)).toEqual([
     `FileNotFound: failed linking dependency/workspace to node_modules for package ${link_name}`,
     "",


### PR DESCRIPTION
### Problem

`bun bd test test/cli/install/bun-link.test.ts` fails on a debug build at current main:

```
(fail) should link dependency without crashing [5024.86ms]
  ^ this test timed out after 5000ms.
```

The other three tests in the file pass, and all four pass with a release binary (`USE_SYSTEM_BUN=1`).

The last step of that test runs `bun install` after the linked package was unlinked and expects exit 1 with a one line error on stderr and a clean summary on stdout. Running the same steps by hand against `build/debug/bun-debug`, the first three steps take about 100-130ms each and the failing install takes about 5.2s, with stdout looking like this:

```
bun install v1.4.0 (827475e21)
<bun_install::package_install::InstallResult>::fail
/workspace/bun/src/install/PackageInstall.rs:216:25

<bun_install::package_install::PackageInstall>::install_from_link
/workspace/bun/src/install/PackageInstall.rs:2145:28
... 11 more frames ...

Failed to install 1 package
[5.17s] done
```

### Cause

The `else` branch of the install failure reporting in `src/install/PackageInstaller.rs` (the branch that prints `failed <step> for package <name>`) has a `#[cfg(bun_debug)]` block that passes the trace captured by `InstallResult::fail` to `bun_crash_handler::dump_stack_trace`. That function is the crash path dumper: on Linux debug builds it spawns `llvm-symbolizer` against the debug binary with inherited stdio, so it costs several seconds per failed package and the frames land on stdout, inside the install summary. When no symbolizer is on `PATH` it prints `Failed to invoke command: llvm-symbolizer ...` plus the WTF fallback trace to stderr, and on macOS it writes the trace to stderr, so the dump shows up on one stream or the other on every platform. The crash handler already moved its other non-fatal callers off this path for the same reason (see the comment on `dump_current_stack_trace_from_core`); this was the last non-crash caller.

The branch is reached by ordinary user facing failures (a `link:` dependency whose target was unlinked, as here, or copy, extract and patch failures), not by bugs in bun, so every such failure in a debug build paid for the symbolizer run. Every `InstallResult::fail` call site passes `None` for the trace, so what gets dumped is the plain call stack at the failure site, which is developer diagnostics rather than something the default output needs.

### Fix

Gate the dump behind the `PackageInstaller` debug scope that is already declared in this file and used for the per package `Installing x@y` log, so it is off by default (including under the test harness, which sets `BUN_DEBUG_QUIET_LOGS=1`) and `BUN_DEBUG_PackageInstaller=1` still prints it. The scope check is the mechanism the codebase already uses for verbose debug build diagnostics, and it keeps the full source line trace available when someone is actually debugging the installer. Release builds are unaffected: the block is still compiled out there.

The test's stderr assertion for the failing install is tightened from `toContain` to the exact line, so the stderr variants of the dump (no symbolizer on `PATH`, macOS) fail the test too; before this change only the Linux-with-symbolizer variant was caught, via the stdout assertion and the timeout.

### Verification

- `bun bd test test/cli/install/bun-link.test.ts`: before, `should link dependency without crashing` times out at 5s; with `PATH` stripped of `llvm-symbolizer` it instead fails the tightened stderr assertion with the `Failed to invoke command: llvm-symbolizer ...` lines and the fallback frames. After, all 4 tests pass and that test takes about 530ms.
- `USE_SYSTEM_BUN=1 bun test test/cli/install/bun-link.test.ts`: passes before and after (release builds never had the dump).
- Manually, with the fixed debug binary: the failing install takes 132ms with a one line stderr and a clean stdout by default, and with `BUN_DEBUG_PackageInstaller=1` it prints `[packageinstaller] Installing zzlinkpkg@link:zzlinkpkg` followed by the same symbolized trace as before (5.2s). The opt-in path is not covered by an automated test: it is debug build only and its runtime is the symbolizer run this change takes off the default path.
- `bun bd test` on `bun-install-hardlink-fallback.test.ts` and `symlink-path-traversal.test.ts` still passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-link.test.ts

<!-- robobun:evidence:end -->