### PR TITLE
console.table: propagate errors thrown while printing the table

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -502,13 +502,13 @@ fn message_with_type_and_level_(
             let mut table_printer = TablePrinter::init(global, level, tabular_data, properties)?;
             table_printer.value_formatter.indent += u32::from(default_indent);
 
-            if enable_colors {
-                let _ = table_printer.print_table::<true>(writer);
+            let printed = if enable_colors {
+                table_printer.print_table::<true>(writer)
             } else {
-                let _ = table_printer.print_table::<false>(writer);
-            }
+                table_printer.print_table::<false>(writer)
+            };
             let _ = writer.flush();
-            return Ok(());
+            return printed;
         }
     }
 

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -363,3 +363,60 @@ console.log("calls=" + calls);`,
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: box("1") + "calls=1\n", stderr: "", exitCode: 0 });
   });
 });
+
+// Reading a cell runs user code (getters, Proxy traps, custom inspect). An
+// exception thrown there must surface from console.table itself, exactly as
+// it does from Bun.inspect.table, rather than being swallowed by the printer.
+describe("console.table propagates exceptions thrown while reading cells", () => {
+  test("a throwing getter on a row", () => {
+    const boom = new Error("getter boom");
+    const row = {};
+    Object.defineProperty(row, "x", {
+      get() {
+        throw boom;
+      },
+      enumerable: true,
+    });
+    expect(() => console.table([row])).toThrow(boom);
+  });
+
+  test("a throwing Proxy trap on the tabular data", () => {
+    const boom = new Error("proxy boom");
+    const data = new Proxy(
+      { a: 1 },
+      {
+        ownKeys() {
+          throw boom;
+        },
+      },
+    );
+    expect(() => console.table(data)).toThrow(boom);
+  });
+
+  test("a throwing custom inspect in a cell", () => {
+    const boom = new Error("inspect boom");
+    const cell = {
+      [Bun.inspect.custom]() {
+        throw boom;
+      },
+    };
+    expect(() => console.table([{ x: cell }])).toThrow(boom);
+  });
+
+  test("nothing is printed and the error is uncaught in a script", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.table([{ get x() { throw new Error("table getter boom"); } }]);
+console.log("unreachable");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("table getter boom");
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
### What

`message_with_type_and_level_` wrote `let _ = table_printer.print_table(...)` and returned `Ok(())`, discarding the `JsResult`.

```js
console.table([{ get x() { throw new Error("boom"); } }]);
```

When a getter, Proxy trap or custom inspect hook throws while the cells are read, `print_table` returns `Err(Thrown)` with the exception pending on the VM, and the host function still reported success. The exception did reach JS through the pending-exception path, but the function's return value disagreed with the VM state, and an `Err(OutOfMemory)` from the printer was dropped outright (no exception raised at all, since it is the caller's job to throw it).

### Fix

Return the `print_table` result from the table branch (still flushing the writer first), so the outer `message_with_type_and_level` handles it like every other error from this function. `Bun.inspect.table` already propagates the same result.

### Tests

`test/js/bun/console/console-table.test.ts`: `console.table` with a throwing getter, a throwing Proxy `ownKeys` trap and a throwing custom inspect hook rethrows the original error, and a script hitting it prints nothing to stdout and exits 1. These lock in the behaviour; they pass before this change as well, since the thrown case already surfaced via the pending exception.
