### PR TITLE
Error.appendStackTrace: fix abort with unset stackTraceLimit, assertion on materialized errors, and self-append use-after-free

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -669,8 +669,21 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
+    // Once .stack is materialized the frames are discarded and never read again;
+    // installing new ones only trips ASSERT(!m_errorInfoMaterialized) in
+    // computeErrorInfo when GC finalizes the error.
+    if (destination->hasMaterializedErrorInfo()) {
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
     if (!destination->stackTrace()) {
-        destination->captureStackTrace(vm, globalObject, 1);
+        // ErrorInstance::captureStackTrace() unwraps stackTraceLimit(), which is
+        // empty once Error.stackTraceLimit has been set to a non-number or deleted.
+        if (globalObject->stackTraceLimit()) {
+            destination->captureStackTrace(vm, globalObject, 1);
+        } else {
+            destination->setStackFrames(vm, {});
+        }
     }
 
     if (source->stackTrace()) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -674,7 +674,10 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return JSC::JSValue::encode(jsUndefined());
     }
 
-    // A materialized error never reads its frames again (see errorConstructorFuncCaptureStackTrace).
+    // Once .stack is materialized the frames are gone. Installing new ones would make the native error
+    // printer (which prefers frames over .stack) show this call site plus the source's frames, and trip
+    // computeErrorInfo's !m_errorInfoMaterialized assertion when GC finalizes the error. Leave both
+    // errors alone instead, as Bun__attachAsyncStackFromPromise does.
     if (destination->hasMaterializedErrorInfo()) {
         return JSC::JSValue::encode(jsUndefined());
     }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -669,6 +669,13 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
+    // Appending a trace to itself would make appendVector copy out of the buffer
+    // it just reallocated (the span overload does not rebase the source
+    // pointer), and the clear() below would then wipe the trace.
+    if (source == destination) {
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
     // Once .stack is materialized the frames are discarded and never read again;
     // installing new ones only trips ASSERT(!m_errorInfoMaterialized) in
     // computeErrorInfo when GC finalizes the error.

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -669,23 +669,18 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    // Appending a trace to itself would make appendVector copy out of the buffer
-    // it just reallocated (the span overload does not rebase the source
-    // pointer), and the clear() below would then wipe the trace.
+    // appendVector() is not self-append safe, and the clear() below would then drop the trace.
     if (source == destination) {
         return JSC::JSValue::encode(jsUndefined());
     }
 
-    // Once .stack is materialized the frames are discarded and never read again;
-    // installing new ones only trips ASSERT(!m_errorInfoMaterialized) in
-    // computeErrorInfo when GC finalizes the error.
+    // A materialized error never reads its frames again (see errorConstructorFuncCaptureStackTrace).
     if (destination->hasMaterializedErrorInfo()) {
         return JSC::JSValue::encode(jsUndefined());
     }
 
     if (!destination->stackTrace()) {
-        // ErrorInstance::captureStackTrace() unwraps stackTraceLimit(), which is
-        // empty once Error.stackTraceLimit has been set to a non-number or deleted.
+        // captureStackTrace() unwraps stackTraceLimit(), which is empty when Error.stackTraceLimit is not a number.
         if (globalObject->stackTraceLimit()) {
             destination->captureStackTrace(vm, globalObject, 1);
         } else {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -674,10 +674,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return JSC::JSValue::encode(jsUndefined());
     }
 
-    // Once .stack is materialized the frames are gone. Installing new ones would make the native error
-    // printer (which prefers frames over .stack) show this call site plus the source's frames, and trip
-    // computeErrorInfo's !m_errorInfoMaterialized assertion when GC finalizes the error. Leave both
-    // errors alone instead, as Bun__attachAsyncStackFromPromise does.
+    // Materializing .stack dropped the frames; frames installed now would replace it in the native printer (same no-op as Bun__attachAsyncStackFromPromise).
     if (destination->hasMaterializedErrorInfo()) {
         return JSC::JSValue::encode(jsUndefined());
     }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -993,7 +993,7 @@ test("captureStackTrace does not crash when stackTraceLimit is non-numeric", () 
   }
 });
 
-test("Error.appendStackTrace moves the source's frames into the destination", () => {
+test("Error.appendStackTrace moves the source's frames behind the destination's own", () => {
   function inner() {
     try {
       null();
@@ -1001,14 +1001,27 @@ test("Error.appendStackTrace moves the source's frames into the destination", ()
       return e;
     }
   }
+  function makeDestination() {
+    const error = new Error("destination");
+    error.name = "DestinationError";
+    return error;
+  }
   const source = inner();
-  const destination = new Error("destination");
+  const destination = makeDestination();
   Error.appendStackTrace(source, destination);
-  expect(destination.stack).toContain("at inner");
+
+  const lines = destination.stack.split("\n");
+  const destinationFrame = lines.findIndex(line => line.includes("at makeDestination"));
+  const sourceFrame = lines.findIndex(line => line.includes("at inner"));
+  expect(lines[0]).toBe("DestinationError: destination");
+  expect(destinationFrame).toBeGreaterThan(0);
+  expect(sourceFrame).toBeGreaterThan(destinationFrame);
+  // The frames are moved, not copied: the source has none left.
+  expect(source.stack).toBeUndefined();
 });
 
-// The rest of these abort the process (or trip ASAN) when they fail, so each
-// runs its scenario in a child.
+// The rest of these can abort the process (or trip ASAN) when they fail, so
+// each runs its scenario in a child.
 test.concurrent("Error.appendStackTrace does not abort when stackTraceLimit is non-numeric or deleted", async () => {
   const src = `
     class Source {
@@ -1041,15 +1054,37 @@ test.concurrent("Error.appendStackTrace does not abort when stackTraceLimit is n
 });
 
 test.concurrent("Error.appendStackTrace is a no-op once the destination's .stack has been materialized", async () => {
+  // Without the guard, release builds install new frames on the destination
+  // (so the native printer shows the appendStackTrace call site instead of the
+  // frames .stack reports) and empty the source; debug builds also assert when
+  // GC finalizes the destination, which is what the new Function sources and
+  // the Bun.gc() calls provoke.
   const src = `
-    const destination = new Error("destination");
-    const stack = destination.stack;
-    for (let i = 0; i < 100; i++) {
-      Error.appendStackTrace(new Function("return new Error('source')")(), destination);
+    function makeDestination() {
+      const error = new Error("destination");
+      error.stack;
+      return error;
     }
+    function appendAll(destination) {
+      let source;
+      for (let i = 0; i < 100; i++) {
+        source = new Function("return new Error('source')")();
+        Error.appendStackTrace(source, destination);
+      }
+      return source;
+    }
+    const destination = makeDestination();
+    const stack = destination.stack;
+    const lastSource = appendAll(destination);
+    const printed = Bun.inspect(destination);
     Bun.gc(true);
     Bun.gc(true);
-    process.stdout.write(JSON.stringify({ unchanged: destination.stack === stack }));
+    process.stdout.write(JSON.stringify({
+      unchanged: destination.stack === stack,
+      printedOwnFrame: printed.includes("at makeDestination"),
+      printedAppendFrame: printed.includes("at appendAll"),
+      sourceIntact: typeof lastSource.stack === "string",
+    }));
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", src],
@@ -1058,7 +1093,7 @@ test.concurrent("Error.appendStackTrace is a no-op once the destination's .stack
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: JSON.stringify({ unchanged: true }),
+    stdout: JSON.stringify({ unchanged: true, printedOwnFrame: true, printedAppendFrame: false, sourceIntact: true }),
     stderr: "",
     exitCode: 0,
   });
@@ -1071,8 +1106,11 @@ test.concurrent(
     // .column, .sourceURL) discards the native frames. The errors are created
     // inside eval'd functions so that each iteration's frames point at code GC
     // can reclaim, which is what makes finalizeUnconditionally look at them.
+    // The unmaterialized sources (c) keeping their frames is the part release
+    // builds can observe.
     const src = `
       const keep = [];
+      const sources = [];
       for (let i = 0; i < 200; i++) {
         eval(\`(function inner\${i}() {
           const a = new Error();
@@ -1085,12 +1123,13 @@ test.concurrent(
           const d = new Error();
           d.sourceURL;
           Error.appendStackTrace(c, d);
-          keep.push(c, d);
+          keep.push(d);
+          sources.push(c);
         })();\`);
       }
       Bun.gc(true);
       Bun.gc(true);
-      process.stdout.write("ok");
+      process.stdout.write(JSON.stringify({ sourcesIntact: sources.every(error => typeof error.stack === "string") }));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", src],
@@ -1098,7 +1137,11 @@ test.concurrent(
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ sourcesIntact: true }),
+      stderr: "",
+      exitCode: 0,
+    });
   },
 );
 

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -993,6 +993,59 @@ test("captureStackTrace does not crash when stackTraceLimit is non-numeric", () 
   }
 });
 
+// Both of these abort the process when they fail, so they run in a child.
+test.concurrent("Error.appendStackTrace does not abort when stackTraceLimit is non-numeric or deleted", async () => {
+  const src = `
+    class Source {
+      constructor() {
+        this.error = new Error("source");
+      }
+    }
+    const source = new Source().error;
+
+    Error.stackTraceLimit = "foo";
+    const destination = new Error("destination");
+    Error.appendStackTrace(source, destination);
+    Error.appendStackTrace(new Error("a"), new Error("b"));
+
+    delete Error.stackTraceLimit;
+    Error.appendStackTrace(new Error("c"), new Error("d"));
+
+    process.stdout.write(JSON.stringify({ appended: destination.stack.includes("at new Source") }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: JSON.stringify({ appended: true }), stderr: "", exitCode: 0 });
+});
+
+test.concurrent("Error.appendStackTrace is a no-op once the destination's .stack has been materialized", async () => {
+  const src = `
+    const destination = new Error("destination");
+    const stack = destination.stack;
+    for (let i = 0; i < 100; i++) {
+      Error.appendStackTrace(new Function("return new Error('source')")(), destination);
+    }
+    Bun.gc(true);
+    Bun.gc(true);
+    process.stdout.write(JSON.stringify({ unchanged: destination.stack === stack }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ unchanged: true }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 test("Error.stackTraceLimit default matches the limit captureStackTrace applies", async () => {
   // Run in a fresh process so nothing has written to Error.stackTraceLimit yet.
   const src = `

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,7 +1,7 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
 import { afterEach, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -993,7 +993,22 @@ test("captureStackTrace does not crash when stackTraceLimit is non-numeric", () 
   }
 });
 
-// Both of these abort the process when they fail, so they run in a child.
+test("Error.appendStackTrace moves the source's frames into the destination", () => {
+  function inner() {
+    try {
+      null();
+    } catch (e) {
+      return e;
+    }
+  }
+  const source = inner();
+  const destination = new Error("destination");
+  Error.appendStackTrace(source, destination);
+  expect(destination.stack).toContain("at inner");
+});
+
+// The rest of these abort the process (or trip ASAN) when they fail, so each
+// runs its scenario in a child.
 test.concurrent("Error.appendStackTrace does not abort when stackTraceLimit is non-numeric or deleted", async () => {
   const src = `
     class Source {
@@ -1008,8 +1023,11 @@ test.concurrent("Error.appendStackTrace does not abort when stackTraceLimit is n
     Error.appendStackTrace(source, destination);
     Error.appendStackTrace(new Error("a"), new Error("b"));
 
-    delete Error.stackTraceLimit;
+    Error.stackTraceLimit = undefined;
     Error.appendStackTrace(new Error("c"), new Error("d"));
+
+    delete Error.stackTraceLimit;
+    Error.appendStackTrace(new Error("e"), new Error("f"));
 
     process.stdout.write(JSON.stringify({ appended: destination.stack.includes("at new Source") }));
   `;
@@ -1045,6 +1063,84 @@ test.concurrent("Error.appendStackTrace is a no-op once the destination's .stack
     exitCode: 0,
   });
 });
+
+test.concurrent(
+  "Error.appendStackTrace onto errors materialized through .sourceURL does not assert when GC finalizes them",
+  async () => {
+    // Reading any of the lazily materialized properties (.stack, .line,
+    // .column, .sourceURL) discards the native frames. The errors are created
+    // inside eval'd functions so that each iteration's frames point at code GC
+    // can reclaim, which is what makes finalizeUnconditionally look at them.
+    const src = `
+      const keep = [];
+      for (let i = 0; i < 200; i++) {
+        eval(\`(function inner\${i}() {
+          const a = new Error();
+          const b = new Error();
+          a.sourceURL;
+          b.sourceURL;
+          Error.appendStackTrace(a, b);
+          keep.push(b);
+          const c = new Error();
+          const d = new Error();
+          d.sourceURL;
+          Error.appendStackTrace(c, d);
+          keep.push(c, d);
+        })();\`);
+      }
+      Bun.gc(true);
+      Bun.gc(true);
+      process.stdout.write("ok");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+  },
+);
+
+test.concurrent(
+  "Error.appendStackTrace with the same error as source and destination leaves its trace alone",
+  async () => {
+    // The trace needs enough frames that appending it to itself reallocates the
+    // vector; the default stackTraceLimit of 10 is plenty once f() has recursed.
+    const src = `
+      function f(n) {
+        if (n > 0) return f(n - 1) + 1;
+        try {
+          null();
+        } catch (e) {
+          Error.appendStackTrace(e, e);
+          // Without the guard the trace ends up empty and .stack is undefined.
+          process.stdout.write(JSON.stringify({ frames: String(e.stack).split("\\n").filter(line => line.includes("at f ")).length }));
+        }
+        return 0;
+      }
+      f(64);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      // WTF allocations normally come from bmalloc, where ASAN cannot see the
+      // freed buffer; Malloc=1 routes them through the system allocator.
+      // detect_leaks=0 keeps LeakSanitizer from reporting JSC's exit-time
+      // allocations under that allocator, and symbolize=0 keeps a failing child
+      // from spending seconds symbolizing the report.
+      env: isASAN
+        ? {
+            ...bunEnv,
+            Malloc: "1",
+            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0", "symbolize=0"].filter(Boolean).join(":"),
+          }
+        : bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: JSON.stringify({ frames: 10 }), stderr: "", exitCode: 0 });
+  },
+);
 
 test("Error.stackTraceLimit default matches the limit captureStackTrace applies", async () => {
   // Run in a fresh process so nothing has written to Error.stackTraceLimit yet.


### PR DESCRIPTION
Consolidates the four open fixes for `Error.appendStackTrace` (`errorConstructorFuncAppendStackTrace` in `src/jsc/bindings/FormatStackTraceForJS.cpp`) into one PR. This branch started as the `stackTraceLimit` fix and now also carries the cases from #35100, #34713 and #32098, which are closed in favour of it.

### Problem

Three ways to crash `Error.appendStackTrace(source, destination)`, all in the same ten lines:

- `Error.stackTraceLimit` set to a non-number (or deleted) and a destination with no frames: `ErrorInstance::captureStackTrace()` does `globalObject->stackTraceLimit().value()` on an empty optional. Bun is built without exceptions, so that is a silent `abort()` (`panic(main thread): abort() called` on release builds, nothing at all under ASAN). Same class as #29388, which fixed the identical `.value()` in `Error.captureStackTrace`. Reported as #35100 and here.
- Destination whose `.stack` (or `.line` / `.column` / `.sourceURL`) has already been read: materializing discards the frames and sets `m_errorInfoMaterialized`, so the `!destination->stackTrace()` branch captures a fresh trace at the `appendStackTrace` call site, appends the source's frames to it and empties the source. The destination's `.stack` string is unaffected, but Bun's native error printer (`ZigException.cpp`, `fromErrorInstance`) prefers an error's frames to its `.stack`, so `console.error(destination)` / `Bun.inspect(destination)` then show the call site and the source's frames instead of the destination's own, and `source.stack` becomes `undefined`. On debug builds the next GC that finalizes the destination additionally trips `ASSERTION FAILED: !m_errorInfoMaterialized` in `ErrorInstance::computeErrorInfo` (`ErrorInstance.cpp:368`). Reported as #34713 and here.
- `source === destination`: `destination->stackTrace()->appendVector(*source->stackTrace())` appends a vector to itself. `appendVector` goes through the `std::span<const T>` overload of `append`, whose `expandCapacity(size_t, U*)` does not rebase a pointer into the buffer it just freed, so once the trace has enough frames to reallocate the copy reads freed memory (`heap-use-after-free` in `errorConstructorFuncAppendStackTrace`, visible under ASAN with `Malloc=1`). The `clear()` that follows then empties the trace and `.stack` becomes `undefined` on every build. Reported as #32098.

### Fix

- `source === destination` returns early, leaving the trace as it was. Appending a trace to itself and then clearing it has no useful meaning, and this is the only way to keep the existing frames.
- A materialized destination makes the call a no-op: the destination's frames are already gone, so there is nothing to append to, and installing frames at this point only desyncs what the printer shows from what `.stack` says (and asserts on debug). Leaving the source untouched as well is deliberate; `Bun__attachAsyncStackFromPromise` (`AsyncStackTrace.cpp`) bails out of materialized errors for the same reason. (`Error.captureStackTrace` handles the materialized case differently, by recomputing `.stack` eagerly; that is the right thing for a fresh capture but not for an append, which has no destination frames left to put in front of the source's.)
- A destination with no frames gets an empty frame list instead of a capture when `stackTraceLimit()` is empty. An error constructed in that state has no frames of its own anyway (`getStackTrace` returns null when the limit is unset), but the source's frames are still appended, so `destination.stack` shows them. This is why the empty list is used rather than #35100's approach of skipping the append as well.
- Verified with `bun bd test test/js/node/v8/capture-stack-trace.test.js` (48 pass). Without the `FormatStackTraceForJS.cpp` change, four of the five `appendStackTrace` tests fail on both profiles: on the release build (`USE_SYSTEM_BUN=1`) the unset-limit test aborts, the self-append test reports zero frames, and the two materialized tests report the printer showing the `appendAll` call site and the sources losing their traces; on a debug + ASAN build the unset-limit and materialized tests abort and the self-append test gets the ASAN use-after-free. The basic two-error test pins existing behaviour and passes on both.

### Tests

All in `test/js/node/v8/capture-stack-trace.test.js`, next to the existing non-numeric `stackTraceLimit` test. Everything that can abort runs in a child process.

- plain two-error append: the destination keeps its header and its own frames first, the source's frames follow, and the source is left with none (existing behaviour, from #32098)
- `stackTraceLimit` set to `"foo"`, to `undefined` (from #35100) and deleted, and the source's frames still land in the destination
- destination materialized through `.stack`, appended to 100 times from `appendAll()`: `.stack` unchanged, `Bun.inspect(destination)` still shows the destination's own frame and not `appendAll`, the last source keeps its trace, then GC'd for the assertion
- source and destination materialized through `.sourceURL` (and only the destination), 200 rounds inside eval'd functions so GC finalizes the frames (from #34713), asserting the unmaterialized sources keep their traces
- self-append with a recursed trace, run with `Malloc=1` under ASAN so the freed buffer is visible, asserting the ten frames survive (from #32098)

### Background

- `ErrorInstance` keeps a native `Vector<StackFrame>` until something reads `.stack` (or line/column/sourceURL); at that point the frames are formatted into properties and dropped, and `m_errorInfoMaterialized` records that this happened. GC's `finalizeUnconditionally` also formats and drops frames early when one of them points at code that is about to be collected, which is the path that asserts if frames exist after materialization.
- `JSGlobalObject::stackTraceLimit()` is a `std::optional<unsigned>`; assigning a non-number to `Error.stackTraceLimit` or deleting it stores `nullopt`, and errors created while it is unset get no frames at all.
- Bun prints errors (`console.error`, `Bun.inspect`, uncaught errors) through `ZigException.cpp`, which uses the error's native frames when it still has any and only falls back to parsing the `.stack` string otherwise; that is why frames installed after materialization are visible even though `.stack` never changes.
- `Error.appendStackTrace` is a Bun-specific, `Private`-visibility helper installed on the `Error` constructor (`ZigGlobalObject.cpp`); it is reachable from user code, which is how the fuzzer hit all three cases.

### CI

Rebased onto current main (head is now 3e632a3a; the only conflict was the `harness` import line in the test file, which now imports both `tempDir` from #37450 and `isASAN` from this branch). After the rebase `bun bd test test/js/node/v8/capture-stack-trace.test.js` passes 49/49 (48 here plus the hidden-frame test from #37450). The code change is unchanged from the previous head.

On the earlier builds (#93764, #93942, #94462) every job that actually ran passed; the only jobs that did not pass were darwin aarch64 lanes and one windows 2019 shard that never got an agent, and the yellow entries were retries of tests unrelated to `Error.appendStackTrace`. Build [#99944](https://buildkite.com/bun/bun/builds/99944) is the run for the rebased head.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (8326d1bd3)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [14.73ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.49ms]
(pass) capture stack trace [6.46ms]
(pass) capture stack trace with message [7.22ms]
(pass) capture stack trace with constructor [4.99ms]
(pass) capture stack trace limit [21.51ms]
(pass) prepare stack trace [10.25ms]
(pass) capture stack trace second argument [17.12ms]
(pass) capture stack trace edge cases [10.73ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [21.23ms]
(pass) prepare stack trace call sites [11.25ms]
(pass) sanity check [12.21ms]
(pass) CallFrame isEval works as expected [6.77ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.55ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.19ms]
(pass) CallFrame.p.isConstructor [3.53ms]
(pass) CallFrame.p.isNative [2.82ms]
(pass) return non-strings from Error.prepareStackTrace [3.14ms]
(pass) CallF
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.15ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.10ms]
(pass) capture stack trace [0.07ms]
(pass) capture stack trace with message [0.07ms]
(pass) capture stack trace with constructor [0.08ms]
(pass) capture stack trace limit [0.25ms]
(pass) prepare stack trace [0.11ms]
(pass) capture stack trace second argument [0.17ms]
(pass) capture stack trace edge cases [0.12ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.26ms]
(pass) prepare stack trace call sites [0.12ms]
(pass) sanity check [0.16ms]
(pass) CallFrame isEval works as expected [0.10ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.09ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.10ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.04ms]
(pass) err.stack should invoke prepareStackTrace [0.22ms]
(pass) Error.prepareStackTrace inside a node:vm works [2.01ms]
(pass) Error.captureStackTrace i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (8326d1bd3)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.53ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.51ms]
(pass) capture stack trace [6.55ms]
(pass) capture stack trace with message [7.10ms]
(pass) capture stack trace with constructor [5.02ms]
(pass) capture stack trace limit [21.55ms]
(pass) prepare stack trace [10.38ms]
(pass) capture stack trace second argument [17.01ms]
(pass) capture stack trace edge cases [10.65ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [21.13ms]
(pass) prepare stack trace call sites [11.21ms]
(pass) sanity check [12.10ms]
(pass) CallFrame isEval works as expected [6.82ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.62ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.17ms]
(pass) CallFrame.p.isConstructor [3.57ms]
(pass) CallFrame.p.isNative [2.89ms]
(pass) return non-strings from Error.prepareStackTrace [3.15ms]
(pass) CallF
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3e632a3ab0
  features     baseline

22 deps, 120 codegen, 1175 objects in 629ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 107 installs across 153 packages (no changes) [6.00ms]
[2/1236] gen ErrorCode+*.h
[3/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1236] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[5/1236] gen bindgenv2
[6/1236] fetch tinycc
[tinycc] up to date
[7/1235] gen .bind.ts → GeneratedBindings.cpp
[8/1235] fetch zlib
[zlib] up to date
[9/1235] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp  |  17 ++-
 test/js/node/v8/capture-stack-trace.test.js | 194 +++++++++++++++++++++++++++-
 2 files changed, 209 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp       8      5      0
test/js/node/v8/capture-stack-trace.test.js      3      3      0
```

</details>

<!-- robobun:evidence:end -->




