### PR TITLE
bun test --parallel: distinguish --bail from a worker panic when reaping

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -59,7 +59,7 @@ pub struct Coordinator<'a> {
     pub(crate) live_workers: u32,
     pub(crate) crashed_files: Vec<u32>,
     pub(crate) aborted: Option<u32>,
-    pub(crate) bailed: bool,
+    pub(crate) stop_reason: Option<StopReason>,
     pub(crate) last_printed_dot: bool,
     /// Kill-on-close Job Object so the OS reaps workers if the coordinator dies
     /// without running its signal handler (e.g. SIGKILL / TerminateProcess).
@@ -67,9 +67,21 @@ pub struct Coordinator<'a> {
     pub(crate) windows_job: Option<*mut c_void>,
 }
 
+/// Why the run stopped dispatching files. A worker panic overrides `Bail`
+/// (see `abort_on_worker_panic`); nothing clears it.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StopReason {
+    /// `--bail=N` reached: idle workers are shut down, inflight files finish.
+    Bail,
+    /// A worker died of a crash signal and every other worker was terminated,
+    /// so the siblings' inflight files are collateral, not crashes of their own.
+    WorkerPanicked,
+}
+
 impl<'a> Coordinator<'a> {
     fn is_done(&self) -> bool {
-        (self.files_done as usize >= self.files.len() || self.bailed) && self.live_workers == 0
+        (self.files_done as usize >= self.files.len() || self.stop_reason.is_some())
+            && self.live_workers == 0
     }
 
     fn has_undispatched_files(&self) -> bool {
@@ -128,7 +140,7 @@ impl<'a> Coordinator<'a> {
             }
             if self.spawned_count < self.parallel_limit
                 && self.has_undispatched_files()
-                && !self.bailed
+                && self.stop_reason.is_none()
             {
                 // Bound the wait so we wake to scale up even if no I/O arrives.
                 const MS_PER_S: i64 = bun_core::time::MS_PER_S as i64;
@@ -244,7 +256,7 @@ impl<'a> Coordinator<'a> {
         if self.spawned_count >= self.parallel_limit {
             return;
         }
-        if self.bailed || !self.has_undispatched_files() {
+        if self.stop_reason.is_some() || !self.has_undispatched_files() {
             return;
         }
         let now = bun_core::time::milli_timestamp();
@@ -272,7 +284,7 @@ impl<'a> Coordinator<'a> {
     }
 
     fn assign_work(&mut self, w: &mut Worker) {
-        if self.bailed {
+        if self.stop_reason.is_some() {
             return w.shutdown();
         }
         if let Some(idx) = w.range.pop_front() {
@@ -307,10 +319,10 @@ impl<'a> Coordinator<'a> {
     }
 
     fn bail_out(&mut self) {
-        if self.bailed {
+        if self.stop_reason.is_some() {
             return;
         }
-        self.bailed = true;
+        self.stop_reason = Some(StopReason::Bail);
         self.break_dots();
         bun_core::pretty_error!(
             "\nBailed out after {} failure{}<r>\n",
@@ -577,8 +589,7 @@ impl<'a> Coordinator<'a> {
             // the exit status reflects the crash. SIGKILL is treated as a
             // regular failure (commonly the OOM killer or the user).
             let panicked = is_panic_status(status);
-            let was_bailed = self.bailed;
-            if was_bailed && !panicked {
+            if self.stop_reason == Some(StopReason::WorkerPanicked) && !panicked {
                 self.account_unfinished(idx, b"aborted: sibling worker panicked");
             } else {
                 self.record_timing(idx, w.dispatched_at);
@@ -604,7 +615,7 @@ impl<'a> Coordinator<'a> {
         }
 
         let mut respawned = false;
-        if !self.bailed && self.has_undispatched_files() {
+        if self.stop_reason.is_none() && self.has_undispatched_files() {
             // SAFETY: fresh derivation — `has_undispatched_files` read the slots.
             let w = unsafe { &mut *self.workers.as_mut_ptr().add(slot) };
             w.ipc = Default::default();
@@ -623,7 +634,7 @@ impl<'a> Coordinator<'a> {
         }
 
         if !respawned {
-            if !self.bailed && self.live_workers == 0 {
+            if self.stop_reason.is_none() && self.live_workers == 0 {
                 self.abort_queued_files(b"no live workers");
             }
             // Explicit early release: `w` is a borrowed slot in self.workers, so
@@ -668,8 +679,8 @@ impl<'a> Coordinator<'a> {
     }
 
     /// A worker was killed by a crash signal — treat this as a Bun bug, not
-    /// a test failure. Print the panic banner (even if --bail already set
-    /// `bailed`), terminate every other worker, and mark all remaining
+    /// a test failure. Print the panic banner (even if --bail already
+    /// stopped the run), terminate every other worker, and mark all remaining
     /// files as aborted so the run ends immediately with a non-zero exit
     /// and the panic's stderr (already flushed via flushCaptured) is the
     /// last meaningful output, not buried under hundreds of later passes.
@@ -689,8 +700,8 @@ impl<'a> Coordinator<'a> {
         // mid-file would keep producing output after the panic banner.
         // Terminate the whole process group (same as the SIGINT path) so the
         // run ends now; reapWorker() will account each inflight file as a
-        // crash when the exit arrives. Runs even if --bail already set
-        // `bailed`, since bailOut() only shutdown()s idle workers and would
+        // crash when the exit arrives. Runs even if --bail already stopped
+        // the run, since bailOut() only shutdown()s idle workers and would
         // leave inflight ones running past the banner.
         // Reachable from reap_worker with the caller's
         // `w: &mut Worker` still live and used afterward; iter_mut() would
@@ -729,10 +740,14 @@ impl<'a> Coordinator<'a> {
                 }
             }
         }
-        if self.bailed {
+        // Overrides an earlier --bail stop so the siblings terminated above
+        // reap as collateral; the queued files are only swept when this panic
+        // is what stopped the run.
+        let already_stopped = self.stop_reason.is_some();
+        self.stop_reason = Some(StopReason::WorkerPanicked);
+        if already_stopped {
             return;
         }
-        self.bailed = true;
         self.abort_queued_files(b"aborted: worker panicked");
     }
 

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -185,7 +185,7 @@ pub(crate) fn run_as_coordinator(
         live_workers: 0,
         crashed_files: Vec::new(),
         aborted: None,
-        bailed: false,
+        stop_reason: None,
         last_printed_dot: false,
         #[cfg(windows)]
         windows_job: Coordinator::create_windows_kill_on_close_job(),

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -200,6 +200,64 @@ test("--parallel --bail stops dispatching new files after threshold", async () =
   expect(exitCode).toBe(1);
 });
 
+test(
+  "--parallel --bail: a worker that dies mid-file after the bail is reported as a crash",
+  async () => {
+    // Two files run side by side. `a` fails (tripping --bail=1) only once `b`
+    // is running; `b` then waits for a's worker to be gone (it is shut down
+    // right after the bail) before exiting mid-file. The coordinator has to
+    // report that exit as a crash of b: only a worker panic makes sibling
+    // deaths collateral, a plain bail does not.
+    const poll = `
+    const deadline = Date.now() + 30_000;
+    function waitFor(cond) { while (!cond() && Date.now() < deadline) Bun.sleepSync(5); }
+  `;
+    using dir = tempDir("parallel-bail-then-exit", {
+      "a.test.js": `
+      import { test, expect } from "bun:test";
+      import { existsSync, writeFileSync } from "node:fs";
+      import { join } from "node:path";
+      ${poll}
+      test("fail once b is running", () => {
+        waitFor(() => existsSync(join(import.meta.dir, "b-started")));
+        writeFileSync(join(import.meta.dir, "a-pid"), String(process.pid));
+        expect(1).toBe(2);
+      }, 60_000);
+    `,
+      "b.test.js": `
+      import { test } from "bun:test";
+      import { existsSync, readFileSync, writeFileSync } from "node:fs";
+      import { join } from "node:path";
+      ${poll}
+      test("exit after a's worker is gone", () => {
+        writeFileSync(join(import.meta.dir, "b-started"), "");
+        const pidFile = join(import.meta.dir, "a-pid");
+        let pid = 0;
+        waitFor(() => existsSync(pidFile) && (pid = Number(readFileSync(pidFile, "utf8"))) > 0);
+        waitFor(() => { try { process.kill(pid, 0); return false; } catch { return true; } });
+        process.exit(7);
+      }, 60_000);
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", "--bail=1"],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Bailed out after 1 failure");
+    expect(stderr).toContain("b.test.js");
+    expect(stderr).toContain("(worker crashed: exit code 7)");
+    expect(stderr).not.toContain("sibling worker panicked");
+    expect(exitCode).toBe(1);
+  },
+  isASAN || isDebug ? 60_000 : 20_000,
+);
+
 // POSIX classifies worker crashes as panics by fatal signal — see
 // is_panic_status. (On Windows a crash caught by Bun's crash handler exits
 // with code 3, indistinguishable from process.exit(3); the Windows


### PR DESCRIPTION
### Repro

Two files under `bun test --parallel=2 --bail=1`: `a` fails, which stops the run; `b` is still running in the other worker and calls `process.exit(7)` mid-file afterwards. Current output:

```
Bailed out after 1 failure

b.test.js:
✗ b.test.js (aborted: sibling worker panicked)
```

No worker panicked. Reproduces 15/15 runs with the added test against the current release.

### Cause

`Coordinator.bailed: bool` covered both "stopped by `--bail=N`" and "stopped because a worker panicked", so `reap_worker` could not tell them apart and reported every post-stop mid-file death as collateral of a panic. After a plain bail such a death is a crash of that file and should go through `account_crash` (crash line, `crashed_files`, timing).

### Fix

`bailed` becomes `stop_reason: Option<StopReason>` with `Bail` and `WorkerPanicked`. Only `WorkerPanicked` turns sibling deaths into "aborted: sibling worker panicked". `abort_on_worker_panic` still upgrades a `Bail` stop to `WorkerPanicked` so the workers it terminates are reported exactly as before, and still only sweeps the queued files when the panic is what stopped the run. All other uses of the flag are unchanged (`is_some()` / `is_none()`).

### Tests

`test/cli/test/parallel.test.ts`: "a worker that dies mid-file after the bail is reported as a crash". The fixture sequences the two workers through files on disk (b waits for a's worker to be gone, which only happens after the bail), so it does not depend on timing. Fails on the current release with the output above, passes with this change; the existing bail and panic tests still pass.
