### PR TITLE
test(worker): keep the terminate() race tests under the default per-test timeout on debug builds

### DIFF
--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -409,16 +409,32 @@ describe("web worker", () => {
     });
 
     // A worker posting faster than the parent can deserialize must not pin the
-    // parent inside one drain: its timers and I/O still get their turn.
+    // parent inside one drain: a drain task delivers a bounded batch and posts the
+    // rest to the next loop iteration, so timers and I/O get their turn in between.
     test("a message flood from a worker does not starve the parent's event loop", async () => {
-      const src = `const p = { s: Buffer.alloc(200, "x").toString(), a: [1, 2, 3], n: 0 };
-        (function burst() { for (let i = 0; i < 2000; i++) { p.n++; postMessage(p) } setImmediate(burst) })()`;
+      const total = 1500; // more than one drain task's budget (drainBatchLimit in WorkerMessagingProxy.cpp)
+      const flag = new Int32Array(new SharedArrayBuffer(4));
+      const src = `onmessage = ({ data: flag }) => {
+        for (let i = 0; i < ${total}; i++) postMessage(i);
+        Atomics.store(flag, 0, 1); Atomics.notify(flag, 0);
+      }`;
       const w = new Worker(URL.createObjectURL(new Blob([src])));
       let received = 0;
-      w.onmessage = () => received++;
-      // Three timer turns while the flood is running is the property; not the timing.
-      for (let i = 0; i < 3; i++) await new Promise<void>(r => setTimeout(r, 10));
-      expect(received).toBeGreaterThan(0);
+      const delivered = Promise.withResolvers<void>();
+      w.onmessage = () => {
+        if (++received === total) delivered.resolve();
+      };
+      w.postMessage(flag);
+      // Block until the whole flood sits in the parent's inbox, so the first drain task
+      // starts out with more than its budget no matter how fast either thread is.
+      Atomics.wait(flag, 0, 0, 30_000);
+      expect(Atomics.load(flag, 0)).toBe(1);
+      // Resumes inside the first drain task. An immediate armed there runs as soon as
+      // that task ends, before the continuation it posted delivers the next batch.
+      await once(w, "message");
+      await new Promise<void>(r => setImmediate(r));
+      expect(received).toBeLessThan(total);
+      await delivered.promise;
       w.terminate();
       await once(w, "close");
     });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -427,12 +427,16 @@ describe("web worker", () => {
       const src = `import vm from "node:vm"; postMessage("busy");
         for (;;) { try { vm.runInNewContext("for(let i=0;i<1e7;i++){}", {}, { timeout: 1000 }) } catch {} await new Promise(r => setImmediate(r)) }`;
       const url = URL.createObjectURL(new Blob([src]));
-      for (let r = 0; r < 6; r++) {
-        const w = new Worker(url);
-        await new Promise(res => (w.onmessage = res));
-        w.terminate();
-        await once(w, "close");
-      }
+      // Concurrently: loading node:vm dominates each worker's start, and six of
+      // them one after another add up to seconds on debug builds.
+      await Promise.all(
+        Array.from({ length: 6 }, async () => {
+          const w = new Worker(url);
+          await new Promise(res => (w.onmessage = res));
+          w.terminate();
+          await once(w, "close");
+        }),
+      );
     });
 
     // terminate() mid `import "node:*"`: the native module's export walk stops
@@ -468,8 +472,9 @@ describe("web worker", () => {
         "side.js": `globalThis.sideRan = true;`,
         "preload.js": `import("./side.js");`,
         // big enough that the entry graph is still transpiling when side.js evaluates
+        // (tens of times side.js's transpile); bigger mostly just slows debug builds down
         "big.js": Array.from(
-          { length: 4000 },
+          { length: 1000 },
           (_, i) => `export function f${i}(x) { return x * ${i} + ${i % 7}; }`,
         ).join("\n"),
         "worker.js": `import "./big.js";
@@ -513,18 +518,23 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
+    // One worker per terminate offset (0-9ms after it reports busy), in two
+    // batches so the second one reuses the pool that just discarded the first
+    // batch's completions. require() rather than import: building node:fs's ESM
+    // namespace also loads its stream classes, which nearly doubled each
+    // worker's start on debug builds.
     test("terminate() while fs.readFile completions keep arriving", async () => {
       using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
           "-e",
-          `const src = \`import { readFile } from "node:fs";
+          `const src = \`const { readFile } = require("node:fs");
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
-           for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
-             const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
+           for (let r = 0; r < 2; r++) await Promise.all(Array.from({ length: 5 }, (_, i) => new Promise(res => {
+             const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), r * 5 + i) })));
            console.log("PASS");`,
           path.join(String(dir), "f.bin"),
         ],

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -381,6 +381,8 @@ describe("web worker", () => {
     // terminate() landing while the worker reports that its entry point does not
     // resolve: the report is skipped, not turned into a panic.
     test("terminate() while the entry point fails to resolve", async () => {
+      // Every round covers the eight terminate offsets once.
+      const rounds = isDebug ? 3 : 12;
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
@@ -394,7 +396,7 @@ describe("web worker", () => {
              await closed;
              done++;
            }
-           for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 8 }, (_, i) => one(r * 8 + i)));
+           for (let r = 0; r < ${rounds}; r++) await Promise.all(Array.from({ length: 8 }, (_, i) => one(r * 8 + i)));
            console.log("done", done);`,
         ],
         env: bunEnv,
@@ -402,7 +404,7 @@ describe("web worker", () => {
         stderr: "inherit",
       });
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout).toBe("done 96\n");
+      expect(stdout).toBe(`done ${rounds * 8}\n`);
       expect(exitCode).toBe(0);
     });
 
@@ -472,9 +474,9 @@ describe("web worker", () => {
         "side.js": `globalThis.sideRan = true;`,
         "preload.js": `import("./side.js");`,
         // big enough that the entry graph is still transpiling when side.js evaluates
-        // (tens of times side.js's transpile); bigger mostly just slows debug builds down
+        // (debug builds transpile far slower, so a quarter of it keeps the same margin)
         "big.js": Array.from(
-          { length: 1000 },
+          { length: isDebug ? 1000 : 4000 },
           (_, i) => `export function f${i}(x) { return x * ${i} + ${i % 7}; }`,
         ).join("\n"),
         "worker.js": `import "./big.js";
@@ -494,10 +496,11 @@ describe("web worker", () => {
 
     // Everything a worker posted before it exited arrives before 'close'.
     test("messages posted right before a natural exit are all delivered before close", async () => {
+      // Several drain batches' worth (1024 each); receiving them is ~1s per round on debug builds.
       const K = 5000;
       const src = `const p = Buffer.alloc(256, "x").toString(); for (let i = 0; i < ${K}; i++) postMessage({ i, p })`;
       const url = URL.createObjectURL(new Blob([src]));
-      for (let r = 0; r < 3; r++) {
+      for (let r = 0; r < (isDebug ? 1 : 3); r++) {
         let got = 0;
         const w = new Worker(url);
         w.onmessage = () => got++;
@@ -518,11 +521,12 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    // One worker per terminate offset (0-9ms after it reports busy), in two
-    // batches so the second one reuses the pool that just discarded the first
-    // batch's completions. require() rather than import: building node:fs's ESM
-    // namespace also loads its stream classes, which nearly doubled each
-    // worker's start on debug builds.
+    // busy is posted from the first completion so that every terminate offset
+    // (0-9ms, each batch covers them once) lands mid-churn on debug builds
+    // too, where the worker's first loop turn alone outlasts the offset range.
+    // Starting one of these workers costs ~0.5s on debug builds, hence one
+    // batch there; require() because importing node:fs also builds its ESM
+    // namespace, which loads the stream classes.
     test("terminate() while fs.readFile completions keep arriving", async () => {
       using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
       await using proc = Bun.spawn({
@@ -530,11 +534,12 @@ describe("web worker", () => {
           bunExe(),
           "-e",
           `const src = \`const { readFile } = require("node:fs");
-             let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
-             postMessage("busy")\`;
+             let n = 0, busy = false;
+             (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => {
+               if (!busy) { busy = true; postMessage("busy") } n--; setImmediate(pump) }) } })()\`;
            const url = URL.createObjectURL(new Blob([src]));
-           for (let r = 0; r < 2; r++) await Promise.all(Array.from({ length: 5 }, (_, i) => new Promise(res => {
-             const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), r * 5 + i) })));
+           for (let r = 0; r < ${isDebug ? 1 : 5}; r++) await Promise.all(Array.from({ length: 10 }, (_, i) => new Promise(res => {
+             const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), i) })));
            console.log("PASS");`,
           path.join(String(dir), "f.bin"),
         ],


### PR DESCRIPTION
### What

`bun bd test test/js/web/workers/worker.test.ts` on a debug+ASAN build fails two of the tests added in #37075 purely on time, and the next few sit close to the limit:

```
(fail) web worker > terminate() races and lifecycle edges > preload with an un-awaited import() does not open message delivery before the entry runs [5004.19ms]
  ^ this test timed out after 5000ms.
(fail) web worker > terminate() races and lifecycle edges > terminate() while fs.readFile completions keep arriving [5005.31ms]
  ^ this test timed out after 5000ms.
```

With `--timeout 120000` they pass in 5.5s and 14.9s, so they are slow, not hung. `terminate() while a node:vm script with a timeout is running` took 4.0s in isolation and timed out at 5.0s in a full-file run while the host was busier; `terminate() while the entry point fails to resolve` (96 workers) and `messages posted right before a natural exit` (3 x 5000 messages) reached 4.4s in the same conditions. CI never sees any of this: it only runs release and release+ASAN binaries and the runner passes `--timeout=90s` (x3 on ASAN). It only affects running the file locally against a debug build, where a worker takes ~150ms to start (~2ms release), loading node:fs or node:vm in it another ~0.4s, and the 4000-function `big.js` ~1.7s per iteration. On a release build the whole file takes under 2s.

### Change

**Repetition counts are gated on `isDebug`; release builds, and therefore CI, run exactly what they ran before.** This is the existing convention for this (`worker-terminate-funnels.test.ts` branches its budget on `isDebug`, `fs.test.ts` its `iterCount`, `worker_threads.test.ts` its default timeout), and it means the ASAN lanes, which are the ones that turn a bad release path into a failure, lose no samples. On a debug build:

- preload test: `big.js` has 1000 functions instead of 4000 (3 iterations as before). What the test relies on is `big.js` transpiling on the pool long enough that `side.js`, requested earlier by the preload, evaluates in a tick before the entry graph arrives; at 1000 functions that is ~107ms vs ~1.5ms on debug. To check it still catches what it was added for (the #37075 review thread: `entry_evaluation_started` set from any `moduleLoaderEvaluate`), I built a debug binary with the root-record check removed from `noteModuleEvaluation` and ran the scenario 20 times per size: the parent's messages were dropped 20/20 at 1000 (18/20 at 4000, 0/20 with an empty `big.js`, so the size matters but 1000 is well past where it does); the real build delivered 5/5. Debug builds do not restore from the runtime transpiler cache and CI disables it (`BUN_RUNTIME_TRANSPILER_CACHE_PATH=0` in the runner and in `bunEnv`), so the one configuration in which a smaller cached `big.js` would weaken the test, a local release run with a warm cache, is the one that keeps 4000.
- entry-resolution test: 3 rounds of 8 instead of 12 (each round covers the eight terminate offsets once); the expectation is derived from the round count.
- natural-exit test: 1 round of 5000 messages instead of 3 (5000 is still several 1024-message drain batches, which is what the count is for).
- readFile test: 1 batch of 10 workers instead of 5 (50 workers on release, where it was 12 x 4 = 48 before). Each batch covers the ten terminate offsets once. The deterministic side of this race is covered elsewhere: `worker-refused-completion.test.ts` has an `fs.readFile` row for the refusal path and `worker-terminate-funnels` terminates at fixed points around `fs.readFile`.

**Carried from #37355:** the message flood test in the same block also fails on every debug build (it asserted on a fixed 30ms window that a debug worker's boot alone exceeds). Its fix is #37355, open separately; the last commit here is that PR's diff, unchanged, so that this file passes as a whole on a debug build. It drops out on rebase if #37355 lands first, and makes #37355 a no-op if this lands first.

**Two changes apply to every build:**

- The vm test starts its 6 workers concurrently instead of one after another. The race (terminate() landing in a worker while a script with a timeout watchdog is running in it) is per worker and unchanged; six concurrent starts cost about one sequential one.
- The readFile worker `require()`s node:fs (importing it also builds the ESM namespace, whose `ReadStream` getter loads the stream classes) and posts `busy` from inside its first completion instead of right after issuing the reads. The second part matters for what the test samples. I had the worker's callbacks count themselves into a SharedArrayBuffer and recorded, per terminate offset, how many had run when terminate() was called / by the time the worker stopped:

  | worker head | debug | release |
  |---|---|---|
  | original (`import`, busy posted synchronously) | 4 of 10 offsets: 0 callbacks; others 1 to 16 | offset 0: 0; others 16 to 226 |
  | `require`, busy posted synchronously | 0 callbacks at all 10 offsets | two offsets 0; others 59 to 250 |
  | `require`, busy posted from the first completion | 1 to 16 at all 10 offsets | 11 to 257 at all 10 offsets |

  On a debug build the worker's first loop turn takes 40-60ms, longer than the whole 0-9ms offset range, so with `busy` posted synchronously every terminate() landed before a single completion had been dispatched, and the original head only reached the dispatch phase at the larger offsets. Anchored to a completion, every offset lands while completions are being dispatched and re-issued on both builds, and some samples now catch completions landing between terminate() and the stop (e.g. 92 run at terminate(), 94 before the stop), which is the race the test is about.

### Verification

Debug build (`bun bd test`, 16-core box under load), before -> after:

| test | before | after |
|---|---|---|
| preload with an un-awaited import() | 5458ms (timed out at 5s) | 1.8 to 1.9s |
| terminate() while fs.readFile completions keep arriving | 14951ms (timed out at 5s) | 1.7 to 2.3s |
| terminate() while a node:vm script with a timeout is running | 4.0 to 5.0s | ~0.8s |
| terminate() while the entry point fails to resolve | 2.6 to 4.4s | ~1.0s |
| messages posted right before a natural exit | 2.9 to 4.4s | ~0.8s |
| whole file | 53s | 33s |

The five tests passed 6/6 debug runs plus 5 more of the readFile test alone, and 20/20 release runs plus 15 more of the readFile test. Full file on debug: 36 pass in 31s (53s before); on release: 36 pass in 1.7s.

`test/js/node/worker_threads/worker_destruction.test.ts` has the same problem in a bigger way (three tests of 50 `worker_threads` workers each take 30 to 45s on a debug build); it is a different file and is being looked at separately.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/workers/worker.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/workers/worker.test.ts
bun test v1.4.0 (9d60ce784)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [12.16ms]
(pass) web worker > preload > string [167.32ms]
(pass) web worker > preload > array of 2 strings [166.00ms]
(pass) web worker > preload > array of string [154.67ms]
(pass) web worker > preload > error in preload doesn't crash parent [148.99ms]
(pass) web worker > worker [134.20ms]
(pass) web worker > worker-env [145.73ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [981.60ms]
(pass) web worker > worker-env with a lot of properties [341.78ms]
(pass) web worker > argv / execArgv defaults [652.29ms]
(pass) web worker > argv / execArgv options [655.69ms]
(pass) web worker > sending 50 messages should just work [192.13ms]
(pass) web worker > worker with event listeners doesn't close event loop [542.18ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [557.58ms]
(pass) web worker > worker with process.exit [197.03ms]
(pass) web worker > worker event > is fired with the right object [7.20ms]
(pass) web worker > error event > is fired with a string of the error [146.47ms]
(pass) web worker > terminate() races and lifecycle edges > parent messages still arrive after a node:vm timeout in the worker [695.52ms]
(pass) web worker > terminate() races and lifecycle edges > postMessage() to a terminated worker is a no-op [171.38ms]
(pass) web worker > terminate() races and lifecycle edges > a long data: URL worker [134.15ms]
(pass) web worker > terminate() races and lifecycle edges > terminate() while the entry point fails to resolve [1053.22ms]
(pass) web worker > terminate() races and lifecycle edges > a message flood from a worker does not starve the parent's event loop [411.61ms]
(pass) web worker > terminate() races and lifecycle edges > terminate() while a node:vm script wi
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/workers/worker.test.ts | 77 ++++++++++++++++++++++++++------------
 1 file changed, 54 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
test/js/web/workers/worker.test.ts      6     15      0
```

</details>

<!-- robobun:evidence:end -->