### PR TITLE
resolver: find packages installed after a failed runtime resolution

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3227,21 +3227,6 @@ fn normalize_specifier_for_resolution<'a>(
     }
 }
 
-/// Heap-backed so only a pointer lives in TLS; see test/js/bun/binary/tls-segment-size.
-#[thread_local]
-static SPECIFIER_CACHE_RESOLVER_BUF: core::cell::Cell<*mut bun_paths::PathBuffer> =
-    core::cell::Cell::new(core::ptr::null_mut());
-
-#[inline]
-fn specifier_cache_resolver_buf() -> *mut bun_paths::PathBuffer {
-    let mut p = SPECIFIER_CACHE_RESOLVER_BUF.get();
-    if p.is_null() {
-        p = bun_core::heap::into_raw(Box::new(bun_paths::PathBuffer::ZEROED));
-        SPECIFIER_CACHE_RESOLVER_BUF.set(p);
-    }
-    p
-}
-
 fn ensure_source_code_printer() {
     if SOURCE_CODE_PRINTER.get().is_none() {
         let writer = bun_js_printer::BufferWriter::init();
@@ -4401,50 +4386,12 @@ impl VirtualMachine {
                     }
                     retry_on_not_found = false;
 
-                    // SAFETY: thread-local heap allocation; sole `&mut` on the JS
-                    // thread for the duration of the bust below.
-                    let buf = unsafe { &mut *specifier_cache_resolver_buf() }.as_mut_slice();
-                    let buster_name: &[u8] = if bun_paths::is_absolute(normalized_specifier) {
-                        if let Some(dir) = bun_paths::dirname(normalized_specifier) {
-                            if dir.len() > buf.len() {
-                                return Err(crate::CrateError::ModuleNotFound);
-                            }
-                            // Normalized without trailing slash.
-                            bun_paths::string_paths::normalize_slashes_only(
-                                buf,
-                                dir,
-                                bun_paths::SEP,
-                            )
-                        } else {
-                            // Absolute but root — fall through to join.
-                            &b""[..]
-                        }
-                    } else {
-                        &b""[..]
-                    };
-                    let buster_name: &[u8] = if !buster_name.is_empty() {
-                        buster_name
-                    } else {
-                        // If the specifier is too long to join, it can't name
-                        // a real directory — skip the cache bust and fail.
-                        if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
-                            return Err(crate::CrateError::ModuleNotFound);
-                        }
-                        let parts: [&[u8]; 3] = [
-                            source_to_use,
-                            normalized_specifier,
-                            bun_paths::path_literal!("..").as_bytes(),
-                        ];
-                        bun_paths::resolve_path::join_abs_string_buf_z::<
-                            bun_paths::resolve_path::platform::Auto,
-                        >(top_level_dir, buf, &parts)
-                        .as_bytes()
-                    };
-
                     // Only re-query if we previously had something cached.
-                    if self.transpiler.resolver.bust_dir_cache(
-                        bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
-                    ) {
+                    if self
+                        .transpiler
+                        .resolver
+                        .bust_dir_cache_for_not_found(source_to_use, normalized_specifier)
+                    {
                         continue;
                     }
                     return Err(crate::CrateError::ModuleNotFound);

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2545,6 +2545,220 @@ impl<'a> Resolver<'a> {
         a || b
     }
 
+    /// After a runtime resolution of `import_path` came back not found, evict
+    /// the cache entries that lookup may have been served stale answers from,
+    /// so the caller can retry it once. Returns whether anything was evicted.
+    ///
+    /// The candidate path and its parent directory are always evicted (`./x`
+    /// is either `x.js` in the parent's listing or `x/index.js`). A package
+    /// path additionally revalidates the `node_modules` search: every
+    /// directory level the lookup walked (or the `require.resolve` `paths`
+    /// roots), plus every `NODE_PATH` entry. A level where the package
+    /// directory exists on disk now gets its cached state for that package
+    /// evicted; a level where it still does not exist costs one `access()` and
+    /// evicts nothing, so a miss for a package that simply is not installed
+    /// does not churn the cache.
+    pub fn bust_dir_cache_for_not_found(&mut self, source_dir: &[u8], import_path: &[u8]) -> bool {
+        // Same parse `load_node_modules` derives the package directory from.
+        let package_name: Option<&[u8]> = if is_package_path(import_path) {
+            crate::package_json::Package::parse(import_path, bufs!(esm_subpath)).map(|esm| esm.name)
+        } else {
+            None
+        };
+
+        let mut busted = false;
+        match self.custom_dir_paths {
+            Some(custom_paths) => {
+                for custom_path in custom_paths {
+                    let custom_utf8 = custom_path.to_utf8_without_ref();
+                    busted |= self.bust_dir_cache_for_not_found_in(
+                        custom_utf8.slice(),
+                        import_path,
+                        package_name,
+                    );
+                }
+            }
+            None => {
+                busted |=
+                    self.bust_dir_cache_for_not_found_in(source_dir, import_path, package_name);
+            }
+        }
+
+        if let Some(name) = package_name {
+            for node_path_dir in self.node_path_entries() {
+                let Some(base) = self
+                    .fs_ref()
+                    .abs_buf_checked(&[node_path_dir], bufs!(node_modules_check))
+                else {
+                    continue;
+                };
+                let base = strings::without_trailing_slash_windows_path(base);
+                if self.package_dir_exists(base, name) {
+                    busted |= self.bust_package_dir_cache(base, name, import_path);
+                }
+            }
+        }
+
+        busted
+    }
+
+    fn bust_dir_cache_for_not_found_in(
+        &mut self,
+        root: &[u8],
+        import_path: &[u8],
+        package_name: Option<&[u8]>,
+    ) -> bool {
+        if !bun_paths::is_absolute(root) {
+            return false;
+        }
+
+        let mut busted = false;
+        {
+            let Some(target) = self
+                .fs_ref()
+                .abs_buf_checked(&[root, import_path], bufs!(esm_absolute_package_path))
+            else {
+                return false;
+            };
+            let target = strings::without_trailing_slash_windows_path(target);
+            busted |= self.bust_dir_cache(target);
+            let parent = strings::without_trailing_slash_windows_path(Dirname::dirname(target));
+            if parent.len() < target.len() {
+                busted |= self.bust_dir_cache(parent);
+            }
+        }
+
+        let Some(name) = package_name else {
+            return busted;
+        };
+        if self.opts.global_cache == GlobalCache::force {
+            return busted;
+        }
+
+        // `check_package_path` starts the walk at the nearest directory that
+        // exists when the source directory itself does not.
+        let mut closest_dir = root;
+        let start: DirInfoRef = loop {
+            if let Some(dir_info) = self.read_dir_info_ignore_error(closest_dir) {
+                break dir_info;
+            }
+            match bun_paths::dirname(closest_dir) {
+                Some(parent) => closest_dir = parent,
+                None => return busted,
+            }
+        };
+
+        // `load_node_modules` only searches levels whose `DirInfo` was built
+        // while a `node_modules` directory existed, and reaches the levels
+        // through cached parent links. A level that gained a `node_modules`
+        // since therefore has to be rebuilt together with every level below
+        // it, or the retry would walk into the same stale `DirInfo`.
+        let mut rebuild_through: Option<usize> = None;
+        let mut depth = 0usize;
+        let mut current = Some(start);
+        while let Some(dir_info) = current {
+            if !dir_info.is_node_modules() {
+                if let Some(node_modules) = self.fs_ref().abs_buf_checked(
+                    &[dir_info.abs_path, b"node_modules"],
+                    bufs!(node_modules_check),
+                ) {
+                    if self.package_dir_exists(node_modules, name) {
+                        busted |= self.bust_package_dir_cache(node_modules, name, import_path);
+                        if !dir_info.has_node_modules() {
+                            rebuild_through = Some(depth);
+                        }
+                    }
+                }
+            }
+            current = dir_info.get_parent();
+            depth += 1;
+        }
+
+        if let Some(rebuild_through) = rebuild_through {
+            let mut current = Some(start);
+            for _ in 0..=rebuild_through {
+                let Some(dir_info) = current else { break };
+                busted |= self.bust_dir_cache(strings::without_trailing_slash_windows_path(
+                    dir_info.abs_path,
+                ));
+                current = dir_info.get_parent();
+            }
+        }
+
+        busted
+    }
+
+    /// One `access()` call; `base` is a `node_modules` directory or a
+    /// `NODE_PATH` entry.
+    fn package_dir_exists(&self, base: &[u8], name: &[u8]) -> bool {
+        let buf = bufs!(esm_absolute_package_path);
+        let end = buf.len() - 1;
+        let Some(len) = self
+            .fs_ref()
+            .abs_buf_checked(&[base, name], &mut buf[..end])
+            .map(<[u8]>::len)
+        else {
+            return false;
+        };
+        buf[len] = 0;
+        bun_sys::exists_z(bun_core::ZStr::from_buf(&buf[..], len))
+    }
+
+    /// `base/name` exists on disk. Evicts the package directory, every
+    /// directory on the literal `base/import_path` chain below `base` (these
+    /// hold the not-found markers and listings the miss was served from), and
+    /// `base` itself when its cached listing predates the package: that
+    /// listing is where the package's own entry, symlink target included, is
+    /// read from.
+    ///
+    /// `base` may live in `bufs!(node_modules_check)`; only
+    /// `esm_absolute_package_path` is used as scratch here.
+    fn bust_package_dir_cache(&mut self, base: &[u8], name: &[u8], import_path: &[u8]) -> bool {
+        let mut busted = false;
+        let buf = bufs!(esm_absolute_package_path);
+
+        if let Some(package_dir) = self.fs_ref().abs_buf_checked(&[base, name], buf) {
+            busted |=
+                self.bust_dir_cache(strings::without_trailing_slash_windows_path(package_dir));
+        }
+
+        if let Some(full_path) = self.fs_ref().abs_buf_checked(&[base, import_path], buf) {
+            // `..` segments in `import_path` can normalize to a path outside of
+            // `base`; only evict what is underneath it. A root `base` (NODE_PATH
+            // naming a filesystem root) already ends in its separator.
+            let base_is_root = ResolvePath::is_sep_any(base[base.len() - 1]);
+            let mut dir = strings::without_trailing_slash_windows_path(full_path);
+            while dir.len() > base.len()
+                && dir.starts_with(base)
+                && (base_is_root || ResolvePath::is_sep_any(dir[base.len()]))
+            {
+                busted |= self.bust_dir_cache(dir);
+                dir = strings::without_trailing_slash_windows_path(Dirname::dirname(dir));
+            }
+        }
+
+        let top_level_entry =
+            &name[..strings::index_of_char_usize(name, b'/').unwrap_or(name.len())];
+        let generation = self.generation;
+        let listed = self
+            .read_dir_info_ignore_error(base)
+            .is_some_and(|dir_info| dir_info.get_entry(generation, top_level_entry).is_some());
+        if !listed {
+            busted |= self.bust_dir_cache(base);
+        }
+
+        busted
+    }
+
+    /// https://nodejs.org/api/modules.html#loading-from-the-global-folders
+    fn node_path_entries(&self) -> strings::TokenizeIterator<'a> {
+        let node_path: &'a [u8] = self
+            .env_loader()
+            .and_then(|env| env.get(b"NODE_PATH"))
+            .unwrap_or(b"");
+        strings::tokenize(node_path, if cfg!(windows) { b";" } else { b":" })
+    }
+
     pub(crate) fn load_node_modules(
         &mut self,
         import_path: &[u8],
@@ -2881,35 +3095,27 @@ impl<'a> Resolver<'a> {
         }
 
         // try resolve from `NODE_PATH`
-        // https://nodejs.org/api/modules.html#loading-from-the-global-folders
-        let node_path: &[u8] = self
-            .env_loader()
-            .and_then(|env| env.get(b"NODE_PATH"))
-            .unwrap_or(b"");
-        if !node_path.is_empty() {
-            let delim = if cfg!(windows) { b';' } else { b':' };
-            for path in node_path.split(|&b| b == delim).filter(|s| !s.is_empty()) {
-                let Some(abs_path) = self
-                    .fs_ref()
-                    .abs_buf_checked(&[path, import_path], bufs!(node_modules_check))
-                else {
-                    continue;
-                };
-                if let Some(debug) = self.debug_logs.as_mut() {
-                    debug.add_note_fmt(format_args!(
-                        "Checking for a package in the NODE_PATH directory \"{}\"",
-                        bstr::BStr::new(abs_path)
-                    ));
+        for path in self.node_path_entries() {
+            let Some(abs_path) = self
+                .fs_ref()
+                .abs_buf_checked(&[path, import_path], bufs!(node_modules_check))
+            else {
+                continue;
+            };
+            if let Some(debug) = self.debug_logs.as_mut() {
+                debug.add_note_fmt(format_args!(
+                    "Checking for a package in the NODE_PATH directory \"{}\"",
+                    bstr::BStr::new(abs_path)
+                ));
+            }
+            if self
+                .load_as_file_or_directory(abs_path, kind, out)
+                .is_success()
+            {
+                if let Some(d) = self.debug_logs.as_mut() {
+                    d.decrease_indent();
                 }
-                if self
-                    .load_as_file_or_directory(abs_path, kind, out)
-                    .is_success()
-                {
-                    if let Some(d) = self.debug_logs.as_mut() {
-                        d.decrease_indent();
-                    }
-                    return MatchStatus::Success;
-                }
+                return MatchStatus::Success;
             }
         }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5246,43 +5246,13 @@ unsafe fn resolve<'a>(
                 }
                 retry_on_not_found = false;
 
-                // Bust the dir cache for the candidate
-                // parent directory and retry once.
-                let mut buf = bun_paths::path_buffer_pool::get();
-                let buster_name: &[u8] = 'name: {
-                    if bun_paths::is_absolute(normalized_specifier) {
-                        if let Some(dir) = bun_core::dirname(normalized_specifier) {
-                            if dir.len() > buf.len() {
-                                return Err(crate::Error::ModuleNotFound);
-                            }
-                            // Normalized without trailing slash.
-                            break 'name bun_paths::string_paths::normalize_slashes_only(
-                                &mut buf[..],
-                                dir,
-                                bun_paths::SEP,
-                            );
-                        }
-                    }
-
-                    // If the specifier is too long to join, it can't name a
-                    // real directory — skip the cache bust and fail.
-                    if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
-                        return Err(crate::Error::ModuleNotFound);
-                    }
-
-                    let parts: [&[u8]; 3] = [source_to_use, normalized_specifier, b".."];
-                    break 'name bun_paths::resolve_path::join_abs_string_buf_z::<
-                        bun_paths::platform::Auto,
-                    >(top_level_dir, &mut buf[..], &parts)
-                    .as_bytes();
-                };
-
                 // Only re-query if we previously had something cached.
                 // SAFETY: see above.
                 if unsafe {
-                    (*vm).transpiler.resolver.bust_dir_cache(
-                        bun_paths::string_paths::without_trailing_slash_windows_path(buster_name),
-                    )
+                    (*vm)
+                        .transpiler
+                        .resolver
+                        .bust_dir_cache_for_not_found(source_to_use, normalized_specifier)
                 } {
                     continue;
                 }

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1600,3 +1600,244 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
     expect(exitCode).toBe(0);
   });
 });
+
+// A lookup that failed must not poison later lookups of the same specifier
+// once the files exist. Node re-walks the filesystem on every miss; Bun caches
+// directory listings and not-found markers, so a miss has to evict the entries
+// it was served from before it is retried. Each script below resolves once
+// (miss), creates the files, and resolves again in the same process.
+describe("files created after a failed lookup resolve on the next lookup", () => {
+  // `attempt` prints the resolved path relative to the script's directory, or
+  // the error code of the miss.
+  const prelude = /* js */ `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const rel = p => path.relative(__dirname, p).split(path.sep).join("/");
+    function attempt(label, fn) {
+      let out;
+      try {
+        out = rel(fn());
+      } catch (e) {
+        out = e.code;
+      }
+      console.log(label + ": " + out);
+    }
+    function writeFiles(files) {
+      for (const [file, contents] of Object.entries(files)) {
+        const abs = path.join(__dirname, file);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, contents);
+      }
+    }
+  `;
+
+  async function runRetryScript(cwd: string, script: string, env: Record<string, string> = {}) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), script],
+      cwd,
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stripAsanWarning(stderr)).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout.replaceAll("\r\n", "\n");
+  }
+
+  // node_modules/ exists (empty) in the package fixtures so the first miss is
+  // a plain node_modules walk rather than an auto-install attempt.
+
+  it.concurrent("scoped package subpath via require.resolve()", async () => {
+    using dir = tempDir("resolve-retry-scoped", {
+      node_modules: {},
+      "main.cjs": /* js */ `
+        ${prelude}
+        attempt("before", () => require.resolve("@later/pkg/bin/tool"));
+        writeFiles({ "node_modules/@later/pkg/bin/tool": "" });
+        attempt("after", () => require.resolve("@later/pkg/bin/tool"));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe(
+      "before: MODULE_NOT_FOUND\nafter: node_modules/@later/pkg/bin/tool\n",
+    );
+  });
+
+  it.concurrent("bare package via require()", async () => {
+    using dir = tempDir("resolve-retry-bare", {
+      node_modules: {},
+      "main.cjs": /* js */ `
+        ${prelude}
+        attempt("before", () => require("later-pkg"));
+        writeFiles({ "node_modules/later-pkg/index.js": "module.exports = __filename;" });
+        attempt("after", () => require("later-pkg"));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe(
+      "before: MODULE_NOT_FOUND\nafter: node_modules/later-pkg/index.js\n",
+    );
+  });
+
+  it.concurrent("package via import()", async () => {
+    using dir = tempDir("resolve-retry-import", {
+      node_modules: {},
+      "main.mjs": /* js */ `
+        import { mkdirSync, writeFileSync } from "node:fs";
+        const load = () => import("later-esm-pkg").then(m => m.default, e => e.code);
+        console.log("before: " + (await load()));
+        mkdirSync("node_modules/later-esm-pkg", { recursive: true });
+        writeFileSync("node_modules/later-esm-pkg/index.js", "export default 'loaded later-esm-pkg';");
+        console.log("after: " + (await load()));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.mjs")).toBe(
+      "before: ERR_MODULE_NOT_FOUND\nafter: loaded later-esm-pkg\n",
+    );
+  });
+
+  it.concurrent("file added to a package that already resolved once", async () => {
+    using dir = tempDir("resolve-retry-existing-pkg", {
+      node_modules: { "existing-pkg": { "index.js": "" } },
+      "main.cjs": /* js */ `
+        ${prelude}
+        attempt("warm", () => require.resolve("existing-pkg"));
+        attempt("before", () => require.resolve("existing-pkg/generated.js"));
+        writeFiles({ "node_modules/existing-pkg/generated.js": "" });
+        attempt("after", () => require.resolve("existing-pkg/generated.js"));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe(
+      "warm: node_modules/existing-pkg/index.js\n" +
+        "before: MODULE_NOT_FOUND\n" +
+        "after: node_modules/existing-pkg/generated.js\n",
+    );
+  });
+
+  // The shape of the `bun` npm package's postinstall: it runs inside
+  // <project>/node_modules/bun, fails to resolve its platform package,
+  // downloads it into a node_modules/ directory of its own (which did not
+  // exist when the first lookup recorded that this directory has none), and
+  // resolves again.
+  it.concurrent("node_modules/ created in the importing directory", async () => {
+    using dir = tempDir("resolve-retry-new-node-modules", {
+      node_modules: {
+        tool: {
+          "install.cjs": /* js */ `
+            ${prelude}
+            attempt("before", () => require.resolve("@tool-platform/linux-x64/bin/tool"));
+            writeFiles({ "node_modules/@tool-platform/linux-x64/bin/tool": "" });
+            attempt("after", () => require.resolve("@tool-platform/linux-x64/bin/tool"));
+          `,
+        },
+      },
+    });
+    expect(await runRetryScript(join(String(dir), "node_modules", "tool"), "install.cjs")).toBe(
+      "before: MODULE_NOT_FOUND\nafter: node_modules/@tool-platform/linux-x64/bin/tool\n",
+    );
+  });
+
+  it.concurrent("node_modules/ created in an ancestor of the importing directory", async () => {
+    using dir = tempDir("resolve-retry-new-ancestor-node-modules", {
+      node_modules: {},
+      packages: {
+        app: {
+          scripts: {
+            "setup.cjs": /* js */ `
+              ${prelude}
+              attempt("before", () => require.resolve("app-dep/lib/entry.js"));
+              writeFiles({ "../node_modules/app-dep/lib/entry.js": "" });
+              attempt("after", () => require.resolve("app-dep/lib/entry.js"));
+            `,
+          },
+        },
+      },
+    });
+    expect(await runRetryScript(join(String(dir), "packages", "app", "scripts"), "setup.cjs")).toBe(
+      "before: MODULE_NOT_FOUND\nafter: ../node_modules/app-dep/lib/entry.js\n",
+    );
+  });
+
+  it.skipIf(isWindows).concurrent("symlinked package resolves to its real path, as in Node", async () => {
+    using dir = tempDir("resolve-retry-symlink", {
+      node_modules: {},
+      vendor: { "linked-pkg": { "index.js": "" } },
+      "main.cjs": /* js */ `
+        ${prelude}
+        attempt("before", () => require.resolve("linked-pkg"));
+        fs.symlinkSync(path.join(__dirname, "vendor/linked-pkg"), path.join(__dirname, "node_modules/linked-pkg"));
+        attempt("after", () => require.resolve("linked-pkg"));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe(
+      "before: MODULE_NOT_FOUND\nafter: vendor/linked-pkg/index.js\n",
+    );
+  });
+
+  it.concurrent("package created in a NODE_PATH directory", async () => {
+    using dir = tempDir("resolve-retry-node-path", {
+      global: {},
+      app: {
+        node_modules: {},
+        "main.cjs": /* js */ `
+          ${prelude}
+          attempt("before", () => require.resolve("global-pkg"));
+          writeFiles({ "../global/global-pkg/index.js": "" });
+          attempt("after", () => require.resolve("global-pkg"));
+        `,
+      },
+    });
+    expect(await runRetryScript(join(String(dir), "app"), "main.cjs", { NODE_PATH: join(String(dir), "global") })).toBe(
+      "before: MODULE_NOT_FOUND\nafter: ../global/global-pkg/index.js\n",
+    );
+  });
+
+  it.concurrent("package created under a require.resolve() `paths` entry", async () => {
+    using dir = tempDir("resolve-retry-paths-option", {
+      node_modules: {},
+      other: { node_modules: {} },
+      "main.cjs": /* js */ `
+        ${prelude}
+        const opts = { paths: [path.join(__dirname, "other")] };
+        attempt("before", () => require.resolve("other-pkg", opts));
+        writeFiles({ "other/node_modules/other-pkg/index.js": "" });
+        attempt("after", () => require.resolve("other-pkg", opts));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe(
+      "before: MODULE_NOT_FOUND\nafter: other/node_modules/other-pkg/index.js\n",
+    );
+  });
+
+  it.concurrent("relative specifier naming a directory created later", async () => {
+    using dir = tempDir("resolve-retry-relative-dir", {
+      "main.cjs": /* js */ `
+        ${prelude}
+        attempt("before", () => require.resolve("./lib"));
+        writeFiles({ "lib/index.js": "" });
+        attempt("after", () => require.resolve("./lib"));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe("before: MODULE_NOT_FOUND\nafter: lib/index.js\n");
+  });
+
+  it.concurrent("a package that is still missing keeps failing", async () => {
+    using dir = tempDir("resolve-retry-still-missing", {
+      node_modules: { "other-pkg": { "index.js": "" } },
+      "main.cjs": /* js */ `
+        ${prelude}
+        attempt("bare", () => require.resolve("never-installed"));
+        attempt("bare again", () => require.resolve("never-installed"));
+        attempt("subpath", () => require.resolve("other-pkg/missing.js"));
+        attempt("subpath again", () => require.resolve("other-pkg/missing.js"));
+        attempt("existing", () => require.resolve("other-pkg"));
+      `,
+    });
+    expect(await runRetryScript(String(dir), "main.cjs")).toBe(
+      "bare: MODULE_NOT_FOUND\n" +
+        "bare again: MODULE_NOT_FOUND\n" +
+        "subpath: MODULE_NOT_FOUND\n" +
+        "subpath again: MODULE_NOT_FOUND\n" +
+        "existing: node_modules/other-pkg/index.js\n",
+    );
+  });
+});


### PR DESCRIPTION
## Repro

```js
// cwd contains an empty node_modules/ (so auto-install stays out of the picture)
const fs = require("fs");
const attempt = s => { try { return require.resolve(s); } catch (e) { return e.code; } };

console.log(attempt("@scope/pkg/bin/tool"));          // MODULE_NOT_FOUND (expected)
fs.mkdirSync("node_modules/@scope/pkg/bin", { recursive: true });
fs.writeFileSync("node_modules/@scope/pkg/bin/tool", "");
console.log(attempt("@scope/pkg/bin/tool"));          // node: .../node_modules/@scope/pkg/bin/tool
                                                      // bun:  MODULE_NOT_FOUND
```

Once a package path has failed to resolve, it keeps failing for the rest of the process no matter what gets installed. The same happens for `require()`, `import()`, a bare `require("pkg")`, a file added to an already resolved package (`pkg/generated.js`), a package created under a `NODE_PATH` entry or under a `require.resolve(id, { paths })` root, a `node_modules/` directory created after the fact in the importing directory or one of its ancestors, and for a relative specifier whose target is a directory created later (`require("./lib")` with `lib/index.js`). Node resolves all of these on the second call. The `node_modules`-created-later case is the shape of the `bun` npm package's own postinstall (`packages/bun-release/src/npm/install.ts`: `require.resolve` fails, the platform package is downloaded into a new `node_modules/` next to the script, `require.resolve` again), which is why it currently has to run under node.

## Cause

`VirtualMachine::_resolve` (and its copy in `jsc_hooks.rs`) retries a not-found resolution once after busting the directory cache, but the only thing it busted was the parent of `join(source_dir, specifier)`. For `./x` that is the directory whose listing is consulted, so files created later were already found. For a package path it is `<source_dir>/@scope/pkg/bin`, which names nothing, so everything the failed walk cached stayed in place:

- `dir_info_cached(<dir>/node_modules/@scope/pkg)` and the `load_as_file_or_directory` probes record not-found markers for `node_modules/@scope`, `.../pkg`, `.../pkg/bin` in both the `DirInfo` cache and the listing cache; the next lookup is answered from those markers.
- `DirInfo::has_node_modules()` is computed from the listing when the `DirInfo` is built, and `load_node_modules` skips levels without it and walks levels through cached parent links, so a `node_modules/` created later in the importing directory is never looked at.
- For `./lib`, the target directory itself had a not-found marker from the load-as-directory probe; only the parent was busted.

## Fix

The bust policy moves into the resolver as `Resolver::bust_dir_cache_for_not_found(source_dir, specifier)`, and both retry loops call it (this also retires the per-thread path buffer each loop kept for building the key). It evicts:

- the candidate path and its parent, for every specifier (the parent is what was busted before; the candidate itself covers the `./lib` directory case), against each search root: the source directory, or the `paths` roots when `require.resolve` was given some;
- for package paths, at every level the failed walk went through (the `DirInfo` parent chain, starting from the nearest existing directory like `check_package_path` does) and for every `NODE_PATH` entry: if `<base>/<package name>` exists on disk now, the package directory, every directory on the literal `<base>/<specifier>` chain below `<base>` (the not-found markers), and `<base>` itself when its cached listing does not contain the package's top-level entry (that listing is where the package entry, including a symlink target, is read from, so a package symlinked in later resolves to its real path like in Node). A level whose `DirInfo` says it has no `node_modules` while the package directory exists under it is rebuilt together with every level below it, since the retry reaches it through the cached parent links.

The existence check is what makes this cheap to have on the miss path: a level where the package still does not exist costs one `access()` and evicts nothing, so `try { require("optional-dep") } catch {}` for something that is not installed behaves exactly as before (the pre-existing parent-directory bust included) plus a handful of failed `access()` calls, and no retry is triggered by the new logic. A miss for a subpath of a package that is installed does evict and re-read that package directory once per miss, which is the same thing the existing retry already does to the parent directory of a missed relative specifier. The per-retry retention of the bust mechanism itself is a separate, already tracked matter (#36675, #36928); this change adds no evictions in the not-installed steady state.

Why this is the right layer: the resolver is the only place that knows which directories a package-path lookup consulted (`node_modules` levels, `paths` roots, `NODE_PATH`), and the invalidation has to mirror exactly that search space; the two runtime loops only know about the source directory. #36678 fixes the neighboring tsconfig `paths` case of the same retry and is independent of this.

Not covered, deliberately: a package whose `exports` map points at a file that is created later (the consulted directory is the exports target, not the specifier path), and edits to an existing `package.json`. Neither is part of the install-then-require pattern this fixes.

## Verification

New tests in `test/js/bun/resolve/resolve.test.ts` (`files created after a failed lookup resolve on the next lookup`): scoped subpath via `require.resolve`, bare package via `require`, package via `import()`, file added to an already resolved package, `node_modules/` created in the importing directory and in an ancestor of it, symlinked package resolving to its real path, `NODE_PATH`, `require.resolve` `paths`, relative directory created later, and a check that packages that stay missing keep failing. 10 of the 11 fail on the unfixed binary (`after: MODULE_NOT_FOUND`), all pass with the fix.

`test/js/bun/resolve/` (352 pass; the only failure is the pre-existing debug-build timeout in `load-same-js-file-a-lot.test.ts`, owned by #36929), `test/js/node/module/` (97 pass) and the `NODE_PATH` bundler tests pass on the debug build. With `BUN_DEBUG_Resolver=1`, misses for packages that are not installed show no new evictions; a subpath miss inside an installed package evicts only that package directory and the missed leaf.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->