### PR TITLE
standalone: env var to disable the post-load madvise of embedded source

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -398,18 +398,6 @@ BUN_OPTIONS="--heap-prof-md" ./myapp
 BUN_OPTIONS="--smol --cpu-prof-md" ./myapp
 ```
 
-### Keeping the embedded source resident
-
-On Linux and macOS, once a standalone executable has loaded its entrypoint, Bun tells the kernel (via `madvise`) that the pages holding the embedded JavaScript source are no longer needed, which lowers the executable's resident memory. The pages are file-backed, so anything that reads the source later (a lazy `require()`, or resolving a stack trace) transparently pages it back in from the executable on disk.
-
-If that re-read is a problem for your deployment (for example, the executable runs from slow or removable storage), set `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE` when running the executable to keep the source pages resident:
-
-```bash terminal icon="terminal"
-BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1 ./myapp
-```
-
-This is a runtime setting read by the compiled executable, so it does not need to be set when running `bun build --compile`. It has no effect on other platforms, or when running scripts with `bun` directly, because the source pages are never released there in the first place.
-
 ---
 
 ## Automatic config loading

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -398,6 +398,18 @@ BUN_OPTIONS="--heap-prof-md" ./myapp
 BUN_OPTIONS="--smol --cpu-prof-md" ./myapp
 ```
 
+### Keeping the embedded source resident
+
+Once a standalone executable has loaded its entrypoint, Bun tells the kernel (via `madvise`) that the pages holding the embedded JavaScript source are no longer needed, which lowers the executable's resident memory. The pages are file-backed, so anything that reads the source later (a lazy `require()`, or resolving a stack trace) transparently pages it back in from the executable on disk.
+
+If that re-read is a problem for your deployment (for example, the executable runs from slow or removable storage), set `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE` when running the executable to keep the source pages resident:
+
+```bash terminal icon="terminal"
+BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1 ./myapp
+```
+
+This is a runtime setting read by the compiled executable — it does not need to be set when running `bun build --compile`. It has no effect on Windows or when running scripts with `bun` directly, since neither releases source pages.
+
 ---
 
 ## Automatic config loading

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -400,7 +400,7 @@ BUN_OPTIONS="--smol --cpu-prof-md" ./myapp
 
 ### Keeping the embedded source resident
 
-Once a standalone executable has loaded its entrypoint, Bun tells the kernel (via `madvise`) that the pages holding the embedded JavaScript source are no longer needed, which lowers the executable's resident memory. The pages are file-backed, so anything that reads the source later (a lazy `require()`, or resolving a stack trace) transparently pages it back in from the executable on disk.
+On Linux and macOS, once a standalone executable has loaded its entrypoint, Bun tells the kernel (via `madvise`) that the pages holding the embedded JavaScript source are no longer needed, which lowers the executable's resident memory. The pages are file-backed, so anything that reads the source later (a lazy `require()`, or resolving a stack trace) transparently pages it back in from the executable on disk.
 
 If that re-read is a problem for your deployment (for example, the executable runs from slow or removable storage), set `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE` when running the executable to keep the source pages resident:
 
@@ -408,7 +408,7 @@ If that re-read is a problem for your deployment (for example, the executable ru
 BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1 ./myapp
 ```
 
-This is a runtime setting read by the compiled executable — it does not need to be set when running `bun build --compile`. It has no effect on Windows or when running scripts with `bun` directly, since neither releases source pages.
+This is a runtime setting read by the compiled executable, so it does not need to be set when running `bun build --compile`. It has no effect on other platforms, or when running scripts with `bun` directly, because the source pages are never released there in the first place.
 
 ---
 

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -252,9 +252,6 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS, "BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH, "BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING", {});
-    // Keep the embedded source section of a `bun build --compile` binary
-    // resident: skips the post-entrypoint madvise(MADV_DONTNEED) in
-    // bun_standalone_graph::Graph::hint_source_pages_dont_need.
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, "BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE", {});
     new_feature_flag!(pub BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW, "BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE, "BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -252,6 +252,10 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS, "BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH, "BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING, "BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING", {});
+    // Keep the embedded source section of a `bun build --compile` binary
+    // resident: skips the post-entrypoint madvise(MADV_DONTNEED) in
+    // bun_standalone_graph::Graph::hint_source_pages_dont_need.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, "BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE", {});
     new_feature_flag!(pub BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW, "BUN_DISABLE_TRANSPILED_SOURCE_CODE_PREVIEW", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE, "BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE", {});
     new_feature_flag!(pub BUN_DUMP_STATE_ON_CRASH, "BUN_DUMP_STATE_ON_CRASH", {});

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2193,7 +2193,8 @@ impl StandaloneModuleGraph {
     /// The pages are clean file-backed COW, so any later read (lazy require,
     /// stack-trace source lookup) faults back in transparently from the
     /// executable on disk. Only applies when running as a compiled
-    /// standalone binary.
+    /// standalone binary; `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`
+    /// skips the hint.
     pub fn hint_source_pages_dont_need() {
         #[cfg(windows)]
         {
@@ -2226,6 +2227,17 @@ impl StandaloneModuleGraph {
             #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
             {
                 if len == 0 {
+                    return;
+                }
+
+                if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE
+                    .get()
+                    .unwrap_or(false)
+                {
+                    bun_core::scoped_log!(
+                        StandaloneModuleGraph,
+                        "hintSourcePagesDontNeed: skipped (BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE)"
+                    );
                     return;
                 }
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2226,18 +2226,11 @@ impl StandaloneModuleGraph {
 
             #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
             {
-                if len == 0 {
-                    return;
-                }
-
-                if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE
-                    .get()
-                    .unwrap_or(false)
+                if len == 0
+                    || bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE
+                        .get()
+                        .unwrap_or(false)
                 {
-                    bun_core::scoped_log!(
-                        StandaloneModuleGraph,
-                        "hintSourcePagesDontNeed: skipped (BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE)"
-                    );
                     return;
                 }
 

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -31,10 +31,22 @@ test.skipIf(isWindows || !isDebug)(
     expect(build.stderr.toString()).not.toContain("error:");
     expect(build.exitCode).toBe(0);
 
-    {
+    // BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE is read by the compiled
+    // executable at runtime (the binary above was built without it); a falsy
+    // value leaves the hint enabled. With the flag set, the function returns
+    // before logging anything, so the only evidence is the missing line.
+    for (const [flag, hinted] of [
+      [undefined, true],
+      ["0", true],
+      ["1", false],
+    ] as const) {
       await using proc = Bun.spawn({
         cmd: [out],
-        env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
+        env: {
+          ...bunEnv,
+          BUN_DEBUG_StandaloneModuleGraph: "1",
+          BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: flag,
+        },
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -44,40 +56,10 @@ test.skipIf(isWindows || !isDebug)(
       expect(stdout).toContain("after-await");
       // Scoped loggers write to the debug-writer stream (stdout by default).
       // Either the success or failure variant proves the call site is reached.
-      expect(stdout).toContain("hintSourcePagesDontNeed:");
-      expect(stdout).not.toContain("hintSourcePagesDontNeed: skipped");
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
-    }
-
-    // BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE is read by the compiled
-    // executable at runtime (the binary above was built without it), and a
-    // falsy value leaves the hint enabled.
-    for (const [value, skipped] of [
-      ["1", true],
-      ["0", false],
-    ] as const) {
-      await using proc = Bun.spawn({
-        cmd: [out],
-        env: {
-          ...bunEnv,
-          BUN_DEBUG_StandaloneModuleGraph: "1",
-          BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: value,
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stdout).toContain("before-await");
-      expect(stdout).toContain("after-await");
-      if (skipped) {
-        expect(stdout).toContain("hintSourcePagesDontNeed: skipped (BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE)");
-        expect(stdout).not.toContain("hintSourcePagesDontNeed: MADV_DONTNEED");
-        expect(stdout).not.toContain("hintSourcePagesDontNeed: madvise failed");
-      } else {
+      if (hinted) {
         expect(stdout).toContain("hintSourcePagesDontNeed:");
-        expect(stdout).not.toContain("hintSourcePagesDontNeed: skipped");
+      } else {
+        expect(stdout).not.toContain("hintSourcePagesDontNeed:");
       }
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -2,6 +2,8 @@
 // entrypoint has top-level await. loadEntryPoint() returns a promise without
 // blocking, so the call site at bun.js.zig:466 is hit synchronously before the
 // main event loop spins — TLA resolution happens later in that loop.
+// BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, read by the compiled binary at
+// runtime, skips the hint.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
 import path from "node:path";
@@ -43,6 +45,40 @@ test.skipIf(isWindows || !isDebug)(
       // Scoped loggers write to the debug-writer stream (stdout by default).
       // Either the success or failure variant proves the call site is reached.
       expect(stdout).toContain("hintSourcePagesDontNeed:");
+      expect(stdout).not.toContain("hintSourcePagesDontNeed: skipped");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+
+    // BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE is read by the compiled
+    // executable at runtime (the binary above was built without it), and a
+    // falsy value leaves the hint enabled.
+    for (const [value, skipped] of [
+      ["1", true],
+      ["0", false],
+    ] as const) {
+      await using proc = Bun.spawn({
+        cmd: [out],
+        env: {
+          ...bunEnv,
+          BUN_DEBUG_StandaloneModuleGraph: "1",
+          BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: value,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain("before-await");
+      expect(stdout).toContain("after-await");
+      if (skipped) {
+        expect(stdout).toContain("hintSourcePagesDontNeed: skipped (BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE)");
+        expect(stdout).not.toContain("hintSourcePagesDontNeed: MADV_DONTNEED");
+        expect(stdout).not.toContain("hintSourcePagesDontNeed: madvise failed");
+      } else {
+        expect(stdout).toContain("hintSourcePagesDontNeed:");
+        expect(stdout).not.toContain("hintSourcePagesDontNeed: skipped");
+      }
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     }


### PR DESCRIPTION
### What does this PR do?

Adds `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE`, a runtime opt-out for the behavior introduced in #29320: a `bun build --compile` executable calls `madvise(MADV_DONTNEED)` on its embedded source section once the entrypoint has loaded, so anything that touches the source afterwards (a lazy `require()`, resolving a stack trace) pages it back in from the executable on disk. Deployments where that re-read is undesirable can set the flag in the environment of the running executable to keep the pages resident:

```sh
BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1 ./myapp
```

The compiled binary reads it at runtime, nothing is baked in at compile time. It follows the existing `BUN_FEATURE_FLAG_DISABLE_*` escape hatches: registered in `env_var.rs`, checked in `hint_source_pages_dont_need()` (which returns early, sharing the existing `len == 0` return), falsy values such as `0` keep the default. No effect on Windows or on the plain interpreter, which never issue the hint. Like the other `BUN_FEATURE_FLAG_DISABLE_*` escape hatches it is not documented.

#37356 is the alternative of removing the madvise call altogether; the two are mutually exclusive.

### How did you verify your code works?

`test/js/bun/compile/standalone-madvise-tla.test.ts` now runs the same compiled binary three times with `BUN_DEBUG_StandaloneModuleGraph=1`: with the variable unset (explicitly removed from the child env so an ambient value on the host cannot leak in), set to `0`, and set to `1`. The first two must log a `hintSourcePagesDontNeed:` line, the last must not log one at all, since the flag path returns before logging anything. The test stays debug-only because it relies on the scoped logger.

Against a debug build without this change the `1` case fails as expected:

```
Expected to not contain: "hintSourcePagesDontNeed:"
Received: "before-await\nafter-await\n[standalonemodulegraph] hintSourcePagesDontNeed: MADV_DONTNEED 4096 bytes\n"
```

With the change, `bun bd test test/js/bun/compile/standalone-madvise-tla.test.ts` passes (22 assertions).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/compile/standalone-madvise-tla.test.ts

<!-- robobun:evidence:end -->