### PR TITLE
streams: drop dead ended = false in NetworkSink and FetchRequestBodySink start

### DIFF
--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -106,7 +106,6 @@ impl FetchRequestBodySink {
                 self.high_water_mark = chunk_size;
             }
         }
-        self.ended = false;
         self.source.start();
         bun_sys::Result::Ok(())
     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2252,7 +2252,6 @@ impl NetworkSink {
                 self.high_water_mark = chunk_size;
             }
         }
-        self.ended = false;
         self.source.start();
         bun_sys::Result::Ok(())
     }


### PR DESCRIPTION
### What

`NetworkSink::start` and `FetchRequestBodySink::start` both return early when `self.ended` is set and then assigned `self.ended = false` a few lines later, so the assignment could only ever write `false` over `false`. Removed in both places. No behaviour change.

Related: #36770 reworks `NetworkSink`'s lifecycle flags more broadly; this is just the two dead lines.

### Verification

`bun bd test test/js/bun/s3/s3.test.ts test/js/web/fetch/fetch.stream.test.ts test/js/web/fetch/body.test.ts test/js/web/fetch/fetch-abort-stream-body.test.ts` passes (the S3 cases that run against a local server included).
