### PR TITLE
Bun.spawn: de-duplicate case-insensitive env names on Windows

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2095,10 +2095,8 @@ impl EnvLine {
 /// so `{ ...process.env, PATH }` (`Path` in process.env) would keep the parent's
 /// value. Keep the lexicographically first spelling of each name, like node:
 /// https://github.com/nodejs/node/blob/v26.3.0/lib/child_process.js#L715-L738
-/// Deliberately unlike node, names fold ASCII case only (as bun's env maps do on
-/// Windows) and `undefined` properties were already dropped, so
-/// `{ HTTP_PROXY: undefined, http_proxy: url }` sets the proxy (node's key sort
-/// makes it set nothing). Output order is irrelevant: libuv re-sorts the block.
+/// Unlike node this folds ASCII only (as bun's env maps do) and never sees
+/// `undefined` properties, so `{ HTTP_PROXY: undefined, http_proxy: url }` sets the proxy.
 fn dedupe_env_names_windows(lines: &mut Vec<EnvLine>) {
     fn cmp_names(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
         a.iter()

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -7,7 +7,7 @@ use crate::ipc as IPC;
 #[cfg(not(windows))]
 use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
-use bun_core::{String as BunString, ZStr, strings};
+use bun_core::{String as BunString, ZStr, ZigString, strings};
 use bun_event_loop::SpawnSyncEventLoop::TickState;
 use bun_io::max_buf::MaxBuf;
 use bun_jsc::{
@@ -2075,37 +2075,56 @@ fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsEr
     global_this.throw_value(err.to_error_instance(global_this))
 }
 
-/// One `KEY=VALUE` line of the child's environment.
+/// One `env` property as the `KEY=VALUE` line handed to the child. On Windows an
+/// `undefined` property is kept as a bare `KEY` so that it removes the other
+/// spellings of its name in `dedupe_env_names_windows`; it is never emitted.
 struct EnvLine {
     line: ZBox,
     key_len: usize,
 }
 
 impl EnvLine {
+    // PERF: per-entry allocation — profile if it shows up on a hot path.
+    fn new(key: &BunString, value: Option<ZigString>) -> JsResult<EnvLine> {
+        let mut buf: Vec<u8> = Vec::new();
+        write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
+        let key_len = buf.len();
+        if let Some(value) = value {
+            write!(&mut buf, "={}", value).map_err(|_| JsError::OutOfMemory)?;
+        }
+        Ok(EnvLine {
+            line: ZBox::from_vec(buf),
+            key_len,
+        })
+    }
+
     fn key(&self) -> &[u8] {
         &self.line.as_bytes()[..self.key_len]
     }
 
-    fn value(&self) -> &[u8] {
-        &self.line.as_bytes()[self.key_len + 1..]
+    /// `None` for an `undefined` property.
+    fn value(&self) -> Option<&[u8]> {
+        self.line.as_bytes().get(self.key_len + 1..)
     }
 }
 
-/// A Windows child reads the first block entry matching a name case-insensitively,
-/// so `{ ...process.env, PATH }` (`Path` in process.env) would keep the parent's
-/// value. Keep the lexicographically first spelling of each name, like node:
-/// https://github.com/nodejs/node/blob/v26.3.0/lib/child_process.js#L715-L738
-/// Unlike node this folds ASCII only (as bun's env maps do) and never sees
-/// `undefined` properties, so `{ HTTP_PROXY: undefined, http_proxy: url }` sets the proxy.
+/// Windows names are case-insensitive and the child reads the first matching block
+/// entry, so `{ ...process.env, PATH: dir }` (spelled `Path` by process.env) would
+/// keep the parent's value. Apply the object like assignments to a Windows
+/// `process.env` (ASCII-folded names, as bun's env maps use): per name the last
+/// property wins and an `undefined` one removes it. node:child_process applies
+/// node's own rule in JS before reaching this.
 fn dedupe_env_names_windows(lines: &mut Vec<EnvLine>) {
     fn cmp_names(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
         a.iter()
             .map(u8::to_ascii_uppercase)
             .cmp(b.iter().map(u8::to_ascii_uppercase))
     }
-    // Own property names are distinct, so the byte-wise tie-break is total.
-    lines.sort_unstable_by(|a, b| cmp_names(a.key(), b.key()).then_with(|| a.key().cmp(b.key())));
-    lines.dedup_by(|later, first| cmp_names(later.key(), first.key()).is_eq());
+    // After reversing, a stable sort leaves each name's last property first in
+    // its group, which is the one `dedup_by` keeps. libuv re-sorts the block.
+    lines.reverse();
+    lines.sort_by(|a, b| cmp_names(a.key(), b.key()));
+    lines.dedup_by(|other, kept| cmp_names(other.key(), kept.key()).is_eq());
 }
 
 /// `storage` receives ownership of every `K=V\0` line whose pointer is pushed
@@ -2132,6 +2151,9 @@ fn append_envp_from_js(
     while let Some(key) = object_iter.next()? {
         let value = object_iter.value;
         if value.is_undefined() {
+            if cfg!(windows) {
+                lines.push(EnvLine::new(&key, None)?);
+            }
             continue;
         }
 
@@ -2163,19 +2185,7 @@ fn append_envp_from_js(
                 .throw());
         }
 
-        // PERF: per-entry allocation — profile if it shows up on a hot path.
-        let line: EnvLine = {
-            let mut buf: Vec<u8> = Vec::new();
-            write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
-            let key_len = buf.len();
-            write!(&mut buf, "={}", value_bunstr.to_zig_string())
-                .map_err(|_| JsError::OutOfMemory)?;
-            EnvLine {
-                line: ZBox::from_vec(buf),
-                key_len,
-            }
-        };
-        lines.push(line);
+        lines.push(EnvLine::new(&key, Some(value_bunstr.to_zig_string()))?);
     }
 
     if cfg!(windows) {
@@ -2191,6 +2201,10 @@ fn append_envp_from_js(
     );
     storage.reserve(lines.len());
     for entry in lines {
+        let Some(value) = entry.value() else {
+            continue;
+        };
+
         // Windows environment variable names are case-insensitive: an env
         // object carrying `Path` (the usual casing there) must still drive
         // the executable lookup, like libuv's spawn does.
@@ -2203,7 +2217,7 @@ fn append_envp_from_js(
             // SAFETY: `entry.line` is moved into `storage` below (a `Vec<ZBox>`
             // that outlives every read of `*path`), and `ZBox` is heap-backed so
             // the bytes don't move when the `ZBox` value itself is moved.
-            *path = unsafe { bun_ptr::detach_lifetime(entry.value()) };
+            *path = unsafe { bun_ptr::detach_lifetime(value) };
         }
 
         envp.push(entry.line.as_ptr());

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -7,7 +7,7 @@ use crate::ipc as IPC;
 #[cfg(not(windows))]
 use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
-use bun_core::{String as BunString, ZStr, ZigString, strings};
+use bun_core::{String as BunString, ZStr, strings};
 use bun_event_loop::SpawnSyncEventLoop::TickState;
 use bun_io::max_buf::MaxBuf;
 use bun_jsc::{
@@ -2075,53 +2075,33 @@ fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsEr
     global_this.throw_value(err.to_error_instance(global_this))
 }
 
-/// One `env` property as the `KEY=VALUE` line handed to the child. On Windows an
-/// `undefined` property is kept as a bare `KEY` so that it removes the other
-/// spellings of its name in `dedupe_env_names_windows`; it is never emitted.
+/// One `KEY=VALUE` line of the child's environment.
 struct EnvLine {
     line: ZBox,
     key_len: usize,
 }
 
 impl EnvLine {
-    // PERF: per-entry allocation — profile if it shows up on a hot path.
-    fn new(key: &BunString, value: Option<ZigString>) -> JsResult<EnvLine> {
-        let mut buf: Vec<u8> = Vec::new();
-        write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
-        let key_len = buf.len();
-        if let Some(value) = value {
-            write!(&mut buf, "={}", value).map_err(|_| JsError::OutOfMemory)?;
-        }
-        Ok(EnvLine {
-            line: ZBox::from_vec(buf),
-            key_len,
-        })
-    }
-
     fn key(&self) -> &[u8] {
         &self.line.as_bytes()[..self.key_len]
     }
 
-    /// `None` for an `undefined` property.
-    fn value(&self) -> Option<&[u8]> {
-        self.line.as_bytes().get(self.key_len + 1..)
+    fn value(&self) -> &[u8] {
+        &self.line.as_bytes()[self.key_len + 1..]
     }
 }
 
 /// Windows names are case-insensitive and the child reads the first matching block
 /// entry, so `{ ...process.env, PATH: dir }` (spelled `Path` by process.env) would
-/// keep the parent's value. Apply the object like assignments to a Windows
-/// `process.env` (ASCII-folded names, as bun's env maps use): per name the last
-/// property wins and an `undefined` one removes it. node:child_process applies
-/// node's own rule in JS before reaching this.
+/// keep the parent's value. As with bun's env maps on Windows (ASCII-folded names,
+/// later writes win), the last property of each name is the one passed on.
 fn dedupe_env_names_windows(lines: &mut Vec<EnvLine>) {
     fn cmp_names(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
         a.iter()
             .map(u8::to_ascii_uppercase)
             .cmp(b.iter().map(u8::to_ascii_uppercase))
     }
-    // After reversing, a stable sort leaves each name's last property first in
-    // its group, which is the one `dedup_by` keeps. libuv re-sorts the block.
+    // Reversed plus a stable sort puts each name's last property first in its run.
     lines.reverse();
     lines.sort_by(|a, b| cmp_names(a.key(), b.key()));
     lines.dedup_by(|other, kept| cmp_names(other.key(), kept.key()).is_eq());
@@ -2151,9 +2131,6 @@ fn append_envp_from_js(
     while let Some(key) = object_iter.next()? {
         let value = object_iter.value;
         if value.is_undefined() {
-            if cfg!(windows) {
-                lines.push(EnvLine::new(&key, None)?);
-            }
             continue;
         }
 
@@ -2185,7 +2162,19 @@ fn append_envp_from_js(
                 .throw());
         }
 
-        lines.push(EnvLine::new(&key, Some(value_bunstr.to_zig_string()))?);
+        // PERF: per-entry allocation — profile if it shows up on a hot path.
+        let line: EnvLine = {
+            let mut buf: Vec<u8> = Vec::new();
+            write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
+            let key_len = buf.len();
+            write!(&mut buf, "={}", value_bunstr.to_zig_string())
+                .map_err(|_| JsError::OutOfMemory)?;
+            EnvLine {
+                line: ZBox::from_vec(buf),
+                key_len,
+            }
+        };
+        lines.push(line);
     }
 
     if cfg!(windows) {
@@ -2201,10 +2190,6 @@ fn append_envp_from_js(
     );
     storage.reserve(lines.len());
     for entry in lines {
-        let Some(value) = entry.value() else {
-            continue;
-        };
-
         // Windows environment variable names are case-insensitive: an env
         // object carrying `Path` (the usual casing there) must still drive
         // the executable lookup, like libuv's spawn does.
@@ -2217,7 +2202,7 @@ fn append_envp_from_js(
             // SAFETY: `entry.line` is moved into `storage` below (a `Vec<ZBox>`
             // that outlives every read of `*path`), and `ZBox` is heap-backed so
             // the bytes don't move when the `ZBox` value itself is moved.
-            *path = unsafe { bun_ptr::detach_lifetime(value) };
+            *path = unsafe { bun_ptr::detach_lifetime(entry.value()) };
         }
 
         envp.push(entry.line.as_ptr());

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -7,7 +7,7 @@ use crate::ipc as IPC;
 #[cfg(not(windows))]
 use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
-use bun_core::{String as BunString, ZStr, strings};
+use bun_core::{String as BunString, ZStr, ZigString, strings};
 use bun_event_loop::SpawnSyncEventLoop::TickState;
 use bun_io::max_buf::MaxBuf;
 use bun_jsc::{
@@ -2085,6 +2085,20 @@ struct EnvLine {
 }
 
 impl EnvLine {
+    // PERF: per-entry allocation — profile if it shows up on a hot path.
+    fn new(key: &BunString, value: Option<ZigString>) -> JsResult<EnvLine> {
+        let mut buf: Vec<u8> = Vec::new();
+        write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
+        let key_len = buf.len();
+        if let Some(value) = value {
+            write!(&mut buf, "={}", value).map_err(|_| JsError::OutOfMemory)?;
+        }
+        Ok(EnvLine {
+            line: ZBox::from_vec(buf),
+            key_len,
+        })
+    }
+
     fn key(&self) -> &[u8] {
         &self.line.as_bytes()[..self.key_len]
     }
@@ -2139,52 +2153,42 @@ fn append_envp_from_js(
     let mut lines: Vec<EnvLine> = Vec::with_capacity(object_iter.len);
     while let Some(key) = object_iter.next()? {
         let value = object_iter.value;
-        if value.is_undefined() && !cfg!(windows) {
+        if value.is_undefined() {
+            if cfg!(windows) {
+                lines.push(EnvLine::new(&key, None)?);
+            }
             continue;
         }
 
-        // PERF: per-entry allocation — profile if it shows up on a hot path.
-        let mut buf: Vec<u8> = Vec::new();
-        write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
-        let key_len = buf.len();
+        let value_bunstr = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
 
-        if !value.is_undefined() {
-            let value_bunstr = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
-
-            // Check for null bytes in env key and value (security: prevent null byte injection)
-            if key.index_of_ascii_char(0).is_some() {
-                return Err(global_this
-                    .err(
-                        jsc::ErrorCode::INVALID_ARG_VALUE,
-                        format_args!(
-                            "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
-                            key.to_zig_string(),
-                            key.to_zig_string()
-                        ),
-                    )
-                    .throw());
-            }
-            if value_bunstr.index_of_ascii_char(0).is_some() {
-                return Err(global_this
-                    .err(
-                        jsc::ErrorCode::INVALID_ARG_VALUE,
-                        format_args!(
-                            "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
-                            key.to_zig_string(),
-                            value_bunstr.to_zig_string()
-                        ),
-                    )
-                    .throw());
-            }
-
-            write!(&mut buf, "={}", value_bunstr.to_zig_string())
-                .map_err(|_| JsError::OutOfMemory)?;
+        // Check for null bytes in env key and value (security: prevent null byte injection)
+        if key.index_of_ascii_char(0).is_some() {
+            return Err(global_this
+                .err(
+                    jsc::ErrorCode::INVALID_ARG_VALUE,
+                    format_args!(
+                        "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
+                        key.to_zig_string(),
+                        key.to_zig_string()
+                    ),
+                )
+                .throw());
+        }
+        if value_bunstr.index_of_ascii_char(0).is_some() {
+            return Err(global_this
+                .err(
+                    jsc::ErrorCode::INVALID_ARG_VALUE,
+                    format_args!(
+                        "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
+                        key.to_zig_string(),
+                        value_bunstr.to_zig_string()
+                    ),
+                )
+                .throw());
         }
 
-        lines.push(EnvLine {
-            line: ZBox::from_vec(buf),
-            key_len,
-        });
+        lines.push(EnvLine::new(&key, Some(value_bunstr.to_zig_string()))?);
     }
 
     if cfg!(windows) {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -7,7 +7,7 @@ use crate::ipc as IPC;
 #[cfg(not(windows))]
 use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
-use bun_core::{String as BunString, ZStr, ZigString, strings};
+use bun_core::{String as BunString, ZStr, strings};
 use bun_event_loop::SpawnSyncEventLoop::TickState;
 use bun_io::max_buf::MaxBuf;
 use bun_jsc::{
@@ -2075,50 +2075,30 @@ fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsEr
     global_this.throw_value(err.to_error_instance(global_this))
 }
 
-/// One property of the `env` option, formatted as the `KEY=VALUE` line handed
-/// to the child. On Windows a property whose value is `undefined` is kept as a
-/// bare `KEY` so that it still claims its name in `dedupe_env_names_windows`;
-/// it is never passed to the child.
+/// One `KEY=VALUE` line of the child's environment.
 struct EnvLine {
     line: ZBox,
     key_len: usize,
 }
 
 impl EnvLine {
-    // PERF: per-entry allocation — profile if it shows up on a hot path.
-    fn new(key: &BunString, value: Option<ZigString>) -> JsResult<EnvLine> {
-        let mut buf: Vec<u8> = Vec::new();
-        write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
-        let key_len = buf.len();
-        if let Some(value) = value {
-            write!(&mut buf, "={}", value).map_err(|_| JsError::OutOfMemory)?;
-        }
-        Ok(EnvLine {
-            line: ZBox::from_vec(buf),
-            key_len,
-        })
-    }
-
     fn key(&self) -> &[u8] {
         &self.line.as_bytes()[..self.key_len]
     }
 
-    /// `None` when the property's value was `undefined`.
-    fn value(&self) -> Option<&[u8]> {
-        self.line.as_bytes().get(self.key_len + 1..)
+    fn value(&self) -> &[u8] {
+        &self.line.as_bytes()[self.key_len + 1..]
     }
 }
 
-/// Windows environment variable names are case-insensitive and the child
-/// resolves a name to the first matching entry of its environment block, so
-/// `{ ...process.env, PATH }` (which `process.env` spells `Path` there) would
-/// otherwise silently keep the parent's value. Keep one entry per name, picking
-/// the same one as node's `child_process` (mirrored in
-/// `src/js/node/child_process.ts`): the first key in lexicographic order, so
-/// `PATH` beats `Path` beats `path` whatever the insertion order. An
-/// `undefined` property takes part in this and, when it wins, removes the
-/// variable, exactly as in node.
+/// A Windows child reads the first block entry matching a name case-insensitively,
+/// so `{ ...process.env, PATH }` (`Path` in process.env) would keep the parent's
+/// value. Keep the lexicographically first spelling of each name, like node:
 /// https://github.com/nodejs/node/blob/v26.3.0/lib/child_process.js#L715-L738
+/// Deliberately unlike node, names fold ASCII case only (as bun's env maps do on
+/// Windows) and `undefined` properties were already dropped, so
+/// `{ HTTP_PROXY: undefined, http_proxy: url }` sets the proxy (node's key sort
+/// makes it set nothing). Output order is irrelevant: libuv re-sorts the block.
 fn dedupe_env_names_windows(lines: &mut Vec<EnvLine>) {
     fn cmp_names(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
         a.iter()
@@ -2154,9 +2134,6 @@ fn append_envp_from_js(
     while let Some(key) = object_iter.next()? {
         let value = object_iter.value;
         if value.is_undefined() {
-            if cfg!(windows) {
-                lines.push(EnvLine::new(&key, None)?);
-            }
             continue;
         }
 
@@ -2188,7 +2165,19 @@ fn append_envp_from_js(
                 .throw());
         }
 
-        lines.push(EnvLine::new(&key, Some(value_bunstr.to_zig_string()))?);
+        // PERF: per-entry allocation — profile if it shows up on a hot path.
+        let line: EnvLine = {
+            let mut buf: Vec<u8> = Vec::new();
+            write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
+            let key_len = buf.len();
+            write!(&mut buf, "={}", value_bunstr.to_zig_string())
+                .map_err(|_| JsError::OutOfMemory)?;
+            EnvLine {
+                line: ZBox::from_vec(buf),
+                key_len,
+            }
+        };
+        lines.push(line);
     }
 
     if cfg!(windows) {
@@ -2204,10 +2193,6 @@ fn append_envp_from_js(
     );
     storage.reserve(lines.len());
     for entry in lines {
-        let Some(value) = entry.value() else {
-            continue;
-        };
-
         // Windows environment variable names are case-insensitive: an env
         // object carrying `Path` (the usual casing there) must still drive
         // the executable lookup, like libuv's spawn does.
@@ -2220,7 +2205,7 @@ fn append_envp_from_js(
             // SAFETY: `entry.line` is moved into `storage` below (a `Vec<ZBox>`
             // that outlives every read of `*path`), and `ZBox` is heap-backed so
             // the bytes don't move when the `ZBox` value itself is moved.
-            *path = unsafe { bun_ptr::detach_lifetime(value) };
+            *path = unsafe { bun_ptr::detach_lifetime(entry.value()) };
         }
 
         envp.push(entry.line.as_ptr());

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2075,6 +2075,47 @@ fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsEr
     global_this.throw_value(err.to_error_instance(global_this))
 }
 
+/// One property of the `env` option, formatted as the `KEY=VALUE` line handed
+/// to the child. On Windows a property whose value is `undefined` is kept as a
+/// bare `KEY` so that it still claims its name in `dedupe_env_names_windows`;
+/// it is never passed to the child.
+struct EnvLine {
+    line: ZBox,
+    key_len: usize,
+}
+
+impl EnvLine {
+    fn key(&self) -> &[u8] {
+        &self.line.as_bytes()[..self.key_len]
+    }
+
+    /// `None` when the property's value was `undefined`.
+    fn value(&self) -> Option<&[u8]> {
+        self.line.as_bytes().get(self.key_len + 1..)
+    }
+}
+
+/// Windows environment variable names are case-insensitive and the child
+/// resolves a name to the first matching entry of its environment block, so
+/// `{ ...process.env, PATH }` (which `process.env` spells `Path` there) would
+/// otherwise silently keep the parent's value. Keep one entry per name, picking
+/// the same one as node's `child_process` (mirrored in
+/// `src/js/node/child_process.ts`): the first key in lexicographic order, so
+/// `PATH` beats `Path` beats `path` whatever the insertion order. An
+/// `undefined` property takes part in this and, when it wins, removes the
+/// variable, exactly as in node.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/child_process.js#L715-L738
+fn dedupe_env_names_windows(lines: &mut Vec<EnvLine>) {
+    fn cmp_names(a: &[u8], b: &[u8]) -> core::cmp::Ordering {
+        a.iter()
+            .map(u8::to_ascii_uppercase)
+            .cmp(b.iter().map(u8::to_ascii_uppercase))
+    }
+    // Own property names are distinct, so the byte-wise tie-break is total.
+    lines.sort_unstable_by(|a, b| cmp_names(a.key(), b.key()).then_with(|| a.key().cmp(b.key())));
+    lines.dedup_by(|later, first| cmp_names(later.key(), first.key()).is_eq());
+}
+
 /// `storage` receives ownership of every `K=V\0` line whose pointer is pushed
 /// into `envp` (and, for `PATH=`, sliced into `*path`); the caller's
 /// `Vec<ZBox>` is dropped after `spawn_process` returns.
@@ -2095,75 +2136,91 @@ fn append_envp_from_js(
     )?;
     // drops at scope exit (was `defer object_iter.deinit()`).
 
+    let mut lines: Vec<EnvLine> = Vec::with_capacity(object_iter.len);
+    while let Some(key) = object_iter.next()? {
+        let value = object_iter.value;
+        if value.is_undefined() && !cfg!(windows) {
+            continue;
+        }
+
+        // PERF: per-entry allocation — profile if it shows up on a hot path.
+        let mut buf: Vec<u8> = Vec::new();
+        write!(&mut buf, "{}", key).map_err(|_| JsError::OutOfMemory)?;
+        let key_len = buf.len();
+
+        if !value.is_undefined() {
+            let value_bunstr = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
+
+            // Check for null bytes in env key and value (security: prevent null byte injection)
+            if key.index_of_ascii_char(0).is_some() {
+                return Err(global_this
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
+                            key.to_zig_string(),
+                            key.to_zig_string()
+                        ),
+                    )
+                    .throw());
+            }
+            if value_bunstr.index_of_ascii_char(0).is_some() {
+                return Err(global_this
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
+                            key.to_zig_string(),
+                            value_bunstr.to_zig_string()
+                        ),
+                    )
+                    .throw());
+            }
+
+            write!(&mut buf, "={}", value_bunstr.to_zig_string())
+                .map_err(|_| JsError::OutOfMemory)?;
+        }
+
+        lines.push(EnvLine {
+            line: ZBox::from_vec(buf),
+            key_len,
+        });
+    }
+
+    if cfg!(windows) {
+        dedupe_env_names_windows(&mut lines);
+    }
+
     envp.reserve_exact(
-        (object_iter.len +
+        (lines.len() +
             // +1 incase there's IPC
             // +1 for null terminator
             2)
         .saturating_sub(envp.len()),
     );
-    storage.reserve(object_iter.len);
-    while let Some(key) = object_iter.next()? {
-        let value = object_iter.value;
-        if value.is_undefined() {
+    storage.reserve(lines.len());
+    for entry in lines {
+        let Some(value) = entry.value() else {
             continue;
-        }
-
-        let value_bunstr = bun_core::OwnedString::new(value.to_bun_string(global_this)?);
-
-        // Check for null bytes in env key and value (security: prevent null byte injection)
-        if key.index_of_ascii_char(0).is_some() {
-            return Err(global_this
-                .err(
-                    jsc::ErrorCode::INVALID_ARG_VALUE,
-                    format_args!(
-                        "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
-                        key.to_zig_string(),
-                        key.to_zig_string()
-                    ),
-                )
-                .throw());
-        }
-        if value_bunstr.index_of_ascii_char(0).is_some() {
-            return Err(global_this
-                .err(
-                    jsc::ErrorCode::INVALID_ARG_VALUE,
-                    format_args!(
-                        "The property 'options.env['{}']' must be a string without null bytes. Received \"{}\"",
-                        key.to_zig_string(),
-                        value_bunstr.to_zig_string()
-                    ),
-                )
-                .throw());
-        }
-
-        // PERF: per-entry allocation — profile if it shows up on a hot path.
-        let line: ZBox = {
-            let mut buf: Vec<u8> = Vec::new();
-            write!(&mut buf, "{}={}", key, value_bunstr.to_zig_string())
-                .map_err(|_| JsError::OutOfMemory)?;
-            ZBox::from_vec(buf)
         };
 
         // Windows environment variable names are case-insensitive: an env
         // object carrying `Path` (the usual casing there) must still drive
         // the executable lookup, like libuv's spawn does.
-        let line_bytes = line.as_bytes();
-        let key_end = strings::index_of_char_usize(line_bytes, b'=').unwrap_or(line_bytes.len());
         let is_path_key = if cfg!(windows) {
-            strings::eql_case_insensitive_ascii(&line_bytes[..key_end], b"PATH", true)
+            strings::eql_case_insensitive_ascii(entry.key(), b"PATH", true)
         } else {
-            &line_bytes[..key_end] == b"PATH"
+            entry.key() == b"PATH"
         };
-        if is_path_key && key_end < line_bytes.len() {
-            // SAFETY: `line` is moved into `storage` below (a `Vec<ZBox>` that
-            // outlives every read of `*path`), and `ZBox` is heap-backed so the
-            // bytes don't move when the `ZBox` value itself is moved.
-            *path = unsafe { bun_ptr::detach_lifetime(&line_bytes[key_end + 1..]) };
+        if is_path_key {
+            // SAFETY: `entry.line` is moved into `storage` below (a `Vec<ZBox>`
+            // that outlives every read of `*path`), and `ZBox` is heap-backed so
+            // the bytes don't move when the `ZBox` value itself is moved.
+            *path = unsafe { bun_ptr::detach_lifetime(value) };
         }
 
-        envp.push(line.as_ptr());
-        storage.push(line);
+        envp.push(entry.line.as_ptr());
+        storage.push(entry.line);
     }
     Ok(())
 }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1423,12 +1423,11 @@ export function joinP(...paths: string[]) {
  * Merges env objects so that a later object's value wins even when it spells
  * a variable name differently (Windows has case-insensitive environment
  * variables, so bunEnv carries `Path` while overrides are usually written as
- * `PATH`). The merged object keeps the first spelling seen for each name.
+ * `PATH`). The merged object keeps the first spelling seen for each name and
+ * drops empty values.
  *
- * Bun.spawn itself de-duplicates such names on Windows the way node's
- * child_process does (the upper-case spelling wins), so a plain
- * `{ ...bunEnv, PATH: "..." }` works too; this helper additionally drops
- * empty values and lets a lower-case override win over an upper-case base.
+ * Bun.spawn applies the same later-property-wins rule to its env object on
+ * Windows itself, so a plain `{ ...bunEnv, PATH: "..." }` works as well.
  */
 export function mergeWindowEnvs(envs: Record<string, string | undefined>[]) {
   const keys: Record<string, string | undefined> = {};

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1420,25 +1420,15 @@ export function joinP(...paths: string[]) {
 }
 
 /**
- * TODO: see if this is the default behavior of node child_process APIs if so,
- * we need to do case-insensitive stuff within our Bun.spawn implementation
+ * Merges env objects so that a later object's value wins even when it spells
+ * a variable name differently (Windows has case-insensitive environment
+ * variables, so bunEnv carries `Path` while overrides are usually written as
+ * `PATH`). The merged object keeps the first spelling seen for each name.
  *
- * Windows has case-insensitive environment variables, so sometimes an
- * object like { Path: "...", PATH: "..." } will be passed. Bun lets
- * the first one win, but we really want the LAST one to win.
- *
- * This is mostly needed if you want to override env vars, such like:
- *   env: {
- *     ...bunEnv,
- *     PATH: "my path override here",
- *   }
- * becomes
- *   env: mergeWindowEnvs([
- *     bunEnv,
- *     {
- *       PATH: "my path override here",
- *     },
- *   ])
+ * Bun.spawn itself de-duplicates such names on Windows the way node's
+ * child_process does (the upper-case spelling wins), so a plain
+ * `{ ...bunEnv, PATH: "..." }` works too; this helper additionally drops
+ * empty values and lets a lower-case override win over an upper-case base.
  */
 export function mergeWindowEnvs(envs: Record<string, string | undefined>[]) {
   const keys: Record<string, string | undefined> = {};

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -1,9 +1,9 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test("spawn env", async () => {
   const env = {};

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -63,10 +63,13 @@ function variableViaSpawnSync(name: string, env: Env) {
 }
 
 describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
-  // The object is applied the way assigning its properties to process.env would
-  // be: of the properties whose names differ only in case, the last one is what
-  // the child gets, and an undefined one removes the variable. (node:child_process
-  // keeps node's own rule, applied in JS before the object reaches Bun.spawn.)
+  // Of the properties whose names differ only in case, the last one is what the
+  // child gets, as with every other env object in bun on Windows. Properties set
+  // to undefined are skipped before that, as on POSIX, so the usual way of
+  // clearing every spelling and then setting one works whichever spelling is set
+  // (a `[key]: value` after the undefined ones lands wherever that key already
+  // was, see the scheme cases in test/js/bun/http/proxy.test.ts).
+  // node:child_process keeps node's own rule, applied in JS before Bun.spawn.
   const cases: [name: string, env: Env, variable: string, expected: Env][] = [
     [
       "{ ...process.env, PATH } overrides the parent's Path",
@@ -99,22 +102,16 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
       { Spawn_Env_Case: "second" },
     ],
     [
-      "{ SPAWN_ENV_CASE: undefined, spawn_env_case }: clearing every spelling, then setting one",
+      "{ SPAWN_ENV_CASE: undefined, spawn_env_case: set }: the set spelling is passed",
       { ...bunEnv, SPAWN_ENV_CASE: undefined, spawn_env_case: "set" },
       "SPAWN_ENV_CASE",
       { spawn_env_case: "set" },
     ],
     [
-      "{ ...env, SPAWN_ENV_CASE: undefined } removes a differently spelled variable",
-      { ...bunEnv, Spawn_Env_Case: "inherited", SPAWN_ENV_CASE: undefined },
+      "{ SPAWN_ENV_CASE: set, spawn_env_case: undefined }: the set spelling is passed",
+      { ...bunEnv, SPAWN_ENV_CASE: "set", spawn_env_case: undefined },
       "SPAWN_ENV_CASE",
-      {},
-    ],
-    [
-      "{ ...env, spawn_env_case: undefined } removes a differently spelled variable",
-      { ...bunEnv, SPAWN_ENV_CASE: "inherited", spawn_env_case: undefined },
-      "SPAWN_ENV_CASE",
-      {},
+      { SPAWN_ENV_CASE: "set" },
     ],
   ];
 

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -108,18 +108,6 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
       "SPAWN_ENV_CASE",
       { Spawn_Env_Case: "mixed" },
     ],
-    [
-      "{ Spawn_Env_Case, SPAWN_ENV_CASE: undefined } removes the variable",
-      { ...bunEnv, Spawn_Env_Case: "mixed", SPAWN_ENV_CASE: undefined },
-      "SPAWN_ENV_CASE",
-      {},
-    ],
-    [
-      "{ SPAWN_ENV_CASE, spawn_env_case: undefined } keeps the upper case one",
-      { ...bunEnv, SPAWN_ENV_CASE: "upper", spawn_env_case: undefined },
-      "SPAWN_ENV_CASE",
-      { SPAWN_ENV_CASE: "upper" },
-    ],
   ];
 
   test.concurrent.each(cases)("%s", async (_name, env, variable, expected) => {
@@ -130,9 +118,37 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
     expect({ spawn: viaSpawn, childProcess: viaChildProcess }).toEqual({ spawn: expected, childProcess: expected });
   });
 
-  test.concurrent("Bun.spawnSync applies the same rule", () => {
+  test("Bun.spawnSync applies the same rule", () => {
     const [, env, variable, expected] = cases[0];
     expect(variableViaSpawnSync(variable, env)).toEqual(expected);
+  });
+
+  // An undefined property is simply absent; it does not take the name away from
+  // another spelling. Tests all over the repo clear every spelling of a variable
+  // with undefined and then set one of them (see test/js/bun/http/proxy.test.ts).
+  // This is deliberately not what node's child_process does on Windows: it picks
+  // the spelling to keep before looking at the values, so whenever the undefined
+  // spelling sorts first the variable ends up unset.
+  const undefinedCases: [name: string, env: Env, expected: Env][] = [
+    [
+      "{ SPAWN_ENV_CASE: undefined, spawn_env_case }: the defined spelling is passed",
+      { ...bunEnv, SPAWN_ENV_CASE: undefined, spawn_env_case: "lower" },
+      { spawn_env_case: "lower" },
+    ],
+    [
+      "{ Spawn_Env_Case, SPAWN_ENV_CASE: undefined }: the defined spelling is passed",
+      { ...bunEnv, Spawn_Env_Case: "mixed", SPAWN_ENV_CASE: undefined },
+      { Spawn_Env_Case: "mixed" },
+    ],
+    [
+      "{ SPAWN_ENV_CASE, spawn_env_case: undefined }: the defined spelling is passed",
+      { ...bunEnv, SPAWN_ENV_CASE: "upper", spawn_env_case: undefined },
+      { SPAWN_ENV_CASE: "upper" },
+    ],
+  ];
+
+  test.concurrent.each(undefinedCases)("%s", async (_name, env, expected) => {
+    expect(await variableViaSpawn("SPAWN_ENV_CASE", env)).toEqual(expected);
   });
 
   // The PATH entry that wins is also the one the executable is looked up in.

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -1,6 +1,8 @@
 import { spawn } from "bun";
-import { test } from "bun:test";
-import { bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { spawnSync as nodeSpawnSync } from "node:child_process";
+import { join } from "node:path";
 
 test("spawn env", async () => {
   const env = {};
@@ -21,4 +23,147 @@ test("spawn env", async () => {
       });
     } catch (e) {}
   }
+});
+
+// Prints, as one JSON object, every variable of the child whose name is `name`
+// in any casing, so the test sees both which spelling the child got and its value.
+function printVariable(name: string) {
+  const upper = JSON.stringify(name.toUpperCase());
+  return `console.log(JSON.stringify(Object.fromEntries(Object.entries(process.env).filter(([k]) => k.toUpperCase() === ${upper}))))`;
+}
+
+type Env = Record<string, string | undefined>;
+
+// bunEnv without the parent's own PATH entry (spelled `Path` or `PATH` depending
+// on what launched the test), so each case below controls every PATH spelling.
+const envWithoutPath: Env = Object.fromEntries(Object.entries(bunEnv).filter(([k]) => k.toUpperCase() !== "PATH"));
+
+async function variableViaSpawn(name: string, env: Env) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", printVariable(name)],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+function variableViaSpawnSync(name: string, env: Env) {
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [bunExe(), "-e", printVariable(name)],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stderr.toString()).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout.toString());
+}
+
+function variableViaChildProcess(name: string, env: Env) {
+  const { stdout, stderr, status } = nodeSpawnSync(bunExe(), ["-e", printVariable(name)], { env, encoding: "utf8" });
+  expect(stderr).toBe("");
+  expect(status).toBe(0);
+  return JSON.parse(stdout);
+}
+
+describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
+  // Same rule as node's child_process (normalizeSpawnArguments): of the keys
+  // that differ only in case, the lexicographically first one (so the upper
+  // case spelling) is passed to the child, whatever order they were added in.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/child_process.js#L715-L738
+  const cases: [name: string, env: Env, variable: string, expected: Env][] = [
+    [
+      "{ ...process.env, PATH } overrides the parent's Path",
+      { ...envWithoutPath, Path: "C:\\from-parent", PATH: "C:\\override" },
+      "PATH",
+      { PATH: "C:\\override" },
+    ],
+    [
+      "{ PATH, Path }: PATH still wins when added first",
+      { ...envWithoutPath, PATH: "C:\\override", Path: "C:\\from-parent" },
+      "PATH",
+      { PATH: "C:\\override" },
+    ],
+    [
+      "{ Spawn_Env_Case, SPAWN_ENV_CASE }: upper case wins",
+      { ...bunEnv, Spawn_Env_Case: "mixed", SPAWN_ENV_CASE: "upper" },
+      "SPAWN_ENV_CASE",
+      { SPAWN_ENV_CASE: "upper" },
+    ],
+    [
+      "{ SPAWN_ENV_CASE, Spawn_Env_Case }: upper case wins when added first",
+      { ...bunEnv, SPAWN_ENV_CASE: "upper", Spawn_Env_Case: "mixed" },
+      "SPAWN_ENV_CASE",
+      { SPAWN_ENV_CASE: "upper" },
+    ],
+    [
+      "{ spawn_env_case, Spawn_Env_Case }: mixed case beats lower case",
+      { ...bunEnv, spawn_env_case: "lower", Spawn_Env_Case: "mixed" },
+      "SPAWN_ENV_CASE",
+      { Spawn_Env_Case: "mixed" },
+    ],
+    [
+      "{ Spawn_Env_Case, SPAWN_ENV_CASE: undefined } removes the variable",
+      { ...bunEnv, Spawn_Env_Case: "mixed", SPAWN_ENV_CASE: undefined },
+      "SPAWN_ENV_CASE",
+      {},
+    ],
+    [
+      "{ SPAWN_ENV_CASE, spawn_env_case: undefined } keeps the upper case one",
+      { ...bunEnv, SPAWN_ENV_CASE: "upper", spawn_env_case: undefined },
+      "SPAWN_ENV_CASE",
+      { SPAWN_ENV_CASE: "upper" },
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_name, env, variable, expected) => {
+    expect({
+      spawn: await variableViaSpawn(variable, env),
+      spawnSync: variableViaSpawnSync(variable, env),
+      childProcess: variableViaChildProcess(variable, env),
+    }).toEqual({ spawn: expected, spawnSync: expected, childProcess: expected });
+  });
+
+  // The PATH entry that wins is also the one the executable is looked up in.
+  // The tool is a batch file: cmd.exe re-resolves its name through the child's
+  // own PATH, so this only runs if the child received the winning entry too.
+  const lookupCases: [name: string, env: (withTool: string, withoutTool: string) => Env][] = [
+    [
+      "{ Path: without the tool, PATH: with the tool }",
+      (withTool, withoutTool) => ({ Path: withoutTool, PATH: withTool }),
+    ],
+    [
+      "{ PATH: with the tool, Path: without the tool }",
+      (withTool, withoutTool) => ({ PATH: withTool, Path: withoutTool }),
+    ],
+  ];
+
+  test.concurrent.each(lookupCases)("executable is looked up in the winning PATH: %s", async (_name, pathEntries) => {
+    using dir = tempDir("spawn-env-path", {
+      "with-tool/spawn-env-tool.cmd": "@echo off\r\necho TOOL_RAN\r\n",
+      "without-tool/.keep": "",
+    });
+    await using proc = Bun.spawn({
+      cmd: ["spawn-env-tool"],
+      env: { ...envWithoutPath, ...pathEntries(join(String(dir), "with-tool"), join(String(dir), "without-tool")) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "TOOL_RAN", stderr: "", exitCode: 0 });
+  });
+});
+
+test.skipIf(isWindows)("env names that differ only in case are distinct variables on POSIX", async () => {
+  const env = { ...bunEnv, Path: "C:\\from-parent", PATH: "C:\\override" };
+  const expected = { Path: "C:\\from-parent", PATH: "C:\\override" };
+  expect({
+    spawn: await variableViaSpawn("PATH", env),
+    spawnSync: variableViaSpawnSync("PATH", env),
+    childProcess: variableViaChildProcess("PATH", env),
+  }).toEqual({ spawn: expected, spawnSync: expected, childProcess: expected });
 });

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -1,9 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { execFile } from "node:child_process";
 import { join } from "node:path";
-import { promisify } from "node:util";
 
 test("spawn env", async () => {
   const env = {};
@@ -64,19 +62,11 @@ function variableViaSpawnSync(name: string, env: Env) {
   return JSON.parse(stdout.toString());
 }
 
-// node:child_process applies node's own de-duplication in JS before reaching
-// Bun.spawn, so this is the reference the Bun.spawn columns are compared to.
-async function variableViaChildProcess(name: string, env: Env) {
-  const { stdout, stderr } = await promisify(execFile)(bunExe(), ["-e", printVariable(name)], { env });
-  expect(stderr).toBe("");
-  return JSON.parse(stdout);
-}
-
 describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
-  // Same rule as node's child_process (normalizeSpawnArguments): of the keys
-  // that differ only in case, the lexicographically first one (so the upper
-  // case spelling) is passed to the child, whatever order they were added in.
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/child_process.js#L715-L738
+  // The object is applied the way assigning its properties to process.env would
+  // be: of the properties whose names differ only in case, the last one is what
+  // the child gets, and an undefined one removes the variable. (node:child_process
+  // keeps node's own rule, applied in JS before the object reaches Bun.spawn.)
   const cases: [name: string, env: Env, variable: string, expected: Env][] = [
     [
       "{ ...process.env, PATH } overrides the parent's Path",
@@ -85,70 +75,56 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
       { PATH: "C:\\override" },
     ],
     [
-      "{ PATH, Path }: PATH still wins when added first",
-      { ...envWithoutPath, PATH: "C:\\override", Path: "C:\\from-parent" },
+      "{ ...env, path } overrides an upper case PATH",
+      { ...envWithoutPath, PATH: "C:\\from-parent", path: "C:\\override" },
       "PATH",
-      { PATH: "C:\\override" },
+      { path: "C:\\override" },
     ],
     [
-      "{ Spawn_Env_Case, SPAWN_ENV_CASE }: upper case wins",
-      { ...bunEnv, Spawn_Env_Case: "mixed", SPAWN_ENV_CASE: "upper" },
+      "{ ...env, spawn_env_case } overrides an inherited SPAWN_ENV_CASE (the http_proxy over HTTP_PROXY shape)",
+      { ...bunEnv, SPAWN_ENV_CASE: "inherited", spawn_env_case: "override" },
       "SPAWN_ENV_CASE",
-      { SPAWN_ENV_CASE: "upper" },
+      { spawn_env_case: "override" },
     ],
     [
-      "{ SPAWN_ENV_CASE, Spawn_Env_Case }: upper case wins when added first",
-      { ...bunEnv, SPAWN_ENV_CASE: "upper", Spawn_Env_Case: "mixed" },
+      "{ Spawn_Env_Case, SPAWN_ENV_CASE }: the later one wins",
+      { ...bunEnv, Spawn_Env_Case: "first", SPAWN_ENV_CASE: "second" },
       "SPAWN_ENV_CASE",
-      { SPAWN_ENV_CASE: "upper" },
+      { SPAWN_ENV_CASE: "second" },
     ],
     [
-      "{ spawn_env_case, Spawn_Env_Case }: mixed case beats lower case",
-      { ...bunEnv, spawn_env_case: "lower", Spawn_Env_Case: "mixed" },
+      "{ SPAWN_ENV_CASE, Spawn_Env_Case }: the later one wins",
+      { ...bunEnv, SPAWN_ENV_CASE: "first", Spawn_Env_Case: "second" },
       "SPAWN_ENV_CASE",
-      { Spawn_Env_Case: "mixed" },
+      { Spawn_Env_Case: "second" },
+    ],
+    [
+      "{ SPAWN_ENV_CASE: undefined, spawn_env_case }: clearing every spelling, then setting one",
+      { ...bunEnv, SPAWN_ENV_CASE: undefined, spawn_env_case: "set" },
+      "SPAWN_ENV_CASE",
+      { spawn_env_case: "set" },
+    ],
+    [
+      "{ ...env, SPAWN_ENV_CASE: undefined } removes a differently spelled variable",
+      { ...bunEnv, Spawn_Env_Case: "inherited", SPAWN_ENV_CASE: undefined },
+      "SPAWN_ENV_CASE",
+      {},
+    ],
+    [
+      "{ ...env, spawn_env_case: undefined } removes a differently spelled variable",
+      { ...bunEnv, SPAWN_ENV_CASE: "inherited", spawn_env_case: undefined },
+      "SPAWN_ENV_CASE",
+      {},
     ],
   ];
 
   test.concurrent.each(cases)("%s", async (_name, env, variable, expected) => {
-    const [viaSpawn, viaChildProcess] = await Promise.all([
-      variableViaSpawn(variable, env),
-      variableViaChildProcess(variable, env),
-    ]);
-    expect({ spawn: viaSpawn, childProcess: viaChildProcess }).toEqual({ spawn: expected, childProcess: expected });
+    expect(await variableViaSpawn(variable, env)).toEqual(expected);
   });
 
   test("Bun.spawnSync applies the same rule", () => {
     const [, env, variable, expected] = cases[0];
     expect(variableViaSpawnSync(variable, env)).toEqual(expected);
-  });
-
-  // An undefined property is simply absent; it does not take the name away from
-  // another spelling. Tests all over the repo clear every spelling of a variable
-  // with undefined and then set one of them (see test/js/bun/http/proxy.test.ts).
-  // This is deliberately not what node's child_process does on Windows: it picks
-  // the spelling to keep before looking at the values, so whenever the undefined
-  // spelling sorts first the variable ends up unset.
-  const undefinedCases: [name: string, env: Env, expected: Env][] = [
-    [
-      "{ SPAWN_ENV_CASE: undefined, spawn_env_case }: the defined spelling is passed",
-      { ...bunEnv, SPAWN_ENV_CASE: undefined, spawn_env_case: "lower" },
-      { spawn_env_case: "lower" },
-    ],
-    [
-      "{ Spawn_Env_Case, SPAWN_ENV_CASE: undefined }: the defined spelling is passed",
-      { ...bunEnv, Spawn_Env_Case: "mixed", SPAWN_ENV_CASE: undefined },
-      { Spawn_Env_Case: "mixed" },
-    ],
-    [
-      "{ SPAWN_ENV_CASE, spawn_env_case: undefined }: the defined spelling is passed",
-      { ...bunEnv, SPAWN_ENV_CASE: "upper", spawn_env_case: undefined },
-      { SPAWN_ENV_CASE: "upper" },
-    ],
-  ];
-
-  test.concurrent.each(undefinedCases)("%s", async (_name, env, expected) => {
-    expect(await variableViaSpawn("SPAWN_ENV_CASE", env)).toEqual(expected);
   });
 
   // The PATH entry that wins is also the one the executable is looked up in.
@@ -160,8 +136,8 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
       (withTool, withoutTool) => ({ Path: withoutTool, PATH: withTool }),
     ],
     [
-      "{ PATH: with the tool, Path: without the tool }",
-      (withTool, withoutTool) => ({ PATH: withTool, Path: withoutTool }),
+      "{ PATH: without the tool, Path: with the tool }",
+      (withTool, withoutTool) => ({ PATH: withoutTool, Path: withTool }),
     ],
   ];
 
@@ -182,15 +158,16 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
 });
 
 test.skipIf(isWindows)("env names that differ only in case are distinct variables on POSIX", async () => {
-  const env = { ...bunEnv, Path: "C:\\from-parent", PATH: "C:\\override" };
-  const expected = { Path: "C:\\from-parent", PATH: "C:\\override" };
-  const [viaSpawn, viaChildProcess] = await Promise.all([
-    variableViaSpawn("PATH", env),
-    variableViaChildProcess("PATH", env),
-  ]);
-  expect({ spawn: viaSpawn, spawnSync: variableViaSpawnSync("PATH", env), childProcess: viaChildProcess }).toEqual({
-    spawn: expected,
-    spawnSync: expected,
-    childProcess: expected,
-  });
+  const env = {
+    ...bunEnv,
+    Path: "C:\\from-parent",
+    PATH: "C:\\override",
+    Spawn_Env_Case: "kept",
+    SPAWN_ENV_CASE: undefined,
+  };
+  const expected = [{ Path: "C:\\from-parent", PATH: "C:\\override" }, { Spawn_Env_Case: "kept" }];
+  expect({
+    spawn: await Promise.all([variableViaSpawn("PATH", env), variableViaSpawn("SPAWN_ENV_CASE", env)]),
+    spawnSync: [variableViaSpawnSync("PATH", env), variableViaSpawnSync("SPAWN_ENV_CASE", env)],
+  }).toEqual({ spawn: expected, spawnSync: expected });
 });

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -1,8 +1,9 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { spawnSync as nodeSpawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { join } from "node:path";
+import { promisify } from "node:util";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 test("spawn env", async () => {
   const env = {};
@@ -63,10 +64,11 @@ function variableViaSpawnSync(name: string, env: Env) {
   return JSON.parse(stdout.toString());
 }
 
-function variableViaChildProcess(name: string, env: Env) {
-  const { stdout, stderr, status } = nodeSpawnSync(bunExe(), ["-e", printVariable(name)], { env, encoding: "utf8" });
+// node:child_process applies node's own de-duplication in JS before reaching
+// Bun.spawn, so this is the reference the Bun.spawn columns are compared to.
+async function variableViaChildProcess(name: string, env: Env) {
+  const { stdout, stderr } = await promisify(execFile)(bunExe(), ["-e", printVariable(name)], { env });
   expect(stderr).toBe("");
-  expect(status).toBe(0);
   return JSON.parse(stdout);
 }
 
@@ -121,11 +123,16 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
   ];
 
   test.concurrent.each(cases)("%s", async (_name, env, variable, expected) => {
-    expect({
-      spawn: await variableViaSpawn(variable, env),
-      spawnSync: variableViaSpawnSync(variable, env),
-      childProcess: variableViaChildProcess(variable, env),
-    }).toEqual({ spawn: expected, spawnSync: expected, childProcess: expected });
+    const [viaSpawn, viaChildProcess] = await Promise.all([
+      variableViaSpawn(variable, env),
+      variableViaChildProcess(variable, env),
+    ]);
+    expect({ spawn: viaSpawn, childProcess: viaChildProcess }).toEqual({ spawn: expected, childProcess: expected });
+  });
+
+  test.concurrent("Bun.spawnSync applies the same rule", () => {
+    const [, env, variable, expected] = cases[0];
+    expect(variableViaSpawnSync(variable, env)).toEqual(expected);
   });
 
   // The PATH entry that wins is also the one the executable is looked up in.
@@ -161,9 +168,13 @@ describe.skipIf(!isWindows)("env names are case-insensitive on Windows", () => {
 test.skipIf(isWindows)("env names that differ only in case are distinct variables on POSIX", async () => {
   const env = { ...bunEnv, Path: "C:\\from-parent", PATH: "C:\\override" };
   const expected = { Path: "C:\\from-parent", PATH: "C:\\override" };
-  expect({
-    spawn: await variableViaSpawn("PATH", env),
-    spawnSync: variableViaSpawnSync("PATH", env),
-    childProcess: variableViaChildProcess("PATH", env),
-  }).toEqual({ spawn: expected, spawnSync: expected, childProcess: expected });
+  const [viaSpawn, viaChildProcess] = await Promise.all([
+    variableViaSpawn("PATH", env),
+    variableViaChildProcess("PATH", env),
+  ]);
+  expect({ spawn: viaSpawn, spawnSync: variableViaSpawnSync("PATH", env), childProcess: viaChildProcess }).toEqual({
+    spawn: expected,
+    spawnSync: expected,
+    childProcess: expected,
+  });
 });


### PR DESCRIPTION
### Problem

On Windows, `Bun.spawn` / `Bun.spawnSync` pass every property of the `env` object to the child as its own `KEY=VALUE` entry. Windows variable names are case-insensitive and `process.env` spells the variable `Path` there, so the usual override pattern produces an environment block with both `Path=<parent>` and `PATH=<override>`, and the child resolves the name to the first entry. The override is silently ignored:

```js
const env = { ...process.env, PATH: "C:\\only-this" };
const script = `console.log(JSON.stringify(Object.entries(process.env).filter(([k]) => k.toUpperCase() === "PATH")))`;

Bun.spawnSync({ cmd: [node, "-e", script], env }).stdout.toString();
// [["Path","C:\\Program Files\\PowerShell\\7;..."]]      parent's Path, override dropped
```

The same loop also took the *last* PATH-like property as the PATH used to look up `cmd[0]`, while the child effectively saw the *first*, so a single spawn could resolve the executable in one directory list and hand the child another. With a `.cmd` tool that only exists in the directory named by the later property, the lookup succeeds but the child's `cmd.exe` cannot find the tool.

This was the only env path in Bun that emitted duplicates. The inherited environment (`bun_dotenv::Map`, `src/dotenv/env_loader.rs`), the shell's `.env()` map (`src/runtime/shell/EnvMap.rs`), the worker env store (`src/jsc/bindings/SharedEnvStore.h`) and the test harness's `mergeWindowEnvs` are all ASCII-case-insensitive maps on Windows in which a later write replaces the value; `node:child_process` de-duplicates in JS (node's own rule) before the object reaches `Bun.spawn`. Repo tests that prepend a directory with `env: { ...bunEnv, PATH }` and spawn with `Bun.spawn` were not actually changing the child's PATH on the Windows lanes.

### Fix

`append_envp_from_js` (`src/runtime/api/bun/js_bun_spawn_bindings.rs`) now collects the formatted lines first and, on Windows, keeps one entry per ASCII-case-insensitive name before anything is pushed to `envp` (`dedupe_env_names_windows` is the fix; the rest of the hunk is the collect-then-emit reshuffle it needs). The lookup PATH is then taken from the entries that are actually emitted, so it is always the one the child receives.

The entry kept is the last property of that name in the object, i.e. the object is read the way every other env map in Bun reads writes on Windows: `{ ...base, PATH: dir }` wins whether `base` spells it `Path` or `PATH`, and `{ ...base, http_proxy: url }` wins on a machine whose environment carries `HTTP_PROXY`. Node's rule for `child_process` (keep the lexicographically first spelling) was considered and rejected: it handles the upper-case override but silently drops a lower-case one over an inherited upper-case variable, the mirror image of this bug, and it buys no consistency because `node:child_process` applies it in JS before calling `Bun.spawn` (and keeps doing so after this change; node's own ported `test-child-process-env.js` covers that layer).

Properties whose value is `undefined` are skipped before the de-duplication, exactly as before and as on POSIX. An earlier revision let them remove the other spellings; that breaks the common shape `{ A: undefined, a: undefined, [key]: value }`, because with `key === "A"` the value lands in `A`'s existing slot and the later `a: undefined` removed it (the scheme cases in `test/js/bun/http/proxy.test.ts`). Names are folded as ASCII, like the maps listed above.

POSIX is unchanged: names are case-sensitive there and a JS object cannot hold the same key twice. Not touched here: the shell's `.env()` map already collapses spellings for the child block, but its lookup PATH is still read with a byte-exact `key == "PATH"` (`src/runtime/shell/subproc.rs`) and a `PATH=x cmd` prefix can still add a second entry; those are being fixed separately in #36509 / #32200 and #36513.

### Tests

`test/js/bun/spawn/spawn-env.test.ts`:

- Windows: `{ ...env, PATH }` over `Path`, `{ ...env, path }` over `PATH`, a lower-case override over an inherited upper-case variable, both insertion orders of a mixed/upper pair, the two clear-then-set shapes with `undefined`, one `Bun.spawnSync` case, and two lookup cases where a `.cmd` tool exists only in the directory named by the later property (spelled `PATH` in one, `Path` in the other).
- POSIX: `{ Path, PATH }` still reaches the child as two variables and an `undefined` spelling is still just skipped, through `Bun.spawn` and `Bun.spawnSync`.

On windows-x64, released bun (`1.4.0-canary`, `827475e21`) fails 8 of the new cases (the child gets the first spelling, one lookup case exits 1 with `'spawn-env-tool' is not recognized as an internal or external command`, the other throws `ENOENT`); the two `undefined` shapes pass before and after and pin that behavior. With this change the file passes, as do `proxy.test.ts`, `spawn.test.ts`, `spawnSync.test.ts`, `spawn-path.test.ts`, `null-byte-injection.test.ts`, `bunx.test.ts` (whose decoy-on-PATH cases now really exercise PATH on Windows) and the `child_process` suites, on Windows and Linux. The bug is Windows-only, so the Windows cases are skipped on POSIX, where the file passes before and after.

The `mergeWindowEnvs` doc comment in `test/harness.ts` described the old behavior and is updated; the helper stays for its callers.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-env.test.ts

<!-- robobun:evidence:end -->