### PR TITLE
Skip a property whose lookup throws without poisoning the rest of the inspect walk

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,27 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+it("a lazily initialized property whose initializer throws is skipped without hiding the rest", async () => {
+  // Bun.$ (the first entry of Bun's static property table) and the Bun.sql
+  // entries are initialized by JS that uses the global Symbol, so with Symbol
+  // clobbered those entries throw when the walk first looks them up. The
+  // exception used to stay pending while the walk moved on, so every entry
+  // after a throwing one was reported as missing (and assertion builds aborted).
+  const fixture = `
+    const RealSymbol = Symbol;
+    globalThis.Symbol = NaN;
+    const out = Bun.inspect(Bun);
+    globalThis.Symbol = RealSymbol;
+    const keys = ["$", "Archive", "sql", "postgres", "SQL", "zstdDecompress"];
+    console.log(keys.filter(key => out.includes("\\n  " + key + ": ")).join(","));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "Archive,zstdDecompress\n", stderr: "", exitCode: 0 });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found abort in `Bun.inspect` / `console.log` / error message formatting (fingerprint `dcf040429030d308`).

The slow path of `JSC__JSValue__forEachPropertyImpl` (`bindings.cpp`) did this for every property:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
CLEAR_IF_EXCEPTION(scope);
```

When the lookup itself throws, `getPropertySlot` returns false and the `continue` skips the clear, so the exception is still pending when the walk looks up the next property. On the `Bun` object the lookups are what run the lazy `PropertyCallback` initializers of the static table, so the next initializer runs with a stale exception pending:

- release builds: `setUpStaticFunctionSlot` sees the stale exception after reifying each later entry and reports it as not found, so every entry after the throwing one disappears from the output. `Bun.inspect(Bun)` after `globalThis.Symbol = NaN` (which makes `Bun.$`'s initializer throw) lists 30 of 115 properties on current main.
- assertion builds: the Rust host function wrapper around the next initializer (`BunObject_lazyPropCb_Archive`) asserts that no exception is pending and aborts. That is the fuzzer's crash: its program ran `new CompressionStream(globalThis)` after an earlier program in the same REPRL process had clobbered `Symbol`; `ERR_INVALID_ARG_VALUE` inspects the received value, the walk reaches `Bun.$`, and the abort follows.

The fix is to clear after `getPropertySlot` regardless of its result, which is what `JSC__JSValue__forEachPropertyOrdered` already does. A throwing entry is now skipped on its own, like a throwing getter.

Second hunk (`BunObject.cpp`): with the first fix in place the same repro reached `Bun.sql` / `Bun.postgres` / `Bun.SQL`, whose getters had a debug-only block that reported the `require()` failure through `reportUncaughtExceptionAtEventLoop` while the exception was still pending on the VM. The other callers of that function clear first; with it pending, the `process._fatalException` lookup inside `Bun__handleUncaughtException` gets reified but reported as missing, and `JSObject::getPropertySlot` then trips the `Structure::storedPrototype` assertion on the stale structure. The exception is propagated to the caller on the next line anyway (accessing `Bun.sql` throws it, enumeration skips the entry), so the report is removed rather than reordered.

### How did you verify your code works?

New test in `test/js/bun/util/inspect.test.js` clobbers `Symbol` in a child process, inspects `Bun`, and checks which of `$`, `Archive`, `sql`, `postgres`, `SQL`, `zstdDecompress` show up. Expected `Archive,zstdDecompress`, clean stderr, exit 0.

- unfixed release build (`USE_SYSTEM_BUN=1`): prints an empty list, every entry is missing
- unfixed debug build: child exits 134 with `Unexpected exception observed ... Symbol is not a function. (In 'Symbol("cwd")' ...)`, the fingerprinted assertion
- debug build with only the `bindings.cpp` hunk: child aborts on the `storedPrototype` assertion via `Bun.sql`
- with both hunks: passes, and the original fuzzer program run the way REPRL runs it (indirect eval with `Symbol` clobbered beforehand) completes; `BUN_JSC_validateExceptionChecks=1` is quiet on the repro

The rest of `inspect.test.js`, `BunObject.test.ts`, and the console table tests pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->