### PR TITLE
compile: accept "glibc" as an explicit libc token in --target

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -226,7 +226,9 @@ To build for macOS x64:
 
 ### Supported targets
 
-The segments of the `--target` value can appear in any order, as long as they're delimited by `-`. Linux targets also accept a libc segment: `-musl` selects the musl build, and `-glibc` (for example `bun-linux-x64-glibc`) explicitly selects the glibc build that the plain `bun-linux-*` targets below use.
+The segments of the `--target` value can appear in any order, as long as they're delimited by `-`.
+
+Linux targets also accept a libc segment, `-glibc` or `-musl` (for example `bun-linux-x64-glibc`), which selects that libc's build of Bun no matter which build is running. Without one, a Linux target uses the libc of the `bun` running the build: the table below describes a glibc build of Bun, while a musl build of Bun turns `bun-linux-x64` into a musl executable.
 
 | --target             | Operating System | Architecture | Modern | Baseline | Libc  |
 | -------------------- | ---------------- | ------------ | ------ | -------- | ----- |

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -228,7 +228,7 @@ To build for macOS x64:
 
 The segments of the `--target` value can appear in any order, as long as they're delimited by `-`.
 
-Linux targets also accept a libc segment, `-glibc` or `-musl` (for example `bun-linux-x64-glibc`), which selects that libc's build of Bun no matter which build is running. Without one, a Linux target uses the libc of the `bun` running the build: the table below describes a glibc build of Bun, while a musl build of Bun turns `bun-linux-x64` into a musl executable.
+Linux targets also accept a libc segment such as `-glibc` or `-musl` (for example `bun-linux-x64-glibc`), which selects that libc's build of Bun no matter which build is running. Without one, a Linux target uses the libc of the `bun` running the build: the table below describes a glibc build of Bun, while a musl build of Bun turns `bun-linux-x64` into a musl executable.
 
 | --target             | Operating System | Architecture | Modern | Baseline | Libc  |
 | -------------------- | ---------------- | ------------ | ------ | -------- | ----- |

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -1284,6 +1284,8 @@ type CompileTarget =
   | "bun-linux-x64-baseline"
   | "bun-linux-x64-modern"
   | "bun-linux-arm64"
+  | "bun-linux-x64-glibc"
+  | "bun-linux-arm64-glibc"
   | "bun-linux-x64-musl"
   | "bun-linux-arm64-musl"
   | "bun-windows-x64"

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -226,7 +226,7 @@ To build for macOS x64:
 
 ### Supported targets
 
-The segments of the `--target` value can appear in any order, as long as they're delimited by `-`.
+The segments of the `--target` value can appear in any order, as long as they're delimited by `-`. Linux targets also accept a libc segment: `-musl` selects the musl build, and `-glibc` (for example `bun-linux-x64-glibc`) explicitly selects the glibc build that the plain `bun-linux-*` targets below use.
 
 | --target             | Operating System | Architecture | Modern | Baseline | Libc  |
 | -------------------- | ---------------- | ------------ | ------ | -------- | ----- |

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -49,7 +49,7 @@ impl Default for CompileTarget {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, strum::IntoStaticStr)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum Libc {
     /// The default libc for the target
     /// "glibc" for linux, unspecified for other OSes
@@ -77,6 +77,15 @@ impl fmt::Display for Libc {
     }
 }
 
+bun_core::comptime_string_map! {
+    /// `--target` segments that pick a libc; only meaningful together with linux.
+    static LIBC_NAMES: Libc = {
+        b"glibc" => Libc::Default,
+        b"musl" => Libc::Musl,
+        b"android" => Libc::Android,
+    };
+}
+
 struct BaselineFormatter {
     baseline: bool,
 }
@@ -90,12 +99,50 @@ impl fmt::Display for BaselineFormatter {
     }
 }
 
-#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
-pub enum ParseError {
-    #[error("UnsupportedTarget")]
-    UnsupportedTarget,
-    #[error("InvalidTarget")]
-    InvalidTarget,
+/// Why a `--target` string was rejected. `Display` is the CLI error message.
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+pub enum ParseError<'a> {
+    /// `segment` is not an architecture, OS, CPU tier, libc or version. `input` is the string
+    /// that was parsed (everything after `bun`), echoed back in the message.
+    UnsupportedSegment {
+        segment: &'a [u8],
+        input: &'a [u8],
+    },
+    /// A `-vX.Y.Z` segment missing one of its three components.
+    IncompleteVersion,
+    /// A libc segment was combined with a non-linux OS.
+    LibcRequiresLinux(Libc),
+    Wasm,
+}
+
+impl fmt::Display for ParseError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ParseError::UnsupportedSegment { segment, input } => write!(
+                f,
+                "Unsupported target {} in \"bun{}\"\n\
+                 To see the supported targets:\n  \
+                 https://bun.com/docs/bundler/executables",
+                bun_fmt::quote(segment),
+                bstr::BStr::new(input),
+            ),
+            ParseError::IncompleteVersion => write!(
+                f,
+                "Please pass a complete version number to --target. For example, --target=bun-v{}",
+                Environment::VERSION_STRING,
+            ),
+            ParseError::LibcRequiresLinux(Libc::Default) => {
+                f.write_str("invalid target, glibc only exists on linux")
+            }
+            ParseError::LibcRequiresLinux(Libc::Musl) => {
+                f.write_str("invalid target, musl libc only exists on linux")
+            }
+            ParseError::LibcRequiresLinux(Libc::Android) => f.write_str(
+                "invalid target, android only exists with linux (use bun-linux-arm64-android)",
+            ),
+            ParseError::Wasm => f.write_str("invalid target, WebAssembly is not supported. Sorry!"),
+        }
+    }
 }
 
 impl CompileTarget {
@@ -238,7 +285,7 @@ impl CompileTarget {
         }
     }
 
-    pub fn try_from(input_: &[u8]) -> Result<CompileTarget, ParseError> {
+    pub fn try_from(input_: &[u8]) -> Result<CompileTarget, ParseError<'_>> {
         let mut this = CompileTarget::default();
         let input = strings::trim(input_, b" \t\r");
         if input.is_empty() {
@@ -284,7 +331,7 @@ impl CompileTarget {
                         || version.version.minor.is_none()
                         || version.version.patch.is_none()
                     {
-                        return Err(ParseError::InvalidTarget);
+                        return Err(ParseError::IncompleteVersion);
                     }
 
                     this.version = Version {
@@ -297,20 +344,15 @@ impl CompileTarget {
                     _found_version = true;
                     continue;
                 }
-            } else if token == b"glibc" {
-                this.libc = Libc::Default;
-                found_libc = true;
-                continue;
-            } else if token == b"musl" {
-                this.libc = Libc::Musl;
-                found_libc = true;
-                continue;
-            } else if token == b"android" {
-                this.libc = Libc::Android;
+            } else if let Some(libc) = LIBC_NAMES.get(token) {
+                this.libc = *libc;
                 found_libc = true;
                 continue;
             } else {
-                return Err(ParseError::UnsupportedTarget);
+                return Err(ParseError::UnsupportedSegment {
+                    segment: token,
+                    input: input_,
+                });
             }
         }
 
@@ -334,11 +376,11 @@ impl CompileTarget {
 
         // Not `libc != Default`: an explicit "glibc" parses to `Default` and is just as invalid off linux.
         if found_libc && this.os != OperatingSystem::Linux {
-            return Err(ParseError::InvalidTarget);
+            return Err(ParseError::LibcRequiresLinux(this.libc));
         }
 
         if this.arch == Architecture::Wasm || this.os == OperatingSystem::Wasm {
-            return Err(ParseError::InvalidTarget);
+            return Err(ParseError::Wasm);
         }
 
         Ok(this)
@@ -347,65 +389,8 @@ impl CompileTarget {
     pub fn from(input_: &[u8]) -> CompileTarget {
         match Self::try_from(input_) {
             Ok(t) => t,
-            Err(ParseError::UnsupportedTarget) => {
-                let input = strings::trim(input_, b" \t\r");
-                let mut splitter = strings::split(input, b"-");
-                let mut unsupported_token: Option<&[u8]> = None;
-                while let Some(token) = splitter.next() {
-                    if token.is_empty() {
-                        continue;
-                    }
-                    if ARCHITECTURE_NAMES.get(token).is_none()
-                        && OPERATING_SYSTEM_NAMES.get(token).is_none()
-                        && token != b"modern"
-                        && token != b"baseline"
-                        && token != b"glibc"
-                        && token != b"musl"
-                        && token != b"android"
-                        && !(strings::has_prefix(token, b"v1.")
-                            || strings::has_prefix(token, b"v0."))
-                    {
-                        unsupported_token = Some(token);
-                        break;
-                    }
-                }
-
-                if let Some(token) = unsupported_token {
-                    bun_core::err_generic!(
-                        "Unsupported target {} in \"bun{}\"\n\
-                         To see the supported targets:\n  \
-                         https://bun.com/docs/bundler/executables",
-                        bun_fmt::quote(token),
-                        bstr::BStr::new(input_),
-                    );
-                } else {
-                    bun_core::err_generic!("Unsupported target: {}", bstr::BStr::new(input_));
-                }
-                Global::exit(1);
-            }
-            Err(ParseError::InvalidTarget) => {
-                let input = strings::trim(input_, b" \t\r");
-                if strings::contains(input, b"musl") && !strings::contains(input, b"linux") {
-                    bun_core::err_generic!("invalid target, musl libc only exists on linux");
-                } else if strings::contains(input, b"glibc") && !strings::contains(input, b"linux")
-                {
-                    bun_core::err_generic!("invalid target, glibc only exists on linux");
-                } else if strings::contains(input, b"android")
-                    && !strings::contains(input, b"linux")
-                {
-                    bun_core::err_generic!(
-                        "invalid target, android only exists with linux (use bun-linux-arm64-android)"
-                    );
-                } else if strings::contains(input, b"wasm") {
-                    bun_core::err_generic!("invalid target, WebAssembly is not supported. Sorry!");
-                } else if strings::contains(input, b"v") {
-                    bun_core::err_generic!(
-                        "Please pass a complete version number to --target. For example, --target=bun-v{}",
-                        Environment::VERSION_STRING,
-                    );
-                } else {
-                    bun_core::err_generic!("Invalid target: {}", bstr::BStr::new(input_));
-                }
+            Err(err) => {
+                bun_core::err_generic!("{}", err);
                 Global::exit(1);
             }
         }

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -297,6 +297,10 @@ impl CompileTarget {
                     _found_version = true;
                     continue;
                 }
+            } else if token == b"glibc" {
+                this.libc = Libc::Default;
+                found_libc = true;
+                continue;
             } else if token == b"musl" {
                 this.libc = Libc::Musl;
                 found_libc = true;
@@ -328,7 +332,8 @@ impl CompileTarget {
             this.baseline = false;
         }
 
-        if this.libc != Libc::Default && this.os != OperatingSystem::Linux {
+        // Not `libc != Default`: an explicit "glibc" parses to `Default` and is just as invalid off linux.
+        if found_libc && this.os != OperatingSystem::Linux {
             return Err(ParseError::InvalidTarget);
         }
 
@@ -354,6 +359,7 @@ impl CompileTarget {
                         && OPERATING_SYSTEM_NAMES.get(token).is_none()
                         && token != b"modern"
                         && token != b"baseline"
+                        && token != b"glibc"
                         && token != b"musl"
                         && token != b"android"
                         && !(strings::has_prefix(token, b"v1.")
@@ -381,6 +387,9 @@ impl CompileTarget {
                 let input = strings::trim(input_, b" \t\r");
                 if strings::contains(input, b"musl") && !strings::contains(input, b"linux") {
                     bun_core::err_generic!("invalid target, musl libc only exists on linux");
+                } else if strings::contains(input, b"glibc") && !strings::contains(input, b"linux")
+                {
+                    bun_core::err_generic!("invalid target, glibc only exists on linux");
                 } else if strings::contains(input, b"android")
                     && !strings::contains(input, b"linux")
                 {

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -102,8 +102,7 @@ impl fmt::Display for BaselineFormatter {
 /// Why a `--target` string was rejected. `Display` is the CLI error message.
 #[derive(thiserror::Error, Debug, Clone, Copy)]
 pub enum ParseError<'a> {
-    /// `segment` is not an architecture, OS, CPU tier, libc or version. `input` is the string
-    /// that was parsed (everything after `bun`), echoed back in the message.
+    /// `segment` of `input` is not an architecture, OS, CPU tier, libc or version.
     UnsupportedSegment {
         segment: &'a [u8],
         input: &'a [u8],

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -122,73 +122,100 @@ describe("Bun.build compile", () => {
   });
 });
 
-// `Bun.Build.Libc` is "glibc" | "musl". "-glibc" explicitly selects the default Linux build, which on
-// a glibc host is the running bun itself, so the accepting tests below never download anything.
-describe("compile target -glibc token", () => {
+// `Bun.Build.Libc` is "glibc" | "musl". "-glibc" selects the glibc build of bun, which on a glibc host
+// is the running binary itself, so the accepting tests below never download anything.
+describe("compile target libc segments", () => {
   const arch = isArm64 ? "arm64" : "x64";
+  // Targets are named `-vX.Y.Z`; Bun.version additionally carries `-debug` / `-canary.N` suffixes.
+  const version = Bun.version.split("-")[0];
+  // Tests that actually compile copy and rewrite the whole bun binary (~1GB under debug+ASAN), which
+  // blows the 5s default; the parse-only tests below stay on the default.
+  const compileTimeout = 60_000;
 
-  test.concurrent.skipIf(!isGlibc)("Bun.build accepts a bun-linux-<arch>-glibc target", async () => {
-    using dir = tempDir("build-compile-glibc-api", {
-      "app.js": `console.log("glibc-target-ok");`,
-    });
+  test.skipIf(!isGlibc)(
+    "Bun.build accepts a bun-linux-<arch>-glibc target",
+    async () => {
+      using dir = tempDir("build-compile-glibc-api", {
+        "app.js": `console.log("glibc-target-ok");`,
+      });
 
-    const result = await Bun.build({
-      entrypoints: [join(String(dir), "app.js")],
-      compile: {
-        target: `bun-linux-${arch}-glibc`,
-        outfile: join(String(dir), "app"),
-      },
-    });
-    expect(result.success).toBe(true);
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "app.js")],
+        compile: {
+          target: `bun-linux-${arch}-glibc`,
+          outfile: join(String(dir), "app"),
+        },
+      });
+      expect(result.success).toBe(true);
 
-    await using proc = Bun.spawn({
-      cmd: [result.outputs[0].path],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
-  });
+      await using proc = Bun.spawn({
+        cmd: [result.outputs[0].path],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
+    },
+    compileTimeout,
+  );
 
-  test.concurrent.skipIf(!isGlibc)("bun build --compile accepts --target=bun-linux-<arch>-glibc", async () => {
-    using dir = tempDir("build-compile-glibc-cli", {
-      "app.js": `console.log("glibc-target-ok");`,
-    });
-    const outfile = join(String(dir), "app");
+  test.skipIf(!isGlibc)(
+    "bun build --compile accepts --target=bun-linux-<arch>-glibc",
+    async () => {
+      using dir = tempDir("build-compile-glibc-cli", {
+        "app.js": `console.log("glibc-target-ok");`,
+      });
+      const outfile = join(String(dir), "app");
 
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", `--target=bun-linux-${arch}-glibc`, "app.js", "--outfile", outfile],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect({ stderr: buildStderr, exitCode: buildExitCode }).toEqual({ stderr: "", exitCode: 0 });
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", `--target=bun-linux-${arch}-glibc`, "app.js", "--outfile", outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildStderr, buildExitCode] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect({ stderr: buildStderr, exitCode: buildExitCode }).toEqual({ stderr: "", exitCode: 0 });
 
-    await using proc = Bun.spawn({
-      cmd: [outfile],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
-  });
+      await using proc = Bun.spawn({
+        cmd: [outfile],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
+    },
+    compileTimeout,
+  );
 
-  // Rejected while parsing the target, on every host: libc is a Linux-only axis, and a recognized
-  // "glibc" must not hide which segment of an otherwise broken target is the unknown one.
+  // Rejected while parsing the target, on every host. The message has to describe what the parser
+  // actually tripped on, not whichever libc word happens to appear somewhere in the target.
   test.concurrent.each([
     ["bun-windows-x64-glibc", "error: invalid target, glibc only exists on linux\n"],
+    ["bun-windows-x64-musl", "error: invalid target, musl libc only exists on linux\n"],
+    [
+      "bun-darwin-arm64-android",
+      "error: invalid target, android only exists with linux (use bun-linux-arm64-android)\n",
+    ],
     [
       "bun-linux-x64-glibc-invalid",
       'error: Unsupported target "invalid" in "bun-linux-x64-glibc-invalid"\n' +
         "To see the supported targets:\n" +
         "  https://bun.com/docs/bundler/executables\n",
     ],
+    [
+      "bun-x64-glibc-v1.2",
+      `error: Please pass a complete version number to --target. For example, --target=bun-v${version}\n`,
+    ],
+    ["bun-wasm", "error: invalid target, WebAssembly is not supported. Sorry!\n"],
   ])("bun build --compile rejects --target=%s", async (target, expectedStderr) => {
-    using dir = tempDir("build-compile-glibc-cli-invalid", {
+    using dir = tempDir("build-compile-target-invalid", {
       "app.js": `console.log("unreachable");`,
     });
 
@@ -209,7 +236,7 @@ describe("compile target -glibc token", () => {
   });
 
   test.each(["bun-darwin-arm64-glibc", "bun-linux-x64-glibc-invalid"])("Bun.build rejects target %s", target => {
-    using dir = tempDir("build-compile-glibc-api-invalid", {
+    using dir = tempDir("build-compile-target-invalid-api", {
       "app.js": `console.log("unreachable");`,
     });
 
@@ -222,6 +249,67 @@ describe("compile target -glibc token", () => {
         },
       }),
     ).toThrow(new TypeError(`Unknown compile target: ${target}`));
+  });
+
+  // Which libc a target resolved to is only visible from a bun built against the other one: the
+  // running bun's own libc is satisfied by the running binary, anything else has to be fetched.
+  // The fetch is pointed at a local 404 server, so instead of downloading, the build fails naming
+  // the bun it resolved to.
+  describe.skipIf(!isLinux)("libc selection", () => {
+    const npmArch = isArm64 ? "aarch64" : "x64";
+    const [otherLibc, otherSuffix] = isMusl ? ["glibc", ""] : ["musl", "-musl"];
+
+    async function compileFor(target: string) {
+      using dir = tempDir("build-compile-libc-selection", {
+        "app.js": `console.log("libc-selection");`,
+      });
+      let fetches = 0;
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch() {
+          fetches++;
+          return new Response(null, { status: 404 });
+        },
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", `--target=${target}`, "app.js", "--outfile", "app"],
+        env: {
+          ...bunEnv,
+          BUN_COMPILE_TARGET_TARBALL_URL: server.url.href,
+          BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+          // A CI proxy must not sit between the build and the local server.
+          HTTP_PROXY: undefined,
+          http_proxy: undefined,
+          HTTPS_PROXY: undefined,
+          https_proxy: undefined,
+        },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      return { stderr, exitCode, fetches };
+    }
+
+    test(
+      "a Linux target without a libc segment is the running bun's libc",
+      async () => {
+        expect(await compileFor(`bun-linux-${arch}`)).toEqual({ stderr: "", exitCode: 0, fetches: 0 });
+      },
+      compileTimeout,
+    );
+
+    test("a libc segment for the other libc selects that build instead of the running bun", async () => {
+      expect(await compileFor(`bun-linux-${arch}-${otherLibc}`)).toEqual({
+        stderr:
+          `Target platform 'bun-linux-${npmArch}${otherSuffix}-v${version}' is not available for download. ` +
+          "Check if this version of Bun supports this target.\n",
+        exitCode: 1,
+        fetches: 1,
+      });
+    });
   });
 });
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isArm64, isGlibc, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
 import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
 import { join } from "path";
 
@@ -119,6 +119,99 @@ describe("Bun.build compile", () => {
 
     // The test passes if compilation succeeds - the actual embedded resource
     // path handling is verified by the successful compilation
+  });
+});
+
+// `Bun.Build.Libc` is "glibc" | "musl". "-glibc" explicitly selects the default Linux build, which on
+// a glibc host is the running bun itself, so the accepting tests below never download anything.
+describe("compile target -glibc token", () => {
+  const arch = isArm64 ? "arm64" : "x64";
+
+  test.concurrent.skipIf(!isGlibc)("Bun.build accepts a bun-linux-<arch>-glibc target", async () => {
+    using dir = tempDir("build-compile-glibc-api", {
+      "app.js": `console.log("glibc-target-ok");`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "app.js")],
+      compile: {
+        target: `bun-linux-${arch}-glibc`,
+        outfile: join(String(dir), "app"),
+      },
+    });
+    expect(result.success).toBe(true);
+
+    await using proc = Bun.spawn({
+      cmd: [result.outputs[0].path],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent.skipIf(!isGlibc)("bun build --compile accepts --target=bun-linux-<arch>-glibc", async () => {
+    using dir = tempDir("build-compile-glibc-cli", {
+      "app.js": `console.log("glibc-target-ok");`,
+    });
+    const outfile = join(String(dir), "app");
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", `--target=bun-linux-${arch}-glibc`, "app.js", "--outfile", outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ stderr: buildStderr, exitCode: buildExitCode }).toEqual({ stderr: "", exitCode: 0 });
+
+    await using proc = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
+  });
+
+  // libc is a Linux-only axis. These are rejected while parsing the target, on every host.
+  test.concurrent("bun build --compile rejects -glibc combined with a non-linux OS", async () => {
+    using dir = tempDir("build-compile-glibc-cli-invalid", {
+      "app.js": `console.log("unreachable");`,
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "--target=bun-windows-x64-glibc", "app.js", "--outfile", "app"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: "error: invalid target, glibc only exists on linux\n",
+      exitCode: 1,
+    });
+  });
+
+  test("Bun.build rejects -glibc combined with a non-linux OS", () => {
+    using dir = tempDir("build-compile-glibc-api-invalid", {
+      "app.js": `console.log("unreachable");`,
+    });
+
+    expect(() =>
+      Bun.build({
+        entrypoints: [join(String(dir), "app.js")],
+        compile: {
+          target: "bun-darwin-arm64-glibc" as Bun.Build.CompileTarget,
+          outfile: join(String(dir), "app"),
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-darwin-arm64-glibc"`);
   });
 });
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -131,6 +131,11 @@ describe("compile target libc segments", () => {
   // Tests that actually compile copy and rewrite the whole bun binary (~1GB under debug+ASAN), which
   // blows the 5s default; the parse-only tests below stay on the default.
   const compileTimeout = 60_000;
+  // `bun build --compile` prints one timed line per stage; only the timings vary. A cross-compile
+  // additionally appends the resolved target to the compile line, so these summaries also assert
+  // that the target was the running binary.
+  const stages = (stdout: string) => stdout.replace(/^\s*\[[\d.]+m?s\] +/gm, "");
+  const bundledAndCompiled = "bundle  1 modules\ncompile  app\n";
 
   test.skipIf(!isGlibc)(
     "Bun.build accepts a bun-linux-<arch>-glibc target",
@@ -166,24 +171,27 @@ describe("compile target libc segments", () => {
       using dir = tempDir("build-compile-glibc-cli", {
         "app.js": `console.log("glibc-target-ok");`,
       });
-      const outfile = join(String(dir), "app");
 
       await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--compile", `--target=bun-linux-${arch}-glibc`, "app.js", "--outfile", outfile],
+        cmd: [bunExe(), "build", "--compile", `--target=bun-linux-${arch}-glibc`, "app.js", "--outfile", "app"],
         env: bunEnv,
         cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [, buildStderr, buildExitCode] = await Promise.all([
+      const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
         build.stdout.text(),
         build.stderr.text(),
         build.exited,
       ]);
-      expect({ stderr: buildStderr, exitCode: buildExitCode }).toEqual({ stderr: "", exitCode: 0 });
+      expect({ stdout: stages(buildStdout), stderr: buildStderr, exitCode: buildExitCode }).toEqual({
+        stdout: bundledAndCompiled,
+        stderr: "",
+        exitCode: 0,
+      });
 
       await using proc = Bun.spawn({
-        cmd: [outfile],
+        cmd: [join(String(dir), "app")],
         env: bunEnv,
         stdout: "pipe",
         stderr: "pipe",
@@ -289,20 +297,26 @@ describe("compile target libc segments", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-      return { stderr, exitCode, fetches };
+      const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      return { stdout: stages(stdout), stderr, exitCode, fetches };
     }
 
     test(
       "a Linux target without a libc segment is the running bun's libc",
       async () => {
-        expect(await compileFor(`bun-linux-${arch}`)).toEqual({ stderr: "", exitCode: 0, fetches: 0 });
+        expect(await compileFor(`bun-linux-${arch}`)).toEqual({
+          stdout: bundledAndCompiled,
+          stderr: "",
+          exitCode: 0,
+          fetches: 0,
+        });
       },
       compileTimeout,
     );
 
     test("a libc segment for the other libc selects that build instead of the running bun", async () => {
       expect(await compileFor(`bun-linux-${arch}-${otherLibc}`)).toEqual({
+        stdout: "bundle  1 modules\n",
         stderr:
           `Target platform 'bun-linux-${npmArch}${otherSuffix}-v${version}' is not available for download. ` +
           "Check if this version of Bun supports this target.\n",

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isGlibc, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
+import { chmodSync, closeSync, cpSync, existsSync, openSync, readdirSync, readSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -177,28 +177,38 @@ describe("compile target -glibc token", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "glibc-target-ok\n", stderr: "", exitCode: 0 });
   });
 
-  // libc is a Linux-only axis. These are rejected while parsing the target, on every host.
-  test.concurrent("bun build --compile rejects -glibc combined with a non-linux OS", async () => {
+  // Rejected while parsing the target, on every host: libc is a Linux-only axis, and a recognized
+  // "glibc" must not hide which segment of an otherwise broken target is the unknown one.
+  test.concurrent.each([
+    ["bun-windows-x64-glibc", "error: invalid target, glibc only exists on linux\n"],
+    [
+      "bun-linux-x64-glibc-invalid",
+      'error: Unsupported target "invalid" in "bun-linux-x64-glibc-invalid"\n' +
+        "To see the supported targets:\n" +
+        "  https://bun.com/docs/bundler/executables\n",
+    ],
+  ])("bun build --compile rejects --target=%s", async (target, expectedStderr) => {
     using dir = tempDir("build-compile-glibc-cli-invalid", {
       "app.js": `console.log("unreachable");`,
     });
 
     await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--compile", "--target=bun-windows-x64-glibc", "app.js", "--outfile", "app"],
+      cmd: [bunExe(), "build", "--compile", `--target=${target}`, "app.js", "--outfile", "app"],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
+    expect({ stdout, stderr, exitCode, files: readdirSync(String(dir)) }).toEqual({
       stdout: "",
-      stderr: "error: invalid target, glibc only exists on linux\n",
+      stderr: expectedStderr,
       exitCode: 1,
+      files: ["app.js"],
     });
   });
 
-  test("Bun.build rejects -glibc combined with a non-linux OS", () => {
+  test.each(["bun-darwin-arm64-glibc", "bun-linux-x64-glibc-invalid"])("Bun.build rejects target %s", target => {
     using dir = tempDir("build-compile-glibc-api-invalid", {
       "app.js": `console.log("unreachable");`,
     });
@@ -207,11 +217,11 @@ describe("compile target -glibc token", () => {
       Bun.build({
         entrypoints: [join(String(dir), "app.js")],
         compile: {
-          target: "bun-darwin-arm64-glibc" as Bun.Build.CompileTarget,
+          target: target as Bun.Build.CompileTarget,
           outfile: join(String(dir), "app"),
         },
       }),
-    ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-darwin-arm64-glibc"`);
+    ).toThrow(new TypeError(`Unknown compile target: ${target}`));
   });
 });
 


### PR DESCRIPTION
### Repro

`Bun.Build.Libc` is declared as `"glibc" | "musl"` and `Bun.Build.CompileTarget` includes `` `bun-linux-${Architecture}-${Libc}` `` (`packages/bun-types/bun.d.ts`, namespace `Build`; `test/integration/bun-types/fixture/build.ts` even asserts `bun-linux-x64-modern-glibc` is assignable), so this type-checks and then fails at runtime on both entry points:

```
$ bun build --compile --target=bun-linux-x64-glibc entry.js --outfile=out
error: Unsupported target "glibc" in "bun-linux-x64-glibc"

$ bun -e 'Bun.build({ entrypoints: ["./entry.js"], compile: { target: "bun-linux-x64-glibc", outfile: "./out" } })'
TypeError: Unknown compile target: bun-linux-x64-glibc
```

Reproduced with bun 1.4.0 (and 1.3.14).

### Cause

Both the CLI (`src/runtime/cli/Arguments.rs`, `--target` with `--compile`) and `Bun.build` (`compile_target_from_slice` in `src/bundler_jsc/options_jsc.rs`, reached from `compile: "..."`, `compile: { target }` and `target: "bun-..."`) parse the string with `CompileTarget::try_from` in `src/options_types/compile_target.rs`. Its segment loop knew arch and OS names, `modern`/`baseline`, `-vX.Y.Z`, `musl` and `android`; anything else, including `glibc`, was rejected.

### Fix

`glibc` is now a libc segment that parses to `Libc::Default`, i.e. exactly the build the plain Linux targets name, so the download URL, cache name and `define_values` are unchanged and on a glibc host `bun-linux-x64-glibc` is still `is_default()` (uses the running binary, downloads nothing). The three libc segments live in one `LIBC_NAMES` map, like the arch and OS tables. The linux-only check keys off "a libc segment was given" rather than `libc != Default`, since `glibc` now maps to `Default`; this is what keeps `bun-windows-x64-glibc` rejected.

The error reporting was restructured at the same time, because the first version of this change had to teach `glibc` to three places: `try_from` returned unit `ParseError` variants, so `from()` re-tokenized the input against a second copy of the segment list to name the bad segment, and chose the "invalid target" message by substring-matching the input. That chain also misattributes errors (`bun-x64-glibc-v1.2`, an incomplete version on a Linux target, would have printed the libc message). `ParseError` now carries the offending segment or the reason (`UnsupportedSegment`, `IncompleteVersion`, `LibcRequiresLinux(libc)`, `Wasm`), its `Display` renders the existing messages verbatim plus the new glibc one (`invalid target, glibc only exists on linux`), and `from()` just prints it. `Bun.build` still throws `Unknown compile target: ...` for every rejection, as before.

Why accept the segment rather than delete it from the types: the types and the types fixture have advertised it since `Bun.build({ compile })` landed, and it is the only way to ask for the glibc build explicitly. `CompileTarget::default()` carries the host libc and `try_from` only resets it for non-Linux targets, so on a musl (or Android) build of bun, `bun-linux-x64` means the host's libc; `-glibc` is the counterpart of `-musl` for that case. That host-following default is unchanged; the docs sentence under "Supported targets" now describes it, since the table there otherwise reads as if plain Linux targets were always glibc.

Types are untouched (`Libc` already matches the runtime). The type still does not model `-android` or the `-vX.Y.Z` suffix; that is a separate, pre-existing gap left for its own change.

### Verification

New tests in `test/bundler/bun-build-compile.test.ts` ("compile target libc segments"):

- `Bun.build` and `bun build --compile` accept `bun-linux-<host arch>-glibc` and the produced executable runs (glibc Linux hosts, where the target is the running binary; no network).
- CLI rejections with exact stderr, on every host: glibc / musl / android combined with a non-Linux OS, `bun-linux-x64-glibc-invalid` (names `invalid`, not `glibc`), `bun-x64-glibc-v1.2` (names the version, not glibc), and `bun-wasm`; plus `Bun.build` rejections for two of those. The musl, android and wasm rows pass before and after and pin the messages through the restructuring.
- "libc selection", Linux only: with the tarball fetch pointed at a local 404 server (`BUN_COMPILE_TARGET_TARBALL_URL`) and an empty `BUN_INSTALL_CACHE_DIR`, a target without a libc segment builds without any fetch, while a segment naming the other libc fails with `Target platform 'bun-linux-<arch>[-musl]-vX.Y.Z' is not available for download` after exactly one fetch. On the musl CI lanes the "other" libc is glibc, which is the only place the `glibc => Libc::Default` mapping is observable (on glibc hosts it is a no-op); on glibc lanes the same test exercises `-musl`.

Without the `src/` change, both accept tests and the glibc, `glibc-invalid` and `glibc-v1.2` rejection rows fail; with it the whole file passes under `bun bd test`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->