### PR TITLE
Clear exceptions left behind by property lookups in forEachProperty

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5671,7 +5672,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,93 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("exceptions thrown while walking properties", () => {
+  async function run(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Bun.$ is the first entry of Bun's property table and its initializer calls
+  // into JS, which throws once the JS stack is exhausted. The lookup then
+  // reports the property as missing with the exception still pending, and the
+  // walk has to drop it before looking at the next property: otherwise every
+  // later lookup fails too (and debug builds assert on the stale exception).
+  it.concurrent("lazy property initializer throwing in the middle of Bun.inspect(Bun)", async () => {
+    const result = await run(`
+      let result;
+      function recurse() {
+        try {
+          recurse();
+        } catch (e) {
+          // Only the innermost frame, right at the stack limit, runs this.
+          if (result === undefined) {
+            try {
+              // Either the walk finishes and the properties after $ are still
+              // there, or it gives up with a RangeError of its own.
+              result = "string " + Bun.inspect(Bun, { depth: 0 }).includes("Archive");
+            } catch (err) {
+              result = err.name;
+            }
+          }
+        }
+      }
+      recurse();
+      console.log(result, typeof Bun.$);
+    `);
+    expect(result).toEqual({
+      stdout: expect.stringMatching(/^(string true|RangeError) function\n$/),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("Proxy get trap throwing for a property found through the prototype chain", async () => {
+    const result = await run(`
+      const proto = new Proxy(
+        { inherited: 2 },
+        {
+          get(target, key, receiver) {
+            if (key === "inherited") throw new Error("get trap");
+            return Reflect.get(target, key, receiver);
+          },
+        },
+      );
+      const object = Object.create(proto);
+      object.own = 1;
+      console.log(Bun.inspect(object));
+    `);
+    expect(result).toEqual({
+      stdout: "{\n  own: 1,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("Proxy getPrototypeOf trap throwing while walking the prototype chain", async () => {
+    const result = await run(`
+      const proto = new Proxy(
+        { inherited: 2 },
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf trap");
+          },
+        },
+      );
+      const object = Object.create(proto);
+      object.own = 1;
+      console.log(Bun.inspect(object));
+    `);
+    expect(result).toEqual({
+      stdout: "{\n  own: 1,\n  inherited: 2,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Found by Fuzzilli. The repro catches a stack overflow and then calls `Bun.inspect(Bun)` from the innermost frame:

```js
function F1() {
  try { new F1(); } catch (e) {}
  Bun.inspect(Bun);
}
new F1();
```

Debug builds die with `ASSERTION FAILED: Unexpected exception observed ... Error Exception: Maximum call stack size exceeded` inside the `Bun.Archive` lazy property callback. Release builds silently return an `inspect` output that is missing every property after `$`.

Root cause is in the slow path of `JSC__JSValue__forEachPropertyImpl` (`bindings.cpp`):

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
// Ignore exceptions from "Get" proxy traps.
CLEAR_IF_EXCEPTION(scope);
```

When the lookup throws, `getPropertySlot` returns false, so the `continue` skipped the clear and the exception stayed pending. `Bun.$` is the first entry of the Bun object's static table and its callback (`constructBunShell`) calls into JS, which throws with the stack exhausted. JSC's `setUpStaticFunctionSlot` reports a throwing property callback as "not found" with the exception pending, and from then on:

* every later static-table lookup on the object also reports not found (`setUpStaticFunctionSlot` checks `vm.exceptionForInspection()` after reifying), which is the truncated output in release builds;
* the next lazy property callback (`Archive`) runs with the stale exception and its exception scope assertion fires in debug builds.

The same `continue` is hit by a Proxy `get` trap that throws for an object found through the prototype chain, and a few lines further down `iterating->getPrototype(globalObject).getObject()` calls `getObject()` on the empty value returned when `getPrototype` throws (stale exception from above, or a Proxy `getPrototypeOf` trap). That one is a plain null dereference in release builds:

```js
const proto = new Proxy({}, { getPrototypeOf() { throw new Error("x"); } });
console.log(Object.create(proto));  // panic: Segmentation fault at address 0x5
```

The fix is the two hunks in `bindings.cpp`: clear the exception right after `getPropertySlot` whether or not the property was found, and stop the prototype walk when `getPrototype` returns empty. `forEachPropertyOrdered` already did the former.

With that fixed, the same repro next tripped the debug-only `reportUncaughtExceptionAtEventLoop` calls in the `Bun.sql` / `Bun.SQL` callbacks (`BunObject.cpp`): they ran the uncaughtException machinery while the exception was still pending (asserting in `Structure::storedPrototype` from `process.get("_fatalException")`), and `Bun__handleUncaughtException` clears the exception, so `RETURN_IF_EXCEPTION` below it would not fire and `sqlValue.getObject()` would run on an empty value. They were added as a development aid back when a throwing property callback crashed without printing anything; the exception now reaches the property access as a normal throw, so this PR removes them.

### How did you verify your code works?

Three tests added to `test/js/bun/util/inspect.test.js` ("exceptions thrown while walking properties"), each spawning `bun -e`:

* lazy property initializer throwing during `Bun.inspect(Bun)`: on the unfixed debug build the child dies with the assertion above; on the unfixed release build it prints `string false` (properties after `$` missing). With the fix, release builds should print `string true` and ASAN builds print `RangeError` (the walk gets past `$` and the following properties, then a nested `forEachProperty` runs out of native stack and throws normally; the test accepts both). `Bun.$` still works afterwards.
* Proxy `get` trap throwing for an inherited property: segfault on the unfixed build, prints `{ own: 1 }` with the fix.
* Proxy `getPrototypeOf` trap throwing: segfault on the unfixed build, prints the object with the fix.

All three fail with `USE_SYSTEM_BUN=1 bun test` and against the unfixed debug build, and pass with `bun bd test`. The rest of `inspect.test.js`, `BunObject.test.ts`, `node/util/bun-inspect.test.ts`, `custom-inspect.test.js` and `console-iterator.test.ts` still pass. I also ran `Bun.inspect(Bun)` at the innermost 400 frames of a stack overflow on the debug build (so different initializers are the ones that throw) without hitting any assertion, and checked that `Bun.$`, `Bun.sql` and `Bun.SQL` reify fine once the stack has unwound.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->