### PR TITLE
bun-release: fail upload-npm before publishing when a release asset is missing

### DIFF
--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -57,10 +57,12 @@ async function build(): Promise<void> {
       missing.push(name);
     }
   }
-  // The root package depends on every platform package at this exact version, so a
-  // platform without an asset has to stop the release before anything is published.
+  // The root package pins every platform package at this exact version, so publishing without one breaks it too.
   if (missing.length) {
-    throw new Error(`Release "${release.tag_name}" is missing assets: ${missing.join(", ")}`);
+    throw new Error(
+      `Release "${release.tag_name}" is missing assets: ${missing.join(", ")}\n` +
+        "Nothing was published: every platform in src/platform.ts must have its zip on the release before any package is published.",
+    );
   }
   await buildRootModule();
   for (const [platform, asset] of assets) {

--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -18,10 +18,16 @@ import { spawn } from "../src/spawn";
 const module = "bun";
 const owner = "@oven";
 
+type Asset = Awaited<ReturnType<typeof getRelease>>["assets"][number];
+
 const [tag, action] = process.argv.slice(2);
 
 const release = await getRelease(tag);
 const version = await getSemver(release.tag_name);
+// Only "publish" handles every platform; the other actions build and pack the host's packages.
+const targets = platforms.filter(
+  ({ os, arch }) => action === "publish" || (os === process.platform && arch === process.arch),
+);
 
 if (action !== "test-only") await build();
 
@@ -40,21 +46,33 @@ if (action === "publish") {
 process.exit(0); // HACK
 
 async function build(): Promise<void> {
+  const assets: [Platform, Asset][] = [];
+  const missing: string[] = [];
+  for (const platform of targets) {
+    const name = `${platform.bin}.zip`;
+    const asset = release.assets.find(asset => asset.name === name);
+    if (asset) {
+      assets.push([platform, asset]);
+    } else {
+      missing.push(name);
+    }
+  }
+  // The root package depends on every platform package at this exact version, so a
+  // platform without an asset has to stop the release before anything is published.
+  if (missing.length) {
+    throw new Error(`Release "${release.tag_name}" is missing assets: ${missing.join(", ")}`);
+  }
   await buildRootModule();
-  for (const platform of platforms) {
-    if (action !== "publish" && (platform.os !== process.platform || platform.arch !== process.arch)) continue;
-    await buildModule(release, platform);
+  for (const [platform, asset] of assets) {
+    await buildModule(platform, asset);
   }
 }
 
 async function publish(dryRun?: boolean): Promise<void> {
-  const modules = platforms
-    .filter(({ os, arch }) => action === "publish" || (os === process.platform && arch === process.arch))
-    .map(({ bin }) => `${owner}/${bin}`);
-  modules.push(module);
-  for (const module of modules) {
-    publishModule(module, dryRun);
+  for (const { bin } of targets) {
+    publishModule(`${owner}/${bin}`, dryRun);
   }
+  publishModule(module, dryRun);
 }
 
 async function buildRootModule(dryRun?: boolean) {
@@ -140,17 +158,9 @@ without *requiring* a postinstall script.
   }
 }
 
-async function buildModule(
-  release: Awaited<ReturnType<typeof getRelease>>,
-  { bin, exe, os, arch, abi }: Platform,
-): Promise<void> {
+async function buildModule({ bin, exe, os, arch, abi }: Platform, asset: Asset): Promise<void> {
   const module = `${owner}/${bin}`;
   log("Building:", `${module}@${version}`);
-  const asset = release.assets.find(({ name }) => name === `${bin}.zip`);
-  if (!asset) {
-    error(`No asset found: ${bin}`);
-    return;
-  }
   const bun = await extractFromZip(asset.browser_download_url, `${bin}/bun`);
   const cwd = join("npm", module);
   mkdirSync(dirname(join(cwd, exe)), { recursive: true });

--- a/packages/bun-release/src/spawn.ts
+++ b/packages/bun-release/src/spawn.ts
@@ -11,14 +11,19 @@ export function spawn(
   stderr: string;
 } {
   debug("spawn", [cmd, ...args].join(" "));
-  const { status, stdout, stderr } = child_process.spawnSync(cmd, args, {
+  const { error, status, stdout, stderr } = child_process.spawnSync(cmd, args, {
     stdio: "pipe",
     encoding: "utf-8",
     ...options,
   });
+  if (error) {
+    debug("child_process.spawnSync failed", error);
+  }
+  // A process that could not be spawned (missing executable, missing cwd) has no
+  // status and no output: report it as a failure whose stderr is the reason.
   return {
     exitCode: status ?? 1,
-    stdout,
-    stderr,
+    stdout: stdout ?? "",
+    stderr: stderr ?? error?.message ?? "",
   };
 }

--- a/test/integration/bun-release/spawn.test.ts
+++ b/test/integration/bun-release/spawn.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+import { spawn } from "../../../packages/bun-release/src/spawn";
+
+// The release scripts read `stdout`/`stderr` of every result (`stderr || stdout`,
+// `stdout.includes(...)`), so they have to be strings even when no process ran.
+
+test("returns the exit code and output of a process that ran", () => {
+  expect(
+    spawn(bunExe(), ["-e", `console.log("out"); console.error("err"); process.exit(3);`], { env: bunEnv }),
+  ).toEqual({
+    exitCode: 3,
+    stdout: "out\n",
+    stderr: "err\n",
+  });
+});
+
+test("returns empty output when stdio is not captured", () => {
+  expect(spawn(bunExe(), ["--version"], { env: bunEnv, stdio: "ignore" })).toEqual({
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+  });
+});
+
+test("reports an executable that does not exist as a failure", () => {
+  using dir = tempDir("bun-release-spawn", {});
+  const exe = path.join(String(dir), "does-not-exist");
+  expect(spawn(exe, ["--version"])).toEqual({
+    exitCode: 1,
+    stdout: "",
+    stderr: expect.stringContaining(exe),
+  });
+});
+
+test("reports a cwd that does not exist as a failure", () => {
+  using dir = tempDir("bun-release-spawn", {});
+  const cwd = path.join(String(dir), "does-not-exist");
+  expect(spawn(bunExe(), ["--version"], { env: bunEnv, cwd })).toEqual({
+    exitCode: 1,
+    stdout: "",
+    stderr: expect.stringContaining("ENOENT"),
+  });
+});

--- a/test/integration/bun-release/upload-npm.test.ts
+++ b/test/integration/bun-release/upload-npm.test.ts
@@ -7,8 +7,11 @@ import { platforms } from "../../../packages/bun-release/src/platform";
 // Runs packages/bun-release/scripts/upload-npm.ts against a fake GitHub release.
 // Its dependencies are stubbed: octokit answers every release lookup with
 // release.json, jszip treats a downloaded "zip" as an archive holding `${body}/bun`,
-// and esbuild (only used to bundle the postinstall script) does nothing.
-const packageDir = path.join(import.meta.dir, "..", "..", "..", "packages", "bun-release");
+// and esbuild (only used to bundle the postinstall script) does nothing. src/spawn.ts
+// (covered by spawn.test.ts) is replaced with a copy that records every command in
+// spawn.log instead of running it, so npm itself is never invoked.
+const repoDir = path.join(import.meta.dir, "..", "..", "..");
+const packageDir = path.join(repoDir, "packages", "bun-release");
 
 const sources: Record<string, string> = {
   "scripts/upload-npm.ts": readFileSync(path.join(packageDir, "scripts", "upload-npm.ts"), "utf8"),
@@ -16,6 +19,13 @@ const sources: Record<string, string> = {
 for (const name of new Bun.Glob("*.ts").scanSync(path.join(packageDir, "src"))) {
   sources[`src/${name}`] = readFileSync(path.join(packageDir, "src", name), "utf8");
 }
+sources["src/spawn.ts"] = `
+  import { appendFileSync } from "fs";
+  export function spawn(cmd, args, options = {}) {
+    appendFileSync(new URL("../spawn.log", import.meta.url), JSON.stringify({ cmd, args, cwd: options.cwd }) + "\\n");
+    return { exitCode: 0, stdout: "", stderr: "" };
+  }
+`;
 
 const stubs = {
   "node_modules/octokit/package.json": JSON.stringify({ name: "octokit", version: "0.0.0", main: "index.js" }),
@@ -47,6 +57,7 @@ const version = "1.0.0";
 const tagName = `bun-v${version}`;
 const missingPrefix = `Release "${tagName}" is missing assets: `;
 const host = platforms.filter(({ os, arch }) => os === process.platform && arch === process.arch);
+const allBins = platforms.map(({ bin }) => bin);
 
 function serveAssets(downloaded: string[]) {
   return Bun.serve({
@@ -72,11 +83,12 @@ function releaseDir(name: string, assets: ReturnType<typeof assetsOn>) {
   });
 }
 
-async function uploadNpm(cwd: string, ...args: string[]) {
+async function uploadNpm(cwd: string, action: string) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join("scripts", "upload-npm.ts"), version, ...args],
+    cmd: [bunExe(), path.join("scripts", "upload-npm.ts"), version, action],
     cwd,
-    env: bunEnv,
+    // src/console.ts switches to "::error::" annotations when GITHUB_ACTION is set.
+    env: { ...bunEnv, GITHUB_ACTION: undefined },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -89,18 +101,35 @@ function missingAssets(stderr: string): string[] | undefined {
   return line?.slice(line.indexOf(missingPrefix) + missingPrefix.length).split(", ");
 }
 
-test.concurrent("builds the host's packages from the release assets", async () => {
+/** The npm commands the script ran, in order, as `{ cwd, args }` with `cwd` relative to the package. */
+function npmCalls(dir: string): { cwd: string; args: string[] }[] {
+  const log = path.join(dir, "spawn.log");
+  if (!existsSync(log)) return [];
+  return readFileSync(log, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map(line => JSON.parse(line))
+    .filter(({ cmd }) => cmd === "npm")
+    .map(({ cwd, args }) => ({ cwd, args }));
+}
+
+function npmCallsFor(bins: string[], args: string[]) {
+  return [...bins.map(bin => ({ cwd: path.join("npm", "@oven", bin), args })), { cwd: path.join("npm", "bun"), args }];
+}
+
+test.concurrent("dry-run builds and packs the host's packages, then the root package", async () => {
   const downloaded: string[] = [];
   using server = serveAssets(downloaded);
-  const bins = platforms.map(({ bin }) => bin);
-  using dir = releaseDir("complete", assetsOn(server, bins));
+  using dir = releaseDir("dry-run", assetsOn(server, allBins));
   const cwd = String(dir);
 
-  const { stderr, exitCode } = await uploadNpm(cwd);
-  expect(stderr).toBe("");
+  const { stderr, exitCode } = await uploadNpm(cwd, "dry-run");
+  // publishModule() echoes each npm command's (here empty) output as a line on stderr.
+  expect(stderr.trim()).toBe("");
   expect(exitCode).toBe(0);
 
-  expect(downloaded).toEqual(host.map(({ bin }) => bin));
+  const hostBins = host.map(({ bin }) => bin);
+  expect(downloaded).toEqual(hostBins);
   for (const { bin, exe, os, arch } of host) {
     const module = path.join(cwd, "npm", "@oven", bin);
     expect(readFileSync(path.join(module, exe), "utf8")).toBe(bin);
@@ -117,35 +146,92 @@ test.concurrent("builds the host's packages from the release assets", async () =
   expect(root.optionalDependencies).toEqual(
     Object.fromEntries(platforms.filter(({ alias }) => !alias).map(({ bin }) => [`@oven/${bin}`, version])),
   );
+  expect(npmCalls(cwd)).toEqual(npmCallsFor(hostBins, ["pack"]));
 });
 
-test.concurrent("fails before building anything when a selected platform has no asset", async () => {
+test.concurrent("dry-run fails before building anything when a host platform has no asset", async () => {
   const downloaded: string[] = [];
   using server = serveAssets(downloaded);
   const [absent] = host;
-  const bins = platforms.filter(platform => platform !== absent).map(({ bin }) => bin);
-  using dir = releaseDir("incomplete", assetsOn(server, bins));
+  using dir = releaseDir(
+    "dry-run-incomplete",
+    assetsOn(
+      server,
+      allBins.filter(bin => bin !== absent.bin),
+    ),
+  );
   const cwd = String(dir);
 
-  const { stderr, exitCode } = await uploadNpm(cwd);
+  const { stderr, exitCode } = await uploadNpm(cwd, "dry-run");
   expect(stderr).toContain(missingPrefix);
   expect(missingAssets(stderr)).toEqual([`${absent.bin}.zip`]);
   expect(exitCode).toBe(1);
 
   expect(downloaded).toEqual([]);
   expect(existsSync(path.join(cwd, "npm"))).toBe(false);
+  expect(npmCalls(cwd)).toEqual([]);
 });
 
-test.concurrent("publish checks every platform in platform.ts for an asset", async () => {
-  // With no assets at all there is never a package directory for `npm publish` to
-  // run in, so this stays harmless even if the check it exercises were missing.
-  using dir = releaseDir("publish", []);
+test.concurrent("publish builds and publishes every platform in platform.ts, then the root package", async () => {
+  const downloaded: string[] = [];
+  using server = serveAssets(downloaded);
+  using dir = releaseDir("publish", assetsOn(server, allBins));
+  const cwd = String(dir);
+
+  const { stderr, exitCode } = await uploadNpm(cwd, "publish");
+  expect(stderr.trim()).toBe("");
+  expect(exitCode).toBe(0);
+
+  expect(downloaded).toEqual(allBins);
+  expect(npmCalls(cwd)).toEqual(npmCallsFor(allBins, ["publish", "--access", "public", "--tag", "latest"]));
+});
+
+test.concurrent("publish publishes nothing when any platform has no asset", async () => {
+  const downloaded: string[] = [];
+  using server = serveAssets(downloaded);
+  const absent = platforms.find(platform => !host.includes(platform))!;
+  using dir = releaseDir(
+    "publish-incomplete",
+    assetsOn(
+      server,
+      allBins.filter(bin => bin !== absent.bin),
+    ),
+  );
   const cwd = String(dir);
 
   const { stderr, exitCode } = await uploadNpm(cwd, "publish");
   expect(stderr).toContain(missingPrefix);
-  expect(missingAssets(stderr)).toEqual(platforms.map(({ bin }) => `${bin}.zip`));
+  expect(missingAssets(stderr)).toEqual([`${absent.bin}.zip`]);
   expect(exitCode).toBe(1);
 
+  expect(downloaded).toEqual([]);
   expect(existsSync(path.join(cwd, "npm"))).toBe(false);
+  expect(npmCalls(cwd)).toEqual([]);
+});
+
+test.concurrent("publish reports every missing asset at once", async () => {
+  using dir = releaseDir("publish-empty", []);
+  const cwd = String(dir);
+
+  const { stderr, exitCode } = await uploadNpm(cwd, "publish");
+  expect(stderr).toContain(missingPrefix);
+  expect(missingAssets(stderr)).toEqual(allBins.map(bin => `${bin}.zip`));
+  expect(exitCode).toBe(1);
+
+  expect(npmCalls(cwd)).toEqual([]);
+});
+
+// The zips come from .buildkite/scripts/upload-release.sh, so a platform added to
+// platform.ts without also being uploaded there fails every release until both agree.
+test("upload-release.sh uploads a zip for every platform in platform.ts", () => {
+  const script = readFileSync(path.join(repoDir, ".buildkite", "scripts", "upload-release.sh"), "utf8");
+  const uploaded = new Set([
+    ...script
+      .match(/artifacts=\(([^)]*)\)/)![1]
+      .split(/\s+/)
+      .filter(Boolean),
+    // The -baseline zips are repacked from the plain ones by alias_baseline_artifact.
+    ...[...script.matchAll(/echo "([^"]+\.zip)"/g)].map(([, zip]) => zip),
+  ]);
+  expect(allBins.map(bin => `${bin}.zip`).filter(zip => !uploaded.has(zip))).toEqual([]);
 });

--- a/test/integration/bun-release/upload-npm.test.ts
+++ b/test/integration/bun-release/upload-npm.test.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+import { platforms } from "../../../packages/bun-release/src/platform";
+
+// Runs packages/bun-release/scripts/upload-npm.ts against a fake GitHub release.
+// Its dependencies are stubbed: octokit answers every release lookup with
+// release.json, jszip treats a downloaded "zip" as an archive holding `${body}/bun`,
+// and esbuild (only used to bundle the postinstall script) does nothing.
+const packageDir = path.join(import.meta.dir, "..", "..", "..", "packages", "bun-release");
+
+const sources: Record<string, string> = {
+  "scripts/upload-npm.ts": readFileSync(path.join(packageDir, "scripts", "upload-npm.ts"), "utf8"),
+};
+for (const name of new Bun.Glob("*.ts").scanSync(path.join(packageDir, "src"))) {
+  sources[`src/${name}`] = readFileSync(path.join(packageDir, "src", name), "utf8");
+}
+
+const stubs = {
+  "node_modules/octokit/package.json": JSON.stringify({ name: "octokit", version: "0.0.0", main: "index.js" }),
+  "node_modules/octokit/index.js": `
+    import release from "../../release.json";
+    export class Octokit {
+      async request(route) {
+        if (route === "GET /repos/{owner}/{repo}/releases/latest") return { data: release };
+        if (route === "GET /repos/{owner}/{repo}/releases/tags/{tag}") return { data: release };
+        throw new Error("unexpected request: " + route);
+      }
+    }
+  `,
+  "node_modules/jszip/package.json": JSON.stringify({ name: "jszip", version: "0.0.0", main: "index.js" }),
+  "node_modules/jszip/index.js": `
+    export async function loadAsync(buffer) {
+      const bin = new TextDecoder().decode(buffer);
+      return { files: { [bin + "/bun"]: { dir: false, async: async () => buffer } } };
+    }
+  `,
+  "node_modules/esbuild/package.json": JSON.stringify({ name: "esbuild", version: "0.0.0", main: "index.js" }),
+  "node_modules/esbuild/index.js": `
+    export function buildSync() { return { errors: [], warnings: [] }; }
+    export function formatMessagesSync() { return []; }
+  `,
+};
+
+const version = "1.0.0";
+const tagName = `bun-v${version}`;
+const missingPrefix = `Release "${tagName}" is missing assets: `;
+const host = platforms.filter(({ os, arch }) => os === process.platform && arch === process.arch);
+
+function serveAssets(downloaded: string[]) {
+  return Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(request) {
+      const bin = path.posix.basename(new URL(request.url).pathname, ".zip");
+      downloaded.push(bin);
+      return new Response(bin);
+    },
+  });
+}
+
+function assetsOn(server: { url: URL }, bins: string[]) {
+  return bins.map(bin => ({ name: `${bin}.zip`, browser_download_url: new URL(`/${bin}.zip`, server.url).href }));
+}
+
+function releaseDir(name: string, assets: ReturnType<typeof assetsOn>) {
+  return tempDir(`bun-release-${name}`, {
+    ...sources,
+    ...stubs,
+    "release.json": JSON.stringify({ tag_name: tagName, assets }),
+  });
+}
+
+async function uploadNpm(cwd: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join("scripts", "upload-npm.ts"), version, ...args],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function missingAssets(stderr: string): string[] | undefined {
+  const line = stderr.split(/\r?\n/).find(line => line.includes(missingPrefix));
+  return line?.slice(line.indexOf(missingPrefix) + missingPrefix.length).split(", ");
+}
+
+test.concurrent("builds the host's packages from the release assets", async () => {
+  const downloaded: string[] = [];
+  using server = serveAssets(downloaded);
+  const bins = platforms.map(({ bin }) => bin);
+  using dir = releaseDir("complete", assetsOn(server, bins));
+  const cwd = String(dir);
+
+  const { stderr, exitCode } = await uploadNpm(cwd);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  expect(downloaded).toEqual(host.map(({ bin }) => bin));
+  for (const { bin, exe, os, arch } of host) {
+    const module = path.join(cwd, "npm", "@oven", bin);
+    expect(readFileSync(path.join(module, exe), "utf8")).toBe(bin);
+    expect(JSON.parse(readFileSync(path.join(module, "package.json"), "utf8"))).toMatchObject({
+      name: `@oven/${bin}`,
+      version,
+      os: [os],
+      cpu: [arch],
+    });
+  }
+  // The root package pins every platform package to its own version, which is why a
+  // release that cannot build one of them must not publish any of them.
+  const root = JSON.parse(readFileSync(path.join(cwd, "npm", "bun", "package.json"), "utf8"));
+  expect(root.optionalDependencies).toEqual(
+    Object.fromEntries(platforms.filter(({ alias }) => !alias).map(({ bin }) => [`@oven/${bin}`, version])),
+  );
+});
+
+test.concurrent("fails before building anything when a selected platform has no asset", async () => {
+  const downloaded: string[] = [];
+  using server = serveAssets(downloaded);
+  const [absent] = host;
+  const bins = platforms.filter(platform => platform !== absent).map(({ bin }) => bin);
+  using dir = releaseDir("incomplete", assetsOn(server, bins));
+  const cwd = String(dir);
+
+  const { stderr, exitCode } = await uploadNpm(cwd);
+  expect(stderr).toContain(missingPrefix);
+  expect(missingAssets(stderr)).toEqual([`${absent.bin}.zip`]);
+  expect(exitCode).toBe(1);
+
+  expect(downloaded).toEqual([]);
+  expect(existsSync(path.join(cwd, "npm"))).toBe(false);
+});
+
+test.concurrent("publish checks every platform in platform.ts for an asset", async () => {
+  // With no assets at all there is never a package directory for `npm publish` to
+  // run in, so this stays harmless even if the check it exercises were missing.
+  using dir = releaseDir("publish", []);
+  const cwd = String(dir);
+
+  const { stderr, exitCode } = await uploadNpm(cwd, "publish");
+  expect(stderr).toContain(missingPrefix);
+  expect(missingAssets(stderr)).toEqual(platforms.map(({ bin }) => `${bin}.zip`));
+  expect(exitCode).toBe(1);
+
+  expect(existsSync(path.join(cwd, "npm"))).toBe(false);
+});

--- a/test/integration/bun-release/upload-npm.test.ts
+++ b/test/integration/bun-release/upload-npm.test.ts
@@ -59,14 +59,14 @@ const missingPrefix = `Release "${tagName}" is missing assets: `;
 const host = platforms.filter(({ os, arch }) => os === process.platform && arch === process.arch);
 const allBins = platforms.map(({ bin }) => bin);
 
-function serveAssets(downloaded: string[]) {
+function serveAssets(downloaded: string[], unavailable?: string) {
   return Bun.serve({
     port: 0,
     hostname: "127.0.0.1",
     fetch(request) {
       const bin = path.posix.basename(new URL(request.url).pathname, ".zip");
       downloaded.push(bin);
-      return new Response(bin);
+      return new Response(bin, { status: bin === unavailable ? 404 : 200 });
     },
   });
 }
@@ -153,13 +153,8 @@ test.concurrent("dry-run fails before building anything when a host platform has
   const downloaded: string[] = [];
   using server = serveAssets(downloaded);
   const [absent] = host;
-  using dir = releaseDir(
-    "dry-run-incomplete",
-    assetsOn(
-      server,
-      allBins.filter(bin => bin !== absent.bin),
-    ),
-  );
+  const bins = allBins.filter(bin => bin !== absent.bin);
+  using dir = releaseDir("dry-run-incomplete", assetsOn(server, bins));
   const cwd = String(dir);
 
   const { stderr, exitCode } = await uploadNpm(cwd, "dry-run");
@@ -186,17 +181,30 @@ test.concurrent("publish builds and publishes every platform in platform.ts, the
   expect(npmCalls(cwd)).toEqual(npmCallsFor(allBins, ["publish", "--access", "public", "--tag", "latest"]));
 });
 
+// An asset can be listed on the release but still fail to download, e.g. while
+// upload-release.sh is replacing it; the packages built before that point stay unpublished.
+test.concurrent("publish publishes nothing when an asset fails to download", async () => {
+  const downloaded: string[] = [];
+  const [built, unavailable] = allBins;
+  using server = serveAssets(downloaded, unavailable);
+  using dir = releaseDir("publish-download-failure", assetsOn(server, allBins));
+  const cwd = String(dir);
+
+  const { stderr, exitCode } = await uploadNpm(cwd, "publish");
+  expect(stderr).toContain(`404: ${new URL(`/${unavailable}.zip`, server.url).href}`);
+  expect(exitCode).toBe(1);
+
+  expect(downloaded).toEqual([built, unavailable]);
+  expect(existsSync(path.join(cwd, "npm", "@oven", built, "package.json"))).toBe(true);
+  expect(npmCalls(cwd)).toEqual([]);
+});
+
 test.concurrent("publish publishes nothing when any platform has no asset", async () => {
   const downloaded: string[] = [];
   using server = serveAssets(downloaded);
   const absent = platforms.find(platform => !host.includes(platform))!;
-  using dir = releaseDir(
-    "publish-incomplete",
-    assetsOn(
-      server,
-      allBins.filter(bin => bin !== absent.bin),
-    ),
-  );
+  const bins = allBins.filter(bin => bin !== absent.bin);
+  using dir = releaseDir("publish-incomplete", assetsOn(server, bins));
   const cwd = String(dir);
 
   const { stderr, exitCode } = await uploadNpm(cwd, "publish");


### PR DESCRIPTION
### What happened

The daily "Release to NPM" job (`bun upload-npm -- canary publish` in `packages/bun-release`) failed every day from 2026-04-26 to 2026-05-19, for example [run 26106111955](https://github.com/oven-sh/bun/actions/runs/26106111955):

```
##[error] No asset found: bun-linux-aarch64-android
##[error] No asset found: bun-linux-x64-android
##[error] No asset found: bun-freebsd-aarch64
##[error] No asset found: bun-freebsd-x64
...
Publishing: @oven/bun-linux-aarch64-musl-baseline@1.3.14-canary.20260519.1+184d037
Publishing: @oven/bun-linux-aarch64-android@1.3.14-canary.20260519.1+184d037
##[error] null
TypeError: null is not an object (evaluating 'stdout.includes')
      at publishModule (packages/bun-release/scripts/upload-npm.ts:194:9)
```

2ee9cad0ea added the android and freebsd entries to `src/platform.ts` before the canary release carried those zips. Ten `@oven/bun-*` packages were published each day and then the script died, so the root `bun` package (published last) was never published and its `canary` dist-tag stayed on the 2026-04-25 build. The canary release has all 16 assets today, so this is latent until the next platform is added ahead of its assets or an asset upload fails. (The publishes are currently failing for an unrelated reason, the rejected `NPM_TOKEN`, see #37341.)

### Cause

`buildModule()` logged `No asset found` and returned, but `publish()` computed its own module list from `platforms` and ran `npm publish` for every one of them. For a platform whose `npm/@oven/<bin>/` directory was never created, `spawnSync` fails to spawn; `src/spawn.ts` normalized `status` (`status ?? 1`) but passed `stdout`/`stderr` through as `null`, which `publishModule()` then called `.includes()` on.

### Fix

* `upload-npm.ts`: `build()` looks up the asset of every selected platform first and throws before anything is built or published, naming every missing zip:

  ```
  error: Release "bun-v1.0.0" is missing assets: bun-linux-x64-musl.zip, bun-linux-x64-musl-baseline.zip
  Nothing was published: every platform in src/platform.ts must have its zip on the release before any package is published.
  ```

  `build()` and `publish()` now iterate the same `targets` list (the predicate was previously duplicated in both), and `buildModule()` takes the asset instead of looking it up again.
* `src/spawn.ts`: `stdout`/`stderr` are always strings; when nothing could be spawned, `stderr` carries the spawn error's message. This is the shared helper behind `upload-npm.ts`, `upload-assets.ts` and the npm postinstall, all of which read the output unconditionally. No caller's control flow changes: a failed spawn still reports `exitCode` 1 as before, it just comes with the reason instead of `null`.

Why fail instead of publishing the platforms that do have assets: `npm/bun/package.json` lists every non-alias platform package in `optionalDependencies` at exactly this version, so a root package published without one of them is broken on that platform, and a stable release missing a platform would otherwise go out with a green job. Stopping before the first `npm publish` also means a version is either fully published or not at all, instead of the partial state above. The producer side already works this way (`.buildkite/scripts/upload-release.sh` aborts when a build artifact is missing). The other consumers of the release in this package, `upload-assets.ts` and `upload-s3.ts`, sign and mirror whatever assets exist, which is fine for them because nothing they produce refers to a platform that is not there; `upload-npm` is the one consumer that publishes a manifest naming every platform, so it is the one that has to be complete. For the incident above the user-visible result is the same as today (no root canary either way), except that the job fails immediately with the list of missing zips.

### Tests

`test/integration/bun-release/upload-npm.test.ts` runs the real script from a temp copy with `octokit`, `jszip` and `esbuild` stubbed (same approach as `test/integration/bun-lambda`), a local server standing in for asset downloads, a fake release, and `src/spawn.ts` swapped for a copy that records each command in a log instead of running it, so the tests can assert exactly which `npm` commands `publish()` would have run, in which directories and in which order, without `npm` ever being invoked:

* `dry-run`, all assets present: builds each host platform package from its own asset, root package lists every platform package, then `npm pack` in each host package directory followed by `npm/bun` (regression guard for the refactored `publish()`, passes before and after)
* `dry-run`, one host platform without an asset: exit 1 naming exactly that zip, nothing downloaded, nothing written under `npm/`, no `npm` command
* `publish`, all assets present: downloads and builds all 16 platforms in `platform.ts` order, then `npm publish --access public --tag latest` in all 16 directories followed by `npm/bun` (the production mode; passes before and after)
* `publish`, all assets listed but one of them answering 404 (an asset can be listed and still fail to download, for example while `upload-release.sh` is replacing it): exit 1 with the fetch error, the package built before it exists on disk, no `npm` command. Passes before and after as well; it is the guard against turning the build loop back into log-and-continue, which none of the other tests notice
* `publish`, one non-host platform without an asset: exit 1 naming that zip, nothing downloaded or written, no `npm` command. Before the fix this is the incident shape: every package including the root one gets handed to `npm publish`
* `publish` with an empty release: exit 1 naming all 16 zips, no `npm` command
* a static check that every `bin` in `platform.ts` has a zip in `.buildkite/scripts/upload-release.sh`'s artifact list or its `-baseline` aliases. That is where the lists drifted apart: against the `upload-release.sh` of 2ee9cad0ea it reports the four android/freebsd zips from the incident plus `bun-darwin-x64-baseline.zip`, which that script did not produce at the time either (the canary release was still carrying an old upload of it, since `gh release upload --clobber` never removes assets, so the existence check alone would not have noticed). At HEAD both lists agree, so this catches the next drift in the PR that introduces it rather than in the next day's release job.

`test/integration/bun-release/spawn.test.ts` covers the real `spawn()` for a process that ran, uncaptured stdio, a missing executable and a missing cwd.

Without the `packages/` changes, 6 of the 11 tests fail (the two happy paths, the download-failure guard, the spawn success case and the static check pass); with them all 11 pass, on Linux (`bun bd test`) and Windows.

The only thing the hermetic tests do not execute is a real `npm`; for that I ran `bun upload-npm -- canary dry-run` against the real canary release (builds the 4 host packages and the root package, then `npm pack`s all 5 in the same order as before) and `bun upload-npm -- 1.0.0 dry-run`, which fails with the message above because bun-v1.0.0 predates the musl packages, leaving `npm/` untouched.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/integration/bun-release/upload-npm.test.ts

<!-- robobun:evidence:end -->