### PR TITLE
ci: strip testFFI before it leaves build-cpp, hard-link files into the zip staging dir

### DIFF
--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -12,6 +12,7 @@ import {
   chmodSync,
   cpSync,
   existsSync,
+  linkSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -287,6 +288,18 @@ export function uploadArtifacts(cfg: Config, output: BunOutput): void {
 
   const testFFI = webkitTestFFIPath(cfg);
   if (existsSync(testFFI)) {
+    // The prebuilt ships it with full debug info: 417 MiB on the linux
+    // lanes, 57 MiB after --strip-debug (symbols stay, so a failure still
+    // has a readable backtrace; test/js/bun/jsc-stress/testFFI.test.ts only
+    // runs it). Unstripped it was uploaded here, downloaded by build-bun,
+    // took ~12s of build-bun's packaging step to deflate, and then rode in
+    // the ~460 MiB profile zip every test shard downloads. cfg.strip is the
+    // target's strip (GNU or llvm-strip, both take --strip-debug); Windows
+    // keeps its debug info in the separate .pdb and is left alone.
+    if (!cfg.windows) {
+      console.log("Stripping debug info from testFFI...");
+      run([cfg.strip, "--strip-debug", testFFI], cfg.buildDir);
+    }
     console.log("Uploading testFFI...");
     upload([relative(cfg.buildDir, testFFI)], cfg.buildDir);
   }
@@ -494,21 +507,21 @@ function makeZip(cfg: Config, name: string, files: string[]): string {
   rmSync(resolve(buildDir, zip), { force: true });
   mkdirSync(stageDir, { recursive: true });
 
-  // Copy files that exist. Some debug outputs (.pdb, .dSYM, .linker-map)
+  // Stage the files that exist. Some debug outputs (.pdb, .dSYM, .linker-map)
   // are optional depending on build config — skip rather than fail so a
   // missing optional file doesn't break packaging.
-  let copied = 0;
+  let staged = 0;
   for (const f of files) {
     const src = resolve(buildDir, f);
     if (!existsSync(src)) {
       console.log(`  (skip missing: ${f})`);
       continue;
     }
-    cpSync(src, resolve(stageDir, basename(f)), { recursive: true });
-    copied++;
+    stageForZip(src, resolve(stageDir, basename(f)));
+    staged++;
   }
 
-  console.log(`Creating ${zip} (${copied} files)...`);
+  console.log(`Creating ${zip} (${staged} files)...`);
   // Relative path `name` puts `name/` prefix inside the zip — what test
   // steps expect: they extract → `chmod +x ${triplet}/bun`.
   run([cfg.cmake, "-E", "tar", "cfv", zip, "--format=zip", name], buildDir);
@@ -517,6 +530,28 @@ function makeZip(cfg: Config, name: string, files: string[]): string {
   rmSync(stageDir, { recursive: true, force: true });
 
   return zip;
+}
+
+/**
+ * Put `src` at `dest` inside the zip staging dir. The staging dir lives next
+ * to the files (same build dir, so normally the same filesystem), and the
+ * staged tree is deleted right after the archiver has read it, so a hard
+ * link does the job without copying: the linux-x64 lane was spending ~6s
+ * copying bun-profile + testFFI + the linker map before the zip even
+ * started. Directories (the darwin .dSYM bundle) and anything that cannot be
+ * linked (another filesystem, a filesystem without hard links) are copied
+ * as before.
+ */
+export function stageForZip(src: string, dest: string): void {
+  if (statSync(src).isDirectory()) {
+    cpSync(src, dest, { recursive: true });
+    return;
+  }
+  try {
+    linkSync(src, dest);
+  } catch {
+    cpSync(src, dest);
+  }
 }
 
 /**

--- a/test/internal/build-ci-packaging.test.ts
+++ b/test/internal/build-ci-packaging.test.ts
@@ -1,0 +1,46 @@
+/**
+ * stageForZip() (scripts/build/ci.ts) assembles the directory that
+ * packageAndUpload() zips: files are hard-linked into it instead of copied
+ * (the staging dir is deleted right after zipping), directories such as the
+ * darwin .dSYM bundle are copied, and anything that cannot be linked falls
+ * back to a copy.
+ */
+import { expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { stageForZip } from "../../scripts/build/ci.ts";
+
+test("files are hard-linked into the staging dir, directories are copied", () => {
+  using dir = tempDir("build-stage-zip", {
+    "out/bun-profile": "binary",
+    "out/bun-profile.dSYM/Contents/Resources/DWARF/bun-profile": "dwarf",
+    "stage/.keep": "",
+  });
+  const root = String(dir);
+  const file = join(root, "out", "bun-profile");
+  const bundle = join(root, "out", "bun-profile.dSYM");
+
+  stageForZip(file, join(root, "stage", "bun-profile"));
+  stageForZip(bundle, join(root, "stage", "bun-profile.dSYM"));
+
+  expect(readFileSync(join(root, "stage", "bun-profile"), "utf8")).toBe("binary");
+  if (!isWindows) {
+    expect(statSync(file).nlink).toBe(2);
+  }
+  expect(
+    readFileSync(join(root, "stage", "bun-profile.dSYM", "Contents", "Resources", "DWARF", "bun-profile"), "utf8"),
+  ).toBe("dwarf");
+  // The bundle was copied, not linked: its files are independent of the originals.
+  expect(statSync(join(bundle, "Contents", "Resources", "DWARF", "bun-profile")).nlink).toBe(1);
+});
+
+test("a file that cannot be linked is copied", () => {
+  using dir = tempDir("build-stage-zip", { "out/features.json": "{}" });
+  const root = String(dir);
+  // Linking onto an existing path fails (EEXIST); the copy path overwrites it.
+  using stage = tempDir("build-stage-zip-dest", { "features.json": "stale" });
+  stageForZip(join(root, "out", "features.json"), join(String(stage), "features.json"));
+  expect(readFileSync(join(String(stage), "features.json"), "utf8")).toBe("{}");
+});


### PR DESCRIPTION
Build-bun's "Package and upload" step is ~33s on the linux lanes (46s on the asan lane) and is on the critical path of every build; the Buildkite timestamps in build 91391's linux-x64 log break it down as ~6s copying files into the zip staging dir, ~12s deflating `testFFI`, ~9s deflating `bun-profile`, ~3s for the stripped zip and ~2.5s uploading. Two of those are avoidable:

**testFFI.** The WebKit prebuilt ships `bin/testFFI` with full debug info: 417 MiB on the linux lanes (32-54 MiB on darwin/freebsd, where it has no DWARF to begin with). It is consumed by exactly one test, `test/js/bun/jsc-stress/testFFI.test.ts`, which runs it and checks the output. Today build-cpp uploads it as-is, build-bun downloads it (part of the 1.8 GiB it pulls in the wait step), deflates it into the profile zip, and the zip (460 MiB for linux-x64) is downloaded by every test shard of the lane. `--strip-debug` takes it to 57 MiB (measured on the x64 `-lto` variant with both GNU strip and llvm-strip; 0.4s; symbols are kept, and the stripped binary still reports `OK: 9524 checks passed`). Doing it in build-cpp before the upload shrinks every later hop. `cfg.strip` is already the per-target strip (GNU cross strip for linux-gnu, llvm-strip for the rest, which handles Mach-O/ELF of any arch); Windows is skipped since its debug info is in the .pdb anyway.

**Staging.** `makeZip` copied ~750 MiB of files into a staging directory that is deleted as soon as `cmake -E tar` has read it. Files are now hard-linked into it (same build dir, so the same filesystem); directories (the darwin `.dSYM` bundle) and anything that fails to link are copied as before. `stageForZip` has a unit test in `test/internal/build-ci-packaging.test.ts`.

Expected from the log arithmetic: package step ~33s -> ~12s per linux lane, a couple of seconds off the build-bun download, and profile zips roughly 360 MiB smaller for the ~20 test shards per linux lane (the zip contract, file names and layout, is unchanged). This PR's own CI run is the verification: the "Package and upload" timestamps, the `testFFI` artifact size, the profile zip sizes, and `testFFI.test.ts` passing on the test lanes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->