### PR TITLE
install: stop debug builds from wiping the shared node shim dir on every start

### DIFF
--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -562,13 +562,6 @@ impl RunCommand {
                 }
             };
 
-            #[cfg(bun_debug)]
-            {
-                // Debug-only cleanup; failures are ignored. The EEXIST branch
-                // below already handles a stale dir.
-                let _ = bun_sys::delete_tree_absolute(Self::BUN_NODE_DIR.as_bytes());
-            }
-
             const NODE_LINK: &ZStr = {
                 const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/node\0").as_bytes();
                 // SAFETY: literal ends in NUL; len excludes it.
@@ -608,13 +601,20 @@ impl RunCommand {
                     match bun_sys::symlink(argv0_z, dest) {
                         Ok(()) => break,
                         Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
-                            // The dir is keyed only on GIT_SHA_SHORT, so two
+                            // The dir is keyed only on GIT_SHA_SHORT (and is a
+                            // single fixed name for debug builds), so two
                             // different binaries built at the same commit (e.g.
                             // side-by-side local builds being benchmarked)
                             // collide here. Blindly reusing the existing link
                             // would make every `--bun` child of the SECOND
                             // binary silently exec the FIRST. Verify the target
                             // before reusing; replace it once if stale.
+                            //
+                            // This is also the only cleanup allowed in this dir:
+                            // concurrent buns of the same build share these
+                            // links and the scripts they already spawned exec
+                            // them at any moment, so a link that points at this
+                            // binary must never be removed, not even briefly.
                             let mut buf = bun_paths::PathBuffer::uninit();
                             let matches = bun_sys::readlink(dest, &mut buf)
                                 .map(|n| &buf[..n] == argv0_z.as_bytes())

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -601,20 +601,11 @@ impl RunCommand {
                     match bun_sys::symlink(argv0_z, dest) {
                         Ok(()) => break,
                         Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
-                            // The dir is keyed only on GIT_SHA_SHORT (and is a
-                            // single fixed name for debug builds), so two
-                            // different binaries built at the same commit (e.g.
-                            // side-by-side local builds being benchmarked)
-                            // collide here. Blindly reusing the existing link
-                            // would make every `--bun` child of the SECOND
-                            // binary silently exec the FIRST. Verify the target
-                            // before reusing; replace it once if stale.
-                            //
-                            // This is also the only cleanup allowed in this dir:
-                            // concurrent buns of the same build share these
-                            // links and the scripts they already spawned exec
-                            // them at any moment, so a link that points at this
-                            // binary must never be removed, not even briefly.
+                            // Another binary at this commit (any debug build, for
+                            // debug builds) may have planted this link: reuse it
+                            // only if it points at us, else re-point it once. No
+                            // other removal is allowed here: scripts spawned by
+                            // concurrent runs of this binary exec these links.
                             let mut buf = bun_paths::PathBuffer::uninit();
                             let matches = bun_sys::readlink(dest, &mut buf)
                                 .map(|n| &buf[..n] == argv0_z.as_bytes())
@@ -687,8 +678,7 @@ impl RunCommand {
             let dir_slice_len = prefix.len() + len + dir_name.len();
 
             let image_path = win::exe_path_w();
-            // The links are hard links, so an existing one can only be checked
-            // by comparing file identity with the running image.
+            // Hard links have no target to read back; compare file identity instead.
             let image_stat = bun_sys::File::openat_os_path(
                 bun_sys::Fd::cwd(),
                 image_path,
@@ -705,11 +695,9 @@ impl RunCommand {
                 let mut made_dir = false;
                 let mut replaced = false;
                 loop {
-                    // `target_path_buffer` is mutated in place between FFI calls
-                    // (the dir-NUL/backslash toggle below).
-                    // Under Stacked Borrows a `*const` derived via `Deref::deref`
-                    // is invalidated by the intervening `&mut` from `IndexMut`, so
-                    // re-derive `as_ptr()` at each FFI call site instead of caching.
+                    // Re-derive `as_ptr()` at every FFI call: the buffer is mutated
+                    // in between (dir NUL/backslash toggle below), which under
+                    // Stacked Borrows invalidates a pointer derived earlier.
                     if win::CreateHardLinkW(target_path_buffer.as_ptr(), image_path.as_ptr(), None)
                         != 0
                     {
@@ -717,10 +705,9 @@ impl RunCommand {
                     }
                     match win::Win32Error::get() {
                         win::Win32Error::ALREADY_EXISTS => {
-                            // Same rules as the POSIX EEXIST branch above. A
-                            // rebuilt binary is a different file from the one
-                            // the existing links were made from, so this also
-                            // covers stale links left by a previous debug build.
+                            // Same rules as the POSIX EEXIST branch. A rebuilt binary
+                            // is a different file, so this also replaces links left
+                            // behind by an earlier debug build.
                             let matches = image_stat.as_ref().is_some_and(|image| {
                                 bun_sys::openat_windows(
                                     bun_sys::Fd::cwd(),

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -707,7 +707,7 @@ impl RunCommand {
                     match win::Win32Error::get() {
                         win::Win32Error::ALREADY_EXISTS => {
                             // As in the POSIX EEXIST branch; a rebuilt binary is a different file.
-                            let matches = image_stat.as_ref().is_some_and(|image| {
+                            let keep = image_stat.as_ref().is_none_or(|image| {
                                 bun_sys::openat_windows(
                                     bun_sys::Fd::cwd(),
                                     &target_path_buffer[..link_len],
@@ -720,7 +720,7 @@ impl RunCommand {
                                     link.st_dev == image.st_dev && link.st_ino == image.st_ino
                                 })
                             });
-                            if matches || replaced {
+                            if keep || replaced {
                                 break;
                             }
                             let _ = win::DeleteFileBun(

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -601,11 +601,14 @@ impl RunCommand {
                     match bun_sys::symlink(argv0_z, dest) {
                         Ok(()) => break,
                         Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
-                            // Another binary at this commit (any debug build, for
-                            // debug builds) may have planted this link: reuse it
-                            // only if it points at us, else re-point it once. No
-                            // other removal is allowed here: scripts spawned by
-                            // concurrent runs of this binary exec these links.
+                            // The dir is keyed only on GIT_SHA_SHORT, so two
+                            // different binaries built at the same commit (e.g.
+                            // side-by-side local builds being benchmarked)
+                            // collide here. Blindly reusing the existing link
+                            // would make every `--bun` child of the SECOND
+                            // binary silently exec the FIRST. Verify the target
+                            // before reusing; replace it once if stale.
+                            // Never remove a matching link: concurrent runs' scripts exec it.
                             let mut buf = bun_paths::PathBuffer::uninit();
                             let matches = bun_sys::readlink(dest, &mut buf)
                                 .map(|n| &buf[..n] == argv0_z.as_bytes())
@@ -695,9 +698,7 @@ impl RunCommand {
                 let mut made_dir = false;
                 let mut replaced = false;
                 loop {
-                    // Re-derive `as_ptr()` at every FFI call: the buffer is mutated
-                    // in between (dir NUL/backslash toggle below), which under
-                    // Stacked Borrows invalidates a pointer derived earlier.
+                    // `as_ptr()` stays inline: the buffer is mutated below (Stacked Borrows).
                     if win::CreateHardLinkW(target_path_buffer.as_ptr(), image_path.as_ptr(), None)
                         != 0
                     {
@@ -705,9 +706,7 @@ impl RunCommand {
                     }
                     match win::Win32Error::get() {
                         win::Win32Error::ALREADY_EXISTS => {
-                            // Same rules as the POSIX EEXIST branch. A rebuilt binary
-                            // is a different file, so this also replaces links left
-                            // behind by an earlier debug build.
+                            // As in the POSIX EEXIST branch; a rebuilt binary is a different file.
                             let matches = image_stat.as_ref().is_some_and(|image| {
                                 bun_sys::openat_windows(
                                     bun_sys::Fd::cwd(),

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -686,39 +686,64 @@ impl RunCommand {
             target_path_buffer[prefix.len() + len..][..dir_name.len()].copy_from_slice(dir_name);
             let dir_slice_len = prefix.len() + len + dir_name.len();
 
-            #[cfg(bun_debug)]
-            {
-                // Debug builds wipe and recreate the bun-node temp dir so the
-                // ALREADY_EXISTS short-circuit below never reuses a stale
-                // hardlink at a previous debug binary.
-                //
-                // The wipe does not always leave the path absent:
-                // `bun-run.test.ts` uses
-                // `describe.concurrent`, so multiple debug processes race on
-                // this shared dir and `make_dir` can legitimately observe
-                // `PathAlreadyExists` after a sibling re-created it. Swallow
-                // the error — the `CreateHardLinkW` retry below already
-                // re-mkdirs on failure, so a lost race here is harmless.
-                let dir_slice_u8 = bun_core::strings::to_utf8_alloc_with_type(
-                    &target_path_buffer[..dir_slice_len],
-                );
-                let _ = bun_sys::delete_tree_absolute(&dir_slice_u8);
-                let _ = bun_sys::Dir::cwd().make_dir(&dir_slice_u8);
-            }
-
             let image_path = win::exe_path_w();
+            // The links are hard links, so an existing one can only be checked
+            // by comparing file identity with the running image.
+            let image_stat = bun_sys::File::openat_os_path(
+                bun_sys::Fd::cwd(),
+                image_path,
+                bun_sys::O::RDONLY,
+                0,
+            )
+            .and_then(|image| image.stat())
+            .ok();
+
             for name in [strings::w!("\\node.exe\0"), strings::w!("\\bun.exe\0")] {
                 target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);
-                // `target_path_buffer` is mutated in place between FFI calls
-                // (the dir-NUL/backslash toggle below).
-                // Under Stacked Borrows a `*const` derived via `Deref::deref`
-                // is invalidated by the intervening `&mut` from `IndexMut`, so
-                // re-derive `as_ptr()` at each FFI call site instead of caching.
-                if win::CreateHardLinkW(target_path_buffer.as_ptr(), image_path.as_ptr(), None) == 0
-                {
+                // `name` includes its NUL terminator; the link path ends before it.
+                let link_len = dir_slice_len + name.len() - 1;
+                let mut made_dir = false;
+                let mut replaced = false;
+                loop {
+                    // `target_path_buffer` is mutated in place between FFI calls
+                    // (the dir-NUL/backslash toggle below).
+                    // Under Stacked Borrows a `*const` derived via `Deref::deref`
+                    // is invalidated by the intervening `&mut` from `IndexMut`, so
+                    // re-derive `as_ptr()` at each FFI call site instead of caching.
+                    if win::CreateHardLinkW(target_path_buffer.as_ptr(), image_path.as_ptr(), None)
+                        != 0
+                    {
+                        break;
+                    }
                     match win::Win32Error::get() {
-                        win::Win32Error::ALREADY_EXISTS => {}
-                        _ => {
+                        win::Win32Error::ALREADY_EXISTS => {
+                            // Same rules as the POSIX EEXIST branch above. A
+                            // rebuilt binary is a different file from the one
+                            // the existing links were made from, so this also
+                            // covers stale links left by a previous debug build.
+                            let matches = image_stat.as_ref().is_some_and(|image| {
+                                bun_sys::openat_windows(
+                                    bun_sys::Fd::cwd(),
+                                    &target_path_buffer[..link_len],
+                                    bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW,
+                                    0,
+                                )
+                                .map(bun_sys::File::from_fd)
+                                .and_then(|link| link.stat())
+                                .is_ok_and(|link| {
+                                    link.st_dev == image.st_dev && link.st_ino == image.st_ino
+                                })
+                            });
+                            if matches || replaced {
+                                break;
+                            }
+                            let _ = win::DeleteFileBun(
+                                &target_path_buffer[..link_len],
+                                win::DeleteFileOptions::default(),
+                            );
+                            replaced = true;
+                        }
+                        _ if !made_dir => {
                             target_path_buffer[dir_slice_len] = 0;
                             // SAFETY: `dir_slice_len` is in-bounds; the byte at
                             // `dir_slice_len` was just set to NUL.
@@ -726,16 +751,9 @@ impl RunCommand {
                                 bun_core::WStr::from_buf(&target_path_buffer[..], dir_slice_len);
                             let _ = bun_sys::mkdir_w(dir_w);
                             target_path_buffer[dir_slice_len] = b'\\' as u16;
-
-                            if win::CreateHardLinkW(
-                                target_path_buffer.as_ptr(),
-                                image_path.as_ptr(),
-                                None,
-                            ) == 0
-                            {
-                                return Ok(());
-                            }
+                            made_dir = true;
                         }
+                        _ => return Ok(()),
                     }
                 }
             }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -90,18 +90,6 @@ async function setupTest(): Promise<TestCtx> {
   }
 }
 
-// An environment with no node in it at all, so that `bun install` has to put its own
-// `node`/`bun` shims on the scripts' PATH. Emptying PATH is not enough: when the test
-// runner itself was started through `bun run` (as `bun bd test` is), the environment
-// carries NODE/npm_node_execpath pointing at the real node, and bun trusts those
-// instead of creating the shims.
-function envWithoutNode(env: Record<string, string>): Record<string, string> {
-  const result = { ...env, PATH: "" };
-  delete result.NODE;
-  delete result.npm_node_execpath;
-  return result;
-}
-
 // The six multi-install tests below are the longest in the file (2-3 serial `bun install`s
 // each, some with cold caches). Declare them first so they start before the ~110 shorter
 // tests and overlap with them instead of forming a serial tail at the end of the run.
@@ -3653,7 +3641,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         stdout: "pipe",
         stdin: "ignore",
         stderr: "pipe",
-        env: envWithoutNode(testEnv),
+        env: { ...testEnv, PATH: "" },
       });
 
       let err = await stderr.text();
@@ -3689,7 +3677,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         stdout: "pipe",
         stderr: "pipe",
         stdin: "ignore",
-        env: envWithoutNode(testEnv),
+        env: { ...testEnv, PATH: "" },
       });
 
       let err = await stderr.text();

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -90,6 +90,18 @@ async function setupTest(): Promise<TestCtx> {
   }
 }
 
+// An environment with no node in it at all, so that `bun install` has to put its own
+// `node`/`bun` shims on the scripts' PATH. Emptying PATH is not enough: when the test
+// runner itself was started through `bun run` (as `bun bd test` is), the environment
+// carries NODE/npm_node_execpath pointing at the real node, and bun trusts those
+// instead of creating the shims.
+function envWithoutNode(env: Record<string, string>): Record<string, string> {
+  const result = { ...env, PATH: "" };
+  delete result.NODE;
+  delete result.npm_node_execpath;
+  return result;
+}
+
 // The six multi-install tests below are the longest in the file (2-3 serial `bun install`s
 // each, some with cold caches). Declare them first so they start before the ~110 shorter
 // tests and overlap with them instead of forming a serial tail at the end of the run.
@@ -3635,19 +3647,14 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         }),
       );
 
-      const originalPath = env.PATH;
-      env.PATH = "";
-
       let { stderr, exited } = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
         stdin: "ignore",
         stderr: "pipe",
-        env: testEnv,
+        env: envWithoutNode(testEnv),
       });
-
-      env.PATH = originalPath;
 
       let err = await stderr.text();
       expect(err).toContain("No packages! Deleted empty lockfile");
@@ -3676,19 +3683,14 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         }),
       );
 
-      const originalPath = env.PATH;
-      env.PATH = "";
-
       let { stderr, exited } = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
         stderr: "pipe",
         stdin: "ignore",
-        env,
+        env: envWithoutNode(testEnv),
       });
-
-      env.PATH = originalPath;
 
       let err = await stderr.text();
       expect(err).toContain("No packages! Deleted empty lockfile");

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1140,14 +1140,21 @@ describe.concurrent("bun run", () => {
       // writes `stop`. A busy loop on purpose: a process that removes and
       // recreates the shim leaves it missing for only a few syscalls, so sample
       // as fast as possible. Deliberately import-free: in debug builds, loading
-      // node:fs alone takes most of a second.
+      // node:fs alone takes most of a second. The deadline is longer than any
+      // per-test timeout, so it only matters if the test run itself was killed
+      // and could not stop this process.
       "watch.js": `
         const shim = Bun.which("node");
+        const deadline = Date.now() + 5 * 60_000;
         console.log(shim);
         while (Bun.file("stop").size === 0) {
           if (Bun.which("node") !== shim) {
             console.log("missing");
             process.exit(1);
+          }
+          if (Date.now() > deadline) {
+            console.log("deadline");
+            process.exit(2);
           }
         }
         console.log("ok");

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, it } from "bun:test";
 import { chmodSync } from "fs";
-import { bunEnv as bunEnv_, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv as bunEnv_, bunExe, forEachLine, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 const bunEnv = {
@@ -1118,5 +1118,73 @@ describe.concurrent("bun run", () => {
       stdout: expect.stringContaining("nested --bun ok"),
       exitCode: 0,
     });
+  });
+
+  // The node/bun shims live in one directory shared by every bun process of
+  // the same build (and, for debug builds, by all debug builds). A bun that is
+  // starting up may add the links but must never remove ones that already
+  // point at it: a script spawned by an earlier process can exec them at any
+  // moment and would fail with `node: not found` or fall through to a real
+  // node. (Debug builds used to wipe the whole directory on every start.)
+  it.skipIf(isWindows)("concurrent --bun runs do not remove the node shim other scripts are using", async () => {
+    using dir = tempDir("bun-run-shim-race", {
+      "package.json": JSON.stringify({
+        name: "shim-race",
+        scripts: {
+          watch: "sh watch.sh",
+          probe: `node -e "process.exit(typeof Bun === 'object' ? 0 : 3)"`,
+        },
+      }),
+      // Resolves `node` once (under --bun that is the shim), then keeps
+      // checking that it still exists until the test creates `stop`. A busy
+      // loop on purpose: a process that removes and recreates the shim leaves
+      // it missing for only a few syscalls, so sample as fast as possible.
+      "watch.sh": `
+        node=$(command -v node) || exit 2
+        echo "$node"
+        while [ ! -e stop ]; do
+          [ -e "$node" ] || { echo "missing"; exit 1; }
+        done
+        echo ok
+      `,
+    });
+    const dirStr = String(dir);
+
+    await using watcher = Bun.spawn({
+      cmd: [bunExe(), "run", "--bun", "watch"],
+      cwd: dirStr,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const watcherLines = forEachLine(watcher.stdout);
+    const { value: shim } = await watcherLines.next();
+    expect(shim).toMatch(/\/bun-node[^/]*\/node$/);
+
+    // Every sibling sets up the shim directory on startup and then runs
+    // `node` through it, all while the watcher's script is still using it.
+    const siblings = await Promise.all(
+      Array.from({ length: 4 }, async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "--bun", "probe"],
+          cwd: dirStr,
+          env: bunEnv,
+          stdout: "ignore",
+          stderr: "pipe",
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        return { stderr, exitCode };
+      }),
+    );
+
+    await Bun.write(join(dirStr, "stop"), "");
+    const [stdout, stderr, exitCode] = await Promise.all([
+      Array.fromAsync(watcherLines),
+      watcher.stderr.text(),
+      watcher.exited,
+    ]);
+
+    expect(siblings.filter(({ exitCode }) => exitCode !== 0)).toEqual([]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: ["ok"], stderr: "$ sh watch.sh\n", exitCode: 0 });
   });
 });

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1140,21 +1140,15 @@ describe.concurrent("bun run", () => {
       // writes `stop`. A busy loop on purpose: a process that removes and
       // recreates the shim leaves it missing for only a few syscalls, so sample
       // as fast as possible. Deliberately import-free: in debug builds, loading
-      // node:fs alone takes most of a second. The deadline is longer than any
-      // per-test timeout, so it only matters if the test run itself was killed
-      // and could not stop this process.
+      // node:fs alone takes most of a second. (`await using` below kills this
+      // process if the test fails before writing `stop`.)
       "watch.js": `
         const shim = Bun.which("node");
-        const deadline = Date.now() + 5 * 60_000;
         console.log(shim);
         while (Bun.file("stop").size === 0) {
           if (Bun.which("node") !== shim) {
             console.log("missing");
             process.exit(1);
-          }
-          if (Date.now() > deadline) {
-            console.log("deadline");
-            process.exit(2);
           }
         }
         console.log("ok");

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1126,27 +1126,33 @@ describe.concurrent("bun run", () => {
   // point at it: a script spawned by an earlier process can exec them at any
   // moment and would fail with `node: not found` or fall through to a real
   // node. (Debug builds used to wipe the whole directory on every start.)
-  it.skipIf(isWindows)("concurrent --bun runs do not remove the node shim other scripts are using", async () => {
+  it("concurrent --bun runs do not remove the node shim other scripts are using", async () => {
     using dir = tempDir("bun-run-shim-race", {
       "package.json": JSON.stringify({
         name: "shim-race",
         scripts: {
-          watch: "sh watch.sh",
-          probe: `node -e "process.exit(typeof Bun === 'object' ? 0 : 3)"`,
+          watch: "node watch.js",
+          probe: "node probe.js",
         },
       }),
-      // Resolves `node` once (under --bun that is the shim), then keeps
-      // checking that it still exists until the test creates `stop`. A busy
-      // loop on purpose: a process that removes and recreates the shim leaves
-      // it missing for only a few syscalls, so sample as fast as possible.
-      "watch.sh": `
-        node=$(command -v node) || exit 2
-        echo "$node"
-        while [ ! -e stop ]; do
-          [ -e "$node" ] || { echo "missing"; exit 1; }
-        done
-        echo ok
+      // Runs as `node` through the shim, reports what `node` resolves to, then
+      // keeps re-resolving it (what a script's PATH lookup does) until the test
+      // writes `stop`. A busy loop on purpose: a process that removes and
+      // recreates the shim leaves it missing for only a few syscalls, so sample
+      // as fast as possible. Deliberately import-free: in debug builds, loading
+      // node:fs alone takes most of a second.
+      "watch.js": `
+        const shim = Bun.which("node");
+        console.log(shim);
+        while (Bun.file("stop").size === 0) {
+          if (Bun.which("node") !== shim) {
+            console.log("missing");
+            process.exit(1);
+          }
+        }
+        console.log("ok");
       `,
+      "probe.js": `process.exit(typeof Bun === "object" ? 0 : 3);`,
     });
     const dirStr = String(dir);
 
@@ -1159,7 +1165,7 @@ describe.concurrent("bun run", () => {
     });
     const watcherLines = forEachLine(watcher.stdout);
     const { value: shim } = await watcherLines.next();
-    expect(shim).toMatch(/\/bun-node[^/]*\/node$/);
+    expect(shim).toMatch(/[\\/]bun-node[^\\/]*[\\/]node(\.exe)?$/);
 
     // Every sibling sets up the shim directory on startup and then runs
     // `node` through it, all while the watcher's script is still using it.
@@ -1177,7 +1183,7 @@ describe.concurrent("bun run", () => {
       }),
     );
 
-    await Bun.write(join(dirStr, "stop"), "");
+    await Bun.write(join(dirStr, "stop"), "stop");
     const [stdout, stderr, exitCode] = await Promise.all([
       Array.fromAsync(watcherLines),
       watcher.stderr.text(),
@@ -1185,6 +1191,6 @@ describe.concurrent("bun run", () => {
     ]);
 
     expect(siblings.filter(({ exitCode }) => exitCode !== 0)).toEqual([]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: ["ok"], stderr: "$ sh watch.sh\n", exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: ["ok"], stderr: "$ node watch.js\n", exitCode: 0 });
   });
 });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -112,6 +112,16 @@ for (let key in bunEnv) {
     delete bunEnv[key];
     delete process.env[key];
   }
+
+  // `bun run <script>` exports these to the script, so a test run started through a
+  // package.json script (`bun bd test`) inherits them while CI, which starts `bun test`
+  // directly, does not. Spawned buns honor them: NODE/npm_node_execpath decide whether
+  // the node shim gets created, and most npm_* values (npm_config_user_agent,
+  // npm_package_name, ...) are only set when absent.
+  if (key === "NODE" || key.startsWith("npm_")) {
+    delete ciEnv[key];
+    delete bunEnv[key];
+  }
 }
 
 delete bunEnv.BUN_INSPECT_CONNECT_TO;


### PR DESCRIPTION
## Repro

Debug builds only (`bun bd`). With a package.json script `probe: node -e "console.log(typeof Bun)"`, start a handful of `bun-debug run --bun probe` at the same time. About 1-2% of them print `undefined` (the script fell through to the real node) or fail with `node: not found`:

```
$ bun /tmp/stress.ts ./build/debug/bun-debug 16 5     # 16 concurrent runs, 5 rounds
FAIL: {"out":"undefined","err":"$ node -e \"console.log(typeof Bun)\"","code":0}
FAIL: {"out":"undefined","err":"$ node -e \"console.log(typeof Bun)\"","code":0}
failures: 2/80
```

Any test file that runs several `--bun` processes or PATH-less lifecycle scripts concurrently (`bun-run.test.ts` and `bun-install-lifecycle-scripts.test.ts` are both `describe.concurrent`) can hit this under `bun bd test`, on Linux and on Windows. Release builds never wiped the directory, so the race itself is debug-only.

## Cause

`RunCommand::create_fake_temporary_node_executable` (src/install/lib.rs) puts the `node` and `bun` links in one directory shared by every running bun of the same build: `<tmp>/bun-node-<sha>`, or the single fixed `<tmp>/bun-node-debug` for debug builds. Under `#[cfg(bun_debug)]` both the POSIX and the Windows arm ran `delete_tree_absolute` on that directory before recreating it, on every process start. A process starting up therefore removed the links a sibling had already planted and put on its scripts' PATH. (On NTFS, deleting a hard link to a running image succeeds as long as another link to it remains, so the Windows wipe removes live links as well; the test below fails on Windows against main too.) Depending on timing the sibling's script found no `node` at all, or the sibling's own `symlink()` failed with ENOENT because the directory was gone between its `mkdir` and `symlink`, in which case it silently went on without the shim directory on PATH.

The wipe existed so that links left behind by an earlier debug binary would not be reused blindly.

## Fix

Drop the wipe in both arms and have the "link already exists" path verify the link instead, so the only thing ever removed from the directory is a link that belongs to some other binary:

- POSIX already did this: the EEXIST branch `readlink`s the link and re-points it once if it targets a different path, and a rebuilt binary at the same path is picked up through the symlink. Only the wipe is removed.
- Windows reused an existing hard link blindly. It now compares the identity (`st_dev`/`st_ino`, volume serial plus file index, the same check `node_fs.rs` uses to detect copying a file onto itself) of the existing link with the running image, reuses it on a match, and otherwise deletes that one link and creates it again, mirroring the POSIX `replaced` loop. A rebuilt binary is a new file, so this keeps the protection the wipe provided, and it also stops Windows release builds from reusing a link made by a different binary at the same commit. The mkdir-and-retry on other errors is unchanged.

Concurrent starts of the same binary now never remove anything. Two different binaries sharing the directory still re-point the links back and forth, which is the pre-existing release behavior on POSIX.

### Test environment

The `bun-install-lifecycle-scripts.test.ts` failures that prompted this had a second, unrelated cause. `bun bd` goes through `bun run`, which exports `NODE`, `npm_node_execpath` and a set of `npm_*` variables to its script, and the harness `bunEnv` spreads `process.env`, so every bun spawned by a test inherits them. `EnvLoader::get_node_path` honors `NODE`/`npm_node_execpath` before looking at PATH, so `bun install` with `PATH=""` never created the shims. Most `npm_*` values are only set when absent, which is also why the `npm_config_user_agent` test in `bunx.test.ts` fails under `bun bd test` on main. `bunEnv` now strips `NODE` and `npm_*` next to the existing `NODE_ENV`/`BUN_DEBUG_*` strips. CI starts `bun test` directly and never had these variables, so this changes local runs only. The two PATH-less lifecycle tests now spawn with `{ ...testEnv, PATH: "" }`; before, one variant spread the env before PATH was cleared and the other spawned with the raw env, so neither waiter-thread variant tested what it said.

## Verification

New test in `test/cli/install/bun-run.test.ts`: one `bun run --bun` whose script runs as `node` through the shim, prints what `node` resolves to, and keeps re-resolving it until told to stop, while four more `bun run --bun` processes start up and run `node` through the shims. The watcher re-resolves about 40k times a second in a debug build and a wipe leaves the link missing for a whole delete-tree, mkdir and relink cycle, so every wipe is caught: against main's `lib.rs` it failed 6/6 on Linux and 6/6 on Windows (plus roughly 200 runs of earlier variants of the same shape, some under load) with

```
-   "exitCode": 0,
+   "exitCode": 1,
-     "ok",
+     "missing",
```

and with this branch it passes 6/6 on both (debug builds). Release builds have no wipe, so in CI the test passes before and after; the fail-before is specific to `bun bd`.

The Windows identity check was also exercised directly: with `%TEMP%\bun-node-debug\node.exe` replaced by a hard link to `cmd.exe`, one `bun-debug run --bun` re-pointed it at `bun-debug.exe` (checked with `fsutil hardlink list`) and left the still-correct `bun.exe` link alone.

Also green with `bun bd test`: `bun-run.test.ts` (Linux 293, Windows 403), `bun-install-lifecycle-scripts.test.ts` (118 on Linux, 3 of which failed before; the two PATH-less tests on Windows), the `npm_config_user_agent` test in `bunx.test.ts` on both platforms (failed locally before), and `test/regression/issue/26207.test.ts`.

Related: #35565 also removes the POSIX wipe, as one part of re-keying the directory per user. This PR is only the race fix and can land independently of that design change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts test/cli/install/bun-run.test.ts

<!-- robobun:evidence:end -->