### PR TITLE
ci: restore the darwin test lanes so they run on the hosted queue

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,11 +186,9 @@ const testPlatforms = [
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
   // lanes — see buildPlatforms).
-  // The macOS test agents are offline; darwin still builds (cross-compiled on
-  // Linux) but isn't tested until they're back.
-  // { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
-  // { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
-  // { os: "darwin", arch: "x64", release: "14", tier: "latest" },
+  { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
+  { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
+  { os: "darwin", arch: "x64", release: "14", tier: "latest" },
   { os: "linux", arch: "aarch64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", profile: "asan", distro: "debian", release: "13", tier: "latest" },
@@ -777,8 +775,7 @@ function getVerifyBaselineStep(platform, options) {
  * traces itself; `packageAndUpload()` is its sole publisher.
  */
 const traceOrderTargets = [
-  // Runs on the macOS test agents, which are offline (see testPlatforms).
-  // { os: "darwin", arch: "aarch64", on: { os: "darwin", arch: "aarch64", release: "26", tier: "latest" } },
+  { os: "darwin", arch: "aarch64", on: { os: "darwin", arch: "aarch64", release: "26", tier: "latest" } },
   { os: "linux", arch: "x64", on: { os: "linux", arch: "x64", distro: "debian", release: "13" } },
 ];
 


### PR DESCRIPTION
### What does this PR do?

#37344 commented out the three darwin `testPlatforms` entries and the darwin `trace-order` target while the mac fleet was offline. #37354 (merged after it, but branched before it) routes darwin tests to Buildkite-hosted agents instead; with the entries gone there is nothing left to route, so **main currently runs no darwin tests at all** (see build 91730: 0 darwin test steps).

This puts the entries back. #37354's filter still drops the two lanes hosted agents can't run (aarch64 `previous`, x64) and gates the rest to `main` / `[macos tests]`, so the effective result is one aarch64 macOS 26 lane on `test-darwin-hosted`, which build 91720 already showed passing in ~13 min. Reverting #37354 when the fleet is back brings all three lanes back with no further edit here.

### How did you verify your code works?

`node .buildkite/ci.mjs --dry-run` on top of current main:
- `main`: `darwin-aarch64-26-test-bun` + `darwin-aarch64-trace-order`, both `queue: test-darwin-hosted`
- PR, plain subject: no darwin test steps
- PR with `[macos tests]`: the single darwin test step