### PR TITLE
node:module: build require.cache without user-writable globals and propagate its exceptions

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -223,10 +223,9 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
 }
 
 $visibility = "Private";
-export function createRequireCache() {
-  var moduleMap = new Map();
+export function createRequireCache(Proxy: ProxyConstructor, inspectCustom: symbol) {
   var inner = {
-    [Symbol.for("nodejs.util.inspect.custom")]() {
+    [inspectCustom]() {
       return { ...proxy };
     },
   };
@@ -254,7 +253,6 @@ export function createRequireCache() {
     },
 
     deleteProperty(_target, key: string) {
-      moduleMap.$delete(key);
       $requireMap.$delete(key);
       $esmRegistryDelete(key);
       $evictIsolationSourceProviderCache(key);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -350,8 +350,11 @@ JSC_DEFINE_HOST_FUNCTION(requireResolvePathsFunction, (JSGlobalObject * globalOb
 
 JSC_DEFINE_CUSTOM_GETTER(jsRequireCacheGetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
-    return JSValue::encode(thisObject->lazyRequireCacheObject());
+    JSObject* cache = thisObject->lazyRequireCacheObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(cache);
 }
 
 JSC_DEFINE_CUSTOM_SETTER(jsRequireCacheSetter,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -52,6 +52,8 @@
 #include "JavaScriptCore/LazyClassStructure.h"
 #include "JavaScriptCore/LazyClassStructureInlines.h"
 #include "JavaScriptCore/ObjectConstructor.h"
+#include "JavaScriptCore/ProxyConstructorInlines.h"
+#include "JavaScriptCore/Symbol.h"
 #include "JavaScriptCore/JSBasePrivate.h"
 #include "JavaScriptCore/ScriptExecutable.h"
 #include "JavaScriptCore/ScriptFetchParameters.h"
@@ -2782,7 +2784,13 @@ JSC::JSObject* GlobalObject::lazyRequireCacheObject()
     auto& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* function = JSFunction::create(vm, this, commonJSCreateRequireCacheCodeGenerator(vm), this);
-    JSValue result = JSC::profiledCall(this, ProfilingReason::API, function, JSC::getCallData(function), this, ArgList());
+
+    // Passed in so the builtin never reads globalThis.Proxy or globalThis.Symbol, which user code can replace.
+    MarkedArgumentBuffer args;
+    args.append(JSC::ProxyConstructor::create(vm, JSC::ProxyConstructor::createStructure(vm, this, functionPrototype())));
+    args.append(JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey("nodejs.util.inspect.custom"_s)));
+
+    JSValue result = JSC::profiledCall(this, ProfilingReason::API, function, JSC::getCallData(function), this, args);
     RETURN_IF_EXCEPTION(scope, nullptr);
     JSObject* cache = asObject(result);
     m_lazyRequireCacheObject.set(vm, this, cache);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2774,6 +2774,21 @@ EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
     return JSC::JSValue::encode(result);
 }
 
+JSC::JSObject* GlobalObject::lazyRequireCacheObject()
+{
+    if (JSObject* cache = m_lazyRequireCacheObject.get())
+        return cache;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* function = JSFunction::create(vm, this, commonJSCreateRequireCacheCodeGenerator(vm), this);
+    JSValue result = JSC::profiledCall(this, ProfilingReason::API, function, JSC::getCallData(function), this, ArgList());
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    JSObject* cache = asObject(result);
+    m_lazyRequireCacheObject.set(vm, this, cache);
+    return cache;
+}
+
 JSC::GCClient::IsoSubspace* GlobalObject::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<GlobalObject, WebCore::UseCustomHeapCellType::Yes>(vm, BUN_SUBSPACE_SLOTS(m_clientSubspaceForWorkerGlobalScope, m_subspaceForWorkerGlobalScope),

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -281,7 +281,7 @@ public:
     JSObject* processBindingFs() const { return m_processBindingFs.getInitializedOnMainThread(this); }
     JSObject* processBindingHTTPParser() const { return m_processBindingHTTPParser.getInitializedOnMainThread(this); }
 
-    JSObject* lazyRequireCacheObject() const { return m_lazyRequireCacheObject.getInitializedOnMainThread(this); }
+    JSObject* lazyRequireCacheObject();
     Bun::JSCommonJSExtensions* lazyRequireExtensionsObject() const { return m_lazyRequireExtensionsObject.getInitializedOnMainThread(this); }
     JSC::JSFunction* modulePrototypeUnderscoreCompileFunction() const { return m_modulePrototypeUnderscoreCompileFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* requireESMFromHijackedExtension() const { return m_commonJSRequireESMFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
@@ -620,7 +620,7 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSBufferSubclassStructure)                           \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSResizableOrGrowableSharedBufferSubclassStructure)  \
     V(private, LazyPropertyOfGlobalObject<JSWeakMap>, m_vmModuleContextMap)                                  \
-    V(public, LazyPropertyOfGlobalObject<JSObject>, m_lazyRequireCacheObject)                                \
+    V(private, WriteBarrier<JSObject>, m_lazyRequireCacheObject)                                             \
     V(public, LazyPropertyOfGlobalObject<Bun::JSCommonJSExtensions>, m_lazyRequireExtensionsObject)          \
     V(private, LazyPropertyOfGlobalObject<JSObject>, m_lazyTestModuleObject)                                 \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_testMatcherUtilsObject)                                \

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -603,8 +603,11 @@ JSC_DEFINE_CUSTOM_SETTER(setterRequireFunction,
 
 static JSValue getModuleCacheObject(VM& vm, JSObject* moduleObject)
 {
-    return uncheckedDowncast<Zig::GlobalObject>(moduleObject->globalObject())
-        ->lazyRequireCacheObject();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* cache = uncheckedDowncast<Zig::GlobalObject>(moduleObject->globalObject())
+                          ->lazyRequireCacheObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return cache;
 }
 
 static JSValue getModuleExtensionsObject(VM& vm, JSObject* moduleObject)
@@ -1157,19 +1160,6 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
         [](const Zig::GlobalObject::Initializer<JSFunction>& init) {
             JSC::JSFunction* requireESM = JSC::JSFunction::create(init.vm, init.owner, commonJSRequireESMFromHijackedExtensionCodeGenerator(init.vm), init.owner);
             init.set(requireESM);
-        });
-
-    globalObject->m_lazyRequireCacheObject.initLater(
-        [](const Zig::GlobalObject::Initializer<JSObject>& init) {
-            JSC::VM& vm = init.vm;
-            JSC::JSGlobalObject* globalObject = init.owner;
-
-            auto* function = JSFunction::create(vm, globalObject, static_cast<JSC::FunctionExecutable*>(commonJSCreateRequireCacheCodeGenerator(vm)), globalObject);
-
-            NakedPtr<JSC::Exception> returnedException = nullptr;
-            auto result = JSC::profiledCall(globalObject, ProfilingReason::API, function, JSC::getCallData(function), globalObject, ArgList(), returnedException);
-            ASSERT(!returnedException);
-            init.set(result.toObject(globalObject));
         });
 
     globalObject->m_lazyRequireExtensionsObject.initLater(

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -867,37 +867,43 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
-  test("require.cache first accessed near the stack limit does not crash", async () => {
+  test("require.cache first accessed near the stack limit throws, and the next access builds it", async () => {
     // Building the cache can fail for reasons that have nothing to do with user
     // code, such as a stack overflow inside the builtin. The failure must throw,
-    // and a later access at normal depth must build the cache.
+    // nothing may be cached, and a later access at normal depth must build the
+    // real cache, not a stand-in object.
     const code = `
       const Module = require("node:module");
       // The deepest frame probes require.cache, then rethrows so the next frame
       // up probes Module._cache. Every frame above that returns normally.
-      let attempts = 0;
+      const probes = [];
       function recurse() {
         try {
           recurse();
         } catch (e) {
-          if (attempts === 0) {
-            attempts++;
-            try {
-              require.cache;
-            } catch {}
-          } else if (attempts === 1) {
-            attempts++;
-            try {
-              Module._cache;
-            } catch {}
-          } else {
-            return;
+          if (probes.length === 2) return;
+          try {
+            probes.push(typeof (probes.length === 0 ? require.cache : Module._cache));
+          } catch (err) {
+            probes.push(err.constructor.name);
           }
           throw e;
         }
       }
       recurse();
-      console.log(JSON.stringify([attempts, typeof require.cache, Module._cache === require.cache]));
+      const cache = require.cache;
+      const hasEvalEntry = Object.keys(cache).some(key => key.endsWith("[eval]"));
+      const marker = {};
+      cache.fs = { exports: marker };
+      console.log(
+        JSON.stringify([
+          probes,
+          Object.getPrototypeOf(cache),
+          Module._cache === cache,
+          hasEvalEntry,
+          require("fs") === marker,
+        ]),
+      );
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", code],
@@ -905,7 +911,7 @@ console.log("survived", require("./late.js"));`,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe(JSON.stringify([2, "object", true]));
+    expect(stdout.trim()).toBe(JSON.stringify([["RangeError", "RangeError"], null, true, true, true]));
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -873,6 +873,8 @@ console.log("survived", require("./late.js"));`,
     // and a later access at normal depth must build the cache.
     const code = `
       const Module = require("node:module");
+      // The deepest frame probes require.cache, then rethrows so the next frame
+      // up probes Module._cache. Every frame above that returns normally.
       let attempts = 0;
       function recurse() {
         try {
@@ -888,11 +890,14 @@ console.log("survived", require("./late.js"));`,
             try {
               Module._cache;
             } catch {}
+          } else {
+            return;
           }
+          throw e;
         }
       }
       recurse();
-      console.log(JSON.stringify([typeof require.cache, Module._cache === require.cache]));
+      console.log(JSON.stringify([attempts, typeof require.cache, Module._cache === require.cache]));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", code],
@@ -900,7 +905,7 @@ console.log("survived", require("./late.js"));`,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe(JSON.stringify(["object", true]));
+    expect(stdout.trim()).toBe(JSON.stringify([2, "object", true]));
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -874,23 +874,26 @@ console.log("survived", require("./late.js"));`,
     // real cache, not a stand-in object.
     const code = `
       const Module = require("node:module");
-      // The deepest frame probes require.cache, then rethrows so the next frame
-      // up probes Module._cache. Every frame above that returns normally.
-      const probes = [];
-      function recurse() {
-        try {
-          recurse();
-        } catch (e) {
-          if (probes.length === 2) return;
+      // One recursion per accessor. Only the deepest frame catches the overflow,
+      // and there any call into the builtin overflows again, so the probe result
+      // does not depend on frame sizes.
+      function probe(useModuleCache) {
+        let outcome;
+        function recurse() {
           try {
-            probes.push(typeof (probes.length === 0 ? require.cache : Module._cache));
-          } catch (err) {
-            probes.push(err.constructor.name);
+            recurse();
+          } catch {
+            try {
+              outcome = typeof (useModuleCache ? Module._cache : require.cache);
+            } catch (err) {
+              outcome = err.constructor.name;
+            }
           }
-          throw e;
         }
+        recurse();
+        return outcome;
       }
-      recurse();
+      const probes = [probe(false), probe(true)];
       const cache = require.cache;
       const hasEvalEntry = Object.keys(cache).some(key => key.endsWith("[eval]"));
       const marker = {};

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -836,29 +836,25 @@ console.log("survived", require("./late.js"));`,
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });
 
-  test("require.cache throws instead of crashing when its builtin throws", async () => {
-    // require.cache is built lazily by a JS builtin that uses the global Proxy.
-    // The first access used to assume that builtin cannot throw.
+  test("require.cache does not depend on user-writable globals", async () => {
+    // require.cache is built lazily by a JS builtin. Native code hands it the
+    // Proxy constructor and the inspect symbol, so it never reads the globals.
     const code = `
-      const RealProxy = Proxy;
-      globalThis.Proxy = undefined;
-      const results = [];
-      try {
-        require.cache;
-        results.push("no throw");
-      } catch (e) {
-        results.push(e.constructor.name);
-      }
-      const Module = require("module");
-      try {
-        Module._cache;
-        results.push("no throw");
-      } catch (e) {
-        results.push(e.constructor.name);
-      }
-      globalThis.Proxy = RealProxy;
-      results.push(typeof require.cache, Module._cache === require.cache);
-      console.log(JSON.stringify(results));
+      const Module = require("node:module");
+      const { Proxy, Map, Symbol } = globalThis;
+      delete globalThis.Proxy;
+      globalThis.Map = globalThis.Symbol = undefined;
+      const cache = require.cache;
+      const moduleCache = Module._cache;
+      Object.assign(globalThis, { Proxy, Map, Symbol });
+      console.log(
+        JSON.stringify([
+          Object.getPrototypeOf(cache),
+          moduleCache === cache,
+          Object.keys(cache).map(key => key.endsWith("[eval]")),
+          Bun.inspect(cache).includes("[eval]"),
+        ]),
+      );
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", code],
@@ -866,28 +862,37 @@ console.log("survived", require("./late.js"));`,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe(JSON.stringify(["TypeError", "TypeError", "object", true]));
+    expect(stdout.trim()).toBe(JSON.stringify([null, true, [true], true]));
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
 
   test("require.cache first accessed near the stack limit does not crash", async () => {
+    // Building the cache can fail for reasons that have nothing to do with user
+    // code, such as a stack overflow inside the builtin. The failure must throw,
+    // and a later access at normal depth must build the cache.
     const code = `
-      let attempted = false;
+      const Module = require("node:module");
+      let attempts = 0;
       function recurse() {
         try {
           recurse();
         } catch (e) {
-          if (!attempted) {
-            attempted = true;
+          if (attempts === 0) {
+            attempts++;
             try {
               require.cache;
+            } catch {}
+          } else if (attempts === 1) {
+            attempts++;
+            try {
+              Module._cache;
             } catch {}
           }
         }
       }
       recurse();
-      console.log(typeof require.cache);
+      console.log(JSON.stringify([typeof require.cache, Module._cache === require.cache]));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", code],
@@ -895,7 +900,7 @@ console.log("survived", require("./late.js"));`,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("object");
+    expect(stdout.trim()).toBe(JSON.stringify(["object", true]));
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -836,6 +836,70 @@ console.log("survived", require("./late.js"));`,
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });
 
+  test("require.cache throws instead of crashing when its builtin throws", async () => {
+    // require.cache is built lazily by a JS builtin that uses the global Proxy.
+    // The first access used to assume that builtin cannot throw.
+    const code = `
+      const RealProxy = Proxy;
+      globalThis.Proxy = undefined;
+      const results = [];
+      try {
+        require.cache;
+        results.push("no throw");
+      } catch (e) {
+        results.push(e.constructor.name);
+      }
+      const Module = require("module");
+      try {
+        Module._cache;
+        results.push("no throw");
+      } catch (e) {
+        results.push(e.constructor.name);
+      }
+      globalThis.Proxy = RealProxy;
+      results.push(typeof require.cache, Module._cache === require.cache);
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe(JSON.stringify(["TypeError", "TypeError", "object", true]));
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("require.cache first accessed near the stack limit does not crash", async () => {
+    const code = `
+      let attempted = false;
+      function recurse() {
+        try {
+          recurse();
+        } catch (e) {
+          if (!attempted) {
+            attempted = true;
+            try {
+              require.cache;
+            } catch {}
+          }
+        }
+      }
+      recurse();
+      console.log(typeof require.cache);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("object");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("Module.runMain", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Problem
- The first access of `require.cache` or `Module._cache` aborts when the `createRequireCache` builtin throws. Debug: `ASSERTION FAILED: !returnedException` at `src/jsc/modules/NodeModuleModule.cpp:1171`. Release: `panic(main thread): abort() called`.
- The builtin ran inside a `LazyProperty` initializer, which cannot fail. It read `Map`, `Symbol.for` and `Proxy` from the global object, so `globalThis.Proxy = undefined; require.cache` threw. A first access near the stack limit threw with no tampering.

### Fix
- `m_lazyRequireCacheObject` becomes a `WriteBarrier<JSObject>` filled by `GlobalObject::lazyRequireCacheObject()`. It returns `nullptr` with the exception pending when the builtin throws. The `require.cache` getter and the `Module._cache` property callback propagate it. A failure caches nothing, so the next access retries.
- Native code passes the builtin a `ProxyConstructor` it creates and the registered `nodejs.util.inspect.custom` symbol. The builtin reads no user-writable global. The unused `moduleMap` is gone (from #40285).
- Correct because the cache is built from intrinsics, like Node's `Module._cache`. The failure modes left (stack overflow, OOM, termination) now surface as exceptions.
- Verified: `test/js/node/module/node-module-module.test.js` (two new tests, both abort on main). Also `require-extensions.test.ts` and the `node:module` GC tests.

### Background
- A `LazyProperty` is JSC's lazily built slot. Its initializer must call `init.set` with a non-null value (`LazyProperty::set` has `RELEASE_ASSERT(value)`). It has no way to report failure.
- A `PropertyCallback` is a static hash table entry whose value a C++ function builds on first lookup. Bun's JSC fork lets the builder return empty with an exception pending (`setUpStaticFunctionSlot`, `reifyAllStaticProperties`).
- `createRequireCache` (`src/js/builtins/CommonJS.ts`) returns the `Proxy` behind `require.cache`. Its traps read and write `$requireMap`.

<details><summary>Notes</summary>

Found by fuzzing. Both the release and the debug build abort on current main (f2fe7d3249).

**Cross-check of the two earlier approaches** (debug build):

| Case | main | #40285 alone (pass intrinsics) | this PR before the fold (fallible initializer) | this PR |
| --- | --- | --- | --- | --- |
| `globalThis.Proxy = undefined; require.cache` | abort (134) | works | throws `TypeError` | works |
| `globalThis.Map = 1` / `Symbol.for = null` / `delete globalThis.Proxy` | abort | works | throws `TypeError` / `ReferenceError` | works |
| first access near the stack limit, no tampering | abort | abort | throws `RangeError`, next access works | throws `RangeError`, next access works |

The fallible initializer is the necessary part: with it alone, a tampered global turns the abort into a thrown error. Passing the intrinsics is a cheap hardening: with it alone, the stack overflow case still aborts because the builtin call still sits inside a `LazyProperty` initializer. The PR carries both. The earlier test that expected a `TypeError` for a clobbered `Proxy` is replaced by #40285's test, which expects `require.cache` to work.

**ESM path.** `node:module` is a lazy native module. The `_cache` export is read through `SyntheticModuleRecord::materializeLazyExport`, which propagates an exception from the property callback: a named import of `_cache` fails to link with the error, a read of `ns._cache` throws it, and the binding stays unmaterialized so the next read retries. Checked `import("node:module")` and `export { _cache } from "node:module"` with `Proxy` and `Symbol` set to `undefined`: both resolve to the same object as `require.cache`.

**Termination.** `LazyProperty::callFunc` wrapped the initializer in `DeferTerminationForAWhile`. The new accessor does not need it: a termination exception raised inside the builtin propagates like any other exception.

**Tests.** `require.cache does not depend on user-writable globals` deletes `Proxy` and sets `Map` and `Symbol` to `undefined`, then reads `require.cache` and `Module._cache` and checks the null prototype, the identity of the two, the `[eval]` entry and the `Bun.inspect` output. `require.cache first accessed near the stack limit throws, and the next access builds it` recurses to the stack limit, probes `require.cache` in the deepest catch block and `Module._cache` one frame up, and records both outcomes. Both probes must throw `RangeError`. The access at normal depth must then return the real cache: null prototype, identical to `Module._cache`, lists the `[eval]` entry, and an entry written through it is what `require()` returns. A stand-in object installed on failure (the #31079 shape) fails the last two checks. 20 of 20 runs pass on the debug ASAN build. Both tests fail on the released binary (the child aborts with exit 134 and empty stdout).

**Runs.** The repros above, the `Module._cache` variant of the stack limit repro and the ESM cases under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1`: no reports. `node-module-module.test.js` (49 pass, 1 skip), `require-extensions.test.ts` (10 pass), `esm-registry-concurrent-gc.test.ts`, `module-children-concurrent-gc.test.ts`, `test/js/node/test/parallel/test-require-cache.js`, and the non-leak test in `test/cli/run/require-cache.test.ts`.

**Scope.** The review of this diff pointed out that `require.cache` is one of several `LazyProperty` slots whose initializer runs JS and so can throw: `m_utilInspectFunction` and `m_utilInspectStylizeColorFunction` (#39382), `m_processEnvObject` on Windows (#38821), `m_lazyTestModuleObject` (caches an empty object on failure), `ImportMetaObject::requireProperty` and `JSMockFunction::mock`. Two changes would fix the class at once instead of one slot per PR. First, an early return from `LazyProperty::callFunc` in the JSC fork when the initializer leaves an exception pending, the way the fork already treats `PropertyCallback` builders. That needs a WebKit PR and a pin bump, and every slot then keeps its `initLater` lambda with a `RETURN_IF_EXCEPTION` inside. Second, a `$Proxy` private global for `src/js`, in the shape of `$Buffer`: `macro(Proxy)` in `BunBuiltinNames.h`, one install on the global object, and `"Proxy"` in `globalsToPrefix` in `src/codegen/replacements.ts`. That is Bun-only, but the prefix rewrites every `Proxy` reference in `src/js` (15 files, including `node:http2` and `node:test`), so it is a change of its own. This PR stays a local fix for the slot with the deterministic repro. If the fork change lands, the accessor here collapses back into the `initLater` lambda and the two caller-side checks and the tests stay as they are.

**History.** Supersedes #31079, which installed an empty object as `require.cache` when the builtin threw. That leaves the cache broken for the rest of the process after a transient failure. Folds in #40285 (same fuzzer finding, intrinsics passed as arguments). The `util.inspect` lazy initializer in `ZigGlobalObject.cpp` has the same shape and aborts when `Symbol` is replaced and an object with an inspect.custom method is logged. That is tracked in #39382 and not changed here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
