### PR TITLE
build: put -glldb before the -g level flags so release C++ gets line tables, not full DWARF

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -286,6 +286,18 @@ export const globalFlags: Flag[] = [
     desc: "DWARF 4 debug info (dsymutil-compatible)",
   },
   {
+    // Must stay ahead of the -gN entries below: every -g flag clang sees
+    // resets the debug-info level, and -glldb (like plain -g) selects the
+    // full standalone kind. With it after -g1, release cc1 invocations got
+    // -debug-info-kind=standalone (check with -###) and every release TU,
+    // deps included, emitted full DWARF: 98% of the ~1.7 GB of objects bun's
+    // own C++ produced in a release build, 740 MB of .debug_* in bun-profile.
+    // test/internal/build-debug-info-flags.test.ts pins the order.
+    flag: "-glldb",
+    when: c => c.unix,
+    desc: "Tune debug info for LLDB (before the level flags; the last -g flag wins)",
+  },
+  {
     // Nix LLVM doesn't support zstd — but we target standard distros.
     // Nix users can override via profile if needed.
     flag: ["-g3", "-gz=zstd"],
@@ -296,11 +308,6 @@ export const globalFlags: Flag[] = [
     flag: "-g1",
     when: c => c.unix && c.release,
     desc: "Minimal debug info for backtraces",
-  },
-  {
-    flag: "-glldb",
-    when: c => c.unix,
-    desc: "Tune debug info for LLDB",
   },
 
   // ─── ASAN (global — passed to deps so they link against the same runtime) ───

--- a/test/internal/build-debug-info-flags.test.ts
+++ b/test/internal/build-debug-info-flags.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Pins the order of the debug-info flags in scripts/build/flags.ts.
+ *
+ * clang takes the debug-info level from the LAST -g flag on the command line,
+ * and -glldb (a tuning flag) counts as one: it resets the level to full and,
+ * for lldb tuning, to the standalone kind. The tables used to emit `-g1 ...
+ * -glldb` for release builds, so `clang -###` showed
+ * `-debug-info-kind=standalone` and every release TU (deps included) carried
+ * full DWARF instead of the line tables the `-g1` entry asks for. The level
+ * flag has to be the last -g flag the tables emit, for bun's own flags and for
+ * the flags forwarded to deps.
+ *
+ * Pure config evaluation: no compiler needed, runs on every host.
+ */
+import { describe, expect, test } from "bun:test";
+import { isMacOS, tempDir } from "harness";
+
+import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { computeDepFlags, computeFlags } from "../../scripts/build/flags.ts";
+
+/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+/**
+ * A linux-x64 target resolves on every host once it is told where its sysroot
+ * is (the path is only recorded, never opened).
+ */
+function linuxConfig(partial: PartialConfig, buildDir: string): Config {
+  return resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildDir, linuxSysroot: buildDir, ...partial },
+    mockToolchain(),
+  );
+}
+
+/**
+ * The -g flags that set the debug-info level or kind, in command-line order.
+ * `-gz=` only selects section compression and is excluded.
+ */
+function levelFlags(flags: string[]): string[] {
+  return flags.filter(f => f.startsWith("-g") && !f.startsWith("-gz"));
+}
+
+/** Every flag list a config produces that reaches a compiler: bun's C and C++ flags and the deps' C and C++ flags. */
+function allCompileFlagLists(cfg: Config): string[][] {
+  const bun = computeFlags(cfg);
+  const deps = computeDepFlags(cfg);
+  return [bun.cflags, bun.cxxflags, deps.cflags, deps.cxxflags];
+}
+
+describe("debug-info flag order", () => {
+  test("release: -g1 is the last -g flag, after -glldb, for bun and for deps", () => {
+    using dir = tempDir("build-debug-info", {});
+    const cfg = linuxConfig({ buildType: "Release" }, String(dir));
+    for (const flags of allCompileFlagLists(cfg)) {
+      expect(levelFlags(flags)).toEqual(["-glldb", "-g1"]);
+    }
+  });
+
+  test("debug: -g3 is the last -g flag, after -glldb, for bun and for deps", () => {
+    using dir = tempDir("build-debug-info", {});
+    const cfg = linuxConfig({ buildType: "Debug" }, String(dir));
+    for (const flags of allCompileFlagLists(cfg)) {
+      expect(levelFlags(flags)).toEqual(["-glldb", "-g3"]);
+      // The compression flag stays attached to the level flag it belongs to.
+      expect(flags.indexOf("-gz=zstd")).toBe(flags.indexOf("-g3") + 1);
+    }
+  });
+
+  // Cross-config path only: on macOS, resolveConfig({ os: "darwin" }) probes
+  // xcode-select for the real SDK. The flag tables are the same either way.
+  test.skipIf(isMacOS)("darwin release: the DWARF version flag comes first and -g1 still ends the list", () => {
+    using dir = tempDir("build-debug-info", {});
+    const cfg = resolveConfig(
+      { os: "darwin", arch: "aarch64", buildType: "Release", buildDir: String(dir) },
+      mockToolchain(),
+    );
+    for (const flags of allCompileFlagLists(cfg)) {
+      expect(levelFlags(flags)).toEqual(["-gdwarf-4", "-glldb", "-g1"]);
+    }
+  });
+});


### PR DESCRIPTION
`flags.ts` emits `-g1` ("Minimal debug info for backtraces") for release builds and then `-glldb` for every unix build. clang takes the debug-info level from the last `-g` flag it sees, and `-glldb` counts as one: it resets the level to full and, for lldb tuning, selects the standalone kind. With the exact release `cxxflags` from `build/release/build.ninja`:

```
$ clang++ <release cxxflags> -### -c x.cpp   # -O3 ... -g1 -glldb
  -debug-info-kind=standalone
$ clang++ <same, -glldb moved before -g1> -###
  -debug-info-kind=line-tables-only
```

So every release TU, vendored deps included, has been emitting full standalone DWARF (the CMake build had the same order, so this is not new). This PR moves the `-glldb` entry ahead of the level entries; debug builds keep `-g3` (same kind as before, only the command line order changes, so the next `bun bd` after pulling recompiles the C++ once), release builds get the line tables the entry has always asked for. Windows (`/Z7`) is untouched.

### Measurements

Fresh C++-only builds (`ci-cpp-only` mode: deps, PCH, bun's C++, archive; no cargo) on a shared 12-core box with ccache disabled, slot-time summed from `.ninja_log`. The box is noisy (its load average drifted from ~30 to ~50 during these runs), so the ThinLTO configuration was built four times before and three times after, interleaved; the vendor objects, which this change barely affects, show the noise floor:

| release + ThinLTO (what CI's build-cpp compiles) | before (4 runs) | after (3 runs) |
|---|---|---|
| bun's own C++ slot-time | 1472 / 1567 / 2027 / 2186s | 1040 / 1171 / 1315s |
| vendor objects slot-time (noise reference) | 480 / 598 / 659 / 622s | 463 / 664 / 618s |
| wall | 142 / 143 / 175 / 189s | 105 / 131 / 132s |
| bun's own object files | 1.9 GB | 88 MB |
| `libbun-profile.a` | 2051 MB | 121 MB |

One pair without LTO (the `bun run build:release` configuration): bun's own C++ slot-time 1888s -> 1118s, wall 176s -> 119s, objects 1.67 GB -> 83 MB, archive 1833 MB -> 118 MB.

The archive row is CI's build-cpp artifact: in build 91391 `gzip -1` of it took ~21s of build-cpp's 25s upload step, and downloading plus gunzipping it took ~13s of build-bun's wait step, before the ThinLTO link reads it. On the link side, `bun-profile` from a local release build carried 740 MB of `.debug_*` sections; the CI LTO lanes finish their link edge with a single-threaded `llvm-objcopy --compress-debug-sections=zlib` over that file, which took 27s on this machine (the WebKit prebuilt's own ~400 MB of DWARF remains, so that pass shrinks rather than disappears). I have not measured the link itself; it ingests ~1.7 GB less debug metadata, so it should get faster too, and the CI run of this PR will show the build-cpp, wait, link and package numbers directly.

Per TU, the cost was a roughly constant 10-15s of DWARF emission for the PCH's type universe regardless of how much code the file contained: `codegen/GeneratedFakeTimersConfig.cpp` (51 lines) compiled in 16s to a 15 MB object; small two-file bundles produced 12-13 MB objects with ~4 KB of text.

### What changes for consumers of release debug info

Release `bun-profile` binaries keep symbol tables, line tables and inlining information, which is what crash backtraces, `llvm-symbolizer`, ASAN/LSAN reports (the asan lane is a release build, so it gets this too) and the order-file tooling use, and it is the same level the Rust half already ships (`debug = "line-tables-only"` in Cargo.toml). What goes away is C++ type and variable information in release binaries, so stepping through release C++ in lldb shows frames and lines but not locals; the debug profile is unchanged.

### Effect on the shipped code

Measured in https://github.com/oven-sh/bun/pull/37376#issuecomment-5252153542: same commit built both ways (ThinLTO, the release flag set), ThinLTO import lists identical, pre-LTO IR identical modulo debug info, and the final .text differs in 7 vendored functions (192 bytes, spill placement and instruction selection, smaller with this PR in every case); interleaved benchmarks of the two stripped binaries show no measurable runtime difference. Everything else in the binary is unchanged apart from the debug sections.

### Test

`test/internal/build-debug-info-flags.test.ts` evaluates the flag tables for linux release/debug and a darwin release target and checks that the level flag is the last `-g` flag in bun's and the deps' C and C++ flag lists. It fails on main (`["-g1", "-glldb"]`) and passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->
