### PR TITLE
compile: reject --target version tokens that are not exactly vX.Y.Z

### DIFF
--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -428,9 +428,7 @@ impl CompileTarget {
     }
 }
 
-/// The version `text` names if it is spelled exactly `X.Y.Z`, which is what the download URL is
-/// built from. `Version::parse` by itself also accepts tags, extra components and overflowing
-/// numbers.
+/// Only exactly `X.Y.Z`; `Version::parse` alone also accepts tags, extra components and overflow.
 fn parse_exact_version(text: &[u8]) -> Option<Version> {
     let parsed = Version::parse(SlicedString::init(text, text)).version;
     let (major, minor, patch) = (parsed.major?, parsed.minor?, parsed.patch?);

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -281,29 +281,10 @@ impl CompileTarget {
                 _found_baseline = true;
                 continue;
             } else if strings::has_prefix(token, b"v1.") || strings::has_prefix(token, b"v0.") {
-                let version_text = &token[1..];
-                let parsed = Version::parse(SlicedString::init(version_text, version_text));
-                let (Some(major), Some(minor), Some(patch)) = (
-                    parsed.version.major,
-                    parsed.version.minor,
-                    parsed.version.patch,
-                ) else {
+                let Some(version) = parse_exact_version(&token[1..]) else {
                     return Err(ParseError::InvalidVersion);
                 };
-                // `Version::parse` is lenient (a fourth component, trailing text and an
-                // overflowing component all still yield a version); the token has to spell
-                // out exactly the version that will be downloaded.
-                if format!("{major}.{minor}.{patch}").as_bytes() != version_text {
-                    return Err(ParseError::InvalidVersion);
-                }
-
-                this.version = Version {
-                    major,
-                    minor,
-                    patch,
-                    tag: Default::default(),
-                    _tag_padding: Default::default(),
-                };
+                this.version = version;
                 _found_version = true;
                 continue;
             } else if token == b"musl" {
@@ -445,6 +426,24 @@ impl CompileTarget {
             const_format::concatcp!("\"", bun_core::Global::package_json_version, "\"").as_bytes();
         [platform, arch, VERSION]
     }
+}
+
+/// The version `text` names if it is spelled exactly `X.Y.Z`, which is what the download URL is
+/// built from. `Version::parse` by itself also accepts tags, extra components and overflowing
+/// numbers.
+fn parse_exact_version(text: &[u8]) -> Option<Version> {
+    let parsed = Version::parse(SlicedString::init(text, text)).version;
+    let (major, minor, patch) = (parsed.major?, parsed.minor?, parsed.patch?);
+    if format!("{major}.{minor}.{patch}").as_bytes() != text {
+        return None;
+    }
+    Some(Version {
+        major,
+        minor,
+        patch,
+        tag: Default::default(),
+        _tag_padding: Default::default(),
+    })
 }
 
 impl fmt::Display for CompileTarget {

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -94,6 +94,9 @@ impl fmt::Display for BaselineFormatter {
 pub enum ParseError {
     #[error("UnsupportedTarget")]
     UnsupportedTarget,
+    /// A `v1.`/`v0.` token that is not exactly `vX.Y.Z`.
+    #[error("InvalidVersion")]
+    InvalidVersion,
     #[error("InvalidTarget")]
     InvalidTarget,
 }
@@ -278,25 +281,31 @@ impl CompileTarget {
                 _found_baseline = true;
                 continue;
             } else if strings::has_prefix(token, b"v1.") || strings::has_prefix(token, b"v0.") {
-                let version = Version::parse(SlicedString::init(&token[1..], &token[1..]));
-                if version.valid {
-                    if version.version.major.is_none()
-                        || version.version.minor.is_none()
-                        || version.version.patch.is_none()
-                    {
-                        return Err(ParseError::InvalidTarget);
-                    }
-
-                    this.version = Version {
-                        major: version.version.major.unwrap(),
-                        minor: version.version.minor.unwrap(),
-                        patch: version.version.patch.unwrap(),
-                        tag: Default::default(),
-                        _tag_padding: Default::default(),
-                    };
-                    _found_version = true;
-                    continue;
+                let version_text = &token[1..];
+                let parsed = Version::parse(SlicedString::init(version_text, version_text));
+                let (Some(major), Some(minor), Some(patch)) = (
+                    parsed.version.major,
+                    parsed.version.minor,
+                    parsed.version.patch,
+                ) else {
+                    return Err(ParseError::InvalidVersion);
+                };
+                // `Version::parse` is lenient (a fourth component, trailing text and an
+                // overflowing component all still yield a version); the token has to spell
+                // out exactly the version that will be downloaded.
+                if format!("{major}.{minor}.{patch}").as_bytes() != version_text {
+                    return Err(ParseError::InvalidVersion);
                 }
+
+                this.version = Version {
+                    major,
+                    minor,
+                    patch,
+                    tag: Default::default(),
+                    _tag_padding: Default::default(),
+                };
+                _found_version = true;
+                continue;
             } else if token == b"musl" {
                 this.libc = Libc::Musl;
                 found_libc = true;
@@ -377,6 +386,13 @@ impl CompileTarget {
                 }
                 Global::exit(1);
             }
+            Err(ParseError::InvalidVersion) => {
+                bun_core::err_generic!(
+                    "Please pass a complete version number to --target. For example, --target=bun-v{}",
+                    Environment::VERSION_STRING,
+                );
+                Global::exit(1);
+            }
             Err(ParseError::InvalidTarget) => {
                 let input = strings::trim(input_, b" \t\r");
                 if strings::contains(input, b"musl") && !strings::contains(input, b"linux") {
@@ -389,11 +405,6 @@ impl CompileTarget {
                     );
                 } else if strings::contains(input, b"wasm") {
                     bun_core::err_generic!("invalid target, WebAssembly is not supported. Sorry!");
-                } else if strings::contains(input, b"v") {
-                    bun_core::err_generic!(
-                        "Please pass a complete version number to --target. For example, --target=bun-v{}",
-                        Environment::VERSION_STRING,
-                    );
                 } else {
                     bun_core::err_generic!("Invalid target: {}", bstr::BStr::new(input_));
                 }

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
+import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync, readdirSync } from "node:fs";
 import { join } from "path";
+
+const os = isMacOS ? "darwin" : isLinux ? "linux" : isWindows ? "windows" : "unknown";
+const arch = isArm64 ? "aarch64" : "x64";
+const musl = isMusl ? "-musl" : "";
+// The platform of the bun running the tests. It is also how bun spells the target back in messages.
+const currentPlatformTarget = `bun-${os}-${arch}${musl}`;
 
 describe("Bun.build compile", () => {
   test("compile with current platform target string", async () => {
@@ -9,17 +15,13 @@ describe("Bun.build compile", () => {
       "app.js": `console.log("Cross-compiled app");`,
     });
 
-    const os = isMacOS ? "darwin" : isLinux ? "linux" : isWindows ? "windows" : "unknown";
-    const arch = isArm64 ? "aarch64" : "x64";
-    const musl = isMusl ? "-musl" : "";
-    const target = `bun-${os}-${arch}${musl}` as any;
     const outdir = join(dir + "", "out");
 
     const result = await Bun.build({
       entrypoints: [join(dir + "", "app.js")],
       outdir,
       compile: {
-        target: target,
+        target: currentPlatformTarget as any,
         outfile: "app-cross",
       },
     });
@@ -49,6 +51,110 @@ describe("Bun.build compile", () => {
         },
       }),
     ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-invalid-platform"`);
+  });
+
+  describe("version token in the target", () => {
+    // Any target other than the running bun is downloaded. Every build below is pointed at a local
+    // server that 404s, so a target that gets past the parser fails right away, offline, with an
+    // error that spells out the target the way it was parsed.
+    let server: ReturnType<typeof Bun.serve>;
+    beforeAll(() => {
+      server = Bun.serve({ port: 0, fetch: () => new Response("", { status: 404 }) });
+    });
+    afterAll(() => server.stop(true));
+
+    async function run(dir: string, args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args],
+        env: {
+          ...bunEnv,
+          BUN_COMPILE_TARGET_TARBALL_URL: String(server.url),
+          BUN_INSTALL_CACHE_DIR: join(dir, "cache"),
+        },
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode, files: readdirSync(dir).sort() };
+    }
+
+    async function buildFromCli(target: string) {
+      using dir = tempDir("build-compile-version-cli", {
+        "app.js": `console.log("hi");`,
+      });
+      return await run(String(dir), ["build", "--compile", `--target=${target}`, "--outfile=app", "app.js"]);
+    }
+
+    // Bun.build() runs in a child process too so that the download settings above apply to it.
+    // Prints what Bun.build() returned, or the message it threw.
+    async function buildFromApi(target: string) {
+      using dir = tempDir("build-compile-version-api", {
+        "app.js": `console.log("hi");`,
+        "api.js": `
+          try {
+            const result = await Bun.build({
+              entrypoints: ["./app.js"],
+              throw: false,
+              compile: { target: process.argv[2], outfile: "./app" },
+            });
+            console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));
+          } catch (error) {
+            console.log(JSON.stringify({ threw: error.message }));
+          }
+        `,
+      });
+      const { stdout, stderr, exitCode, files } = await run(String(dir), ["api.js", target]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return { result: JSON.parse(stdout), files };
+    }
+
+    test("a version other than the running one is downloaded as written", async () => {
+      const target = `${currentPlatformTarget}-v1.2.3`;
+      const message = `Target platform '${target}' is not available for download. Check if this version of Bun supports this target.`;
+
+      const cli = await buildFromCli(target);
+      expect(cli.stderr).toContain(message);
+      expect(cli.files).toEqual(["app.js"]);
+      expect(cli.exitCode).toBe(1);
+
+      const api = await buildFromApi(target);
+      expect(api.result).toEqual({ success: false, logs: [message] });
+      expect(api.files).toEqual(["api.js", "app.js"]);
+    });
+
+    // These used to get through. A token Semver could not parse at all was dropped, so the first
+    // five built for the running bun; trailing text and an overflowing component were accepted as
+    // whatever Semver made of them, so the next two tried to download v1.2.3 and v1.0.7.
+    const rejectedTargets = [
+      `${currentPlatformTarget}-v1.2.3.4.5`,
+      `${currentPlatformTarget}-v1.2.3.`,
+      `${currentPlatformTarget}-v1..2`,
+      `${currentPlatformTarget}-v0.a`,
+      "bun-v1.2.3.4.5",
+      `${currentPlatformTarget}-v1.2.3rc1`,
+      `${currentPlatformTarget}-v1.99999999999999999999.7`,
+      // The error is about the version no matter which other tokens are present.
+      "bun-musl-v1.2.3.4.5",
+      // Incomplete versions were already rejected.
+      `${currentPlatformTarget}-v1.2`,
+      "bun-v1.",
+    ];
+
+    test.each(rejectedTargets)("bun build --compile rejects --target=%s", async target => {
+      const { stdout, stderr, exitCode, files } = await buildFromCli(target);
+      expect(stderr).toContain("error: Please pass a complete version number to --target");
+      expect(stdout).toBe("");
+      expect(files).toEqual(["app.js"]);
+      expect(exitCode).toBe(1);
+    });
+
+    test.each(rejectedTargets)("Bun.build rejects %s", async target => {
+      const { result, files } = await buildFromApi(target);
+      expect(result).toEqual({ threw: `Unknown compile target: ${target}` });
+      expect(files).toEqual(["api.js", "app.js"]);
+    });
   });
 
   // One compile per test: each compile copies the whole bun binary (~1 GB under debug+ASAN),


### PR DESCRIPTION
### Repro

```
$ echo 'console.log(1)' > entry.js
$ bun build --compile --target=bun-linux-x64-v1.2.3.4.5 entry.js --outfile=out
   [5ms]  bundle  1 modules
 [204ms] compile  out
$ echo $?
0
```

The version token is not a version, but the build succeeds and `out` is built from the running bun (1.4.0 here), with no download. `Bun.build({ compile: { target: "bun-linux-x64-v1.2.3.4.5" } })` does the same. `-v1.2.3.`, `-v1..2` and `-v0.a` take the same path. Two more shapes get through differently: `-v1.2.3rc1` downloads 1.2.3 and `-v1.99999999999999999999.7` downloads 1.0.7. By contrast `-v1.2` and `-v1.` are already rejected ("Please pass a complete version number to --target"). Reproduced with bun 1.4.0.

### Cause

`CompileTarget::try_from` (`src/options_types/compile_target.rs`) walks the `-` separated tokens; every arm either records the token or returns an error, except the `v1.` / `v0.` arm. It calls `Version::parse` and only handles `version.valid`: when Semver rejects the token there is no else branch, so the loop moves on to the next token and `this.version` keeps its default, the running version. The Zig original had the same shape.

`Version::parse` is also lenient by design (it is the package manager's parser): trailing text becomes a tag and a component that overflows is read as 0 (`parse_version_number` does `unwrap_or(ZERO)`), with `valid` still set. So checking `valid` alone would still let `-v1.2.3rc1` and the overflowing token select a version the user did not write.

### Fix

The arm now requires the token to print back as itself: after taking major/minor/patch out of the parse result (a missing component is rejected as before), `format!("{major}.{minor}.{patch}")` has to equal the text after the `v`. Anything else is `ParseError::InvalidVersion`. That covers the dropped tokens, trailing text and overflow with one rule, and it is the rule that matters for this token: the download URL and cache name are built from exactly those three numbers, so the token has to name that version and nothing else.

Why reject rather than keep the lenient readings: this token exists to pin which bun the executable is built from. Building from a different one (the running bun, 1.2.3 instead of 1.2.3rc1, 1.0.7 instead of the written version) while exiting 0 is the one outcome `--target` is there to prevent. `-v1.2.3rc1`-style tokens were never meaningful for this flag: pre-release bun builds are not published under these versions, and anything with a `-` in it is split into separate tokens before this arm sees it.

`InvalidVersion` is its own variant because `CompileTarget::from` used to pick the CLI message by substring matching the whole target string, checking for `musl` / `android` before `v`; with the version arm now rejecting more inputs, `bun-musl-v1.2.3.4.5` would have been reported as "musl libc only exists on linux". `from()` prints the existing version message for the new variant and no longer needs the `v` heuristic; the musl / android / wasm messages for the remaining `InvalidTarget` producers are unchanged. `Bun.build` (`compile_target_from_slice`) ignores the variant and keeps throwing `Unknown compile target: ...`.

The `UnsupportedTarget` token scan in `from()` still treats `v1.`/`v0.` tokens as known, which stays correct: the version arm now always consumes them, either as a version or as `InvalidVersion`.

### Verification

New tests in `test/bundler/bun-build-compile.test.ts` ("version token in the target"). Both entry points run in a child process whose download is pointed at a local `Bun.serve` that returns 404 (`BUN_COMPILE_TARGET_TARBALL_URL`, plus `BUN_INSTALL_CACHE_DIR` set to an empty directory), so every case runs offline and a target that gets past the parser fails immediately with an error naming the parsed target.

- Control: `bun-<host platform>-v1.2.3` reaches the download step as `v1.2.3` on both entry points ("Target platform 'bun-linux-x64-v1.2.3' is not available for download", `Bun.build` with `throw: false` returns `success: false` with that log), which checks that the version actually lands in the target rather than just that the token is accepted.
- Rejected, on both entry points: the four dropped shapes above plus bare `bun-v1.2.3.4.5`, the trailing-text and overflow tokens, `bun-musl-v1.2.3.4.5` (CLI reports the version message, not the musl one), and the two incomplete shapes that were already rejected. The CLI cases check the message, an empty stdout, exit code 1 and that nothing was written; the `Bun.build` cases check the exact thrown message.

With `src/options_types/compile_target.rs` at main, the 8 newly rejected targets fail on both entry points (16 failures; the five dropped shapes build successfully, the other three hit the local server); the control and the two incomplete shapes pass either way. With the change, the whole file passes under `bun bd test`.

#37385 (a `glibc` token) edits the same token loop and the same test file; whichever lands second has a small textual rebase, the two changes do not interact otherwise.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->