### PR TITLE
build: write the long edges (cargo, big TUs) first in build.ninja so fresh builds start them first

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,30 +113,23 @@ version = "0.0.0"
 edition = "2024"
 
 # ─── Release optimization ───────────────────────────────────────────────────
-# The `lto` / `codegen-units` below are NOT what ships. scripts/build/rust.ts
-# pins every CI configuration through CARGO_PROFILE_RELEASE_* env overrides:
-# the cross-language LTO lanes emit per-crate bitcode (`lto = off`,
-# `codegen-units = 1`) and lld's ThinLTO optimizes the Rust crate graph
-# together with the C++ side and the WebKit prebuilt; the lanes without an
-# LTO prebuilt (freebsd, android, windows-arm64) are pinned to the fat/1 they
-# have always used; asan is pinned to off/16. So these two values only reach
-# builds nobody ships: local `bun run build:release`, release-assertions,
-# release-local, and a plain `cargo build --release`.
-#
-# For those the priority is wall-clock time. `lto = "fat"` + `codegen-units
-# = 1` made the cargo step a ~4 minute single thread on a 12-core machine
-# (bun_bin's fat LTO alone ~3 minutes, bun_runtime's single-CGU codegen
-# another minute) while the rest of the machine sat idle: a clean cargo build
-# measured 283s, vs 88s with the settings below, and a fresh
-# `bun run build:release` went from 406s to 222s. Thin LTO still inlines
-# across crates, it just does the work on every core.
+# Zig's release build is one compilation unit with whole-program optimization.
+# Cargo's defaults (lto=false, codegen-units=16) leave us at ~105 crates × 16
+# CGUs ≈ 1680 separately-optimized units with NO cross-crate inlining beyond
+# `#[inline]`-annotated leaf fns. `lto = "fat"` + `codegen-units = 1` collapses
+# the whole Rust crate graph into one LLVM module, matching Zig's shape.
 #
 # `panic = "abort"` — the `std::panic` hook in `bun_crash_handler` aborts,
 # so `catch_unwind` is unreachable for Rust panics regardless, and no landing
 # pads means smaller `.pdata`/`.xdata`.
+#
+# Cross-language LTO (`-C linker-plugin-lto`, so Rust bitcode joins the C++
+# `-flto=full` link) is wired in `scripts/build/rust.ts` behind `cfg.lto`; it
+# requires the *linker's* LLVM to be ≥ rustc's bundled LLVM, so the build
+# points `-fuse-ld` at rustc's `rust-lld` rather than clang's when enabled.
 [profile.release]
-lto = "thin"
-codegen-units = 16
+lto = "fat"
+codegen-units = 1
 debug = "line-tables-only"
 strip = "none"
 panic = "abort"
@@ -153,6 +146,20 @@ panic = "abort"
 # (rustc ignores it); Darwin's `"unpacked"` is the `.o`-is-the-debuginfo mode
 # `dsymutil` already expects.
 split-debuginfo = "unpacked"
+
+# Fast-iteration release build for local benching when fat LTO's link time
+# (minutes) is in the way. `bun run build:release --cargo-profile=release-dev`.
+[profile.release-dev]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
+# Release with debuginfo retained for `perf record` / flamegraphs. Same opt
+# level as release; binary is large but profilable.
+[profile.release-profiling]
+inherits = "release"
+debug = "line-tables-only"
+strip = "none"
 
 # `bun_shim_impl.exe` — the Windows .bin/ launcher PE that gets
 # `include_bytes!`'d into bun.exe and copied next to every package binary by
@@ -174,10 +181,9 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 # Pin these so the shim PE is byte-identical across bun's own profiles.
-# rust.ts sets CARGO_PROFILE_RELEASE_{LTO,CODEGEN_UNITS,DEBUG_ASSERTIONS} for
-# the main bun_bin build and the shim build shares that env; without explicit
-# values here (lto/codegen-units above, the two below) the env overrides on
-# `release` would be inherited.
+# rust.ts sets CARGO_PROFILE_RELEASE_{LTO,DEBUG_ASSERTIONS} for the main
+# bun_bin build and the shim build shares that env; without explicit values
+# here the env overrides on `release` would be inherited.
 debug-assertions = false
 overflow-checks = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,23 +113,30 @@ version = "0.0.0"
 edition = "2024"
 
 # ─── Release optimization ───────────────────────────────────────────────────
-# Zig's release build is one compilation unit with whole-program optimization.
-# Cargo's defaults (lto=false, codegen-units=16) leave us at ~105 crates × 16
-# CGUs ≈ 1680 separately-optimized units with NO cross-crate inlining beyond
-# `#[inline]`-annotated leaf fns. `lto = "fat"` + `codegen-units = 1` collapses
-# the whole Rust crate graph into one LLVM module, matching Zig's shape.
+# The `lto` / `codegen-units` below are NOT what ships. scripts/build/rust.ts
+# pins every CI configuration through CARGO_PROFILE_RELEASE_* env overrides:
+# the cross-language LTO lanes emit per-crate bitcode (`lto = off`,
+# `codegen-units = 1`) and lld's ThinLTO optimizes the Rust crate graph
+# together with the C++ side and the WebKit prebuilt; the lanes without an
+# LTO prebuilt (freebsd, android, windows-arm64) are pinned to the fat/1 they
+# have always used; asan is pinned to off/16. So these two values only reach
+# builds nobody ships: local `bun run build:release`, release-assertions,
+# release-local, and a plain `cargo build --release`.
+#
+# For those the priority is wall-clock time. `lto = "fat"` + `codegen-units
+# = 1` made the cargo step a ~4 minute single thread on a 12-core machine
+# (bun_bin's fat LTO alone ~3 minutes, bun_runtime's single-CGU codegen
+# another minute) while the rest of the machine sat idle: a clean cargo build
+# measured 283s, vs 88s with the settings below, and a fresh
+# `bun run build:release` went from 406s to 222s. Thin LTO still inlines
+# across crates, it just does the work on every core.
 #
 # `panic = "abort"` — the `std::panic` hook in `bun_crash_handler` aborts,
 # so `catch_unwind` is unreachable for Rust panics regardless, and no landing
 # pads means smaller `.pdata`/`.xdata`.
-#
-# Cross-language LTO (`-C linker-plugin-lto`, so Rust bitcode joins the C++
-# `-flto=full` link) is wired in `scripts/build/rust.ts` behind `cfg.lto`; it
-# requires the *linker's* LLVM to be ≥ rustc's bundled LLVM, so the build
-# points `-fuse-ld` at rustc's `rust-lld` rather than clang's when enabled.
 [profile.release]
-lto = "fat"
-codegen-units = 1
+lto = "thin"
+codegen-units = 16
 debug = "line-tables-only"
 strip = "none"
 panic = "abort"
@@ -146,13 +153,6 @@ panic = "abort"
 # (rustc ignores it); Darwin's `"unpacked"` is the `.o`-is-the-debuginfo mode
 # `dsymutil` already expects.
 split-debuginfo = "unpacked"
-
-# Fast-iteration release build for local benching when fat LTO's link time
-# (minutes) is in the way. `bun run build:release --cargo-profile=release-dev`.
-[profile.release-dev]
-inherits = "release"
-lto = "thin"
-codegen-units = 16
 
 # Release with debuginfo retained for `perf record` / flamegraphs. Same opt
 # level as release; binary is large but profilable.
@@ -181,9 +181,10 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 # Pin these so the shim PE is byte-identical across bun's own profiles.
-# rust.ts sets CARGO_PROFILE_RELEASE_{LTO,DEBUG_ASSERTIONS} for the main
-# bun_bin build and the shim build shares that env; without explicit values
-# here the env overrides on `release` would be inherited.
+# rust.ts sets CARGO_PROFILE_RELEASE_{LTO,CODEGEN_UNITS,DEBUG_ASSERTIONS} for
+# the main bun_bin build and the shim build shares that env; without explicit
+# values here (lto/codegen-units above, the two below) the env overrides on
+# `release` would be inherited.
 debug-assertions = false
 overflow-checks = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,13 +154,6 @@ panic = "abort"
 # `dsymutil` already expects.
 split-debuginfo = "unpacked"
 
-# Release with debuginfo retained for `perf record` / flamegraphs. Same opt
-# level as release; binary is large but profilable.
-[profile.release-profiling]
-inherits = "release"
-debug = "line-tables-only"
-strip = "none"
-
 # `bun_shim_impl.exe` — the Windows .bin/ launcher PE that gets
 # `include_bytes!`'d into bun.exe and copied next to every package binary by
 # `bun install`. Zig built it freestanding ReleaseFast (no libc,

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -79,6 +79,8 @@ Edge dependency types:
 
 **`restat = 1`** — after the command runs, re-stat outputs; if mtime didn't change, prune downstream. Critical for idempotent steps (fetch no-op, codegen unchanged).
 
+**Statement order is the schedule.** Ninja ranks ready edges by how many edges follow them, which is the same for every compile and for cargo (one link), and breaks ties by position in `build.ninja`. So whatever is written first starts first: before `BuildNode.priority` existed, cargo (the longest edge of the whole build) was written after ~1100 dep objects and started minutes late on small machines. `Ninja.write()` puts statements that carry a `priority` ahead of everything else, highest first (`SchedulePriority` in `ninja.ts`: cargo, then unified bundles largest-first, then generated TUs, then standalone bun sources largest-first); everything else keeps emission order. Adding a long-running edge? Give it a priority. `ninja -C build/debug -t commands` is unaffected by any of this — it only changes order.
+
 **`depfile`** — compiler writes `foo.o.d` listing every `#include`d header. Ninja reads it on the next build to know which headers this `.o` depends on. Codegen headers are order-only for this reason: they're declared outputs with restat, the depfile gives exact per-file header deps on build 2+, and order-only just ensures they exist for build 1. Dep outputs (`lib*.a`) are a different story — PCH, cc, and no-PCH cxx use them as _implicit_ deps, because local sub-builds (e.g. WebKit) rewrite forwarding headers as undeclared side effects and order-only would lag one build behind (see Gotchas).
 
 ## Iterating on the build system

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -37,7 +37,7 @@ import { lolhtml } from "./deps/lolhtml.ts";
 import { assert } from "./error.ts";
 import { bunIncludes, computeFlags, extraFlagsFor, linkDepends } from "./flags.ts";
 import { writeIfChanged } from "./fs.ts";
-import type { BuildNode, Ninja } from "./ninja.ts";
+import { SchedulePriority, type BuildNode, type Ninja } from "./ninja.ts";
 import { emitRust, linkerMapPath, rustLibPath, rustLtoLinkInputs } from "./rust.ts";
 import { quote, slash } from "./shell.ts";
 import { emitShims, machoPostlinkCommand, machoPostlinkImplicitInputs } from "./shims.ts";
@@ -330,8 +330,20 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // phony can point at its own .o files.
 
   // Codegen .cpp files — compiled like regular sources.
-  cxxSources.push(...codegen.cppSources);
-  cxxSources.push(...codegen.bindgenV2Cpp);
+  const generatedCxx = [...codegen.cppSources, ...codegen.bindgenV2Cpp];
+  cxxSources.push(...generatedCxx);
+
+  // Scheduling tiers (see SchedulePriority). split.unified and
+  // split.standalone are already ordered largest-first, and the stable sort in
+  // Ninja.write() keeps that order within a tier.
+  const unifiedSet = new Set(split.unified);
+  const generatedSet = new Set(generatedCxx);
+  const priorityFor = (src: string): number =>
+    unifiedSet.has(src)
+      ? SchedulePriority.unifiedBundle
+      : generatedSet.has(src)
+        ? SchedulePriority.generatedTu
+        : SchedulePriority.standaloneTu;
 
   // All deps must be ready (headers extracted, libs built) before compile.
   //
@@ -371,6 +383,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     const extraFlags = extraFlagsFor(cfg, relSrc);
     const opts: Parameters<typeof cxx>[3] = {
       flags: [...cxxFlagsFull, ...extraFlags],
+      priority: priorityFor(src),
     };
     if (pchOut !== undefined && !noPchSources.has(src)) {
       // PCH has implicit deps on depHeaderSignal. cxx has implicit dep on PCH.

--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -218,6 +218,8 @@ export interface CompileOpts {
   orderOnlyInputs?: string[];
   /** Job pool override. */
   pool?: string;
+  /** Scheduling hint — see `BuildNode.priority`. */
+  priority?: number;
 }
 
 /**
@@ -305,6 +307,7 @@ function compile(n: Ninja, cfg: Config, src: string, opts: CompileOpts, lang: "c
   };
   if (implicitInputs.length > 0) node.implicitInputs = implicitInputs;
   if (opts.pool !== undefined) node.pool = opts.pool;
+  if (opts.priority !== undefined) node.priority = opts.priority;
   n.build(node);
 
   // Record for compile_commands.json

--- a/scripts/build/ninja.ts
+++ b/scripts/build/ninja.ts
@@ -136,11 +136,16 @@ export class Ninja {
   private readonly ninjaVersion: string;
 
   private readonly lines: string[] = [];
-  /** `rule` blocks. Written before every build statement so prioritized statements can reference any rule. */
-  private readonly ruleLines: string[] = [];
+  /**
+   * `rule` blocks and top-level variables. Written before every build
+   * statement, so where a statement ends up in the file (which `priority`
+   * changes) never affects which rules and variables it can see.
+   */
+  private readonly declarations: string[] = [];
   /** Build statements with a `priority`, written ahead of `lines` (see BuildNode.priority). */
   private readonly prioritized: { priority: number; text: string }[] = [];
   private readonly ruleNames = new Set<string>();
+  private readonly variableNames = new Set<string>();
   private readonly outputSet = new Set<string>();
   private readonly pools = new Map<string, number>();
   private readonly defaults: string[] = [];
@@ -166,10 +171,17 @@ export class Ninja {
     return relative(this.buildDir, path);
   }
 
-  /** Define a top-level ninja variable. */
+  /**
+   * Define a top-level ninja variable. Visible to every build statement
+   * regardless of emission order (see `declarations`), which is also why a
+   * name can only be defined once: ninja would otherwise give statements
+   * different values depending on where they land in the file.
+   */
   variable(name: string, value: string): void {
     assert(/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name), `Invalid ninja variable name: ${name}`);
-    this.lines.push(`${name} = ${ninjaEscapeVarValue(value)}`);
+    assert(!this.variableNames.has(name), `Duplicate ninja variable: ${name}`);
+    this.variableNames.add(name);
+    this.declarations.push(`${name} = ${ninjaEscapeVarValue(value)}`, "");
   }
 
   /** Add a comment line to the output. */
@@ -197,7 +209,7 @@ export class Ninja {
     assert(!this.ruleNames.has(name), `Duplicate rule: ${name}`);
     this.ruleNames.add(name);
 
-    const out = this.ruleLines;
+    const out = this.declarations;
     out.push(`rule ${name}`);
     out.push(`  command = ${spec.command}`);
     if (spec.description !== undefined) {
@@ -372,7 +384,7 @@ export class Ninja {
           ]
         : [];
 
-    return [...header, ...poolLines, ...this.ruleLines, ...prioritizedLines, ...this.lines, ...defaultLines].join("\n");
+    return [...header, ...poolLines, ...this.declarations, ...prioritizedLines, ...this.lines, ...defaultLines].join("\n");
   }
 
   /**

--- a/scripts/build/ninja.ts
+++ b/scripts/build/ninja.ts
@@ -68,7 +68,41 @@ export interface BuildNode {
   vars?: Record<string, string>;
   /** Job pool override (overrides rule's pool). */
   pool?: string;
+  /**
+   * Scheduling hint — see `SchedulePriority`. Ninja ranks ready edges by how
+   * many edges still follow them (the same for every compile, for cargo, and
+   * for every dep object: one link) and breaks the tie by position in
+   * build.ninja, so the order statements are written in is the order ninja
+   * starts them in. Statements with a priority are written ahead of
+   * everything else, highest first; statements without one keep emission
+   * order. Pure ordering: no effect on what gets built or on the command
+   * hashes in .ninja_log.
+   */
+  priority?: number;
 }
+
+/**
+ * Priorities for the edges that decide a fresh build's wall-clock time, so
+ * they start as soon as their inputs exist instead of after the ~1100 dep
+ * objects emitted before them. Measured on cold release builds: cargo, the
+ * longest edge in every profile, started 13s after its codegen inputs were
+ * ready on a 12-core machine and ~190s after on a 6-slot one; the generated
+ * TUs are emitted last, so ZigGeneratedClasses.cpp.o (27s) was the last
+ * compile to start and the C++ side finished ~10s after every other object
+ * was done. Tiers follow the measured durations: cargo (minutes) > unified
+ * bundles (3-70s, emitted largest first) > generated TUs (8-27s; they don't
+ * exist at configure time, so no size to sort by) > standalone bun sources
+ * (2-40s, largest first) > everything unprioritized (dep objects, mostly
+ * well under a second each, which pack in around the long edges). The one
+ * long dep object, sqlite3.c (84s), waits for nothing and was reached 12s
+ * into the build even on 12 cores, so it gets by without a priority.
+ */
+export const SchedulePriority = {
+  cargo: 400,
+  unifiedBundle: 300,
+  generatedTu: 200,
+  standaloneTu: 100,
+} as const;
 
 /**
  * A compile_commands.json entry.
@@ -102,6 +136,10 @@ export class Ninja {
   private readonly ninjaVersion: string;
 
   private readonly lines: string[] = [];
+  /** `rule` blocks. Written before every build statement so prioritized statements can reference any rule. */
+  private readonly ruleLines: string[] = [];
+  /** Build statements with a `priority`, written ahead of `lines` (see BuildNode.priority). */
+  private readonly prioritized: { priority: number; text: string }[] = [];
   private readonly ruleNames = new Set<string>();
   private readonly outputSet = new Set<string>();
   private readonly pools = new Map<string, number>();
@@ -159,33 +197,34 @@ export class Ninja {
     assert(!this.ruleNames.has(name), `Duplicate rule: ${name}`);
     this.ruleNames.add(name);
 
-    this.lines.push(`rule ${name}`);
-    this.lines.push(`  command = ${spec.command}`);
+    const out = this.ruleLines;
+    out.push(`rule ${name}`);
+    out.push(`  command = ${spec.command}`);
     if (spec.description !== undefined) {
-      this.lines.push(`  description = ${spec.description}`);
+      out.push(`  description = ${spec.description}`);
     }
     if (spec.depfile !== undefined) {
-      this.lines.push(`  depfile = ${spec.depfile}`);
+      out.push(`  depfile = ${spec.depfile}`);
     }
     if (spec.deps !== undefined) {
-      this.lines.push(`  deps = ${spec.deps}`);
+      out.push(`  deps = ${spec.deps}`);
     }
     if (spec.restat === true) {
-      this.lines.push(`  restat = 1`);
+      out.push(`  restat = 1`);
     }
     if (spec.generator === true) {
-      this.lines.push(`  generator = 1`);
+      out.push(`  generator = 1`);
     }
     if (spec.pool !== undefined) {
-      this.lines.push(`  pool = ${spec.pool}`);
+      out.push(`  pool = ${spec.pool}`);
     }
     if (spec.rspfile !== undefined) {
-      this.lines.push(`  rspfile = ${spec.rspfile}`);
+      out.push(`  rspfile = ${spec.rspfile}`);
     }
     if (spec.rspfile_content !== undefined) {
-      this.lines.push(`  rspfile_content = ${spec.rspfile_content}`);
+      out.push(`  rspfile_content = ${spec.rspfile_content}`);
     }
-    this.lines.push("");
+    out.push("");
   }
 
   /**
@@ -234,17 +273,23 @@ export class Ninja {
     }
 
     // Wrap long lines with $\n continuations for readability
-    this.lines.push(wrapLongLine(line));
+    const stmt: string[] = [wrapLongLine(line)];
 
     if (node.pool !== undefined) {
-      this.lines.push(`  pool = ${node.pool}`);
+      stmt.push(`  pool = ${node.pool}`);
     }
     if (node.vars !== undefined) {
       for (const [k, v] of Object.entries(node.vars)) {
-        this.lines.push(`  ${k} = ${ninjaEscapeVarValue(v)}`);
+        stmt.push(`  ${k} = ${ninjaEscapeVarValue(v)}`);
       }
     }
-    this.lines.push("");
+    stmt.push("");
+
+    if (node.priority !== undefined) {
+      this.prioritized.push({ priority: node.priority, text: stmt.join("\n") });
+    } else {
+      this.lines.push(...stmt);
+    }
   }
 
   /** Shorthand for a phony target (groups other targets). */
@@ -312,7 +357,22 @@ export class Ninja {
     const defaultLines: string[] =
       this.defaults.length > 0 ? [`default ${this.defaults.map(ninjaEscapePath).join(" ")}`, ""] : [];
 
-    return [...header, ...poolLines, ...this.lines, ...defaultLines].join("\n");
+    // Stable sort: equal priorities keep emission order, which the emitters
+    // use to put the largest inputs of a tier first.
+    const prioritizedLines: string[] =
+      this.prioritized.length > 0
+        ? [
+            `# ─── Scheduling order ───`,
+            `# Ninja starts ready edges in file order; the long edges come first. See BuildNode.priority.`,
+            ``,
+            ...this.prioritized
+              .slice()
+              .sort((a, b) => b.priority - a.priority)
+              .map(p => p.text),
+          ]
+        : [];
+
+    return [...header, ...poolLines, ...this.ruleLines, ...prioritizedLines, ...this.lines, ...defaultLines].join("\n");
   }
 
   /**

--- a/scripts/build/ninja.ts
+++ b/scripts/build/ninja.ts
@@ -384,7 +384,9 @@ export class Ninja {
           ]
         : [];
 
-    return [...header, ...poolLines, ...this.declarations, ...prioritizedLines, ...this.lines, ...defaultLines].join("\n");
+    return [...header, ...poolLines, ...this.declarations, ...prioritizedLines, ...this.lines, ...defaultLines].join(
+      "\n",
+    );
   }
 
   /**

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -674,41 +674,18 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     // bitcode with its ThinLTO summary intact: the whole link is one uniform
     // ThinLTO graph and cross-module importing works across Rust↔C++/JSC.
     // `fat` would pre-merge the crates into one summary-less blob the thin
-    // link can't import from. (Every shipping configuration pins its lto /
-    // codegen-units here rather than inheriting Cargo.toml's
-    // `[profile.release]`, which is tuned for local build time — see the
-    // comment above it in Cargo.toml.)
+    // link can't import from. (The workspace `[profile.release] lto = "fat"`
+    // exists for non-LTO release builds, where the rust .a is linked as
+    // already-codegen'd machine code and still wants intra-Rust inlining.)
     env.CARGO_PROFILE_RELEASE_LTO = "off";
-    // One pre-link module per crate, so the bitcode lld sees is the same
-    // shape it has always been for shipped builds. This is also what makes
-    // `bun_runtime` the tail of every CI cargo step: in build 91391 all 209
-    // crates had started by +45s and cargo finished at +107s, the difference
-    // being bun_runtime's single-CGU pre-link optimization. Relaxing this to
-    // 16 recovers most of that minute per lane but changes the module
-    // boundaries ThinLTO imports across, so it needs a bench (btg profile)
-    // before it changes what ships.
-    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
   } else if (cfg.asan) {
     // release-asan has `cfg.lto` forced off (config.ts), but without this
-    // override Cargo.toml's `[profile.release] lto` still applies and rustc
-    // runs an intra-Rust LTO pass over IR that ASAN instrumentation has
-    // already ~doubled. ASAN builds don't need intra-Rust LTO; turn it off.
-    // Parallel codegen for the same reason: ASAN binaries never ship, and
-    // with one CGU the CI asan lane's cargo step was ~165s of bun_runtime
-    // compiling alone on a 16-vCPU box (PR build 91592: every other crate
-    // done by +45s, cargo finished at +212s).
+    // override Cargo.toml's `[profile.release] lto = "fat"` still applies —
+    // rustc merges every crate into one module and codegens it serially, on
+    // IR that ASAN instrumentation has already ~doubled. That's the 15-min
+    // cargo step vs 4m36s for the linker-plugin-lto build (which defers
+    // codegen to lld). ASAN builds don't need intra-Rust LTO; turn it off.
     env.CARGO_PROFILE_RELEASE_LTO = "off";
-    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16";
-  } else if (cfg.ci) {
-    // The shipping lanes without a -lto WebKit prebuilt (freebsd, android,
-    // windows-arm64 — see ltoDefault in config.ts): rustc does the Rust-side
-    // LTO itself. Pinned to what these lanes have always shipped, so the
-    // Cargo.toml profile can be tuned for local builds without changing
-    // their codegen. This is also why their cargo step takes ~4-5 minutes;
-    // thin + 16 (measured 283s -> 88s locally) is the obvious candidate once
-    // someone has benchmarked it on these targets.
-    env.CARGO_PROFILE_RELEASE_LTO = "fat";
-    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
   }
   if (cfg.assertions) {
     // Turn `debug_assert!()` / `#[cfg(debug_assertions)]` on in the release
@@ -882,10 +859,10 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // lol-html source fetch before cargo resolves the path dep.
     implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.codegenInputs, ...inputs.vendorStamps, ...shimInputs],
     orderOnlyInputs: inputs.codegenOrderOnly,
-    // The longest edge of the graph in every profile (measured 88s release /
-    // 68s debug for a clean cargo build on 12 cores, vs 3-70s for the largest
+    // The longest edge of the graph in every profile (a clean cargo build
+    // measured 283s release / 68s debug on 12 cores, vs 3-90s for the largest
     // C++ TUs), so it must start the moment codegen is done — not after ninja
-    // has worked through the dep objects emitted ahead of it.
+    // has worked through the ~1100 dep objects emitted ahead of it.
     priority: SchedulePriority.cargo,
     vars: {
       cwd: cfg.cwd,

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -28,7 +28,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { bunExeName, type Config } from "./config.ts";
 import { assert } from "./error.ts";
-import type { Ninja } from "./ninja.ts";
+import { SchedulePriority, type Ninja } from "./ninja.ts";
 import { rustLtoFixCliPath } from "./rust-lto-fix-cli.ts";
 import { quote, quoteArgs } from "./shell.ts";
 import { streamPath } from "./stream.ts";
@@ -674,18 +674,41 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     // bitcode with its ThinLTO summary intact: the whole link is one uniform
     // ThinLTO graph and cross-module importing works across Rust↔C++/JSC.
     // `fat` would pre-merge the crates into one summary-less blob the thin
-    // link can't import from. (The workspace `[profile.release] lto = "fat"`
-    // exists for non-LTO release builds, where the rust .a is linked as
-    // already-codegen'd machine code and still wants intra-Rust inlining.)
+    // link can't import from. (Every shipping configuration pins its lto /
+    // codegen-units here rather than inheriting Cargo.toml's
+    // `[profile.release]`, which is tuned for local build time — see the
+    // comment above it in Cargo.toml.)
     env.CARGO_PROFILE_RELEASE_LTO = "off";
+    // One pre-link module per crate, so the bitcode lld sees is the same
+    // shape it has always been for shipped builds. This is also what makes
+    // `bun_runtime` the tail of every CI cargo step: in build 91391 all 209
+    // crates had started by +45s and cargo finished at +107s, the difference
+    // being bun_runtime's single-CGU pre-link optimization. Relaxing this to
+    // 16 recovers most of that minute per lane but changes the module
+    // boundaries ThinLTO imports across, so it needs a bench (btg profile)
+    // before it changes what ships.
+    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
   } else if (cfg.asan) {
     // release-asan has `cfg.lto` forced off (config.ts), but without this
-    // override Cargo.toml's `[profile.release] lto = "fat"` still applies —
-    // rustc merges every crate into one module and codegens it serially, on
-    // IR that ASAN instrumentation has already ~doubled. That's the 15-min
-    // cargo step vs 4m36s for the linker-plugin-lto build (which defers
-    // codegen to lld). ASAN builds don't need intra-Rust LTO; turn it off.
+    // override Cargo.toml's `[profile.release] lto` still applies and rustc
+    // runs an intra-Rust LTO pass over IR that ASAN instrumentation has
+    // already ~doubled. ASAN builds don't need intra-Rust LTO; turn it off.
+    // Parallel codegen for the same reason: ASAN binaries never ship, and
+    // with one CGU the CI asan lane's cargo step was ~165s of bun_runtime
+    // compiling alone on a 16-vCPU box (PR build 91592: every other crate
+    // done by +45s, cargo finished at +212s).
     env.CARGO_PROFILE_RELEASE_LTO = "off";
+    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16";
+  } else if (cfg.ci) {
+    // The shipping lanes without a -lto WebKit prebuilt (freebsd, android,
+    // windows-arm64 — see ltoDefault in config.ts): rustc does the Rust-side
+    // LTO itself. Pinned to what these lanes have always shipped, so the
+    // Cargo.toml profile can be tuned for local builds without changing
+    // their codegen. This is also why their cargo step takes ~4-5 minutes;
+    // thin + 16 (measured 283s -> 88s locally) is the obvious candidate once
+    // someone has benchmarked it on these targets.
+    env.CARGO_PROFILE_RELEASE_LTO = "fat";
+    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
   }
   if (cfg.assertions) {
     // Turn `debug_assert!()` / `#[cfg(debug_assertions)]` on in the release
@@ -819,6 +842,8 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
       // shimDest: rebuilt when a sibling build dir (other arch/profile)
       // overwrote the shared exe.
       implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.vendorStamps, shimDest],
+      // Gates the main cargo build below, so it inherits its urgency.
+      priority: SchedulePriority.cargo,
       vars: {
         cwd: cfg.cwd,
         args: quoteArgs(shimArgs, hostWin),
@@ -857,6 +882,11 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // lol-html source fetch before cargo resolves the path dep.
     implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.codegenInputs, ...inputs.vendorStamps, ...shimInputs],
     orderOnlyInputs: inputs.codegenOrderOnly,
+    // The longest edge of the graph in every profile (measured 88s release /
+    // 68s debug for a clean cargo build on 12 cores, vs 3-70s for the largest
+    // C++ TUs), so it must start the moment codegen is done — not after ninja
+    // has worked through the dep objects emitted ahead of it.
+    priority: SchedulePriority.cargo,
     vars: {
       cwd: cfg.cwd,
       args: quoteArgs(args, hostWin),

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -35,7 +35,7 @@
  * fine-grained incremental during heavy single-file iteration.
  */
 
-import { mkdirSync, readdirSync, rmSync } from "node:fs";
+import { mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { basename, dirname, relative, resolve } from "node:path";
 import type { Config } from "./config.ts";
 import { assert } from "./error.ts";
@@ -182,9 +182,15 @@ function bundleSizeFor(cfg: Config): number {
 }
 
 export interface UnifiedSplit {
-  /** Generated UnifiedSource-*.cpp absolute paths to compile. */
+  /**
+   * Generated UnifiedSource-*.cpp absolute paths to compile, largest bundle
+   * (by member source bytes) first. Emitting them in this order is what puts
+   * the 50-70s bundles at the front of ninja's queue — see
+   * `SchedulePriority` in ninja.ts. Composition is unaffected; only the
+   * order of the returned list depends on file sizes.
+   */
   unified: string[];
-  /** Sources that compile standalone (no-unify list, or alone in their dir). */
+  /** Sources that compile standalone (no-unify list, or alone in their dir), largest first, same reason. */
   standalone: string[];
   /**
    * Original .cpp paths that were bundled (i.e. NOT in `standalone`). Used to
@@ -238,7 +244,7 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
     arr.push(abs);
   }
 
-  const unified: string[] = [];
+  const unified: { out: string; bytes: number }[] = [];
   const bundled: string[] = [];
   const tagToDir = new Map<string, string>();
   // Stable iteration: sort directory keys and basenames by code unit (default
@@ -277,7 +283,7 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
       // native backslashes in `#include "C:\..."` are escape sequences.
       const body = chunk.map(f => `#include "${slash(relative(outDir, f))}"`).join("\n") + "\n";
       writeIfChanged(out, body);
-      unified.push(out);
+      unified.push({ out, bytes: chunk.reduce((sum, f) => sum + statSync(f).size, 0) });
       bundled.push(...chunk);
     }
   }
@@ -285,10 +291,26 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
   // Prune stale bundles from previous configures (e.g. a directory shrank
   // from 3 bundles to 1). They're not in the ninja graph so they wouldn't be
   // built, but leaving them confuses grep/clangd indexing.
-  const live = new Set(unified.map(p => basename(p)));
+  const live = new Set(unified.map(b => basename(b.out)));
   for (const f of readdirSync(outDir)) {
     if (f.endsWith(".cpp") && !live.has(f)) rmSync(resolve(outDir, f));
   }
 
-  return { unified, standalone, bundled };
+  return {
+    unified: largestFirst(unified).map(b => b.out),
+    standalone: largestFirst(standalone.map(src => ({ out: src, bytes: statSync(src).size }))).map(b => b.out),
+    bundled,
+  };
+}
+
+/**
+ * Source bytes are the cost proxy. Measured on a cold release build, 10 of the
+ * 12 slowest standalone TUs were among the 12 largest files (the exceptions
+ * are the small highway_*.cpp SIMD instantiations, which still finish long
+ * before the big bundles do), and a bundle's compile time tracks how much
+ * source it pulls in on top of the shared PCH. Ties keep the deterministic
+ * input order.
+ */
+function largestFirst<T extends { bytes: number }>(items: T[]): T[] {
+  return items.slice().sort((a, b) => b.bytes - a.bytes);
 }

--- a/test/internal/build-post-link-ordering.test.ts
+++ b/test/internal/build-post-link-ordering.test.ts
@@ -215,11 +215,16 @@ describe("scheduling order", () => {
     registerRustRules(n, cfg);
     // Stands in for the ~1100 dep objects emitBun emits before emitRust().
     n.rule("cc", { command: "cc $out" });
-    n.build({ outputs: [resolve(buildDir, "obj/vendor/dep.c.o")], rule: "cc", inputs: [] });
+    const depObject = resolve(buildDir, "obj/vendor/dep.c.o");
+    n.build({ outputs: [depObject], rule: "cc", inputs: [] });
     const [lib] = emitRust(n, cfg, { codegenInputs: [], codegenOrderOnly: [], rustSources: [], vendorStamps: [] });
 
+    // n.rel() is how the writer spells both paths (native separators).
     const order = buildOrder(n.toString());
-    expect(order.indexOf(n.rel(lib!))).toBeLessThan(order.indexOf("obj/vendor/dep.c.o"));
+    const libIndex = order.indexOf(n.rel(lib!));
+    const depIndex = order.indexOf(n.rel(depObject));
+    expect({ libFound: libIndex >= 0, depFound: depIndex >= 0 }).toEqual({ libFound: true, depFound: true });
+    expect(libIndex).toBeLessThan(depIndex);
     expect(SchedulePriority.cargo).toBeGreaterThan(SchedulePriority.unifiedBundle);
   });
 

--- a/test/internal/build-post-link-ordering.test.ts
+++ b/test/internal/build-post-link-ordering.test.ts
@@ -1,23 +1,33 @@
 /**
- * Regression tests for ninja ordering of post-link steps (strip, smoke test,
- * dsymutil) in scripts/build/bun.ts.
+ * Regression tests for the ordering scripts/build emits into build.ninja.
  *
- * The smoke_test and dsymutil rule commands are wrapped through
- * `cfg.jsRuntime` (= process.execPath). When `bun` on PATH resolves inside the
- * build directory, that path is the strip output itself (build/release/bun),
- * and without an ordering edge ninja will run strip and the wrapper exec
+ * Post-link steps (strip, smoke test, dsymutil — scripts/build/bun.ts): the
+ * smoke_test and dsymutil rule commands are wrapped through `cfg.jsRuntime`
+ * (= process.execPath). When `bun` on PATH resolves inside the build
+ * directory, that path is the strip output itself (build/release/bun), and
+ * without an ordering edge ninja will run strip and the wrapper exec
  * concurrently, failing with "Permission denied" on the half-written file.
+ *
+ * Scheduling order (scripts/build/ninja.ts `BuildNode.priority`): ninja starts
+ * ready edges of equal depth in file order, so the long edges (cargo, the big
+ * unified bundles) have to be written first or a fresh build starts them
+ * after ~1100 dep objects. These tests pin the writer's ordering, the
+ * largest-first source order it relies on, and the cargo profile pins that
+ * keep the shipped Rust codegen independent of Cargo.toml's local-build
+ * profile.
  *
  * These exercise the ninja-emission logic only (no compiler or ninja needed),
  * so they run on every host.
  */
 import { describe, expect, test } from "bun:test";
 import { isMacOS, tempDir } from "harness";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 
 import { emitPostLink } from "../../scripts/build/bun.ts";
 import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
-import { Ninja } from "../../scripts/build/ninja.ts";
+import { Ninja, SchedulePriority } from "../../scripts/build/ninja.ts";
+import { cargoBuildInvocation, emitRust, registerRustRules } from "../../scripts/build/rust.ts";
+import { generateUnifiedSources } from "../../scripts/build/unified.ts";
 
 /** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
 function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
@@ -134,5 +144,138 @@ describe("emitPostLink ninja ordering", () => {
     // Cross-compile: smoke_test short-circuits to a `check` phony (the
     // binary can't run on this host), so the strip race can't happen there.
     expect(buildEdge(out, "phony")).toBe("build check: phony bun-profile");
+  });
+});
+
+/** Outputs of every build statement, in file order (continuations unwrapped). */
+function buildOrder(ninja: string): string[] {
+  return ninja
+    .replace(/ \$\n +/g, " ")
+    .split("\n")
+    .filter(l => l.startsWith("build "))
+    .map(l => l.slice("build ".length, l.indexOf(":")));
+}
+
+/**
+ * A linux-x64 target resolves on every host once it is told where its sysroot
+ * is (the path is only recorded, never opened), which keeps these independent
+ * of the machine running the tests. `lto` is passed explicitly because its
+ * default also depends on `ci`.
+ */
+function linuxConfig(partial: PartialConfig, buildDir: string, toolchain = mockToolchain()): Config {
+  return resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildType: "Release", buildDir, linuxSysroot: buildDir, ...partial },
+    toolchain,
+  );
+}
+
+describe("scheduling order", () => {
+  test("prioritized statements are written after every rule and before everything else, highest first, stable", () => {
+    using dir = tempDir("build-schedule", {});
+    const n = new Ninja({ buildDir: String(dir) });
+    n.rule("early", { command: "early $out" });
+    n.build({ outputs: ["plain-1"], rule: "early", inputs: [] });
+    n.build({ outputs: ["low-a"], rule: "early", inputs: [], priority: 100, vars: { flags: "-a" }, pool: "console" });
+    n.build({ outputs: ["plain-2"], rule: "early", inputs: [] });
+    // Registered after statements that get hoisted above it: rules must
+    // still all precede the first build statement or ninja rejects the file.
+    n.rule("late", { command: "late $out" });
+    n.build({ outputs: ["high"], rule: "late", inputs: [], priority: 300 });
+    n.build({ outputs: ["low-b"], rule: "early", inputs: [], priority: 100 });
+    const out = n.toString();
+
+    expect(buildOrder(out)).toEqual(["high", "low-a", "low-b", "plain-1", "plain-2"]);
+    expect(out.indexOf("rule late")).toBeLessThan(out.indexOf("build high"));
+    // Priority only moves a statement; its body is written unchanged.
+    expect(out).toContain("build low-a: early\n  pool = console\n  flags = -a\n");
+  });
+
+  test("without priorities the writer keeps emission order and emits no scheduling section", () => {
+    using dir = tempDir("build-schedule", {});
+    const n = new Ninja({ buildDir: String(dir) });
+    n.rule("r", { command: "r $out" });
+    n.build({ outputs: ["b"], rule: "r", inputs: [] });
+    n.build({ outputs: ["a"], rule: "r", inputs: [] });
+    const out = n.toString();
+    expect(buildOrder(out)).toEqual(["b", "a"]);
+    expect(out).not.toContain("Scheduling order");
+  });
+
+  test("the cargo edge is hoisted ahead of statements emitted before it", () => {
+    using dir = tempDir("build-schedule", {});
+    const buildDir = String(dir);
+    const cfg = linuxConfig({ lto: false }, buildDir, mockToolchain({ cargo: "/fake/bin/cargo" }));
+    const n = new Ninja({ buildDir });
+    registerRustRules(n, cfg);
+    // Stands in for the ~1100 dep objects emitBun emits before emitRust().
+    n.rule("cc", { command: "cc $out" });
+    n.build({ outputs: [resolve(buildDir, "obj/vendor/dep.c.o")], rule: "cc", inputs: [] });
+    const [lib] = emitRust(n, cfg, { codegenInputs: [], codegenOrderOnly: [], rustSources: [], vendorStamps: [] });
+
+    const order = buildOrder(n.toString());
+    expect(order.indexOf(n.rel(lib!))).toBeLessThan(order.indexOf("obj/vendor/dep.c.o"));
+    expect(SchedulePriority.cargo).toBeGreaterThan(SchedulePriority.unifiedBundle);
+  });
+
+  test("unified bundles and standalone sources come back largest first", () => {
+    const big = Buffer.alloc(4000, "x").toString();
+    const small = "int x;\n";
+    using dir = tempDir("build-schedule", {
+      // Directory names sort the small inputs first; the result must not.
+      "a_small/one.cpp": small,
+      "a_small/two.cpp": small,
+      "b_big/one.cpp": big,
+      "b_big/two.cpp": big,
+      // A directory with a single file compiles standalone.
+      "c_alone_small/only.cpp": small,
+      "d_alone_big/only.cpp": big,
+    });
+    const root = String(dir);
+    const buildDir = join(root, "build");
+    // Debug: 8 files per bundle, so each two-file directory is one bundle.
+    const cfg = linuxConfig({ buildType: "Debug", asan: false }, buildDir);
+    const sources = [
+      "a_small/one.cpp",
+      "a_small/two.cpp",
+      "b_big/one.cpp",
+      "b_big/two.cpp",
+      "c_alone_small/only.cpp",
+      "d_alone_big/only.cpp",
+    ].map(p => join(root, p));
+
+    const split = generateUnifiedSources(cfg, sources);
+
+    expect(split.unified.map(p => basename(p))).toEqual([
+      expect.stringMatching(/^UnifiedSource-.*b_big-0\.cpp$/),
+      expect.stringMatching(/^UnifiedSource-.*a_small-0\.cpp$/),
+    ]);
+    expect(split.standalone).toEqual([join(root, "d_alone_big/only.cpp"), join(root, "c_alone_small/only.cpp")]);
+    expect(split.bundled.sort()).toEqual(sources.slice(0, 4).sort());
+  });
+});
+
+describe("cargo release profile pins", () => {
+  const pins = (cfg: Config) => {
+    const { CARGO_PROFILE_RELEASE_LTO: lto, CARGO_PROFILE_RELEASE_CODEGEN_UNITS: cgu } = cargoBuildInvocation(cfg).env;
+    return { lto, cgu };
+  };
+
+  test("shipping configurations never inherit lto/codegen-units from Cargo.toml", () => {
+    using dir = tempDir("build-cargo-pins", {});
+    const buildDir = String(dir);
+    // Cross-language LTO lanes: per-crate bitcode for lld's ThinLTO.
+    expect(pins(linuxConfig({ ci: true, lto: true }, buildDir))).toEqual({ lto: "off", cgu: "1" });
+    // Lanes with no -lto WebKit prebuilt (freebsd, android, windows-arm64):
+    // rustc does the Rust-side LTO itself, exactly as before Cargo.toml's
+    // profile was retuned for local builds.
+    expect(pins(linuxConfig({ ci: true, lto: false }, buildDir))).toEqual({ lto: "fat", cgu: "1" });
+    // ASAN never ships and bun_runtime was its single-threaded tail.
+    expect(pins(linuxConfig({ ci: true, lto: false, asan: true }, buildDir))).toEqual({ lto: "off", cgu: "16" });
+    expect(pins(linuxConfig({ lto: false, asan: true }, buildDir))).toEqual({ lto: "off", cgu: "16" });
+  });
+
+  test("a local release build takes Cargo.toml's profile as-is", () => {
+    using dir = tempDir("build-cargo-pins", {});
+    expect(pins(linuxConfig({ lto: false }, String(dir)))).toEqual({ lto: undefined, cgu: undefined });
   });
 });

--- a/test/internal/build-post-link-ordering.test.ts
+++ b/test/internal/build-post-link-ordering.test.ts
@@ -177,17 +177,23 @@ describe("scheduling order", () => {
     n.build({ outputs: ["plain-1"], rule: "early", inputs: [] });
     n.build({ outputs: ["low-a"], rule: "early", inputs: [], priority: 100, vars: { flags: "-a" }, pool: "console" });
     n.build({ outputs: ["plain-2"], rule: "early", inputs: [] });
-    // Registered after statements that get hoisted above it: rules must
-    // still all precede the first build statement or ninja rejects the file.
-    n.rule("late", { command: "late $out" });
+    // Declared after statements that get hoisted above them: rules must
+    // still all precede the first build statement or ninja rejects the file,
+    // and a top-level variable defined this late must still be visible to
+    // the hoisted statements that reference it.
+    n.rule("late", { command: "late $late_flags $out" });
+    n.variable("late_flags", "-x");
     n.build({ outputs: ["high"], rule: "late", inputs: [], priority: 300 });
     n.build({ outputs: ["low-b"], rule: "early", inputs: [], priority: 100 });
     const out = n.toString();
 
     expect(buildOrder(out)).toEqual(["high", "low-a", "low-b", "plain-1", "plain-2"]);
-    expect(out.indexOf("rule late")).toBeLessThan(out.indexOf("build high"));
+    const firstBuild = out.indexOf("\nbuild ");
+    expect(out.indexOf("rule late")).toBeLessThan(firstBuild);
+    expect(out.indexOf("late_flags = -x")).toBeLessThan(firstBuild);
     // Priority only moves a statement; its body is written unchanged.
     expect(out).toContain("build low-a: early\n  pool = console\n  flags = -a\n");
+    expect(() => n.variable("late_flags", "-y")).toThrow("Duplicate ninja variable: late_flags");
   });
 
   test("without priorities the writer keeps emission order and emits no scheduling section", () => {

--- a/test/internal/build-post-link-ordering.test.ts
+++ b/test/internal/build-post-link-ordering.test.ts
@@ -12,9 +12,7 @@
  * ready edges of equal depth in file order, so the long edges (cargo, the big
  * unified bundles) have to be written first or a fresh build starts them
  * after ~1100 dep objects. These tests pin the writer's ordering, the
- * largest-first source order it relies on, and the cargo profile pins that
- * keep the shipped Rust codegen independent of Cargo.toml's local-build
- * profile.
+ * largest-first source order it relies on.
  *
  * These exercise the ninja-emission logic only (no compiler or ninja needed),
  * so they run on every host.
@@ -26,7 +24,7 @@ import { basename, join, resolve } from "node:path";
 import { emitPostLink } from "../../scripts/build/bun.ts";
 import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
 import { Ninja, SchedulePriority } from "../../scripts/build/ninja.ts";
-import { cargoBuildInvocation, emitRust, registerRustRules } from "../../scripts/build/rust.ts";
+import { emitRust, registerRustRules } from "../../scripts/build/rust.ts";
 import { generateUnifiedSources } from "../../scripts/build/unified.ts";
 
 /** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
@@ -262,31 +260,5 @@ describe("scheduling order", () => {
     ]);
     expect(split.standalone).toEqual([join(root, "d_alone_big/only.cpp"), join(root, "c_alone_small/only.cpp")]);
     expect(split.bundled.sort()).toEqual(sources.slice(0, 4).sort());
-  });
-});
-
-describe("cargo release profile pins", () => {
-  const pins = (cfg: Config) => {
-    const { CARGO_PROFILE_RELEASE_LTO: lto, CARGO_PROFILE_RELEASE_CODEGEN_UNITS: cgu } = cargoBuildInvocation(cfg).env;
-    return { lto, cgu };
-  };
-
-  test("shipping configurations never inherit lto/codegen-units from Cargo.toml", () => {
-    using dir = tempDir("build-cargo-pins", {});
-    const buildDir = String(dir);
-    // Cross-language LTO lanes: per-crate bitcode for lld's ThinLTO.
-    expect(pins(linuxConfig({ ci: true, lto: true }, buildDir))).toEqual({ lto: "off", cgu: "1" });
-    // Lanes with no -lto WebKit prebuilt (freebsd, android, windows-arm64):
-    // rustc does the Rust-side LTO itself, exactly as before Cargo.toml's
-    // profile was retuned for local builds.
-    expect(pins(linuxConfig({ ci: true, lto: false }, buildDir))).toEqual({ lto: "fat", cgu: "1" });
-    // ASAN never ships and bun_runtime was its single-threaded tail.
-    expect(pins(linuxConfig({ ci: true, lto: false, asan: true }, buildDir))).toEqual({ lto: "off", cgu: "16" });
-    expect(pins(linuxConfig({ lto: false, asan: true }, buildDir))).toEqual({ lto: "off", cgu: "16" });
-  });
-
-  test("a local release build takes Cargo.toml's profile as-is", () => {
-    using dir = tempDir("build-cargo-pins", {});
-    expect(pins(linuxConfig({ lto: false }, String(dir)))).toEqual({ lto: undefined, cgu: undefined });
   });
 });


### PR DESCRIPTION
Ninja orders ready edges by how many edges follow them, and every compile plus the cargo edge feed the single link edge, so among them ties are broken by position in `build.ninja`. `emitBun` emits deps, then codegen, then cargo, then the C++ sources with the generated TUs last, which makes emission order the schedule of a fresh build:

- The cargo edge, the longest edge in every profile (a clean cargo build is 283s for release and 68s for debug on a 12-core machine; the largest C++ TU is ~90s), was started only after ninja had handed out the ~1100 dep objects written ahead of it: 13s after its codegen inputs were ready on a 12-core box, 187s after on the 6-slot machine whose `.ninja_log` I started from (cargo ready at 32s, started at 219s, build done at 953s).
- `ZigGeneratedClasses.cpp.o` and the other generated TUs are written last, so they were the last compiles to start both locally and in CI's build-cpp (last three objects to finish in build 91391: `SubtleCrypto`, `ZigGlobalObject`, `ZigGeneratedClasses`).

I verified the tie-break with a toy graph on ninja 1.12; ninja does not consult `.ninja_log` durations, so writing the long edges first is the lever.

### Change

`BuildNode.priority` (ninja.ts): `Ninja.write()` emits prioritized statements ahead of everything else, highest first and stable within a tier; rules and top-level variables are written before the first build statement so a hoisted statement can reference any of them regardless of emission order (variables are also rejected on redefinition, since position-dependent values would no longer make sense). Tiers (`SchedulePriority`): cargo, unified bundles (returned largest-first by member source bytes from `unified.ts`), generated TUs, standalone bun sources (largest-first). Dep objects keep emission order and pack in around the long edges. `compile.ts` and `bun.ts`/`rust.ts` plumb the priorities.

This is a pure reordering: `ninja -t commands` and `ninja -t targets all` are byte-identical before and after for the release config, and switching an up-to-date `build/debug` between the old and new emission order in both directions recompiles nothing.

### Effect

On the 12-core box the measured effect is cargo starting the moment codegen finishes (22s instead of 35s into the build); with the release profile's fat LTO the build stays bound by the cargo edge, so the wall-clock gain there is that 13s. The gain grows as the dispatch delay grows, i.e. on machines with few job slots (the 6-slot case above) and, for the C++ tail, on machines with many (a list-scheduling simulation over the measured durations gives roughly -35s for the C++ phase at 16 slots locally and ~-8s for CI's build-cpp). It also means any future reduction of the cargo edge is realized in full rather than being hidden behind the dep phase.

### Tests

`test/internal/build-post-link-ordering.test.ts` (the existing ninja-ordering test file) gains cases for the writer's ordering (including rules and variables declared after hoisted statements), the cargo edge being hoisted, and the largest-first unified/standalone order.

An earlier revision of this PR also switched `[profile.release]` to thin LTO for local builds; that is intentionally dropped (a release build should be built like a release build), so Cargo.toml is untouched.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->