### PR TITLE
codegen: expand the $ERR_*/$inherits* macros with one regex and a map (bundle-modules ~5x faster)

### DIFF
--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -14,20 +14,13 @@ export const replacements: ReplacementRule[] = [
 ];
 
 /**
- * `$<name>(` calls that expand to a call with a numeric id prepended to the
- * arguments: `$ERR_FOO(` → `$makeErrorWithCode(<n>, ` for every error code in
- * ErrorCode.ts and `$inheritsBlob(` → `$inherits(<id>, ` for js_classes.ts.
- * Keyed by name (after the `$` → `__intrinsic__` rewrite) and applied with one
- * regex, `intrinsicCall` below. These used to be ~370 entries of
- * `replacements`, and running every one of them over each of the ~120k code
- * chunks bundle-modules slices was ~90% of that codegen step's time.
- *
- * Values are inserted verbatim, so they are spelled with `__intrinsic__`, which
- * is what the `$` in the `to:` strings above expands to.
+ * `$ERR_FOO(` → `$makeErrorWithCode(<n>, ` and `$inheritsFoo(` → `$inherits(<id>, `,
+ * keyed by name and applied in one pass by `intrinsicCall`. Values are inserted
+ * verbatim, after the `$` → `__intrinsic__` rewrite, so they are spelled with `__intrinsic__`.
  */
 const intrinsicCallReplacements = new Map<string, string>();
 
-/** First definition of a name wins, as it did when each name was its own rule. */
+/** First definition of a name wins. */
 function defineIntrinsicCall(name: string, to: string): void {
   if (!/^[A-Za-z0-9_]+$/.test(name)) throw new Error(`intrinsic call name must be an identifier: ${name}`);
   if (!intrinsicCallReplacements.has(name)) intrinsicCallReplacements.set(name, to);
@@ -49,11 +42,6 @@ for (let id = 0; id < jsclasses.length; id++) {
   defineIntrinsicCall(`inherits${jsclasses[id][0]}`, `__intrinsic__inherits(${id}, `);
 }
 
-/**
- * Matches what each of the former per-name rules matched (`\b__intrinsic__<name>\(`):
- * the name is a maximal identifier run, so a match corresponds to exactly one
- * entry of the map or, when the name is not in it, to no former rule at all.
- */
 const intrinsicCall = /\b__intrinsic__([A-Za-z0-9_]+)\(/g;
 
 // These rules are run on the entire file, including within strings.
@@ -214,9 +202,6 @@ export function applyReplacements(src: string, length: number) {
       replacement.toRaw ?? replacement.to!.replaceAll("$", "__intrinsic__").replaceAll("%", "$"),
     );
   }
-  // Independent of the rules above: none of them produces or consumes a
-  // `__intrinsic__<name>(` call that is in the map, so running this after all
-  // of them matches the old interleaved rule order.
   if (slice.includes("__intrinsic__")) {
     slice = slice.replace(intrinsicCall, (call, name) => intrinsicCallReplacements.get(name) ?? call);
   }

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -13,11 +13,7 @@ export const replacements: ReplacementRule[] = [
   { from: /\bexport\s*default/g, to: "$exports =" },
 ];
 
-/**
- * `$ERR_FOO(` → `$makeErrorWithCode(<n>, ` and `$inheritsFoo(` → `$inherits(<id>, `,
- * keyed by name and applied in one pass by `intrinsicCall`. Values are inserted
- * verbatim, after the `$` → `__intrinsic__` rewrite, so they are spelled with `__intrinsic__`.
- */
+/** `__intrinsic__<name>(` → value; applied by `intrinsicCall` after the `$` rewrite, so values spell out `__intrinsic__`. */
 const intrinsicCallReplacements = new Map<string, string>();
 
 /** First definition of a name wins. */

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -13,31 +13,48 @@ export const replacements: ReplacementRule[] = [
   { from: /\bexport\s*default/g, to: "$exports =" },
 ];
 
+/**
+ * `$<name>(` calls that expand to a call with a numeric id prepended to the
+ * arguments: `$ERR_FOO(` → `$makeErrorWithCode(<n>, ` for every error code in
+ * ErrorCode.ts and `$inheritsBlob(` → `$inherits(<id>, ` for js_classes.ts.
+ * Keyed by name (after the `$` → `__intrinsic__` rewrite) and applied with one
+ * regex, `intrinsicCall` below. These used to be ~370 entries of
+ * `replacements`, and running every one of them over each of the ~120k code
+ * chunks bundle-modules slices was ~90% of that codegen step's time.
+ *
+ * Values are inserted verbatim, so they are spelled with `__intrinsic__`, which
+ * is what the `$` in the `to:` strings above expands to.
+ */
+const intrinsicCallReplacements = new Map<string, string>();
+
+/** First definition of a name wins, as it did when each name was its own rule. */
+function defineIntrinsicCall(name: string, to: string): void {
+  if (!/^[A-Za-z0-9_]+$/.test(name)) throw new Error(`intrinsic call name must be an identifier: ${name}`);
+  if (!intrinsicCallReplacements.has(name)) intrinsicCallReplacements.set(name, to);
+}
+
 let error_i = 0;
 for (let i = 0; i < NodeErrors.length; i++) {
   const [code, _constructor, _name, ...other_constructors] = NodeErrors[i];
-  replacements.push({
-    from: new RegExp(`\\b\\__intrinsic__${code}\\(`, "g"),
-    to: `$makeErrorWithCode(${error_i}, `,
-  });
+  defineIntrinsicCall(code, `__intrinsic__makeErrorWithCode(${error_i}, `);
   error_i += 1;
   for (const con of other_constructors) {
     if (con == null) continue;
-    replacements.push({
-      from: new RegExp(`\\b\\__intrinsic__${code}_${con.name}\\(`, "g"),
-      to: `$makeErrorWithCode(${error_i}, `,
-    });
+    defineIntrinsicCall(`${code}_${con.name}`, `__intrinsic__makeErrorWithCode(${error_i}, `);
     error_i += 1;
   }
 }
 
 for (let id = 0; id < jsclasses.length; id++) {
-  const name = jsclasses[id][0];
-  replacements.push({
-    from: new RegExp(`\\b\\__intrinsic__inherits${name}\\(`, "g"),
-    to: `$inherits(${id}, `,
-  });
+  defineIntrinsicCall(`inherits${jsclasses[id][0]}`, `__intrinsic__inherits(${id}, `);
 }
+
+/**
+ * Matches what each of the former per-name rules matched (`\b__intrinsic__<name>\(`):
+ * the name is a maximal identifier run, so a match corresponds to exactly one
+ * entry of the map or, when the name is not in it, to no former rule at all.
+ */
+const intrinsicCall = /\b__intrinsic__([A-Za-z0-9_]+)\(/g;
 
 // These rules are run on the entire file, including within strings.
 export const globalReplacements: ReplacementRule[] = [
@@ -196,6 +213,12 @@ export function applyReplacements(src: string, length: number) {
       replacement.from,
       replacement.toRaw ?? replacement.to!.replaceAll("$", "__intrinsic__").replaceAll("%", "$"),
     );
+  }
+  // Independent of the rules above: none of them produces or consumes a
+  // `__intrinsic__<name>(` call that is in the map, so running this after all
+  // of them matches the old interleaved rule order.
+  if (slice.includes("__intrinsic__")) {
+    slice = slice.replace(intrinsicCall, (call, name) => intrinsicCallReplacements.get(name) ?? call);
   }
   let match;
   if ((match = slice.match(function_regexp)) && rest.startsWith("(")) {

--- a/test/internal/codegen-replacements.test.ts
+++ b/test/internal/codegen-replacements.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The `$ERR_*(` / `$inherits*(` macro expansion bundle-modules applies to the
+ * builtin JS sources (src/codegen/replacements.ts). The error ids must follow
+ * the numbering ErrorCode.ts implies (one id per code, then one per extra
+ * constructor, in file order), because the C++ side that backs
+ * `$makeErrorWithCode` is generated from the same list.
+ */
+import { expect, test } from "bun:test";
+
+import { sliceSourceCode } from "../../src/codegen/builtin-parser.ts";
+import { applyReplacements } from "../../src/codegen/replacements.ts";
+import NodeErrors from "../../src/jsc/bindings/ErrorCode.ts";
+import jsclasses from "../../src/jsc/bindings/js_classes.ts";
+
+/** Runs the code-chunk replacements over `code` as one chunk. */
+function replaceAll(code: string): string {
+  const [replaced, rest] = applyReplacements(code, code.length);
+  expect(rest).toBe("");
+  return replaced as string;
+}
+
+/** `{ name: id }` for every `$<name>(` error macro, numbered the way ErrorCode.ts implies. */
+function expectedErrorIds(): Map<string, number> {
+  const ids = new Map<string, number>();
+  let id = 0;
+  for (const [code, , , ...extraConstructors] of NodeErrors) {
+    if (!ids.has(code)) ids.set(code, id);
+    id++;
+    for (const ctor of extraConstructors) {
+      if (ctor == null) continue;
+      const name = `${code}_${ctor.name}`;
+      if (!ids.has(name)) ids.set(name, id);
+      id++;
+    }
+  }
+  return ids;
+}
+
+test("every error code expands to $makeErrorWithCode with its id", () => {
+  const ids = expectedErrorIds();
+  expect(ids.size).toBeGreaterThan(300);
+  for (const [name, id] of ids) {
+    expect(replaceAll(` throw $${name}("x");`)).toBe(` throw __intrinsic__makeErrorWithCode(${id}, "x");`);
+  }
+  // The `<code>_<Constructor>` variants are part of what was just checked.
+  const plainCodes = new Set(NodeErrors.map(([code]) => code));
+  expect([...ids.keys()].filter(name => !plainCodes.has(name)).length).toBeGreaterThan(0);
+});
+
+test("$inherits<Class>( expands to $inherits(<index>, ", () => {
+  jsclasses.forEach(([name], index) => {
+    expect(replaceAll(` return $inherits${name}(value);`)).toBe(` return __intrinsic__inherits(${index}, value);`);
+  });
+});
+
+test("unknown intrinsics, non-call uses and mid-identifier dollars are left alone", () => {
+  const [firstCode] = NodeErrors[0];
+  expect(replaceAll(` $notAnErrorCode(1)`)).toBe(` __intrinsic__notAnErrorCode(1)`);
+  // Only calls expand: a bare reference keeps the generic intrinsic spelling.
+  expect(replaceAll(` const f = $${firstCode};`)).toBe(` const f = __intrinsic__${firstCode};`);
+  // `$` inside an identifier is not a macro.
+  expect(replaceAll(` foo$${firstCode}(1)`)).toBe(` foo$${firstCode}(1)`);
+  // A longer name that merely starts with a known code is a different (unknown) macro.
+  expect(replaceAll(` $${firstCode}_NOT_A_CONSTRUCTOR(1)`)).toBe(` __intrinsic__${firstCode}_NOT_A_CONSTRUCTOR(1)`);
+});
+
+test("nested macros expand in one pass and compose with the other rules", () => {
+  const ids = expectedErrorIds();
+  const [a] = NodeErrors[0];
+  const [b] = NodeErrors[1];
+  const [klass] = jsclasses[0];
+  expect(replaceAll(` f($${a}($${b}(x)), $inherits${klass}(y)); throw new TypeError("t");`)).toBe(
+    ` f(__intrinsic__makeErrorWithCode(${ids.get(a)}, __intrinsic__makeErrorWithCode(${ids.get(b)}, x)), ` +
+      `__intrinsic__inherits(0, y)); __intrinsic__throwTypeError("t");`,
+  );
+});
+
+test("sliceSourceCode applies the expansion to code but not to string contents", () => {
+  const [code] = NodeErrors[0];
+  const id = expectedErrorIds().get(code);
+  const { result, rest } = sliceSourceCode(`{ const s = "$${code}("; return $${code}(s); }`, true);
+  expect(rest).toBe("");
+  expect(result).toBe(`{ const s = "$${code}("; return __intrinsic__makeErrorWithCode(${id}, s); }`);
+});


### PR DESCRIPTION
`bundle-modules` is the codegen step that both the PCH (via the `InternalModuleRegistry+*.h` / `SyntheticModuleType.h` / `BunBuiltinNames+extras.h` headers) and cargo (via the generated `.rs` files) wait for at the start of every fresh build, and it re-runs on every build that touches `src/js`. Its own timing output puts almost all of its time in "Preprocess modules", and the reason is in `replacements.ts`: it generated one regex rule per Node error code plus one per `js_classes` entry (~370 rules), and `applyReplacements` ran every rule over every code chunk `sliceSourceCode` produces, which for the builtin modules is on the order of 120k chunks, so ~45M regex executions per run.

Every generated rule had the same shape, `\b__intrinsic__<name>\(` with a literal replacement, so they are now a `Map` keyed by name, applied with a single `\b__intrinsic__([A-Za-z0-9_]+)\(` pass after the handwritten rules. The name in a match is a maximal identifier run followed by `(`, so a match corresponds to exactly the one old rule for that name (or to none); the old rules never matched each other's output or the handwritten rules' output, so applying the map after all of them is equivalent to the old interleaving; the first definition of a name wins, as it did when the first rule for a name consumed the match. Names are asserted to be identifiers so a future non-identifier name fails loudly instead of silently never matching.

### Verification

- Byte-identical output: configured a release build, ran `ninja codegen` before and after the change, and `diff -r` of the `codegen/` and `js/` output trees is empty; running ninja again after the change reports no work to do (the edge re-runs because `replacements.ts` is one of its inputs, then `restat` prunes everything downstream).
- Timing on a 12-core machine, re-running the edge by touching a module, three runs each: "Preprocess modules" 9.2-10.3s -> 1.2-1.4s, the whole bundle step 10.2-11.2s -> 1.8-2.0s. CI's build-bun log for build 91391 shows the same phase at 7.9s of the 8.5s step on a much faster core, so expect roughly 8.5s -> ~1s there, which is how much earlier cargo starts on each lane.
- `test/internal/codegen-replacements.test.ts` pins the contract for every error name (id numbering follows ErrorCode.ts order, including the `<code>_<Constructor>` variants) and every `js_classes` entry, plus non-expansion of unknown names, bare references and longer names that merely start with a known code, nesting, composition with the handwritten rules, and an end-to-end `sliceSourceCode` case showing string contents are untouched. It passes against both the old and the new implementation.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/codegen-replacements.test.ts
bun test v1.4.0 (8e9c455d2)

test/internal/codegen-replacements.test.ts:
(fail) every error code expands to $makeErrorWithCode with its id [26917.12ms]
  ^ this test timed out after 5000ms.
(pass) $inherits<Class>( expands to $inherits(<index>,  [401.58ms]
(pass) unknown intrinsics, non-call uses and mid-identifier dollars are left alone [292.87ms]
(pass) nested macros expand in one pass and compose with the other rules [103.37ms]
(pass) sliceSourceCode applies the expansion to code but not to string contents [340.75ms]

 4 pass
 1 fail
 758 expect() calls
Ran 5 tests across 1 file. [32.46s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (9008ae7ab)

test/internal/codegen-replacements.test.ts:
(pass) every error code expands to $makeErrorWithCode with its id [87.01ms]
(pass) $inherits<Class>( expands to $inherits(<index>,  [1.18ms]
(pass) unknown intrinsics, non-call uses and mid-identifier dollars are left alone [0.91ms]
(pass) nested macros expand in one pass and compose with the other rules [0.64ms]
(pass) sliceSourceCode applies the expansion to code but not to string contents [1.58ms]

 5 pass
 0 fail
 758 expect() calls
Ran 5 tests across 1 file. [337.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/codegen-replacements.test.ts
bun test v1.4.0 (8e9c455d2)

test/internal/codegen-replacements.test.ts:
(pass) every error code expands to $makeErrorWithCode with its id [1075.00ms]
(pass) $inherits<Class>( expands to $inherits(<index>,  [15.40ms]
(pass) unknown intrinsics, non-call uses and mid-identifier dollars are left alone [9.66ms]
(pass) nested macros expand in one pass and compose with the other rules [32.55ms]
(pass) sliceSourceCode applies the expansion to code but not to string contents [53.12ms]

 5 pass
 0 fail
 758 expect() calls
Ran 5 tests across 1 file. [5.28s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1243ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/1] reconfigure
[1/1239] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [10.00ms]
[2/1239] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1239] gen ErrorCode+*.h
[4/1239] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [16.00ms]
[5/1239] gen bindgenv2
[6/1239] fetch picohttpparser
[picohttpparser] up to date
[7/1239] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1239] fetch tinycc
[tinycc] up to date
[9/1238] gen .bind.ts → GeneratedBindings.cpp
[10/1238] fetch zlib
[zlib] up to date
[11/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[12/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JS
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/replacements.ts                | 30 ++++++-----
 test/internal/codegen-replacements.test.ts | 84 ++++++++++++++++++++++++++++++
 2 files changed, 101 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/codegen/replacements.ts                     6     10      0
test/internal/codegen-replacements.test.ts      0      2      0
```

</details>

<!-- robobun:evidence:end -->