### PR TITLE
test(worker): make the message flood test deterministic instead of racing worker boot

### DIFF
--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -410,29 +410,37 @@ describe("web worker", () => {
     // parent inside one drain: a drain task delivers a bounded batch and posts the
     // rest to the next loop iteration, so timers and I/O get their turn in between.
     test("a message flood from a worker does not starve the parent's event loop", async () => {
-      const total = 1500; // more than one drain task's budget (drainBatchLimit in WorkerMessagingProxy.cpp)
+      const budget = 1024; // drainBatchLimit in WorkerMessagingProxy.cpp
+      // Two budgets plus one: the continuation the first task posts has to yield and
+      // post another one as well.
+      const total = 2 * budget + 1;
       const flag = new Int32Array(new SharedArrayBuffer(4));
       const src = `onmessage = ({ data: flag }) => {
         for (let i = 0; i < ${total}; i++) postMessage(i);
         Atomics.store(flag, 0, 1); Atomics.notify(flag, 0);
       }`;
       const w = new Worker(URL.createObjectURL(new Blob([src])));
-      let received = 0;
-      const delivered = Promise.withResolvers<void>();
-      w.onmessage = () => {
-        if (++received === total) delivered.resolve();
-      };
+      const got: number[] = [];
+      w.onmessage = e => got.push(e.data);
       w.postMessage(flag);
       // Block until the whole flood sits in the parent's inbox, so the first drain task
       // starts out with more than its budget no matter how fast either thread is.
       Atomics.wait(flag, 0, 0, 30_000);
       expect(Atomics.load(flag, 0)).toBe(1);
-      // Resumes inside the first drain task. An immediate armed there runs as soon as
-      // that task ends, before the continuation it posted delivers the next batch.
+      // Resumes inside the first drain task. An immediate armed there runs as soon as the
+      // task ends and before the continuation it posted runs, so each immediate sees what
+      // exactly one more task delivered; two in a row seeing the same count is the end.
       await once(w, "message");
-      await new Promise<void>(r => setImmediate(r));
-      expect(received).toBeLessThan(total);
-      await delivered.promise;
+      const afterEachTask: number[] = [];
+      do {
+        await new Promise<void>(r => setImmediate(r));
+        afterEachTask.push(got.length);
+      } while (afterEachTask.at(-1) !== afterEachTask.at(-2));
+      // [1024, 2048, 2049, 2049]: neither the first task nor its continuation delivered
+      // everything, and everything still arrived, in order.
+      expect(afterEachTask[0]).toBeLessThan(total);
+      expect(afterEachTask[1]).toBeLessThan(total);
+      expect(got).toEqual(Array.from({ length: total }, (_, i) => i));
       w.terminate();
       await once(w, "close");
     });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -414,9 +414,17 @@ describe("web worker", () => {
       const w = new Worker(URL.createObjectURL(new Blob([src])));
       let received = 0;
       w.onmessage = () => received++;
+      // Booting the worker is not the property under test (on a debug build it takes
+      // far longer than the timer turns below): start once the flood has reached the parent.
+      await once(w, "message");
       // Three timer turns while the flood is running is the property; not the timing.
-      for (let i = 0; i < 3; i++) await new Promise<void>(r => setTimeout(r, 10));
-      expect(received).toBeGreaterThan(0);
+      // A message landing after each turn shows the flood was still running during it.
+      for (let i = 0; i < 3; i++) {
+        const before = received;
+        await new Promise<void>(r => setTimeout(r, 10));
+        await once(w, "message");
+        expect(received).toBeGreaterThan(before);
+      }
       w.terminate();
       await once(w, "close");
     });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -412,18 +412,15 @@ describe("web worker", () => {
       const src = `const p = { s: Buffer.alloc(200, "x").toString(), a: [1, 2, 3], n: 0 };
         (function burst() { for (let i = 0; i < 2000; i++) { p.n++; postMessage(p) } setImmediate(burst) })()`;
       const w = new Worker(URL.createObjectURL(new Blob([src])));
-      let received = 0;
-      w.onmessage = () => received++;
       // Booting the worker is not the property under test (on a debug build it takes
       // far longer than the timer turns below): start once the flood has reached the parent.
       await once(w, "message");
       // Three timer turns while the flood is running is the property; not the timing.
-      // A message landing after each turn shows the flood was still running during it.
+      // Pinned inside one drain, the parent never gets to the timer; the message awaited
+      // after each turn shows the flood was still running while the turn was taken.
       for (let i = 0; i < 3; i++) {
-        const before = received;
         await new Promise<void>(r => setTimeout(r, 10));
         await once(w, "message");
-        expect(received).toBeGreaterThan(before);
       }
       w.terminate();
       await once(w, "close");

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -425,12 +425,12 @@ describe("web worker", () => {
       w.postMessage(flag);
       // Block until the whole flood sits in the parent's inbox, so the first drain task
       // starts out with more than its budget no matter how fast either thread is.
-      expect(Atomics.wait(flag, 0, 0, 30_000)).toBe("ok");
+      Atomics.wait(flag, 0, 0, 30_000);
+      expect(Atomics.load(flag, 0)).toBe(1);
       // Resumes inside the first drain task. An immediate armed there runs as soon as
       // that task ends, before the continuation it posted delivers the next batch.
       await once(w, "message");
       await new Promise<void>(r => setImmediate(r));
-      expect(received).toBeGreaterThan(0);
       expect(received).toBeLessThan(total);
       await delivered.promise;
       w.terminate();

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -407,21 +407,32 @@ describe("web worker", () => {
     });
 
     // A worker posting faster than the parent can deserialize must not pin the
-    // parent inside one drain: its timers and I/O still get their turn.
+    // parent inside one drain: a drain task delivers a bounded batch and posts the
+    // rest to the next loop iteration, so timers and I/O get their turn in between.
     test("a message flood from a worker does not starve the parent's event loop", async () => {
-      const src = `const p = { s: Buffer.alloc(200, "x").toString(), a: [1, 2, 3], n: 0 };
-        (function burst() { for (let i = 0; i < 2000; i++) { p.n++; postMessage(p) } setImmediate(burst) })()`;
+      const total = 1500; // more than one drain task's budget (drainBatchLimit in WorkerMessagingProxy.cpp)
+      const flag = new Int32Array(new SharedArrayBuffer(4));
+      const src = `onmessage = ({ data: flag }) => {
+        for (let i = 0; i < ${total}; i++) postMessage(i);
+        Atomics.store(flag, 0, 1); Atomics.notify(flag, 0);
+      }`;
       const w = new Worker(URL.createObjectURL(new Blob([src])));
-      // Booting the worker is not the property under test (on a debug build it takes
-      // far longer than the timer turns below): start once the flood has reached the parent.
+      let received = 0;
+      const delivered = Promise.withResolvers<void>();
+      w.onmessage = () => {
+        if (++received === total) delivered.resolve();
+      };
+      w.postMessage(flag);
+      // Block until the whole flood sits in the parent's inbox, so the first drain task
+      // starts out with more than its budget no matter how fast either thread is.
+      expect(Atomics.wait(flag, 0, 0, 30_000)).toBe("ok");
+      // Resumes inside the first drain task. An immediate armed there runs as soon as
+      // that task ends, before the continuation it posted delivers the next batch.
       await once(w, "message");
-      // Three timer turns while the flood is running is the property; not the timing.
-      // Pinned inside one drain, the parent never gets to the timer; the message awaited
-      // after each turn shows the flood was still running while the turn was taken.
-      for (let i = 0; i < 3; i++) {
-        await new Promise<void>(r => setTimeout(r, 10));
-        await once(w, "message");
-      }
+      await new Promise<void>(r => setImmediate(r));
+      expect(received).toBeGreaterThan(0);
+      expect(received).toBeLessThan(total);
+      await delivered.promise;
       w.terminate();
       await once(w, "close");
     });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -436,10 +436,9 @@ describe("web worker", () => {
         await new Promise<void>(r => setImmediate(r));
         afterEachTask.push(got.length);
       } while (afterEachTask.at(-1) !== afterEachTask.at(-2));
-      // [1024, 2048, 2049, 2049]: neither the first task nor its continuation delivered
-      // everything, and everything still arrived, in order.
-      expect(afterEachTask[0]).toBeLessThan(total);
-      expect(afterEachTask[1]).toBeLessThan(total);
+      // The first task and its continuation each stop at the budget, the third delivers
+      // the one left over, and everything arrives in order.
+      expect(afterEachTask).toEqual([budget, 2 * budget, total, total]);
       expect(got).toEqual(Array.from({ length: total }, (_, i) => i));
       w.terminate();
       await once(w, "close");


### PR DESCRIPTION
Test-only change to `test/js/web/workers/worker.test.ts`.

### Problem

"a message flood from a worker does not starve the parent's event loop" (added in #37075) starts three 10ms timer turns at `new Worker(...)` and then asserts `received > 0`. That makes it an assertion that the worker booted and posted its first message within roughly 30ms of construction, which has nothing to do with the property the test is for. On a debug+ASAN build the first message lands about 150ms after construction (release: 2-3ms), so the test fails every time:

```
$ bun bd test test/js/web/workers/worker.test.ts -t "message flood"
419 |       expect(received).toBeGreaterThan(0);
                             ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0
(fail) web worker > terminate() races and lifecycle edges > a message flood from a worker does not starve the parent's event loop [65.13ms]
```

4/4 runs fail on a debug build of main (23d233b206), both in isolation and as part of the whole file. CI is green because its ASAN lanes are release builds, which boot a worker well inside the window; any slower machine or build turns it red. On the failing path the test also never reaches `terminate()`, so the flooding worker keeps running under the rest of the file.

The test also only exercised the thing it guards when the worker happened to outrun the parent. `WorkerMessagingProxy::drainMessagesToWorkerObject` delivers at most `drainBatchLimit` (1024) messages per task and posts the rest to the next loop iteration; a drain that does not yield only shows up if the inbox never runs dry. Measured with the test's flood: on a release build the worker outruns the parent, on a debug build a worker posts about 3k messages/s and the parent keeps up, and on a release+ASAN build it is somewhere in between (review measurement: bounded batches in about 5 of 13 runs). So on debug builds a drain with no bound passed the test, and where the test did detect one, the failure was the whole file hanging, since the runner's per-test timeout lives on the loop being pinned.

### Fix

The backlog is now built deterministically instead of by racing the worker. The parent creates a shared flag, posts it to the worker, and blocks in `Atomics.wait` while the worker posts 2 * 1024 + 1 messages and then sets the flag (the flag itself is asserted afterwards: the wait returns `"not-equal"` rather than `"ok"` if the worker was already done, and a worker that never gets there is an assertion failure instead of a hang). When the parent resumes, everything is already in its inbox, so the first drain task starts with more than its budget on every build, however fast or slow either thread is, and the continuation it posts still has more than its budget too, so it has to yield and re-post as well.

The test then resumes inside the first drain task (`await once(w, "message")`) and re-arms an immediate until a tick delivers nothing new, recording the count after each one. An immediate armed during a task runs at the start of the next tick, before the continuation that task posted is promoted, and microtasks drain right after the immediate callback, so each immediate sees exactly one more task's worth of messages. The recorded counts are `[1024, 2048, 2049, 2049]` on every build (95/95 iterations across release and debug+ASAN, idle and with the machine oversubscribed by 32 busy loops). The test asserts that sequence (`[budget, 2 * budget, total, total]`; the total is derived from the budget anyway, so pinning the batch size adds no coupling) and that every message arrived, in order. The flood is finite, so every failure mode is an ordinary assertion failure. Checked with three local mutations of `WorkerMessagingProxy.cpp` on the debug build, each of which fails at the sequence assertion:

- first drain task made unbounded (`DrainBudget::UntilEmpty` in `postMessageToWorkerObject`): `[2049, 2049]`
- continuation made unbounded (`UntilEmpty` in the re-posted task): `[1024, 2049, 2049]` (the 1500-message revision of this test passed this mutation)
- re-post of the remaining messages removed: `[1024, 1024]` (previously a hang)

The per-message microtask checkpoint on the same path is already covered by "round-trip burst delivers in order with microtasks between each" in `message-port-pipe.test.ts`, so this test does not repeat it.

### Verification

Debug+ASAN build (where the old test fails 4/4): passes in isolation (~500-900ms each on this loaded machine) and within the whole file. Release build: passes, ~8ms per run. The three mutations above each fail as listed on the debug build. The 1500-message revision of this test was green on all 190 CI jobs in build #92008; this revision uses the same mechanism with a longer backlog.

#37374 (debug-build timing of the other tests in this describe block) carries an earlier revision of this test; whichever lands first, the other rebases onto it.
