### PR TITLE
bun-release: make the postinstall's npm install and registry download fallbacks work

### DIFF
--- a/packages/bun-release/src/fs.ts
+++ b/packages/bun-release/src/fs.ts
@@ -55,14 +55,15 @@ export function rm(path: string): void {
   fs.rmdirSync(path);
 }
 
-export function rename(path: string, newPath: string): void {
-  debug("rename", path, newPath);
+export function rename(oldPath: string, newPath: string): void {
+  debug("rename", oldPath, newPath);
   try {
-    fs.renameSync(path, newPath);
+    fs.renameSync(oldPath, newPath);
     return;
   } catch (error) {
     debug("fs.renameSync failed", error);
-    // If there is an error, delete the new path and try again.
+    // If there is an error, delete the new path, ensure its parent
+    // directory exists and try again.
   }
   try {
     rm(newPath);
@@ -70,7 +71,13 @@ export function rename(path: string, newPath: string): void {
     debug("rm failed", error);
     // The path could have been deleted already.
   }
-  fs.renameSync(path, newPath);
+  try {
+    fs.mkdirSync(path.dirname(newPath), { recursive: true });
+  } catch (error) {
+    debug("fs.mkdirSync failed", error);
+    // Let the rename below report what is wrong with the path.
+  }
+  fs.renameSync(oldPath, newPath);
 }
 
 export function write(dst: string, content: string | ArrayBuffer | ArrayBufferView): void {

--- a/packages/bun-release/src/fs.ts
+++ b/packages/bun-release/src/fs.ts
@@ -12,9 +12,8 @@ export function basename(...paths: (string | string[])[]): string {
   return path.basename(join(...paths));
 }
 
-export function tmp(): string {
-  const tmpdir = process.env["RUNNER_TEMP"] ?? os.tmpdir();
-  const dir = fs.mkdtempSync(join(tmpdir, "bun-"));
+export function tmp(parent: string = process.env["RUNNER_TEMP"] ?? os.tmpdir()): string {
+  const dir = fs.mkdtempSync(join(parent, "bun-"));
   debug("tmp", dir);
   return dir;
 }

--- a/packages/bun-release/src/npm/install.ts
+++ b/packages/bun-release/src/npm/install.ts
@@ -27,42 +27,46 @@ export async function importBun(): Promise<string> {
 
 async function requireBun(platform: Platform): Promise<string> {
   const module = `${owner}/${platform.bin}`;
-  function resolveBun() {
-    const exe = require.resolve(join(module, platform.exe));
-    const { exitCode, stderr, stdout } = spawn(exe, ["--version"]);
-    if (exitCode === 0) {
-      return exe;
-    }
-    throw new Error(stderr || stdout);
-  }
   try {
-    return resolveBun();
+    return checkBun(require.resolve(join(module, platform.exe)));
   } catch (cause) {
-    debug("resolveBun failed", cause);
+    debug("resolve failed", cause);
     error(
       `Failed to find package "${module}".`,
       `You may have used the "--no-optional" flag when running "npm install".`,
     );
   }
-  const cwd = join("node_modules", module);
+  const dst = join(__dirname, "node_modules", module);
   try {
-    installBun(platform, cwd);
+    installBun(platform, dst);
   } catch (cause) {
     debug("installBun failed", cause);
     error(`Failed to install package "${module}" using "npm install".`, cause);
     try {
-      await downloadBun(platform, cwd);
+      await downloadBun(platform, dst);
     } catch (cause) {
       debug("downloadBun failed", cause);
       error(`Failed to download package "${module}" from "registry.npmjs.org".`, cause);
     }
   }
-  return resolveBun();
+  // Not require.resolve() again: when `bun install` runs this script without node installed,
+  // it runs under bun, whose resolver remembers that the lookup above failed.
+  return checkBun(join(dst, platform.exe));
+}
+
+function checkBun(exe: string): string {
+  const { exitCode, stderr, stdout } = spawn(exe, ["--version"]);
+  if (exitCode === 0) {
+    return exe;
+  }
+  throw new Error(stderr || stdout);
 }
 
 function installBun(platform: Platform, dst: string): void {
   const module = `${owner}/${platform.bin}`;
-  const cwd = tmp();
+  // Inside this package rather than the system temporary directory, which can be a different
+  // file system that the rename below cannot move the package out of.
+  const cwd = tmp(__dirname);
   try {
     write(join(cwd, "package.json"), "{}");
     const { exitCode, stdout, stderr } = spawn(

--- a/packages/bun-release/src/npm/install.ts
+++ b/packages/bun-release/src/npm/install.ts
@@ -65,7 +65,7 @@ function installBun(platform: Platform, dst: string): void {
   const cwd = tmp();
   try {
     write(join(cwd, "package.json"), "{}");
-    const { exitCode } = spawn(
+    const { exitCode, stdout, stderr } = spawn(
       "npm",
       ["install", "--loglevel=error", "--prefer-offline", "--no-audit", "--progress=false", `${module}@${version}`],
       {
@@ -77,9 +77,10 @@ function installBun(platform: Platform, dst: string): void {
         },
       },
     );
-    if (exitCode === 0) {
-      rename(join(cwd, "node_modules", module), dst);
+    if (exitCode !== 0) {
+      throw new Error(stderr || stdout || `npm exited with code ${exitCode}`);
     }
+    rename(join(cwd, "node_modules", module), dst);
   } finally {
     try {
       rm(cwd);

--- a/packages/bun-release/src/npm/install.ts
+++ b/packages/bun-release/src/npm/install.ts
@@ -69,20 +69,30 @@ function installBun(platform: Platform, dst: string): void {
   const cwd = tmp(__dirname);
   try {
     write(join(cwd, "package.json"), "{}");
-    const { exitCode, stdout, stderr } = spawn(
+    const command = [
       "npm",
-      ["install", "--loglevel=error", "--prefer-offline", "--no-audit", "--progress=false", `${module}@${version}`],
-      {
-        cwd,
-        stdio: "pipe",
-        env: {
-          ...process.env,
-          npm_config_global: undefined,
-        },
+      "install",
+      "--loglevel=error",
+      "--prefer-offline",
+      "--no-audit",
+      "--progress=false",
+      `${module}@${version}`,
+    ];
+    const options = {
+      cwd,
+      env: {
+        ...process.env,
+        npm_config_global: undefined,
       },
-    );
+    };
+    // On Windows npm is npm.cmd, which only a shell can run.
+    const { exitCode, stdout, stderr } =
+      os === "win32"
+        ? spawn(command.join(" "), [], { ...options, shell: true })
+        : spawn(command[0], command.slice(1), options);
     if (exitCode !== 0) {
-      throw new Error(stderr || stdout || `npm exited with code ${exitCode}`);
+      error(stderr || stdout);
+      throw new Error("npm install failed");
     }
     rename(join(cwd, "node_modules", module), dst);
   } finally {

--- a/packages/bun-release/src/spawn.ts
+++ b/packages/bun-release/src/spawn.ts
@@ -11,14 +11,19 @@ export function spawn(
   stderr: string;
 } {
   debug("spawn", [cmd, ...args].join(" "));
-  const { status, stdout, stderr } = child_process.spawnSync(cmd, args, {
+  const { error, status, stdout, stderr } = child_process.spawnSync(cmd, args, {
     stdio: "pipe",
     encoding: "utf-8",
     ...options,
   });
+  if (error) {
+    debug("child_process.spawnSync failed", error);
+  }
+  // A process that could not be spawned (missing executable, missing cwd) has no
+  // status and no output: report it as a failure whose stderr is the reason.
   return {
     exitCode: status ?? 1,
-    stdout,
-    stderr,
+    stdout: stdout ?? "",
+    stderr: stderr ?? error?.message ?? "",
   };
 }

--- a/test/integration/bun-release/npm-postinstall.test.ts
+++ b/test/integration/bun-release/npm-postinstall.test.ts
@@ -64,31 +64,57 @@ function tarball(files: Record<string, Buffer | string>): Buffer {
 const tgz = tarball({ "package.json": JSON.stringify({ name: pkg, version }), [platform.exe]: binary });
 
 // installBun() runs `npm install <pkg>@<version>` in a scratch directory and moves
-// node_modules/<pkg> out of it. These stand in for npm there, as scripts for the runtime under
-// test since PATH holds nothing but them. Windows never runs them (a file without an extension
-// is not executable there), so there every `npm install` fails before running anything, which
-// is also what happens in production: node does not run npm.cmd without a shell.
-function failingNpm(runtime: string): DirectoryTree {
-  return { "fake-bin/npm": `#!${runtime}\nconsole.error("npm ERR! code E404");\nprocess.exit(1);\n` };
+// node_modules/<pkg> out of it. These stand in for npm there: a script for the runtime under
+// test (PATH holds nothing but fake-bin), which on Windows is reached through an npm.cmd, the
+// way the real npm is.
+function fakeNpm(runtime: string, script: (root: string) => string): DirectoryTree {
+  return {
+    "fake-bin/npm": ({ root }) => `#!${runtime}\n${script(root)}`,
+    "fake-bin/npm.cmd": `@"${runtime.replaceAll("/", "\\")}" "%~dp0npm" %*\r\n`,
+  };
 }
+function failingNpm(runtime: string): DirectoryTree {
+  return fakeNpm(runtime, () => `console.error("npm ERR! code E404");\nprocess.exit(1);\n`);
+}
+// Installs <root>/binary as the package and records how it was invoked in <root>/npm-call.json.
 function installingNpm(runtime: string): DirectoryTree {
   const exe = path.posix.join("node_modules", pkg, platform.exe);
   return {
     "binary": binary,
-    "fake-bin/npm": ({ root }) => `#!${runtime}
-const fs = require("fs");
-fs.writeFileSync(${JSON.stringify(path.join(root, "npm-cwd"))}, process.cwd());
+    ...fakeNpm(
+      runtime,
+      root => `const fs = require("fs");
+fs.writeFileSync(
+  ${JSON.stringify(path.join(root, "npm-call.json"))},
+  JSON.stringify({ cwd: process.cwd(), argv: process.argv.slice(2), global: "npm_config_global" in process.env }),
+);
 fs.mkdirSync(${JSON.stringify(path.posix.dirname(exe))}, { recursive: true });
 fs.copyFileSync(${JSON.stringify(path.join(root, "binary"))}, ${JSON.stringify(exe)});
 fs.chmodSync(${JSON.stringify(exe)}, 0o755);
 `,
+    ),
   };
 }
+const npmInstallArgs = [
+  "install",
+  "--loglevel=error",
+  "--prefer-offline",
+  "--no-audit",
+  "--progress=false",
+  `${pkg}@${version}`,
+];
 
-// The script's PATH is replaced with fake-bin. On Windows process.env spells the variable
-// `Path`, and Bun.spawn gives the child the first of two keys differing only in case, so the
-// inherited key has to go rather than be shadowed by `PATH`.
-const envWithoutPath = Object.fromEntries(Object.entries(bunEnv).filter(([key]) => key.toUpperCase() !== "PATH"));
+// The script gets PATH pointing at fake-bin only. The inherited PATH has to be removed rather
+// than shadowed: on Windows process.env spells it `Path`, and Bun.spawn gives the child the
+// first of two keys differing only in case. The other variables are the ones console.ts
+// changes the script's output on. npm_config_global is what `npm install -g bun` runs the
+// script with, and what installBun() must not pass on to its own `npm install`.
+const scriptEnv = Object.fromEntries(
+  Object.entries(bunEnv).filter(
+    ([key]) => !["PATH", "DEBUG", "LOG_LEVEL", "RUNNER_DEBUG", "GITHUB_ACTION"].includes(key.toUpperCase()),
+  ),
+);
+scriptEnv.npm_config_global = "true";
 
 async function postinstall(runtime: string, name: string, options: { npm?: DirectoryTree; tarball?: Buffer }) {
   const bunPackage: DirectoryTree = {
@@ -110,12 +136,13 @@ async function postinstall(runtime: string, name: string, options: { npm?: Direc
   await using proc = Bun.spawn({
     cmd: [runtime, "-r", "./fetch.cjs", "install.js"],
     cwd: bunPackageDir,
-    env: { ...envWithoutPath, PATH: path.join(root, "fake-bin") },
+    env: { ...scriptEnv, PATH: path.join(root, "fake-bin") },
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const npmCwd = path.join(root, "npm-cwd");
+  const npmCallFile = path.join(root, "npm-call.json");
+  const npmCall = existsSync(npmCallFile) ? JSON.parse(readFileSync(npmCallFile, "utf8")) : undefined;
   return {
     stdout,
     stderr,
@@ -123,28 +150,33 @@ async function postinstall(runtime: string, name: string, options: { npm?: Direc
     bin: readFileSync(path.join(bunPackageDir, "bin", "bun.exe")),
     // Everything the script left in its own directory, so a scratch directory would show up.
     files: readdirSync(bunPackageDir).sort(),
-    // Where installingNpm()'s npm was run, relative to the script's directory.
-    npmCwd: existsSync(npmCwd) ? path.relative(bunPackageDir, readFileSync(npmCwd, "utf8")) : undefined,
+    // installingNpm()'s record, with npm's cwd made relative to the script's directory.
+    npmCall: npmCall && { ...npmCall, cwd: path.relative(bunPackageDir, npmCall.cwd) },
   };
 }
 
 const notFound = `Failed to find package "${pkg}". You may have used the "--no-optional" flag when running "npm install".`;
 const npmFailed = `Failed to install package "${pkg}" using "npm install".`;
+// installBun() prints npm's output (the fake's one line) before requireBun() reports the failure.
+const npmFailedOutput = `${notFound}\nnpm ERR! code E404\n\n${npmFailed}`;
 
-for (const [name, runtime] of [
-  ["node", nodeExe()],
-  ["bun", bunExe()],
-] as const) {
-  describe.skipIf(!runtime).concurrent(`bun npm package postinstall run with ${name}`, () => {
+const runtimes = [
+  // spawnError: how each runtime's spawnSync() describes a missing npm, which installBun()
+  // prints in that case. On Windows it is the shell that reports it instead.
+  { name: "node", exe: nodeExe(), spawnError: "spawnSync npm ENOENT" },
+  { name: "bun", exe: bunExe(), spawnError: 'Executable not found in $PATH: "npm"' },
+];
+
+for (const { name, exe, spawnError } of runtimes) {
+  const runtime = exe!;
+  const npmMissing = isWindows ? "'npm' is not recognized" : spawnError;
+  describe.skipIf(!exe).concurrent(`bun npm package postinstall run with ${name}`, () => {
     test('downloads the tarball from the registry when "npm install" fails', async () => {
-      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime!, `${name}-download`, {
-        npm: failingNpm(runtime!),
+      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime, `${name}-download`, {
+        npm: failingNpm(runtime),
         tarball: tgz,
       });
-      expect(stderr).toContain(notFound);
-      expect(stderr).toContain(npmFailed);
-      // The reported error carries npm's output, except on Windows where npm never ran (see failingNpm).
-      if (!isWindows) expect(stderr).toContain("npm ERR! code E404");
+      expect(stderr).toStartWith(npmFailedOutput);
       expect(stderr).not.toContain("Failed to download");
       expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
       expect(bin.equals(binary)).toBe(true);
@@ -153,8 +185,8 @@ for (const [name, runtime] of [
     });
 
     test("downloads the tarball from the registry when npm is not installed", async () => {
-      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime!, `${name}-no-npm`, { tarball: tgz });
-      expect(stderr).toContain(notFound);
+      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime, `${name}-no-npm`, { tarball: tgz });
+      expect(stderr).toStartWith(`${notFound}\n${npmMissing}`);
       expect(stderr).toContain(npmFailed);
       expect(stderr).not.toContain("Failed to download");
       expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
@@ -164,9 +196,10 @@ for (const [name, runtime] of [
     });
 
     test('fails and reports both attempts when "npm install" and the download fail', async () => {
-      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime!, `${name}-neither`, {
-        npm: failingNpm(runtime!),
+      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime, `${name}-neither`, {
+        npm: failingNpm(runtime),
       });
+      expect(stderr).toStartWith(npmFailedOutput);
       for (const { bin } of supportedPlatforms) {
         expect(stderr).toContain(`Failed to find package "@oven/${bin}".`);
         expect(stderr).toContain(`Failed to install package "@oven/${bin}" using "npm install".`);
@@ -179,18 +212,22 @@ for (const [name, runtime] of [
       expect(exitCode).toBe(1);
     });
 
-    // `npm install` cannot succeed on Windows (see failingNpm).
-    test.skipIf(isWindows)('uses the package "npm install" installed without downloading', async () => {
-      const { stdout, stderr, exitCode, bin, files, npmCwd } = await postinstall(runtime!, `${name}-npm`, {
-        npm: installingNpm(runtime!),
+    test('uses the package "npm install" installed without downloading', async () => {
+      const { stdout, stderr, exitCode, bin, files, npmCall } = await postinstall(runtime, `${name}-npm`, {
+        npm: installingNpm(runtime),
         tarball: tgz,
       });
       expect(stderr).toBe(`${notFound}\n`);
       expect(stdout).toBe("");
       expect(bin.equals(binary)).toBe(true);
-      // npm ran in a scratch directory directly inside the script's own directory (so on the
-      // same file system as the node_modules the package is moved to), since removed.
-      expect(npmCwd).toMatch(/^bun-[^/\\]+$/);
+      expect(npmCall).toEqual({
+        // A scratch directory directly inside the script's own directory, so on the same file
+        // system as the node_modules the package is moved to.
+        cwd: expect.stringMatching(/^bun-[^/\\]+$/),
+        argv: npmInstallArgs,
+        global: false,
+      });
+      // The scratch directory is gone again.
       expect(files).toEqual(["bin", "bun.tgz", "fetch.cjs", "install.js", "node_modules"]);
       expect(exitCode).toBe(0);
     });

--- a/test/integration/bun-release/npm-postinstall.test.ts
+++ b/test/integration/bun-release/npm-postinstall.test.ts
@@ -3,8 +3,8 @@ import { buildSync } from "esbuild";
 import { chmodSync, readFileSync } from "fs";
 import { bunEnv, bunExe, isWindows, nodeExe, tempDir, type DirectoryTree } from "harness";
 import path from "path";
-import { supportedPlatforms } from "../../../packages/bun-release/src/platform";
 import { gzipSync } from "zlib";
+import { supportedPlatforms } from "../../../packages/bun-release/src/platform";
 
 // The `bun` npm package's postinstall, bundled with esbuild as upload-npm.ts does and run with
 // node as npm does, in a project that installed bun without its optionalDependencies:

--- a/test/integration/bun-release/npm-postinstall.test.ts
+++ b/test/integration/bun-release/npm-postinstall.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { buildSync } from "esbuild";
+import { chmodSync, readFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, nodeExe, tempDir, type DirectoryTree } from "harness";
+import path from "path";
+import { supportedPlatforms } from "../../../packages/bun-release/src/platform";
+import { gzipSync } from "zlib";
+
+// The `bun` npm package's postinstall, bundled with esbuild as upload-npm.ts does and run with
+// node as npm does, in a project that installed bun without its optionalDependencies:
+// node_modules/bun holds the package and the platform package @oven/<bin> is missing. The
+// script then has to get the platform package with `npm install`, and failing that, by
+// downloading its tarball from the registry.
+const node = nodeExe();
+const packageDir = path.join(import.meta.dir, "..", "..", "..", "packages", "bun-release");
+const version = "1.0.0";
+const [platform] = supportedPlatforms;
+const pkg = `@oven/${platform.bin}`;
+const tarballUrl = ({ bin }: { bin: string }) => `https://registry.npmjs.org/@oven/${bin}/-/${bin}-${version}.tgz`;
+
+const installJs = buildSync({
+  entryPoints: [path.join(packageDir, "scripts", "npm-postinstall.ts")],
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  write: false,
+  define: { version: JSON.stringify(version), module: '"bun"', owner: '"@oven"' },
+}).outputFiles[0].text;
+
+// downloadBun() fetches a fixed registry.npmjs.org URL, so fetch is replaced before the
+// script runs: it serves the tarball the test put next to the script, or 404s without one.
+const fetchCjs = `
+const fs = require("fs");
+const path = require("path");
+globalThis.fetch = async url => {
+  console.log("fetch", url);
+  const tgz = path.join(__dirname, "bun.tgz");
+  return fs.existsSync(tgz) ? new Response(fs.readFileSync(tgz)) : new Response(null, { status: 404 });
+};
+`;
+
+// resolveBun() runs the installed binary with --version, so the fixture binary has to be
+// runnable: a shell script on POSIX, and on Windows (where it is spawned as bin/bun.exe) the
+// bun running this test.
+const binary: Buffer = isWindows ? readFileSync(bunExe()) : Buffer.from("#!/bin/sh\nexit 0\n");
+
+// downloadBun() reads only the name and size of each tar entry. Like `npm pack`, every
+// entry is prefixed with `package/`.
+function tarball(files: Record<string, Buffer | string>): Buffer {
+  const blocks: Buffer[] = [];
+  for (const [name, content] of Object.entries(files)) {
+    const data = Buffer.from(content);
+    const header = Buffer.alloc(512);
+    header.write(`package/${name}`, 0);
+    header.write(data.length.toString(8).padStart(11, "0"), 124);
+    blocks.push(header, data, Buffer.alloc((512 - (data.length % 512)) % 512));
+  }
+  blocks.push(Buffer.alloc(1024));
+  return gzipSync(Buffer.concat(blocks));
+}
+
+const tgz = tarball({ "package.json": JSON.stringify({ name: pkg, version }), [platform.exe]: binary });
+
+// installBun() runs `npm install <pkg>@<version>` in an empty temporary directory and moves
+// node_modules/<pkg> out of it. These stand in for npm there. They are node scripts because
+// PATH holds nothing but them. On Windows node cannot spawn `npm` (an npm.cmd) without a shell
+// in the first place, so there every `npm install` fails before running anything.
+const failingNpm: DirectoryTree = {
+  "fake-bin/npm": `#!${node}\nconsole.error("npm ERR! code E404");\nprocess.exit(1);\n`,
+};
+const installingNpm: DirectoryTree = {
+  "binary": binary,
+  "fake-bin/npm": ({ root }) => {
+    const exe = path.posix.join("node_modules", pkg, platform.exe);
+    return `#!${node}
+const fs = require("fs");
+fs.mkdirSync(${JSON.stringify(path.posix.dirname(exe))}, { recursive: true });
+fs.copyFileSync(${JSON.stringify(path.join(root, "binary"))}, ${JSON.stringify(exe)});
+fs.chmodSync(${JSON.stringify(exe)}, 0o755);
+`;
+  },
+};
+
+async function postinstall(name: string, options: { npm?: DirectoryTree; tarball?: Buffer }) {
+  const bunPackage: DirectoryTree = {
+    "install.js": installJs,
+    "fetch.cjs": fetchCjs,
+    // upload-npm.ts ships placeholders that optimizeBun() replaces with the installed binary.
+    "bin/bun.exe": "placeholder",
+    "bin/bunx.exe": "placeholder",
+  };
+  if (options.tarball) bunPackage["bun.tgz"] = options.tarball;
+  using dir = tempDir(`bun-npm-postinstall-${name}`, {
+    "fake-bin": {},
+    ...options.npm,
+    "node_modules": { bun: bunPackage },
+  });
+  const root = String(dir);
+  if (options.npm) chmodSync(path.join(root, "fake-bin", "npm"), 0o755);
+  await using proc = Bun.spawn({
+    cmd: [node!, "-r", "./fetch.cjs", "install.js"],
+    cwd: path.join(root, "node_modules", "bun"),
+    env: { ...bunEnv, PATH: path.join(root, "fake-bin") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const bin = readFileSync(path.join(root, "node_modules", "bun", "bin", "bun.exe"));
+  return { stdout, stderr, exitCode, bin };
+}
+
+const notFound = `Failed to find package "${pkg}". You may have used the "--no-optional" flag when running "npm install".`;
+const npmFailed = `Failed to install package "${pkg}" using "npm install".`;
+
+describe.skipIf(!node).concurrent("bun npm package postinstall", () => {
+  test('downloads the tarball from the registry when "npm install" fails', async () => {
+    const { stdout, stderr, exitCode, bin } = await postinstall("download", { npm: failingNpm, tarball: tgz });
+    expect(stderr).toContain(notFound);
+    expect(stderr).toContain(npmFailed);
+    // The reported error carries npm's output, except on Windows where npm never ran (see failingNpm).
+    if (!isWindows) expect(stderr).toContain("npm ERR! code E404");
+    expect(stderr).not.toContain("Failed to download");
+    expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
+    expect(bin.equals(binary)).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("downloads the tarball from the registry when npm is not installed", async () => {
+    const { stdout, stderr, exitCode, bin } = await postinstall("no-npm", { tarball: tgz });
+    expect(stderr).toContain(notFound);
+    expect(stderr).toContain(npmFailed);
+    expect(stderr).not.toContain("Failed to download");
+    expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
+    expect(bin.equals(binary)).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test('fails and reports both attempts when "npm install" and the download fail', async () => {
+    const { stdout, stderr, exitCode, bin } = await postinstall("neither", { npm: failingNpm });
+    for (const { bin } of supportedPlatforms) {
+      expect(stderr).toContain(`Failed to find package "@oven/${bin}".`);
+      expect(stderr).toContain(`Failed to install package "@oven/${bin}" using "npm install".`);
+      expect(stderr).toContain(`Failed to download package "@oven/${bin}" from "registry.npmjs.org".`);
+    }
+    expect(stderr).toContain('Error: Failed to install package "bun"');
+    expect(stdout).toBe(supportedPlatforms.map(platform => `fetch ${tarballUrl(platform)}\n`).join(""));
+    expect(bin.toString()).toBe("placeholder");
+    expect(exitCode).toBe(1);
+  });
+
+  // `npm install` cannot succeed on Windows (see failingNpm).
+  test.skipIf(isWindows)('uses the package "npm install" installed without downloading', async () => {
+    const { stdout, stderr, exitCode, bin } = await postinstall("npm", { npm: installingNpm, tarball: tgz });
+    expect(stderr).toBe(`${notFound}\n`);
+    expect(stdout).toBe("");
+    expect(bin.equals(binary)).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/integration/bun-release/npm-postinstall.test.ts
+++ b/test/integration/bun-release/npm-postinstall.test.ts
@@ -56,15 +56,18 @@ function tarball(files: Record<string, Buffer | string>): Buffer {
     blocks.push(header, data, Buffer.alloc((512 - (data.length % 512)) % 512));
   }
   blocks.push(Buffer.alloc(1024));
-  return gzipSync(Buffer.concat(blocks));
+  // Stored rather than deflated: on Windows the payload is bun.exe, and compressing it would
+  // take longer than everything else in this file.
+  return gzipSync(Buffer.concat(blocks), { level: 0 });
 }
 
 const tgz = tarball({ "package.json": JSON.stringify({ name: pkg, version }), [platform.exe]: binary });
 
 // installBun() runs `npm install <pkg>@<version>` in an empty temporary directory and moves
-// node_modules/<pkg> out of it. These stand in for npm there. They are node scripts because
-// PATH holds nothing but them. On Windows node cannot spawn `npm` (an npm.cmd) without a shell
-// in the first place, so there every `npm install` fails before running anything.
+// node_modules/<pkg> out of it. These stand in for npm there, as node scripts since PATH holds
+// nothing but them. Windows never runs them: without a shell node only spawns .exe/.com files,
+// which rules out the real npm (an npm.cmd) too, so there every `npm install` fails before
+// running anything.
 const failingNpm: DirectoryTree = {
   "fake-bin/npm": `#!${node}\nconsole.error("npm ERR! code E404");\nprocess.exit(1);\n`,
 };
@@ -80,6 +83,11 @@ fs.chmodSync(${JSON.stringify(exe)}, 0o755);
 `;
   },
 };
+
+// The script's PATH is replaced with fake-bin. On Windows process.env spells the variable
+// `Path`, and Bun.spawn gives the child the first of two keys differing only in case, so the
+// inherited key has to go rather than be shadowed by `PATH`.
+const envWithoutPath = Object.fromEntries(Object.entries(bunEnv).filter(([key]) => key.toUpperCase() !== "PATH"));
 
 async function postinstall(name: string, options: { npm?: DirectoryTree; tarball?: Buffer }) {
   const bunPackage: DirectoryTree = {
@@ -100,7 +108,7 @@ async function postinstall(name: string, options: { npm?: DirectoryTree; tarball
   await using proc = Bun.spawn({
     cmd: [node!, "-r", "./fetch.cjs", "install.js"],
     cwd: path.join(root, "node_modules", "bun"),
-    env: { ...bunEnv, PATH: path.join(root, "fake-bin") },
+    env: { ...envWithoutPath, PATH: path.join(root, "fake-bin") },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/integration/bun-release/npm-postinstall.test.ts
+++ b/test/integration/bun-release/npm-postinstall.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { buildSync } from "esbuild";
-import { chmodSync, readFileSync } from "fs";
+import { chmodSync, existsSync, readdirSync, readFileSync } from "fs";
 import { bunEnv, bunExe, isWindows, nodeExe, tempDir, type DirectoryTree } from "harness";
 import path from "path";
 import { gzipSync } from "zlib";
 import { supportedPlatforms } from "../../../packages/bun-release/src/platform";
 
-// The `bun` npm package's postinstall, bundled with esbuild as upload-npm.ts does and run with
-// node as npm does, in a project that installed bun without its optionalDependencies:
-// node_modules/bun holds the package and the platform package @oven/<bin> is missing. The
-// script then has to get the platform package with `npm install`, and failing that, by
-// downloading its tarball from the registry.
-const node = nodeExe();
+// The `bun` npm package's postinstall, bundled with esbuild as upload-npm.ts does, run in a
+// project that installed bun without its optionalDependencies: node_modules/bun holds the
+// package and the platform package @oven/<bin> is missing. The script then has to get the
+// platform package with `npm install`, and failing that, by downloading its tarball from the
+// registry. npm runs the script with node; `bun install` on a machine without node runs it
+// with bun standing in for node; so it is run with both.
 const packageDir = path.join(import.meta.dir, "..", "..", "..", "packages", "bun-release");
 const version = "1.0.0";
 const [platform] = supportedPlatforms;
@@ -39,7 +39,7 @@ globalThis.fetch = async url => {
 };
 `;
 
-// resolveBun() runs the installed binary with --version, so the fixture binary has to be
+// The script runs the installed binary with --version, so the fixture binary has to be
 // runnable: a shell script on POSIX, and on Windows (where it is spawned as bin/bun.exe) the
 // bun running this test.
 const binary: Buffer = isWindows ? readFileSync(bunExe()) : Buffer.from("#!/bin/sh\nexit 0\n");
@@ -63,33 +63,34 @@ function tarball(files: Record<string, Buffer | string>): Buffer {
 
 const tgz = tarball({ "package.json": JSON.stringify({ name: pkg, version }), [platform.exe]: binary });
 
-// installBun() runs `npm install <pkg>@<version>` in an empty temporary directory and moves
-// node_modules/<pkg> out of it. These stand in for npm there, as node scripts since PATH holds
-// nothing but them. Windows never runs them: without a shell node only spawns .exe/.com files,
-// which rules out the real npm (an npm.cmd) too, so there every `npm install` fails before
-// running anything.
-const failingNpm: DirectoryTree = {
-  "fake-bin/npm": `#!${node}\nconsole.error("npm ERR! code E404");\nprocess.exit(1);\n`,
-};
-const installingNpm: DirectoryTree = {
-  "binary": binary,
-  "fake-bin/npm": ({ root }) => {
-    const exe = path.posix.join("node_modules", pkg, platform.exe);
-    return `#!${node}
+// installBun() runs `npm install <pkg>@<version>` in a scratch directory and moves
+// node_modules/<pkg> out of it. These stand in for npm there, as scripts for the runtime under
+// test since PATH holds nothing but them. Windows never runs them (a file without an extension
+// is not executable there), so there every `npm install` fails before running anything, which
+// is also what happens in production: node does not run npm.cmd without a shell.
+function failingNpm(runtime: string): DirectoryTree {
+  return { "fake-bin/npm": `#!${runtime}\nconsole.error("npm ERR! code E404");\nprocess.exit(1);\n` };
+}
+function installingNpm(runtime: string): DirectoryTree {
+  const exe = path.posix.join("node_modules", pkg, platform.exe);
+  return {
+    "binary": binary,
+    "fake-bin/npm": ({ root }) => `#!${runtime}
 const fs = require("fs");
+fs.writeFileSync(${JSON.stringify(path.join(root, "npm-cwd"))}, process.cwd());
 fs.mkdirSync(${JSON.stringify(path.posix.dirname(exe))}, { recursive: true });
 fs.copyFileSync(${JSON.stringify(path.join(root, "binary"))}, ${JSON.stringify(exe)});
 fs.chmodSync(${JSON.stringify(exe)}, 0o755);
-`;
-  },
-};
+`,
+  };
+}
 
 // The script's PATH is replaced with fake-bin. On Windows process.env spells the variable
 // `Path`, and Bun.spawn gives the child the first of two keys differing only in case, so the
 // inherited key has to go rather than be shadowed by `PATH`.
 const envWithoutPath = Object.fromEntries(Object.entries(bunEnv).filter(([key]) => key.toUpperCase() !== "PATH"));
 
-async function postinstall(name: string, options: { npm?: DirectoryTree; tarball?: Buffer }) {
+async function postinstall(runtime: string, name: string, options: { npm?: DirectoryTree; tarball?: Buffer }) {
   const bunPackage: DirectoryTree = {
     "install.js": installJs,
     "fetch.cjs": fetchCjs,
@@ -104,64 +105,94 @@ async function postinstall(name: string, options: { npm?: DirectoryTree; tarball
     "node_modules": { bun: bunPackage },
   });
   const root = String(dir);
+  const bunPackageDir = path.join(root, "node_modules", "bun");
   if (options.npm) chmodSync(path.join(root, "fake-bin", "npm"), 0o755);
   await using proc = Bun.spawn({
-    cmd: [node!, "-r", "./fetch.cjs", "install.js"],
-    cwd: path.join(root, "node_modules", "bun"),
+    cmd: [runtime, "-r", "./fetch.cjs", "install.js"],
+    cwd: bunPackageDir,
     env: { ...envWithoutPath, PATH: path.join(root, "fake-bin") },
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const bin = readFileSync(path.join(root, "node_modules", "bun", "bin", "bun.exe"));
-  return { stdout, stderr, exitCode, bin };
+  const npmCwd = path.join(root, "npm-cwd");
+  return {
+    stdout,
+    stderr,
+    exitCode,
+    bin: readFileSync(path.join(bunPackageDir, "bin", "bun.exe")),
+    // Everything the script left in its own directory, so a scratch directory would show up.
+    files: readdirSync(bunPackageDir).sort(),
+    // Where installingNpm()'s npm was run, relative to the script's directory.
+    npmCwd: existsSync(npmCwd) ? path.relative(bunPackageDir, readFileSync(npmCwd, "utf8")) : undefined,
+  };
 }
 
 const notFound = `Failed to find package "${pkg}". You may have used the "--no-optional" flag when running "npm install".`;
 const npmFailed = `Failed to install package "${pkg}" using "npm install".`;
 
-describe.skipIf(!node).concurrent("bun npm package postinstall", () => {
-  test('downloads the tarball from the registry when "npm install" fails', async () => {
-    const { stdout, stderr, exitCode, bin } = await postinstall("download", { npm: failingNpm, tarball: tgz });
-    expect(stderr).toContain(notFound);
-    expect(stderr).toContain(npmFailed);
-    // The reported error carries npm's output, except on Windows where npm never ran (see failingNpm).
-    if (!isWindows) expect(stderr).toContain("npm ERR! code E404");
-    expect(stderr).not.toContain("Failed to download");
-    expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
-    expect(bin.equals(binary)).toBe(true);
-    expect(exitCode).toBe(0);
-  });
+for (const [name, runtime] of [
+  ["node", nodeExe()],
+  ["bun", bunExe()],
+] as const) {
+  describe.skipIf(!runtime).concurrent(`bun npm package postinstall run with ${name}`, () => {
+    test('downloads the tarball from the registry when "npm install" fails', async () => {
+      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime!, `${name}-download`, {
+        npm: failingNpm(runtime!),
+        tarball: tgz,
+      });
+      expect(stderr).toContain(notFound);
+      expect(stderr).toContain(npmFailed);
+      // The reported error carries npm's output, except on Windows where npm never ran (see failingNpm).
+      if (!isWindows) expect(stderr).toContain("npm ERR! code E404");
+      expect(stderr).not.toContain("Failed to download");
+      expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
+      expect(bin.equals(binary)).toBe(true);
+      expect(files).toEqual(["bin", "bun.tgz", "fetch.cjs", "install.js", "node_modules"]);
+      expect(exitCode).toBe(0);
+    });
 
-  test("downloads the tarball from the registry when npm is not installed", async () => {
-    const { stdout, stderr, exitCode, bin } = await postinstall("no-npm", { tarball: tgz });
-    expect(stderr).toContain(notFound);
-    expect(stderr).toContain(npmFailed);
-    expect(stderr).not.toContain("Failed to download");
-    expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
-    expect(bin.equals(binary)).toBe(true);
-    expect(exitCode).toBe(0);
-  });
+    test("downloads the tarball from the registry when npm is not installed", async () => {
+      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime!, `${name}-no-npm`, { tarball: tgz });
+      expect(stderr).toContain(notFound);
+      expect(stderr).toContain(npmFailed);
+      expect(stderr).not.toContain("Failed to download");
+      expect(stdout).toBe(`fetch ${tarballUrl(platform)}\n`);
+      expect(bin.equals(binary)).toBe(true);
+      expect(files).toEqual(["bin", "bun.tgz", "fetch.cjs", "install.js", "node_modules"]);
+      expect(exitCode).toBe(0);
+    });
 
-  test('fails and reports both attempts when "npm install" and the download fail', async () => {
-    const { stdout, stderr, exitCode, bin } = await postinstall("neither", { npm: failingNpm });
-    for (const { bin } of supportedPlatforms) {
-      expect(stderr).toContain(`Failed to find package "@oven/${bin}".`);
-      expect(stderr).toContain(`Failed to install package "@oven/${bin}" using "npm install".`);
-      expect(stderr).toContain(`Failed to download package "@oven/${bin}" from "registry.npmjs.org".`);
-    }
-    expect(stderr).toContain('Error: Failed to install package "bun"');
-    expect(stdout).toBe(supportedPlatforms.map(platform => `fetch ${tarballUrl(platform)}\n`).join(""));
-    expect(bin.toString()).toBe("placeholder");
-    expect(exitCode).toBe(1);
-  });
+    test('fails and reports both attempts when "npm install" and the download fail', async () => {
+      const { stdout, stderr, exitCode, bin, files } = await postinstall(runtime!, `${name}-neither`, {
+        npm: failingNpm(runtime!),
+      });
+      for (const { bin } of supportedPlatforms) {
+        expect(stderr).toContain(`Failed to find package "@oven/${bin}".`);
+        expect(stderr).toContain(`Failed to install package "@oven/${bin}" using "npm install".`);
+        expect(stderr).toContain(`Failed to download package "@oven/${bin}" from "registry.npmjs.org".`);
+      }
+      expect(stderr).toContain('Failed to install package "bun"');
+      expect(stdout).toBe(supportedPlatforms.map(platform => `fetch ${tarballUrl(platform)}\n`).join(""));
+      expect(bin.toString()).toBe("placeholder");
+      expect(files).toEqual(["bin", "fetch.cjs", "install.js"]);
+      expect(exitCode).toBe(1);
+    });
 
-  // `npm install` cannot succeed on Windows (see failingNpm).
-  test.skipIf(isWindows)('uses the package "npm install" installed without downloading', async () => {
-    const { stdout, stderr, exitCode, bin } = await postinstall("npm", { npm: installingNpm, tarball: tgz });
-    expect(stderr).toBe(`${notFound}\n`);
-    expect(stdout).toBe("");
-    expect(bin.equals(binary)).toBe(true);
-    expect(exitCode).toBe(0);
+    // `npm install` cannot succeed on Windows (see failingNpm).
+    test.skipIf(isWindows)('uses the package "npm install" installed without downloading', async () => {
+      const { stdout, stderr, exitCode, bin, files, npmCwd } = await postinstall(runtime!, `${name}-npm`, {
+        npm: installingNpm(runtime!),
+        tarball: tgz,
+      });
+      expect(stderr).toBe(`${notFound}\n`);
+      expect(stdout).toBe("");
+      expect(bin.equals(binary)).toBe(true);
+      // npm ran in a scratch directory directly inside the script's own directory (so on the
+      // same file system as the node_modules the package is moved to), since removed.
+      expect(npmCwd).toMatch(/^bun-[^/\\]+$/);
+      expect(files).toEqual(["bin", "bun.tgz", "fetch.cjs", "install.js", "node_modules"]);
+      expect(exitCode).toBe(0);
+    });
   });
-});
+}


### PR DESCRIPTION
### What happens

The `bun` npm package's postinstall (`packages/bun-release/scripts/npm-postinstall.ts`, bundled into the package's `install.js`) is structured as: resolve `@oven/<bin>`; if it is missing (an install that skipped `optionalDependencies`), run `npm install @oven/<bin>@<version>` into a scratch directory and move it into place; if that throws, download the tarball straight from `registry.npmjs.org`. When `npm install` fails, none of that happens:

```
Failed to find package "@oven/bun-linux-x64". You may have used the "--no-optional" flag when running "npm install".
Error: Failed to install package "bun"
```

The registry download is never attempted. This hits any machine where that `npm install` exits non-zero or cannot run at all: a registry mirror without the `@oven` scope, installs driven by a package manager that is not npm, and every Windows machine, where `npm` is `npm.cmd`, which `spawnSync("npm")` cannot start without a shell (ENOENT under node 26).

### Cause

`requireBun()`'s recovery path has never worked end to end. All of this dates back to cab1f860e4, which ported esbuild's install script:

1. `installBun()` (`src/npm/install.ts`) did `if (exitCode === 0) rename(...)` and otherwise returned normally, so the `catch` in `requireBun()` that logs `Failed to install package ... using "npm install"` and calls `downloadBun()` was unreachable on the failure it describes. esbuild runs npm with `execSync`, which throws on a non-zero exit; the port swapped in `src/spawn.ts`, which returns the status, and lost the throw.
2. When `npm install` did succeed, `rename()` (`src/fs.ts`) of the package into `node_modules/@oven/<bin>` failed with ENOENT: that is inside the bun package directory, whose own `node_modules/` does not exist at that point. (`downloadBun()` is unaffected because `write()` creates parent directories.)
3. The scratch directory came from `os.tmpdir()`, so where `/tmp` is a separate file system (tmpfs, containers) the rename fails with EXDEV even with 2 fixed. esbuild creates its scratch directory inside its own package for this reason.
4. `execSync` runs its command through a shell, which is how esbuild's `npm install` works on Windows; the port's `spawnSync("npm", ...)` does not, so on Windows npm was never started at all.
5. After installing or downloading, the binary was looked up with `require.resolve()` a second time. `bun` is a default trusted dependency, and `bun install` runs lifecycle scripts with bun standing in for `node` when node is not installed (`PackageManager.rs`, `create_fake_temporary_node_executable`), so on such machines this script runs under bun, whose resolver remembers that the first lookup failed and fails the second one too (reported separately as a runtime bug), ending in the same `Failed to install package "bun"` after a successful download.

### Fix

* `installBun()`: on a non-zero exit it prints npm's output (or, for a process that could not be started, the spawn error) and throws, the shape `upload-npm.ts` already uses for its npm calls, so the fallback runs and the reason is in the log. On Windows the command runs through the shell, as esbuild's does. The scratch directory is created inside the package directory (`tmp()` takes an optional parent; its other callers, `upload-s3.ts` and `upload-assets.ts`, are unchanged).
* `spawn()`: a process that could not be started is reported with the spawn error as its stderr instead of `null` output. This is the same change as in #37343 (identical file contents, so whichever lands second is a no-op there); it is needed here so that the line printed above says `spawnSync npm ENOENT` rather than nothing.
* `rename()` creates the destination's parent directory on its retry, the way `write()` already does. Its parameter is renamed so it stops shadowing the `path` module it now needs. `optimizeBun()`, the only other caller, renames into the package's shipped `bin/` directory, which exists, so it is unaffected.
* `requireBun()` checks the binary at the path `installBun()`/`downloadBun()` put it (`checkBun()`, the `--version` run that used to be inside `resolveBun()`) instead of resolving again. The destination is anchored on the script's directory, as `optimizeBun()` already is; npm runs the script with that directory as cwd, so the location is unchanged.

Not done: invoking npm through `npm_execpath` instead of PATH. Other package managers set `npm_execpath` to their own entry points, so that would need user-agent sniffing, and when npm runs the script it puts the running node's directory first on PATH, so `npm` already resolves to the npm that is running. The plain `npm` on PATH is also what esbuild's script runs.

### Tests

`test/integration/bun-release/npm-postinstall.test.ts` bundles the real `npm-postinstall.ts` with esbuild (the same `define`s `upload-npm.ts` uses) and runs it from `node_modules/bun/` in a temp project, once with node and once with bun (the two runtimes it runs under in practice). PATH holds only a directory with a fake `npm` (a script for the runtime under test, reached through an `npm.cmd` on Windows like the real one), `fetch` is replaced by a preload that serves a tarball from disk or answers 404, the script is run with `npm_config_global` set the way `npm install -g bun` does, and the variables `console.ts` changes its output on are not forwarded. The fixture binary is a shell script on POSIX and the test's own `bun.exe` on Windows, since the script runs it with `--version`. Per runtime:

* `npm install` exits 1 printing `npm ERR! code E404`: stderr starts with the "Failed to find package" line, npm's output and the "using npm install" line; the tarball is fetched; `bin/bun.exe` is the fixture binary; exit 0
* no `npm` on PATH: stderr starts with the "Failed to find package" line followed by the spawn error (`spawnSync npm ENOENT` under node, bun's wording under bun, cmd.exe's on Windows); otherwise the same
* `npm install` fails and the registry answers 404: all three failure messages per supported platform, `Failed to install package "bun"`, the placeholder `bin/bun.exe` untouched, nothing created in the package, exit 1
* `npm install` succeeds: nothing is fetched, `bin/bun.exe` is the binary npm installed, stderr is exactly the "Failed to find package" line, and the fake's record of the call is exactly the expected arguments, `npm_config_global` absent, and a cwd directly inside the package directory that no longer exists afterwards

Each change is pinned: against main's `packages/bun-release/src` all 8 fail; reverting the throw or the printing of npm's output fails 6; reverting `rename()`'s parent directory, the scratch directory location, or the `npm_config_global` removal fails the two "npm install succeeds" cases; reverting `spawn.ts` fails the two "no npm" cases; restoring the second `require.resolve()` fails the three bun-runtime cases that reach it while the node ones pass; the Windows shell is what makes the fake npm run at all on the Windows lanes. 8 pass on Linux (`bun bd test`) and on Windows (x64, system bun, both runtimes), and the file still passes with `DEBUG`/`LOG_LEVEL`/`GITHUB_ACTION` set in the environment running it.
