### PR TITLE
shell rm: replace RemoveFileVTable's correlated bool and Option with an enum

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -921,8 +921,9 @@ impl ShellRmTask {
             EntryKindHint::Idk | EntryKindHint::File => {
                 let mut vtable = RemoveFileVTable {
                     task: self,
-                    child_of_dir: false,
-                    need_to_wait_out: Some(&mut waiting),
+                    on_dir: OnDir::Recurse {
+                        need_to_wait_out: &mut waiting,
+                    },
                 };
                 self.remove_entry_file(dir_task, path, is_absolute, &mut buf, &mut vtable)?;
             }
@@ -1022,10 +1023,7 @@ impl ShellRmTask {
         let mut iterator = dir_iterator::iterate(fd);
         let mut child_vtable = RemoveFileVTable {
             task: self,
-            child_of_dir: true,
-            // Never read: `child_of_dir == true` makes both vtable callbacks
-            // enqueue and return early before reaching `remove_entry_dir`.
-            need_to_wait_out: None,
+            on_dir: OnDir::Enqueue,
         };
 
         // The loop may have already enqueued child DirTasks (bumping
@@ -1595,14 +1593,47 @@ impl RemoveFileHandler for DummyRemoveFile {
 
 struct RemoveFileVTable<'a> {
     task: &'a ShellRmTask,
-    child_of_dir: bool,
-    /// Out-param forwarded to [`ShellRmTask::remove_entry_dir`] on the
-    /// `child_of_dir == false` path so [`ShellRmTask::remove_entry`] learns
-    /// — without re-reading the (possibly already-freed) DirTask — that
-    /// `need_to_wait` was published. `None` when `child_of_dir == true`, where
-    /// both callbacks return before the recursive call.
-    need_to_wait_out: Option<&'a mut bool>,
+    on_dir: OnDir<'a>,
 }
+
+/// What [`RemoveFileVTable`] does when the entry it was asked to unlink turns
+/// out to be a directory.
+enum OnDir<'a> {
+    /// The entry is a child found while iterating a directory
+    /// ([`ShellRmTask::remove_entry_dir`]): enqueue it as its own [`DirTask`].
+    Enqueue,
+    /// The entry is the [`DirTask`] itself ([`ShellRmTask::remove_entry`]):
+    /// recurse into [`ShellRmTask::remove_entry_dir`] here. The out-param lets
+    /// `remove_entry` learn that `need_to_wait` was published without
+    /// re-reading the (possibly already-freed) DirTask.
+    Recurse { need_to_wait_out: &'a mut bool },
+}
+
+impl RemoveFileVTable<'_> {
+    fn on_dir(
+        &mut self,
+        parent: *mut DirTask,
+        path: &ZStr,
+        is_absolute: bool,
+        buf: &mut bun_paths::PathBuffer,
+    ) -> bun_sys::Maybe<()> {
+        match &mut self.on_dir {
+            OnDir::Enqueue => {
+                self.task.enqueue_no_join(
+                    parent,
+                    ZBox::from_bytes(path.as_bytes()),
+                    EntryKindHint::Dir,
+                );
+                Ok(())
+            }
+            OnDir::Recurse { need_to_wait_out } => {
+                self.task
+                    .remove_entry_dir(parent, is_absolute, buf, need_to_wait_out)
+            }
+        }
+    }
+}
+
 impl RemoveFileHandler for RemoveFileVTable<'_> {
     fn on_is_dir(
         &mut self,
@@ -1611,21 +1642,7 @@ impl RemoveFileHandler for RemoveFileVTable<'_> {
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
-        if self.child_of_dir {
-            self.task.enqueue_no_join(
-                parent,
-                ZBox::from_bytes(path.as_bytes()),
-                EntryKindHint::Dir,
-            );
-            return Ok(());
-        }
-        // `child_of_dir == false` is only constructed in `remove_entry`, which
-        // sets `need_to_wait_out` to `Some(&mut waiting)`.
-        let out = self
-            .need_to_wait_out
-            .as_deref_mut()
-            .expect("set when child_of_dir == false");
-        self.task.remove_entry_dir(parent, is_absolute, buf, out)
+        self.on_dir(parent, path, is_absolute, buf)
     }
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     fn on_dir_not_empty(
@@ -1635,20 +1652,7 @@ impl RemoveFileHandler for RemoveFileVTable<'_> {
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
     ) -> bun_sys::Maybe<()> {
-        if self.child_of_dir {
-            self.task.enqueue_no_join(
-                parent,
-                ZBox::from_bytes(path.as_bytes()),
-                EntryKindHint::Dir,
-            );
-            return Ok(());
-        }
-        // See `on_is_dir`.
-        let out = self
-            .need_to_wait_out
-            .as_deref_mut()
-            .expect("set when child_of_dir == false");
-        self.task.remove_entry_dir(parent, is_absolute, buf, out)
+        self.on_dir(parent, path, is_absolute, buf)
     }
 }
 


### PR DESCRIPTION
### What

`RemoveFileVTable.child_of_dir: bool` and `need_to_wait_out: Option<&mut bool>` were perfectly correlated: `remove_entry_dir` built it with `true` / `None` for the entries it iterates, `remove_entry` with `false` / `Some(&mut waiting)` for the entry itself. Both `on_is_dir` and `on_dir_not_empty` re-derived that with an `expect()`, and their bodies were identical.

### Fix

Replace the pair with an `OnDir` enum (`Enqueue` or `Recurse { need_to_wait_out }`) and have both trait callbacks delegate to one `on_dir` method. No behaviour change.

### Verification

`bun bd test test/js/bun/shell/commands/rm.test.ts` passes. `cargo check -p bun_runtime` for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc` also passes, since `on_dir_not_empty` is only compiled off Linux.
