### PR TITLE
bunx: return PathTooLong when a probed path does not fit the path buffer

### DIFF
--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -373,24 +373,15 @@ impl BunxCommand {
         package_name: &[u8],
     ) -> crate::Result<Box<[u8]>> {
         let mut subpath = PathBuffer::uninit();
-        let len = {
-            let total = subpath.len();
-            let mut cursor: &mut [u8] = &mut subpath[..];
-            write!(
-                cursor,
-                "{}",
-                format_args!(
-                    "node_modules{sep}{pkg}{sep}package.json",
-                    sep = bun_paths::SEP as char,
-                    pkg = BStr::new(package_name),
-                ),
-            )
-            .expect("unreachable");
-            total - cursor.len()
-        };
-        subpath[len] = 0;
-        // SAFETY: subpath[len] == 0 written above
-        let subpath_z = ZStr::from_buf(&subpath[..], len);
+        let subpath_z = bun_core::fmt::buf_print_z(
+            &mut subpath,
+            format_args!(
+                "node_modules{sep}{pkg}{sep}package.json",
+                sep = bun_paths::SEP as char,
+                pkg = BStr::new(package_name),
+            ),
+        )
+        .map_err(|_| crate::Error::PathTooLong)?;
         Self::get_bin_name_from_subpath(transpiler, dir_fd, subpath_z)
     }
 
@@ -402,21 +393,15 @@ impl BunxCommand {
     ) -> crate::Result<Box<[u8]>> {
         let mut subpath = PathBuffer::uninit();
         if with_stale_check {
-            let len = {
-                let total = subpath.len();
-                let mut cursor: &mut [u8] = &mut subpath[..];
-                write!(
-                    cursor,
+            let subpath_z = bun_core::fmt::buf_print_z(
+                &mut subpath,
+                format_args!(
                     "{}{}package.json",
                     BStr::new(tempdir_name),
                     bun_paths::SEP as char,
-                )
-                .expect("unreachable");
-                total - cursor.len()
-            };
-            subpath[len] = 0;
-            // SAFETY: subpath[len] == 0 written above
-            let subpath_z = ZStr::from_buf(&subpath[..], len);
+                ),
+            )
+            .map_err(|_| crate::Error::PathTooLong)?;
             let target_package_json_fd = match bun_sys::openat(Fd::cwd(), subpath_z, O::RDONLY, 0) {
                 Ok(fd) => fd,
                 Err(_) => return Err(crate::Error::NeedToInstall),
@@ -470,22 +455,16 @@ impl BunxCommand {
             let _ = target_package_json.close();
         }
 
-        let len = {
-            let total = subpath.len();
-            let mut cursor: &mut [u8] = &mut subpath[..];
-            write!(
-                cursor,
+        let subpath_z = bun_core::fmt::buf_print_z(
+            &mut subpath,
+            format_args!(
                 "{tmp}{sep}node_modules{sep}{pkg}{sep}package.json",
                 tmp = BStr::new(tempdir_name),
                 sep = bun_paths::SEP as char,
                 pkg = BStr::new(package_name),
-            )
-            .expect("unreachable");
-            total - cursor.len()
-        };
-        subpath[len] = 0;
-        // SAFETY: subpath[len] == 0 written above
-        let subpath_z = ZStr::from_buf(&subpath[..], len);
+            ),
+        )
+        .map_err(|_| crate::Error::PathTooLong)?;
 
         Self::get_bin_name_from_subpath(transpiler, Fd::cwd(), subpath_z)
     }
@@ -1179,7 +1158,7 @@ impl BunxCommand {
                                         bin = BStr::new(&package_name_for_bin),
                                         exe = EXE_SUFFIX,
                                     )
-                                    .expect("unreachable");
+                                    .map_err(|_| crate::Error::PathTooLong)?;
                                     let written = buf_total - cursor.len();
                                     // SAFETY: `written` bytes initialized above
                                     unsafe {
@@ -1460,7 +1439,7 @@ impl BunxCommand {
                 bin = BStr::new(initial_bin_name),
                 exe = EXE_SUFFIX,
             )
-            .expect("unreachable");
+            .map_err(|_| crate::Error::PathTooLong)?;
             let written = buf_total - cursor.len();
             // SAFETY: `written` bytes initialized above
             unsafe { core::slice::from_raw_parts(absolute_in_cache_dir_buf.as_ptr(), written) }
@@ -1525,7 +1504,7 @@ impl BunxCommand {
                             BStr::new(&package_name_for_bin),
                             EXE_SUFFIX,
                         )
-                        .expect("unreachable");
+                        .map_err(|_| crate::Error::PathTooLong)?;
                         let written = buf_total - cursor.len();
                         // SAFETY: `written` bytes initialized above
                         unsafe {

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1453,53 +1453,77 @@ describe("paths that do not fit in the path buffer", () => {
     expect(exitCode).toBe(1);
   });
 
-  // $TMPDIR is deep enough that <cache>/node_modules/<pkg>/package.json, which
-  // bunx reads to learn the bin name, does not fit, while the shorter
-  // <cache>/node_modules/.bin/<bin> probe made before it still does. `overBy`
-  // is the number of bytes the package.json path exceeds the buffer by; at 0
-  // the path itself fits but its NUL terminator does not. Unix only: the cache
-  // location includes the uid, and on Windows the buffer is sized for the
-  // longest path the OS can address, so no existing directory can overflow it.
-  it.concurrent.skipIf(isWindows).each([0, 64])(
-    "cached package.json path exceeds the path buffer by %d bytes",
-    async overBy => {
-      const maxPathBytes = isLinux ? 4096 : 1024;
-      const { x_dir, env } = setup();
-      const scope = `@${Buffer.alloc(100, "s").toString()}`;
-      const bin = "bunx-deep-cache-fixture";
-      const pkg = `${scope}/${bin}`;
-      const cacheDirName = `bunx-${process.getuid!()}-${pkg}@latest`;
+  // $TMPDIR is padded so that <cache>/node_modules/<pkg>/package.json, which
+  // bunx reads to learn the cached package's bin name, lands right at the
+  // buffer size, while the shorter <cache>/node_modules/.bin/<name> probes
+  // always fit. `overBy` is the package.json path length minus the buffer
+  // size: one byte under, it fits together with its NUL terminator, bunx reads
+  // it and runs the bin it names (this also pins the cache layout the other two
+  // cases depend on); at exactly the buffer size only the terminator is out of
+  // room. Unix only: the cache location includes the uid, and on Windows the
+  // buffer is sized for the longest path the OS can address, so no existing
+  // directory can overflow it.
+  it.concurrent.skipIf(isWindows).each([
+    ["one byte under the path buffer size", -1],
+    ["exactly the path buffer size", 0],
+    ["64 bytes over the path buffer size", 64],
+  ] as const)("cached package.json path is %s", async (_label, overBy) => {
+    const maxPathBytes = isLinux ? 4096 : 1024;
+    const { x_dir, env } = setup();
+    const scope = `@${Buffer.alloc(100, "s").toString()}`;
+    const name = "bunx-deep-cache-fixture";
+    const pkg = `${scope}/${name}`;
+    const realBin = "deep-cache-real-bin";
+    const cacheDirName = `bunx-${process.getuid!()}-${pkg}@latest`;
 
-      // Pad the temp dir with nested directories until
-      // `${tmp}/${cacheDirName}/node_modules/${pkg}/package.json` is exactly
-      // maxPathBytes + overBy long. Each component stays well under NAME_MAX.
-      const tmpLength = maxPathBytes + overBy - `/${cacheDirName}/node_modules/${pkg}/package.json`.length;
-      let tmp = env.TMPDIR;
-      while (tmp.length < tmpLength) {
-        let component = Math.min(200, tmpLength - tmp.length - 1);
-        // Never leave exactly one byte, which would need an empty component.
-        if (tmpLength - tmp.length - 1 - component === 1) component--;
-        tmp += "/" + Buffer.alloc(component, "p").toString();
-      }
-      expect(tmp).toHaveLength(tmpLength);
-      expect(`${tmp}/${cacheDirName}/node_modules/.bin/${bin}`.length).toBeLessThan(maxPathBytes);
+    // Pad the temp dir with nested directories until
+    // `${tmp}/${cacheDirName}/node_modules/${pkg}/package.json` is exactly
+    // maxPathBytes + overBy long. Each component stays well under NAME_MAX.
+    const tmpLength = maxPathBytes + overBy - `/${cacheDirName}/node_modules/${pkg}/package.json`.length;
+    let tmp = env.TMPDIR;
+    while (tmp.length < tmpLength) {
+      let component = Math.min(200, tmpLength - tmp.length - 1);
+      // Never leave exactly one byte, which would need an empty component.
+      if (tmpLength - tmp.length - 1 - component === 1) component--;
+      tmp += "/" + Buffer.alloc(component, "p").toString();
+    }
+    expect(tmp).toHaveLength(tmpLength);
+    // `name` is the longer of the two bin names bunx probes for.
+    expect(realBin.length).toBeLessThanOrEqual(name.length);
+    expect(`${tmp}/${cacheDirName}/node_modules/.bin/${name}`.length).toBeLessThan(maxPathBytes);
 
-      const cacheDir = join(tmp, cacheDirName);
-      await mkdir(cacheDir, { recursive: true });
-      chmodSync(cacheDir, 0o755);
-      chmodSync(resolve(cacheDir, ".."), 0o755);
-      // A fresh cache entry, so bunx goes on to look up the bin name inside it.
-      await writeFile(join(cacheDir, "package.json"), "{}\n");
+    const cacheDir = join(tmp, cacheDirName);
+    const binDir = join(cacheDir, "node_modules", ".bin");
+    await mkdir(binDir, { recursive: true });
+    chmodSync(cacheDir, 0o755);
+    chmodSync(resolve(cacheDir, ".."), 0o755);
+    // A fresh cache entry, so bunx goes on to look up the bin name inside it.
+    await writeFile(join(cacheDir, "package.json"), "{}\n");
+    // The bin is always there; whether bunx can find out about it depends only
+    // on whether the package.json path fits.
+    await writeFile(join(binDir, realBin), "#!/bin/sh\necho DEEP_CACHE_REAL_BIN_RAN\n");
+    chmodSync(join(binDir, realBin), 0o755);
+    if (overBy < 0) {
+      const packageJson = join(cacheDir, "node_modules", pkg, "package.json");
+      expect(packageJson).toHaveLength(maxPathBytes + overBy);
+      await mkdir(join(cacheDir, "node_modules", pkg), { recursive: true });
+      await writeFile(packageJson, JSON.stringify({ name: pkg, version: "1.0.0", bin: { [realBin]: "cli.js" } }));
+    }
 
-      const [err, out, exitCode] = await run(
-        x_dir,
-        { ...env, TMPDIR: tmp, TMP: tmp, TEMP: tmp, BUN_TMPDIR: tmp },
-        "--no-install",
-        pkg,
-      );
-      expect(err).toContain(`Could not find an existing '${bin}' binary to run.`);
+    const [err, out, exitCode] = await run(
+      x_dir,
+      { ...env, TMPDIR: tmp, TMP: tmp, TEMP: tmp, BUN_TMPDIR: tmp },
+      "--no-install",
+      pkg,
+    );
+    if (overBy < 0) {
+      expect(err).toBe("");
+      expect(out).toBe("DEEP_CACHE_REAL_BIN_RAN\n");
+      expect(exitCode).toBe(0);
+    } else {
+      expect(err).toContain(`Could not find an existing '${name}' binary to run.`);
       expect(out).toHaveLength(0);
       expect(exitCode).toBe(1);
-    },
-  );
+    }
+  });
 });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, readdirSorted, tmpdirSync } from "harness";
 import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
@@ -1380,3 +1380,126 @@ it.concurrent.skipIf(isWindows)(
     }
   },
 );
+
+// bunx formats every path it probes into a fixed-size path buffer (4096 bytes
+// on Linux, 1024 on macOS). The inputs are not bounded: the bin name comes out
+// of a package.json (the project's node_modules or the bunx cache) and the
+// cache directory is derived from $TMPDIR. A path that does not fit must be
+// reported as an error, not abort the process.
+describe("paths that do not fit in the path buffer", () => {
+  // Longer than the path buffer on every platform (~96 KiB on Windows).
+  const longBinName = Buffer.alloc(100_000, "x").toString();
+  const longBinPackageJson = (name: string) =>
+    JSON.stringify({ name, version: "1.0.0", bin: { [longBinName]: "cli.js" } });
+
+  let port: number;
+
+  beforeAll(() => {
+    dummyBeforeAll();
+    port = getPort()!;
+  });
+
+  afterAll(() => {
+    dummyAfterAll();
+  });
+
+  const run = (cwd: string, env: Record<string, string>, ...args: string[]) => {
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", ...args],
+      cwd,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+  };
+
+  // The bin name is read from the package already installed in the project,
+  // before bunx installs anything.
+  it.concurrent("bin name from the project's node_modules", async () => {
+    const { x_dir, env } = setup();
+    const pkg = "bunx-long-bin-fixture";
+    await mkdir(join(x_dir, "node_modules", pkg), { recursive: true });
+    await writeFile(join(x_dir, "node_modules", pkg, "package.json"), longBinPackageJson(pkg));
+
+    const [err, out, exitCode] = await run(x_dir, env, "--no-install", pkg);
+    expect(err).toContain("PathTooLong");
+    expect(out).toHaveLength(0);
+    expect(exitCode).toBe(1);
+  });
+
+  // The bin name is read from the package.json bunx just installed into its
+  // cache, after `bun add` has run.
+  it("bin name from the package installed into the bunx cache", async () => {
+    const { x_dir, env } = setup();
+    const pkg = "bunx-long-bin-fixture";
+    const pkgRoot = tmpdirSync();
+    await mkdir(join(pkgRoot, "package"), { recursive: true });
+    await writeFile(join(pkgRoot, "package", "package.json"), longBinPackageJson(pkg));
+    await writeFile(join(pkgRoot, "package", "cli.js"), `#!/usr/bin/env node\nconsole.log("ran");\n`);
+    const tgzDir = tmpdirSync();
+    await Bun.$`tar -czf ${join(tgzDir, `${pkg}-1.0.0.tgz`)} -C ${pkgRoot} package`;
+
+    // The manifest does not declare the bin: if it did, `bun add` would fail to
+    // link it (ENAMETOOLONG) and bunx would exit with that error before it gets
+    // to read the installed package.json.
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls, { "1.0.0": { as: "1.0.0" } }, 0, tgzDir));
+
+    const [err, , exitCode] = await run(x_dir, { ...env, npm_config_registry: `http://localhost:${port}/` }, pkg);
+    expect(urls).toContain(`http://localhost:${port}/${pkg}-1.0.0.tgz`);
+    expect(err).toContain("PathTooLong");
+    expect(exitCode).toBe(1);
+  });
+
+  // $TMPDIR is deep enough that <cache>/node_modules/<pkg>/package.json, which
+  // bunx reads to learn the bin name, does not fit, while the shorter
+  // <cache>/node_modules/.bin/<bin> probe made before it still does. `overBy`
+  // is the number of bytes the package.json path exceeds the buffer by; at 0
+  // the path itself fits but its NUL terminator does not. Unix only: the cache
+  // location includes the uid, and on Windows the buffer is sized for the
+  // longest path the OS can address, so no existing directory can overflow it.
+  it.concurrent.skipIf(isWindows).each([0, 64])(
+    "cached package.json path exceeds the path buffer by %d bytes",
+    async overBy => {
+      const maxPathBytes = isLinux ? 4096 : 1024;
+      const { x_dir, env } = setup();
+      const scope = `@${Buffer.alloc(100, "s").toString()}`;
+      const bin = "bunx-deep-cache-fixture";
+      const pkg = `${scope}/${bin}`;
+      const cacheDirName = `bunx-${process.getuid!()}-${pkg}@latest`;
+
+      // Pad the temp dir with nested directories until
+      // `${tmp}/${cacheDirName}/node_modules/${pkg}/package.json` is exactly
+      // maxPathBytes + overBy long. Each component stays well under NAME_MAX.
+      const tmpLength = maxPathBytes + overBy - `/${cacheDirName}/node_modules/${pkg}/package.json`.length;
+      let tmp = env.TMPDIR;
+      while (tmp.length < tmpLength) {
+        let component = Math.min(200, tmpLength - tmp.length - 1);
+        // Never leave exactly one byte, which would need an empty component.
+        if (tmpLength - tmp.length - 1 - component === 1) component--;
+        tmp += "/" + Buffer.alloc(component, "p").toString();
+      }
+      expect(tmp).toHaveLength(tmpLength);
+      expect(`${tmp}/${cacheDirName}/node_modules/.bin/${bin}`.length).toBeLessThan(maxPathBytes);
+
+      const cacheDir = join(tmp, cacheDirName);
+      await mkdir(cacheDir, { recursive: true });
+      chmodSync(cacheDir, 0o755);
+      chmodSync(resolve(cacheDir, ".."), 0o755);
+      // A fresh cache entry, so bunx goes on to look up the bin name inside it.
+      await writeFile(join(cacheDir, "package.json"), "{}\n");
+
+      const [err, out, exitCode] = await run(
+        x_dir,
+        { ...env, TMPDIR: tmp, TMP: tmp, TEMP: tmp, BUN_TMPDIR: tmp },
+        "--no-install",
+        pkg,
+      );
+      expect(err).toContain(`Could not find an existing '${bin}' binary to run.`);
+      expect(out).toHaveLength(0);
+      expect(exitCode).toBe(1);
+    },
+  );
+});


### PR DESCRIPTION
### What does this PR do?

`bun x` aborts with a crash report instead of reporting an error when one of the paths it probes does not fit in the fixed-size path buffer. Surfaced while reviewing #32022 (which deliberately keeps this behavior as-is); pre-existing on main, and the same `catch unreachable` was in the Zig version.

Repro, no registry needed (the bin name comes out of a package.json, so its length is up to the package, not the user running `bunx`):

```sh
mkdir -p node_modules/pkg
bun -e 'require("fs").writeFileSync("node_modules/pkg/package.json",
  JSON.stringify({ name: "pkg", bin: { ["x".repeat(100000)]: "cli.js" } }))'
bun x --no-install pkg
```

```
panic: unreachable: Error { kind: WriteZero, message: "failed to write whole buffer" }
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

(exit 134). The same package installed through a registry crashes at the post-install probe instead, and a deep enough `$TMPDIR` crashes the cached package.json lookup, either with the panic above or, when the path fills the buffer exactly, with `panic: index out of bounds: the len is 4096 but the index is 4096`.

### Cause

`bunx_command.rs` formats six paths into a `PathBuffer` (4096 bytes on Linux, 1024 on macOS). Only the first `<cache>/node_modules/.bin/<bin>` probe mapped a failed write to `crate::Error::PathTooLong`. The other five called `.expect("unreachable")` on the `write!` result:

- the bin-name retry probes, before installing (`package_name_for_bin` read from the project's or the cache's package.json) and after installing (read from the package `bun add` just put in the cache), plus the post-install re-probe of the initial bin name;
- the three package.json lookup paths in `get_bin_name_from_project_directory` / `get_bin_name_from_temp_directory`, where `<cache>/node_modules/<pkg>/package.json` is 8 + `len(pkg) - len(bin)` bytes longer than the `.bin` probe that already passed. Those three also wrote the NUL terminator at `subpath[len]` after the write, which indexes past the buffer when the path is exactly `MAX_PATH_BYTES` long.

### Fix

- The three `.bin` probe sites: `.expect("unreachable")` becomes `.map_err(|_| crate::Error::PathTooLong)?`, the same as the first probe. These are the fixing lines; `bun x` then exits 1 with `error: An internal error occurred (PathTooLong)` exactly as the first probe already does. (On the #32022 branch the two post-install sites are one helper, `try_run_cached_bin`, and take the same one-line change.)
- The three package.json lookups use `bun_core::fmt::buf_print_z`, which fails unless the path plus its terminator fits, and map that to `PathTooLong` too. The callers already treat any error from these lookups as "no usable bin here": before installing that means proceeding to the install step (or the normal `--no-install` message), after installing it means the existing "could not determine executable to run" error. This also deletes the three manual NUL writes and their `from_buf` calls.

Why an error rather than skipping the probe: a bin whose path does not fit cannot be executed from the cache no matter what else bunx tries, and falling through would report "could not determine executable" for what is really a path length problem. Returning `PathTooLong` keeps all probes reporting the same thing the first one has always reported.

### Tests

New `describe("paths that do not fit in the path buffer")` in `test/cli/install/bunx.test.ts`, one test per reachable site:

- `bin name from the project's node_modules`: pre-install retry probe, offline, all platforms (the 100,000 byte bin name is longer than the buffer on Windows too).
- `bin name from the package installed into the bunx cache`: post-install retry probe, via the dummy registry. The manifest intentionally does not declare the bin; if it does, `bun add` fails to link it (`ENAMETOOLONG`) and bunx exits with that error before reaching the probe, which is also why this site is only reachable when the manifest and the tarball's package.json disagree.
- `cached package.json path is exactly the path buffer size` / `64 bytes over the path buffer size`: the `get_bin_name_from_temp_directory` lookup, with `$TMPDIR` padded so that the package.json path is exactly at, or 64 bytes past, the buffer size while the `.bin` probes still fit. These two can only observe the generic `--no-install` message (the lookup's error is folded into "need to install", see above), and a wrong reconstruction of the cache layout would produce that same message, so the table also has `one byte under the path buffer size`: same setup plus a real package.json and bin in the cache, asserting that bunx reads the package.json at its tightest fitting length and runs the bin. That case passes before and after the fix; it exists to pin the layout the other two depend on. Unix only: the cache path includes the uid, and on Windows the buffer is sized for the longest path the OS can address.

The four "does not fit" cases fail on the released binary (`USE_SYSTEM_BUN=1`; three with the `WriteZero` panic, the exactly-at-size case with the index out of bounds panic) and all five pass with `bun bd test`. The existing bunx registry, `--package`, scoped-package and cache-directory tests still pass, which covers the rewritten lookups on their normal path.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->