### PR TITLE
process: register the default 'warning' listener at process creation, like Node

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,9 +186,11 @@ const testPlatforms = [
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
   // lanes — see buildPlatforms).
-  { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
-  { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
-  { os: "darwin", arch: "x64", release: "14", tier: "latest" },
+  // The macOS test agents are offline; darwin still builds (cross-compiled on
+  // Linux) but isn't tested until they're back.
+  // { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
+  // { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
+  // { os: "darwin", arch: "x64", release: "14", tier: "latest" },
   { os: "linux", arch: "aarch64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", profile: "asan", distro: "debian", release: "13", tier: "latest" },
@@ -756,7 +758,8 @@ function getVerifyBaselineStep(platform, options) {
  * traces itself; `packageAndUpload()` is its sole publisher.
  */
 const traceOrderTargets = [
-  { os: "darwin", arch: "aarch64", on: { os: "darwin", arch: "aarch64", release: "26", tier: "latest" } },
+  // Runs on the macOS test agents, which are offline (see testPlatforms).
+  // { os: "darwin", arch: "aarch64", on: { os: "darwin", arch: "aarch64", release: "26", tier: "latest" } },
   { os: "linux", arch: "x64", on: { os: "linux", arch: "x64", distro: "debian", release: "13" } },
 ];
 

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -660,9 +660,6 @@ export function createOnWarning(process, redirectPath, disabledArr) {
   }
 
   return function onWarning(warning) {
-    // Node only seeds this from --no-warnings; also honoring a runtime assignment lets
-    // test/js/node/test/common apply a test's `--no-warnings` flag without re-spawning.
-    if (process.noProcessWarnings) return;
     if (!(warning instanceof Error)) return;
     const name = warning.name || "Warning";
     const isDeprecation = name === "DeprecationWarning";

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -632,9 +632,10 @@ export function rawDebug() {
   } catch {}
 }
 
-export function installOnWarningListener(process, redirectPath, disabledArr) {
-  // Port of https://github.com/nodejs/node/blob/main/lib/internal/process/warning.js onWarning,
-  // registered as a real 'warning' listener so removeAllListeners('warning') silences it.
+// Port of https://github.com/nodejs/node/blob/main/lib/internal/process/warning.js onWarning.
+// The 'warning' listener itself is a native trampoline registered when `process` is created
+// (BunProcess.cpp); this builds the printer it forwards to on the first warning.
+export function createOnWarning(process, redirectPath, disabledArr) {
   const appendFileSync = redirectPath ? require("node:fs").appendFileSync : undefined;
   // --disable-warning names/codes as a Set: matches Node's SafeSet lookup
   // and avoids an FFI + utf8() encode per emit.
@@ -658,7 +659,10 @@ export function installOnWarningListener(process, redirectPath, disabledArr) {
     process.stderr.write(message + "\n");
   }
 
-  function onWarning(warning) {
+  return function onWarning(warning) {
+    // Node only seeds this from --no-warnings; also honoring a runtime assignment lets
+    // test/js/node/test/common apply a test's `--no-warnings` flag without re-spawning.
+    if (process.noProcessWarnings) return;
     if (!(warning instanceof Error)) return;
     const name = warning.name || "Warning";
     const isDeprecation = name === "DeprecationWarning";
@@ -689,11 +693,7 @@ export function installOnWarningListener(process, redirectPath, disabledArr) {
         `(Use \`${basename(process.argv0 || "node")} --trace-warnings ...\` to show where the warning was created)`,
       );
     }
-  }
-
-  // prependListener: user listeners added before the first emitWarning must
-  // still fire *after* the print, matching Node's bootstrap ordering.
-  process.prependListener("warning", onWarning);
+  };
 }
 
 export function loadEnvFile(path) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -47,6 +47,7 @@
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include "wtf-bindings.h"
 #include "EventLoopTask.h"
+#include "JSEventListener.h"
 #include <JavaScriptCore/StructureCache.h>
 
 #include <webcore/SerializedScriptValue.h>
@@ -1690,27 +1691,15 @@ Process::~Process()
 
 extern "C" bool Bun__NODE_NO_WARNINGS();
 
-// Install the JS onWarning listener (once per Process). Gated by
-// --no-warnings / NODE_NO_WARNINGS to match Node's pre_execution.js.
-static void ensureOnWarningInstalled(Zig::GlobalObject* globalObject, Process* process)
+JSObject* Process::ensureOnWarning(Zig::GlobalObject* globalObject)
 {
-    if (process->m_warningListenerInstalled)
-        return;
-    process->m_warningListenerInstalled = true;
-    if (Bun__NODE_NO_WARNINGS() || Bun__Node__ProcessNoWarnings)
-        return;
+    if (auto* onWarning = m_onWarning.get())
+        return onWarning;
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // Also honor the JS property (Node's --no-warnings alias name) so the
-    // Node-test common harness can suppress the printer in-process when it
-    // skips the --no-warnings re-spawn to install --expose-* shims instead.
-    JSValue noWarnings = process->getIfPropertyExists(globalObject, JSC::Identifier::fromString(vm, "noProcessWarnings"_s));
-    RETURN_IF_EXCEPTION(scope, );
-    if (noWarnings && noWarnings.toBoolean(globalObject))
-        return;
-    auto* installer = JSC::JSFunction::create(vm, globalObject, processObjectInternalsInstallOnWarningListenerCodeGenerator(vm), globalObject);
+    auto* factory = JSC::JSFunction::create(vm, globalObject, processObjectInternalsCreateOnWarningCodeGenerator(vm), globalObject);
     JSC::MarkedArgumentBuffer args;
-    args.append(process);
+    args.append(this);
     // --redirect-warnings, then NODE_REDIRECT_WARNINGS.
     JSValue redirectPath = jsUndefined();
     BunString redirect;
@@ -1734,17 +1723,46 @@ static void ensureOnWarningInstalled(Zig::GlobalObject* globalObject, Process* p
         lens.grow(nDisabled);
         Bun__Node__getDisabledWarnings(bufs.begin(), lens.begin(), nDisabled);
         auto* array = JSC::constructEmptyArray(globalObject, nullptr, static_cast<unsigned>(nDisabled));
-        RETURN_IF_EXCEPTION(scope, );
+        RETURN_IF_EXCEPTION(scope, nullptr);
         for (size_t i = 0; i < nDisabled; i++) {
             array->putDirectIndex(globalObject, static_cast<unsigned>(i),
                 jsString(vm, WTF::String::fromUTF8(std::span { bufs[i], lens[i] })));
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, nullptr);
         }
         disabled = array;
     }
     args.append(disabled);
-    // The caller has a ThrowScope and RETURN_IF_EXCEPTION immediately after.
-    RELEASE_AND_RETURN(scope, void(JSC::profiledCall(globalObject, ProfilingReason::API, installer, JSC::getCallData(installer), globalObject->globalThis(), args)));
+    JSValue onWarning = JSC::profiledCall(globalObject, ProfilingReason::API, factory, JSC::getCallData(factory), jsUndefined(), args);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_onWarning.set(vm, this, asObject(onWarning));
+    return asObject(onWarning);
+}
+
+JSC_DEFINE_HOST_FUNCTION(Process_functionDefaultOnWarning, (JSC::JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* process = globalObject->processObject();
+    auto* onWarning = process->ensureOnWarning(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::MarkedArgumentBuffer args;
+    args.append(callFrame->argument(0));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::profiledCall(globalObject, ProfilingReason::API, onWarning, JSC::getCallData(onWarning), process, args)));
+}
+
+// Node registers its printer as an ordinary 'warning' listener during bootstrap
+// (lib/internal/process/pre_execution.js setupWarningHandler), so user code observes
+// listenerCount('warning') === 1 and removeAllListeners('warning') silences it. Only this
+// stub is registered up front; the printer behind it is built on the first warning.
+void Process::installDefaultWarningListener(JSC::VM& vm)
+{
+    if (Bun__NODE_NO_WARNINGS() || Bun__Node__ProcessNoWarnings)
+        return;
+    auto* globalObject = defaultGlobalObject(this->globalObject());
+    auto* onWarning = JSFunction::create(vm, globalObject, 1, "onWarning"_s, Process_functionDefaultOnWarning, ImplementationVisibility::Public);
+    wrapped().addListener(builtinNames(vm).warningPublicName(), WebCore::JSEventListener::create(*onWarning, *this, false, globalObject->world()), false, false);
+    wrapped().setThisObject(this);
 }
 
 // Node's doEmitWarning: process.emit('warning', warning). The default print is a real
@@ -2132,12 +2150,6 @@ JSValue Process::emitWarningErrorInstance(JSC::JSGlobalObject* lexicalGlobalObje
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* process = globalObject->processObject();
-
-    // Lazily install onWarning before the first emit; every emitWarning path
-    // funnels through here so the listener is present by the time the
-    // nextTick-scheduled 'warning' event fires.
-    ensureOnWarningInstalled(globalObject, process);
-    RETURN_IF_EXCEPTION(scope, {});
 
     auto warningName = errorInstance.get(lexicalGlobalObject, vm.propertyNames->name);
     RETURN_IF_EXCEPTION(scope, {});
@@ -3665,6 +3677,7 @@ void Process::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_cachedCwd);
     visitor.append(thisObject->m_argv);
     visitor.append(thisObject->m_execArgv);
+    visitor.append(thisObject->m_onWarning);
 
     thisObject->m_cpuUsageStructure.visit(visitor);
     thisObject->m_resourceUsageStructure.visit(visitor);
@@ -4910,6 +4923,8 @@ void Process::finishCreation(JSC::VM& vm)
 {
     Base::finishCreation(vm);
 
+    // Before the hook below: onDidChangeListeners loads the signal tables on any add.
+    installDefaultWarningListener(vm);
     wrapped().onDidChangeListener = &onDidChangeListeners;
 
     m_cpuUsageStructure.initLater([](const JSC::LazyProperty<Process, JSC::Structure>::Initializer& init) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1740,10 +1740,14 @@ JSObject* Process::ensureOnWarning(Zig::GlobalObject* globalObject)
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionDefaultOnWarning, (JSC::JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& vm = JSC::getVM(globalObject);
+    auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* process = globalObject->processObject();
+    // The emitter invokes with the process it was registered on (setThisObject below);
+    // fall back for a listener plucked out of listeners('warning') and called bare.
+    auto* process = dynamicDowncast<Process>(callFrame->thisValue());
+    if (!process)
+        process = defaultGlobalObject(lexicalGlobalObject)->processObject();
+    auto* globalObject = defaultGlobalObject(process->globalObject());
     auto* onWarning = process->ensureOnWarning(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::MarkedArgumentBuffer args;
@@ -1762,6 +1766,8 @@ void Process::installDefaultWarningListener(JSC::VM& vm)
     auto* globalObject = defaultGlobalObject(this->globalObject());
     auto* onWarning = JSFunction::create(vm, globalObject, 1, "onWarning"_s, Process_functionDefaultOnWarning, ImplementationVisibility::Public);
     wrapped().addListener(builtinNames(vm).warningPublicName(), WebCore::JSEventListener::create(*onWarning, *this, false, globalObject->world()), false, false);
+    // The listener map holds the function weakly and is only marked through this object.
+    vm.writeBarrier(this, onWarning);
     wrapped().setThisObject(this);
 }
 

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -32,6 +32,10 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<JSString> m_cachedCwd;
     WriteBarrier<Unknown> m_argv;
     WriteBarrier<Unknown> m_execArgv;
+    // The JS warning printer (ProcessObjectInternals createOnWarning), built on the first warning.
+    WriteBarrier<JSObject> m_onWarning;
+
+    void installDefaultWarningListener(JSC::VM&);
 
 public:
     Process(JSC::Structure* structure, WebCore::JSDOMGlobalObject& globalObject, Ref<WebCore::EventEmitter>&& impl)
@@ -51,8 +55,6 @@ public:
 
     bool m_isExitCodeObservable = false;
     bool m_sourceMapsEnabled = false;
-    // Lazy install guard for the JS onWarning 'warning' listener.
-    bool m_warningListenerInstalled = false;
     // Node's per-Environment EmitProcessEnvWarning one-shot for DEP0104.
     bool m_emitEnvNonstringWarning = true;
     // Re-entry guard for dispatchExitInternal. Per-Process (i.e. per-VM): a
@@ -77,6 +79,8 @@ public:
     // Some Node.js events want to be emitted on the next tick rather than synchronously.
     // This is equivalent to `process.nextTick(() => process.emit(eventName, event))` from JavaScript.
     void emitOnNextTick(Zig::GlobalObject* globalObject, ASCIILiteral eventName, JSValue event);
+
+    JSObject* ensureOnWarning(Zig::GlobalObject*);
 
     static JSValue emitWarningErrorInstance(JSC::JSGlobalObject* lexicalGlobalObject, JSValue errorInstance);
     static JSValue emitWarning(JSC::JSGlobalObject* lexicalGlobalObject, JSValue warning, JSValue type, JSValue code, JSValue ctor);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2116,6 +2116,107 @@ it("removeAllListeners('warning') silences the default print", async () => {
   expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
 });
 
+// Node registers onWarning at bootstrap (pre_execution.js setupWarningHandler),
+// so it is already in the listener list before user code runs. Verified against
+// node v24.18.0: every script below prints the same thing there.
+describe("default 'warning' listener is registered at startup", () => {
+  const env = { ...bunEnv, NODE_NO_WARNINGS: undefined };
+
+  async function run(cmd, extraEnv) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...cmd],
+      env: extraEnv ? { ...env, ...extraEnv } : env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent("removeAllListeners('warning') before the first warning silences the print", async () => {
+    expect(await run(["-e", `process.removeAllListeners("warning"); process.emitWarning("hidden");`])).toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("a user listener installed after removeAllListeners is the only consumer", async () => {
+    expect(
+      await run([
+        "-e",
+        `process.removeAllListeners("warning");
+         process.on("warning", w => console.log("user:" + w.name + ":" + w.message));
+         process.emitWarning("hidden");`,
+      ]),
+    ).toEqual({ stdout: "user:Warning:hidden\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("is observable via listenerCount/listeners and removable by reference", async () => {
+    expect(
+      await run([
+        "-e",
+        `const [onWarning, ...rest] = process.listeners("warning");
+         console.log(JSON.stringify({ count: process.listenerCount("warning"), name: onWarning.name, rest: rest.length }));
+         process.removeListener("warning", onWarning);
+         console.log(process.listenerCount("warning"));
+         process.emitWarning("hidden");`,
+      ]),
+    ).toEqual({ stdout: `{"count":1,"name":"onWarning","rest":0}\n0\n`, stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("prints before a user listener added later runs", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "-e",
+      `process.on("warning", () => process.stderr.write("user-listener\\n"));
+       process.emitWarning("shown");`,
+    ]);
+    expect(stderr).toMatch(
+      /^\(node:\d+\) Warning: shown\n\(Use `.*--trace-warnings \.\.\.` to show where the warning was created\)\nuser-listener\n$/,
+    );
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
+  });
+
+  it.concurrent("a bare process.emit('warning') with no prior emitWarning() still prints", async () => {
+    const { stdout, stderr, exitCode } = await run(["-e", `process.emit("warning", new Error("bare"));`]);
+    expect(stderr).toMatch(/^\(node:\d+\) Error: bare\n\(Use `.*--trace-warnings/);
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
+  });
+
+  it.concurrent.each([
+    ["--no-warnings", ["--no-warnings"], undefined],
+    ["NODE_NO_WARNINGS=1", [], { NODE_NO_WARNINGS: "1" }],
+  ])("%s registers no default listener but user listeners still fire", async (_, flags, extraEnv) => {
+    expect(
+      await run(
+        [
+          ...flags,
+          "-e",
+          `console.log(process.listenerCount("warning"));
+           process.on("warning", w => console.log("user:" + w.message));
+           process.emitWarning("quiet");`,
+        ],
+        extraEnv,
+      ),
+    ).toEqual({ stdout: "0\nuser:quiet\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("each worker_threads Worker gets its own default listener", async () => {
+    const worker = `const { parentPort } = require("node:worker_threads");
+       const before = process.listenerCount("warning");
+       process.removeAllListeners("warning");
+       process.emitWarning("hidden-in-worker");
+       setImmediate(() => parentPort.postMessage(before + ":" + process.listenerCount("warning")));`;
+    expect(
+      await run([
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         new Worker(${JSON.stringify(worker)}, { eval: true }).on("message", m => console.log(m));`,
+      ]),
+    ).toEqual({ stdout: "1:0\n", stderr: "", exitCode: 0 });
+  });
+});
+
 it("--disable-warning suppresses print but not user 'warning' listeners", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -164,10 +164,11 @@ if (process.argv.length === 2 &&
         (process.features.inspector || !flag.startsWith('--inspect'))) {
       if (flag === "--no-warnings" && process.versions.bun) {
         // Keep scanning so a later --expose-internals / --expose-gc in the
-        // same Flags line still installs its shim in-process. Bun's onWarning
-        // printer re-reads Node's process.noProcessWarnings alias on every
-        // warning, so setting it here silences the print like the flag does.
+        // same Flags line still installs its shim in-process. This runs before
+        // the test registers any listener, so dropping the bootstrap printer
+        // plus seeding the alias is exactly the state --no-warnings produces.
         process.noProcessWarnings = true;
+        process.removeAllListeners('warning');
         continue;
       }
       if ((flag === "--expose-gc" || flag === "--expose_gc") && process.versions.bun) {

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -165,8 +165,8 @@ if (process.argv.length === 2 &&
       if (flag === "--no-warnings" && process.versions.bun) {
         // Keep scanning so a later --expose-internals / --expose-gc in the
         // same Flags line still installs its shim in-process. Bun's onWarning
-        // printer installs lazily on the first emitWarning and honors Node's
-        // process.noProcessWarnings alias read at that point, so set it here.
+        // printer re-reads Node's process.noProcessWarnings alias on every
+        // warning, so setting it here silences the print like the flag does.
         process.noProcessWarnings = true;
         continue;
       }


### PR DESCRIPTION
### What does this PR do?

Registers the default `'warning'` printer when `process` is created, the way Node's bootstrap does (`lib/internal/process/pre_execution.js` `setupWarningHandler`), instead of on the first `emitWarning()`.

#31831 made the printer a real `'warning'` listener but installed it lazily, which its description called out as a divergence: `process.removeAllListeners('warning')` at startup did not silence it. That idiom is how programs (CLIs rendering a TUI, test runners) opt out of the default print, and it silenced warnings on every Bun release before #31831 (a user listener suppressed the native print), so this is a regression for them:

```js
process.removeAllListeners("warning");
process.on("warning", w => console.log("user listener got:", w.name));
process.emitWarning("hello");
```

| runtime | stderr |
|---|---|
| node v26.3.0 (and v24.18.0) | (nothing) |
| bun 1.4.0-canary (before #31831) | (nothing) |
| bun main | `(node:PID) Warning: hello` + `(Use \`bun --trace-warnings ...\`)` |
| this PR | (nothing) |

**The fix** is `Process::installDefaultWarningListener`, called from `Process::finishCreation`. To keep the printer's setup (`--redirect-warnings`, `--disable-warning`, `require("node:fs")`) off the startup path, what gets registered up front is a native `onWarning` stub; `Process::ensureOnWarning` builds the JS printer (`createOnWarning`, the former `installOnWarningListener` minus the `prependListener` call) on the first warning and the stub forwards to it. Startup cost is one native `JSFunction` and one listener-map entry per `process` object; the listener is added before `onDidChangeListener` is wired so it does not trigger the signal-table loading that hook does on every add.

Observable results, all matching Node (every script in the tests, plus the extra probes listed under verification, was run under node v26.3.0 and v24.18.0 and prints byte-identical output modulo pid/argv0):

- `process.listenerCount('warning')` is `1` at startup, `process.listeners('warning')[0].name === 'onWarning'`, and removing it by reference or via `removeAllListeners` silences the print.
- `--no-warnings` / `NODE_NO_WARNINGS=1` register nothing (`listenerCount === 0`); user listeners still fire.
- Each `worker_threads` Worker gets its own listener.
- Print-before-user-listener ordering is unchanged.
- A bare `process.emit('warning', err)` with no prior `emitWarning()` now prints, as in Node (the other divergence #31831's description listed).

The printer no longer reads `process.noProcessWarnings` at all (Node's doesn't; it is only a read-only alias of the flag). `test/js/node/test/common`, which used that read to apply a test's `--no-warnings` flag in-process, now removes the bootstrap listener instead — it loads before any test listener exists, so that is the same state the flag produces.

### How did you verify your code works?

New `describe("default 'warning' listener is registered at startup")` block in `test/js/node/process/process.test.js` (8 cases). On the unfixed build the `removeAllListeners`-before-first-warning cases print the warning, `listenerCount` is `0`, the worker case reports `0:1`, and the bare-`emit` case prints nothing; all pass with `bun bd test`. Node's own suite has no test for the startup listener (which is how #31831 missed it), so these are hand-written; the existing warning-pipeline tests (`test-process-warning*.js`, `test-process-warnings.mjs`, `test-process-emitwarning.js`, `test-env-var-no-warnings.js`, `test-process-redirect-warnings*.js`, `test-common-expect-warning.js`, the max-listeners and timers warning tests) still pass.

Beyond the test scripts, these were also diffed against node v26.3.0 and v24.18.0 on the built binary and came out identical: no-arg `removeAllListeners()`, the `--trace-warnings` hint printed once across two warnings, calling `process.listeners('warning')[0]` directly with an Error and with a non-Error, `--trace-warnings` stacks, `--redirect-warnings` / `NODE_REDIRECT_WARNINGS`, and `--disable-warning`. The new native path was also exercised under `BUN_JSC_validateExceptionChecks=1`.
