### PR TITLE
build: stop the configure-time rustc probe from installing rust-toolchain.toml's component list (36s in every CI build job)

### DIFF
--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -658,36 +658,59 @@ export function findRustLld(os: OS): {
   // and the silent failure leaves `rustLld` undefined, which falls back to the
   // system lld. With cross-language LTO that means lld 21 reading rust-emitted
   // LLVM 22 bitcode → `Invalid record`. Pre-flight a `rustup toolchain
-  // install` so the proxy resolves instantly: idempotent ~70ms when already
-  // installed, downloads on a stale agent. Skip when there's no pinned channel
-  // or no rustup — the `rustc` queries below will just use whatever's there.
+  // install` so the proxy resolves instantly: idempotent (~0.5s, it re-checks
+  // the channel manifest) when already installed, downloads on a stale agent.
+  // `-q` also hides the download progress, so say how long it took whenever
+  // it evidently did more than that check: every build job of CI build 91391
+  // spent 34-36s in here without a line of output. Skip when there's no
+  // pinned channel or no rustup — the `rustc` queries below will just use
+  // whatever's there.
   const rustup = findTool({ names: ["rustup"], paths: [join(cargoHome, "bin")], required: false })?.path;
   const channel = readRustToolchainChannel();
   if (rustup !== undefined && channel !== undefined) {
+    const started = performance.now();
     spawnSync(
       rustup,
       ["-q", "toolchain", "install", channel, "--no-self-update", "--profile", "minimal", "--component", "rust-src"],
       {
         encoding: "utf8",
         timeout: 300_000,
-        stdio: ["ignore", "ignore", "inherit"], // surface download/error output; `-q` hides `info:` noise
+        stdio: ["ignore", "ignore", "inherit"], // surface error output; `-q` hides `info:` noise
       },
     );
+    const seconds = (performance.now() - started) / 1000;
+    if (seconds >= 5) {
+      console.log(
+        `rustup spent ${seconds.toFixed(0)}s installing the pinned toolchain (${channel}); it was missing or incomplete on this machine`,
+      );
+    }
   }
 
   // One spawn for both sysroot and host triple / LLVM version. `-vV` prints
   // `host: <triple>` and `LLVM version: X.Y.Z`; sysroot needs its own query.
-  // Generous timeout: if the toolchain install above was skipped (no rustup),
-  // this proxy invocation may still be the one that auto-installs.
+  //
+  // RUSTUP_TOOLCHAIN pins the proxy to the channel the pre-flight just
+  // ensured. Without it the proxy, running in the repo root, applies
+  // rust-toolchain.toml in full: besides selecting the channel it installs
+  // every entry of its `components` and `targets` lists that is missing
+  // (rustfmt, clippy, miri, llvm-tools and the std of 11 targets — ~2.4 GB),
+  // with its output piped into nowhere here. The build itself installs what
+  // it needs (rust-src above, the target's std in the rust_build_cross rule),
+  // and the toml still applies to anyone running cargo directly. Generous
+  // timeout: without rustup there is no pre-flight and this proxy invocation
+  // may still be the one that auto-installs the channel.
+  const env = channel !== undefined ? { ...process.env, RUSTUP_TOOLCHAIN: channel } : process.env;
   const sysroot = spawnSync(rustc, ["--print", "sysroot"], {
     encoding: "utf8",
     timeout: 300_000,
     stdio: ["ignore", "pipe", "pipe"],
+    env,
   }).stdout?.trim();
   const vv = spawnSync(rustc, ["-vV"], {
     encoding: "utf8",
     timeout: 30_000,
     stdio: ["ignore", "pipe", "pipe"],
+    env,
   }).stdout;
   if (!sysroot || !vv) return none;
 

--- a/test/internal/build-rust-toolchain-probe.test.ts
+++ b/test/internal/build-rust-toolchain-probe.test.ts
@@ -1,0 +1,52 @@
+/**
+ * findRustLld() (scripts/build/tools.ts) queries rustc at configure time.
+ * rustc is normally a rustup proxy, and a proxy invoked in the repo root
+ * applies rust-toolchain.toml in full, which includes installing every
+ * component and target the file lists that happens to be missing (~2.4 GB;
+ * measured 36s per CI job, silently, because the proxy's output is piped).
+ * The probe must therefore pin the proxy to the channel with RUSTUP_TOOLCHAIN.
+ *
+ * The rustc here is a shell script that reports the RUSTUP_TOOLCHAIN it was
+ * given as its sysroot; PATH is emptied so no real rustup runs a pre-flight.
+ */
+import { afterEach, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { chmodSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { findRustLld } from "../../scripts/build/tools.ts";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+const channel = /^\s*channel\s*=\s*"([^"]+)"/m.exec(readFileSync(join(repoRoot, "rust-toolchain.toml"), "utf8"))![1];
+
+const savedEnv = { CARGO_HOME: process.env.CARGO_HOME, PATH: process.env.PATH };
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+test.skipIf(isWindows)("the configure-time rustc probe pins the rustup proxy to the pinned channel", () => {
+  using dir = tempDir("build-rustc-probe", {
+    "bin/rustc": [
+      "#!/bin/sh",
+      'case "$1" in',
+      '  --print) printf "%s\\n" "sysroot-for:${RUSTUP_TOOLCHAIN:-unset}" ;;',
+      '  -vV) printf "host: x86_64-unknown-linux-gnu\\nLLVM version: 22.1.4\\n" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+  });
+  chmodSync(join(String(dir), "bin", "rustc"), 0o755);
+  process.env.CARGO_HOME = String(dir);
+  process.env.PATH = join(String(dir), "bin");
+
+  expect(findRustLld("linux")).toEqual({
+    rustSysroot: `sysroot-for:${channel}`,
+    rustHostTriple: "x86_64-unknown-linux-gnu",
+    rustLlvmVersion: "22.1.4",
+    // The fake sysroot has no lib/rustlib/<host>/bin/gcc-ld/ld.lld.
+    rustLld: undefined,
+  });
+});

--- a/test/internal/build-rust-toolchain-probe.test.ts
+++ b/test/internal/build-rust-toolchain-probe.test.ts
@@ -7,7 +7,8 @@
  * The probe must therefore pin the proxy to the channel with RUSTUP_TOOLCHAIN.
  *
  * The rustc here is a shell script that reports the RUSTUP_TOOLCHAIN it was
- * given as its sysroot; PATH is emptied so no real rustup runs a pre-flight.
+ * given as its sysroot and as its host triple, so both probes are covered;
+ * PATH is emptied so no real rustup runs a pre-flight.
  */
 import { afterEach, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
@@ -33,7 +34,7 @@ test.skipIf(isWindows)("the configure-time rustc probe pins the rustup proxy to 
       "#!/bin/sh",
       'case "$1" in',
       '  --print) printf "%s\\n" "sysroot-for:${RUSTUP_TOOLCHAIN:-unset}" ;;',
-      '  -vV) printf "host: x86_64-unknown-linux-gnu\\nLLVM version: 22.1.4\\n" ;;',
+      '  -vV) printf "host: host-for:%s\\nLLVM version: 22.1.4\\n" "${RUSTUP_TOOLCHAIN:-unset}" ;;',
       "esac",
       "",
     ].join("\n"),
@@ -44,7 +45,8 @@ test.skipIf(isWindows)("the configure-time rustc probe pins the rustup proxy to 
 
   expect(findRustLld("linux")).toEqual({
     rustSysroot: `sysroot-for:${channel}`,
-    rustHostTriple: "x86_64-unknown-linux-gnu",
+    // Both probes (sysroot and -vV) must carry the pin.
+    rustHostTriple: `host-for:${channel}`,
     rustLlvmVersion: "22.1.4",
     // The fake sysroot has no lib/rustlib/<host>/bin/gcc-ld/ld.lld.
     rustLld: undefined,


### PR DESCRIPTION
Every build job in CI spends 34-36s in the "Configure" group with no output (build 91391: all 34 build-cpp/build-bun jobs, every lane; the same configure takes ~0.9s locally). Both build-cpp and build-bun are on the build's critical path, so this is ~30s of wall clock per build plus ~13 agent-minutes.

It is `findRustLld()` in `tools.ts`. After pre-flighting `rustup toolchain install <pinned channel>`, it runs `rustc --print sysroot` and `rustc -vV`. `rustc` is the rustup proxy, the cwd is the repo root, and a proxy invoked there applies `rust-toolchain.toml` in full: not just the channel, but installing every `components` and `targets` entry that is missing (rustfmt, clippy, miri, llvm-tools, and `rust-std` for ten cross targets). The probe's stderr is piped and discarded, so nothing shows in the log. The images have the channel but not that list, so every job downloads ~1.7 GB and installs it into an instance that is thrown away a few minutes later.

Reproduced here with a fresh `RUSTUP_HOME`:

| step | time | toolchain dir |
|---|---|---|
| pre-flight `rustup toolchain install <channel> --profile minimal --component rust-src` | 16s | 663 MB |
| `rustc --print sysroot` with `RUSTUP_TOOLCHAIN=<channel>` (this PR) | 17ms | 663 MB |
| `rustc --print sysroot` in the repo root without it (main) | 36s ("downloading 14 components") | 2.4 GB |

### Change

- The two rustc probes run with `RUSTUP_TOOLCHAIN` set to the channel the pre-flight just ensured, so the proxy resolves the toolchain and nothing else. The build itself installs what it needs (`rust-src` in the pre-flight, the target's `rust-std` in the `rust_build_cross` rule), and `rust-toolchain.toml` still applies to anyone running cargo/clippy/rustfmt directly, which is what its component list is for. The visible behaviour change for developers is that `bun bd` after a channel bump no longer also downloads those ~1.7 GB; the first direct `cargo clippy` etc. does, with rustup's normal output.
- The pre-flight prints how long it took when that was 5s or more (it runs with `-q`, which also hides download progress), so an image missing the channel itself shows up as a line in the configure group instead of as silent time. Locally it stays silent (~0.4s).

If this PR's own CI run still shows a multi-second configure, that line will say why; the remaining fix in that case is baking the pinned channel into the images in `bootstrap.sh`, which I have left out of this PR because it needs an image rebuild to verify.

### Test

`test/internal/build-rust-toolchain-probe.test.ts` points `CARGO_HOME` at a directory whose `bin/rustc` is a script that reports the `RUSTUP_TOOLCHAIN` it received as its sysroot (PATH is emptied so no real rustup pre-flight runs) and checks `findRustLld()` returns the channel from `rust-toolchain.toml`. On main it returns `unset`.
