### PR TITLE
test(bundler): fix compile/HelloWorldWithProcessVersionsBun on debug builds

### DIFF
--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -62,6 +62,9 @@ describe("bundler", () => {
       expect(exitCode).toBe(0);
     });
   }
+  // --compile inlines `process.versions.bun` as the exact `Bun.version` string of
+  // this binary, "-debug" suffix included on debug builds. Unlike the CLI banners
+  // (which print the version without "-debug"), nothing needs stripping here.
   itBundled("compile/HelloWorldWithProcessVersionsBun", {
     compile: true,
     files: {
@@ -69,7 +72,7 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version.replaceAll("-debug", "")}") {
+        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version}") {
           process.exitCode = 0;
         }
       `,
@@ -88,8 +91,7 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        const another = require("./${process.platform}-${process.arch}.js").replaceAll("-debug", "");
-        if (another === "${Bun.version.replaceAll("-debug", "")}") {
+        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version}") {
           process.exitCode = 0;
         }
       `,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -62,9 +62,9 @@ describe("bundler", () => {
       expect(exitCode).toBe(0);
     });
   }
-  // --compile inlines `process.versions.bun` as the exact `Bun.version` string of
-  // this binary, "-debug" suffix included on debug builds. Unlike the CLI banners
-  // (which print the version without "-debug"), nothing needs stripping here.
+  // The fixture module evaluates to whatever --compile inlined for `process.versions.bun`.
+  // That must be the exact version the embedded runtime reports, "-debug" suffix and all
+  // on debug builds, so the two are compared without normalizing either side.
   itBundled("compile/HelloWorldWithProcessVersionsBun", {
     compile: true,
     files: {
@@ -72,9 +72,9 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version}") {
-          process.exitCode = 0;
-        }
+        const inlined = require("./${process.platform}-${process.arch}.js");
+        if (inlined !== Bun.version) throw new Error("inlined " + inlined + ", runtime is " + Bun.version);
+        process.exitCode = 0;
       `,
       [`/${process.platform}-${process.arch}.js`]: "module.exports = process.versions.bun;",
     },
@@ -91,9 +91,9 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version}") {
-          process.exitCode = 0;
-        }
+        const inlined = require("./${process.platform}-${process.arch}.js");
+        if (inlined !== Bun.version) throw new Error("inlined " + inlined + ", runtime is " + Bun.version);
+        process.exitCode = 0;
       `,
       [`/${process.platform}-${process.arch}.js`]: "module.exports = process.versions.bun;",
     },


### PR DESCRIPTION
### What does this PR do?

Test-only change. `compile/HelloWorldWithProcessVersionsBun` in `test/bundler/bundler_compile.test.ts` fails on every debug build; it passes in CI only because release builds have no `-debug` version suffix.

```
$ bun bd test test/bundler/bundler_compile.test.ts -t compile/HelloWorldWithProcessVersionsBun
error: Runtime failed
      at <anonymous> (test/bundler/expectBundled.ts:1820:23)
(fail) bundler > compile/HelloWorldWithProcessVersionsBun
(pass) bundler > compile/HelloWorldWithProcessVersionsBunAPI
```

Cause: the compiled program compares `require("./<platform>-<arch>.js")`, which evaluates to the `process.versions.bun` string that `--compile` inlined at bundle time, against `"${Bun.version.replaceAll("-debug", "")}"` interpolated by the test runner. The inlined value is `Global::package_json_version` (`define_values` in `src/options_types/compile_target.rs`), which is `"1.4.0-debug"` on a debug build, so the comparison is `"1.4.0-debug" === "1.4.0"` and the program exits 1. Compiling a small program with the debug binary shows the strings involved:

```
{"inlined":"1.4.0-debug","runtime":"1.4.0-debug","bunVersion":"1.4.0-debug"}
```

The `-debug` stripping is the right idiom for tests that match CLI banners, which print `package_json_version_with_sha` (`"1.4.0 (abc1234)"` on debug builds); `process.versions.bun` and `Bun.version` are `package_json_version` and do carry the suffix.

History, for the record: the one-sided strip dates from #14940, but there the fixture was the first key of `files`, and expectBundled uses the first key as the entry point, so the compiled program was the one-line fixture and the comparison never ran. #21915 moved `/entry.ts` first, which is when the CLI variant started failing on debug builds, and added the `BunAPI` variant, which strips `-debug` from both sides and so passes.

Fix: the program compares the inlined value against `Bun.version` read inside the compiled executable, and on a mismatch throws with both strings, so a future failure says `inlined X, runtime is Y` instead of a bare `Runtime failed`. Both variants use the same check.

Why this comparison is the right one: `Bun.version` and the `--compile` define are the same `package_json_version` constant of one binary, and the executable produced by `bun build --compile` embeds the binary that ran the bundler, so inside the output the inlined value and `Bun.version` come from the same binary on debug, release and canary builds (`package_json_version` never carries the canary tag). That is exactly the property inlining has to preserve, and nothing on either side needs normalizing. Reading `Bun.version` inside the executable rather than interpolating the test runner's value also keeps the CLI variant correct under expectBundled's documented `BUN_EXE` override, where the bundler (and therefore the embedded runtime) is a different build than the runner.

### How did you verify your code works?

- main, `bun bd test ... -t compile/HelloWorldWithProcessVersionsBun`: CLI variant fails as above, API variant passes. `USE_SYSTEM_BUN=1` (release) passes, so the failure is debug-only.
- this branch, `bun bd test ...`: both pass. `USE_SYSTEM_BUN=1 bun test ...` (a `1.4.0-canary.1` build): both pass. `BUN_EXE=build/release/bun bun bd test ...` (debug runner, release bundler): both pass.
- Negative check of the new message: compiling the entry with `--define 'process.versions.bun="9.9.9"'` exits 1 with `error: inlined 9.9.9, runtime is 1.4.0-debug`.

The fix is in the test itself, so the fail-before is the unmodified test on a debug build (first bullet); there is no `src/` change.

Separately, while reading `define_values` I noticed that `--target=bun-<os>-<arch>-vX.Y.Z` inlines the host's version rather than the target's. That is runtime behavior and is not changed here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->