### PR TITLE
types: accept android, freebsd, libc-first, and -vX.Y.Z compile targets

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2774,6 +2774,13 @@ declare module "bun" {
     type Architecture = "x64" | "arm64" | "aarch64";
     type Libc = "glibc" | "musl" | "android";
     type SIMD = "baseline" | "modern";
+    /**
+     * Platforms a standalone executable can be built for. Covers the spellings
+     * used by the docs and by the published `@oven/bun-*` package names; the
+     * runtime additionally accepts the same segments in any order. Unlike
+     * {@link CompileTarget}, a `Platform` never carries a version suffix, so
+     * this union stays finite.
+     */
     type Platform =
       | `bun-darwin-${Architecture}`
       | `bun-darwin-${Architecture}-${SIMD}`

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2772,17 +2772,31 @@ declare module "bun" {
 
   namespace Build {
     type Architecture = "x64" | "arm64" | "aarch64";
-    type Libc = "glibc" | "musl";
+    type Libc = "glibc" | "musl" | "android";
     type SIMD = "baseline" | "modern";
-    type CompileTarget =
+    type Platform =
       | `bun-darwin-${Architecture}`
       | `bun-darwin-${Architecture}-${SIMD}`
       | `bun-linux-${Architecture}`
       | `bun-linux-${Architecture}-${Libc}`
       | `bun-linux-${Architecture}-${SIMD}`
       | `bun-linux-${Architecture}-${SIMD}-${Libc}`
+      | `bun-linux-${Architecture}-${Libc}-${SIMD}`
+      | `bun-freebsd-${Architecture}`
       | `bun-windows-${Architecture}`
       | `bun-windows-x64-${SIMD}`;
+    /**
+     * Platform to build a standalone executable for, optionally followed by
+     * `-v<major>.<minor>.<patch>` to embed that version of Bun instead of the
+     * one running the build.
+     *
+     * Equivalent CLI flag: `--target` (with `--compile`)
+     *
+     * @example "bun-linux-x64"
+     * @example "bun-linux-arm64-android"
+     * @example "bun-darwin-arm64-v1.2.3"
+     */
+    type CompileTarget = Platform | `${Platform}-v${number}.${number}.${number}`;
   }
 
   /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2793,11 +2793,8 @@ declare module "bun" {
       | `bun-windows-${Architecture}`
       | `bun-windows-x64-${SIMD}`;
     /**
-     * Platform to build a standalone executable for, optionally followed by
-     * `-v<major>.<minor>.<patch>` to embed that version of Bun instead of the
-     * one running the build.
-     *
-     * Equivalent CLI flag: `--target` (with `--compile`)
+     * A {@link Platform}, optionally followed by `-v<major>.<minor>.<patch>` to
+     * embed that version of Bun instead of the one running the build.
      *
      * @example "bun-linux-x64"
      * @example "bun-linux-arm64-android"
@@ -3246,6 +3243,14 @@ declare module "bun" {
   }
 
   interface CompileBuildOptions {
+    /**
+     * Platform to build the executable for, optionally pinned to a Bun version
+     * with a `-v<major>.<minor>.<patch>` suffix. Defaults to the platform and
+     * version of the Bun running the build; anything else is downloaded from
+     * npm the first time it is used.
+     *
+     * Equivalent CLI flag: `--target`
+     */
     target?: Bun.Build.CompileTarget;
     execArgv?: string[];
     executablePath?: string;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -112,6 +112,29 @@ async function createIsolatedFixture(packages?: string[]): Promise<string> {
   return fixtureDir;
 }
 
+// Runs on debug builds too: spawning tsc over a file or two is cheap, unlike the
+// in-process LanguageService runs in `typeTest`.
+async function tsc(name: string, files: Record<string, string>) {
+  const checkDir = join(TEMP_DIR, name);
+  const tsconfig = structuredClone(sourceTsconfig);
+  tsconfig.include = Object.keys(files);
+  tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+  await mkdir(checkDir, { recursive: true });
+  await makeTree(checkDir, { ...files, "tsconfig.json": JSON.stringify(tsconfig, null, 2) });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+    env: bunEnv,
+    cwd: checkDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
 function typeTest(name: string, config: TypeTestConfig) {
   // This file only tests the bun-types .d.ts, not bun's own code. Driving the
   // TypeScript LanguageService in-process under a debug build is ~40x slower,
@@ -358,36 +381,29 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      const result = await tsc("mmap-options-check", {
         "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
            view satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
       });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
+      expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    });
+  });
+
+  describe("Bun.build", () => {
+    // fixture/build.ts holds the Bun.Build.CompileTarget cases (android, freebsd, libc before the
+    // SIMD level, -vX.Y.Z suffix), so the release-only runs above cover them as well.
+    test("fixture/build.ts type-checks", async () => {
+      const result = await tsc("build-fixture-check", {
+        "build.ts": await Bun.file(join(FIXTURE_SOURCE_DIR, "build.ts")).text(),
+        "utilities.ts": await Bun.file(join(FIXTURE_SOURCE_DIR, "utilities.ts")).text(),
       });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+      expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
     });
   });
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -8,6 +8,8 @@ import { dirname, join, relative } from "node:path";
 
 import ts from "typescript";
 
+import { platforms } from "../../../packages/bun-release/src/platform";
+
 const BUN_REPO_ROOT = fileURLToPath(import.meta.resolve("../../../"));
 const BUN_TYPES_PACKAGE_ROOT = join(BUN_REPO_ROOT, "packages", "bun-types");
 const FIXTURE_SOURCE_DIR = fileURLToPath(import.meta.resolve("./fixture"));
@@ -401,6 +403,20 @@ describe("@types/bun integration test", () => {
       const result = await tsc("build-fixture-check", {
         "build.ts": await Bun.file(join(FIXTURE_SOURCE_DIR, "build.ts")).text(),
         "utilities.ts": await Bun.file(join(FIXTURE_SOURCE_DIR, "utilities.ts")).text(),
+      });
+
+      expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    });
+
+    // `--target` downloads `@oven/<bin>` for the bins in packages/bun-release/src/platform.ts,
+    // so a bin added there has to be a valid target here too.
+    test("every published platform is a CompileTarget", async () => {
+      const result = await tsc("published-platforms-check", {
+        "platforms.ts": platforms
+          .map(
+            ({ bin }) => `"${bin}" satisfies Bun.Build.Platform;\n"${bin}-v1.2.3" satisfies Bun.Build.CompileTarget;`,
+          )
+          .join("\n"),
       });
 
       expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -16,6 +16,51 @@ expectAssignable<Bun.Build.CompileTarget>("bun-darwin-x64-modern");
 expectAssignable<Bun.Build.CompileTarget>("bun-darwin-arm64-baseline");
 expectAssignable<Bun.Build.CompileTarget>("bun-windows-x64-modern");
 
+// Targets the runtime accepts and bun publishes: android and freebsd (added to the
+// runtime in #29676), the npm package spelling with the libc before the SIMD level,
+// and a pinned Bun version suffix.
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-android");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-aarch64-android");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-android");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-modern-android");
+expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-x64");
+expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-arm64");
+expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-aarch64");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-musl-baseline");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-musl-modern");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-v1.2.3");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-v1.10.0");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-musl-v1.2.3");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-musl-baseline-v1.2.3");
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-android-v1.2.3");
+expectAssignable<Bun.Build.CompileTarget>("bun-darwin-arm64-v1.2.3");
+expectAssignable<Bun.Build.CompileTarget>("bun-windows-x64-baseline-v1.2.3");
+expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-x64-v1.2.3");
+
+// Spellings the runtime rejects stay rejected.
+// @ts-expect-error - android is a Linux libc, the runtime rejects it with any other OS
+expectAssignable<Bun.Build.CompileTarget>("bun-windows-x64-android");
+// @ts-expect-error - musl only exists on Linux
+expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-x64-musl");
+// @ts-expect-error - the version suffix must be a complete major.minor.patch
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-v1.2");
+// @ts-expect-error - the version suffix starts with "v"
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-1.2.3");
+// @ts-expect-error - the version must be numeric
+expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-vlatest");
+
+Bun.build({
+  entrypoints: ["hey"],
+  compile: "bun-linux-arm64-android",
+});
+
+Bun.build({
+  entrypoints: ["hey"],
+  compile: {
+    target: "bun-freebsd-x64-v1.2.3",
+  },
+});
+
 Bun.build({
   entrypoints: ["hey"],
   splitting: false,

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -16,18 +16,18 @@ expectAssignable<Bun.Build.CompileTarget>("bun-darwin-x64-modern");
 expectAssignable<Bun.Build.CompileTarget>("bun-darwin-arm64-baseline");
 expectAssignable<Bun.Build.CompileTarget>("bun-windows-x64-modern");
 
-// Targets the runtime accepts and bun publishes: android and freebsd (added to the
-// runtime in #29676), the npm package spelling with the libc before the SIMD level,
-// and a pinned Bun version suffix.
+// Every published @oven/bun-* package name is checked against Build.Platform in
+// bun-types.test.ts. These are the spellings that list does not contain.
+
+// android and freebsd (runtime support landed in #29676), with the docs' arch names
 expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-android");
-expectAssignable<Bun.Build.CompileTarget>("bun-linux-aarch64-android");
-expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-android");
 expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-modern-android");
-expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-x64");
 expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-arm64");
-expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-aarch64");
-expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-musl-baseline");
+
+// libc before the SIMD level, as in the package names (bun-linux-x64-musl-baseline)
 expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-musl-modern");
+
+// pinned Bun version
 expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-v1.2.3");
 expectAssignable<Bun.Build.CompileTarget>("bun-linux-x64-v1.10.0");
 expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-musl-v1.2.3");
@@ -36,6 +36,12 @@ expectAssignable<Bun.Build.CompileTarget>("bun-linux-arm64-android-v1.2.3");
 expectAssignable<Bun.Build.CompileTarget>("bun-darwin-arm64-v1.2.3");
 expectAssignable<Bun.Build.CompileTarget>("bun-windows-x64-baseline-v1.2.3");
 expectAssignable<Bun.Build.CompileTarget>("bun-freebsd-x64-v1.2.3");
+
+// Build.Platform is the version-less subset of Build.CompileTarget.
+expectType<Bun.Build.Platform>().extends<Bun.Build.CompileTarget>();
+expectAssignable<Bun.Build.Platform>("bun-linux-arm64-android");
+// @ts-expect-error - only CompileTarget takes a version suffix
+expectAssignable<Bun.Build.Platform>("bun-linux-x64-v1.2.3");
 
 // Spellings the runtime rejects stay rejected.
 // @ts-expect-error - android is a Linux libc, the runtime rejects it with any other OS


### PR DESCRIPTION
### What does this PR do?

`Bun.Build.CompileTarget` (the type behind `compile: "..."` and `compile: { target }` in `Bun.build`) rejects several target strings that `bun build --compile --target` and `Bun.build` accept and that bun actually publishes:

```ts
await Bun.build({ entrypoints: ["./app.ts"], compile: { target: "bun-linux-arm64-android" } });
// error TS2322: Type '"bun-linux-arm64-android"' is not assignable to type 'CompileTarget | undefined'.
```

The runtime parser (`CompileTarget::try_from` in `src/options_types/compile_target.rs`, shared by the CLI and all three `Bun.build` entry points through `compile_target_from_slice`) accepts, and the type did not model:

- `-android` (`Libc::Android`; `@oven/bun-linux-aarch64-android` and `@oven/bun-linux-x64-android` are published, see `packages/bun-release/src/platform.ts`). This is also the spelling the runtime's own error hint recommends.
- `bun-freebsd-<arch>` (`@oven/bun-freebsd-x64` and `@oven/bun-freebsd-aarch64`, added to the runtime together with android in #29676, which is when the type fell behind).
- The libc before the SIMD level, e.g. `bun-linux-x64-musl-baseline`. That is the npm package name and the spelling bun itself prints for the target; the type only had `-baseline-musl`.
- A trailing `-v<major>.<minor>.<patch>`, which `docs/bundler/executables.mdx` documents as the way to build against a different version of Bun.

The fix adds `"android"` to `Libc`, a freebsd member and the libc-first order, and splits the result out as `Bun.Build.Platform` so the version suffix can be expressed once:

```ts
type CompileTarget = Platform | `${Platform}-v${number}.${number}.${number}`;
```

`Platform` stays a finite union for anyone who needs to enumerate targets; only `CompileTarget` gains the template member (its JSDoc says so, and the fixture pins it). `${number}` is the usual TypeScript approximation of a numeric segment; the runtime still validates the version when it parses the string.

`CompileBuildOptions.target` also gets a JSDoc. Hovering the option shows the property's doc rather than the alias's, and a template member never shows up in string completions, so the property doc is the only place the version suffix can be discovered from an editor (checked with the TypeScript language service: quick info and the `target` completion entry were empty before, and now carry the description).

Where the line is drawn: the parser is order-insensitive (the docs say so too, and `try_from` just walks the `-` separated tokens), so the type cannot mirror it literally without listing permutations. As before this PR, it lists the spellings the docs and the published package names use; the libc-first member is added because that is the order the package names use. Still not modelled on purpose: other segment orders, the undocumented alias tokens (`win32`, `macos`, `x86_64`, `amd64`, ...), and targets with only an OS or only a version (`bun-linux`, `bun-v1.2.3`). `bun-linux-x64-glibc` is advertised by the type but rejected by the parser today; that is being fixed on the runtime side separately and is unchanged here. Docs for the android and freebsd targets are a separate change.

### How did you verify your code works?

Runtime side (what the type is mirroring), checked with bun 1.4.0 through `compile: "<target>"`, `compile: { target }` and `target: "bun-..."`, with `BUN_COMPILE_TARGET_TARBALL_URL` pointed at a local server returning 404 so nothing is downloaded. An accepted target gets as far as the download step and reports itself in normalized form; a rejected one throws while parsing the config:

<details><summary>output</summary>

```
bun-linux-arm64-android        Target platform 'bun-linux-aarch64-android-v1.4.0' is not available for download. ...
bun-linux-x64-android          Target platform 'bun-linux-x64-android-v1.4.0' is not available for download. ...
bun-freebsd-x64                Target platform 'bun-freebsd-x64-v1.4.0' is not available for download. ...
bun-freebsd-arm64              Target platform 'bun-freebsd-aarch64-v1.4.0' is not available for download. ...
bun-linux-x64-musl-baseline    Target platform 'bun-linux-x64-musl-baseline-v1.4.0' is not available for download. ...
bun-linux-arm64-musl-v1.2.3    Target platform 'bun-linux-aarch64-musl-v1.2.3' is not available for download. ...
bun-linux-x64-glibc            threw: Unknown compile target: bun-linux-x64-glibc
bun-linux-x64-v1.2             threw: Unknown compile target: bun-linux-x64-v1.2
bun-windows-x64-android        threw: Unknown compile target: bun-windows-x64-android
bun-freebsd-x64-musl           threw: Unknown compile target: bun-freebsd-x64-musl
```

(The 1.4.0 android and freebsd packages 404 because 1.4.0 is not released yet; 1.3.14 of both is on the registry.)

</details>

Type side, two tests:

- `bun-types.test.ts` gets a check generated from `packages/bun-release/src/platform.ts` (the list of `@oven/bun-*` packages `--target` can download): every `bin` there must satisfy `Platform`, and `bin-v1.2.3` must satisfy `CompileTarget`. Run against the previous union (renamed to `Platform` for the comparison), the bare-bin lines fail for exactly the five packages this PR is about (`bun-linux-x64-musl-baseline`, the two android and the two freebsd packages) and the `-v1.2.3` lines fail for all 16; it goes red again the next time a package is added there without updating the type.
- `fixture/build.ts` covers the spellings that list cannot express: the docs' `arm64` forms, `-modern-android`, `-musl-modern`, the version suffix on several platforms, `Platform` being the version-less subset of `CompileTarget`, and `@ts-expect-error` cases for strings the parser rejects (`-android` off Linux, `-musl` on freebsd, incomplete, unprefixed and non-numeric versions, a version on `Platform`), plus both `compile` option positions. The existing fixture runs are release-only (`typeTest` skips on debug builds), so `bun-types.test.ts` also runs `tsc` over this one fixture file.

Both `tsc` checks use a helper factored out of the existing `Bun.mmap` check, which is otherwise unchanged. `bun test test/integration/bun-types/bun-types.test.ts`: 16 pass with the `.d.ts` change; without it the two new cases and the whole-fixture runs fail (one diagnostic per new `build.ts` line, 32 for the generated file), and the `@ts-expect-error` lines are satisfied either way. Collapsing `Platform` into `CompileTarget` is caught by the fixture (unused `@ts-expect-error`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (a56a816b4)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.85ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1476.22ms]
403 |       const result = await tsc("build-fixture-check", {
404 |         "build.ts": await Bun.file(join(FIXTURE_SOURCE_DIR, "build.ts")).text(),
405 |         "utilities.ts": await Bun.file(join(FIXTURE_SOURCE_DIR, "utilities.ts")).text(),
406 |       });
407 | 
408 |       expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 1,
    "stderr": "",
-   "stdout": "",
+   "stdout": 
+ "build.ts(23,43): error TS2345: Argument of type '"bun-
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.26ms]
151 |     expect(emptyInterfaces).toEqual(config.emptyInterfaces);
152 | 
153 |     if (typeof config.diagnostics === "function") {
154 |       config.diagnostics(diagnostics);
155 |     } else {
156 |       expect(diagnostics).toEqual(config.diagnostics);
                                ^
error: expect(received).toEqual(expected)

- []
+ [
+   {
+     "code": 2345,
+     "line": "build.ts:23:43",
+     "message": "Argument of type '"bun-linux-arm64-android"' is not assignable to parameter of type 'CompileTarget'.",
+   },
+   {
+     "code": 2345,
+     "line": "build.ts:24:43",
+     "message": "Argument of type '"bun-linux-x64-modern-android"' is not assignable to parameter of type 'CompileTarget'.",
+   },
+   {
+     "code": 2345,
+     "line": "build.ts:25:43",
+     "message": "Argument of type '"bun-freebsd-arm64"' is not assignable to parameter of type 'CompileTarget'.",
+   },
+   {
+     "code": 2345,
+     "line": "build.ts:28:43",
+     "message": "Argument of type '"bun-linux-arm64-musl-mo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (a56a816b4)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.78ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1455.43ms]
(pass) @types/bun integration test > Bun.build > fixture/build.ts type-checks [1437.44ms]
(pass) @types/bun integration test > Bun.build > every published platform is a CompileTarget [1444.64ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/bun integration 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 751ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9212ms)
Bundle modules (44ms)
Postprocesss modules (201ms)
Bundle Functions (741ms)
Generate Code (31ms)

[10.25s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_js_printer
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts                  | 30 +++++++++++-
 test/integration/bun-types/bun-types.test.ts | 70 ++++++++++++++++++++--------
 test/integration/bun-types/fixture/build.ts  | 51 ++++++++++++++++++++
 3 files changed, 130 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/bun.d.ts                       6      6      0
test/integration/bun-types/bun-types.test.ts      2      4      0
test/integration/bun-types/fixture/build.ts       2      4      0
```

</details>

<!-- robobun:evidence:end -->