### PR TITLE
test: make malformed-integrity-base64.test.ts hermetic

### DIFF
--- a/test/regression/issue/malformed-integrity-base64.test.ts
+++ b/test/regression/issue/malformed-integrity-base64.test.ts
@@ -2,64 +2,56 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 test("malformed integrity base64 in lockfile should be handled gracefully", async () => {
+  // Decodes to 100 bytes, larger than any digest bun supports (sha512 is 64 bytes).
+  // Parsing this used to write past the end of the fixed-size digest buffer.
+  const oversizedBase64 = Buffer.alloc(100, 0xaa).toString("base64");
+
   await using dir = tempDir("malformed-integrity-test", {
     "package.json": JSON.stringify({
       name: "test-malformed-integrity",
       version: "1.0.0",
       dependencies: {
-        "lodash": "4.17.21", // Use a real package that exists
+        "lodash": "4.17.21",
       },
     }),
-  });
-
-  // First create a normal lockfile by running install
-  const { exitCode: installExitCode } = Bun.spawnSync({
-    cmd: [bunExe(), "install"],
-    cwd: dir,
-    env: bunEnv,
-  });
-
-  if (installExitCode !== 0) {
-    throw new Error("Initial install failed");
-  }
-
-  // Now modify the lockfile to have malformed integrity data
-  // The original panic occurs when parsing this during lockfile loading
-  const oversizedBytes = new Uint8Array(100); // Way larger than any hash digest (max 64 bytes)
-  oversizedBytes.fill(0xaa);
-  const oversizedBase64 = Buffer.from(oversizedBytes).toString("base64");
-
-  const lockfile = {
-    lockfileVersion: 1,
-    workspaces: {
-      "": {
-        name: "test-malformed-integrity",
-        dependencies: {
-          "lodash": "4.17.21",
+    "bun.lock": JSON.stringify(
+      {
+        lockfileVersion: 1,
+        workspaces: {
+          "": {
+            name: "test-malformed-integrity",
+            dependencies: {
+              "lodash": "4.17.21",
+            },
+          },
+        },
+        packages: {
+          "lodash": ["lodash@4.17.21", "", {}, `sha256-${oversizedBase64}`],
         },
       },
-    },
-    packages: {
-      "lodash": ["lodash@4.17.21", "", {}, `sha256-${oversizedBase64}`], // This causes the panic
-    },
-  };
+      null,
+      2,
+    ),
+  });
 
-  await Bun.write(`${dir}/bun.lock`, JSON.stringify(lockfile, null, 2));
-
-  // Now run any command that would parse the lockfile - this should not panic
-  const { stdout, stderr, exitCode } = Bun.spawnSync({
+  // The integrity string is parsed while the lockfile is loaded, so a --dry-run
+  // reaches it without downloading anything. Nothing here needs a registry.
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "install", "--dry-run"],
     cwd: dir,
     env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(normalizeBunSnapshot(stdout.toString(), dir)).toMatchInlineSnapshot(`
+  expect(normalizeBunSnapshot(stdout, dir)).toMatchInlineSnapshot(`
     "bun install <version> (<revision>)
 
      lodash@4.17.21 done"
   `);
-  const err = normalizeBunSnapshot(stderr.toString(), dir);
+  const err = normalizeBunSnapshot(stderr, dir);
   expect(err).toContain("warn: Unsupported or malformed integrity hash; ignoring");
   expect(err).not.toContain("error:");
-  expect(exitCode).toMatchInlineSnapshot(`0`);
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/malformed-integrity-base64.test.ts
+++ b/test/regression/issue/malformed-integrity-base64.test.ts
@@ -1,10 +1,24 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
 
 test("malformed integrity base64 in lockfile should be handled gracefully", async () => {
   // Decodes to 100 bytes, larger than any digest bun supports (sha512 is 64 bytes).
   // Parsing this used to write past the end of the fixed-size digest buffer.
   const oversizedBase64 = Buffer.alloc(100, 0xaa).toString("base64");
+
+  // The integrity string is parsed while bun.lock is loaded, and the lockfile
+  // satisfies package.json, so the --dry-run below has nothing to resolve. The
+  // registry only exists to prove that: it must never receive a request.
+  const registryRequests: string[] = [];
+  using registry = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      registryRequests.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
 
   await using dir = tempDir("malformed-integrity-test", {
     "package.json": JSON.stringify({
@@ -34,12 +48,16 @@ test("malformed integrity base64 in lockfile should be handled gracefully", asyn
     ),
   });
 
-  // The integrity string is parsed while the lockfile is loaded, so a --dry-run
-  // reaches it without downloading anything. Nothing here needs a registry.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "install", "--dry-run"],
     cwd: dir,
-    env: bunEnv,
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: registry.url.href,
+      // The CI runner shares one cache between tests; a warm one could satisfy a
+      // resolution without a registry request and hide it from the check below.
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -53,5 +71,6 @@ test("malformed integrity base64 in lockfile should be handled gracefully", asyn
   const err = normalizeBunSnapshot(stderr, dir);
   expect(err).toContain("warn: Unsupported or malformed integrity hash; ignoring");
   expect(err).not.toContain("error:");
+  expect(registryRequests).toEqual([]);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

`test/regression/issue/malformed-integrity-base64.test.ts` ran a real `bun install` of `lodash@4.17.21` with no registry configured, so every run fetched from registry.npmjs.org. Tests are not supposed to contact live registries (REVIEW.md, test/CLAUDE.md), and this one did not need to: it overwrote the lockfile that install produced with a hand-written `bun.lock` one step later, and the only command whose output is asserted is `bun install --dry-run` on the hand-written lockfile.

The test now writes `package.json` and the crafted `bun.lock` up front and runs only the `--dry-run`, with `BUN_CONFIG_REGISTRY` pointed at a local `Bun.serve` stub on 127.0.0.1 that records every request, and its own empty `BUN_INSTALL_CACHE_DIR`. It asserts the stub received no requests, in addition to the unchanged stdout snapshot, integrity warning, and exit code checks.

### What CI showed

On #37335 (whose only source change is compiled out on release test lanes) the file was annotated "failed in the parallel batch, passed alone" in two consecutive builds. The job logs (build 91655, alpine 3.23 aarch64; build 91753, debian 13 x64) show the same thing both times: the file was still running after 251s / 252s inside a 3-wide batch when the runner interrupted the batch for producing no output, and it passed in about 120ms when re-run alone. The old test used `spawnSync` with piped stderr and only looked at the exit code, so whatever the stalled install printed is gone, and the logs do not say which of the two spawned commands stalled. In build 91753 another test in the same batch installed from npm a few seconds earlier, so the registry was reachable; a single stalled fetch is the simplest explanation (bun's install HTTP idle timeout is 300s, longer than the runner's 4 minute batch interrupt, so a stalled fetch surfaces exactly like this). The `--dry-run` command is the same in both versions of the test and runs in well under a second, so if the stall was somewhere in there rather than in the network install, the new test will keep showing it, now with the registry out of the picture.

### Why the install can go, and why the stub is there

The integrity string is parsed while `bun.lock` is loaded (`src/install/lockfile/bun.lock.rs`, the `Integrity::parse` call that emits "Unsupported or malformed integrity hash; ignoring"), which is the out-of-bounds write #21936 fixed. The crafted lockfile satisfies `package.json`, so the dry run has nothing to resolve, and `--dry-run` skips the install phase (`install_with_manager.rs`, the `install_summary` block), so `node_modules` from the deleted install was never read.

That property is easy to lose silently, which is what the stub is for: `--dry-run` does still resolve (manifest and tarball requests included) whenever the lockfile stops satisfying `package.json`, and `install_with_manager` prefetches DNS for the registry hostname unless it is an IP literal or a proxy is configured, so even the happy path with plain `bunEnv` still looked up registry.npmjs.org. Checked by deleting the root `dependencies` from the crafted lockfile: the version of this test without the stub still passed (lodash resolved from the registry or the shared cache, same stdout, same warning, exit 0), while the version in this PR fails. The IP literal registry URL also removes the DNS lookup.

### Verification

```
$ bun bd test test/regression/issue/malformed-integrity-base64.test.ts
(pass) malformed integrity base64 in lockfile should be handled gracefully [654.52ms]
```

The new test makes no network access: the registry it is given is the local stub, which the test asserts was never contacted, and the cache directory it is given is never created. For comparison, the old test with `BUN_CONFIG_REGISTRY` pointed at a closed port fails at `Initial install failed`, i.e. it could not run without a registry. Runtime on a release build went from about 4.6s to under 10ms.

Test-only change; no runtime code is touched. Other files under `test/regression/issue/` that install real packages from npm (26657, 24131, patch-bounds-check, ctrl-c, 11806, 28193, 07740, 00631, 24364, 26225) are a separate cleanup and are not part of this PR.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/malformed-integrity-base64.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/malformed-integrity-base64.test.ts"
bun test v1.4.0 (0d06453d2)

test/regression/issue/malformed-integrity-base64.test.ts:
(pass) malformed integrity base64 in lockfile should be handled gracefully [362.73ms]

 1 pass
 0 fail
 1 snapshots, 5 expect() calls
Ran 1 test across 1 file. [4.07s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../issue/malformed-integrity-base64.test.ts       | 91 ++++++++++++----------
 1 file changed, 51 insertions(+), 40 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/regression/issue/malformed-integrity-base64.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->