### PR TITLE
bun-release: derive each @oven/bun-* package description from its platform

### DIFF
--- a/packages/bun-release/scripts/upload-npm.ts
+++ b/packages/bun-release/scripts/upload-npm.ts
@@ -12,7 +12,7 @@ import { fetch } from "../src/fetch";
 import { chmod, copy, exists, join, write, writeJson } from "../src/fs";
 import { getRelease, getSemver } from "../src/github";
 import type { Platform } from "../src/platform";
-import { platforms } from "../src/platform";
+import { describePlatform, platforms } from "../src/platform";
 import { spawn } from "../src/spawn";
 
 const module = "bun";
@@ -159,7 +159,7 @@ async function buildModule(
   writeJson(join(cwd, "package.json"), {
     name: module,
     version: version,
-    description: "This is the macOS arm64 binary for Bun, a fast all-in-one JavaScript runtime.",
+    description: `This is the ${describePlatform({ os, arch, abi })} binary for Bun, a fast all-in-one JavaScript runtime.`,
     homepage: "https://bun.com",
     bugs: "https://github.com/oven-sh/issues",
     license: "MIT",

--- a/packages/bun-release/src/platform.ts
+++ b/packages/bun-release/src/platform.ts
@@ -130,6 +130,20 @@ export const platforms: Platform[] = [
   },
 ];
 
+const osNames: Record<string, string> = {
+  darwin: "macOS",
+  linux: "Linux",
+  android: "Android",
+  freebsd: "FreeBSD",
+  win32: "Windows",
+};
+
+/** The target a platform package's binary is built for, e.g. "macOS arm64" or "Linux x64 (musl)". */
+export function describePlatform({ os, arch, abi }: Pick<Platform, "os" | "arch" | "abi">): string {
+  const target = `${osNames[os] ?? os} ${arch}`;
+  return abi === "musl" ? `${target} (musl)` : target;
+}
+
 export function getSupportedPlatforms(os: string, arch: string, abi: string | undefined): Platform[] {
   return platforms
     .filter(

--- a/test/integration/bun-release/platform.test.ts
+++ b/test/integration/bun-release/platform.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { describePlatform, platforms } from "../../../packages/bun-release/src/platform";
+
+// upload-npm.ts writes `This is the ${describePlatform(platform)} binary for Bun, ...` as the
+// package.json description of every @oven/bun-* package, so each entry in platform.ts has to
+// describe its own target (they all used to be published as "the macOS arm64 binary").
+test("describePlatform names the target of every platform package", () => {
+  expect(Object.fromEntries(platforms.map(platform => [platform.bin, describePlatform(platform)]))).toEqual({
+    "bun-darwin-aarch64": "macOS arm64",
+    "bun-darwin-x64": "macOS x64",
+    "bun-darwin-x64-baseline": "macOS x64",
+    "bun-linux-aarch64": "Linux arm64",
+    "bun-linux-x64": "Linux x64",
+    "bun-linux-x64-baseline": "Linux x64",
+    "bun-linux-aarch64-musl": "Linux arm64 (musl)",
+    "bun-linux-x64-musl": "Linux x64 (musl)",
+    "bun-linux-x64-musl-baseline": "Linux x64 (musl)",
+    "bun-linux-aarch64-android": "Android arm64",
+    "bun-linux-x64-android": "Android x64",
+    "bun-freebsd-aarch64": "FreeBSD arm64",
+    "bun-freebsd-x64": "FreeBSD x64",
+    "bun-windows-x64": "Windows x64",
+    "bun-windows-x64-baseline": "Windows x64",
+    "bun-windows-aarch64": "Windows arm64",
+  });
+});

--- a/test/integration/bun-release/upload-npm.test.ts
+++ b/test/integration/bun-release/upload-npm.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+import { describePlatform, platforms } from "../../../packages/bun-release/src/platform";
+
+// Runs packages/bun-release/scripts/upload-npm.ts against a fake GitHub release.
+// Its dependencies are stubbed: octokit answers every release lookup with
+// release.json, jszip treats a downloaded "zip" as an archive holding `${body}/bun`,
+// and esbuild (only used to bundle the postinstall script) does nothing.
+const packageDir = path.join(import.meta.dir, "..", "..", "..", "packages", "bun-release");
+
+const sources: Record<string, string> = {
+  "scripts/upload-npm.ts": readFileSync(path.join(packageDir, "scripts", "upload-npm.ts"), "utf8"),
+};
+for (const name of new Bun.Glob("*.ts").scanSync(path.join(packageDir, "src"))) {
+  sources[`src/${name}`] = readFileSync(path.join(packageDir, "src", name), "utf8");
+}
+
+const stubs = {
+  "node_modules/octokit/package.json": JSON.stringify({ name: "octokit", version: "0.0.0", main: "index.js" }),
+  "node_modules/octokit/index.js": `
+    import release from "../../release.json";
+    export class Octokit {
+      async request(route) {
+        if (route === "GET /repos/{owner}/{repo}/releases/latest") return { data: release };
+        if (route === "GET /repos/{owner}/{repo}/releases/tags/{tag}") return { data: release };
+        throw new Error("unexpected request: " + route);
+      }
+    }
+  `,
+  "node_modules/jszip/package.json": JSON.stringify({ name: "jszip", version: "0.0.0", main: "index.js" }),
+  "node_modules/jszip/index.js": `
+    export async function loadAsync(buffer) {
+      const bin = new TextDecoder().decode(buffer);
+      return { files: { [bin + "/bun"]: { dir: false, async: async () => buffer } } };
+    }
+  `,
+  "node_modules/esbuild/package.json": JSON.stringify({ name: "esbuild", version: "0.0.0", main: "index.js" }),
+  "node_modules/esbuild/index.js": `
+    export function buildSync() { return { errors: [], warnings: [] }; }
+    export function formatMessagesSync() { return []; }
+  `,
+};
+
+const version = "1.0.0";
+// Without an action argument the script builds (but does not publish) the packages
+// whose platform matches the machine it runs on.
+const host = platforms.filter(({ os, arch }) => os === process.platform && arch === process.arch);
+
+test.concurrent("each platform package is described as its own platform's binary", async () => {
+  const downloaded: string[] = [];
+  using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(request) {
+      const bin = path.posix.basename(new URL(request.url).pathname, ".zip");
+      downloaded.push(bin);
+      return new Response(bin);
+    },
+  });
+  using dir = tempDir("bun-release-descriptions", {
+    ...sources,
+    ...stubs,
+    "release.json": JSON.stringify({
+      tag_name: `bun-v${version}`,
+      assets: platforms.map(({ bin }) => ({
+        name: `${bin}.zip`,
+        browser_download_url: new URL(`/${bin}.zip`, server.url).href,
+      })),
+    }),
+  });
+  const cwd = String(dir);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join("scripts", "upload-npm.ts"), version],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+
+  expect(host).not.toBeEmpty();
+  expect(downloaded).toEqual(host.map(({ bin }) => bin));
+  // On a linux-x64 host this covers the glibc and musl packages and their baseline
+  // aliases, so the abi has to make it into the description as well as the os and arch.
+  for (const platform of host) {
+    const { bin, os, arch } = platform;
+    const manifest = path.join(cwd, "npm", "@oven", bin, "package.json");
+    expect(JSON.parse(readFileSync(manifest, "utf8"))).toMatchObject({
+      name: `@oven/${bin}`,
+      version,
+      description: `This is the ${describePlatform(platform)} binary for Bun, a fast all-in-one JavaScript runtime.`,
+      os: [os],
+      cpu: [arch],
+    });
+  }
+});


### PR DESCRIPTION
### What

`buildModule()` in `packages/bun-release/scripts/upload-npm.ts` writes the same hard-coded description into the `package.json` of every platform package, so all 16 `@oven/bun-*` packages on npm currently describe themselves as the macOS arm64 build:

```
$ npm view @oven/bun-linux-x64-musl description
This is the macOS arm64 binary for Bun, a fast all-in-one JavaScript runtime.
$ npm view @oven/bun-windows-aarch64 description
This is the macOS arm64 binary for Bun, a fast all-in-one JavaScript runtime.
```

The string was copied from `npm/@oven/bun-darwin-aarch64/README.md`. The per-package READMEs that exist already say the right thing for their own platform; the `description` field (what npm search results and the package header show) is the only place that was wrong. Cosmetic, no effect on installs.

### Fix

`buildModule()` already has the platform's `os`, `arch` and `abi` in hand for the `os`/`cpu`/`libc` fields, so the description is now derived from the same values through a small `describePlatform()` helper in `src/platform.ts`. The wording follows the existing READMEs ("macOS arm64", "Linux x64", ...), with musl builds marked as such since that is what distinguishes them from the glibc package with the same os/cpu; the Android packages already say Android through their `os`, so the `android` abi adds nothing.

<details>
<summary>Resulting descriptions</summary>

```
@oven/bun-darwin-aarch64             This is the macOS arm64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-darwin-x64                 This is the macOS x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-darwin-x64-baseline        This is the macOS x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-aarch64              This is the Linux arm64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-x64                  This is the Linux x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-x64-baseline         This is the Linux x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-aarch64-musl         This is the Linux arm64 (musl) binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-x64-musl             This is the Linux x64 (musl) binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-x64-musl-baseline    This is the Linux x64 (musl) binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-aarch64-android      This is the Android arm64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-linux-x64-android          This is the Android x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-freebsd-aarch64            This is the FreeBSD arm64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-freebsd-x64                This is the FreeBSD x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-windows-x64                This is the Windows x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-windows-x64-baseline       This is the Windows x64 binary for Bun, a fast all-in-one JavaScript runtime.
@oven/bun-windows-aarch64            This is the Windows arm64 binary for Bun, a fast all-in-one JavaScript runtime.
```

</details>

The helper lives in `src/platform.ts`, next to the `platforms` table it describes, where it can be tested against every entry. It is only referenced from `upload-npm.ts`; the `install.js` postinstall bundle that ships inside the `bun` package is byte-identical before and after this change.

This only takes effect for releases published after it lands; already published versions keep the old description.

### Tests

- `test/integration/bun-release/platform.test.ts` pins the target name of every entry in `platforms`, so adding a platform (or an OS without a display name) fails the test until its expected line is added.
- `test/integration/bun-release/upload-npm.test.ts` runs `upload-npm.ts` against a stubbed release (octokit, jszip and esbuild replaced in a temp dir, assets served from a local `Bun.serve`) and checks the `package.json` the script writes for each of the host's packages. On linux-x64 that is the glibc and musl packages plus their baseline aliases. Reverting the `description` line makes it fail with `macOS arm64` in place of `Linux x64`; dropping `abi` from the call makes it fail on the musl packages. The helper test alone catches neither, which is why both tests are here.

Both fail on main and pass with this change. The `upload-npm.test.ts` harness is the same one #37343 adds for its missing-asset checks; whichever of the two lands second folds the files together (the `src/` changes merge cleanly in either order).

### Related

@RiskyMH fixed this same line in #20945 (July 2025) as part of a larger update. That PR has been conflicting with main for some time: its `libc` handling has since landed in a different form, and `platforms` has grown android, freebsd and arm64 musl entries that its inline os map predates. This PR carries only the description part forward, adapted to the current platform list. The other pieces of #20945 that are still relevant (the missing musl READMEs, the `bugs` URL pointing at `oven-sh/issues`) are not touched here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/integration/bun-release/upload-npm.test.ts

<!-- robobun:evidence:end -->