### PR TITLE
error.stack: report frames at new X(...) at the new keyword

### DIFF
--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -13,9 +13,8 @@ static bool isLineTerminator(char16_t c)
     return c == '\n' || c == '\r' || c == 0x2028 || c == 0x2029;
 }
 
-/// Moves `pos` (the divot of an expression) back `amount` code units, to the start of the
-/// expression. When that crosses a line boundary the line and column have to be recounted from
-/// the source text. If that is not possible, `pos` is left pointing at the divot.
+/// Moves `pos` (an expression's divot) back `amount` code units to the start of the expression,
+/// recounting the line and column from the source when that crosses a line break.
 static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* code)
 {
     if (amount <= 0 || pos.byte_position < amount)
@@ -33,8 +32,7 @@ static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, Code
     if (!provider)
         return;
 
-    // eval, new Function and node:vm code is not transpiled, so unlike transpiled modules
-    // its source can be 16-bit. StringView indexing handles both encodings.
+    // Untranspiled sources (eval, new Function, node:vm) can be 16-bit; indexing handles both.
     WTF::StringView source = provider->source();
     if (static_cast<unsigned>(pos.byte_position) > source.length())
         return;
@@ -51,8 +49,7 @@ static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, Code
     int i = start - 1;
     for (; i >= 0 && !isLineTerminator(source[i]); i--)
         column++;
-    // Columns JSC reports on the first line of a source include the source's start column
-    // (node:vm's columnOffset); the fast path above inherits that from the divot's column.
+    // JSC's columns on the first line of a source include its start column (node:vm columnOffset).
     if (i < 0)
         column += provider->startPosition().m_column.zeroBasedInt();
 

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -56,9 +56,27 @@ static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, Code
     pos.byte_position = start;
 }
 
+// JavaScriptCore puts the divot of these at the `(` or the end of the callee; V8 reports the `new`.
+static bool isConstruct(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
+{
+    switch (code->instructionAt(bc)->opcodeID()) {
+    case op_construct:
+    case op_construct_varargs:
+    case op_super_construct:
+    case op_super_construct_varargs:
+        return true;
+    default:
+        return false;
+    }
+}
+
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
 {
     auto expr = code->expressionInfoForBytecodeIndex(bc);
+    // Uncomment to debug this:
+    // printf("lc = %u : %u (byte = %u)\n", expr.lineColumn.line, expr.lineColumn.column, expr.divot);
+    // printf("off = %u : %u\n", expr.startOffset, expr.endOffset);
+    // printf("name = %s\n", code->instructionAt(bc)->name());
 
     ZigStackFramePosition pos {
         .line_zero_based = OrdinalNumber::fromOneBasedInt(expr.lineColumn.line).zeroBasedInt(),
@@ -66,43 +84,48 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
         .byte_position = (int)expr.divot,
     };
 
-    auto inst = code->instructionAt(bc);
-
-    /// JavaScriptCore places error divots at different places than v8
-    // Uncomment to debug this:
-    // printf("lc = %d : %d (byte = %d)\n", pos.line.oneBasedInt(), pos.column.oneBasedInt(), expr.divot);
-    // printf("off = %d : %d\n", expr.startOffset, expr.endOffset);
-    // printf("name = %s\n", inst->name());
-
-    switch (inst->opcodeID()) {
-    case op_construct:
-    case op_construct_varargs:
-    case op_super_construct:
-    case op_super_construct_varargs:
-        // The divot by default is pointing at the `(` or the end of the class name.
-        // We want to point at the `new` keyword, which is conveniently at the
-        // expression start.
+    if (isConstruct(code, bc))
         adjustPositionBackwards(pos, expr.startOffset, code);
-        break;
-
-    default:
-        break;
-    }
 
     return pos;
 }
 
-ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame)
+ZigStackFramePosition getAdjustedLineColumnForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
 {
-    if (!frame.hasLineAndColumnInfo() || !frame.hasBytecodeIndex()) {
-        return ZigStackFramePosition {
-            .line_zero_based = -1,
-            .column_zero_based = -1,
-            .byte_position = -1,
-        };
+    if (isConstruct(code, bc)) {
+        auto pos = getAdjustedPositionForBytecode(code, bc);
+        pos.byte_position = -1;
+        return pos;
     }
 
+    // Cached per bytecode index, unlike expressionInfoForBytecodeIndex, which decodes a whole
+    // chapter of expression info on every call.
+    auto lineColumn = code->lineColumnForBytecodeIndex(bc);
+    return ZigStackFramePosition {
+        .line_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.line).zeroBasedInt(),
+        .column_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.column).zeroBasedInt(),
+        .byte_position = -1,
+    };
+}
+
+static constexpr ZigStackFramePosition noPosition {
+    .line_zero_based = -1,
+    .column_zero_based = -1,
+    .byte_position = -1,
+};
+
+ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame)
+{
+    if (!frame.hasLineAndColumnInfo() || !frame.hasBytecodeIndex())
+        return noPosition;
     return getAdjustedPositionForBytecode(frame.codeBlock(), frame.bytecodeIndex());
+}
+
+ZigStackFramePosition getAdjustedLineColumnForStackFrame(const JSC::StackFrame& frame)
+{
+    if (!frame.hasLineAndColumnInfo() || !frame.hasBytecodeIndex())
+        return noPosition;
+    return getAdjustedLineColumnForBytecode(frame.codeBlock(), frame.bytecodeIndex());
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -13,8 +13,7 @@ static bool isLineTerminator(char16_t c)
     return c == '\n' || c == '\r' || c == 0x2028 || c == 0x2029;
 }
 
-/// Moves `pos` (an expression's divot) back `amount` code units to the start of the expression,
-/// recounting the line and column from the source when that crosses a line break.
+/// Moves the divot in `pos` back `amount` code units, recounting line/column when that crosses a line break.
 static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* code)
 {
     if (amount <= 0 || pos.byte_position < amount)

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -73,10 +73,6 @@ static bool isConstruct(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
 {
     auto expr = code->expressionInfoForBytecodeIndex(bc);
-    // Uncomment to debug this:
-    // printf("lc = %u : %u (byte = %u)\n", expr.lineColumn.line, expr.lineColumn.column, expr.divot);
-    // printf("off = %u : %u\n", expr.startOffset, expr.endOffset);
-    // printf("name = %s\n", code->instructionAt(bc)->name());
 
     ZigStackFramePosition pos {
         .line_zero_based = OrdinalNumber::fromOneBasedInt(expr.lineColumn.line).zeroBasedInt(),
@@ -98,8 +94,7 @@ ZigStackFramePosition getAdjustedLineColumnForBytecode(JSC::CodeBlock* code, JSC
         return pos;
     }
 
-    // Cached per bytecode index, unlike expressionInfoForBytecodeIndex, which decodes a whole
-    // chapter of expression info on every call.
+    // Cached per bytecode index; expressionInfoForBytecodeIndex decodes a whole chapter every call.
     auto lineColumn = code->lineColumnForBytecodeIndex(bc);
     return ZigStackFramePosition {
         .line_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.line).zeroBasedInt(),

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -7,6 +7,12 @@
 namespace Bun {
 using namespace JSC;
 
+// The LineTerminator set JSC's lexer counts lines with (LF, CR, U+2028, U+2029).
+static bool isLineTerminator(char16_t c)
+{
+    return c == '\n' || c == '\r' || c == 0x2028 || c == 0x2029;
+}
+
 /// Moves `pos` (the divot of an expression) back `amount` code units, to the start of the
 /// expression. When that crosses a line boundary the line and column have to be recounted from
 /// the source text. If that is not possible, `pos` is left pointing at the divot.
@@ -34,13 +40,21 @@ static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, Code
         return;
 
     for (int i = start; i < pos.byte_position; i++) {
-        if (source[i] == '\n')
-            pos.line_zero_based--;
+        if (!isLineTerminator(source[i]))
+            continue;
+        pos.line_zero_based--;
+        if (source[i] == '\r' && i + 1 < pos.byte_position && source[i + 1] == '\n')
+            i++;
     }
 
     int column = 0;
-    for (int i = start - 1; i >= 0 && source[i] != '\n'; i--)
+    int i = start - 1;
+    for (; i >= 0 && !isLineTerminator(source[i]); i--)
         column++;
+    // Columns JSC reports on the first line of a source include the source's start column
+    // (node:vm's columnOffset); the fast path above inherits that from the divot's column.
+    if (i < 0)
+        column += provider->startPosition().m_column.zeroBasedInt();
 
     pos.column_zero_based = column;
     pos.byte_position = start;

--- a/src/jsc/bindings/ErrorStackFrame.cpp
+++ b/src/jsc/bindings/ErrorStackFrame.cpp
@@ -1,65 +1,49 @@
 #include "root.h"
+#include "ErrorStackFrame.h"
 #include "JavaScriptCore/CodeBlock.h"
-#include "headers-handwritten.h"
-#include "JavaScriptCore/BytecodeIndex.h"
-#include "wtf/Assertions.h"
+#include "JavaScriptCore/StackFrame.h"
 #include "wtf/text/OrdinalNumber.h"
 
 namespace Bun {
 using namespace JSC;
 
-/// Adjust a `ZigStackFramePosition` by a number of bytes. This accounts for when the adjustment
-/// crosses line boundaries, and thus requires the source code in order to properly compute
-/// the result.
-void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* code)
+/// Moves `pos` (the divot of an expression) back `amount` code units, to the start of the
+/// expression. When that crosses a line boundary the line and column have to be recounted from
+/// the source text. If that is not possible, `pos` is left pointing at the divot.
+static void adjustPositionBackwards(ZigStackFramePosition& pos, int amount, CodeBlock* code)
 {
-    if (pos.byte_position - amount < 0) {
-        pos.line_zero_based = 0;
-        pos.column_zero_based = 0;
-        pos.byte_position = 0;
+    if (amount <= 0 || pos.byte_position < amount)
+        return;
+
+    int start = pos.byte_position - amount;
+
+    if (pos.column_zero_based >= amount) {
+        pos.column_zero_based -= amount;
+        pos.byte_position = start;
         return;
     }
 
-    pos.column_zero_based = pos.column_zero_based - amount;
-    if (pos.column_zero_based < 0) {
-        auto* provider = code->source().provider();
-        if (!provider) {
-            pos.line_zero_based = 0;
-            pos.column_zero_based = 0;
-            pos.byte_position = 0;
-            return;
-        }
+    auto* provider = code->source().provider();
+    if (!provider)
+        return;
 
-        auto source = provider->source();
-        if (!source.is8Bit()) {
-            // Debug-only assertion
-            // Bun does not yet use 16-bit sources anywhere. The transpiler ensures everything
-            // fit's into latin1 / 8-bit strings for on-average lower memory usage.
-            ASSERT_NOT_REACHED("16-bit source re-mapping is not implemented here.");
+    // eval, new Function and node:vm code is not transpiled, so unlike transpiled modules
+    // its source can be 16-bit. StringView indexing handles both encodings.
+    WTF::StringView source = provider->source();
+    if (static_cast<unsigned>(pos.byte_position) > source.length())
+        return;
 
-            pos.line_zero_based = 0;
-            pos.column_zero_based = 0;
-            pos.byte_position = 0;
-            return;
-        }
-
-        for (int i = 0; i < amount; i++) {
-            if (source[pos.byte_position - i] == '\n') {
-                pos.line_zero_based = pos.line_zero_based - 1;
-            }
-        }
-
-        int columns = 0;
-        // Initial -1 to skip the newline that gets counted.
-        int i = pos.byte_position - amount - 1;
-        while (i > 0 && source[i] != '\n') {
-            columns += 1;
-            i -= 1;
-        }
-        pos.column_zero_based = columns;
+    for (int i = start; i < pos.byte_position; i++) {
+        if (source[i] == '\n')
+            pos.line_zero_based--;
     }
 
-    pos.byte_position -= amount;
+    int column = 0;
+    for (int i = start - 1; i >= 0 && source[i] != '\n'; i--)
+        column++;
+
+    pos.column_zero_based = column;
+    pos.byte_position = start;
 }
 
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc)
@@ -96,6 +80,19 @@ ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::
     }
 
     return pos;
+}
+
+ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame)
+{
+    if (!frame.hasLineAndColumnInfo() || !frame.hasBytecodeIndex()) {
+        return ZigStackFramePosition {
+            .line_zero_based = -1,
+            .column_zero_based = -1,
+            .byte_position = -1,
+        };
+    }
+
+    return getAdjustedPositionForBytecode(frame.codeBlock(), frame.bytecodeIndex());
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -11,14 +11,13 @@ class StackFrame;
 
 namespace Bun {
 
-/// Position of the bytecode at `bc` where V8 would report it: `new X(...)` at `new`, not after `X`.
-/// byte_position is that position's offset into the source, for cutting out source lines.
+/// Position of the bytecode at `bc` where V8 would report it (`new X(...)` at `new`), with its source offset.
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// The line and column of the above (byte_position is -1), cheaper for the frames that are not at a construct.
+/// Line and column of the above only (byte_position is -1); cheap for frames that are not at a construct.
 ZigStackFramePosition getAdjustedLineColumnForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// The two above for a captured frame. Frames without a code block get -1 in every field (invalid position).
+/// The two above for a captured frame; -1 in every field (an invalid position) without a code block.
 ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame);
 ZigStackFramePosition getAdjustedLineColumnForStackFrame(const JSC::StackFrame& frame);
 

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -11,12 +11,10 @@ class StackFrame;
 
 namespace Bun {
 
-/// Source position of the bytecode at `bc`, moved to where V8 reports it
-/// (`new X(...)` is reported at `new`, JSC's divot is at the end of `X`).
+/// Position of the bytecode at `bc` where V8 would report it: `new X(...)` at `new`, not after `X`.
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// Same for a captured stack frame. Frames without a code block (native, wasm) get a position
-/// with every field set to -1, which Bun__remapStackFramePositions skips.
+/// Same for a captured frame. Frames without a code block get -1 in every field (invalid position).
 ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -1,9 +1,22 @@
+#pragma once
+
 #include "root.h"
 #include "headers-handwritten.h"
 #include "JavaScriptCore/BytecodeIndex.h"
 
+namespace JSC {
+class CodeBlock;
+class StackFrame;
+}
+
 namespace Bun {
 
+/// Source position of the bytecode at `bc`, moved to where V8 reports it
+/// (`new X(...)` is reported at `new`, JSC's divot is at the end of `X`).
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
+
+/// Same for a captured stack frame. Frames without a code block (native, wasm) get a position
+/// with every field set to -1, which Bun__remapStackFramePositions skips.
+ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackFrame.h
+++ b/src/jsc/bindings/ErrorStackFrame.h
@@ -12,9 +12,14 @@ class StackFrame;
 namespace Bun {
 
 /// Position of the bytecode at `bc` where V8 would report it: `new X(...)` at `new`, not after `X`.
+/// byte_position is that position's offset into the source, for cutting out source lines.
 ZigStackFramePosition getAdjustedPositionForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
 
-/// Same for a captured frame. Frames without a code block get -1 in every field (invalid position).
+/// The line and column of the above (byte_position is -1), cheaper for the frames that are not at a construct.
+ZigStackFramePosition getAdjustedLineColumnForBytecode(JSC::CodeBlock* code, JSC::BytecodeIndex bc);
+
+/// The two above for a captured frame. Frames without a code block get -1 in every field (invalid position).
 ZigStackFramePosition getAdjustedPositionForStackFrame(const JSC::StackFrame& frame);
+ZigStackFramePosition getAdjustedLineColumnForStackFrame(const JSC::StackFrame& frame);
 
 } // namespace Bun

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -423,7 +423,7 @@ bool JSCStackFrame::calculateSourcePositions()
         return false;
     }
 
-    auto location = Bun::getAdjustedPositionForBytecode(m_codeBlock, m_bytecodeIndex);
+    auto location = Bun::getAdjustedLineColumnForBytecode(m_codeBlock, m_bytecodeIndex);
     m_sourcePositions.line = location.line();
     m_sourcePositions.column = location.column();
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -265,8 +265,7 @@ WTF::String formatStackTrace(
 
         if (!frame.hasLineAndColumnInfo()) continue;
 
-        // Same position Bun.inspect (ZigException.cpp) and CallSite use. Source maps have a
-        // mapping at the start of a `new` expression, not at JSC's divot after the callee.
+        // Same position as Bun.inspect and CallSite; source maps have a mapping at `new`, not at JSC's divot.
         originalPositions[i] = Bun::getAdjustedPositionForStackFrame(frame);
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -266,7 +266,7 @@ WTF::String formatStackTrace(
         if (!frame.hasLineAndColumnInfo()) continue;
 
         // Same position as Bun.inspect and CallSite; source maps have a mapping at `new`, not at JSC's divot.
-        originalPositions[i] = Bun::getAdjustedPositionForStackFrame(frame);
+        originalPositions[i] = Bun::getAdjustedLineColumnForStackFrame(frame);
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
         if (auto* callee = frame.callee()) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -315,8 +315,10 @@ WTF::String formatStackTrace(
         OrdinalNumber displayLine = {};
         OrdinalNumber displayColumn = {};
         WTF::String sourceURLForFrame = sourceURLs[i];
+        // Still -1 for the frames pass 1 skipped (no code block) or could not position.
+        bool hasPosition = originalPositions[i].line_zero_based >= 0;
 
-        if (frame.hasLineAndColumnInfo()) {
+        if (hasPosition) {
             originalLine = originalPositions[i].line();
             originalColumn = originalPositions[i].column();
             displayLine = originalLine;
@@ -371,14 +373,11 @@ WTF::String formatStackTrace(
 
         if (!sourceURLForFrame.isEmpty()) {
             sb.append(sourceURLForFrame);
-            if (displayLine.zeroBasedInt() > 0 || displayColumn.zeroBasedInt() > 0) {
+            if (hasPosition) {
                 sb.append(':');
                 sb.append(displayLine.oneBasedInt());
-
-                if (displayColumn.zeroBasedInt() > 0) {
-                    sb.append(':');
-                    sb.append(displayColumn.oneBasedInt());
-                }
+                sb.append(':');
+                sb.append(displayColumn.oneBasedInt());
             }
         }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -21,6 +21,7 @@
 
 #include "BunClientData.h"
 #include "CallSite.h"
+#include "ErrorStackFrame.h"
 #include "ErrorStackTrace.h"
 #include "headers-handwritten.h"
 
@@ -243,11 +244,11 @@ WTF::String formatStackTrace(
     // file's map once instead of per frame.
     WTF::Vector<ZigStackFrame, 8> remappedFrames;
     WTF::Vector<WTF::String, 8> sourceURLs;
-    WTF::Vector<LineColumn, 8> originalLineColumns;
+    WTF::Vector<ZigStackFramePosition, 8> originalPositions;
     remappedFrames.grow(framesCount);
     memset(remappedFrames.begin(), 0, sizeof(ZigStackFrame) * framesCount);
     sourceURLs.grow(framesCount);
-    originalLineColumns.grow(framesCount);
+    originalPositions.grow(framesCount);
     bool anyRemap = false;
 
     for (size_t i = 0; i < framesCount; i++) {
@@ -260,11 +261,15 @@ WTF::String formatStackTrace(
         remappedFrame.position.line_zero_based = -1;
         remappedFrame.position.column_zero_based = -1;
         remappedFrame.position.byte_position = -1;
-        originalLineColumns[i] = {};
+        originalPositions[i] = remappedFrame.position;
 
         if (!frame.hasLineAndColumnInfo()) continue;
 
-        originalLineColumns[i] = frame.computeLineAndColumn();
+        // Same position Bun.inspect (ZigException.cpp) and CallSite use. Besides keeping
+        // the three in agreement, source maps have a mapping at the start of a `new`
+        // expression but usually not at JSC's divot (the end of the callee), so remapping
+        // the divot snaps to whatever mapping happens to precede it.
+        originalPositions[i] = Bun::getAdjustedPositionForStackFrame(frame);
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;
         if (auto* callee = frame.callee()) {
@@ -280,8 +285,7 @@ WTF::String formatStackTrace(
         if (isDefinitelyNotRunninginNodeVMGlobalObject || isDefaultGlobalObjectInAFinalizer) {
             // https://github.com/oven-sh/bun/issues/3595
             if (!sourceURLs[i].isEmpty()) {
-                remappedFrame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line).zeroBasedInt();
-                remappedFrame.position.column_zero_based = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column).zeroBasedInt();
+                remappedFrame.position = originalPositions[i];
                 remappedFrame.source_url = Bun::toStringRef(sourceURLs[i]);
                 anyRemap = true;
             }
@@ -316,8 +320,8 @@ WTF::String formatStackTrace(
         WTF::String sourceURLForFrame = sourceURLs[i];
 
         if (frame.hasLineAndColumnInfo()) {
-            originalLine = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line);
-            originalColumn = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column);
+            originalLine = originalPositions[i].line();
+            originalColumn = originalPositions[i].column();
             displayLine = originalLine;
             displayColumn = originalColumn;
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -265,10 +265,8 @@ WTF::String formatStackTrace(
 
         if (!frame.hasLineAndColumnInfo()) continue;
 
-        // Same position Bun.inspect (ZigException.cpp) and CallSite use. Besides keeping
-        // the three in agreement, source maps have a mapping at the start of a `new`
-        // expression but usually not at JSC's divot (the end of the callee), so remapping
-        // the divot snaps to whatever mapping happens to precede it.
+        // Same position Bun.inspect (ZigException.cpp) and CallSite use. Source maps have a
+        // mapping at the start of a `new` expression, not at JSC's divot after the callee.
         originalPositions[i] = Bun::getAdjustedPositionForStackFrame(frame);
 
         JSC::JSGlobalObject* globalObjectForFrame = lexicalGlobalObject;

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -144,20 +144,9 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
     if (sourceString.isNull()) [[unlikely]]
         return;
 
-    if (!stackFrame.hasBytecodeIndex()) {
-        if (stackFrame.hasLineAndColumnInfo()) {
-            auto lineColumn = stackFrame.computeLineAndColumn();
-            position.line_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.line).zeroBasedInt();
-            position.column_zero_based = OrdinalNumber::fromOneBasedInt(lineColumn.column).zeroBasedInt();
-        }
-
-        position.byte_position = -1;
-        return;
-    }
-
-    auto location = Bun::getAdjustedPositionForBytecode(code, stackFrame.bytecodeIndex());
-    memcpy(&position, &location, sizeof(ZigStackFramePosition));
-    if (flags == PopulateStackTraceFlags::OnlyPosition)
+    auto location = Bun::getAdjustedPositionForStackFrame(stackFrame);
+    position = location;
+    if (flags == PopulateStackTraceFlags::OnlyPosition || location.byte_position < 0)
         return;
 
     if (source_lines_count > 1 && source_lines != nullptr && sourceString.is8Bit()) {

--- a/test/bake/dev/server-sourcemap.test.ts
+++ b/test/bake/dev/server-sourcemap.test.ts
@@ -43,7 +43,9 @@ export async function getStaticPaths() {
     // Strip ANSI codes for cleaner checking
     const cleanLines = lines.replace(/\x1b\[[0-9;]*m/g, "");
 
-    const hasCorrectThrowLine = cleanLines.includes("myFunc") && cleanLines.includes("6:16");
+    // Frames remap to the declaration position here, like the `throwError`/`6:1`
+    // and `helperFunction`/`5:1` expectations below.
+    const hasCorrectThrowLine = /at myFunc \(.*pages[/\\]\[\.\.\.slug\]\.tsx:6:1\)/.test(cleanLines);
     // const hasCorrectCallLine = cleanLines.includes("MyPage") && cleanLines.includes("2") && cleanLines.includes("3");
     const hasCorrectFileName = cleanLines.includes("pages/[...slug].tsx");
 

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -148,4 +148,143 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// V8 reports a frame that is sitting at `new X(...)` at the `new` keyword. JSC's own position
+// is the end of `X`. Bun.inspect and Error.prepareStackTrace CallSites already move it back to
+// `new`; error.stack has to agree with them (and with Node).
+describe("error.stack column of a frame at `new X(...)` is the `new` keyword", () => {
+  // Keep this flush left: the expected line:column values below are positions in this source
+  // (the leading newline is dropped, so `class Thrower` is line 1).
+  const fixture = `
+class Thrower {
+  constructor() {
+    throw new Error("thrown by Thrower");
+  }
+}
+class MyError extends Error {}
+class Captures {
+  constructor(target) {
+    Error.captureStackTrace(target);
+  }
+}
+function customError() {
+  throw new MyError("custom");
+}
+function globalConstructor() {
+  return new Map(1);
+}
+function userConstructor() {
+  return new Thrower(1);
+}
+function spreadArguments(args) {
+  return new Map(...args);
+}
+function localBinding() {
+  const Ctor = Thrower;
+  return new Ctor(1);
+}
+function splitAcrossLines() {
+  return new
+    Map(1);
+}
+function viaCaptureStackTrace() {
+  const target = {};
+  new Captures(target);
+  return target.stack;
+}
+
+// "fixture.js:LINE:COLUMN" of the frame for the function called \`name\`.
+function frame(stack, name) {
+  const line = stack.split("\\n").find(line => line.includes("at " + name + " ("));
+  return line?.match(/fixture\\.js:\\d+:\\d+/)?.[0] ?? stack;
+}
+function caught(fn, ...args) {
+  try {
+    fn(...args);
+  } catch (e) {
+    return e;
+  }
+  throw new Error(fn.name + " did not throw");
+}
+
+const custom = caught(customError);
+console.log(
+  JSON.stringify({
+    customError: frame(custom.stack, "customError"),
+    customErrorLineColumn: [custom.line, custom.column],
+    globalConstructor: frame(caught(globalConstructor).stack, "globalConstructor"),
+    userConstructor: frame(caught(userConstructor).stack, "userConstructor"),
+    spreadArguments: frame(caught(spreadArguments, [1]).stack, "spreadArguments"),
+    localBinding: frame(caught(localBinding).stack, "localBinding"),
+    splitAcrossLines: frame(caught(splitAcrossLines).stack, "splitAcrossLines"),
+    viaCaptureStackTrace: frame(viaCaptureStackTrace(), "viaCaptureStackTrace"),
+  }),
+);
+`;
+
+  test.concurrent("in a transpiled file", async () => {
+    using dir = tempDir("stack-new-column", { "fixture.js": fixture.slice(1) });
+    const result = await bunRun(join(String(dir), "fixture.js"));
+    expect(result).toSpawn();
+    expect(JSON.parse(result.stdout)).toEqual({
+      customError: "fixture.js:13:9",
+      customErrorLineColumn: [13, 9],
+      globalConstructor: "fixture.js:16:10",
+      userConstructor: "fixture.js:19:10",
+      spreadArguments: "fixture.js:22:10",
+      localBinding: "fixture.js:26:10",
+      splitAcrossLines: "fixture.js:29:10",
+      viaCaptureStackTrace: "fixture.js:34:3",
+    });
+  });
+
+  // eval'd code is not transpiled, so `new` and its callee can really be on different lines and
+  // the position has to be recounted from the source text, which is 16-bit when the evaluated
+  // string is not latin1. The same position feeds error.stack, Bun.inspect and CallSites.
+  test.concurrent("in eval'd code with `new` on an earlier line than the callee", async () => {
+    const script = `
+const sources = {
+  latin1: "// latin1\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n",
+  utf16: "// \\u4e2d\\u6587\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n",
+  // \`new\` on the first line of the source, and a line break right after the callee.
+  firstLine: "function construct() { return new\\n  Map\\n  (1); }\\nconstruct();\\n",
+};
+const results = {};
+for (const [name, source] of Object.entries(sources)) {
+  const caught = () => {
+    try {
+      (0, eval)(source);
+    } catch (e) {
+      return e;
+    }
+  };
+  const lineColumn = text => text.match(/at construct \\(.*:(\\d+):(\\d+)\\)/).slice(1).join(":");
+
+  const stack = lineColumn(caught().stack);
+  const inspect = lineColumn(Bun.inspect(caught()));
+
+  const error = caught();
+  Error.prepareStackTrace = (_, callSites) => callSites;
+  const callSite = error.stack.find(callSite => callSite.getFunctionName() === "construct");
+  Error.prepareStackTrace = undefined;
+
+  results[name] = { stack, inspect, callSiteLine: callSite.getLineNumber() };
+}
+console.log(JSON.stringify(results));
+`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      latin1: { stack: "3:10", inspect: "3:10", callSiteLine: 3 },
+      utf16: { stack: "3:10", inspect: "3:10", callSiteLine: 3 },
+      firstLine: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+    });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -193,6 +193,13 @@ function viaCaptureStackTrace() {
   new Captures(target);
   return target.stack;
 }
+// Column 1 used to be left out of the frame (\`fixture.js:39\` instead of \`fixture.js:39:1\`).
+function callAtColumnOne() {
+customError();
+}
+function constructAtColumnOne() {
+new Thrower(1);
+}
 
 // "fixture.js:LINE:COLUMN" of the frame for the function called \`name\`.
 function frame(stack, name) {
@@ -219,6 +226,8 @@ console.log(
     localBinding: frame(caught(localBinding).stack, "localBinding"),
     splitAcrossLines: frame(caught(splitAcrossLines).stack, "splitAcrossLines"),
     viaCaptureStackTrace: frame(viaCaptureStackTrace(), "viaCaptureStackTrace"),
+    callAtColumnOne: frame(caught(callAtColumnOne).stack, "callAtColumnOne"),
+    constructAtColumnOne: frame(caught(constructAtColumnOne).stack, "constructAtColumnOne"),
   }),
 );
 `;
@@ -236,6 +245,8 @@ console.log(
       localBinding: "fixture.js:26:10",
       splitAcrossLines: "fixture.js:29:10",
       viaCaptureStackTrace: "fixture.js:34:3",
+      callAtColumnOne: "fixture.js:39:1",
+      constructAtColumnOne: "fixture.js:42:1",
     });
   });
 
@@ -281,6 +292,13 @@ for (const [name, { source, options }] of Object.entries(cases)) {
 
   results[name] = result;
 }
+
+// A script that starts with the \`new\` puts the frame at 1:1, which used to be taken for "no position".
+try {
+  vm.runInThisContext("new Map(1)", { filename: "byte-zero.js" });
+} catch (e) {
+  results.byteZero = e.stack.match(/at byte-zero\\.js(:\\d+:\\d+)?/)[0];
+}
 console.log(JSON.stringify(results));
 `;
     await using proc = Bun.spawn({
@@ -298,6 +316,7 @@ console.log(JSON.stringify(results));
       crlf: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
       lineSeparator: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
       columnOffset: { stack: "1:131", inspect: "1:131" },
+      byteZero: "at byte-zero.js:1:1",
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -200,6 +200,12 @@ customError();
 function constructAtColumnOne() {
 new Thrower(1);
 }
+// The transpiler keeps this callee on several lines, so JSC's divot ends up two lines below the \`new\`.
+function classExpressionCallee() {
+  return new class extends Thrower {
+    marker() {}
+  }(1);
+}
 
 // "fixture.js:LINE:COLUMN" of the frame for the function called \`name\`.
 function frame(stack, name) {
@@ -228,6 +234,7 @@ console.log(
     viaCaptureStackTrace: frame(viaCaptureStackTrace(), "viaCaptureStackTrace"),
     callAtColumnOne: frame(caught(callAtColumnOne).stack, "callAtColumnOne"),
     constructAtColumnOne: frame(caught(constructAtColumnOne).stack, "constructAtColumnOne"),
+    classExpressionCallee: frame(caught(classExpressionCallee).stack, "classExpressionCallee"),
   }),
 );
 `;
@@ -247,12 +254,13 @@ console.log(
       viaCaptureStackTrace: "fixture.js:34:3",
       callAtColumnOne: "fixture.js:39:1",
       constructAtColumnOne: "fixture.js:42:1",
+      classExpressionCallee: "fixture.js:46:10",
     });
   });
 
-  // eval'd and node:vm code is not transpiled, so `new` and its callee can really be on different
-  // lines and the position has to be recounted from the source text, which is 16-bit when the
-  // evaluated string is not latin1. The same position feeds error.stack, Bun.inspect and CallSites.
+  // eval'd and node:vm code is not transpiled, so the text the line and column get recounted from
+  // is whatever the user wrote, including 16-bit strings and every kind of line terminator. The
+  // same position feeds error.stack, Bun.inspect and CallSites.
   test.concurrent("in eval'd or node:vm code with `new` on an earlier line than the callee", async () => {
     const script = `
 const vm = require("node:vm");
@@ -261,10 +269,14 @@ const cases = {
   utf16: { source: "// \\u4e2d\\u6587\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n" },
   // \`new\` on the first line of the source, and a line break right after the callee.
   firstLine: { source: "function construct() { return new\\n  Map\\n  (1); }\\nconstruct();\\n" },
-  // The other line terminators JavaScript has.
+  // The other line terminators JavaScript has, between the \`new\` and the callee (counted to find
+  // the line) and, in the second-line variants, before the \`new\` too (where the column count stops).
   carriageReturn: { source: "function construct() { return new\\r  Map(1); }\\rconstruct();\\r" },
+  carriageReturnSecondLine: { source: "// x\\rfunction construct() { return new\\r  Map(1); }\\rconstruct();\\r" },
   crlf: { source: "function construct() { return new\\r\\n  Map(1); }\\r\\nconstruct();\\r\\n" },
   lineSeparator: { source: "function construct() { return new\\u2028  Map(1); }\\u2028construct();\\u2028" },
+  lineSeparatorSecondLine: { source: "// x\\u2028function construct() { return new\\u2028  Map(1); }\\u2028construct();\\u2028" },
+  paragraphSeparatorSecondLine: { source: "// x\\u2029function construct() { return new\\u2029  Map(1); }\\u2029construct();\\u2029" },
   // node:vm's columnOffset applies to the first line of the source.
   columnOffset: { source: "function construct() { return new\\n  Map(1); }\\nconstruct();\\n", options: { columnOffset: 100 } },
 };
@@ -313,8 +325,11 @@ console.log(JSON.stringify(results));
       utf16: { stack: "3:10", inspect: "3:10", callSiteLine: 3 },
       firstLine: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
       carriageReturn: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+      carriageReturnSecondLine: { stack: "2:31", inspect: "2:31", callSiteLine: 2 },
       crlf: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
       lineSeparator: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+      lineSeparatorSecondLine: { stack: "2:31", inspect: "2:31", callSiteLine: 2 },
+      paragraphSeparatorSecondLine: { stack: "2:31", inspect: "2:31", callSiteLine: 2 },
       columnOffset: { stack: "1:131", inspect: "1:131" },
       byteZero: "at byte-zero.js:1:1",
     });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -239,37 +239,47 @@ console.log(
     });
   });
 
-  // eval'd code is not transpiled, so `new` and its callee can really be on different lines and
-  // the position has to be recounted from the source text, which is 16-bit when the evaluated
-  // string is not latin1. The same position feeds error.stack, Bun.inspect and CallSites.
-  test.concurrent("in eval'd code with `new` on an earlier line than the callee", async () => {
+  // eval'd and node:vm code is not transpiled, so `new` and its callee can really be on different
+  // lines and the position has to be recounted from the source text, which is 16-bit when the
+  // evaluated string is not latin1. The same position feeds error.stack, Bun.inspect and CallSites.
+  test.concurrent("in eval'd or node:vm code with `new` on an earlier line than the callee", async () => {
     const script = `
-const sources = {
-  latin1: "// latin1\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n",
-  utf16: "// \\u4e2d\\u6587\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n",
+const vm = require("node:vm");
+const cases = {
+  latin1: { source: "// latin1\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n" },
+  utf16: { source: "// \\u4e2d\\u6587\\nfunction construct() {\\n  return new\\n    Map(1);\\n}\\nconstruct();\\n" },
   // \`new\` on the first line of the source, and a line break right after the callee.
-  firstLine: "function construct() { return new\\n  Map\\n  (1); }\\nconstruct();\\n",
+  firstLine: { source: "function construct() { return new\\n  Map\\n  (1); }\\nconstruct();\\n" },
+  // The other line terminators JavaScript has.
+  carriageReturn: { source: "function construct() { return new\\r  Map(1); }\\rconstruct();\\r" },
+  crlf: { source: "function construct() { return new\\r\\n  Map(1); }\\r\\nconstruct();\\r\\n" },
+  lineSeparator: { source: "function construct() { return new\\u2028  Map(1); }\\u2028construct();\\u2028" },
+  // node:vm's columnOffset applies to the first line of the source.
+  columnOffset: { source: "function construct() { return new\\n  Map(1); }\\nconstruct();\\n", options: { columnOffset: 100 } },
 };
 const results = {};
-for (const [name, source] of Object.entries(sources)) {
+for (const [name, { source, options }] of Object.entries(cases)) {
   const caught = () => {
     try {
-      (0, eval)(source);
+      options ? vm.runInThisContext(source, options) : (0, eval)(source);
     } catch (e) {
       return e;
     }
   };
   const lineColumn = text => text.match(/at construct \\(.*:(\\d+):(\\d+)\\)/).slice(1).join(":");
 
-  const stack = lineColumn(caught().stack);
-  const inspect = lineColumn(Bun.inspect(caught()));
+  const result = { stack: lineColumn(caught().stack), inspect: lineColumn(Bun.inspect(caught())) };
 
-  const error = caught();
-  Error.prepareStackTrace = (_, callSites) => callSites;
-  const callSite = error.stack.find(callSite => callSite.getFunctionName() === "construct");
-  Error.prepareStackTrace = undefined;
+  // node:vm materializes .stack as a string while the error leaves the script, so
+  // Error.prepareStackTrace can only be observed for the eval'd cases.
+  if (!options) {
+    const error = caught();
+    Error.prepareStackTrace = (_, callSites) => callSites;
+    result.callSiteLine = error.stack.find(callSite => callSite.getFunctionName() === "construct").getLineNumber();
+    Error.prepareStackTrace = undefined;
+  }
 
-  results[name] = { stack, inspect, callSiteLine: callSite.getLineNumber() };
+  results[name] = result;
 }
 console.log(JSON.stringify(results));
 `;
@@ -284,6 +294,10 @@ console.log(JSON.stringify(results));
       latin1: { stack: "3:10", inspect: "3:10", callSiteLine: 3 },
       utf16: { stack: "3:10", inspect: "3:10", callSiteLine: 3 },
       firstLine: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+      carriageReturn: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+      crlf: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+      lineSeparator: { stack: "1:31", inspect: "1:31", callSiteLine: 1 },
+      columnOffset: { stack: "1:131", inspect: "1:131" },
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/test/parallel/test-vm-basic.js
+++ b/test/js/node/test/parallel/test-vm-basic.js
@@ -277,17 +277,16 @@ const vm = require('vm');
   // Setting value to run the last three tests
   Error.stackTraceLimit = 1;
 
-  // Bun's compileFunction stack frames differ from Node's: JSC attributes
-  // the throw to a different column (and columnOffset is not applied), the
-  // wrapper costs one line when lineOffset is 0, and the anonymous source is
-  // labeled differently.
+  // Bun's compileFunction stack frames differ from Node's: columnOffset is
+  // not applied, the wrapper costs one line when lineOffset is 0, and the
+  // anonymous source is labeled differently.
   assert.throws(() => {
     vm.compileFunction('throw new Error("Sample Error")')();
   }, {
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:2:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:2:7)'
   });
 
   assert.throws(() => {
@@ -300,7 +299,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:4:7'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:4:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:4:7)'
   });
 
   assert.throws(() => {
@@ -313,7 +312,7 @@ const vm = require('vm');
     message: 'Sample Error',
     stack: typeof Bun === 'undefined'
       ? 'Error: Sample Error\n    at <anonymous>:1:10'
-      : 'Error: Sample Error\n    at <anonymous> (file:///:2:16)'
+      : 'Error: Sample Error\n    at <anonymous> (file:///:2:7)'
   });
 
   assert.strictEqual(

--- a/test/js/node/test/parallel/test-vm-context.js
+++ b/test/js/node/test/parallel/test-vm-context.js
@@ -112,11 +112,9 @@ assert.strictEqual(script.runInContext(ctx), false);
     });
   }, (err) => {
     stack = err.stack;
-    // JSC attributes the throw to a different column than V8, which also
-    // moves the caret marker.
-    return typeof Bun === 'undefined'
-      ? /^ \^/m.test(stack) && /expected-filename\.js:33:131/.test(stack)
-      : /^ *\^/m.test(stack) && /expected-filename\.js:33:140/.test(stack);
+    // Bun places the caret marker at a different column than V8.
+    return (typeof Bun === 'undefined' ? /^ \^/m : /^ *\^/m).test(stack) &&
+      /expected-filename\.js:33:131/.test(stack);
   }, `stack not formatted as expected: ${stack}`);
 }
 

--- a/test/js/node/test/parallel/test-vm-run-in-new-context.js
+++ b/test/js/node/test/parallel/test-vm-run-in-new-context.js
@@ -86,9 +86,7 @@ for (const arg of [filename, { filename }]) {
     assert.strictEqual(lines[1].trim(), code);
     // Skip lines[2] and lines[3]. They're just a ^ and blank line.
     assert.strictEqual(lines[4].trim(), 'Error: foo');
-    // JSC attributes the throw to a different column than V8.
-    assert.strictEqual(lines[5].trim(),
-                       typeof Bun === 'undefined' ? `at ${filename}:1:7` : `at ${filename}:1:16`);
+    assert.strictEqual(lines[5].trim(), `at ${filename}:1:7`);
     // The rest of the stack is uninteresting.
     return true;
   });

--- a/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
+++ b/test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap
@@ -6,7 +6,7 @@ throw new Error("hello");
                         ^
 
 Error: hello
-    at hellohello.js:2:16
+    at hellohello.js:2:7
     at runInNewContext (unknown)
     at <anonymous> (<this-url>:6:5)"
 `;


### PR DESCRIPTION
### Problem

For a frame that is sitting at a `new X(...)` expression, the column in the `error.stack` string points at `X` (or somewhere else entirely), while Node, `Bun.inspect(err)` / the uncaught error printer, and `Error.prepareStackTrace` CallSites all point at the `new` keyword.

```js
class Thrower { constructor() { throw new Error("x"); } }
class MyError extends Error {}
function customError() {
  throw new MyError("custom");   // `new` is column 9
}
function userConstructor() {
  return new Thrower(1);         // `new` is column 10
}
function localBinding() {
  const Ctor = Thrower;
  return new Ctor(1);            // line 11, `new` is column 10
}
```

| frame | node | bun 1.4 `err.stack` | bun 1.4 `Bun.inspect(err)` | this PR `err.stack` |
|---|---|---|---|---|
| `customError` | `:4:9` | `:4:13` | `:4:9` | `:4:9` |
| `userConstructor` | `:7:10` | `:7:14` | `:7:10` | `:7:10` |
| `localBinding` | `:11:10` | `:10:16` (previous line) | `:11:10` | `:11:10` |

The same applies to `new Map(1)`, `new Map(...args)`, `Error.captureStackTrace`, and `err.line` / `err.column`. In code that is not transpiled (`node:vm`, `eval`) it also applies to `throw new Error(...)`: `vm.runInNewContext('throw new Error("foo")')` reports `:1:16` where node reports `:1:7`.

### Cause

JSC's position for a construct is the divot at the end of the callee. Since #11581, `Bun::getAdjustedPositionForBytecode` (ErrorStackFrame.cpp) moves `op_construct*` / `op_super_construct*` positions back to the start of the expression, which is where V8 reports them, and both the code frame printer (ZigException.cpp) and the CallSite path (`JSCStackFrame::getSourcePositions`) use it. `formatStackTrace` in FormatStackTraceForJS.cpp, which produces the `.stack` string, still used the raw `frame.computeLineAndColumn()` and fed that into the source map remap. The transpiler's source map has a mapping at the start of the `new` expression but none at the divot, so the remap snaps the divot to whatever mapping precedes it: normally the callee identifier, and when the callee was inlined (`localBinding` above) the identifier's original location on another line.

### Fix

* `formatStackTrace` takes its positions from the same adjustment the other two consumers use (new `getAdjustedLineColumnForStackFrame` wrapper in ErrorStackFrame.cpp), so the three renderings agree and the remap starts from a position the source map has. `err.line` / `err.column` / `originalLine` / `originalColumn` are derived from the same values and follow. The line/column variant looks at the opcode first: only construct frames decode the expression info (needed for the divot and start offset), every other frame keeps using `CodeBlock::lineColumnForBytecodeIndex`, the cached lookup `computeLineAndColumn()` used before, so the `.stack` path costs what it did before for the frames it does not change. The CallSite path (`JSCStackFrame::calculateSourcePositions`) is moved to the same variant, it was decoding every frame; `ZigException.cpp` keeps the full variant because the source preview needs the offset.
* `formatStackTrace` used to decide whether a frame has a position by checking for a non-zero line or column, so a frame at column 1 printed as `file.js:8` and a frame at 1:1 printed no position at all. Constructs at the start of a line now legitimately land on column 1, so the `:line:column` suffix is keyed on whether pass 1 produced a position instead. Calls at column 1 gain their `:1` too (`at file.js:8:1`, which is what node prints; `Bun.inspect` already printed it).
* `ZigException.cpp` is switched to the same helper. No behavior change: its fallback for a frame with a code block but no bytecode index was unreachable (JSC always records both), and would have hit the `RELEASE_ASSERT` in `lineColumnForBytecodeIndex` if it ever ran; the helper reports no position instead.
* `adjustPositionBackwards`, which now has one more caller, is made to work when `new` and the callee are on different lines. Transpiled code mostly takes the same-line path (the printer puts `new` and a simple callee back on one line; a class or function expression callee still spans lines, covered by the `classExpressionCallee` case, which main reports two lines off), and `eval`, `new Function` and `node:vm` code hits it with whatever text the user wrote, in the encoding of the string it came from. On a 16-bit source the function zeroed the position in release builds and hit `ASSERT_NOT_REACHED` in debug builds, reachable today through `Bun.inspect` and `Error.prepareStackTrace`. It now indexes the `StringView` directly (works for both encodings), counts the same line terminators JSC's lexer counts (LF, CR, CRLF, U+2028, U+2029) and only the ones between the expression start and the divot (the old loop also looked at the character at the divot, so `return new\n  Map\n  (1)` printed `at construct (file.js:)` with no position), counts the column correctly when the expression starts on the first line of the source (the `i > 0` loop bound was off by one, and the source's start column, node:vm's `columnOffset`, which JSC includes in first-line columns, was dropped), and leaves the divot position alone instead of reporting `1:1` when it cannot recount.

### Why this is the right behavior

The `.stack` string is what external tools read (source map remappers, error reporters, test runners building code frames from stack strings), and V8 reports the `new` keyword there. Bun already chose the `new` keyword in #11581 for its other two renderings of the same frame; the string was the odd one out, and because of the source map behavior above the old column was not a consistent JSC flavored answer either, just whatever mapping happened to sit before the divot. Three node:vm tests from Node's suite had been given Bun-specific expected columns for this (#32018): with this change `test-vm-run-in-new-context.js` and `test-vm-context.js` produce Node's column and go back to the upstream assertion (the latter still needs its loose caret check), and `test-vm-basic.js` now only differs in the ways its comment already lists.

What does not change: frames at calls, `throw`, property accesses and so on (only construct opcodes are adjusted); `Bun.inspect` and CallSite output for constructs on a single line; `new Error(...)` in transpiled code, which the runtime transpiler currently lowers to a call. Cost: for frames that are not at a construct, the `.stack` path runs the same cached `lineColumnForBytecodeIndex` lookup it ran before; an earlier revision of this PR decoded the expression info for every frame, which review flagged, hence the opcode check. Construct frames pay one expression info decode, which `Bun.inspect` and CallSites were already paying for every frame; the CallSite path now pays it only for constructs too. Release builds, CPU time per `new Error().stack`, minimum of 8 interleaved runs on a heavily loaded machine (so only good to a few percent): 10 small frames: pre-PR 8.1us, decode-every-frame revision 8.4us, this revision 8.0us; error created at the end of a 3000-statement function: 7.0us / 7.4us / 7.2us (the pre-PR binary is the published canary of a slightly older base, the other two are local builds).

### Tests

`test/js/bun/test/stack.test.ts`:

* A transpiled fixture covering a custom error class, a global constructor, a user constructor called from the frame, `new` with spread (`op_construct_varargs`), a callee the transpiler inlines (wrong line before), `new` split across lines, `Error.captureStackTrace`, and `err.line` / `err.column`. Before this change it reports `13:13, 16:14, 19:14, 22:14, 25:16, 30:5, 34:7` instead of `13:9, 16:10, 19:10, 22:10, 26:10, 29:10, 34:3`. Two more cases put the call and the construct at column 1; before this change they print `fixture.js:39` (no column) and `fixture.js:42:5`, now `39:1` and `42:1`.
* eval'd and node:vm sources with `new` on an earlier line than the callee (latin1, UTF-16, one where the expression starts on line 1 with a line break right after the callee, CR / CRLF / U+2028 separators between `new` and the callee and, with `new` on line 2, CR / U+2028 / U+2029 before it as well (so the column count has to stop at them), a vm script with `columnOffset: 100`, and a vm script that starts with the `new`, whose frame used to print as `at byte-zero.js:1:8` and now prints `:1:1`), checking `.stack`, `Bun.inspect` and CallSites. Before this change `.stack` reports the divot (`4:8`, `4:8`, `2:6`, ...); the UTF-16 source reports `1:1` from `Bun.inspect` and line 1 from CallSites in release builds and aborts on `ASSERT_NOT_REACHED` in debug builds; the line 1 source prints no position at all from `Bun.inspect`. Node reports `3:10`, `3:10`, `1:31`, `1:31` x3 and `1:131` for these, which is what they now produce everywhere.

Updated expectations: the `vm-sourceUrl.test.ts` snapshot (`2:16` -> `2:7`, node prints `2:7`), the three node:vm tests above (which still pass on Node v26), and the first case of `test/bake/dev/server-sourcemap.test.ts`. That file's server-side frames currently land one line above the statement (the server HMR chunk's source map accounts for the client chunk's one-line prefix, a pre-existing bug that is being handled separately), and the column is whatever mapping on that line precedes the frame's generated column: for `throw new Error(...)` the old divot column picked the `(` of `function myFunc(` (`6:16`), the `new` column picks column 1 like the `throwError`/`6:1`, `helperFunction`/`5:1` and churn cases in the same file already do.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/server-sourcemap.test.ts test/js/bun/test/stack.test.ts
bun test v1.4.0 (b0386de2d)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-fDJv5e
bun add v1.4.0 (b0386de2d)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [364.00ms]
bun install v1.4.0 (b0386de2d)

Checked 6 installs across 7 packages (no changes) [98.00ms]
[0;30mdev|[0m Started development server: http://localhost:32931
[0;30mdev|[0m [32mBundled page in 2382ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (2f732e4a9)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-TA7HTu
bun add v1.4.0-canary.1 (2f732e4a9)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [9.00ms]
bun install v1.4.0-canary.1 (2f732e4a9)

Checked 6 installs across 7 packages (no changes) [0.00ms]
[0;30mdev|[0m Started development server: http://localhost:39807
[0;30mdev|[0m [32mBundled page in 68ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSON[0m[3m[1m.stringify[0m(params)}[0m<[0m/h1>[0m[2m;[0m
[0;30mdev|[0m [0m[1m4 |[0m }
[0;30mdev|[0m [0m[1m5 |[0m 
[0;30mdev|[0m [0m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/server-sourcemap.test.ts test/js/bun/test/stack.test.ts
bun test v1.4.0 (b0386de2d)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-xi4mYv
bun add v1.4.0 (b0386de2d)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [223.00ms]
bun install v1.4.0 (b0386de2d)

Checked 6 installs across 7 packages (no changes) [126.00ms]
[0;30mdev|[0m Started development server: http://localhost:35675
[0;30mdev|[0m [32mBundled page in 2285ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 956ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (14922ms)
Bundle modules (70ms)
Postprocesss modules (194ms)
Bundle Functions (1029ms)
Generate Code (37ms)

[16.28s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/12] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorStackFrame.cpp               | 163 ++++++++++--------
 src/jsc/bindings/ErrorStackFrame.h                 |  15 ++
 src/jsc/bindings/ErrorStackTrace.cpp               |   2 +-
 src/jsc/bindings/FormatStackTraceForJS.cpp         |  30 ++--
 src/jsc/bindings/ZigException.cpp                  |  17 +-
 test/bake/dev/server-sourcemap.test.ts             |   4 +-
 test/js/bun/test/stack.test.ts                     | 191 ++++++++++++++++++++-
 test/js/node/test/parallel/test-vm-basic.js        |  13 +-
 test/js/node/test/parallel/test-vm-context.js      |   8 +-
 .../test/parallel/test-vm-run-in-new-context.js    |   4 +-
 .../vm/__snapshots__/vm-sourceUrl.test.ts.snap     |   2 +-
 11 files changed, 331 insertions(+), 118 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/ErrorStackFrame.cpp                          5     12      0
src/jsc/bindings/ErrorStackFrame.h                            3      7      0
src/jsc/bindings/ErrorStackTrace.cpp                          3      1      0
src/jsc/bindings/FormatStackTraceForJS.cpp                    7     11      0
src/jsc/bindings/ZigException.cpp                             5      1      0
test/bake/dev/server-sourcemap.test.ts                        1      1      0
test/js/bun/test/stack.test.ts                                9     23      0
test/js/node/test/parallel/test-vm-basic.js                   1      3      0
test/js/node/test/parallel/test-vm-context.js                 1      1      0
test/js/node/test/parallel/test-vm-run-in-new-context.js      1      2      0
test/js/node/vm/__snapshots__/vm-sourceUrl.test.ts.snap       0      0      0
```

</details>

<!-- robobun:evidence:end -->