### PR TITLE
error: don't add a synthetic <parse> frame to SyntaxErrors that aren't parser errors

### DIFF
--- a/src/jsc/bindings/AsyncStackTrace.cpp
+++ b/src/jsc/bindings/AsyncStackTrace.cpp
@@ -4,6 +4,7 @@
 
 #include "BunClientData.h"
 #include "ErrorStackFrame.h"
+#include "FormatStackTraceForJS.h"
 
 #include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/ErrorInstance.h>
@@ -174,5 +175,6 @@ extern "C" void Bun__attachAsyncStackFromPromise(JSC::JSGlobalObject* globalObje
     if (frames.isEmpty())
         return;
 
+    Bun::clearStaleErrorLocation(instance);
     instance->setStackFrames(vm, WTF::move(frames));
 }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,7 +177,12 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            if (err->errorType() == ErrorType::SyntaxError && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
+            // The synthetic <parse> frame shows the source JSC's parser rejected, which it
+            // records on the error via addErrorInfo(). A SyntaxError from user code, JSON.parse,
+            // RegExp, etc. records no sourceURL, so there is no parse location to show.
+            // (isParseError() is not usable here: ParserError::toErrorObject sets it only after
+            // addErrorInfo() has already materialized .stack.)
+            if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:
                 // /* empty comment */

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,7 +177,7 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // Only parser errors record a sourceURL (addErrorInfo); it is what the <parse> frame shows.
+            // Parser errors record the rejected source's URL via addErrorInfo(); it is what this frame shows.
             if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,8 +177,7 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // Only JSC's parser records a sourceURL on the error (addErrorInfo); it is the location
-            // this frame shows. isParseError() is set after addErrorInfo() has already formatted .stack.
+            // Only parser errors record a sourceURL (addErrorInfo); it is what the <parse> frame shows.
             if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -654,9 +654,7 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
 
 void clearStaleErrorLocation(JSC::ErrorInstance* instance)
 {
-    // A parser error's recorded location is the parse failure (rendered as the <parse> frame).
-    // Any other recorded location came from frames the instance used to have (written back by
-    // the GC finalizer, or copied by structured clone) and is superseded by the new frames.
+    // Only a parse location outlives the frames; any other one was derived from the old frames.
     if (instance->isParseError())
         return;
     instance->setSourceURL(String());

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -652,6 +652,18 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
     return result;
 }
 
+void clearStaleErrorLocation(JSC::ErrorInstance* instance)
+{
+    // A parser error's recorded location is the parse failure (rendered as the <parse> frame).
+    // Any other recorded location came from frames the instance used to have (written back by
+    // the GC finalizer, or copied by structured clone) and is superseded by the new frames.
+    if (instance->isParseError())
+        return;
+    instance->setSourceURL(String());
+    instance->setLine(0);
+    instance->setColumn(0);
+}
+
 JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(lexicalGlobalObject);
@@ -667,6 +679,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (!destination->stackTrace()) {
+        clearStaleErrorLocation(destination);
         destination->captureStackTrace(vm, globalObject, 1);
     }
 
@@ -777,6 +790,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
     JSCStackTrace::getFramesForCaller(vm, callFrame, errorObject, caller, stackTrace, stackTraceLimit);
 
     if (auto* instance = dynamicDowncast<JSC::ErrorInstance>(errorObject)) {
+        clearStaleErrorLocation(instance);
         if (instance->hasMaterializedErrorInfo()) {
             // Error info was already materialized (e.g. .stack was previously accessed).
             // Don't call setStackFrames — it would leave m_errorInfoMaterialized=true with

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -198,15 +198,12 @@ WTF::String formatStackTrace(
                 String sourceURLForFrame = err->sourceURL();
 
                 // If it's not a Zig::GlobalObject, don't bother source-mapping it.
-                if (globalObject && !sourceURLForFrame.isEmpty()) {
-                    // https://github.com/oven-sh/bun/issues/3595
-                    if (!sourceURLForFrame.isEmpty()) {
-                        remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
-                        // This ensures the lifetime of the sourceURL is accounted for correctly
-                        Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
+                if (globalObject) {
+                    remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
+                    // This ensures the lifetime of the sourceURL is accounted for correctly
+                    Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
 
-                        sourceURLForFrame = remappedFrame.source_url.toWTFString();
-                    }
+                    sourceURLForFrame = remappedFrame.source_url.toWTFString();
                 }
 
                 // there is always a newline before each stack frame line, ensuring that the name + message

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,11 +177,8 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // The synthetic <parse> frame shows the source JSC's parser rejected, which it
-            // records on the error via addErrorInfo(). A SyntaxError from user code, JSON.parse,
-            // RegExp, etc. records no sourceURL, so there is no parse location to show.
-            // (isParseError() is not usable here: ParserError::toErrorObject sets it only after
-            // addErrorInfo() has already materialized .stack.)
+            // Only JSC's parser records a sourceURL on the error (addErrorInfo); it is the location
+            // this frame shows. isParseError() is set after addErrorInfo() has already formatted .stack.
             if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -70,6 +70,9 @@ WTF::String formatStackTrace(
     WTF::Vector<JSC::StackFrame>& stackTrace,
     JSC::JSObject* errorInstance);
 
+// Call before giving an existing ErrorInstance new frames.
+void clearStaleErrorLocation(JSC::ErrorInstance* instance);
+
 // JSC Host Functions - Error constructor methods
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace);
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace);

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, bunRun, gcTick, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 import vm from "node:vm";
 
@@ -199,6 +199,36 @@ describe("SyntaxError .stack", () => {
     // Math.max is not on the stack, so every frame is dropped.
     Error.captureStackTrace(err, Math.max);
     expect(err.stack).toBe("SyntaxError: no frames");
+  });
+
+  // An instance can also carry a location copied from frames it no longer has: structured
+  // clone copies one, and the GC finalizer writes one back when it formats the stack of an
+  // error whose frames died. Re-capturing from a different file than that location must not
+  // turn it into a <parse> frame. The error is constructed in a function attributed to
+  // another file; a fresh function each time so the GC case has something to collect.
+  const constructElsewhere = () =>
+    (new Function('return new SyntaxError("made elsewhere");\n//# sourceURL=elsewhere.js') as () => SyntaxError)();
+
+  const recaptured = (err: SyntaxError) => {
+    Error.captureStackTrace(err);
+    return { stack: normalizeBunSnapshot(err.stack!), sourceURL: (err as any).sourceURL };
+  };
+
+  test("a structuredClone()d SyntaxError re-captured from another file has no <parse> frame", () => {
+    expect(recaptured(structuredClone(constructElsewhere()))).toEqual({
+      stack: "SyntaxError: made elsewhere\n    at recaptured (file:NN:NN)\n    at <anonymous> (file:NN:NN)",
+      sourceURL: expect.stringContaining("stack.test.ts"),
+    });
+  });
+
+  test("a SyntaxError whose frames were collected, re-captured from another file, has no <parse> frame", async () => {
+    const err = constructElsewhere();
+    await gcTick();
+    await gcTick();
+    expect(recaptured(err)).toEqual({
+      stack: "SyntaxError: made elsewhere\n    at recaptured (file:NN:NN)\n    at <anonymous> (file:NN:NN)",
+      sourceURL: expect.stringContaining("stack.test.ts"),
+    });
   });
 
   test("Bun.inspect() of a SyntaxError whose .stack was already read shows the real frame", () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,7 +1,8 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
+import vm from "node:vm";
 
 test("name property is used for function calls in Error.stack", () => {
   function WRONG() {
@@ -148,4 +149,143 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// When JSC's parser rejects a source it records that source's URL and line on the
+// SyntaxError, and .stack renders them as a synthetic "at <parse> (url:line)" frame.
+// Every other SyntaxError has no such location and must format like node's: the
+// header followed by the real frames.
+describe("SyntaxError .stack", () => {
+  test("new SyntaxError() has no <parse> frame", () => {
+    const err = new SyntaxError("user made");
+    expect(normalizeBunSnapshot(err.stack!)).toMatchInlineSnapshot(`
+      "SyntaxError: user made
+          at <anonymous> (file:NN:NN)"
+    `);
+  });
+
+  const caught = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (e) {
+      return e as Error;
+    }
+    throw new Error("expected fn to throw");
+  };
+
+  test.each([
+    ["SyntaxError() called without new", () => SyntaxError("user made")],
+    ["a SyntaxError subclass", () => new (class MySyntaxError extends SyntaxError {})("user made")],
+    ["JSON.parse()", () => caught(() => JSON.parse("{"))],
+    ["new RegExp()", () => caught(() => new RegExp("[a-0]"))],
+  ])("%s has no <parse> frame", (_, make) => {
+    const stack = make().stack!;
+    expect(stack).not.toContain("<parse>");
+    // The real frames are still there; the outermost one is this test callback.
+    expect(stack.split("\n").at(-1)).toMatch(/^    at .*stack\.test\.ts:\d+:\d+\)?$/);
+  });
+
+  test("Error.captureStackTrace() on a SyntaxError adds no <parse> frame", () => {
+    const err = new SyntaxError("captured");
+    Error.captureStackTrace(err);
+    expect(normalizeBunSnapshot(err.stack!)).toMatchInlineSnapshot(`
+      "SyntaxError: captured
+          at <anonymous> (file:NN:NN)"
+    `);
+  });
+
+  test("a SyntaxError with no frames at all is just the header", () => {
+    const err = new SyntaxError("no frames");
+    // Math.max is not on the stack, so every frame is dropped.
+    Error.captureStackTrace(err, Math.max);
+    expect(err.stack).toBe("SyntaxError: no frames");
+  });
+
+  test("Bun.inspect() of a SyntaxError whose .stack was already read shows the real frame", () => {
+    const err = new SyntaxError("inspected");
+    // Once .stack is materialized the printer works from the string instead of the frames.
+    void err.stack;
+    const printed = Bun.inspect(err);
+    expect(printed).toContain("SyntaxError: inspected");
+    expect(printed).not.toContain("<parse>");
+    expect(printed).toMatch(/stack\.test\.ts:\d+:\d+/);
+  });
+
+  test("an uncaught SyntaxError whose .stack was already read still reports where it was created", async () => {
+    using dir = tempDir("syntax-error-stack", {
+      "index.js": ['const err = new SyntaxError("boom");', "void err.stack;", "throw err;", ""].join("\n"),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("SyntaxError: boom");
+    expect(stderr).not.toContain("<parse>");
+    expect(stderr).toMatch(/index\.js:1:\d+/);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a parser SyntaxError keeps its <parse> frame", () => {
+    const err = caught(() => new vm.Script("\n\n/[a-0]/", { filename: "my-script.js" }));
+    expect(err.stack!.split("\n")).toContain("    at <parse> (my-script.js:3)");
+  });
+
+  test("a parser SyntaxError in a source without a URL has no <parse> frame", () => {
+    // There is no file to point at, so an "at <parse> (:4)" line would only be noise.
+    const stack = caught(() => new Function("{")).stack!;
+    expect(stack).not.toContain("<parse>");
+    expect(stack.split("\n").at(-1)).toMatch(/^    at .*stack\.test\.ts:\d+:\d+\)?$/);
+  });
+
+  test("a parser SyntaxError from importing a module keeps its <parse> frame", async () => {
+    // Bun's transpiler accepts these modules; JSC's parser rejects the regex. A top-level
+    // await import() fails while no JS frame is on the stack, so the errors only get frames
+    // (and a .stack) from Error.captureStackTrace.
+    const badModule = ["module.exports = 1;", '"".match(/[a-0]/);', ""].join("\n");
+    using dir = tempDir("parse-error-import", {
+      "bad-a.cjs": badModule,
+      "bad-b.cjs": badModule,
+      "index.mjs": `
+        let a, b;
+        try {
+          await import("./bad-a.cjs");
+        } catch (e) {
+          a = e;
+        }
+        try {
+          await import("./bad-b.cjs");
+        } catch (e) {
+          b = e;
+        }
+        // Math.max is not on the stack, so no frames are captured for a.
+        Error.captureStackTrace(a, Math.max);
+        Error.captureStackTrace(b);
+        console.log(JSON.stringify([a.stack, b.stack]));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const [noFrames, withFrames] = JSON.parse(stdout) as [string, string];
+    expect(noFrames.split("\n")).toEqual([
+      expect.stringMatching(/^SyntaxError: /),
+      expect.stringMatching(/^    at <parse> \(.*bad-a\.cjs:\d+\)$/),
+    ]);
+    expect(withFrames.split("\n").slice(0, 3)).toEqual([
+      expect.stringMatching(/^SyntaxError: /),
+      expect.stringMatching(/^    at <parse> \(.*bad-b\.cjs:\d+\)$/),
+      expect.stringMatching(/^    at .*index\.mjs:\d+:\d+\)?$/),
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -222,7 +222,8 @@ describe("SyntaxError .stack", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toContain("SyntaxError: boom");
     expect(stderr).not.toContain("<parse>");
     expect(stderr).toMatch(/index\.js:1:\d+/);
@@ -235,10 +236,17 @@ describe("SyntaxError .stack", () => {
   });
 
   test("a parser SyntaxError in a source without a URL has no <parse> frame", () => {
-    // There is no file to point at, so an "at <parse> (:4)" line would only be noise.
-    const stack = caught(() => new Function("{")).stack!;
+    // There is no file to point at, so an "at <parse> (:1)" line would only be noise.
+    // Not new Function("{") or eval: those materialize .stack from inside JSC's own parse-error
+    // path, which never checks for an exception from the stack hook, so they abort under
+    // BUN_JSC_validateExceptionChecks (see #30823). node:vm's path checks.
+    const stack = caught(() => vm.compileFunction("{")).stack!;
     expect(stack).not.toContain("<parse>");
     expect(stack.split("\n").at(-1)).toMatch(/^    at .*stack\.test\.ts:\d+:\d+\)?$/);
+
+    // The same source with a URL keeps the frame.
+    const named = caught(() => vm.compileFunction("{", [], { filename: "named.js" })).stack!;
+    expect(named.split("\n")).toContain("    at <parse> (named.js:1)");
   });
 
   test("a parser SyntaxError from importing a module keeps its <parse> frame", async () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -206,8 +206,12 @@ describe("SyntaxError .stack", () => {
   // error whose frames died. Re-capturing from a different file than that location must not
   // turn it into a <parse> frame. The error is constructed in a function attributed to
   // another file; a fresh function each time so the GC case has something to collect.
-  const constructElsewhere = () =>
-    (new Function('return new SyntaxError("made elsewhere");\n//# sourceURL=elsewhere.js') as () => SyntaxError)();
+  const constructElsewhere = () => {
+    const construct = new Function(
+      'return new SyntaxError("made elsewhere");\n//# sourceURL=elsewhere.js',
+    ) as () => SyntaxError;
+    return { err: construct(), construct: new WeakRef(construct) };
+  };
 
   const recaptured = (err: SyntaxError) => {
     Error.captureStackTrace(err);
@@ -215,16 +219,23 @@ describe("SyntaxError .stack", () => {
   };
 
   test("a structuredClone()d SyntaxError re-captured from another file has no <parse> frame", () => {
-    expect(recaptured(structuredClone(constructElsewhere()))).toEqual({
+    expect(recaptured(structuredClone(constructElsewhere().err))).toEqual({
       stack: "SyntaxError: made elsewhere\n    at recaptured (file:NN:NN)\n    at <anonymous> (file:NN:NN)",
       sourceURL: expect.stringContaining("stack.test.ts"),
     });
   });
 
   test("a SyntaxError whose frames were collected, re-captured from another file, has no <parse> frame", async () => {
-    const err = constructElsewhere();
-    await gcTick();
-    await gcTick();
+    const { err, construct } = constructElsewhere();
+    // The finalizer only runs once the function in the error's frames is actually collected.
+    // Nothing can be read off `err` to check that without materializing it, so watch the
+    // function instead. deref() keeps its target alive for the rest of the current job, which
+    // is why each check is followed by two ticks: the second one collects in a fresh job.
+    for (let i = 0; construct.deref() !== undefined; i++) {
+      expect(i).toBeLessThan(10);
+      await gcTick();
+      await gcTick();
+    }
     expect(recaptured(err)).toEqual({
       stack: "SyntaxError: made elsewhere\n    at recaptured (file:NN:NN)\n    at <anonymous> (file:NN:NN)",
       sourceURL: expect.stringContaining("stack.test.ts"),


### PR DESCRIPTION
### What does this PR do?

Any `SyntaxError` that did not come out of JSC's parser got a fabricated first frame in its `.stack`:

```js
const e = new SyntaxError("user made");
console.log(e.stack);
```

```
# bun 1.4.0
SyntaxError: user made
    at <parse> (:0)
    at /tmp/se.js:1:15

# node
SyntaxError: user made
    at Object.<anonymous> (/tmp/se.js:1:11)
```

The same `at <parse> (:0)` line shows up on `SyntaxError()` without `new`, subclasses, `Error.captureStackTrace()` on a SyntaxError, and the SyntaxErrors thrown by `JSON.parse()` and `new RegExp()`. Anything that reads frames by index out of `.stack` is off by one for these errors.

It also breaks Bun's own error output. Once `.stack` has been read (a logger, a test framework, `util.inspect`), the error printer re-parses the stack string, and it parses the bogus line and stops there, so an uncaught user-constructed SyntaxError prints with no location at all:

```
SyntaxError: thrown after materialize
      at <parse> (1:1)
```

### Cause

`formatStackTrace()` in `src/jsc/bindings/FormatStackTraceForJS.cpp` appends the synthetic `<parse>` frame for every `ErrorInstance` of type SyntaxError whose first frame does not come from `err->sourceURL()`. That check was written for parser errors, where `addErrorInfo()` has recorded the URL and line of the source that failed to parse. For every other SyntaxError `err->sourceURL()` is empty, so the comparison is always true and the frame is rendered from an empty URL and line 0.

### Fix

Only emit the frame when the error actually records a sourceURL. The frame's whole content is that URL and line, and the parser is what records them, so this is the direct statement of what the branch was meant to test. Errors with a recorded URL behave exactly as before in both arms of the existing condition (`vm.Script` with a filename, modules that JSC rejects after Bun's transpiler accepted them, with or without frames). Everything else now formats as header plus real frames, which is what node prints.

`ErrorInstance::isParseError()` looked like the obvious discriminator but does not work here: `ParserError::toErrorObject()` calls `addErrorInfo()`, which materializes `.stack` immediately, and only sets the flag afterwards, so it is still false while the stack is being formatted (verified: gating on it dropped the frame for every parser error; the `vm.Script` and `import()` tests below fail that way).

The new condition makes the two `!sourceURLForFrame.isEmpty()` guards inside the branch always true, so they are deleted along with the #3595 reference on them (the same guard in the per-frame loop below still does work and keeps its reference).

Review found one more way a non-parser SyntaxError can carry a sourceURL: the GC finalizer writes the first frame's URL back onto an instance whose frames died, and structured clone copies one over. An error in that state that is then `Error.captureStackTrace()`d from a different file still satisfied the check and printed `at <parse> (<file it was constructed in>:N)` (pre-existing; node prints only the new frames). So the second part of the fix: `captureStackTrace`, `appendStackTrace` and the async stack attach clear that recorded location before installing frames (`clearStaleErrorLocation`), except on parser errors, where it is the parse failure itself. `isParseError()` is reliable at these points because they can only run after `toErrorObject()` has returned; the `import()` tests below cover that exemption. This also makes the clone's `.sourceURL`/`.line`/`.column` agree with its new `.stack` instead of keeping the construction site.

One deliberate consequence: parser errors for sources with no URL (`new Function("{")`, `eval("{")`, `vm.compileFunction()` without a filename) previously printed `at <parse> (:4)` / `at <parse> (:0)` / `at <parse> (:1)`. With no file to point at that line carried nothing, and node prints no such line either, so they now format like the rest. The new tests pin this.

### Tests

Added to `test/js/bun/test/stack.test.ts`:

- `new SyntaxError()`, `SyntaxError()` without `new`, a subclass, `JSON.parse()`, `new RegExp()`: no `<parse>` line, real frames still present
- `Error.captureStackTrace()` on a SyntaxError, and the zero-frame case (`captureStackTrace(err, Math.max)`), which exercises the `stackTrace.isEmpty()` arm
- A `structuredClone()`d SyntaxError, and one whose frames were collected, each constructed in a function attributed to another file via `//# sourceURL` and re-captured here: no `<parse>` line, and `.sourceURL` now points at the capture site. The GC test holds a `WeakRef` to the constructing function and runs `gcTick()` until it is gone, so the finalizer write-back it depends on is asserted rather than assumed
- `Bun.inspect()` of a SyntaxError after `.stack` was read, and an uncaught one in a child process, both still report the creation site
- `vm.compileFunction("{")` (URL-less parser error) gets no `<parse>` line, while the same call with a `filename` keeps it. This uses node:vm rather than `new Function("{")` because materializing `.stack` from inside JSC's own parse-error path leaves the stack hook's exception unchecked, which aborts under `BUN_JSC_validateExceptionChecks` on the debug CI lane; that is pre-existing and is what #30823 addresses.
- Guards for what must keep working: `new vm.Script(..., { filename })` keeps `at <parse> (my-script.js:3)`, and two `await import()`s of modules JSC rejects keep `at <parse> (<path>:N)` both with zero captured frames and with frames

```
USE_SYSTEM_BUN=1 bun test test/js/bun/test/stack.test.ts   # 12 of the new tests fail, the 2 guards pass
bun bd test test/js/bun/test/stack.test.ts                  # 20 pass, also under BUN_JSC_validateExceptionChecks=1
```

Also ran `test/js/node/v8/capture-stack-trace.test.js`, `test/js/node/vm/vm.test.ts`, `test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js`, `test/js/web/workers/structured-clone.test.ts`, `test/js/node/worker_threads/worker_threads.test.ts`, the async stack tests in `test/js/node/fs/promises.test.js`, `test/js/bun/util/bun-file.test.ts` and `test/js/web/streams/streams.test.js`, and the `node:repl` SyntaxError printing tests against the debug build: all pass.

Longer term the condition in `formatStackTrace()` itself could use `isParseError()` if the WebKit fork set the flag before `addErrorInfo()` materializes the stack; that would make `clearStaleErrorLocation` unnecessary. That needs a WebKit bump, so it is left out of this PR.

Related but separate: #36634 changes how the location is remapped inside this branch for real parser errors; it does not touch the condition, and the two changes compose.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts
bun test v1.4.0 (053affe65)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [14.53ms]
(pass) name property is used for function calls in Bun.inspect [10.89ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [312.12ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-debug+053affe65 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [315.75ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-debug+053affe65 (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [759.12ms]
Error: error from qux
    at qux (/workspace/bun/test/js/bun/test/sta
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (cbab6f483)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [0.61ms]
(pass) name property is used for function calls in Bun.inspect [0.26ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [10.03ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-canary.1+cbab6f483 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [7.98ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-canary.1+cbab6f483 (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [14.62ms]
Error: error from qux
    at qux (/workspace/bun/test/js/bun/test/stack.test.ts:137:16)
    at baz (/workspace/bun/test/js/bun/test/stack.test.ts:134:18)
    at async bar (/workspace/bun/test/js/bun/test/stack.test.ts:130:18
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts
bun test v1.4.0 (053affe65)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [7.52ms]
(pass) name property is used for function calls in Bun.inspect [10.51ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [329.17ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.0-debug+053affe65 (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [352.04ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.0-debug+053affe65 (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [767.17ms]
Error: error from qux
    at qux (/workspace/bun/test/js/bun/test/stac
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (9859ms)
Bundle modules (57ms)
Postprocesss modules (103ms)
Bundle Functions (868ms)
Generate Code (28ms)

[10.93s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/AsyncStackTrace.cpp       |   2 +
 src/jsc/bindings/FormatStackTraceForJS.cpp |  30 +++--
 src/jsc/bindings/FormatStackTraceForJS.h   |   3 +
 test/js/bun/test/stack.test.ts             | 193 ++++++++++++++++++++++++++++-
 4 files changed, 216 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/AsyncStackTrace.cpp            2      2      0
src/jsc/bindings/FormatStackTraceForJS.cpp      5     10      0
src/jsc/bindings/FormatStackTraceForJS.h        1      2      0
test/js/bun/test/stack.test.ts                  5     11      0
```

</details>

<!-- robobun:evidence:end -->