### PR TITLE
ci: run darwin tests on Buildkite-hosted agents while the mac fleet is offline

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -398,6 +398,31 @@ function getLinkBunAgent(platform, options) {
   });
 }
 
+// TEMPORARY (2026-08-10): the bare-metal macOS fleet behind `test-darwin` is
+// offline being reimaged. Until it is back, darwin tests run on Buildkite-hosted
+// M4 agents in this queue instead. Hosted agents are Apple Silicon only and the
+// queue is pinned to a single macOS 26 image, so only the aarch64 `latest` lane
+// can run there; and they bill per minute, so darwin tests run on main (the
+// canary gate) or when a commit subject opts in with `[macos tests]`, not on
+// every PR push. Delete this block, `darwinTestsEnabled`, and the filter in
+// getPipeline() to go back to the fleet.
+const darwinHostedQueue = "test-darwin-hosted";
+
+/**
+ * @returns {boolean}
+ */
+function darwinTestsEnabled() {
+  return isMainBranch() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
+}
+
+/**
+ * @param {Platform} platform
+ * @returns {boolean}
+ */
+function isRunnableDarwinTestPlatform(platform) {
+  return platform.os !== "darwin" || (platform.arch === "aarch64" && platform.tier === "latest");
+}
+
 /**
  * @param {Platform} platform
  * @param {PipelineOptions} options
@@ -407,17 +432,9 @@ function getTestAgent(platform, options) {
   const { os, arch, profile, tier } = platform;
 
   if (os === "darwin") {
-    // `release-tier` is emitted by scripts/agent.mjs based on the box's macOS
-    // major version. arm64 splits into `latest` (current macOS) + `previous`
-    // (anything older). x64 is NOT tier-targeted — single entry, any Intel
-    // box — because the tier split bottlenecked the smaller pool and Intel
-    // can't run latest anyway.
-    return {
-      queue: `test-${os}`,
-      os,
-      arch,
-      ...(arch === "aarch64" ? { "release-tier": tier } : {}),
-    };
+    // Hosted agents carry none of the fleet's os/arch/release-tier tags; the
+    // queue is the whole selector. See darwinHostedQueue above.
+    return { queue: darwinHostedQueue };
   }
 
   // TODO: delete this block when we upgrade to mimalloc v3
@@ -1575,7 +1592,12 @@ async function getPipeline(options = {}) {
   // Tests run on main too so the canary release step below can gate on them.
   // ASAN is PR-only (see includeASAN above), so the asan test lane is dropped
   // on main along with its build.
-  const relevantTestPlatforms = includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan");
+  // Darwin is further narrowed while the fleet is offline (see darwinHostedQueue):
+  // no darwin tests at all unless enabled, and only the lane hosted agents can
+  // run when it is.
+  const relevantTestPlatforms = (includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan"))
+    .filter(platform => platform.os !== "darwin" || darwinTestsEnabled())
+    .filter(isRunnableDarwinTestPlatform);
   /** @type {string[]} */
   const testStepKeys = [];
   {

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -404,15 +404,17 @@ function getLinkBunAgent(platform, options) {
 // queue is pinned to a single macOS 26 image, so only the aarch64 `latest` lane
 // can run there; and they bill per minute, so darwin tests run on main (the
 // canary gate) or when a commit subject opts in with `[macos tests]`, not on
-// every PR push. Delete this block, `darwinTestsEnabled`, and the filter in
-// getPipeline() to go back to the fleet.
+// every PR push. A manual (UI) build that picks a darwin lane in the options
+// form is its own opt-in. To go back to the fleet, revert the commit that added
+// this block: it also restores the tag-based `test-darwin` selector in
+// getTestAgent() and drops the filter in getPipeline().
 const darwinHostedQueue = "test-darwin-hosted";
 
 /**
  * @returns {boolean}
  */
 function darwinTestsEnabled() {
-  return isMainBranch() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
+  return isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Stopgap while the bare-metal macOS test fleet (`test-darwin` queue) is offline being reimaged.

- Darwin test steps now target a `test-darwin-hosted` queue backed by Buildkite-hosted M4 agents, instead of selecting fleet agents by `os`/`arch`/`release-tier` tags.
- Only the aarch64 `latest` (macOS 26) lane runs there. Hosted agents are Apple Silicon only and the queue is pinned to a single image, so the aarch64 `previous` and the x64 lanes are dropped until the fleet returns.
- Darwin tests run on `main`, or on a PR when the commit subject contains `[macos tests]`. Other PR pushes skip them, to bound hosted-agent spend. Darwin **build** lanes are unaffected (they cross-compile on Linux), so PRs still prove darwin compiles.

Needs the `test-darwin-hosted` queue to exist in the `CI` cluster before merge (Buildkite hosted, `MACOS_ARM64_M4_6X28`, macOS 26 image). Until it does, darwin test jobs on main will wait for an agent, which is no worse than today.

Revert this PR when the fleet is back.

### How did you verify your code works?

`node .buildkite/ci.mjs --dry-run` with Buildkite env for three cases:
- `main`: one `darwin-aarch64-26-test-bun` step, `agents: { queue: test-darwin-hosted }`
- PR, plain subject: darwin build steps present, zero darwin test steps
- PR with `[macos tests]` in the subject: same single darwin test step as main