### PR TITLE
Suggest bounded fd limits in the fd-exhaustion error hints

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1293,21 +1293,21 @@ mod draft {
                 #[cfg(target_os = "macos")]
                 {
                     pretty_error!(
-                        "<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>sudo launchctl limit maxfiles 2147483646<r>\n  <cyan>ulimit -n 2147483646<r>\n\nThat will only work until you reboot.\n",
+                        "<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>sudo launchctl limit maxfiles 65536 200000<r>\n  <cyan>ulimit -n 65536<r>\n\nThat will only work until you reboot.\n",
                         bun_fmt::nullable_fallback(limit, b"<unknown>"),
                     );
                 }
                 #[cfg(target_os = "freebsd")]
                 {
                     pretty_error!(
-                        "\n<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>sudo sysctl kern.maxfiles=2147483646 kern.maxfilesperproc=2147483646<r>\n  <cyan>ulimit -n 2147483646<r>\n\nTo persist across reboots, add to /etc/sysctl.conf and edit /etc/login.conf.\n",
+                        "\n<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>sudo sysctl kern.maxfiles=200000 kern.maxfilesperproc=65536<r>\n  <cyan>ulimit -n 65536<r>\n\nTo persist across reboots, add to /etc/sysctl.conf and edit /etc/login.conf.\n",
                         bun_fmt::nullable_fallback(limit, b"<unknown>"),
                     );
                 }
                 #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
                 {
                     pretty_error!(
-                        "\n<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>sudo echo -e \"\\nfs.file-max=2147483646\\n\" >> /etc/sysctl.conf<r>\n  <cyan>sudo sysctl -p<r>\n  <cyan>ulimit -n 2147483646<r>\n",
+                        "\n<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>echo \"fs.file-max=2097152\" | sudo tee -a /etc/sysctl.conf<r>\n  <cyan>sudo sysctl -p<r>\n  <cyan>ulimit -n 65536<r>\n",
                         bun_fmt::nullable_fallback(limit, b"<unknown>"),
                     );
 
@@ -1315,7 +1315,7 @@ mod draft {
                         if !user.is_empty() {
                             let user = bstr::BStr::new(user);
                             pretty_error!(
-                                "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 2147483646<r>\n <cyan>{} hard nofile 2147483646<r>\n",
+                                "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 65536<r>\n <cyan>{} hard nofile 200000<r>\n",
                                 user,
                                 user,
                             );
@@ -1336,21 +1336,21 @@ mod draft {
                 #[cfg(target_os = "macos")]
                 {
                     pretty_error!(
-                        "\n<r><red>error<r>: bun ran out of file descriptors <d>(<red>ProcessFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 2147483646<r>\n\nYou may also need to run:\n\n  <cyan>sudo launchctl limit maxfiles 2147483646<r>\n",
+                        "\n<r><red>error<r>: bun ran out of file descriptors <d>(<red>ProcessFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 65536<r>\n\nYou may also need to run:\n\n  <cyan>sudo launchctl limit maxfiles 65536 200000<r>\n",
                         bun_fmt::nullable_fallback(limit, b"<unknown>"),
                     );
                 }
                 #[cfg(target_os = "freebsd")]
                 {
                     pretty_error!(
-                        "\n<r><red>error<r>: bun ran out of file descriptors <d>(<red>ProcessFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 2147483646<r>\n  <cyan>sudo sysctl kern.maxfilesperproc=2147483646<r>\n",
+                        "\n<r><red>error<r>: bun ran out of file descriptors <d>(<red>ProcessFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 65536<r>\n  <cyan>sudo sysctl kern.maxfilesperproc=65536<r>\n",
                         bun_fmt::nullable_fallback(limit, b"<unknown>"),
                     );
                 }
                 #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
                 {
                     pretty_error!(
-                        "\n<r><red>error<r>: bun ran out of file descriptors <d>(<red>ProcessFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 2147483646<r>\n\nThat will only work for the current shell. To fix this for the entire system, run:\n\n  <cyan>sudo echo -e \"\\nfs.file-max=2147483646\\n\" >> /etc/sysctl.conf<r>\n  <cyan>sudo sysctl -p<r>\n",
+                        "\n<r><red>error<r>: bun ran out of file descriptors <d>(<red>ProcessFdQuotaExceeded<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 65536<r>\n\nThat will only work for the current shell. To fix this for the entire system, run:\n\n  <cyan>echo \"fs.file-max=2097152\" | sudo tee -a /etc/sysctl.conf<r>\n  <cyan>sudo sysctl -p<r>\n",
                         bun_fmt::nullable_fallback(limit, b"<unknown>"),
                     );
 
@@ -1358,7 +1358,7 @@ mod draft {
                         if !user.is_empty() {
                             let user = bstr::BStr::new(user);
                             pretty_error!(
-                                "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 2147483646<r>\n <cyan>{} hard nofile 2147483646<r>\n",
+                                "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 65536<r>\n <cyan>{} hard nofile 200000<r>\n",
                                 user,
                                 user,
                             );
@@ -1381,7 +1381,7 @@ mod draft {
 
                 if limit.rlim_cur > 0 && limit.rlim_cur < (8192 * 2) {
                     pretty_error!(
-                        "\n<r><red>error<r>: An unknown error occurred, possibly due to low max file descriptors <d>(<red>Unexpected<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 2147483646<r>\n",
+                        "\n<r><red>error<r>: An unknown error occurred, possibly due to low max file descriptors <d>(<red>Unexpected<r><d>)<r>\n\n<d>Current limit: {}<r>\n\nTo fix this, try running:\n\n  <cyan>ulimit -n 65536<r>\n",
                         limit.rlim_cur,
                     );
 
@@ -1391,7 +1391,7 @@ mod draft {
                             if !user.is_empty() {
                                 let user = bstr::BStr::new(user);
                                 pretty_error!(
-                                    "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 2147483646<r>\n <cyan>{} hard nofile 2147483646<r>\n",
+                                    "\nIf that still doesn't work, you may need to add these lines to /etc/security/limits.conf:\n\n <cyan>{} soft nofile 65536<r>\n <cyan>{} hard nofile 200000<r>\n",
                                     user,
                                     user,
                                 );
@@ -1401,7 +1401,7 @@ mod draft {
                     #[cfg(target_os = "macos")]
                     {
                         pretty_error!(
-                            "\nIf that still doesn't work, you may need to run:\n\n  <cyan>sudo launchctl limit maxfiles 2147483646<r>\n",
+                            "\nIf that still doesn't work, you may need to run:\n\n  <cyan>sudo launchctl limit maxfiles 65536 200000<r>\n",
                         );
                     }
                 } else {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isMacOS, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -190,12 +190,15 @@ test.if(isPosix)("fd limit hint suggests bounded values", async () => {
       "--debug-crash-handler-use-trace-string",
     ],
     env: noReportEnv,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "ignore", "pipe"],
   });
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).toContain("possibly due to low max file descriptors");
   expect(stderr).toContain("ulimit -n 65536");
+  if (isMacOS) {
+    expect(stderr).toContain("sudo launchctl limit maxfiles 65536 200000");
+  }
   expect(stderr).not.toContain("2147483646");
   expect(exitCode).not.toBe(0);
 });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -170,6 +170,36 @@ describe.if(isPosix)("cwd deleted before startup", () => {
   });
 });
 
+// The fd-exhaustion remediation hint must suggest bounded limits. It used to
+// print `ulimit -n 2147483646` (and `sudo launchctl limit maxfiles 2147483646`
+// on macOS, where a maxfiles limit that large makes every new terminal's
+// `login` iterate the fd table for minutes, and SIP blocks lowering it back
+// without a reboot). See #37337.
+test.if(isPosix)("fd limit hint suggests bounded values", async () => {
+  await using proc = Bun.spawn({
+    // The hint only prints when the current fd limit is low (< 16384); lower
+    // it in a wrapper shell so the check triggers deterministically.
+    cmd: [
+      "/bin/sh",
+      "-c",
+      `ulimit -n 8192 && exec "$@"`,
+      "--",
+      bunExe(),
+      path.join(import.meta.dir, "fixture-crash.js"),
+      "rootError",
+      "--debug-crash-handler-use-trace-string",
+    ],
+    env: noReportEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("possibly due to low max file descriptors");
+  expect(stderr).toContain("ulimit -n 65536");
+  expect(stderr).not.toContain("2147483646");
+  expect(exitCode).not.toBe(0);
+});
+
 // Windows: the VEH handler must walk the stack from the fault CONTEXT record
 // (RtlVirtualUnwind), not from inside the handler. When the fault is in an
 // external DLL the old RtlCaptureStackBackTrace path could stop at


### PR DESCRIPTION
### What does this PR do?

Fixes #37337. Related to #6601: the commands quoted there are the ones this PR replaces, but its underlying error is a separate root cause, so it is not closed by this change.

The crash handler's fd-exhaustion hints (`SystemFdQuotaExceeded`, `ProcessFdQuotaExceeded`, and the low-limit `Unexpected` fallback in `src/crash_handler/lib.rs`) told users to raise fd limits to `2147483646` (INT32_MAX - 1). On macOS, following the printed `sudo launchctl limit maxfiles 2147483646` makes every new terminal's `login` process spin at 100% CPU for minutes (it iterates the fd table up to the limit before spawning the shell), and SIP rejects lowering the limit back, so the only way out is a reboot. Reported via opencode (a Bun single-file executable) in #37337, with the same advice also reaching users through other Bun-built CLIs.

### Changes

- All hint strings now suggest bounded values: `ulimit -n 65536` per process, `sudo launchctl limit maxfiles 65536 200000` (soft and hard) on macOS, `kern.maxfiles=200000 kern.maxfilesperproc=65536` on FreeBSD, `fs.file-max=2097152` and `soft nofile 65536` / `hard nofile 200000` in limits.conf on Linux.
- The Linux sysctl.conf line now pipes through `sudo tee -a`; the previous `sudo echo ... >> /etc/sysctl.conf` performed the redirect in the unprivileged shell, so it failed for non-root users.

### Verification

Added a test in `test/cli/run/run-crash-handler.test.ts` that spawns bun under `ulimit -n 8192` and triggers the hint via the existing `rootError` test hook, asserting the hint suggests `ulimit -n 65536` and no longer contains `2147483646`. Fails against the previous hint text:

```
Expected to contain: "ulimit -n 65536"
Received: "...To fix this, try running:\n\n  ulimit -n 2147483646\n"
```

All 24 tests in the file pass with the fix (`bun bd test test/cli/run/run-crash-handler.test.ts`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->
