### PR TITLE
transpiler: stop minifying `new Error()` (and other known-global constructs) into calls that JSC tail-calls

### DIFF
--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -103,7 +103,6 @@ impl KnownGlobal {
         let constructor = lookup(original_name)?;
 
         match constructor {
-            // Error constructors can be called without 'new' with identical behavior
             KnownGlobal::Error
             | KnownGlobal::TypeError
             | KnownGlobal::SyntaxError
@@ -112,8 +111,11 @@ impl KnownGlobal {
             | KnownGlobal::EvalError
             | KnownGlobal::URIError
             | KnownGlobal::AggregateError => {
-                // Convert `new Error(...)` to `Error(...)` to save bytes
-                Some(Self::call_from_new(e, loc))
+                // `Error(...)` builds the same object as `new Error(...)`, but not the
+                // same `.stack`: in strict mode JSC turns `return Error(...)` into a
+                // proper tail call, so the function creating the error is already gone
+                // when the stack is captured. `new` is never a tail call. Keep it.
+                None
             }
 
             KnownGlobal::Object => {

--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -110,11 +110,13 @@ impl KnownGlobal {
             | KnownGlobal::ReferenceError
             | KnownGlobal::EvalError
             | KnownGlobal::URIError
-            | KnownGlobal::AggregateError => {
-                // `Error(...)` builds the same object as `new Error(...)`, but not the
-                // same `.stack`: in strict mode JSC turns `return Error(...)` into a
-                // proper tail call, so the function creating the error is already gone
-                // when the stack is captured. `new` is never a tail call. Keep it.
+            | KnownGlobal::AggregateError
+            | KnownGlobal::Function => {
+                // These build the same object with or without `new`, but they read the calling
+                // frame, and in strict mode JSC compiles `return Error(...)` to a proper tail
+                // call that has already popped it: the error's `.stack` loses the function that
+                // created it, and a `Function(...)` body takes its source origin (the base for
+                // `import()` inside it) from the caller's caller. `new` is never a tail call.
                 None
             }
 
@@ -257,10 +259,6 @@ impl KnownGlobal {
                 }
             }
 
-            KnownGlobal::Function => {
-                // Just remove 'new' for Function
-                Some(Self::call_from_new(e, loc))
-            }
             KnownGlobal::RegExp => {
                 // Don't optimize RegExp - the semantics are too complex:
                 // - new RegExp(re) creates a copy, but RegExp(re) returns the same instance

--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -65,18 +65,6 @@ fn lookup(name: &[u8]) -> Option<KnownGlobal> {
 }
 
 impl KnownGlobal {
-    #[inline(always)]
-    fn call_from_new(e: &mut E::New, loc: crate::Loc) -> js_ast::Expr {
-        let call = E::Call {
-            target: e.target,
-            args: bun_alloc::AstAlloc::take(&mut e.args),
-            close_paren_loc: e.close_parens_loc,
-            can_be_unwrapped_if_unused: e.can_be_unwrapped_if_unused,
-            ..Default::default()
-        };
-        js_ast::Expr::init(call, loc)
-    }
-
     // `_bump` is unused; the `Vec` uses the global arena.
     #[inline(never)]
     pub fn minify_global_constructor(
@@ -102,6 +90,9 @@ impl KnownGlobal {
         let original_name = symbol.original_name.slice();
         let constructor = lookup(original_name)?;
 
+        // `new X(...)` is only ever folded into a literal, never rewritten into the call `X(...)`:
+        // in strict mode `return X(...)` is a proper tail call, so the frame creating the value is
+        // gone by the time `X` captures a stack trace, reads its source origin (`Function`) or throws.
         match constructor {
             KnownGlobal::Error
             | KnownGlobal::TypeError
@@ -111,10 +102,9 @@ impl KnownGlobal {
             | KnownGlobal::EvalError
             | KnownGlobal::URIError
             | KnownGlobal::AggregateError
-            | KnownGlobal::Function => {
-                // Kept: these read the calling frame, which a strict-mode `return Error(...)` tail call has already popped.
-                None
-            }
+            | KnownGlobal::Function
+            // `RegExp(re)` would also return `re` itself where `new RegExp(re)` copies it.
+            | KnownGlobal::RegExp => None,
 
             KnownGlobal::Object => {
                 let n = e.args.len_u32();
@@ -141,8 +131,7 @@ impl KnownGlobal {
                     }
                 }
 
-                // For other cases, just remove 'new'
-                Some(Self::call_from_new(e, loc))
+                None
             }
 
             KnownGlobal::Array => {
@@ -176,7 +165,6 @@ impl KnownGlobal {
                         // For other types, check via knownPrimitive
                         let primitive = arg.known_primitive();
                         // Only convert if we know for certain it's not a number
-                        // unknown could be a number at runtime, so we must preserve Array() call
                         match primitive {
                             js_ast::expr::PrimitiveType::Null
                             | js_ast::expr::PrimitiveType::Undefined
@@ -195,7 +183,7 @@ impl KnownGlobal {
                             js_ast::expr::PrimitiveType::Number => {
                                 let val = match arg.data {
                                     js_ast::ExprData::ENumber(num) => num.value(),
-                                    _ => return Some(Self::call_from_new(e, loc)),
+                                    _ => return None,
                                 };
                                 if
                                 // only want this with whitespace minification
@@ -231,13 +219,11 @@ impl KnownGlobal {
                                         loc,
                                     ));
                                 }
-                                Some(Self::call_from_new(e, loc))
+                                None
                             }
+                            // Could be a number, so `new Array(x)` may mean a length.
                             js_ast::expr::PrimitiveType::Unknown
-                            | js_ast::expr::PrimitiveType::Mixed => {
-                                // Could be a number, preserve Array() call
-                                Some(Self::call_from_new(e, loc))
-                            }
+                            | js_ast::expr::PrimitiveType::Mixed => None,
                         }
                     }
                     // > 1
@@ -255,14 +241,6 @@ impl KnownGlobal {
                 }
             }
 
-            KnownGlobal::RegExp => {
-                // Don't optimize RegExp - the semantics are too complex:
-                // - new RegExp(re) creates a copy, but RegExp(re) returns the same instance
-                // - This affects object identity and lastIndex behavior
-                // - The difference only applies when flags are undefined
-                // Keep the original new RegExp() call to preserve correct semantics
-                None
-            }
             KnownGlobal::WeakSet | KnownGlobal::WeakMap => {
                 let n = e.args.len_u32();
 

--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -135,6 +135,16 @@ impl KnownGlobal {
             }
 
             KnownGlobal::Array => {
+                // `new Array(5, ...rest)` is `new Array(5)`, a length, when `rest` is empty.
+                if e
+                    .args
+                    .slice()
+                    .iter()
+                    .any(|arg| matches!(arg.data, js_ast::ExprData::ESpread(_)))
+                {
+                    return None;
+                }
+
                 let n = e.args.len_u32();
 
                 match n {

--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -112,11 +112,7 @@ impl KnownGlobal {
             | KnownGlobal::URIError
             | KnownGlobal::AggregateError
             | KnownGlobal::Function => {
-                // These build the same object with or without `new`, but they read the calling
-                // frame, and in strict mode JSC compiles `return Error(...)` to a proper tail
-                // call that has already popped it: the error's `.stack` loses the function that
-                // created it, and a `Function(...)` body takes its source origin (the base for
-                // `import()` inside it) from the caller's caller. `new` is never a tail call.
+                // Kept: these read the calling frame, which a strict-mode `return Error(...)` tail call has already popped.
                 None
             }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: `new Error(...)` (and the other native error constructors, `Function`,
+/// `Object`, `Array`) is no longer rewritten into a plain call; older entries hold the
+/// call form, which JSC tail-calls and so drops the creating function from the stack.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1070,8 +1070,9 @@ describe("bundler", () => {
       "{}", // new Object() -> {}
       "{}", // new Object(null) -> {}
       "{ a: 1 }", // new Object({ a: 1 }) -> { a: 1 }
-      'Function("return 42")',
-      'Function("a", "b", "return a + b")',
+      // kept for the same reason as the Error constructors: the body's source origin comes from the calling frame
+      'new Function("return 42")',
+      'new Function("a", "b", "return a + b")',
       'new RegExp("test")',
       'new RegExp("test", "gi")',
       "new RegExp(/abc/)",

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -819,7 +819,10 @@ describe("bundler", () => {
     },
   });
 
-  itBundled("minify/ErrorConstructorOptimization", {
+  // `Error(...)` creates the same object as `new Error(...)`, but in strict mode JSC compiles
+  // `return Error(...)` to a tail call, which removes the creating function from the stack trace.
+  // `new` is never a tail call, so it has to stay.
+  itBundled("minify/ErrorConstructorKeepsNew", {
     files: {
       "/entry.js": /* js */ `
         // Test all Error constructors
@@ -862,31 +865,52 @@ describe("bundler", () => {
       `,
     },
     capture: [
-      "Error()",
-      'Error("message")',
-      'Error("message", { cause: "cause" })',
-      "TypeError()",
-      'TypeError("type error")',
-      "SyntaxError()",
-      'SyntaxError("syntax error")',
-      "RangeError()",
-      'RangeError("range error")',
-      "ReferenceError()",
-      'ReferenceError("ref error")',
-      "EvalError()",
-      'EvalError("eval error")',
-      "URIError()",
-      'URIError("uri error")',
-      'AggregateError([], "aggregate error")',
-      'AggregateError([Error("e1")], "multiple")',
-      "Error(msg)",
-      "TypeError(getErrorMessage())",
+      "new Error",
+      'new Error("message")',
+      'new Error("message", { cause: "cause" })',
+      "new TypeError",
+      'new TypeError("type error")',
+      "new SyntaxError",
+      'new SyntaxError("syntax error")',
+      "new RangeError",
+      'new RangeError("range error")',
+      "new ReferenceError",
+      'new ReferenceError("ref error")',
+      "new EvalError",
+      'new EvalError("eval error")',
+      "new URIError",
+      'new URIError("uri error")',
+      'new AggregateError([], "aggregate error")',
+      'new AggregateError([new Error("e1")], "multiple")',
+      "new Error(msg)",
+      "new TypeError(getErrorMessage())",
       "/* @__PURE__ */ new Date",
       "/* @__PURE__ */ new Map",
       "/* @__PURE__ */ new Set",
     ],
     minifySyntax: true,
     target: "bun",
+  });
+
+  itBundled("minify/ErrorReturnedFromFunctionKeepsItsFrame", {
+    files: {
+      "/entry.js": /* js */ `
+        function makeError() {
+          return new Error("made");
+        }
+        function makeTypeError() {
+          const err = new TypeError("made");
+          return err;
+        }
+        const frames = [makeError, makeTypeError].map(make => make().stack.includes("at " + make.name + " "));
+        console.log(JSON.stringify(frames));
+      `,
+    },
+    minifySyntax: true,
+    target: "bun",
+    run: {
+      stdout: "[true,true]",
+    },
   });
 
   itBundled("minify/ErrorConstructorWithVariables", {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1027,6 +1027,7 @@ describe("bundler", () => {
         capture(new Array(3));
         capture(new Array(unknownValue));
         capture(new Array(...unknownValue));
+        capture(new Array(5, ...unknownValue));
         capture(new Array(1, 2, 3));
         
         // Test Array with non-numeric single arguments (should convert to literal)
@@ -1063,11 +1064,13 @@ describe("bundler", () => {
     },
     capture: [
       "[]", // new Array() -> []
-      // A single argument may be a length, so these cannot become literals. They are not turned
-      // into `Array(...)` calls either (see ErrorConstructorKeepsNew); `new` stays as written.
+      // A single argument (possibly what a spread leaves behind at runtime) may be a length, so these
+      // cannot become literals. They are not turned into `Array(...)` calls either (see
+      // ErrorConstructorKeepsNew); `new` stays as written.
       "new Array(3)",
       "new Array(unknownValue)",
       "new Array(...unknownValue)",
+      "new Array(5, ...unknownValue)",
       `[
   1,
   2,
@@ -1166,6 +1169,12 @@ describe("bundler", () => {
         const a3 = new Array(n);
         const a4 = Array(n);
         capture(a3.length === a4.length && a3.length === 3 && a3[0] === undefined);
+
+        // A spread can leave a single number behind at runtime, and then it is a length
+        const none = [];
+        const a5 = new Array(5, ...none);
+        capture(a5.length === 5);
+        capture(0 in a5 === false);
         
         // Test Object semantics
         const o1 = new Object();
@@ -1194,6 +1203,8 @@ describe("bundler", () => {
       "0 in sparse === !1",
       'JSON.stringify(sparse) === "[null,null,null,null,null]"',
       "a3.length === a4.length && a3.length === 3 && a3[0] === void 0",
+      "a5.length === 5",
+      "0 in a5 === !1",
       "typeof o1 === typeof o2",
       "o1.constructor === o2.constructor",
       "typeof f1 === typeof f2",
@@ -1204,7 +1215,7 @@ describe("bundler", () => {
     minifySyntax: true,
     target: "bun",
     run: {
-      stdout: "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue",
+      stdout: "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue",
     },
   });
 

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -892,7 +892,7 @@ describe("bundler", () => {
     target: "bun",
   });
 
-  itBundled("minify/ErrorReturnedFromFunctionKeepsItsFrame", {
+  itBundled("minify/ReturnedConstructorKeepsItsFrame", {
     files: {
       "/entry.js": /* js */ `
         function makeError() {
@@ -902,14 +902,28 @@ describe("bundler", () => {
           const err = new TypeError("made");
           return err;
         }
-        const frames = [makeError, makeTypeError].map(make => make().stack.includes("at " + make.name + " "));
+        function makeArray(...lengths) {
+          return new Array(...lengths);
+        }
+        function thrownBy(make) {
+          try {
+            make(-1);
+          } catch (err) {
+            return err;
+          }
+        }
+        const frames = [
+          [makeError, makeError()],
+          [makeTypeError, makeTypeError()],
+          [makeArray, thrownBy(makeArray)],
+        ].map(([fn, err]) => err.stack.includes("at " + fn.name + " "));
         console.log(JSON.stringify(frames));
       `,
     },
     minifySyntax: true,
     target: "bun",
     run: {
-      stdout: "[true,true]",
+      stdout: "[true,true,true]",
     },
   });
 
@@ -1011,6 +1025,8 @@ describe("bundler", () => {
         // Test Array constructor
         capture(new Array());
         capture(new Array(3));
+        capture(new Array(unknownValue));
+        capture(new Array(...unknownValue));
         capture(new Array(1, 2, 3));
         
         // Test Array with non-numeric single arguments (should convert to literal)
@@ -1024,6 +1040,7 @@ describe("bundler", () => {
         capture(new Object());
         capture(new Object(null));
         capture(new Object({ a: 1 }));
+        capture(new Object(unknownValue));
         
         // Test Function constructor
         capture(new Function("return 42"));
@@ -1046,7 +1063,11 @@ describe("bundler", () => {
     },
     capture: [
       "[]", // new Array() -> []
-      "Array(3)", // new Array(3) stays as Array(3) because it creates sparse array
+      // A single argument may be a length, so these cannot become literals. They are not turned
+      // into `Array(...)` calls either (see ErrorConstructorKeepsNew); `new` stays as written.
+      "new Array(3)",
+      "new Array(unknownValue)",
+      "new Array(...unknownValue)",
       `[
   1,
   2,
@@ -1070,7 +1091,7 @@ describe("bundler", () => {
       "{}", // new Object() -> {}
       "{}", // new Object(null) -> {}
       "{ a: 1 }", // new Object({ a: 1 }) -> { a: 1 }
-      // kept for the same reason as the Error constructors: the body's source origin comes from the calling frame
+      "new Object(unknownValue)", // nothing to fold into a literal; kept as written
       'new Function("return 42")',
       'new Function("a", "b", "return a + b")',
       'new RegExp("test")',
@@ -1115,8 +1136,8 @@ describe("bundler", () => {
       "[,,,,,,,,]", // new Array(8) -> [undefined x 8]
       "[,,,,,,,,,]", // new Array(9) -> [undefined x 9]
       "[,,,,,,,,,,]", // new Array(10) -> [undefined x 10]
-      "Array(11)", // new Array(11) -> Array(11)
-      "Array(4.5)", // new Array(4.5) is Array(4.5) because it's not an integer
+      "new Array(11)", // too long to spell out as a literal; kept as written
+      "new Array(4.5)", // not an integer; kept as written
     ],
     minifySyntax: true,
     minifyWhitespace: true,

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -57,9 +57,9 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5629:at"],
+          ["react.development.js:524:'getContextName'", "1:5637:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
-          ["react.development.js:696:''Component'", '1:7691:\'Component "%s"'],
+          ["react.development.js:696:''Component'", '1:7699:\'Component "%s"'],
           ["entry.tsx:6:'\"Content-Type\"'", '100:18848:"Content-Type"'],
           ["entry.tsx:11:'<html>'", "100:19102:void"],
           ["entry.tsx:23:'await'", "100:19201:await"],
@@ -67,7 +67,7 @@ describe("bundler", () => {
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 222360,
+      "out/entry.js": 222388,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -57,17 +57,17 @@ describe("bundler", () => {
           "../entry.tsx",
         ],
         mappings: [
-          ["react.development.js:524:'getContextName'", "1:5623:at"],
+          ["react.development.js:524:'getContextName'", "1:5629:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
-          ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19062:void"],
-          ["entry.tsx:23:'await'", "100:19161:await"],
+          ["react.development.js:696:''Component'", '1:7691:\'Component "%s"'],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18848:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19102:void"],
+          ["entry.tsx:23:'await'", "100:19201:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 222000,
+      "out/entry.js": 222360,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -252,3 +252,37 @@ describe("unterminated string literals in large files", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// Rewriting `return new Function(...)` into `return Function(...)` makes it a proper tail call in
+// strict mode code, and the Function constructor then takes the source origin for the new body
+// from whichever frame is left: the caller's caller, in another file.
+test("a function body built with `return new Function()` resolves import() relative to the returning module", async () => {
+  using dir = tempDir("transpiler-new-function-origin", {
+    "main.mjs": /* js */ `
+      import { make } from "./lib/make.mjs";
+      const { which } = await make()();
+      console.log(which);
+    `,
+    "lib/make.mjs": /* js */ `
+      export function make() {
+        return new Function("return import('./which.mjs')");
+      }
+    `,
+    "lib/which.mjs": `export const which = "lib/which.mjs";`,
+    "which.mjs": `export const which = "which.mjs";`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("lib/which.mjs\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -567,7 +567,7 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
         const match = nextLine.match(/\s*at.*?:1003:(\d+)$/);
         if (!match) throw new Error("invalid string: " + nextLine);
         const col = match[1];
-        expect(Number(col)).toBe(1 + "throw new ".length + counter * 2);
+        expect(Number(col)).toBe(1 + "throw ".length + counter * 2);
       },
     });
     await runner.exited;
@@ -614,7 +614,7 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
         const match = nextLine.match(/\s*at.*?:(\d+):(\d+)\)?$/);
         if (!match) throw new Error("no :line:col in: " + JSON.stringify(nextLine));
         if (match[1] !== "1003") throw new Error("expected :1003: but got: " + JSON.stringify(nextLine));
-        expect(Number(match[2])).toBe(1 + "throw new ".length + counter * 2);
+        expect(Number(match[2])).toBe(1 + "throw ".length + counter * 2);
       },
     });
     await runner.exited;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1950,8 +1950,8 @@ it.concurrent("dev error page embeds the thrown error, its stack, and build/reso
   expect(exception.stack.frames[0]).toEqual({
     function_name: "inner",
     file: join(String(dir), "server.ts"),
-    // 1-based, pointing at `TypeError` — the same position `bun` prints to the terminal
-    position: { line: 3, column: 19 },
+    // 1-based, pointing at `new`, the same position `bun` prints to the terminal
+    position: { line: 3, column: 15 },
     scope: 3, // function
   });
   expect(exception.stack.source_lines).toContainEqual({

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -77,7 +77,7 @@ test("err.line and err.column are set", async () => {
         line: 3,
         column: 17,
         originalLine: 1,
-        originalColumn: 18,
+        originalColumn: 22,
       },
       null,
       2,
@@ -148,4 +148,48 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// Modules are strict mode code, and in strict mode JSC turns `return f()` into a proper tail
+// call: the returning function's frame is gone by the time `f` captures the stack. `new f()` is
+// never a tail call, so the transpiler must not rewrite `new Error()` into `Error()` to save bytes.
+test("a function returning `new Error()` is in the error's stack", () => {
+  const factories: Record<string, () => Error> = {
+    error() {
+      return new Error("error");
+    },
+    typeError() {
+      return new TypeError("typeError");
+    },
+    syntaxError() {
+      return new SyntaxError("syntaxError");
+    },
+    rangeError() {
+      return new RangeError("rangeError");
+    },
+    referenceError() {
+      return new ReferenceError("referenceError");
+    },
+    evalError() {
+      return new EvalError("evalError");
+    },
+    uriError() {
+      return new URIError("uriError");
+    },
+    aggregateError() {
+      return new AggregateError([], "aggregateError");
+    },
+    viaConst() {
+      // the single-use binding gets inlined into the return statement
+      const e = new Error("viaConst");
+      return e;
+    },
+    arrow: () => new Error("arrow"),
+  };
+
+  const missingOwnFrame = Object.keys(factories).filter(
+    name => !factories[name]().stack!.includes(`\n    at ${name} (`),
+  );
+
+  expect(missingOwnFrame).toEqual([]);
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -193,3 +193,18 @@ test("a function returning `new Error()` is in the error's stack", () => {
 
   expect(missingOwnFrame).toEqual([]);
 });
+
+test("a function whose returned `new Array()` throws is in the error's stack", () => {
+  function makeArray(...lengths: number[]) {
+    return new Array(...lengths);
+  }
+
+  let thrown: RangeError | undefined;
+  try {
+    makeArray(-1);
+  } catch (e) {
+    thrown = e as RangeError;
+  }
+
+  expect(thrown!.stack).toContain("\n    at makeArray (");
+});

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -49,7 +49,7 @@ test("verify we print error messages passed to done callbacks", () => {
     27 |   done(new Error(msg + "(sync)"));
     ^
     error: you should see this(sync)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:27:12)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:27:8)
     (fail) error done callback (sync)
     27 |   done(new Error(msg + "(sync)"));
     28 | });
@@ -59,7 +59,7 @@ test("verify we print error messages passed to done callbacks", () => {
     32 |   done(new Error(msg + "(async with await)"));
     ^
     error: you should see this(async with await)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:32:12)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:32:8)
     (fail) error done callback (async with await)
     32 |   done(new Error(msg + "(async with await)"));
     33 | });
@@ -69,7 +69,7 @@ test("verify we print error messages passed to done callbacks", () => {
     37 |   done(new Error(msg + "(async with Bun.sleep)"));
     ^
     error: you should see this(async with Bun.sleep)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:12)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:8)
     (fail) error done callback (async with Bun.sleep)
     37 |   done(new Error(msg + "(async with Bun.sleep)"));
     38 | });
@@ -79,7 +79,7 @@ test("verify we print error messages passed to done callbacks", () => {
     42 |     done(new Error(msg + "(async)"));
     ^
     error: you should see this(async)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:14)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:10)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:3)
     (fail) error done callback (async)
     43 |   });
@@ -90,7 +90,7 @@ test("verify we print error messages passed to done callbacks", () => {
     48 |     done(new Error(msg + "(async, setTimeout)"));
     ^
     error: you should see this(async, setTimeout)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:48:14)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:48:10)
     (fail) error done callback (async, setTimeout)
     49 |   }, 0);
     50 | });
@@ -100,7 +100,7 @@ test("verify we print error messages passed to done callbacks", () => {
     54 |     done(new Error(msg + "(async, setImmediate)"));
     ^
     error: you should see this(async, setImmediate)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:14)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:10)
     (fail) error done callback (async, setImmediate)
     55 |   });
     56 | });
@@ -110,7 +110,7 @@ test("verify we print error messages passed to done callbacks", () => {
     60 |     done(new Error(msg + "(async, nextTick)"));
     ^
     error: you should see this(async, nextTick)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:60:14)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:60:10)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:5)
     (fail) error done callback (async, nextTick)
     62 | });
@@ -121,7 +121,7 @@ test("verify we print error messages passed to done callbacks", () => {
     67 |       done(new Error(msg + "(async, setTimeout, Promise.resolve)"));
     ^
     error: you should see this(async, setTimeout, Promise.resolve)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:67:16)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:67:12)
     (fail) error done callback (async, setTimeout, Promise.resolve)
     70 | });
     71 |
@@ -131,7 +131,7 @@ test("verify we print error messages passed to done callbacks", () => {
     75 |       done(new Error(msg + "(async, setImmediate, Promise.resolve)"));
     ^
     error: you should see this(async, setImmediate, Promise.resolve)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:75:16)
+    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:75:12)
     (fail) error done callback (async, setImmediate, Promise.resolve)
 
     0 pass

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -735,10 +735,10 @@ test("my-test", () => {
       const stackLines = output.split("\n").filter(line => line.trim().startsWith("at "));
       expect(stackLines.length).toBeGreaterThan(0);
       if (process.platform === "win32") {
-        expect(stackLines[0]).toContain(`<dir>\\my-test.test.js:5:15`.replace("<dir>", test_dir));
+        expect(stackLines[0]).toContain(`<dir>\\my-test.test.js:5:11`.replace("<dir>", test_dir));
       }
       if (process.platform !== "win32") {
-        expect(stackLines[0]).toContain(`<dir>/my-test.test.js:5:15`.replace("<dir>", test_dir));
+        expect(stackLines[0]).toContain(`<dir>/my-test.test.js:5:11`.replace("<dir>", test_dir));
       }
 
       expect(output).toContain("1 pass"); // since the error is unhandled and in a hook, the error does not get attributed to the hook and the test is still allowed to run

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -13,17 +13,17 @@ test("error.cause", () => {
 3 | test("error.cause", () => {
 4 |   const err = new Error("error 1");
 5 |   const err2 = new Error("error 2", { cause: err });
-                       ^
+                   ^
 error: error 2
-      at <anonymous> ([dir]/inspect-error.test.js:5:20)
+      at <anonymous> ([dir]/inspect-error.test.js:5:16)
 
 1 | import { describe, expect, jest, test } from "bun:test";
 2 | 
 3 | test("error.cause", () => {
 4 |   const err = new Error("error 1");
-                      ^
+                  ^
 error: error 1
-      at <anonymous> ([dir]/inspect-error.test.js:4:19)
+      at <anonymous> ([dir]/inspect-error.test.js:4:15)
 "
 `);
 });
@@ -41,9 +41,9 @@ test("Error", () => {
 30 | 
 31 | test("Error", () => {
 32 |   const err = new Error("my message");
-                       ^
+                   ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:32:19)
+      at <anonymous> ([dir]/inspect-error.test.js:32:15)
 "
 `);
 });
@@ -71,22 +71,12 @@ note: "duplicateConstDecl" was originally declared here
   }
 });
 
-const normalizeError = str => {
-  // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
-    const splits = str.split("\n");
-    for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
-        splits.splice(i, 1);
-        i--;
-      }
-    }
-    return splits.join("\n");
-  }
-
-  return str;
-};
+// Debug builds show frames of Bun's internal JS, which have no file: "at require (51:24)".
+const normalizeError = str =>
+  str
+    .split("\n")
+    .filter(line => !/^\s+at .* \(:?\d+:\d+\)$/.test(line))
+    .join("\n");
 
 test("Error inside minified file (no color) ", () => {
   try {
@@ -109,9 +99,9 @@ test("Error inside minified file (no color) ", () => {
       26 | exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};expo
 
       error: error inside long minified file!
-            at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
+            at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2846)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:82:7)"
     `);
   }
 });
@@ -138,9 +128,9 @@ test("Error inside minified file (color) ", () => {
       26 | exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};exports.forwardRef=function(a){return{$$typeof:v,render:a}};expo | ... truncated 
 
       error: error inside long minified file!
-            at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
+            at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2846)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:110:7)"
     `);
   }
 });
@@ -154,7 +144,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:139:19)"
 `);
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -741,7 +741,7 @@ it("ErrorEvent", () => {
     NNN |    lineno: 42,
     NNN |    colno: 10,
     NNN |    error: new Error("Test error"),
-                         ^
+                     ^
     error: Test error
         at <anonymous> (file:NN:NN)
     ,

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -21,9 +21,9 @@ test("reportError", () => {
   expect(output.replaceAll("\\", "/").replaceAll("/reportError.ts", "[file]")).toMatchInlineSnapshot(
     `
 "1 | reportError(new Error("reportError Test!"));
-                    ^
+                ^
 error: reportError Test!
-      at [file]:1:17
+      at [file]:1:13
 error: true
 true
 error: false

--- a/test/js/web/console/console-log.test.ts
+++ b/test/js/web/console/console-log.test.ts
@@ -122,7 +122,7 @@ Quote"Backslash
 55 | console.warn("Warning log");
 56 | console.warn(new Error("console.warn an error"));
 57 | console.error(new Error("console.error an error"));
-                       ^
+                   ^
 error: console.error an error
       at <file>:NN:NN
 

--- a/test/regression/issue/minify-new-array-with-if.test.ts
+++ b/test/regression/issue/minify-new-array-with-if.test.ts
@@ -15,7 +15,7 @@ test("minifying new Array(if (0) 1 else 2) works", async () => {
   });
 
   expect(await file(join(testDir, "outdir/entry.js")).text()).toMatchInlineSnapshot(`
-    "console.log(Array(Math.random()>-1?1:2));
+    "console.log(new Array(Math.random()>-1?1:2));
     "
   `);
 });


### PR DESCRIPTION
### What does this PR do?

An error created with `return new Error(...)` has no stack frame for the function that created it. Error factory helpers are common (`const e = new Error(msg); return e;` has the same problem, since the single-use binding gets inlined into the `return`), so a lot of user stack traces are missing their most useful frame.

```js
function a() { return new Error("a"); }
function b() { const e = new TypeError("b"); return e; }
const c = () => new RangeError("c");
for (const fn of [a, b, c]) console.log(fn().stack.split("\n")[1]);
```

```
# bun 1.3.14, 1.4.0, main      # bun with this PR            # node
    at /tmp/x.js:4:41              at a (/tmp/x.js:1:27)        at a (/tmp/x.js:1:23)
    at /tmp/x.js:4:41              at b (/tmp/x.js:2:30)        at b (/tmp/x.js:2:26)
    at /tmp/x.js:4:41              at c (/tmp/x.js:3:21)        at c (/tmp/x.js:3:17)
```

(The remaining four column difference in the `.stack` string is a separate, pre-existing thing: that formatter reports the constructor name's column for any `new X()` frame, user classes included, while Bun's code frames and V8 report the `new` keyword.)

### Cause

`KnownGlobal::minify_global_constructor` (`src/ast/known_global.rs`) rewrites `new Error(...)`, and the other seven native error constructors, into plain calls `Error(...)` to save four bytes. It runs whenever `minify_syntax` is on, which is always the case for the runtime transpiler (`bun run`, `bun test`, ...) and for `bun build --minify`.

Modules are strict mode code, and JSC implements proper tail calls in strict mode. `return Error("a")` is a call in tail position, so JSC emits `op_tail_call` and pops `a()`'s frame before the Error constructor runs; the stack captured in `ErrorInstance::finishCreation` never contains it (`BUN_JSC_dumpGeneratedBytecodes=1` shows `tail_call` for `a` versus `call` when another statement follows). Constructs are never tail calls, which is why `throw new Error()`, class constructors, and any function with a statement between the `new` and the `return` were unaffected.

### Fix

Keep the `new` on the error constructors. The rewrite is not semantics preserving on JSC: `Error()` and `new Error()` build the same object, but in tail position they do not produce the same `.stack`. Tail calls themselves stay enabled (disabling them was rejected in #26001 for performance); this only stops the transpiler from turning constructs the user wrote into tail calls they did not write. esbuild's `--minify` keeps `new Error()` as well. The cost is 4 bytes per error construction in `--minify` output (2 for the zero-argument form, which prints as `new Error`); the React SSR development bundle in `bundler_npm.test.ts` grows by 360 bytes from 222000.

The same function stripped `new` from `new Function(...)`, and that constructor reads the calling frame too: it takes the source origin of the new body from it, which is what a dynamic `import()` inside the body resolves against. With `return new Function("return import('./x.mjs')")` in `lib/make.mjs`, Bun resolved `./x.mjs` relative to the module that called `make()` instead of `lib/` (node: `lib/`). Same fix, so it is included here.

That left `new Object(x)` and `new Array(x)` (non-literal argument, or a possible length) as the only constructs still rewritten into calls, and `Array` has the same problem once more: `return Array(...lengths)` is a varargs tail call, so the RangeError thrown for an invalid length has no frame for the function that asked for the array (a direct `Array(n)` only keeps its frame because JSC's bytecode generator special-cases that callee; `Object(x)` cannot throw). Rather than document which calls happen to be safe, `minify_global_constructor` now only ever folds a construct into a literal (`new Object()` to `{}`, `new Array(1, 2)` to `[1, 2]`, `new Array(3)` to `[,,,]` under whitespace minification, and so on) and never into a call; `call_from_new` is gone. That costs another 4 bytes per `new Array(n)` / `new Object(x)` site in `--minify` output, 28 bytes on the React SSR bundle (222388 total). The constructors that are deliberately not folded stay in the table, as `RegExp` did, so the rule is recorded next to the code that would do it.

While here, the one literal folding that was not equivalent is fixed too: `new Array(5, ...rest)` was folded into `[5, ...rest]`, but with an empty `rest` the original is `new Array(5)`, a length. Any spread argument now leaves the construct alone; `GlobalConstructorSemanticsPreserved` runs that case.

Since the runtime transpiler cache stores transpiled output and is keyed only on cache version, source hash and option flags, entries written by earlier builds would keep serving the call form; `EXPECTED_VERSION` in `RuntimeTranspilerCache.rs` moves to 26, as the note at the top of `parser.rs` asks for.

As a consequence, the position Bun reports for an error created with `new XError(...)` in code frames and call sites moves back from the constructor name to the `new` keyword, which is where V8 reports it and where Bun reported it before #22493 introduced the rewrite. The snapshots and column assertions that #22493 updated are updated back (`inspect-error`, `inspect`, `reportError`, `console-log`, `test-test`, `test-error-code-done-callback`, `hot`, `stack`, `bundler_npm`), as is the dev error page frame position in `serve.test.ts`. `inspect-error.test.js`'s helper that strips debug-build-only internal frames also had to learn the current `at require (51:24)` format, otherwise the file cannot pass under a debug build.

### How did you verify your code works?

New tests, all failing on the unfixed build and passing with the fix:

- `test/js/bun/test/stack.test.ts`: a function returning `new Error()` is in the error's stack. Covers all eight constructors, the inlined `const` shape, and an expression-bodied arrow; on the unfixed build all ten factories are missing from their error's stack. A second test checks the RangeError from `return new Array(...lengths)` still names the function (unfixed build: `at Array (unknown)` followed directly by the caller).
- `test/bundler/bundler_minify.test.ts`: `minify/ErrorConstructorKeepsNew` (bundler output keeps `new` for every error constructor with `minifySyntax`; previously `ErrorConstructorOptimization` asserted the opposite), `minify/ReturnedConstructorKeepsItsFrame` (runs the minified bundle and checks the Error, inlined TypeError and throwing Array frames), and the `new Function(...)`, `new Object(x)`, `new Array(n)` / `new Array(...xs)` captures in `minify/AdditionalGlobalConstructorOptimization` and `minify/ArrayConstructorWithNumberAndMinifyWhitespace`, which previously asserted the call form.
- `test/bundler/transpiler/runtime-transpiler.test.ts`: a body built with `return new Function()` resolves `import()` relative to the returning module (prints `which.mjs` instead of `lib/which.mjs` on the unfixed build).

Every other test file touched here fails on the unfixed build, because of the column change or because it pinned the call form (`bundler_npm`, `minify-new-array-with-if`), and passes with the fix. I also ran `test/js/bun/test`, `test/js/bun/util`, `test/js/node/util`, `test/js/node/v8`, `test/js/web/console`, `test/regression/issue`, `test/bundler/transpiler`, `test/cli/run` and `test/cli/hot` against the debug build; the remaining failures there are debug-build timeouts, tests needing services or network, or cross-file pollution when many files run in one process, and the stack related ones among them pass when run on their own.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_npm.test.ts test/cli/hot/hot.test.ts test/js/bun/http/serve.test.ts test/js/bun/test/test-test.test.ts test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->