### PR TITLE
ci: shard darwin tests 10-wide while they run on hosted agents

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -864,7 +864,11 @@ function getTestBunStep(platform, options, testOptions = {}) {
     agents: getTestAgent(platform, options),
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    parallelism: os === "darwin" ? 2 : os === "windows" ? 8 : 20,
+    // darwin: 10 while on hosted agents (see darwinHostedQueue), which scale
+    // one agent per shard; it was 2 for the bare-metal fleet's few boxes per
+    // lane. Each shard repeats ~2 min of checkout + artifact + install, so
+    // going much wider mostly buys setup time.
+    parallelism: os === "darwin" ? 10 : os === "windows" ? 8 : 20,
     timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",


### PR DESCRIPTION
### What does this PR do?

Darwin test steps were pinned to `parallelism: 2` because the bare-metal fleet only had a couple of boxes per lane. On the Buildkite-hosted queue from #37354 every shard gets its own M4 agent, so widen darwin to 10 shards.

Expected effect per main build: the ~26 min darwin suite (2 × 13 min on hosted today, build 91720) becomes ~26/10 + ~2 min per-shard setup ≈ 4-5 min wall clock, for roughly +30% billed minutes (each shard repeats checkout / artifact download / `bun install`). Not going wider than 10 because beyond that the fixed setup dominates.

Revisit together with the #37354 revert once the fleet is back (the fleet can still absorb 10 queued shards per lane, it just serializes them).

### How did you verify your code works?

`node --check`; the value only feeds the step's `parallelism` field, and `runner.node.mjs` already shards by `BUILDKITE_PARALLEL_JOB`/`_COUNT` (linux runs 20-wide the same way).