### PR TITLE
test: stop the regression tests in test/regression/issue from contacting npm

### DIFF
--- a/test/bun.lock
+++ b/test/bun.lock
@@ -46,6 +46,7 @@
         "fast-glob": "3.3.1",
         "fastify": "5.2.2",
         "filenamify": "6.0.0",
+        "form-data": "4.0.0",
         "happy-dom": "17.0.3",
         "hono": "4.7.2",
         "http2-wrapper": "2.2.1",

--- a/test/package.json
+++ b/test/package.json
@@ -49,6 +49,7 @@
     "fast-glob": "3.3.1",
     "fastify": "5.2.2",
     "filenamify": "6.0.0",
+    "form-data": "4.0.0",
     "happy-dom": "17.0.3",
     "hono": "4.7.2",
     "http2-wrapper": "2.2.1",

--- a/test/regression/issue/00631.test.ts
+++ b/test/regression/issue/00631.test.ts
@@ -1,44 +1,45 @@
-import { describe, expect, it } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
-import { bunEnv, bunExe, tmpdirSync } from "../../harness.js";
+
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
 
 describe.concurrent("issue/00631", () => {
   it("JSON strings escaped properly", async () => {
-    const testDir = tmpdirSync();
-
-    // Clean up from prior runs if necessary
-    rmSync(testDir, { recursive: true, force: true });
-
-    // Create a directory with our test package file
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(join(testDir, "package.json"), String.raw`{"testRegex":"\\a\n\\b\\"}`);
+    using testDir = tempDir("issue-00631", {
+      "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n`,
+      "package.json": String.raw`{"testRegex":"\\a\n\\b\\"}`,
+    });
 
     // Attempt to add a package, causing the package file to be parsed, modified,
     //  written, and reparsed.  This verifies that escaped backslashes in JSON
     //  survive the roundtrip
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "add", "left-pad"],
+      cmd: [bunExe(), "add", "no-deps"],
       env: bunEnv,
-      cwd: testDir,
+      cwd: String(testDir),
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) {
-      console.log(stderr);
-    }
-    expect(exitCode).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
 
-    const packageContents = readFileSync(join(testDir, "package.json"), { encoding: "utf8" });
+    const packageContents = readFileSync(join(String(testDir), "package.json"), { encoding: "utf8" });
     expect(packageContents).toBe(String.raw`{
   "testRegex": "\\a\n\\b\\",
   "dependencies": {
-    "left-pad": "^1.3.0"
+    "no-deps": "^2.0.0"
   }
 }`);
-
-    //// If successful clean up test artifacts
-    rmSync(testDir, { recursive: true });
   });
 });

--- a/test/regression/issue/026039.test.ts
+++ b/test/regression/issue/026039.test.ts
@@ -3,33 +3,52 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 // Test for https://github.com/oven-sh/bun/issues/26039
 // When parsing a bun.lock file with an empty registry URL for a scoped package,
-// bun should use the scope-specific registry from bunfig.toml, not the default npm registry.
-test("frozen lockfile should use scope-specific registry for scoped packages", async () => {
-  await using dir = tempDir("scoped-registry-test", {
+// bun should use the scope-specific registry from bunfig.toml, not the default registry.
+//
+// One local server stands in for both registries: `/scoped/` is the registry
+// configured for the @example scope and `/default/` is the default registry.
+// Neither has the package, so the install fails either way; what matters is
+// which of the two the tarball was requested from.
+async function frozenInstall(name: string, packageName: string) {
+  const requests: string[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requests.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const registry = `http://localhost:${server.port}`;
+
+  await using dir = tempDir(name, {
     "package.json": JSON.stringify({
-      name: "test-scoped-registry",
+      name,
       version: "1.0.0",
       dependencies: {
-        "@example/test-package": "^1.0.0",
+        [packageName]: "^1.0.0",
       },
     }),
     "bunfig.toml": `
+[install]
+cache = false
+registry = "${registry}/default/"
+
 [install.scopes]
-example = { url = "https://npm.pkg.github.com" }
+example = { url = "${registry}/scoped/" }
 `,
-    // bun.lock with empty string for registry URL - this should trigger the scope lookup
+    // bun.lock with an empty string for the registry URL - this is what triggers the scope lookup
     "bun.lock": JSON.stringify(
       {
         lockfileVersion: 1,
         workspaces: {
           "": {
             dependencies: {
-              "@example/test-package": "^1.0.0",
+              [packageName]: "^1.0.0",
             },
           },
         },
         packages: {
-          "@example/test-package": ["@example/test-package@1.0.0", "", {}, "sha512-AAAA"],
+          [packageName]: [`${packageName}@1.0.0`, "", {}, "sha512-AAAA"],
         },
       },
       null,
@@ -37,69 +56,39 @@ example = { url = "https://npm.pkg.github.com" }
     ),
   });
 
-  // Run bun install --frozen-lockfile. It will fail because the package doesn't exist,
-  // but the error message should show the correct registry URL (npm.pkg.github.com, not registry.npmjs.org)
-  const { stderr, exitCode } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "install", "--frozen-lockfile"],
-    cwd: dir,
+    cwd: String(dir),
     env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
   });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const stderrText = stderr.toString();
+  return { registry, requests: [...new Set(requests)], stdout, stderr, exitCode };
+}
 
-  // Before the fix, this would try to fetch from https://registry.npmjs.org/@example/test-package/-/test-package-1.0.0.tgz
-  // After the fix, it should try to fetch from https://npm.pkg.github.com/@example/test-package/-/test-package-1.0.0.tgz
-  expect(stderrText).toContain("npm.pkg.github.com");
-  expect(stderrText).not.toContain("registry.npmjs.org");
+test.concurrent("frozen lockfile should use scope-specific registry for scoped packages", async () => {
+  const { registry, requests, stderr, exitCode } = await frozenInstall("scoped-registry-test", "@example/test-package");
+
+  // Before the fix this was requested from the default registry instead.
+  expect(requests).toEqual(["/scoped/@example/test-package/-/test-package-1.0.0.tgz"]);
+  expect(stderr).toContain(`${registry}/scoped/@example/test-package/-/test-package-1.0.0.tgz`);
+  expect(stderr).not.toContain("/default/");
   // The install should fail because the package doesn't exist on the registry
   expect(exitCode).not.toBe(0);
 });
 
 // Test that non-scoped packages still use the default registry when registry URL is empty
-test("frozen lockfile should use default registry for non-scoped packages", async () => {
-  await using dir = tempDir("non-scoped-registry-test", {
-    "package.json": JSON.stringify({
-      name: "test-non-scoped-registry",
-      version: "1.0.0",
-      dependencies: {
-        "fake-nonexistent-package": "^1.0.0",
-      },
-    }),
-    "bunfig.toml": `
-[install.scopes]
-example = { url = "https://npm.pkg.github.com" }
-`,
-    // bun.lock with empty string for registry URL for non-scoped package
-    "bun.lock": JSON.stringify(
-      {
-        lockfileVersion: 1,
-        workspaces: {
-          "": {
-            dependencies: {
-              "fake-nonexistent-package": "^1.0.0",
-            },
-          },
-        },
-        packages: {
-          "fake-nonexistent-package": ["fake-nonexistent-package@1.0.0", "", {}, "sha512-BBBB"],
-        },
-      },
-      null,
-      2,
-    ),
-  });
+test.concurrent("frozen lockfile should use default registry for non-scoped packages", async () => {
+  const { registry, requests, stderr, exitCode } = await frozenInstall(
+    "non-scoped-registry-test",
+    "fake-nonexistent-package",
+  );
 
-  const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), "install", "--frozen-lockfile"],
-    cwd: dir,
-    env: bunEnv,
-  });
-
-  const stderrText = stderr.toString();
-
-  // Non-scoped packages should still use the default registry
-  expect(stderrText).toContain("registry.npmjs.org");
-  expect(stderrText).not.toContain("npm.pkg.github.com");
+  expect(requests).toEqual(["/default/fake-nonexistent-package/-/fake-nonexistent-package-1.0.0.tgz"]);
+  expect(stderr).toContain(`${registry}/default/fake-nonexistent-package/-/fake-nonexistent-package-1.0.0.tgz`);
+  expect(stderr).not.toContain("/scoped/");
   // The install should fail because the package doesn't exist on the registry
   expect(exitCode).not.toBe(0);
 });

--- a/test/regression/issue/026039.test.ts
+++ b/test/regression/issue/026039.test.ts
@@ -12,13 +12,14 @@ import { bunEnv, bunExe, tempDir } from "harness";
 async function frozenInstall(name: string, packageName: string) {
   const requests: string[] = [];
   await using server = Bun.serve({
+    hostname: "127.0.0.1",
     port: 0,
     fetch(req) {
       requests.push(new URL(req.url).pathname);
       return new Response("not found", { status: 404 });
     },
   });
-  const registry = `http://localhost:${server.port}`;
+  const registry = `http://127.0.0.1:${server.port}`;
 
   await using dir = tempDir(name, {
     "package.json": JSON.stringify({

--- a/test/regression/issue/07740.test.ts
+++ b/test/regression/issue/07740.test.ts
@@ -1,27 +1,44 @@
-import { bunEnv, bunExe, tempDir } from "harness";
+import { afterAll, beforeAll, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
 
-it("duplicate dependencies should warn instead of error", () => {
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+it("duplicate dependencies should warn instead of error", async () => {
   const package_json = JSON.stringify({
     devDependencies: {
-      "empty-package-for-bun-test-runner": "1.0.0",
+      "no-deps": "1.0.0",
     },
     dependencies: {
-      "empty-package-for-bun-test-runner": "1.0.0",
+      "no-deps": "1.0.0",
     },
   });
 
   using dir = tempDir("07740", {
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n`,
     "package.json": package_json,
   });
 
-  const proc = Bun.spawnSync([bunExe(), "install"], {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
     env: bunEnv,
-    cwd: dir,
+    cwd: String(dir),
+    stdout: "pipe",
     stderr: "pipe",
   });
 
-  const stderr = proc.stderr.toString("utf-8").trim();
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("error: Duplicate dependency:");
   expect(stderr).toContain("warn: Duplicate dependency");
+  expect(stdout).toContain("1 package installed");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/11806.test.ts
+++ b/test/regression/issue/11806.test.ts
@@ -1,38 +1,71 @@
-import { expect, test } from "bun:test";
-import { bunExe, tempDir } from "harness";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
+import { join } from "path";
 
-test("11806", () => {
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+async function run(cmd: string[], cwd: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...cmd],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// https://github.com/oven-sh/bun/issues/11806
+// `bun add` inside a workspace member whose package.json contains escaped
+// backslashes (`"testRegex": ".*\\.spec\\.ts$"`) rewrote the file in a way that
+// no longer parsed.
+test("11806", async () => {
+  const apiPackageJson = {
+    "name": "api",
+    "jest": {
+      "testRegex": ".*\\.spec\\.ts$",
+    },
+    "devDependencies": {
+      "no-deps": "^1.0.0",
+    },
+  };
+
   using dir = tempDir("11806", {
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n`,
     "package.json": JSON.stringify({
       "name": "project",
       "workspaces": ["apps/*"],
     }),
     "apps": {
       "api": {
-        "package.json": JSON.stringify({
-          "name": "api",
-          "jest": {
-            "testRegex": ".*\\.spec\\.ts$",
-          },
-          "devDependencies": {
-            "typescript": "^5.7.3",
-          },
-        }),
+        "package.json": JSON.stringify(apiPackageJson),
       },
     },
   });
+  const apiDir = join(String(dir), "apps", "api");
 
-  const result1 = Bun.spawnSync({
-    cmd: [bunExe(), "install"],
-    stdio: ["inherit", "inherit", "inherit"],
-    cwd: dir + "/apps/api",
-  });
-  expect(result1.exitCode).toBe(0);
+  const install = await run(["install"], apiDir);
+  expect(install).toMatchObject({ exitCode: 0 });
 
-  const result2 = Bun.spawnSync({
-    cmd: [bunExe(), "add", "--dev", "typescript"],
-    stdio: ["inherit", "inherit", "inherit"],
-    cwd: dir + "/apps/api",
-  });
-  expect(result2.exitCode).toBe(0);
+  const add = await run(["add", "--dev", "a-dep"], apiDir);
+  expect(add).toMatchObject({ exitCode: 0 });
+
+  // The rewritten package.json must still parse, keep the escaped regex as-is,
+  // and contain the new dependency.
+  const rewritten = JSON.parse(await Bun.file(join(apiDir, "package.json")).text());
+  expect(rewritten.jest).toEqual(apiPackageJson.jest);
+  expect(Object.keys(rewritten.devDependencies).sort()).toEqual(["a-dep", "no-deps"]);
+
+  // And a second install still accepts it.
+  expect(await run(["install"], apiDir)).toMatchObject({ exitCode: 0 });
 });

--- a/test/regression/issue/15276.test.ts
+++ b/test/regression/issue/15276.test.ts
@@ -1,12 +1,14 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
+// https://github.com/oven-sh/bun/issues/15276
 test("parsing npm aliases without package manager does not crash", async () => {
   // Easiest way to repro this regression is `bunx bunbunbunbunbun@npm:another-bun@1.0.0`. The package
   // doesn't need to exist, we just need `bunx` to parse the package version, so the registry is a local
   // server that has nothing.
   const requests: string[] = [];
   await using registry = Bun.serve({
+    hostname: "127.0.0.1",
     port: 0,
     fetch(req) {
       requests.push(new URL(req.url).pathname);
@@ -18,7 +20,7 @@ test("parsing npm aliases without package manager does not crash", async () => {
     cmd: [bunExe(), "x", "bunbunbunbunbun@npm:another-bun@1.0.0"],
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...bunEnv, npm_config_registry: `http://localhost:${registry.port}/` },
+    env: { ...bunEnv, npm_config_registry: `http://127.0.0.1:${registry.port}/` },
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 

--- a/test/regression/issue/15276.test.ts
+++ b/test/regression/issue/15276.test.ts
@@ -1,17 +1,30 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("parsing npm aliases without package manager does not crash", () => {
-  // Easiest way to repro this regression with `bunx bunbunbunbunbun@npm:another-bun@1.0.0`. The package
-  // doesn't need to exist, we just need `bunx` to parse the package version.
-  const { stdout, stderr, exitCode } = Bun.spawnSync({
+test("parsing npm aliases without package manager does not crash", async () => {
+  // Easiest way to repro this regression is `bunx bunbunbunbunbun@npm:another-bun@1.0.0`. The package
+  // doesn't need to exist, we just need `bunx` to parse the package version, so the registry is a local
+  // server that has nothing.
+  const requests: string[] = [];
+  await using registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requests.push(new URL(req.url).pathname);
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "x", "bunbunbunbunbun@npm:another-bun@1.0.0"],
     stdout: "pipe",
     stderr: "pipe",
-    env: bunEnv,
+    env: { ...bunEnv, npm_config_registry: `http://localhost:${registry.port}/` },
   });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).toContain("error: bunbunbunbunbun@npm:another-bun@1.0.0 failed to resolve");
+  expect(stdout).toBe("");
   expect(exitCode).toBe(1);
-  expect(stderr.toString()).toContain("error: bunbunbunbunbun@npm:another-bun@1.0.0 failed to resolve");
-  expect(stdout.toString()).toBe("");
+  // The alias was parsed: it is the alias target that gets looked up.
+  expect([...new Set(requests)]).toEqual(["/another-bun"]);
 });

--- a/test/regression/issue/24131.test.ts
+++ b/test/regression/issue/24131.test.ts
@@ -1,17 +1,30 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
+
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
 
 describe("issue #24131 - 'l' key should select package in interactive update", () => {
   it("should select package when pressing 'l' to toggle use_latest", async () => {
+    // The local registry's `no-deps` has 1.0.0 through 2.0.0 (latest), so the
+    // pinned 1.0.0 shows up in the interactive list with a newer latest version.
     using dir = tempDir("issue-24131", {
+      "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n`,
       "package.json": JSON.stringify({
         name: "test-project",
         version: "1.0.0",
         dependencies: {
-          // Use a very old version that definitely has updates available
-          "is-even": "0.1.0",
+          "no-deps": "1.0.0",
         },
       }),
     });
@@ -25,16 +38,16 @@ describe("issue #24131 - 'l' key should select package in interactive update", (
       stderr: "pipe",
     });
 
-    const installExitCode = await installProc.exited;
-    expect(installExitCode).toBe(0);
+    const [installStdout, installStderr, installExitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect({ installStdout, installStderr, installExitCode }).toMatchObject({ installExitCode: 0 });
 
-    // Read the initial package.json to verify starting state
-    const initialPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
-    expect(initialPackageJson.dependencies["is-even"]).toBe("0.1.0");
-
-    // Now run update --interactive
-    // Press 'l' to toggle use_latest (which should also select the package)
-    // Then press 'y' or Enter to confirm
+    // Now run update --interactive.
+    // 'l' toggles use_latest and should also select the package (the fix);
+    // '\r' (Enter) confirms the selection.
     await using updateProc = Bun.spawn({
       cmd: [bunExe(), "update", "--interactive"],
       cwd: String(dir),
@@ -44,8 +57,6 @@ describe("issue #24131 - 'l' key should select package in interactive update", (
       stderr: "pipe",
     });
 
-    // 'l' toggles use_latest and should also select the package (the fix)
-    // '\r' (Enter) confirms the selection
     updateProc.stdin.write("l\r");
     updateProc.stdin.end();
 
@@ -55,16 +66,19 @@ describe("issue #24131 - 'l' key should select package in interactive update", (
       updateProc.exited,
     ]);
 
-    // Check that package.json was updated - this proves 'l' selected the package
-    // Before the fix, 'l' would toggle use_latest but not select the package,
-    // so Enter would result in no packages being updated
-    const updatedPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
-    const updatedVersion = updatedPackageJson.dependencies["is-even"];
-
-    // The version should have changed from "0.1.0"
-    // This assertion failing means 'l' did not select the package
-    expect(updatedVersion).not.toBe("0.1.0");
-
+    // Before the fix, 'l' toggled use_latest without selecting the package, so
+    // Enter confirmed an empty selection and nothing was updated.
+    expect(stdout).toContain("Selected 1 package to update");
+    expect(stdout).not.toContain("No packages selected for update");
+    expect(stderr).not.toContain("No packages selected for update");
     expect(exitCode).toBe(0);
+
+    const updatedPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
+    expect(updatedPackageJson.dependencies["no-deps"]).toBe("2.0.0");
+
+    const installedPackageJson = JSON.parse(
+      readFileSync(join(String(dir), "node_modules", "no-deps", "package.json"), "utf8"),
+    );
+    expect(installedPackageJson.version).toBe("2.0.0");
   });
 });

--- a/test/regression/issue/24364.test.ts
+++ b/test/regression/issue/24364.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../../..");
 
 test("react-tailwind template passes tsc --noEmit", async () => {
   // Read template files from source
@@ -9,31 +11,44 @@ test("react-tailwind template passes tsc --noEmit", async () => {
   // (no SeCreateSymbolicLinkPrivilege / core.symlinks=false) write a
   // 12-byte text file instead of a directory link, so go to the canonical
   // path directly.
-  const templateDir = join(import.meta.dir, "../../../src/runtime/cli/init/react-tailwind");
+  const templateDir = join(repoRoot, "src/runtime/cli/init/react-tailwind");
   const buildTs = readFileSync(join(templateDir, "build.ts"), "utf8");
   const tsconfigJson = readFileSync(join(templateDir, "tsconfig.json"), "utf8");
 
-  // Create temp directory with template files
+  // Create temp directory with template files. The only package build.ts
+  // imports is bun-plugin-tailwind, whose published type declarations amount
+  // to `declare const plugin: BunPlugin; export default plugin;`.
   using dir = tempDir("issue-24364", {
     "build.ts": buildTs,
     "tsconfig.json": tsconfigJson,
+    "node_modules/bun-plugin-tailwind/package.json": JSON.stringify({
+      name: "bun-plugin-tailwind",
+      version: "0.0.0",
+      types: "./index.d.ts",
+    }),
+    "node_modules/bun-plugin-tailwind/index.d.ts": `import type { BunPlugin } from "bun";
+declare const plugin: BunPlugin;
+export default plugin;
+`,
   });
 
-  // Install typescript and bun types
-  await using install = Bun.spawn({
-    cmd: [bunExe(), "add", "-d", "typescript", "@types/bun", "@types/react", "bun-plugin-tailwind"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  // The template's tsconfig asks for `"types": ["bun", "react"]`. Instead of
+  // installing @types/bun and @types/react, resolve them from the repo:
+  // packages/@types/bun is the in-tree @types/bun (it references
+  // packages/bun-types), and @types/react comes from test/node_modules.
+  const typeRoots = [join(repoRoot, "packages/@types"), dirname(dirname(require.resolve("@types/react/package.json")))];
 
-  const [, , installExitCode] = await Promise.all([install.stdout.text(), install.stderr.text(), install.exited]);
-  expect(installExitCode).toBe(0);
-
-  // Run tsc --noEmit (use bunExe() x for cross-platform compatibility)
+  // What matters is that the template typechecks, not which runtime runs the
+  // compiler, and tsc under a debug+ASAN bun is 10-50x slower (same as
+  // test/cli/init/init.test.ts).
   await using tsc = Bun.spawn({
-    cmd: [bunExe(), "x", "tsc", "--noEmit"],
+    cmd: [
+      nodeExe() ?? bunExe(),
+      require.resolve("typescript/lib/tsc.js"),
+      "--noEmit",
+      "--typeRoots",
+      typeRoots.join(","),
+    ],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",

--- a/test/regression/issue/26225.test.ts
+++ b/test/regression/issue/26225.test.ts
@@ -1,5 +1,9 @@
-import { expect, test } from "bun:test";
+import { expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+
+// Loading form-data (and the mime-db table behind it) in the child takes ~3s on
+// a debug build, which is most of the default per-test budget.
+setDefaultTimeout(30_000);
 
 // Test for GitHub issue #26225
 // Multipart uploads using form-data + node-fetch@2 + fs.createReadStream() are truncated

--- a/test/regression/issue/26225.test.ts
+++ b/test/regression/issue/26225.test.ts
@@ -1,12 +1,31 @@
-import { expect, setDefaultTimeout, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-
-// These tests install npm packages, so they need a longer timeout
-setDefaultTimeout(30_000);
 
 // Test for GitHub issue #26225
 // Multipart uploads using form-data + node-fetch@2 + fs.createReadStream() are truncated
-test("node-fetch with form-data and fs.createReadStream works correctly", async () => {
+//
+// `node-fetch` always resolves to Bun's bundled implementation (the one this
+// issue is about), so nothing needs to be installed for it. `form-data` is the
+// real npm package from test/node_modules, required by absolute path; its
+// CombinedStream body is the old-style stream that used to get truncated.
+const formDataPath = require.resolve("form-data");
+
+async function runClient(name: string, clientJs: string) {
+  using dir = tempDir(name, { "client.js": clientJs });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "client.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("node-fetch with form-data and fs.createReadStream works correctly", async () => {
   using server = Bun.serve({
     port: 0,
     async fetch(req) {
@@ -30,18 +49,12 @@ test("node-fetch with form-data and fs.createReadStream works correctly", async 
     },
   });
 
-  using dir = tempDir("test-26225", {
-    "package.json": JSON.stringify({
-      name: "test-26225",
-      dependencies: {
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.7.0",
-      },
-    }),
-    "client.js": `
+  const { stdout, stderr, exitCode } = await runClient(
+    "test-26225",
+    `
 const fs = require('fs');
 const path = require('path');
-const FormData = require('form-data');
+const FormData = require(${JSON.stringify(formDataPath)});
 const fetch = require('node-fetch');
 
 const tmpFile = path.join(__dirname, 'test.txt');
@@ -64,47 +77,15 @@ fetch('http://localhost:${server.port}', {
     process.exit(1);
   });
 `,
-  });
+  );
 
-  // Install dependencies
-  const installProc = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const installExitCode = await installProc.exited;
-  expect(installExitCode).toBe(0);
-
-  // Run the client
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "client.js"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  if (stderr) {
-    console.error("stderr:", stderr);
-  }
-  if (!stdout.trim()) {
-    console.error("stdout was empty, exit code:", exitCode);
-  }
-
-  expect(stdout.trim()).not.toBe("");
-  const result = JSON.parse(stdout.trim());
-  expect(result.success).toBe(true);
-  expect(result.bytesReceived).toBe(1024);
-  expect(result.contentValid).toBe(true);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ success: true, bytesReceived: 1024, contentValid: true });
   expect(exitCode).toBe(0);
 });
 
 // Test that regular async iterables still work
-test("node-fetch with async iterable body still works", async () => {
+test.concurrent("node-fetch with async iterable body still works", async () => {
   using server = Bun.serve({
     port: 0,
     async fetch(req) {
@@ -120,14 +101,9 @@ test("node-fetch with async iterable body still works", async () => {
     },
   });
 
-  using dir = tempDir("test-26225-async", {
-    "package.json": JSON.stringify({
-      name: "test-26225-async",
-      dependencies: {
-        "node-fetch": "^2.7.0",
-      },
-    }),
-    "client.js": `
+  const { stdout, stderr, exitCode } = await runClient(
+    "test-26225-async",
+    `
 const fetch = require('node-fetch');
 
 // Create an async iterable body
@@ -147,43 +123,15 @@ fetch('http://localhost:${server.port}', {
     process.exit(1);
   });
 `,
-  });
+  );
 
-  // Install dependencies
-  const installProc = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const installExitCode = await installProc.exited;
-  expect(installExitCode).toBe(0);
-
-  // Run the client
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "client.js"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  if (stderr) {
-    console.error("stderr:", stderr);
-  }
-
-  expect(stdout.trim()).not.toBe("");
-  const result = JSON.parse(stdout.trim());
-  expect(result.success).toBe(true);
-  expect(result.content).toBe("Hello, World!");
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ success: true, bytesReceived: 13, content: "Hello, World!" });
   expect(exitCode).toBe(0);
 });
 
 // Test with larger file to ensure streaming works
-test("node-fetch with form-data and large file stream", async () => {
+test.concurrent("node-fetch with form-data and large file stream", async () => {
   const fileSize = 1024 * 100; // 100KB
 
   using server = Bun.serve({
@@ -215,18 +163,12 @@ test("node-fetch with form-data and large file stream", async () => {
     },
   });
 
-  using dir = tempDir("test-26225-large", {
-    "package.json": JSON.stringify({
-      name: "test-26225-large",
-      dependencies: {
-        "form-data": "^4.0.0",
-        "node-fetch": "^2.7.0",
-      },
-    }),
-    "client.js": `
+  const { stdout, stderr, exitCode } = await runClient(
+    "test-26225-large",
+    `
 const fs = require('fs');
 const path = require('path');
-const FormData = require('form-data');
+const FormData = require(${JSON.stringify(formDataPath)});
 const fetch = require('node-fetch');
 
 const fileSize = ${fileSize};
@@ -250,38 +192,9 @@ fetch('http://localhost:${server.port}', {
     process.exit(1);
   });
 `,
-  });
+  );
 
-  // Install dependencies
-  const installProc = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const installExitCode = await installProc.exited;
-  expect(installExitCode).toBe(0);
-
-  // Run the client
-  const proc = Bun.spawn({
-    cmd: [bunExe(), "client.js"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  if (stderr) {
-    console.error("stderr:", stderr);
-  }
-
-  expect(stdout.trim()).not.toBe("");
-  const result = JSON.parse(stdout.trim());
-  expect(result.success).toBe(true);
-  expect(result.bytesReceived).toBe(fileSize);
-  expect(result.contentValid).toBe(true);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ success: true, bytesReceived: fileSize, contentValid: true });
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/26225.test.ts
+++ b/test/regression/issue/26225.test.ts
@@ -5,7 +5,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // a debug build, which is most of the default per-test budget.
 setDefaultTimeout(30_000);
 
-// Test for GitHub issue #26225
+// https://github.com/oven-sh/bun/issues/26225
 // Multipart uploads using form-data + node-fetch@2 + fs.createReadStream() are truncated
 //
 // `node-fetch` always resolves to Bun's bundled implementation (the one this

--- a/test/regression/issue/26657.test.ts
+++ b/test/regression/issue/26657.test.ts
@@ -1,194 +1,108 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
-describe("bun update -i select all with 'A' key", () => {
-  // Issue #26657: When pressing 'A' to select all packages in interactive update,
-  // the UI shows "Selected X packages to update" but then shows "No packages selected for update"
-  // because packages where current_version == update_version were silently filtered out.
+// Issue #26657: pressing 'A' in `bun update --interactive` showed
+// "Selected X packages to update" and then "No packages selected for update",
+// because packages whose current version already equals the highest version
+// allowed by their range were silently dropped instead of being bumped to latest.
+//
+// The local registry's `no-deps` has 1.0.0, 1.0.1, 1.1.0 and 2.0.0 (latest).
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+function project(name: string, range: string) {
+  return tempDir(name, {
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n`,
+    "package.json": JSON.stringify({
+      name: "test-project",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": range,
+      },
+    }),
+  });
+}
+
+async function install(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+}
+
+// Press 'A' to select every package, then Enter to confirm.
+async function updateInteractiveSelectAll(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "update", "--interactive"],
+    cwd: dir,
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  proc.stdin.write("A\r");
+  proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function installedVersion(dir: string): string {
+  return JSON.parse(readFileSync(join(dir, "node_modules", "no-deps", "package.json"), "utf8")).version;
+}
+
+function declaredRange(dir: string): string {
+  return JSON.parse(readFileSync(join(dir, "package.json"), "utf8")).dependencies["no-deps"];
+}
+
+describe.concurrent("bun update -i select all with 'A' key", () => {
   test("should update packages when 'A' is pressed to select all", async () => {
-    // Create a project with a package that has an old version
-    // The package constraint allows higher versions, and there's a newer latest version
-    using dir = tempDir("update-interactive-select-all", {
-      "package.json": JSON.stringify({
-        name: "test-project",
-        version: "1.0.0",
-        dependencies: {
-          // Use a very old version that definitely has updates available
-          "is-even": "0.1.0",
-        },
-      }),
-    });
+    // An exact pin: the current version is the only version the range allows,
+    // so the only update on offer is the jump to latest.
+    using dir = project("update-interactive-select-all", "1.0.0");
+    await install(String(dir));
+    expect(installedVersion(String(dir))).toBe("1.0.0");
 
-    // First, run bun install to create initial node_modules
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const { stdout, stderr, exitCode } = await updateInteractiveSelectAll(String(dir));
 
-    const [installStdout, installStderr, installExitCode] = await Promise.all([
-      installProc.stdout.text(),
-      installProc.stderr.text(),
-      installProc.exited,
-    ]);
+    expect(stdout).toContain("Selected 1 package to update");
+    expect(stdout).not.toContain("No packages selected for update");
+    expect(stderr).not.toContain("No packages selected for update");
+    expect(exitCode).toBe(0);
 
-    // Check install succeeded before proceeding
-    if (installExitCode !== 0) {
-      console.log("Install STDOUT:", installStdout);
-      console.log("Install STDERR:", installStderr);
-    }
-    expect(installExitCode).toBe(0);
-
-    // Verify initial installation
-    const initialPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
-    expect(initialPackageJson.dependencies["is-even"]).toBe("0.1.0");
-
-    // Now run update --interactive and press 'A' to select all, then Enter to confirm
-    await using updateProc = Bun.spawn({
-      cmd: [bunExe(), "update", "--interactive"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    try {
-      // Press 'A' to select all packages, then Enter to confirm
-      updateProc.stdin.write("A"); // select all
-      updateProc.stdin.write("\r"); // enter to confirm
-      updateProc.stdin.end();
-
-      const [stdout, stderr, exitCode] = await Promise.all([
-        updateProc.stdout.text(),
-        updateProc.stderr.text(),
-        updateProc.exited,
-      ]);
-
-      // Debug output if test fails
-      if (exitCode !== 0) {
-        console.log("STDOUT:", stdout);
-        console.log("STDERR:", stderr);
-      }
-
-      // The bug was that it would say "No packages selected for update"
-      // Check that this error message does NOT appear (check before exitCode for better error messages)
-      expect(stdout).not.toContain("No packages selected for update");
-      expect(stderr).not.toContain("No packages selected for update");
-
-      expect(exitCode).toBe(0);
-
-      // Check that package.json was updated
-      const updatedPackageJson = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
-      const updatedVersion = updatedPackageJson.dependencies["is-even"];
-
-      // The version should have changed from "0.1.0"
-      expect(updatedVersion).not.toBe("0.1.0");
-
-      // Verify node_modules was actually updated
-      const installedPkgJson = JSON.parse(
-        readFileSync(join(String(dir), "node_modules", "is-even", "package.json"), "utf8"),
-      );
-      const installedVersion = installedPkgJson.version;
-
-      // The installed version should NOT be the old version
-      expect(installedVersion).not.toBe("0.1.0");
-      expect(Bun.semver.satisfies(installedVersion, ">0.1.0")).toBe(true);
-    } catch (err) {
-      // Ensure cleanup on failure
-      updateProc.stdin.end();
-      updateProc.kill();
-      throw err;
-    }
+    expect(declaredRange(String(dir))).toBe("2.0.0");
+    expect(installedVersion(String(dir))).toBe("2.0.0");
   });
 
   test("should handle packages where current equals update version but not latest", async () => {
-    // This is the core of issue #26657: packages that are at the highest version
-    // within their semver constraint but not at the latest version overall
-    using dir = tempDir("update-interactive-select-all-constrained", {
-      "package.json": JSON.stringify({
-        name: "test-project",
-        version: "1.0.0",
-        dependencies: {
-          // Use a version constraint that limits updates
-          // The point is to have packages where current == update_version but current != latest
-          "is-even": "^1.0.0",
-        },
-      }),
-    });
+    // ^1.0.0 resolves to 1.1.0, the highest version inside the range, so the
+    // "update" column already equals the current version while latest is 2.0.0.
+    using dir = project("update-interactive-select-all-constrained", "^1.0.0");
+    await install(String(dir));
+    expect(installedVersion(String(dir))).toBe("1.1.0");
 
-    // First install
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    const { stdout, stderr, exitCode } = await updateInteractiveSelectAll(String(dir));
 
-    const [installStdout, installStderr, installExitCode] = await Promise.all([
-      installProc.stdout.text(),
-      installProc.stderr.text(),
-      installProc.exited,
-    ]);
+    expect(stdout).toContain("Selected 1 package to update");
+    expect(stdout).not.toContain("No packages selected for update");
+    expect(stderr).not.toContain("No packages selected for update");
+    expect(exitCode).toBe(0);
 
-    // Check install succeeded before proceeding
-    if (installExitCode !== 0) {
-      console.log("Install STDOUT:", installStdout);
-      console.log("Install STDERR:", installStderr);
-    }
-    expect(installExitCode).toBe(0);
-
-    // Get the installed version
-    const installedPkgJson = JSON.parse(
-      readFileSync(join(String(dir), "node_modules", "is-even", "package.json"), "utf8"),
-    );
-    const currentVersion = installedPkgJson.version;
-
-    // Now run update --interactive with 'A' to select all
-    await using updateProc = Bun.spawn({
-      cmd: [bunExe(), "update", "--interactive"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    try {
-      updateProc.stdin.write("A"); // select all
-      updateProc.stdin.write("\r"); // confirm
-      updateProc.stdin.end();
-
-      const [stdout, stderr, exitCode] = await Promise.all([
-        updateProc.stdout.text(),
-        updateProc.stderr.text(),
-        updateProc.exited,
-      ]);
-
-      // If there were packages shown in the list, they should have been processed
-      // The key assertion: we should NOT see "Selected X packages" followed by "No packages selected"
-      const selectedMatch = stdout.match(/Selected (\d+) package/);
-      if (selectedMatch) {
-        const selectedCount = parseInt(selectedMatch[1], 10);
-        if (selectedCount > 0) {
-          // If packages were selected, they should have been processed (check before exitCode)
-          expect(stdout).not.toContain("No packages selected for update");
-          expect(stderr).not.toContain("No packages selected for update");
-        }
-      }
-
-      // The command should succeed without "No packages selected for update" error
-      // (unless there are genuinely no outdated packages, which is a valid state)
-      expect(exitCode).toBe(0);
-    } catch (err) {
-      updateProc.stdin.end();
-      updateProc.kill();
-      throw err;
-    }
+    expect(declaredRange(String(dir))).toBe("^2.0.0");
+    expect(installedVersion(String(dir))).toBe("2.0.0");
   });
 });

--- a/test/regression/issue/28193.test.ts
+++ b/test/regression/issue/28193.test.ts
@@ -1,56 +1,69 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
 
-test("bun install prints error when security scanner is unavailable", async () => {
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+function bunfig(scanner: string) {
+  return `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n\n[install.security]\nscanner = "${scanner}"\n`;
+}
+
+async function install(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent("bun install prints error when security scanner is unavailable", async () => {
   using dir = tempDir("issue-28193", {
     "package.json": JSON.stringify({
       name: "test-28193",
       dependencies: {
-        "is-even": "1.0.0",
+        "no-deps": "1.0.0",
       },
     }),
-    "bunfig.toml": `[install.security]\nscanner = "@nonexistent-scanner/does-not-exist"\n`,
+    "bunfig.toml": bunfig("@nonexistent-scanner/does-not-exist"),
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(dir) + "/.cache" },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stderr, exitCode } = await install(String(dir));
 
   // Should print an error message about the scanner failure, not exit silently
-  expect(stderr).toContain("security scanner");
+  expect(stderr).toContain("security scanner failed: SecurityScannerNotInDependencies");
   expect(exitCode).toBe(1);
-}, 30_000);
+});
 
-test("bun install prints error when scanner package is invalid", async () => {
-  // When the scanner is a devDependency but not a valid scanner module,
-  // the install should fail with a clear error message
+test.concurrent("bun install prints error when scanner package is invalid", async () => {
+  // The scanner is a devDependency that installs fine but is not a scanner
+  // module (no-deps exports its package.json); the install should fail with a
+  // clear error message.
   using dir = tempDir("issue-28193-invalid", {
     "package.json": JSON.stringify({
       name: "test-28193-invalid",
       devDependencies: {
-        "is-even": "1.0.0",
+        "no-deps": "1.0.0",
       },
     }),
-    "bunfig.toml": `[install.security]\nscanner = "is-even"\n`,
+    "bunfig.toml": bunfig("no-deps"),
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install"],
-    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(dir) + "/.cache" },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, stderr, exitCode } = await install(String(dir));
 
   // Should print an error about the scanner, not exit silently
-  expect(stderr).toContain("security scanner");
+  expect(stdout).toContain("Security scanner installed successfully.");
+  expect(stderr).toContain("security scanner failed: ScannerFailed");
   expect(exitCode).toBe(1);
-}, 30_000);
+});

--- a/test/regression/issue/28193.test.ts
+++ b/test/regression/issue/28193.test.ts
@@ -1,7 +1,5 @@
-import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
-
-setDefaultTimeout(30_000);
 
 let registry: VerdaccioRegistry;
 

--- a/test/regression/issue/28193.test.ts
+++ b/test/regression/issue/28193.test.ts
@@ -1,5 +1,7 @@
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, tempDir, VerdaccioRegistry } from "harness";
+
+setDefaultTimeout(30_000);
 
 let registry: VerdaccioRegistry;
 

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -98,17 +98,20 @@ beforeAll(() => {
         "dev": "long-running",
       },
       devDependencies: {
-        "long-running": "file:./long-running",
+        // The source folder must not be called `long-running`: `bun long-running`
+        // tries to resolve that name as a path in cwd before falling back to
+        // node_modules/.bin, and a directory of that name would be run directly.
+        "long-running": "file:./long-running-src",
       },
     }),
-    "long-running/package.json": JSON.stringify({
+    "long-running-src/package.json": JSON.stringify({
       name: "long-running",
       version: "1.0.0",
       bin: { "long-running": "cli.js" },
     }),
     // Like vite, this never exits on its own within the test; the timer only
     // bounds how long a stray process can outlive a failed test.
-    "long-running/cli.js": `#!/usr/bin/env node
+    "long-running-src/cli.js": `#!/usr/bin/env node
 console.log("long-running is ready");
 setTimeout(() => {}, 60_000);
 `,

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -77,28 +77,47 @@ test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bu
   expect(result.signalCode).toBe("SIGKILL");
 });
 
-// Share a single vite install across all of the parameterized SIGINT tests below.
-// Each test only spawns vite, waits for first stdout, sends SIGINT, and asserts on
-// exit state — none of them mutate the project directory, so reusing one install
-// avoids redundant `bun install` + tempdir setup work per iteration.
-let viteDir: string;
-let viteInstallExitCode: number | null;
+// The parameterized SIGINT tests below run a long-lived bin (originally vite's
+// dev server) through the different ways `bun` can launch one: a node_modules
+// bin by name, a package.json script, and the bin file itself, with and without
+// --bun. `long-running` is a local stand-in for vite: it prints a line once it
+// is up and then idles without installing a SIGINT handler, so the signal must
+// terminate it. It is installed as a file: dependency so `bun install` links
+// node_modules/.bin the same way it would for a registry package, without
+// contacting a registry.
+//
+// Each test only spawns the bin, waits for first stdout, sends SIGINT, and
+// asserts on exit state — none of them mutate the project directory, so one
+// shared install in beforeAll is enough.
+let projectDir: string;
+let installExitCode: number | null;
 
 beforeAll(() => {
-  viteDir = tempDirWithFiles("ctrlc", {
+  projectDir = tempDirWithFiles("ctrlc", {
     "package.json": JSON.stringify({
       name: "ctrlc",
       scripts: {
-        "dev": "vite",
+        "dev": "long-running",
       },
       devDependencies: {
-        "vite": "^6.0.1",
+        "long-running": "file:./long-running",
       },
     }),
+    "long-running/package.json": JSON.stringify({
+      name: "long-running",
+      version: "1.0.0",
+      bin: { "long-running": "cli.js" },
+    }),
+    // Like vite, this never exits on its own within the test; the timer only
+    // bounds how long a stray process can outlive a failed test.
+    "long-running/cli.js": `#!/usr/bin/env node
+console.log("long-running is ready");
+setTimeout(() => {}, 60_000);
+`,
   });
-  viteInstallExitCode = Bun.spawnSync({
+  installExitCode = Bun.spawnSync({
     cmd: [bunExe(), "install"],
-    cwd: viteDir,
+    cwd: projectDir,
     env: bunEnv,
     stdin: "inherit",
     stdout: "inherit",
@@ -107,25 +126,25 @@ beforeAll(() => {
 });
 
 for (const mode of [
-  ["vite"],
+  ["long-running"],
   ["dev"],
-  ...(isWindows ? [] : [["./node_modules/.bin/vite"]]),
-  ["--bun", "vite"],
+  ...(isWindows ? [] : [["./node_modules/.bin/long-running"]]),
+  ["--bun", "long-running"],
   ["--bun", "dev"],
-  ...(isWindows ? [] : [["--bun", "./node_modules/.bin/vite"]]),
+  ...(isWindows ? [] : [["--bun", "./node_modules/.bin/long-running"]]),
 ]) {
   it("kills on SIGINT in: 'bun " + mode.join(" ") + "'", async () => {
-    expect(viteInstallExitCode).toBe(0);
+    expect(installExitCode).toBe(0);
     const proc = Bun.spawn({
       cmd: [bunExe(), ...mode],
-      cwd: viteDir,
+      cwd: projectDir,
       stdin: "inherit",
       stdout: "pipe",
       stderr: "inherit",
-      env: { ...bunEnv, PORT: "9876" },
+      env: bunEnv,
     });
 
-    // wait for vite to start
+    // wait for the bin to start
     const reader = proc.stdout.getReader();
     await reader.read(); // wait for first bit of stdout
     reader.releaseLock();

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -77,18 +77,16 @@ test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bu
   expect(result.signalCode).toBe("SIGKILL");
 });
 
-// The parameterized SIGINT tests below run a long-lived bin (originally vite's
-// dev server) through the different ways `bun` can launch one: a node_modules
-// bin by name, a package.json script, and the bin file itself, with and without
-// --bun. `long-running` is a local stand-in for vite: it prints a line once it
-// is up and then idles without installing a SIGINT handler, so the signal must
-// terminate it. It is installed as a file: dependency so `bun install` links
-// node_modules/.bin the same way it would for a registry package, without
-// contacting a registry.
+// The parameterized SIGINT tests below launch a long-lived bin every way `bun`
+// can launch one: by bin name, through a package.json script, and as a plain
+// file, each with and without --bun. `long-running` stands in for the vite dev
+// server these tests used to install from npm: it prints a line once it is up
+// and then idles without a SIGINT handler, so the signal must terminate it. A
+// file: dependency makes `bun install` link node_modules/.bin exactly as it
+// would for a registry package, without needing a registry.
 //
-// Each test only spawns the bin, waits for first stdout, sends SIGINT, and
-// asserts on exit state — none of them mutate the project directory, so one
-// shared install in beforeAll is enough.
+// None of the tests mutate the project directory, so one shared install in
+// beforeAll is enough.
 let projectDir: string;
 let installExitCode: number | null;
 

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -134,6 +134,8 @@ for (const mode of [
   ["--bun", "dev"],
   ...(isWindows ? [] : [["--bun", "./node_modules/.bin/long-running"]]),
 ]) {
+  // Deliberately serial: each case gives the process tree 300ms to die after
+  // SIGINT, and launching all six at once on a debug build eats into that.
   it("kills on SIGINT in: 'bun " + mode.join(" ") + "'", async () => {
     expect(installExitCode).toBe(0);
     const proc = Bun.spawn({

--- a/test/regression/issue/patch-bounds-check.test.ts
+++ b/test/regression/issue/patch-bounds-check.test.ts
@@ -1,35 +1,46 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDir } from "harness";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot as normalizeBunSnapshot_, tempDir, VerdaccioRegistry } from "harness";
+import { join } from "path";
 
 const normalizeBunSnapshot = (str: string) => {
   str = normalizeBunSnapshot_(str);
   str = str.replace(/.*Resolved, downloaded and extracted.*\n?/g, "");
   str = str.replaceAll("fstatat()", "stat()");
-  str = str.replace(/ \(v[\d.]+ available\)/g, "");
   return str;
 };
 
-test("patch application should handle out-of-bounds line numbers gracefully", async () => {
-  await using dir = tempDir("patch-bounds-test", {
+let registry: VerdaccioRegistry;
+
+beforeAll(async () => {
+  registry = new VerdaccioRegistry();
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+// The local registry's basic-1@1.0.0 ships a one-line index.js:
+//   console.log("basic-1 1.0.0");
+// so any hunk below that claims more of the file than that is out of bounds.
+function project(name: string, patch: string) {
+  return tempDir(name, {
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.registryUrl()}"\n`,
     "package.json": JSON.stringify({
       name: "test-pkg",
       version: "1.0.0",
       dependencies: {
-        "lodash": "4.17.21",
+        "basic-1": "1.0.0",
       },
       patchedDependencies: {
-        "lodash@4.17.21": "patches/lodash+4.17.21.patch",
+        "basic-1@1.0.0": "patches/basic-1+1.0.0.patch",
       },
     }),
-    "patches/lodash+4.17.21.patch": `--- a/index.js
-+++ b/index.js
-@@ -1000,3 +1000,4 @@
- module.exports = require('./lodash');
- 
- // This line doesn't exist but the patch says it does
-+// Add this line way beyond the actual file bounds`,
+    "patches/basic-1+1.0.0.patch": patch,
   });
+}
 
+async function install(dir: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "install", "--linker=hoisted"],
     env: bunEnv,
@@ -39,106 +50,88 @@ test("patch application should handle out-of-bounds line numbers gracefully", as
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout), stderr: normalizeBunSnapshot(stderr), exitCode };
+}
+
+test.concurrent("patch application should handle out-of-bounds line numbers gracefully", async () => {
+  using dir = project(
+    "patch-bounds-test",
+    `--- a/index.js
++++ b/index.js
+@@ -1000,3 +1000,4 @@
+ console.log("basic-1 1.0.0");
+ 
+ // This line doesn't exist but the patch says it does
++// Add this line way beyond the actual file bounds`,
+  );
+
+  const { stdout, stderr, exitCode } = await install(String(dir));
 
   // Should fail gracefully with proper error message, not crash
-  expect(exitCode).toBe(1);
-  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+  expect(stderr).toMatchInlineSnapshot(`
     "Resolving dependencies
     error: failed applying patch file: EINVAL: Invalid argument (stat())
-    error: failed to apply patchfile (patches/lodash+4.17.21.patch)"
+    error: failed to apply patchfile (patches/basic-1+1.0.0.patch)"
   `);
-  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);
+  expect(stdout).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);
+  expect(exitCode).toBe(1);
 });
 
-test("patch application should handle deletion beyond file bounds", async () => {
-  await using dir = tempDir("patch-deletion-bounds-test", {
-    "package.json": JSON.stringify({
-      name: "test-pkg",
-      version: "1.0.0",
-      dependencies: {
-        "lodash": "4.17.21",
-      },
-      patchedDependencies: {
-        "lodash@4.17.21": "patches/lodash+4.17.21.patch",
-      },
-    }),
-    "patches/lodash+4.17.21.patch": `--- a/index.js
+test.concurrent("patch application should handle deletion beyond file bounds", async () => {
+  using dir = project(
+    "patch-deletion-bounds-test",
+    `--- a/index.js
 +++ b/index.js
 @@ -1,5 +1,3 @@
- module.exports = require('./lodash');
+ console.log("basic-1 1.0.0");
 -line 2
 -line 3
 -line 4
 -line 5`,
-  });
+  );
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install", "--linker=hoisted"],
-    env: bunEnv,
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const { stdout, stderr, exitCode } = await install(String(dir));
 
   // Should fail gracefully, not crash
-  expect(exitCode).toBe(1);
-  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+  expect(stderr).toMatchInlineSnapshot(`
     "Resolving dependencies
     error: failed to parse patchfile: hunk_header_integrity_check_failed
-    error: failed to apply patchfile (patches/lodash+4.17.21.patch)"
+    error: failed to apply patchfile (patches/basic-1+1.0.0.patch)"
   `);
-  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);
+  expect(stdout).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);
+  expect(exitCode).toBe(1);
 });
 
-test("patch application should work correctly with valid patches", async () => {
-  await using dir = tempDir("patch-valid-test", {
-    "package.json": JSON.stringify({
-      name: "test-pkg",
-      version: "1.0.0",
-      dependencies: {
-        "lodash": "4.17.21",
-      },
-      patchedDependencies: {
-        "lodash@4.17.21": "patches/lodash+4.17.21.patch",
-      },
-    }),
-    "patches/lodash+4.17.21.patch": `--- a/index.js
+test.concurrent("patch application should work correctly with valid patches", async () => {
+  using dir = project(
+    "patch-valid-test",
+    `--- a/index.js
 +++ b/index.js
 @@ -1 +1,2 @@
 +// Valid patch comment
- module.exports = require('./lodash');`,
-  });
+ console.log("basic-1 1.0.0");`,
+  );
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install", "--linker=hoisted"],
-    env: bunEnv,
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  const { stdout, stderr, exitCode } = await install(String(dir));
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  // Valid patch should succeed
-  expect(exitCode).toBe(0);
-  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+  expect(stderr).toMatchInlineSnapshot(`
     "Resolving dependencies
     Saved lockfile"
   `);
-  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+  expect(stdout).toMatchInlineSnapshot(`
     "bun install <version> (<revision>)
 
-    + lodash@4.17.21
+    + basic-1@1.0.0
 
     1 package installed"
   `);
+  expect(exitCode).toBe(0);
 
   // Verify the patch was applied
-  const patchedFile = await Bun.file(`${dir}/node_modules/lodash/index.js`).text();
+  const patchedFile = await Bun.file(join(String(dir), "node_modules", "basic-1", "index.js")).text();
   expect(patchedFile).toMatchInlineSnapshot(`
     "// Valid patch comment
-    module.exports = require('./lodash');"
+    console.log("basic-1 1.0.0");
+    "
   `);
 });


### PR DESCRIPTION
### What does this PR do?

Twelve files under `test/regression/issue/` talked to registry.npmjs.org (two of them also to npm.pkg.github.com) on every run: ten ran `bun install` / `bun add` / `bun update` / `bunx` against real package names with no registry configured (`bunEnv` sets no registry, and the CI runner gives each file a fresh `BUN_INSTALL_CACHE_DIR`, so nothing was cached between files), and two sent requests they expected to fail. Tests are not supposed to contact live registries (REVIEW.md, CLAUDE.md), and this class of test shows up in CI as "failed in the parallel batch, passed alone" when a batch of install tests hits npm at once (builds 91655 and 91753 for the sibling file fixed in #37375).

With the registries unreachable (`HTTPS_PROXY` pointed at a closed port, which bun's registry client honours while `localhost` stays reachable through `NO_PROXY`), main fails 14 of the 15 tests in the nine registry-install files plus both tests in 026039, and ctrl-c.test.ts fails in `beforeAll` installing vite:

```
error: ConnectionRefused downloading package manifest is-even
error: is-even@0.1.0 failed to resolve
(fail) bun update -i select all with 'A' key > should update packages when 'A' is pressed to select all
...
 1 pass
 14 fail
Ran 15 tests across 9 files.
```

(The one pass is 07740, which only asserted on a warning printed before the network was touched; it still requested npm. 15276 passes offline too, but a logging proxy shows it attempting registry.npmjs.org six times per run, and 026039 eighteen connections across the two hosts.)

### Changes

Files that only need "some package" or "a package with newer versions" now start the `VerdaccioRegistry` from `harness` (the registry CLAUDE.md tells tests to use) and point `bunfig.toml` at it. The fixtures it serves already have what these tests need:

| file | before | after |
| --- | --- | --- |
| 26657 (`update -i`, `A` selects all) | is-even `0.1.0` and `^1.0.0` from npm | `no-deps` `1.0.0` (exact pin) and `^1.0.0` (resolves to 1.1.0, latest is 2.0.0). Both cases now assert `Selected 1 package to update` and that package.json / node_modules end up on 2.0.0. The second case used to be vacuous: is-even `^1.0.0` was already at latest, so `update -i` had nothing to show. Now it covers the scenario its comment describes (current == highest in range != latest). |
| 24131 (`update -i`, `l` selects) | is-even `0.1.0` | `no-deps` `1.0.0`, asserts the update to `2.0.0`. Sending only Enter makes it fail with `Selected 0 packages to update`, so the `l` behaviour is what is being asserted. |
| patch-bounds-check | lodash `4.17.21` | `basic-1@1.0.0`, whose index.js is the single line `console.log("basic-1 1.0.0");`. Same three error / success snapshots; the `(vX available)` normalisation went away because there is no newer version to advertise. |
| 11806 (`bun add` in a workspace member) | typescript | `no-deps` declared, `bun add --dev a-dep`. Also asserts the rewritten package.json still parses, keeps the escaped `testRegex`, and contains the new dep (the issue was a package.json that no longer parsed after the rewrite); spawns now use `bunEnv`. |
| 28193 (security scanner errors) | is-even | `no-deps`. Assertions pinned to the exact lines #28196 added (`security scanner failed: SecurityScannerNotInDependencies` / `ScannerFailed`) plus `Security scanner installed successfully.` for the second case, so the test proves the replacement package still takes both tests down the same two paths as before. The per-test 30s timeouts are gone: they only existed for the downloads, and a file-level default would also have capped the registry's `beforeAll` below the `--timeout` the CI runner passes. |
| 07740 (duplicate dependency warning) | empty-package-for-bun-test-runner | `no-deps`; now also asserts the install succeeds. |
| 00631 (`bun add` JSON escaping) | `bun add left-pad` -> `^1.3.0` | `bun add no-deps` -> `^2.0.0`; otherwise the same byte-for-byte package.json assertion. |

Two files only need a registry that has nothing, so they get an in-test `Bun.serve` that 404s and records the paths it was asked for:

- **026039** (empty registry field in bun.lock must use the scope's registry): one server serves as both registries, `/scoped/` configured for `@example` and `/default/` as `[install].registry`. The tests now assert which prefix the tarball was requested from (`/scoped/@example/test-package/-/test-package-1.0.0.tgz` vs `/default/fake-nonexistent-package/-/...`) in addition to the error line and the non-zero exit, which is the same property the old hostname assertions encoded. The default registry is configured explicitly instead of being implicit npm; it goes through the same default-scope lookup, and a regression to "always use the default" would show up as a `/default/` request in the scoped test.
- **15276** (`bunx name@npm:target@version` alias parsing): same `failed to resolve` assertion against the local registry via `npm_config_registry` (the way bunx.test.ts configures it), plus an assertion that the manifest requested was `/another-bun`, i.e. the alias target was what got parsed out.

The other three needed something other than a registry:

- **ctrl-c**: the six `kills on SIGINT in: 'bun ...'` cases installed vite from npm and used it as "a bin that prints something and then stays alive". They now install a local `file:` package with a bin that does exactly that (and no SIGINT handler), so `bun install` still creates `node_modules/.bin` the way the `bun <bin>` / `bun <script>` / `bun ./node_modules/.bin/<bin>` / `--bun` variants need, with no registry involved. The package source lives in `long-running-src/`, not `long-running/`: `bun long-running` first tries to resolve that name as a path in cwd, and a directory of that name with a `main` or index.js would be run directly instead of going through `node_modules/.bin` (verified both ways; with the `-src` folder every variant goes through `.bin`, under node without `--bun` and under bun with it). The vite-specific `PORT: "9876"` env goes away with it.
- **26225** (node-fetch + form-data truncation): `node-fetch` is a hardcoded module override (`src/resolve_builtins/HardcodedModule.rs`), so `require("node-fetch")` resolved to Bun's bundled implementation whether or not the npm package was installed; the install only ever mattered for `form-data`, whose `CombinedStream` body is the old-style stream the fix in #26226 is about. `form-data` is added to test/package.json (4.0.0 was already in test/bun.lock as a transitive dependency, so the lockfile change is the one root-dependency line) and the client requires it by absolute path. No install in the test any more; the client scripts and the three server-side checks are unchanged. The file-level timeout it already had stays because loading form-data's mime table takes ~3s on a debug build.
- **24364** (react-tailwind template type-checks): instead of `bun add -d typescript @types/bun @types/react bun-plugin-tailwind`, tsc from test/node_modules runs with `--typeRoots` pointing at `packages/@types` (the in-tree `@types/bun`, which references `packages/bun-types`) and test/node_modules' `@types/react`, plus a two-line stub of bun-plugin-tailwind's published declarations (`declare const plugin: BunPlugin; export default plugin;`). `--listFiles` confirms the program is built from `packages/bun-types/*.d.ts`, and appending `const x: number = "nope"` to the copied build.ts makes it fail, so the template is still what is being checked (now against the types in the tree rather than the last published ones). tsc runs under node when available, as test/cli/init/init.test.ts already does, because tsc under a debug+ASAN bun takes about 90s here.

Not touched: `30205.test.ts` builds a node-gyp addon (same setup as test/napi/napi-app, which has the same dependency on npm; making those hermetic is a separate change). `update-interactive-formatting.test.ts` looked like the same class but makes no registry requests at all (checked with the logging proxy below), so it is left alone.

### Why this is the right fix rather than deleting the tests

Every one of these files pins a real past regression, and each still exercises the same code path it did before: the package name (or the registry host) was incidental in all of them. Where the replacement could have changed what is exercised, the new assertions pin it (28193's error names, 24131's `Selected 1 package`, 026039's and 15276's recorded request paths, 24364's `--listFiles` check described above). The only behavioural coverage that changed is 26657's second case, which went from asserting nothing to asserting the scenario it was written for.

### Verification

All twelve files pass against a debug build with `HTTP(S)_PROXY` pointed at a local proxy that records every connection it is asked to open and then closes it. The tests opened none (the single entry in the log is the build script's own rustup check):

```
$ HTTPS_PROXY=http://127.0.0.1:$PORT HTTP_PROXY=http://127.0.0.1:$PORT bun bd test test/regression/issue/{026039,15276,26657,24131,patch-bounds-check,ctrl-c,11806,28193,07740,00631,24364,26225}.test.ts
 26 pass
 0 fail
Ran 26 tests across 12 files. [19.92s]
$ sort proxy.log | uniq -c
      1 CONNECT static.rust-lang.org:443 HTTP/1.1
```

The same files pass on the release build under the same proxy. Running main's versions of 026039 and 15276 behind the same proxy logs `6 CONNECT npm.pkg.github.com:443` and `12 CONNECT registry.npmjs.org:443`, and the nine install files fail as shown at the top. Release-build wall time for the ten originally listed files went from ~14s (dominated by downloads, the vite install alone ~2s) to ~6s, most of which is verdaccio startup.

Test-only change; no runtime code is touched.
