### PR TITLE
node:stream: install the Readable operators with the class instead of the node:stream module

### DIFF
--- a/src/js/internal/stream.ts
+++ b/src/js/internal/stream.ts
@@ -1,10 +1,8 @@
 "use strict";
 
-const ObjectKeys = Object.keys;
 const ObjectDefineProperty = Object.defineProperty;
 
 const customPromisify = Symbol.for("nodejs.util.promisify.custom");
-const { streamReturningOperators, promiseReturningOperators } = require("internal/streams/operators");
 const compose = require("internal/streams/compose");
 const { setDefaultHighWaterMark, getDefaultHighWaterMark } = require("internal/streams/state");
 const { pipeline } = require("internal/streams/pipeline");
@@ -22,46 +20,6 @@ Stream.isReadable = utils.isReadable;
 Stream.isWritable = utils.isWritable;
 
 Stream.Readable = require("internal/streams/readable");
-const streamKeys = ObjectKeys(streamReturningOperators);
-for (let i = 0; i < streamKeys.length; i++) {
-  const key = streamKeys[i];
-  const op = streamReturningOperators[key];
-  function fn(...args) {
-    if (new.target) {
-      throw $ERR_ILLEGAL_CONSTRUCTOR();
-    }
-    return Stream.Readable.from(op.$apply(this, args));
-  }
-  ObjectDefineProperty(fn, "name", { __proto__: null, value: op.name });
-  ObjectDefineProperty(fn, "length", { __proto__: null, value: op.length });
-  ObjectDefineProperty(Stream.Readable.prototype, key, {
-    __proto__: null,
-    value: fn,
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  });
-}
-const promiseKeys = ObjectKeys(promiseReturningOperators);
-for (let i = 0; i < promiseKeys.length; i++) {
-  const key = promiseKeys[i];
-  const op = promiseReturningOperators[key];
-  function fn(...args) {
-    if (new.target) {
-      throw $ERR_ILLEGAL_CONSTRUCTOR();
-    }
-    return Promise.$resolve().then(() => op.$apply(this, args));
-  }
-  ObjectDefineProperty(fn, "name", { __proto__: null, value: op.name });
-  ObjectDefineProperty(fn, "length", { __proto__: null, value: op.length });
-  ObjectDefineProperty(Stream.Readable.prototype, key, {
-    __proto__: null,
-    value: fn,
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  });
-}
 Stream.Writable = require("internal/streams/writable");
 Stream.Duplex = require("internal/streams/duplex");
 Stream.Transform = require("internal/streams/transform");

--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -28,6 +28,7 @@ const { SafeSet } = require("internal/primordials");
 const { kAutoDestroyed } = require("internal/shared");
 
 const ObjectDefineProperties = Object.defineProperties;
+const ObjectDefineProperty = Object.defineProperty;
 const SymbolAsyncDispose = Symbol.asyncDispose;
 const NumberIsNaN = Number.isNaN;
 const NumberIsInteger = Number.isInteger;
@@ -1723,5 +1724,49 @@ Readable.wrap = function (src, options) {
     },
   }).wrap(src);
 };
+
+// Node installs these from lib/stream.js. Here net, tls, crypto, child_process and _stream_*
+// load this module without going through node:stream, so they are installed with the class.
+const { streamReturningOperators, promiseReturningOperators } = require("internal/streams/operators");
+const opStreamKeys = ObjectKeys(streamReturningOperators);
+for (let i = 0; i < opStreamKeys.length; i++) {
+  const key = opStreamKeys[i];
+  const op = streamReturningOperators[key];
+  function fn(...args) {
+    if (new.target) {
+      throw $ERR_ILLEGAL_CONSTRUCTOR();
+    }
+    return Readable.from(op.$apply(this, args));
+  }
+  ObjectDefineProperty(fn, "name", { __proto__: null, value: op.name });
+  ObjectDefineProperty(fn, "length", { __proto__: null, value: op.length });
+  ObjectDefineProperty(Readable.prototype, key, {
+    __proto__: null,
+    value: fn,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+}
+const opPromiseKeys = ObjectKeys(promiseReturningOperators);
+for (let i = 0; i < opPromiseKeys.length; i++) {
+  const key = opPromiseKeys[i];
+  const op = promiseReturningOperators[key];
+  function fn(...args) {
+    if (new.target) {
+      throw $ERR_ILLEGAL_CONSTRUCTOR();
+    }
+    return Promise.$resolve().then(() => op.$apply(this, args));
+  }
+  ObjectDefineProperty(fn, "name", { __proto__: null, value: op.name });
+  ObjectDefineProperty(fn, "length", { __proto__: null, value: op.length });
+  ObjectDefineProperty(Readable.prototype, key, {
+    __proto__: null,
+    value: fn,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+}
 
 export default Readable as unknown as typeof import("node:stream").Readable;

--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -1725,8 +1725,7 @@ Readable.wrap = function (src, options) {
   }).wrap(src);
 };
 
-// Node installs these from lib/stream.js. Here net, tls, crypto, child_process and _stream_*
-// load this module without going through node:stream, so they are installed with the class.
+// Node does this in lib/stream.js; here not every user of Readable loads node:stream.
 const { streamReturningOperators, promiseReturningOperators } = require("internal/streams/operators");
 const opStreamKeys = ObjectKeys(streamReturningOperators);
 for (let i = 0; i < opStreamKeys.length; i++) {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1745,6 +1745,88 @@ describe("stream operators argument validation (nodejs/node#59529)", () => {
   });
 });
 
+// These modules reach the Readable class without loading node:stream, which is where the
+// operators used to be installed. Every script below runs in a fresh process for that reason.
+describe("stream operators exist on Readables created without loading node:stream", () => {
+  const operators = [
+    "drop",
+    "filter",
+    "flatMap",
+    "map",
+    "take",
+    "every",
+    "forEach",
+    "reduce",
+    "toArray",
+    "some",
+    "find",
+  ];
+
+  async function run(script) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent.each([
+    ["net.Socket", `new (require("node:net").Socket)()`],
+    ["crypto.createHash()", `require("node:crypto").createHash("sha256")`],
+    [
+      "child_process stdout",
+      `require("node:child_process").spawn(process.execPath, ["--version"], { stdio: ["ignore", "pipe", "ignore"] }).stdout`,
+    ],
+    ["_stream_readable", `require("node:_stream_readable").prototype`],
+    ["_stream_duplex", `require("node:_stream_duplex").prototype`],
+    ["_stream_transform", `require("node:_stream_transform").prototype`],
+    ["_stream_passthrough", `require("node:_stream_passthrough").prototype`],
+  ])("%s", async (_, expression) => {
+    // Careful with variable names in these scripts: `bun -e` exposes the builtin modules as
+    // globals, and a top-level `const stream = ...` is enough to make it load node:stream.
+    const result = await run(`
+      const readable = ${expression};
+      const found = {};
+      for (const name of ${JSON.stringify(operators)}) found[name] = typeof readable[name];
+      console.log(JSON.stringify(found));
+    `);
+    expect(result).toEqual({
+      stdout: JSON.stringify(Object.fromEntries(operators.map(name => [name, "function"]))) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("map() and toArray() work on a net.Socket", async () => {
+    const result = await run(`
+      const net = require("node:net");
+      const server = net.createServer(socket => socket.end("hello"));
+      server.listen(0, "127.0.0.1", async () => {
+        const socket = net.connect(server.address().port, "127.0.0.1");
+        const chunks = await socket.map(chunk => chunk.toString().toUpperCase()).toArray();
+        server.close();
+        console.log(chunks.join(""));
+      });
+    `);
+    expect(result).toEqual({ stdout: "HELLO\n", stderr: "", exitCode: 0 });
+  });
+
+  it.concurrent("filter(), map() and toArray() work on a _stream_readable Readable", async () => {
+    const result = await run(`
+      const Readable = require("node:_stream_readable");
+      Readable.from([1, 2, 3, 4, 5])
+        .filter(n => n % 2 === 1)
+        .map(n => n * 10)
+        .toArray()
+        .then(values => console.log(JSON.stringify(values)));
+    `);
+    expect(result).toEqual({ stdout: "[10,30,50]\n", stderr: "", exitCode: 0 });
+  });
+});
+
 describe("duplexPair teardown (test-duplex-error.js)", () => {
   const once = (emitter, event) => new Promise(resolve => emitter.once(event, resolve));
 

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1763,8 +1763,10 @@ describe("stream operators exist on Readables created without loading node:strea
   ];
 
   async function run(script) {
+    // `bun -e` exposes the builtin modules as globals, and a top-level `const stream = ...` in the
+    // script would be enough to load node:stream. Block scoping the script keeps it away from them.
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
+      cmd: [bunExe(), "-e", `{${script}}`],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1785,12 +1787,10 @@ describe("stream operators exist on Readables created without loading node:strea
     ["_stream_transform", `require("node:_stream_transform").prototype`],
     ["_stream_passthrough", `require("node:_stream_passthrough").prototype`],
   ])("%s", async (_, expression) => {
-    // Careful with variable names in these scripts: `bun -e` exposes the builtin modules as
-    // globals, and a top-level `const stream = ...` is enough to make it load node:stream.
     const result = await run(`
-      const readable = ${expression};
+      const target = ${expression};
       const found = {};
-      for (const name of ${JSON.stringify(operators)}) found[name] = typeof readable[name];
+      for (const name of ${JSON.stringify(operators)}) found[name] = typeof target[name];
       console.log(JSON.stringify(found));
     `);
     expect(result).toEqual({


### PR DESCRIPTION
### What does this PR do?

`Readable.prototype.map/filter/flatMap/drop/take/forEach/toArray/some/every/find/reduce` were missing from any stream reached without `require("node:stream")`:

```sh
$ bun -e 'const net = require("node:net"); console.log(typeof new net.Socket().map)'
undefined
$ bun -e 'const net = require("node:net"); require("node:stream"); console.log(typeof new net.Socket().map)'
function
$ node -e 'const net = require("node:net"); console.log(typeof new net.Socket().map)'
function
```

Same for `crypto.createHash()` (and Hmac/Cipheriv, via LazyTransform), child process stdio streams, and the `_stream_readable` / `_stream_duplex` / `_stream_transform` / `_stream_passthrough` modules. Whether `socket.toArray()` worked depended on whether something else in the process happened to have loaded `node:stream` first.

**Cause.** The operator wrappers were installed on `Readable.prototype` by `src/js/internal/stream.ts`, the module behind `node:stream`. That mirrors Node's `lib/stream.js`, but in Node every internal user of the class goes through `require('stream')`, so the install always runs before user code can get hold of a Readable. In Bun, `net`, `tls`, `crypto`, `child_process`, `worker_threads`, `_http_incoming`, `internal/streams/native-readable` and the public `_stream_*` modules require `internal/streams/readable` / `internal/streams/duplex` directly (on purpose, to avoid loading the whole umbrella at startup), so the class existed without its operators.

**Fix.** Install the operators at the end of `internal/streams/readable.ts`, where the class is defined, and drop the loops from `internal/stream.ts`. Loading the class is now what completes the prototype, so it no longer matters which module reaches it first, and future direct consumers (for example #27400, which would route `fs` streams and `zlib` around the umbrella as well) stay correct without having to know about this. `internal/streams/operators` only depends on `validators`, `shared` and `end-of-stream`, all of which `readable.ts` already loads, so this introduces no require cycle; the cost is that loading the class now also evaluates `operators.ts` itself (the eleven operator functions, about 400 lines, no further requires), which is what `require("node:stream")` was already paying and is what #35541 settled on too. The wrappers themselves are unchanged except that they call `Readable.from` directly instead of going through `Stream.Readable` at call time (`Readable.from` is still looked up when the operator runs); `name`, `length` and the property attributes are the same as before and match Node.

#35541 contains this same move as one piece of a much larger lazy-loading change (it needs it, because it makes `Stream.Readable` itself lazy). This PR is only the user-visible fix plus a test so it can land on its own; that PR would drop its copy of the block when rebased.

### How did you verify your code works?

Added tests to `test/js/node/stream/node-stream.test.js`. Each spawns a fresh `bun -e` that never requires `node:stream` (the script is wrapped in a block, because `-e` exposes the builtin modules as globals and a top-level `const stream` would be enough to load `node:stream` and mask the bug): a table checks that all eleven operators are functions on `net.Socket`, `crypto.createHash()`, a child process `stdout` and the prototypes exported by the four `_stream_*` modules, and two more tests actually run `map().toArray()` on a connected `net.Socket` and `filter().map().toArray()` on a `_stream_readable` stream. All nine fail on the current release (`USE_SYSTEM_BUN=1`: every operator is `undefined`, `socket.map is not a function`) and pass with this change.

With the debug build I also ran the rest of `test/js/node/stream/` and the vendored Node tests for the operators (`test-stream-map`, `-filter`, `-flatMap`, `-forEach`, `-reduce`, `-toArray`, `-drop-take`, `-some-find-every`, `-compose`, `-compose-operator`, `-duplex-from`, `-iterator-helpers-test262-tests`) plus a handful of `crypto` hash/stream, `child_process` stdio, `net`, `tls` and `worker` stdio tests; all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->
