### PR TITLE
Leave module/exports unbound in files with ESM exports

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2712,12 +2712,15 @@ impl EqlKindT for StrictEql {
 }
 
 /// Minimal parser surface needed by `Data::eql` — only the arena and the
-/// module ref are touched. Kept separate from
+/// CommonJS `module` check are touched. Kept separate from
 /// `ast::p::ParserLike` so this file does not grow that trait (out of scope);
 /// blanket-impl'd for every `P<...>` instantiation below.
 pub trait EqlParser {
     fn arena(&self) -> &Bump;
-    fn module_ref(&self) -> Ref;
+    /// Whether an identifier bound to `ref_` is CommonJS `module` (the file's
+    /// binding, or a free `module` in a file with ESM exports), for the
+    /// `require.main === module` rewrite.
+    fn is_module_ref(&self, ref_: Ref) -> bool;
 }
 // `impl EqlParser for P<...>` lives in `bun_js_parser` (next to `P`).
 
@@ -2848,7 +2851,7 @@ impl Data {
                 // always re-ordered to the right side.
                 if matches!(right, Data::ERequireMain) {
                     if let Some(id) = left.as_e_identifier() {
-                        if id.ref_.eql(p.module_ref()) {
+                        if p.is_module_ref(id.ref_) {
                             return Equality::RequireMainAndModule;
                         }
                     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2717,9 +2717,7 @@ impl EqlKindT for StrictEql {
 /// blanket-impl'd for every `P<...>` instantiation below.
 pub trait EqlParser {
     fn arena(&self) -> &Bump;
-    /// Whether an identifier bound to `ref_` is CommonJS `module` (the file's
-    /// binding, or a free `module` in a file with ESM exports), for the
-    /// `require.main === module` rewrite.
+    /// Is `ref_` the `module` operand of `require.main === module`?
     fn is_module_ref(&self, ref_: Ref) -> bool;
 }
 // `impl EqlParser for P<...>` lives in `bun_js_parser` (next to `P`).

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -253,9 +253,18 @@ impl<'a, const IS_TS: bool, const SCAN: bool> bun_ast::expr::EqlParser
     fn arena(&self) -> &bun_alloc::Arena {
         self.arena
     }
-    #[inline]
-    fn module_ref(&self) -> Ref {
-        self.module_ref
+    fn is_module_ref(&self, ref_: Ref) -> bool {
+        if ref_.eql(self.module_ref) {
+            return true;
+        }
+        if !ref_.is_symbol() {
+            return false;
+        }
+        // A file with ESM exports has no `module` binding (see
+        // `prepare_for_visit_pass`), so its `require.main === module` refers to
+        // an unbound `module`. Keep rewriting that to `import.meta.main`.
+        let symbol = &self.symbols[ref_.inner_index() as usize];
+        symbol.kind == bun_ast::symbol::Kind::Unbound && symbol.original_name.slice() == b"module"
     }
 }
 

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -260,9 +260,7 @@ impl<'a, const IS_TS: bool, const SCAN: bool> bun_ast::expr::EqlParser
         if !ref_.is_symbol() {
             return false;
         }
-        // A file with ESM exports has no `module` binding (see
-        // `prepare_for_visit_pass`), so its `require.main === module` refers to
-        // an unbound `module`. Keep rewriting that to `import.meta.main`.
+        // Files with ESM exports leave `module` unbound (see `prepare_for_visit_pass`).
         let symbol = &self.symbols[ref_.inner_index() as usize];
         symbol.kind == bun_ast::symbol::Kind::Unbound && symbol.original_name.slice() == b"module"
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2847,19 +2847,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .generated
             .ensure_unused_capacity(generated_symbols_count as usize * 3);
 
-        // An `export` keyword or top-level `await` makes the file ESM regardless
-        // of anything else (see `exports_kind` in `parse_entry`), and an ESM file
-        // has no `exports`/`module` bindings: the bundler only declares these
-        // symbols for CommonJS-wrapped files and reuses `exports_ref` as the ESM
-        // namespace object. So keep them out of the scope and let a bare
-        // `exports`/`module` resolve like any other global (printed as-is,
-        // replaceable by `--define`). The symbols still exist because the linker
-        // and `export =` use them by ref.
-        //
-        // Unlike `is_file_considered_to_have_esm_exports`, `options.module_type`
-        // is not consulted: a `.mjs`/`"type": "module"` file without ESM syntax
-        // is still classified by whether it uses `module`/`exports`, which needs
-        // the bindings.
+        // `export` or top-level `await` makes the file ESM regardless of `module`/
+        // `exports` usage (see `exports_kind` in `parse_entry`; `module_type` alone
+        // does not), so those are not bindings there: user references stay free
+        // identifiers. The linker and `export =` still use the symbols by ref.
         if self.esm_export_keyword.len > 0 || self.top_level_await_keyword.len > 0 {
             self.exports_ref = self.new_symbol(js_ast::symbol::Kind::Hoisted, b"exports");
             self.module_ref = self.new_symbol(js_ast::symbol::Kind::Hoisted, b"module");

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2847,10 +2847,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .generated
             .ensure_unused_capacity(generated_symbols_count as usize * 3);
 
-        self.exports_ref =
-            self.declare_common_js_symbol(js_ast::symbol::Kind::Hoisted, b"exports")?;
-        self.module_ref =
-            self.declare_common_js_symbol(js_ast::symbol::Kind::Hoisted, b"module")?;
+        // An `export` keyword or top-level `await` makes the file ESM regardless
+        // of anything else (see `exports_kind` in `parse_entry`), and an ESM file
+        // has no `exports`/`module` bindings: the bundler only declares these
+        // symbols for CommonJS-wrapped files and reuses `exports_ref` as the ESM
+        // namespace object. So keep them out of the scope and let a bare
+        // `exports`/`module` resolve like any other global (printed as-is,
+        // replaceable by `--define`). The symbols still exist because the linker
+        // and `export =` use them by ref.
+        //
+        // Unlike `is_file_considered_to_have_esm_exports`, `options.module_type`
+        // is not consulted: a `.mjs`/`"type": "module"` file without ESM syntax
+        // is still classified by whether it uses `module`/`exports`, which needs
+        // the bindings.
+        if self.esm_export_keyword.len > 0 || self.top_level_await_keyword.len > 0 {
+            self.exports_ref = self.new_symbol(js_ast::symbol::Kind::Hoisted, b"exports");
+            self.module_ref = self.new_symbol(js_ast::symbol::Kind::Hoisted, b"module");
+        } else {
+            self.exports_ref =
+                self.declare_common_js_symbol(js_ast::symbol::Kind::Hoisted, b"exports")?;
+            self.module_ref =
+                self.declare_common_js_symbol(js_ast::symbol::Kind::Hoisted, b"module")?;
+        }
 
         self.require_ref =
             self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"require")?;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2718,6 +2718,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Substitution::Failure(expr)
     }
 
+    /// `export` or top-level `await`: the file is ESM however it uses `module`/`exports`.
+    #[inline]
+    pub(crate) fn is_esm_by_syntax(&self) -> bool {
+        self.esm_export_keyword.len > 0 || self.top_level_await_keyword.len > 0
+    }
+
     pub(crate) fn prepare_for_visit_pass(&mut self) -> Result<(), crate::Error> {
         {
             // The wrapper stores only the arena and a non-capturing
@@ -2755,9 +2761,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.scope_order_to_visit = buf.into_bump_slice();
         }
 
-        self.is_file_considered_to_have_esm_exports = !self.top_level_await_keyword.is_empty()
-            || !self.esm_export_keyword.is_empty()
-            || self.options.module_type == options::ModuleType::Esm;
+        self.is_file_considered_to_have_esm_exports =
+            self.is_esm_by_syntax() || self.options.module_type == options::ModuleType::Esm;
 
         self.push_scope_for_visit_pass(js_ast::scope::Kind::Entry, loc_module_scope)?;
         self.fn_or_arrow_data_visit.is_outside_fn_or_arrow = true;
@@ -2847,11 +2852,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .generated
             .ensure_unused_capacity(generated_symbols_count as usize * 3);
 
-        // `export` or top-level `await` makes the file ESM regardless of `module`/
-        // `exports` usage (see `exports_kind` in `parse_entry`; `module_type` alone
-        // does not), so those are not bindings there: user references stay free
-        // identifiers. The linker and `export =` still use the symbols by ref.
-        if self.esm_export_keyword.len > 0 || self.top_level_await_keyword.len > 0 {
+        // ESM has no `exports`/`module` bindings; the symbols are only used by ref.
+        if self.is_esm_by_syntax() {
             self.exports_ref = self.new_symbol(js_ast::symbol::Kind::Hoisted, b"exports");
             self.module_ref = self.new_symbol(js_ast::symbol::Kind::Hoisted, b"module");
         } else {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1453,7 +1453,7 @@ impl<'a> Parser<'a> {
 
         if p.is_deoptimized_commonjs() {
             exports_kind = js_ast::ExportsKind::Cjs;
-        } else if p.esm_export_keyword.len > 0 || p.top_level_await_keyword.len > 0 {
+        } else if p.is_esm_by_syntax() {
             exports_kind = js_ast::ExportsKind::Esm;
         } else if uses_exports_ref || uses_module_ref || p.has_top_level_return || p.has_with_scope
         {

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -89,8 +89,7 @@ fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool, const SCAN_ONLY: boo
     }
 }
 
-/// `require.main === module` (any equality operator) becomes `import.meta.main`.
-/// `ERequireMain` was reordered to the right, so the `module` identifier is `e_.left`.
+/// Replaces `require.main === module` (any equality operator) with `import.meta.main`.
 fn fold_require_main_and_module<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
     e_: &E::Binary,
     p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
@@ -98,8 +97,10 @@ fn fold_require_main_and_module<'a, const TYPESCRIPT: bool, const SCAN_ONLY: boo
     loc: bun_ast::Loc,
 ) -> Expr {
     p.ignore_usage_of_runtime_require();
-    if let ExprData::EIdentifier(id) = e_.left.data {
-        p.ignore_usage(id.ref_);
+    for operand in [e_.left, e_.right] {
+        if let ExprData::EIdentifier(id) = operand.data {
+            p.ignore_usage(id.ref_);
+        }
     }
     p.value_for_import_meta_main(inverted, loc)
 }

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -89,11 +89,8 @@ fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool, const SCAN_ONLY: boo
     }
 }
 
-/// Replace `require.main === module` (any of the four equality operators) with
-/// `import.meta.main`. Both operands disappear: `require.main` is the
-/// `ERequireMain` on the right (equality operands were reordered above) and
-/// `module` is the identifier on the left, which is either the CommonJS
-/// `module_ref` or, in a file with ESM exports, an unbound `module`.
+/// `require.main === module` (any equality operator) becomes `import.meta.main`.
+/// `ERequireMain` was reordered to the right, so the `module` identifier is `e_.left`.
 fn fold_require_main_and_module<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
     e_: &E::Binary,
     p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -89,6 +89,24 @@ fn data_eql<'a, const STRICT: bool, const TYPESCRIPT: bool, const SCAN_ONLY: boo
     }
 }
 
+/// Replace `require.main === module` (any of the four equality operators) with
+/// `import.meta.main`. Both operands disappear: `require.main` is the
+/// `ERequireMain` on the right (equality operands were reordered above) and
+/// `module` is the identifier on the left, which is either the CommonJS
+/// `module_ref` or, in a file with ESM exports, an unbound `module`.
+fn fold_require_main_and_module<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+    e_: &E::Binary,
+    p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+    inverted: bool,
+    loc: bun_ast::Loc,
+) -> Expr {
+    p.ignore_usage_of_runtime_require();
+    if let ExprData::EIdentifier(id) = e_.left.data {
+        p.ignore_usage(id.ref_);
+    }
+    p.value_for_import_meta_main(inverted, loc)
+}
+
 pub struct BinaryExpressionVisitor {
     /// Arena handle to the in-place `E::Binary` node.
     /// `StoreRef` is the safe arena back-reference: `Copy` + `Deref`/`DerefMut`
@@ -237,9 +255,7 @@ impl BinaryExpressionVisitor {
             Op::Code::BinLooseEq => {
                 match data_eql::<false, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
-                        p.ignore_usage_of_runtime_require();
-                        p.ignore_usage(p.module_ref);
-                        return p.value_for_import_meta_main(false, v.loc);
+                        return fold_require_main_and_module(e_, p, false, v.loc);
                     }
                     Equality::Equal => return p.new_expr(E::Boolean { value: true }, v.loc),
                     Equality::NotEqual => return p.new_expr(E::Boolean { value: false }, v.loc),
@@ -267,9 +283,7 @@ impl BinaryExpressionVisitor {
             Op::Code::BinStrictEq => {
                 match data_eql::<true, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
-                        p.ignore_usage(p.module_ref);
-                        p.ignore_usage_of_runtime_require();
-                        return p.value_for_import_meta_main(false, v.loc);
+                        return fold_require_main_and_module(e_, p, false, v.loc);
                     }
                     Equality::Equal => return p.new_expr(E::Boolean { value: true }, v.loc),
                     Equality::NotEqual => return p.new_expr(E::Boolean { value: false }, v.loc),
@@ -290,9 +304,7 @@ impl BinaryExpressionVisitor {
             Op::Code::BinLooseNe => {
                 match data_eql::<false, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
-                        p.ignore_usage(p.module_ref);
-                        p.ignore_usage_of_runtime_require();
-                        return p.value_for_import_meta_main(true, v.loc);
+                        return fold_require_main_and_module(e_, p, true, v.loc);
                     }
                     Equality::Equal => return p.new_expr(E::Boolean { value: false }, v.loc),
                     Equality::NotEqual => return p.new_expr(E::Boolean { value: true }, v.loc),
@@ -317,9 +329,7 @@ impl BinaryExpressionVisitor {
             Op::Code::BinStrictNe => {
                 match data_eql::<true, TYPESCRIPT, SCAN_ONLY>(&e_.left.data, &e_.right.data, p) {
                     Equality::RequireMainAndModule => {
-                        p.ignore_usage(p.module_ref);
-                        p.ignore_usage_of_runtime_require();
-                        return p.value_for_import_meta_main(true, v.loc);
+                        return fold_require_main_and_module(e_, p, true, v.loc);
                     }
                     Equality::Equal => return p.new_expr(E::Boolean { value: false }, v.loc),
                     Equality::NotEqual => return p.new_expr(E::Boolean { value: true }, v.loc),

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,9 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: Files with `export` or top-level `await` no longer bind `module`/
-/// `exports`, so `module.require()` in them is no longer rewritten to `require()`
-/// and `--define` applies to the identifiers.
+/// Version 26: `module`/`exports` are free identifiers in files with `export` or top-level `await`.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: Files with `export` or top-level `await` no longer bind `module`/
+/// `exports`, so `module.require()` in them is no longer rewritten to `require()`
+/// and `--define` applies to the identifiers.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2146,6 +2146,110 @@ describe("bundler", () => {
       api.expectFile("/out.js").toMatch(/[^\.:]module/); // `.module` and `node:module` are not ok.
     },
   });
+  // A file with ESM exports has no CommonJS `module`/`exports` bindings, so bare
+  // references to them are free identifiers and must be left alone. They used to
+  // bind to the file's internal CommonJS symbols, which the bundler renamed to
+  // `module_<file>` (never declared) and `exports_<file>` (the ESM namespace
+  // object), and `module.id` was inlined.
+  itBundled("edgecase/ESMFileModuleAndExportsAreFreeIdentifiers", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { describeEnv } from './lib';
+        // Exporting keeps ESM syntax in the output so it also runs as an ES module.
+        export const env = describeEnv();
+        console.log(env);
+      `,
+      "/lib.ts": /* ts */ `
+        globalThis['ca' + 'pture'] = x => x;
+        declare const module: any;
+        declare const exports: any;
+
+        export function describeEnv() {
+          return [
+            capture(typeof module),
+            capture(typeof exports),
+            typeof module === 'undefined' ? 'no module' : capture(module.id),
+            typeof exports === 'undefined' ? 'no exports' : capture(exports.foo),
+            capture(require.main === module),
+          ].join(', ');
+        }
+      `,
+    },
+    capture: ["typeof module", "typeof exports", "module.id", "exports.foo", "false"],
+    run: {
+      stdout: "undefined, undefined, no module, no exports, false",
+    },
+  });
+  itBundled("edgecase/ESMFileModuleAndExportsAreFreeIdentifiersMinified", {
+    files: {
+      "/entry.ts": /* ts */ `
+        globalThis['ca' + 'pture'] = x => x;
+        await Promise.resolve();
+        console.log(capture(typeof module), capture(typeof exports));
+      `,
+    },
+    minifyIdentifiers: true,
+    capture: ["typeof module", "typeof exports"],
+    run: {
+      stdout: "undefined undefined",
+    },
+  });
+  // With the CommonJS output format the free identifiers refer to the output
+  // file's own `module`/`exports`, as they would in the unbundled source.
+  itBundled("edgecase/ESMFileModuleAndExportsAreFreeIdentifiersFormatCJS", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { install } from './install';
+        install();
+      `,
+      "/install.ts": /* ts */ `
+        declare const module: any;
+        declare const exports: any;
+
+        export function install() {
+          console.log(typeof module, typeof exports, module.exports === exports);
+        }
+      `,
+    },
+    format: "cjs",
+    target: "node",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toMatch(/\b(?:module|exports)_install\b/);
+    },
+    run: [{ stdout: "object object true" }, { runtime: "node", stdout: "object object true" }],
+  });
+  // `define` only applies to free identifiers, so it replaces `module`/`exports`
+  // in a file with ESM exports but not in a CommonJS file, where they are the
+  // wrapper's arguments.
+  itBundled("edgecase/DefineModuleAndExportsInESMFile", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { esm } from './esm';
+        import { cjs } from './cjs';
+        console.log(esm(), cjs());
+      `,
+      "/esm.ts": /* ts */ `
+        declare const module: string;
+        declare const exports: string;
+
+        export function esm() {
+          return module + ' ' + exports;
+        }
+      `,
+      "/cjs.js": /* js */ `
+        exports.cjs = function () {
+          return typeof module + ' ' + typeof exports;
+        };
+      `,
+    },
+    define: {
+      module: '"defined-module"',
+      exports: '"defined-exports"',
+    },
+    run: {
+      stdout: "defined-module defined-exports object object",
+    },
+  });
   itBundled("edgecase/IdentifierInEnum#13081", {
     files: {
       "/entry.ts": `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2150,7 +2150,7 @@ describe("bundler", () => {
   // references to them are free identifiers and must be left alone. They used to
   // bind to the file's internal CommonJS symbols, which the bundler renamed to
   // `module_<file>` (never declared) and `exports_<file>` (the ESM namespace
-  // object), and `module.id` was inlined.
+  // object), `module.id` was inlined and `module.require()` became `require()`.
   itBundled("edgecase/ESMFileModuleAndExportsAreFreeIdentifiers", {
     files: {
       "/entry.ts": /* ts */ `
@@ -2169,15 +2169,58 @@ describe("bundler", () => {
             capture(typeof module),
             capture(typeof exports),
             typeof module === 'undefined' ? 'no module' : capture(module.id),
+            typeof module === 'undefined' ? 'no require' : capture(module.require('node:fs')),
             typeof exports === 'undefined' ? 'no exports' : capture(exports.foo),
             capture(require.main === module),
           ].join(', ');
         }
       `,
     },
-    capture: ["typeof module", "typeof exports", "module.id", "exports.foo", "false"],
+    capture: ["typeof module", "typeof exports", "module.id", 'module.require("node:fs")', "exports.foo", "false"],
     run: {
-      stdout: "undefined, undefined, no module, no exports, false",
+      stdout: "undefined, undefined, no module, no require, no exports, false",
+    },
+  });
+  // The same applies to assignments. A file with ESM exports that also assigns
+  // `module.exports`/`exports.x` behind a dual-mode guard stays an ES module with
+  // the assignments left as written. The assignments used to target the renamed
+  // internal symbols, and a file doing both used to be converted to CommonJS,
+  // dropping its `export` statements.
+  itBundled("edgecase/ESMFileWithGuardedCommonJSAssignmentsStaysESM", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { a } from './assigns-module-exports';
+        import { b } from './assigns-exports';
+        import { c } from './assigns-both';
+        export const result = a + b + c;
+        console.log(result);
+      `,
+      "/assigns-module-exports.ts": /* ts */ `
+        globalThis['ca' + 'pture'] = x => x;
+        declare const module: any;
+        export const a = 1;
+        if (typeof module !== 'undefined') capture(module.exports = { a });
+      `,
+      "/assigns-exports.ts": /* ts */ `
+        declare const exports: any;
+        export const b = 2;
+        if (typeof exports !== 'undefined') capture(exports.b = b);
+      `,
+      "/assigns-both.ts": /* ts */ `
+        declare const module: any;
+        declare const exports: any;
+        export const c = 3;
+        if (typeof exports !== 'undefined') capture(exports.c = c);
+        if (typeof module !== 'undefined') capture(module.exports = { c });
+      `,
+    },
+    capture: ["module.exports = { a }", "exports.b = b", "exports.c = c", "module.exports = { c }"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__commonJS");
+      api.expectFile("/out.js").not.toMatch(/\b(?:module|exports)_assigns/);
+    },
+    run: {
+      stdout: "6",
     },
   });
   itBundled("edgecase/ESMFileModuleAndExportsAreFreeIdentifiersMinified", {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3074,6 +3074,12 @@ console.log(resolve.length)
       );
     });
 
+    it("module.require() is only rewritten to require() where module is a CommonJS binding", () => {
+      expectPrinted_("const x = module.require('y')", 'const x = require("y")');
+      expectPrinted_("export const x = module.require('y')", 'export const x = module.require("y")');
+      expectPrinted_("await 0;\nconst x = module.require('y')", 'await 0;\nconst x = module.require("y")');
+    });
+
     it("jsx symbol should work", () => {
       expectBunPrinted_(`var x = jsx; export default x;`, "var x = jsx;\nexport default x");
     });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3052,6 +3052,28 @@ console.log(resolve.length)
       expectPrinted_("Math.log('hi')", 'console.error("hi")');
     });
 
+    it("define replaces module/exports only where they are not CommonJS bindings", () => {
+      const defineModule = new Bun.Transpiler({
+        loader: "ts",
+        define: { module: '"defined-module"', exports: '"defined-exports"' },
+      });
+      const print = code => defineModule.transformSync(code).trim();
+
+      // A file with an `export` or top-level `await` has no `module`/`exports` bindings.
+      expect(print("export const a = [module, exports];")).toBe(
+        'export const a = ["defined-module", "defined-exports"];',
+      );
+      expect(print("await 0;\nconsole.log(module, exports);")).toBe(
+        'await 0;\nconsole.log("defined-module", "defined-exports");',
+      );
+
+      // A CommonJS file binds them to the wrapper's arguments, so the define does not apply.
+      expect(print("console.log(module, exports);")).toBe("console.log(module, exports);");
+      expect(print("import x from './x';\nconsole.log(module, exports, x);")).toBe(
+        'import x from "./x";\nconsole.log(module, exports, x);',
+      );
+    });
+
     it("jsx symbol should work", () => {
       expectBunPrinted_(`var x = jsx; export default x;`, "var x = jsx;\nexport default x");
     });


### PR DESCRIPTION
### Problem

Bundling an ES module that mentions the free identifiers `module` or `exports` produces a bundle that references symbols which are never declared, and `--define module=...` / `define: { module }` is ignored for it.

```ts
// a.ts
declare const module: string;
export function f() { return `mod=${module}`; }
// entry.ts
import { f } from "./a";
console.log(f());
```

```
$ bun build ./entry.ts --target=node --format=cjs --outfile=out.js && node out.js
ReferenceError: module_a is not defined
```

The bundle contains ``return `mod=${module_a}` ``; nothing declares `module_a`. esbuild emits `` `mod=${module}` `` and, with `--define:module='"bun"'`, `` `mod=${"bun"}` ``.

More of the same bug in one file (`export const a = 1;` plus a few references), current output:

```js
console.log(exports_e, exports_e.foo, "e.ts", module_e.require, typeof module_e, typeof exports_e);
```

`module.exports` and `exports` became the file's ESM namespace object (so `typeof exports` is `"object"`), `module.id` was inlined, `module_e` is undeclared, and with `--minify` the references became whatever letter the minifier picked (`typeof a`). A file mixing `export` with `module.exports = {...}` was even switched to CommonJS and its `export` statements silently dropped.

The `bun` npm package's postinstall (`packages/bun-release/scripts/npm-postinstall.ts`) hits this when bundled with `Bun.build({ define: { module: '"bun"' } })`: `install.ts` ends up with an undeclared `module_install`.

### Cause

`prepare_for_visit_pass` unconditionally declares the CommonJS `exports`/`module` symbols in the module scope, so every bare `exports`/`module` in the file binds to `exports_ref`/`module_ref` and the CommonJS-specific folds (`module.exports` rewriting, `module.id` inlining, named-export unwrapping) run on it. But a file containing an `export` statement or top-level `await` is classified ESM no matter what (`exports_kind` selection in `parse_entry.rs`), and for ESM files the linker never declares `module_ref`, reuses `exports_ref` as the namespace object, and renames both to `module_<file>` / `exports_<file>` on the assumption that nothing user-visible refers to them. The define pass never saw the identifiers either, since it only substitutes unbound symbols.

### Fix

When the file has an `export` keyword or top-level `await` (now the shared `is_esm_by_syntax()` predicate, which is also what the `exports_kind` selection in `parse_entry.rs` and `is_file_considered_to_have_esm_exports` use), create `exports_ref`/`module_ref` without putting them in scope (they are still needed by ref: namespace object, `export =`, HMR). A bare `exports`/`module` then resolves to an ordinary unbound symbol: printed verbatim, reserved by the renamer, and eligible for `define`. This is what esbuild does (`prepareForVisitPass`: "You can still use `require` in ESM, just not `module` or `exports`"). The CommonJS folds keyed on those symbols stop applying to such files as a consequence: `module.exports` rewriting and named-export unwrapping, `module.id`/`filename`/`path` inlining, and the webpack-compat rewrite of `module.require(x)` to `require(x)` (so that call is now printed as written in these files). esbuild applies none of them to such files either. Note that this does not change which files count as ESM: for example a TypeScript file with only `export type` declarations plus `module.exports = ...` was already classified ESM (and already failed with `module is not defined` at runtime); it now bundles to a verbatim `module.exports` instead of an undeclared `module_<file>`.

`options.module_type` is deliberately not part of the condition: a `.mjs` / `"type": "module"` file without ESM syntax is still classified by its use of `module`/`exports` (see also #33807), and that needs the bindings.

Bun's `require.main === module` -> `import.meta.main` rewrite is kept for ESM files: `EqlParser::is_module_ref` now also accepts an unbound identifier named `module` (which can only exist in a file without the binding), and the four equality arms drop the use of whichever identifier matched instead of always `module_ref`.

### Why this is the right behavior

The binding decision now agrees with the classification decision the parser already makes: whenever the file is going to be ESM regardless of what else it contains, it gets no CommonJS bindings, exactly like the environment it will run in. Free `module`/`exports` then mean whatever the output environment provides: `undefined` in an ESM bundle (so `typeof module !== "undefined"` dual-mode guards take the ESM path), the real wrapper values in `--format=cjs` output, and the defined value under `define`. This matches esbuild for every case above. Files without ESM syntax, import-only files, and TypeScript `export =` (which resets the export keyword) are untouched and keep CommonJS semantics, so defines for `module`/`exports` still do not apply there (covered by the existing `extra/DefineModule*` tests).

Observable changes outside the bundler, all limited to files that contain `export` or top-level `await` and mention `module`/`exports`: `--define module=...`/`exports=...` now applies to them at runtime and in `Bun.Transpiler`; a `module.require(...)` call in such a file is no longer rewritten to `require(...)` (the rewrite exists for CommonJS files, and Node/esbuild do not apply it to ES modules either); and the dev server no longer binds their `module`/`exports` to the closure's placeholder arguments (those were `undefined` at runtime, so `typeof` guards behave the same). Because the runtime transpiler output changes, `EXPECTED_VERSION` in `RuntimeTranspilerCache.rs` is bumped to 26 so cached entries from older builds are not replayed.

### Tests

`test/bundler/bundler_edgecase.test.ts`:
- `ESMFileModuleAndExportsAreFreeIdentifiers`: captures `typeof module`, `typeof exports`, `module.id`, `module.require("node:fs")`, `exports.foo` verbatim and the `require.main === module` fold, and runs the ESM bundle. Before: `typeof module_lib`, `typeof exports_lib`, `"lib.ts"`, the require rewritten to the bundler's builtin stub, `exports_lib.foo`.
- `ESMFileWithGuardedCommonJSAssignmentsStaysESM`: three exporting files with guarded `module.exports = ...` / `exports.x = ...` assignments (one file doing both). The assignments are captured verbatim, the output contains no `__commonJS` wrapper, and the entry imports all three. Before: `module_assigns_module_exports.exports = ...`, `exports_assigns_exports.b = ...`, and the file doing both converted to a CommonJS wrapper.
- `...Minified`: top-level await file with `minifyIdentifiers`. Before: `typeof a`, `typeof e`.
- `...FormatCJS`: `--format=cjs --target=node`, run under both bun and node; `module`/`exports` refer to the output file's own CommonJS module. Before: `ReferenceError: module_install is not defined`.
- `DefineModuleAndExportsInESMFile`: `define` replaces them in the ESM file and not in a CommonJS file in the same bundle. Before: `ReferenceError: module_esm is not defined`.

`test/bundler/transpiler/transpiler.test.js`: `Bun.Transpiler` with `define` for `module`/`exports` substitutes in `export` / top-level-await sources and leaves CommonJS and import-only sources alone (before: no substitution in the ESM cases), and `module.require('y')` still prints as `require("y")` in a CommonJS source but as written in `export` / top-level-await sources (before: rewritten in all three).

All seven fail on the unpatched binary and pass with this change. Also ran `test/bundler/` (the only failures are pre-existing debug-build-only ones unrelated to this change: `compile/HelloWorldWithProcessVersionsBun`, the native-plugin install hook timeout, and one compile test timeout), plus `test/bake/dev/bundle.test.ts`, `test/bake/dev/esm.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/cli/run/run-eval.test.ts`, `test/cli/run/run-importmetamain.ts`, `test/js/bun/transpiler/repl-transform.test.ts` and `test/js/third_party/es-module-lexer`, all passing.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->