### PR TITLE
build --compile: inline the --target version into process.versions.bun

### DIFF
--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -410,7 +410,9 @@ impl CompileTarget {
         ]
     }
 
-    pub fn define_values(&self) -> [&'static [u8]; 3] {
+    /// Values for [`define_keys`](Self::define_keys): they describe the target
+    /// executable, not the bun running the build.
+    pub fn define_values(&self) -> [Box<[u8]>; 3] {
         // Each axis gets its own exhaustive match so that adding a variant to
         // `OperatingSystem` / `Architecture` / `Libc` is a compile error here,
         // not a runtime panic behind a wildcard arm.
@@ -430,9 +432,20 @@ impl CompileTarget {
             Architecture::Arm64 => b"\"arm64\"",
             Architecture::Wasm => b"\"wasm\"",
         };
-        const VERSION: &[u8] =
-            const_format::concatcp!("\"", bun_core::Global::package_json_version, "\"").as_bytes();
-        [platform, arch, VERSION]
+        // Mirrors the runtime's own `process.versions.bun`: the default target
+        // embeds this very executable (so the "-debug" suffix of debug builds is
+        // kept); any other target embeds the release build of `self.version`.
+        let version: Box<[u8]> = if self.is_default() {
+            Box::from(const_format::concatcp!("\"", Global::package_json_version, "\"").as_bytes())
+        } else {
+            format!(
+                "\"{}.{}.{}\"",
+                self.version.major, self.version.minor, self.version.patch
+            )
+            .into_bytes()
+            .into_boxed_slice()
+        };
+        [Box::from(platform), Box::from(arch), version]
     }
 }
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1202,7 +1202,7 @@ pub mod js_bundler {
                     let define_values = compile.compile_target.define_values();
                     debug_assert_eq!(define_keys.len(), define_values.len());
                     for (key, value) in define_keys.iter().zip(define_values) {
-                        this.define.insert(key, value)?;
+                        this.define.insert(key, &value)?;
                     }
 
                     let base_public_path = StandaloneModuleGraph::target_base_public_path(

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -95,7 +95,7 @@ impl BuildCommand {
                 keys.append(&mut define.keys);
                 let mut values: Vec<Box<[u8]>> =
                     Vec::with_capacity(compile_define_values.len() + define.values.len());
-                values.extend(compile_define_values.iter().map(|s| Box::<[u8]>::from(*s)));
+                values.extend(compile_define_values);
                 values.append(&mut define.values);
 
                 define.keys = keys;
@@ -106,10 +106,7 @@ impl BuildCommand {
                         .iter()
                         .map(|s| Box::<[u8]>::from(*s))
                         .collect(),
-                    values: compile_define_values
-                        .iter()
-                        .map(|s| Box::<[u8]>::from(*s))
-                        .collect(),
+                    values: compile_define_values.into(),
                 });
             }
         }

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -122,6 +122,82 @@ describe("Bun.build compile", () => {
   });
 });
 
+// --compile inlines process.platform / process.arch / process.versions.bun as
+// constants describing the target executable, so the version has to come from
+// the `-vX.Y.Z` segment of the target rather than from the bun running the build.
+// Using the running bun as the base executable avoids downloading a real v1.2.3
+// and keeps the non-inlined `Bun.version` visibly different from the inlined value.
+describe("compile inlines process.versions.bun of the --target version", () => {
+  const files = {
+    "app.js": `console.log(JSON.stringify({
+      inlined: process.versions.bun,
+      runtime: Bun.version,
+      platform: process.platform,
+      arch: process.arch,
+    }));`,
+  };
+  const expected = {
+    stdout:
+      JSON.stringify({
+        inlined: "1.2.3",
+        runtime: Bun.version,
+        platform: process.platform,
+        arch: process.arch,
+      }) + "\n",
+    stderr: "",
+    exitCode: 0,
+  };
+
+  async function run(exe: string) {
+    await using proc = Bun.spawn({ cmd: [exe], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("bun build --compile --target=bun-v1.2.3", async () => {
+    using dir = tempDir("build-compile-target-version-cli", files);
+    const cwd = String(dir);
+
+    await using build = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "--target=bun-v1.2.3",
+        `--compile-executable-path=${bunExe()}`,
+        "./app.js",
+        "--outfile=app",
+      ],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).not.toContain("error:");
+    expect(buildExitCode).toBe(0);
+
+    expect(await run(join(cwd, isWindows ? "app.exe" : "app"))).toEqual(expected);
+  });
+
+  test("Bun.build({ compile: { target: 'bun-v1.2.3' } })", async () => {
+    using dir = tempDir("build-compile-target-version-api", files);
+    const cwd = String(dir);
+
+    const result = await Bun.build({
+      entrypoints: [join(cwd, "app.js")],
+      compile: {
+        target: "bun-v1.2.3" as Bun.Build.CompileTarget,
+        executablePath: bunExe(),
+        outfile: join(cwd, "app"),
+      },
+    });
+    expect(result.success).toBe(true);
+
+    expect(await run(result.outputs[0].path)).toEqual(expected);
+  });
+});
+
 describe("compiled binary validity", () => {
   test("output binary has valid executable header", async () => {
     using dir = tempDir("build-compile-valid-header", {


### PR DESCRIPTION
`bun build --compile` inlines `process.versions.bun` as a string constant (#14940). The constant was always the version of the bun running the build, even when `--target` asked for a different version of Bun.

## Repro

Host bun 1.4.0, base executable is a real 1.3.14 build (`--compile-executable-path` stands in for the download; the registry download path produces the same executable):

```js
// entry.js
console.log(process.versions.bun, Bun.version);
```

```
$ bun build --compile --target=bun-linux-x64-v1.3.14 --compile-executable-path=/usr/local/bin/bun entry.js --outfile=app
$ ./app
1.4.0 1.3.14
```

The executable runs the 1.3.14 runtime (`Bun.version`, or `Object.getOwnPropertyDescriptor(process.versions, "bun").value`, both report 1.3.14), but every `process.versions.bun` read in the bundled code was replaced with `"1.4.0"`. Any version check in the bundled code is testing the wrong version. The same happens through `Bun.build({ compile: { target: "bun-...-v1.3.14" } })`, and a debug host inlined `"1.4.0-debug"` into executables built on a release base.

## Cause

`CompileTarget::define_values()` in `src/options_types/compile_target.rs` computed `process.platform` and `process.arch` from the target, but `process.versions.bun` from the compile time constant `Global::package_json_version`, ignoring the `version` parsed out of `--target`.

## Fix

The version define now comes from the target, matching what the embedded runtime reports for itself:

- default target (`is_default()`): the running executable is what gets embedded, so it stays `package_json_version`. This is the only case where the value can carry a `-debug` suffix, and it still does (the existing `compile/HelloWorldWithProcessVersionsBun*` tests and #37373 assert exactly that).
- any other target: `"<major>.<minor>.<patch>"` of the target, which is what the release build downloaded for that target reports.

`define_values()` returns owned `Box<[u8]>` now; the CLI (`build_command.rs`) and `Bun.build` (`JSBundler.rs`) callers were already copying the values into owned storage, so they only got simpler. Both entry points go through this one function, as does `Bun.build({ target: "bun-..." })`.

## Verification

New tests in `test/bundler/bun-build-compile.test.ts` compile `--target=bun-v1.2.3` through the CLI and through `Bun.build`, using the running bun as the base executable (no download), and assert the executable prints `process.versions.bun === "1.2.3"` while `Bun.version` is still the host's, with `process.platform` / `process.arch` still inlined correctly. Both fail on the unfixed build (`"inlined":"1.4.0"` instead of `"1.2.3"`) and pass with this change. The existing default-target tests in `bundler_compile.test.ts` pass unchanged, including with the tightened assertions from #37373 applied locally.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->