### PR TITLE
libwebp: dispatch the AVX2 kernels on x64 and initialise the VP8L dsp tables once

### DIFF
--- a/scripts/build/deps/libwebp.ts
+++ b/scripts/build/deps/libwebp.ts
@@ -16,9 +16,13 @@
  * and let the preprocessor prune. The x86 levels above the baseline need the
  * two-part wiring described at X86_ISAS below.
  *
- * Threading: WEBP_USE_THREAD is left OFF. The decoder/encoder are invoked
- * from Bun's worker pool already; libwebp's internal pthread pool would just
- * oversubscribe.
+ * Threading: WEBP_USE_THREAD is left OFF. Bun only uses the one-shot API
+ * (WebPDecodeRGBA, WebPEncodeRGBA, WebPEncodeLosslessRGBA), which never
+ * starts libwebp's worker threads either way; all the flag would add is a
+ * mutex around each dsp init body, and only on non-Windows targets (cpu.h
+ * drops it under _WIN32). The two init bodies that are not safe to run
+ * concurrently are instead latched once from src/runtime/image/codec_webp.rs,
+ * which covers every target.
  */
 
 import type { Dependency, DirectSource } from "../source.ts";

--- a/scripts/build/deps/libwebp.ts
+++ b/scripts/build/deps/libwebp.ts
@@ -9,18 +9,19 @@
  * carry-through for #30197), but the full mux/demux is linked since the
  * TUs are tiny and the EXIF/XMP chunks will need the same plumbing later.
  *
- * DirectBuild: no config.h, no codegen. Every dsp/*_{sse2,sse41,neon,msa,
- * mips}*.c file self-guards on WEBP_USE_<ISA> (derived from compiler arch
+ * DirectBuild: no config.h, no codegen. Every dsp/*_{sse2,sse41,avx2,neon,
+ * msa,mips}*.c file self-guards on WEBP_USE_<ISA> (derived from compiler arch
  * macros in src/dsp/cpu.h), so the off-target ones compile to empty TUs —
  * same pattern as libdeflate's arm/x86 cpu_features split. We list them all
- * and let the preprocessor prune.
+ * and let the preprocessor prune. The x86 levels above the baseline need the
+ * two-part wiring described at X86_ISAS below.
  *
  * Threading: WEBP_USE_THREAD is left OFF. The decoder/encoder are invoked
  * from Bun's worker pool already; libwebp's internal pthread pool would just
  * oversubscribe.
  */
 
-import type { Dependency } from "../source.ts";
+import type { Dependency, DirectSource } from "../source.ts";
 
 const LIBWEBP_COMMIT = "b7e29b9d75bd31422b00c2a446d49d7af06c328d"; // v1.6.0
 
@@ -89,26 +90,45 @@ const SHARPYUV = [
   "sharpyuv_gamma", "sharpyuv_neon", "sharpyuv_sse2",
 ];
 
-// dsp/*_{sse2,sse41,avx2}.c each compile a single ISA variant. libwebp's
-// cpu.h gates them on `__SSE2__`/`__SSE4_1__`/`__AVX2__` *or* `_MSC_VER &&
-// _M_X64` — real MSVC accepts AVX2 intrinsics without /arch, but clang-cl
-// defines _MSC_VER and still requires `-mavx2`, so the file builds on Linux
-// baseline (gate stays off) and explodes on Windows baseline (gate forced on,
-// no ISA). Match upstream cmake/cpu.cmake: pass the ISA flag per-file on x64
-// (on arm64 these compile to the stub body and the x86 -m flags are invalid).
-// Runtime CPU dispatch in dsp/cpu.c picks the best available, so a baseline
-// binary still runs on pre-AVX2 hardware.
-function simd(path: string, x64: boolean) {
-  if (x64) {
-    for (const [suf, flag] of [
-      ["_avx2.c", "-mavx2"],
-      ["_sse41.c", "-msse4.1"],
-      ["_sse2.c", "-msse2"],
-    ] as const) {
-      if (path.endsWith(suf)) return { path, cflags: [flag] };
-    }
-  }
-  return path;
+/**
+ * x86 ISA levels libwebp ships kernels for. Each level is wired up in two
+ * halves, the same split upstream's cmake/cpu.cmake and configure.ac make:
+ *
+ *   - The kernel TUs (dsp/*<suffix>) are compiled with `flag`. cpu.h turns
+ *     the compiler's `__AVX2__` etc. into WEBP_USE_<ISA>, which the kernel
+ *     file guards its body on; without it the file is just a stub Init.
+ *     clang-cl needs the flag too: it defines _MSC_VER, which cpu.h reads as
+ *     "MSVC, intrinsics work without /arch", so the kernel body is forced on.
+ *   - Every TU gets `define` (WEBP_HAVE_<ISA>), which is what the dispatchers
+ *     (dsp/lossless.c, lossless_enc.c, dec.c, ...) compile their
+ *     `if (VP8GetCPUInfo(kAVX2)) VP8LDspInitAVX2();` under. Upstream sets
+ *     these in config.h; without one, cpu.h derives WEBP_HAVE_<ISA> from each
+ *     TU's own target, and the dispatchers are built at -march=nehalem. SSE2
+ *     and SSE4.1 fell out of that, AVX2 did not, so on linux/darwin the AVX2
+ *     kernels were linked in but never called. (clang-cl's _MSC_VER path
+ *     implies all three, so on Windows these defines are a no-op; cpu.h only
+ *     defines the ones that aren't already defined.)
+ *
+ * The define only says the kernels are linked in; the Init call stays behind
+ * dsp/cpu.c's cpuid + xgetbv check, so the baseline binary still runs on
+ * pre-AVX2 hardware. Neither half applies on arm64: the x86 kernel files
+ * compile to stubs, the -m flags are invalid, and the dispatch blocks sit
+ * under an SSE2 gate that is compiled out.
+ */
+const X86_ISAS = [
+  { define: "WEBP_HAVE_AVX2", suffix: "_avx2.c", flag: "-mavx2" },
+  { define: "WEBP_HAVE_SSE41", suffix: "_sse41.c", flag: "-msse4.1" },
+  { define: "WEBP_HAVE_SSE2", suffix: "_sse2.c", flag: "-msse2" },
+];
+
+function simd(path: string, x64: boolean): string | DirectSource {
+  if (!x64) return path;
+  const isa = X86_ISAS.find(isa => path.endsWith(isa.suffix));
+  return isa === undefined ? path : { path, cflags: [isa.flag] };
+}
+
+function x86Defines(x64: boolean): Record<string, true> {
+  return x64 ? Object.fromEntries(X86_ISAS.map(isa => [isa.define, true])) : {};
 }
 
 export const libwebp: Dependency = {
@@ -132,6 +152,7 @@ export const libwebp: Dependency = {
       ...MUX.map(f => `src/mux/${f}.c`),
       ...SHARPYUV.map(f => simd(`sharpyuv/${f}.c`, cfg.x64)),
     ],
+    defines: x86Defines(cfg.x64),
     // src/webp/*.h is the public API; internal headers use "src/..."
     // includes from the repo root, sharpyuv uses "sharpyuv/...".
     includes: [".", "src"],

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -1088,13 +1088,17 @@ bun_image::N_AVX3_ZEN4::VertPass  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI
 
 
 # ----------------------------------------------------------------------------
-# libwebp lossless DSP AVX2 variants (src/dsp/lossless*_avx2.c). Gate:
-# VP8GetCPUInfo (vendor/libwebp/src/dsp/cpu.c) checks CPUID for AVX2 before
-# VP8LDspInitAVX2/VP8LEncDspInitAVX2 install these into the function-pointer
-# table. Only seen on Windows because cpu.h enables WEBP_USE_AVX2 under
-# _MSC_VER && _M_X64 even without __AVX2__; on Linux baseline the gate stays
-# off and the functions compile to WEBP_DSP_INIT_STUB.
-# (40 symbols)
+# libwebp lossless DSP AVX2 kernels (vendor/libwebp/src/dsp/lossless_avx2.c,
+# lossless_enc_avx2.c). Gate: VP8LDspInit / VP8LEncDspInit (dsp/lossless.c,
+# lossless_enc.c) only call VP8LDspInitAVX2 / VP8LEncDspInitAVX2, which install
+# these into the function-pointer tables, after VP8GetCPUInfo(kAVX2)
+# (dsp/cpu.c: CPUID AVX + OSXSAVE, XGETBV, CPUID.7 AVX2). Same set as the
+# libwebp block in allowlist-x64.txt: scripts/build/deps/libwebp.ts defines
+# WEBP_HAVE_AVX2 for the dispatchers on every x64 target (here cpu.h already
+# implied it via _MSC_VER && _M_X64, which is why this block predates the
+# linux one). lossless_avx2.c only has PredictorAdd variants 0-4 and 8-12;
+# the encoder side has PredictorSub 0-13.
+# (36 symbols)
 # ----------------------------------------------------------------------------
 AddGreenToBlueAndRed_AVX2  [AVX, AVX2]
 AddVectorEq_AVX2  [AVX, AVX2]
@@ -1113,15 +1117,11 @@ PredictorAdd1_AVX2   [AVX, AVX2]
 PredictorAdd2_AVX2   [AVX, AVX2]
 PredictorAdd3_AVX2   [AVX, AVX2]
 PredictorAdd4_AVX2   [AVX, AVX2]
-PredictorAdd5_AVX2   [AVX, AVX2]
-PredictorAdd6_AVX2   [AVX, AVX2]
-PredictorAdd7_AVX2   [AVX, AVX2]
 PredictorAdd8_AVX2   [AVX, AVX2]
 PredictorAdd9_AVX2   [AVX, AVX2]
 PredictorAdd10_AVX2  [AVX, AVX2]
 PredictorAdd11_AVX2  [AVX, AVX2]
 PredictorAdd12_AVX2  [AVX, AVX2]
-PredictorAdd13_AVX2  [AVX, AVX2]
 PredictorSub0_AVX2   [AVX, AVX2]
 PredictorSub1_AVX2   [AVX, AVX2]
 PredictorSub2_AVX2   [AVX, AVX2]

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1024,6 +1024,55 @@ _ZN9bun_image9N_AVX3_DLL9HorizPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX2, AVX512DQ
 
 
 # ----------------------------------------------------------------------------
+# libwebp lossless DSP AVX2 kernels (vendor/libwebp/src/dsp/lossless_avx2.c,
+# lossless_enc_avx2.c). Gate: VP8LDspInit / VP8LEncDspInit (dsp/lossless.c,
+# lossless_enc.c) only call VP8LDspInitAVX2 / VP8LEncDspInitAVX2, which install
+# these into the function-pointer tables, after VP8GetCPUInfo(kAVX2)
+# (dsp/cpu.c: CPUID AVX + OSXSAVE, XGETBV, CPUID.7 AVX2). The dispatchers only
+# compile that call because scripts/build/deps/libwebp.ts defines
+# WEBP_HAVE_AVX2; the Init functions themselves are plain pointer stores and
+# are not flagged. Same set as the libwebp block in allowlist-x64-windows.txt.
+# (36 symbols)
+# ----------------------------------------------------------------------------
+AddGreenToBlueAndRed_AVX2  [AVX, AVX2]
+AddVectorEq_AVX2  [AVX, AVX2]
+AddVector_AVX2  [AVX, AVX2]
+BundleColorMap_AVX2  [AVX, AVX2]
+CollectColorBlueTransforms_AVX2  [AVX, AVX2]
+CollectColorRedTransforms_AVX2  [AVX, AVX2]
+CombinedShannonEntropy_AVX2  [AVX, AVX2]
+ConvertBGRAToRGBA_AVX2  [AVX, AVX2]
+SubtractGreenFromBlueAndRed_AVX2  [AVX, AVX2]
+TransformColorInverse_AVX2  [AVX, AVX2]
+TransformColor_AVX2  [AVX, AVX2]
+VectorMismatch_AVX2  [AVX, AVX2]
+PredictorAdd0_AVX2   [AVX, AVX2]
+PredictorAdd1_AVX2   [AVX, AVX2]
+PredictorAdd2_AVX2   [AVX, AVX2]
+PredictorAdd3_AVX2   [AVX, AVX2]
+PredictorAdd4_AVX2   [AVX, AVX2]
+PredictorAdd8_AVX2   [AVX, AVX2]
+PredictorAdd9_AVX2   [AVX, AVX2]
+PredictorAdd10_AVX2  [AVX, AVX2]
+PredictorAdd11_AVX2  [AVX, AVX2]
+PredictorAdd12_AVX2  [AVX, AVX2]
+PredictorSub0_AVX2   [AVX, AVX2]
+PredictorSub1_AVX2   [AVX, AVX2]
+PredictorSub2_AVX2   [AVX, AVX2]
+PredictorSub3_AVX2   [AVX, AVX2]
+PredictorSub4_AVX2   [AVX, AVX2]
+PredictorSub5_AVX2   [AVX, AVX2]
+PredictorSub6_AVX2   [AVX, AVX2]
+PredictorSub7_AVX2   [AVX, AVX2]
+PredictorSub8_AVX2   [AVX, AVX2]
+PredictorSub9_AVX2   [AVX, AVX2]
+PredictorSub10_AVX2  [AVX, AVX2]
+PredictorSub11_AVX2  [AVX, AVX2]
+PredictorSub12_AVX2  [AVX, AVX2]
+PredictorSub13_AVX2  [AVX, AVX2]
+
+
+# ----------------------------------------------------------------------------
 # JSC LLInt. Data-in-.text false positive, NOT a gate.
 #
 # ENABLE(LLINT_EMBEDDED_OPCODE_ID) is on for x86_64 (WTF/wtf/PlatformEnable.h),

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -29,21 +29,13 @@ unsafe extern "C" {
     fn VP8LEncDspInit();
 }
 
-/// libwebp fills its per-ISA function-pointer tables from whichever codec call
-/// comes first, and in our build (no `WEBP_USE_THREAD`; on Windows libwebp
-/// never locks regardless) every thread that finds the flag unset runs the
-/// whole init body at once. That is only safe while the bodies are idempotent,
-/// and the two VP8L ones are not: `VP8LDspInitSSE2` / `VP8LEncDspInitSSE2`
-/// build the `*_SSE` tail tables by copying the live dispatch table, which a
-/// thread a few ns ahead may already have filled with the AVX2 kernels, and
-/// those kernels hand their <8-pixel tails to the `*_SSE` tables. A process
-/// that loses that race is left with predictor kernels that tail-call
-/// themselves forever: the next image using the predictor transform wedges a
-/// worker thread at 100% CPU.
-/// Run the init once, serialised, before any codec call; libwebp's own calls
-/// then find the flags set. `VP8LEncDspInit` nests `VP8LDspInit`, so this
-/// covers both tables. Every other dsp init body only stores fixed values, so
-/// concurrent re-runs of those are harmless.
+/// libwebp initialises its dispatch tables lazily and, without
+/// `WEBP_USE_THREAD` (and always on Windows), unsynchronised: concurrent first
+/// calls all run the init bodies. The VP8L bodies are not idempotent (their
+/// SSE2 stage snapshots the live table into the `*_SSE` tail tables the AVX2
+/// kernels delegate to), so racing inits can leave a kernel delegating to
+/// itself. Initialise once up front so libwebp's own calls find it done;
+/// `VP8LEncDspInit` also runs `VP8LDspInit`.
 fn init_dsp() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -26,6 +26,31 @@ unsafe extern "C" {
         out: *mut *mut u8,
     ) -> usize;
     pub(crate) fn WebPFree(ptr: *mut c_void);
+    fn VP8LEncDspInit();
+}
+
+/// libwebp fills its per-ISA function-pointer tables from whichever codec call
+/// comes first, and in our build (no `WEBP_USE_THREAD`; on Windows libwebp
+/// never locks regardless) every thread that finds the flag unset runs the
+/// whole init body at once. That is only safe while the bodies are idempotent,
+/// and the two VP8L ones are not: `VP8LDspInitSSE2` / `VP8LEncDspInitSSE2`
+/// build the `*_SSE` tail tables by copying the live dispatch table, which a
+/// thread a few ns ahead may already have filled with the AVX2 kernels, and
+/// those kernels hand their <8-pixel tails to the `*_SSE` tables. A process
+/// that loses that race is left with predictor kernels that tail-call
+/// themselves forever: the next image using the predictor transform wedges a
+/// worker thread at 100% CPU.
+/// Run the init once, serialised, before any codec call; libwebp's own calls
+/// then find the flags set. `VP8LEncDspInit` nests `VP8LDspInit`, so this
+/// covers both tables. Every other dsp init body only stores fixed values, so
+/// concurrent re-runs of those are harmless.
+fn init_dsp() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // SAFETY: no preconditions; writes only libwebp's own static tables,
+        // and `Once` keeps any other caller out until it returns.
+        unsafe { VP8LEncDspInit() }
+    });
 }
 
 // ─── libwebpmux / libwebpdemux ──────────────────────────────────────────────
@@ -134,6 +159,7 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, c
     let w: u32 = u32::try_from(cw).expect("int cast");
     let h: u32 = u32::try_from(ch).expect("int cast");
     codecs::guard(w, h, max_pixels)?;
+    init_dsp();
     // SAFETY: bytes.ptr/len describe a valid readable slice; cw/ch are valid out-params.
     let ptr = unsafe { WebPDecodeRGBA(bytes.as_ptr(), bytes.len(), &raw mut cw, &raw mut ch) };
     if ptr.is_null() {
@@ -231,6 +257,7 @@ pub(crate) fn encode(
     lossless: bool,
     icc_profile: Option<&[u8]>,
 ) -> Result<codecs::Encoded, codecs::Error> {
+    init_dsp();
     let mut out: *mut u8 = core::ptr::null_mut();
     let stride: c_int = c_int::try_from(w * 4).expect("int cast");
     let len = if lossless {

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -29,18 +29,11 @@ unsafe extern "C" {
     fn VP8LEncDspInit();
 }
 
-/// libwebp initialises its dispatch tables lazily and, without
-/// `WEBP_USE_THREAD` (and always on Windows), unsynchronised: concurrent first
-/// calls all run the init bodies. The VP8L bodies are not idempotent (their
-/// SSE2 stage snapshots the live table into the `*_SSE` tail tables the AVX2
-/// kernels delegate to), so racing inits can leave a kernel delegating to
-/// itself. Initialise once up front so libwebp's own calls find it done;
-/// `VP8LEncDspInit` also runs `VP8LDspInit`.
+/// libwebp's lazy dsp init is unlocked in our build and the VP8L init bodies are not idempotent.
 fn init_dsp() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
-        // SAFETY: no preconditions; writes only libwebp's own static tables,
-        // and `Once` keeps any other caller out until it returns.
+        // SAFETY: no preconditions; only writes libwebp's own static tables, serialised by `Once`.
         unsafe { VP8LEncDspInit() }
     });
 }

--- a/test/internal/libwebp-simd-config.test.ts
+++ b/test/internal/libwebp-simd-config.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Configure-time checks for the x86 SIMD wiring in scripts/build/deps/libwebp.ts.
+ *
+ * libwebp's dsp dispatchers (src/dsp/lossless.c, lossless_enc.c, dec.c, ...)
+ * only compile their `if (VP8GetCPUInfo(kAVX2)) VP8LDspInitAVX2();` call when
+ * WEBP_HAVE_AVX2 is defined in the dispatcher's own TU. Upstream gets that from
+ * config.h; bun builds libwebp without one and at -march=nehalem, so the
+ * define has to come from the dep spec. Without it the *_avx2.c kernels are
+ * still compiled (with -mavx2) but nothing ever calls them in the linux and
+ * macOS x64 builds (clang-cl's _MSC_VER makes cpu.h imply the define on
+ * Windows).
+ *
+ * Only libwebp.build(cfg) is exercised (no compiler involved), so this runs on
+ * every platform.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { resolveConfig, type Arch, type Toolchain } from "../../scripts/build/config.ts";
+import { libwebp } from "../../scripts/build/deps/libwebp.ts";
+import type { DirectBuild } from "../../scripts/build/source.ts";
+
+/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+/**
+ * libwebp's build spec for a Linux glibc release target of the given arch.
+ * linuxSysroot is stubbed so resolveConfig's cross-arch block never throws,
+ * whatever the host is.
+ */
+function libwebpBuild(arch: Arch, baseline?: boolean): DirectBuild {
+  const cfg = resolveConfig(
+    { os: "linux", arch, abi: "gnu", buildType: "Release", baseline, linuxSysroot: "/fake/linux-sysroot" },
+    mockToolchain(),
+  );
+  const spec = libwebp.build(cfg);
+  if (spec.kind !== "direct") throw new Error(`expected libwebp to be a direct build, got ${spec.kind}`);
+  return spec;
+}
+
+/** The WEBP_HAVE_<ISA> macros the spec defines for every TU, sorted. */
+function haveDefines(spec: DirectBuild): string[] {
+  return Object.keys(spec.defines ?? {})
+    .filter(name => name.startsWith("WEBP_HAVE_"))
+    .sort();
+}
+
+/** source path -> per-file cflags (bare-string sources have none). */
+function perFileFlags(spec: DirectBuild): Map<string, string[]> {
+  return new Map(spec.sources.map(s => (typeof s === "string" ? [s, []] : [s.path, s.cflags])));
+}
+
+/** Sources whose per-file cflags include `flag`, sorted. */
+function sourcesWithFlag(spec: DirectBuild, flag: string): string[] {
+  return [...perFileFlags(spec)]
+    .filter(([, cflags]) => cflags.includes(flag))
+    .map(([path]) => path)
+    .sort();
+}
+
+const isaFlags: Record<string, string> = {
+  WEBP_HAVE_SSE2: "-msse2",
+  WEBP_HAVE_SSE41: "-msse4.1",
+  WEBP_HAVE_AVX2: "-mavx2",
+};
+
+describe("libwebp x86 SIMD wiring", () => {
+  test.each([
+    ["baseline", true],
+    ["non-baseline", false],
+  ])("x64 (%s) tells the dispatchers about every ISA level it builds kernels for", (_, baseline) => {
+    const spec = libwebpBuild("x64", baseline);
+    expect(haveDefines(spec)).toEqual(["WEBP_HAVE_AVX2", "WEBP_HAVE_SSE2", "WEBP_HAVE_SSE41"]);
+
+    // The define and the kernels have to travel together: a level that is
+    // compiled but not announced is dead code (the bug this guards against),
+    // and one that is announced but not compiled makes the dispatcher call
+    // libwebp's empty stub Init.
+    for (const [define, flag] of Object.entries(isaFlags)) {
+      expect(spec.defines).toMatchObject({ [define]: true });
+      expect(sourcesWithFlag(spec, flag)).not.toBeEmpty();
+    }
+  });
+
+  test("x64 defines WEBP_HAVE_AVX2 without raising any non-kernel TU above the baseline -march", () => {
+    const spec = libwebpBuild("x64");
+    const flags = perFileFlags(spec);
+
+    // The dispatchers that consume WEBP_HAVE_AVX2 are built at the baseline
+    // -march; the runtime cpuid check in dsp/cpu.c is what keeps the AVX2
+    // kernels off pre-AVX2 CPUs, so -mavx2 must reach exactly the kernel TUs.
+    expect(flags.get("src/dsp/lossless.c")).toEqual([]);
+    expect(flags.get("src/dsp/lossless_enc.c")).toEqual([]);
+    expect(sourcesWithFlag(spec, "-mavx2")).toEqual(["src/dsp/lossless_avx2.c", "src/dsp/lossless_enc_avx2.c"]);
+    expect(spec.cflags ?? []).not.toContain("-mavx2");
+
+    // Every per-file flag is the one matching the file's ISA suffix, and
+    // files without a suffix get none.
+    const expected = [...flags.keys()].map(path => {
+      const cflags = path.endsWith("_avx2.c")
+        ? ["-mavx2"]
+        : path.endsWith("_sse41.c")
+          ? ["-msse4.1"]
+          : path.endsWith("_sse2.c")
+            ? ["-msse2"]
+            : [];
+      return [path, cflags];
+    });
+    expect([...flags]).toEqual(expected);
+  });
+
+  test("arm64 gets neither the x86 defines nor the x86 -m flags", () => {
+    const spec = libwebpBuild("aarch64");
+    expect(haveDefines(spec)).toEqual([]);
+    expect(spec.sources.filter(s => typeof s !== "string")).toEqual([]);
+    // The x86 kernel files are still listed; cpu.h turns them into stub Inits there.
+    expect(spec.sources).toContain("src/dsp/lossless_avx2.c");
+    expect(spec.sources).toContain("src/dsp/lossless_enc_avx2.c");
+  });
+});

--- a/test/internal/source-lints/libwebp-simd-config.test.ts
+++ b/test/internal/source-lints/libwebp-simd-config.test.ts
@@ -10,61 +10,18 @@
  * macOS x64 builds (clang-cl's _MSC_VER makes cpu.h imply the define on
  * Windows).
  *
- * Only libwebp.build(cfg) is exercised (no compiler involved), so this runs on
- * every platform.
+ * libwebp.build() only reads cfg.x64, so the spec is built from a partial
+ * Config (as test/js/bun/perf/linker-order.test.ts does); no toolchain or
+ * compiler is involved.
  */
 import { describe, expect, test } from "bun:test";
 
-import { resolveConfig, type Arch, type Toolchain } from "../../scripts/build/config.ts";
-import { libwebp } from "../../scripts/build/deps/libwebp.ts";
-import type { DirectBuild } from "../../scripts/build/source.ts";
+import type { Config } from "../../../scripts/build/config.ts";
+import { libwebp } from "../../../scripts/build/deps/libwebp.ts";
+import type { DirectBuild } from "../../../scripts/build/source.ts";
 
-/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
-function mockToolchain(): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang",
-    cxx: "/fake/llvm/bin/clang++",
-    hostCc: undefined,
-    hostCxx: undefined,
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-ar",
-    ranlib: "/fake/llvm/bin/llvm-ranlib",
-    ld: "/fake/llvm/bin/ld.lld",
-    ld64Lld: "/fake/llvm/bin/ld64.lld",
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/bin/strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
-    ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: undefined,
-    mt: undefined,
-    nasm: undefined,
-  };
-}
-
-/**
- * libwebp's build spec for a Linux glibc release target of the given arch.
- * linuxSysroot is stubbed so resolveConfig's cross-arch block never throws,
- * whatever the host is.
- */
-function libwebpBuild(arch: Arch, baseline?: boolean): DirectBuild {
-  const cfg = resolveConfig(
-    { os: "linux", arch, abi: "gnu", buildType: "Release", baseline, linuxSysroot: "/fake/linux-sysroot" },
-    mockToolchain(),
-  );
-  const spec = libwebp.build(cfg);
+function libwebpBuild(x64: boolean): DirectBuild {
+  const spec = libwebp.build({ x64 } as Config);
   if (spec.kind !== "direct") throw new Error(`expected libwebp to be a direct build, got ${spec.kind}`);
   return spec;
 }
@@ -89,6 +46,13 @@ function sourcesWithFlag(spec: DirectBuild, flag: string): string[] {
     .sort();
 }
 
+/** The per-file flag each kernel-file suffix gets; every other file gets none. */
+const flagForSuffix: Array<[suffix: string, flag: string]> = [
+  ["_avx2.c", "-mavx2"],
+  ["_sse41.c", "-msse4.1"],
+  ["_sse2.c", "-msse2"],
+];
+
 const isaFlags: Record<string, string> = {
   WEBP_HAVE_SSE2: "-msse2",
   WEBP_HAVE_SSE41: "-msse4.1",
@@ -96,11 +60,8 @@ const isaFlags: Record<string, string> = {
 };
 
 describe("libwebp x86 SIMD wiring", () => {
-  test.each([
-    ["baseline", true],
-    ["non-baseline", false],
-  ])("x64 (%s) tells the dispatchers about every ISA level it builds kernels for", (_, baseline) => {
-    const spec = libwebpBuild("x64", baseline);
+  test("x64 tells the dispatchers about every ISA level it builds kernels for", () => {
+    const spec = libwebpBuild(true);
     expect(haveDefines(spec)).toEqual(["WEBP_HAVE_AVX2", "WEBP_HAVE_SSE2", "WEBP_HAVE_SSE41"]);
 
     // The define and the kernels have to travel together: a level that is
@@ -114,7 +75,7 @@ describe("libwebp x86 SIMD wiring", () => {
   });
 
   test("x64 defines WEBP_HAVE_AVX2 without raising any non-kernel TU above the baseline -march", () => {
-    const spec = libwebpBuild("x64");
+    const spec = libwebpBuild(true);
     const flags = perFileFlags(spec);
 
     // The dispatchers that consume WEBP_HAVE_AVX2 are built at the baseline
@@ -125,23 +86,15 @@ describe("libwebp x86 SIMD wiring", () => {
     expect(sourcesWithFlag(spec, "-mavx2")).toEqual(["src/dsp/lossless_avx2.c", "src/dsp/lossless_enc_avx2.c"]);
     expect(spec.cflags ?? []).not.toContain("-mavx2");
 
-    // Every per-file flag is the one matching the file's ISA suffix, and
-    // files without a suffix get none.
-    const expected = [...flags.keys()].map(path => {
-      const cflags = path.endsWith("_avx2.c")
-        ? ["-mavx2"]
-        : path.endsWith("_sse41.c")
-          ? ["-msse4.1"]
-          : path.endsWith("_sse2.c")
-            ? ["-msse2"]
-            : [];
-      return [path, cflags];
+    const expected = [...flags.keys()].map((path): [string, string[]] => {
+      const match = flagForSuffix.find(([suffix]) => path.endsWith(suffix));
+      return [path, match === undefined ? [] : [match[1]]];
     });
     expect([...flags]).toEqual(expected);
   });
 
   test("arm64 gets neither the x86 defines nor the x86 -m flags", () => {
-    const spec = libwebpBuild("aarch64");
+    const spec = libwebpBuild(false);
     expect(haveDefines(spec)).toEqual([]);
     expect(spec.sources.filter(s => typeof s !== "string")).toEqual([]);
     // The x86 kernel files are still listed; cpu.h turns them into stub Inits there.

--- a/test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts
+++ b/test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts
@@ -192,8 +192,9 @@ describe("WebP lossless: libwebp VP8GetCPUInfo runtime dispatch", () => {
   // libwebp's VP8L encoder and decoder pick SSE2 / SSE4.1 / AVX2 (x64) or
   // NEON kernels at init based on cpuid; the AVX2 ones are linked into the
   // baseline binary and must stay behind that check. 64 pixels wide so the
-  // 8-pixel-wide kernels run, with a gradient plus noise so the encoder uses
-  // the predictor and colour transforms (the bulk of the SIMD surface).
+  // 8-pixel-wide kernels run (and the decoder's per-row tails go through the
+  // kernels' SSE fallbacks), with a gradient plus noise so the colour
+  // transform, entropy and predictor kernels all run on both sides.
   function pngChunk(type: string, data: Uint8Array): Buffer {
     const typeAndData = Buffer.concat([Buffer.from(type, "latin1"), data]);
     const length = Buffer.alloc(4);
@@ -233,6 +234,17 @@ describe("WebP lossless: libwebp VP8GetCPUInfo runtime dispatch", () => {
     const webp = await new Bun.Image(png).webp({ lossless: true }).bytes();
     expect(Buffer.from(webp.subarray(12, 16)).toString("latin1")).toBe("VP8L");
     expect(await new Bun.Image(webp).metadata()).toEqual({ width, height, format: "webp" });
+
+    // libwebp's kernels are bit-exact across ISA levels, so the encoder must
+    // produce the same bytes here whichever tier cpuid selected: this file
+    // runs natively (AVX2 on current x64 CI, NEON on arm64) and under the
+    // no-AVX emulators in scripts/verify-baseline.ts (SSE4.1). Pinning the
+    // output makes those runs a cross-tier identity check. A libwebp bump
+    // that changes the encoder may legitimately move these two values.
+    expect(webp.length).toBe(1256);
+    expect(new Bun.CryptoHasher("sha256").update(webp).digest("hex")).toBe(
+      "42c1218d6ecca9090b109cf61e3fe003c4e30138e88c83e0e3460c2e5330a541",
+    );
 
     // Both PNGs are produced by the same encoder from what must be the same
     // pixels, so the lossless round-trip shows up as byte-identical output.

--- a/test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts
+++ b/test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts
@@ -6,6 +6,7 @@
 // to catch both SIGILL and miscompilation from wrong instruction lowering.
 
 import { describe, expect, test } from "bun:test";
+import { crc32, deflateSync } from "node:zlib";
 
 // Use Buffer.alloc instead of "x".repeat() — repeat is slow in debug JSC builds.
 const ascii256 = Buffer.alloc(256, "a").toString();
@@ -184,6 +185,60 @@ describe("Latin-1 to UTF-8 — @Vector(16, u8) ungated", () => {
     const utf8Buf = Buffer.from(latin1Str, "utf-8");
     expect(utf8Buf.length).toBeGreaterThan(256);
     expect(utf8Buf.toString("utf-8").length).toBe(256);
+  });
+});
+
+describe("WebP lossless: libwebp VP8GetCPUInfo runtime dispatch", () => {
+  // libwebp's VP8L encoder and decoder pick SSE2 / SSE4.1 / AVX2 (x64) or
+  // NEON kernels at init based on cpuid; the AVX2 ones are linked into the
+  // baseline binary and must stay behind that check. 64 pixels wide so the
+  // 8-pixel-wide kernels run, with a gradient plus noise so the encoder uses
+  // the predictor and colour transforms (the bulk of the SIMD surface).
+  function pngChunk(type: string, data: Uint8Array): Buffer {
+    const typeAndData = Buffer.concat([Buffer.from(type, "latin1"), data]);
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(typeAndData));
+    return Buffer.concat([length, typeAndData, crc]);
+  }
+
+  const width = 64;
+  const height = 16;
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // RGBA
+  const rows = Buffer.alloc(height * (1 + width * 4));
+  let seed = 0x9e3779b9;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      const offset = y * (1 + width * 4) + 1 + x * 4;
+      rows[offset] = (x * 4 + (seed & 7)) & 255;
+      rows[offset + 1] = (y * 16 + ((seed >>> 8) & 7)) & 255;
+      rows[offset + 2] = (x * 2 + y * 3 + ((seed >>> 16) & 7)) & 255;
+      rows[offset + 3] = y < height / 2 ? 255 : 128;
+    }
+  }
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(rows)),
+    pngChunk("IEND", new Uint8Array(0)),
+  ]);
+
+  test("encode + decode round-trips every pixel", async () => {
+    const webp = await new Bun.Image(png).webp({ lossless: true }).bytes();
+    expect(Buffer.from(webp.subarray(12, 16)).toString("latin1")).toBe("VP8L");
+    expect(await new Bun.Image(webp).metadata()).toEqual({ width, height, format: "webp" });
+
+    // Both PNGs are produced by the same encoder from what must be the same
+    // pixels, so the lossless round-trip shows up as byte-identical output.
+    const viaWebp = await new Bun.Image(webp).png().bytes();
+    const viaPng = await new Bun.Image(png).png().bytes();
+    expect(viaWebp).toEqual(viaPng);
   });
 });
 


### PR DESCRIPTION
### What

The vendored libwebp's AVX2 kernels (`src/dsp/lossless_avx2.c`, `lossless_enc_avx2.c`) are compiled with `-mavx2` and linked into bun, but on linux and macOS x64 nothing ever calls them. The dispatchers only know about SSE2/SSE4.1:

```
$ llvm-nm build/release/obj/vendor/libwebp/src/dsp/lossless.c.o | grep DspInit
                 U VP8LDspInitSSE2
                 U VP8LDspInitSSE41
$ llvm-nm build/release/bun-profile | grep -E 'VP8L(Enc)?DspInit(SSE41|AVX2)$'
0000000001f70cc0 t VP8LDspInitSSE41
0000000001f6f080 t VP8LEncDspInitSSE41
```

No `VP8LDspInitAVX2` / `VP8LEncDspInitAVX2` anywhere in the binary (found while auditing the dep objects in the release link).

Wiring the kernels up also exposed a libwebp initialisation race (below) that Windows x64 builds, where the kernels were already live, have had all along; this PR fixes that too, since it is what makes turning the kernels on safe.

### Why the kernels are dead

`src/dsp/lossless.c` and `lossless_enc.c` wrap the AVX2 branch of their runtime dispatch in `#if defined(WEBP_HAVE_AVX2)`:

```c
if (VP8GetCPUInfo(kSSE4_1)) {
  VP8LDspInitSSE41();
#if defined(WEBP_HAVE_AVX2)
  if (VP8GetCPUInfo(kAVX2)) VP8LDspInitAVX2();
#endif
}
```

Upstream's cmake and autotools builds put `WEBP_HAVE_AVX2` (and `_SSE2`/`_SSE41`) in `config.h`, which every TU includes, and pass `-mavx2` only to the `*_avx2.c` objects. Our direct build has no `config.h`, so `src/dsp/cpu.h` falls back to deriving `WEBP_HAVE_<ISA>` from the macros of the TU being compiled. The kernel TUs get `-mavx2` and so define it for themselves, but the dispatcher TUs are built at our `-march=nehalem` (every x64 build is) and never see `__AVX2__`, so the call above is compiled out. SSE2 and SSE4.1 happened to work because nehalem implies both.

Windows is different: clang-cl defines `_MSC_VER`, and `cpu.h` treats `_MSC_VER && _M_X64` as "all three ISAs available" for every TU (checked by preprocessing `lossless.c` with `--target=x86_64-pc-windows-msvc`: the AVX2 call is present with or without this change), which is also why `allowlist-x64-windows.txt` already listed these kernels.

### Fix 1: the defines (`scripts/build/deps/libwebp.ts`)

The dep spec keeps one table of x86 ISA levels. It already assigned the per-file `-m` flag by filename suffix; it now also emits the matching `WEBP_HAVE_<ISA>` define for every libwebp TU on x64, which is what upstream's `config.h` provides. The two halves come from the same table so a future level can't be compiled without also being announced to the dispatchers.

Safe for the baseline (nehalem) binary: the define only says "the kernels are linked in"; whether they run is still decided by `dsp/cpu.c` at runtime (cpuid AVX + OSXSAVE, xgetbv for YMM state, then cpuid.7 AVX2), and the Init is only reached after the SSE2 and SSE4.1 Inits. `-mavx2` still reaches exactly the two kernel TUs. The defines are redundant on Windows and arm64 gets none of this; `cpu.h` only defines the macros it doesn't already see, so there are no redefinition warnings (checked with `-Wall` across every dsp and sharpyuv TU on the linux and windows-msvc targets). Under ThinLTO the kernels carry `+avx2` target features, which LLVM does not inline into callers without them, and upstream's own builds use exactly this layout, so no `-fno-lto` is needed.

**verify-baseline.** With the kernels reachable, `--gc-sections` keeps them and the static scan in the linux x64 / x64-musl lanes flagged exactly the 36 functions the two AVX2 files define (all `[AVX, AVX2]`; the Init functions are plain stores and are not flagged), while the QEMU Nehalem phase of the same jobs passed. They are added to `allowlist-x64.txt` with the gate documented. The existing Windows block is brought in line: its header said the kernels were Windows-only, and it listed `PredictorAdd5/6/7/13_AVX2`, which `lossless_avx2.c` does not define (the AVX2 decoder covers predictors 0-4 and 8-12), so those four stale entries are dropped and both blocks hold the same 36 symbols.

### Fix 2: the init race (`src/runtime/image/codec_webp.rs`)

Self-review of the first version of this PR turned up the following. libwebp initialises its dispatch tables lazily from the first codec call, and `WEBP_DSP_INIT` (`src/dsp/cpu.h`) is a plain check-flag / run-body / set-flag unless `WEBP_USE_THREAD` is defined (it never locks on `_WIN32`). Our build leaves it off, so every worker thread that reaches `VP8LDspInit` / `VP8LEncDspInit` before the flag is set runs the whole body; in a burst of 32 concurrent first encodes on this branch's release build, 8 pool threads were inside `VP8LEncDspInit`'s body at the same time. That is upstream's design and it is fine while the bodies are idempotent, which these two are not: `VP8LDspInitSSE2` (`lossless_sse2.c:717`) and `VP8LEncDspInitSSE2` (`lossless_enc_sse2.c:739`) fill the `VP8LPredictorsAdd_SSE` / `VP8LPredictorsSub_SSE` tables by `memcpy` from the live dispatch table, and every AVX2 predictor kernel hands its `<8` pixel tail to those tables. If one thread's AVX2 stage lands between another thread's SSE2 assignments and its `memcpy`, the tail tables end up holding the AVX2 kernels, permanently (the flag is set afterwards), and from then on every tail call is a kernel tail-calling itself (`jmp *%r8`) with the same arguments: a silent 100% CPU hang of that worker, on every later image that uses the predictor transform (the decoder hits it on the first tile of every row; the encoder uses the batch table for lossy images with alpha).

This was the state on Windows before this PR; the defines above would have extended it to linux and macOS. The window is a few ns, so it does not show up in plain stress runs (0 hangs in ~8000 bursts here, with the pool pre-warmed or not), but it is easy to demonstrate by letting the debugger pick the interleaving between two real worker threads:

<details>
<summary>gdb transcript, release build of this branch without the latch, 32 concurrent first decodes of a 61x31 lossless image</summary>

Thread B is stopped at `lossless_sse2.c:717` (before its memcpy); thread A, also inside the body, is run alone until `VP8LDspInitAVX2` returns; then B is resumed alone.

```
=== 2 pool threads are inside VP8LDspInit's body at the same time; B = thread 12 (Bun Pool 0), stopped before memcpy(Add_SSE, Add) ===
=== A = thread 14 (Bun Pool 2) ===
Add[1] now                 : 0x1f72770 <PredictorAdd1_SSE2>
Add[1] after A's AVX2 init : 0x1f6c4e0 <PredictorAdd1_AVX2>
Add_SSE[1] before B resumes: 0x1f72770 <PredictorAdd1_SSE2>

Thread 12 "Bun Pool 0" hit Breakpoint 3, PredictorAdd1_AVX2 (..., num_pixels=4, ...) at lossless_avx2.c:62

=== B stopped ===
Add_SSE[1] after B's memcpy: 0x1f6c4e0 <PredictorAdd1_AVX2>
decode finished (VP8LDelete reached): False
PredictorAdd1_AVX2 entered 2001 times so far while decoding one 61x31 image
#0  PredictorAdd1_AVX2 (num_pixels=4) at lossless_avx2.c:62
#1  PredictorInverseTransform_C at lossless.c:252
#2  VP8LInverseTransform at lossless.c:408
#3  ApplyInverseTransforms at vp8l_dec.c:808
```

Breakpoint 3 had an ignore count of 2000; a normal decode of this image enters `PredictorAdd1_AVX2` 30 times (once per row) and delegates each 4-pixel tail to `PredictorAdd1_SSE2`. The same driver on the encoder side (`lossless_enc_sse2.c:739`) leaves all 14 `VP8LPredictorsSub_SSE` entries pointing at the AVX2 kernels.

</details>

The fix runs `VP8LEncDspInit()` (which nests `VP8LDspInit()`) once behind a `std::sync::Once` before the first `WebPDecodeRGBA` / `WebPEncode*` call, so libwebp's own init calls find the flags already set; `Once` also provides the release/acquire the volatile flag lacks. With the latch, the same burst under gdb shows each table copy running exactly once, from `codec_webp::init_dsp`, and the two-thread setup above can no longer be constructed because only one thread ever enters the body. This covers Windows, which `WEBP_USE_THREAD` would not (the lock is dropped on `_WIN32`), so that flag stays off; its comment in `libwebp.ts`, which talked about a worker pool the one-shot API never starts, is corrected. The other twelve dsp init bodies only store fixed values (grepped: these two memcpys are the only copies from a live table), so their concurrent re-runs stay harmless as before.

### Verification

After the change both dispatchers reference the AVX2 inits and the release binary contains them:

```
$ llvm-nm build/debug/obj/vendor/libwebp/src/dsp/lossless.c.o | grep DspInit
                 U VP8LDspInitAVX2
                 U VP8LDspInitSSE2
                 U VP8LDspInitSSE41
$ llvm-nm build/release/bun-profile | grep -E 'VP8L(Enc)?DspInit(SSE2|SSE41|AVX2)$'
0000000001f6c3c0 t VP8LDspInitAVX2
...
0000000001f6eda0 t VP8LEncDspInitAVX2
```

On an AVX2 host (Xeon 8375C), encoding and decoding five lossless images (noise, gradient, photo-like, alpha, palette; widths 61 to 97 so both the 8-pixel AVX2 loops and the SSE tails run) under gdb hits `VP8LDspInitAVX2` and `VP8LEncDspInitAVX2` once each and then the kernels themselves (`TransformColor_AVX2` 1203x, `CollectColorBlueTransforms_AVX2` 7665x, `VectorMismatch_AVX2` 5009x, `PredictorSub11/12/13_AVX2`, `BundleColorMap_AVX2`, `PredictorAdd12_AVX2`, `AddGreenToBlueAndRed_AVX2`, `TransformColorInverse_AVX2`, `ConvertBGRAToRGBA_AVX2` 268x). The encoded bytes (lossless and lossy) and decoded pixels of all five images hash identically between the unfixed release build of the same revision (`81cfca931`) and the final debug and release builds of this branch, so this changes which code runs, not the output.

`bun bd test test/js/bun/image/` (220 tests, ASAN, includes the lossless round-trips and the webp-lossless byte-flip fuzz) passes on the final build. `bun scripts/verify-baseline.ts --binary build/release/bun-profile --arch x64 --emulator qemu-x86_64` on a binary built from this branch passes both phases (static: 0 violations, the 36 libwebp symbols allowlisted, none stale; emulated: all fixtures including the new one). `cargo clippy -p bun_runtime` is clean.

### Tests

* `test/internal/source-lints/libwebp-simd-config.test.ts` builds the libwebp spec from a partial `Config` (the dep only reads `cfg.x64`) and checks that x64 defines `WEBP_HAVE_SSE2/SSE41/AVX2` with flagged kernel sources for each, that `-mavx2` lands on exactly `lossless_avx2.c` and `lossless_enc_avx2.c` with every other file's flags matching its suffix (so the bug can't be "fixed" by raising the whole dep to AVX2), and that arm64 gets neither. The define test fails against main's `libwebp.ts`; the other two are invariants that hold before and after. It lives in source-lints because it never touches the binary (that directory's README criterion).
* `test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts`, the file `scripts/verify-baseline.ts` runs under `qemu -cpu Nehalem` / SDE `-nhm` / `qemu -cpu cortex-a53`, gains a 64x16 lossless encode + decode that exercises 9 of the 36 AVX2 kernels natively (both encoder and decoder side, including the decoder's per-row `*_SSE` tail delegation). It pins the encoded output (1256 bytes, sha256 `42c1218d...a541`), which is identical on the AVX2 tier (release and debug/ASAN), on the SSE4.1 tier natively (unfixed bun) and under QEMU Nehalem, so the native and emulated runs of the same file double as a cross-tier byte-identity check. A libwebp bump that changes the encoder moves the golden; the comment says so. This is a guard, not a fail-before test.
* The init race has no deterministic JS-level reproduction (it needs the debugger to align two threads within a few ns); the evidence is the transcript above plus the once-only check on the fixed build. Both gdb drivers are reproducible from the description: break at the SSE2 memcpy line, `set scheduler-locking on`, run the second thread to `VP8LDspInitAVX2`, resume the first.

Note for the fail-before check: Fix 1 is in `scripts/`, so `git stash push -- src/ packages/` leaves it in place; the failing-before run of the config test was produced against `origin/main`'s `libwebp.ts`.
