### PR TITLE
streams: remove NetworkSink's write-only cancel flag and unreachable EOF branch

### DIFF
--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2186,7 +2186,6 @@ pub struct NetworkSink {
     pub(crate) upstream_error: jsc::strong::Optional,
     pub(crate) ended: bool,
     pub(crate) done: bool,
-    pub(crate) cancel: bool,
 }
 
 impl Default for NetworkSink {
@@ -2202,7 +2201,6 @@ impl Default for NetworkSink {
             upstream_error: jsc::strong::Optional::empty(),
             ended: false,
             done: false,
-            cancel: false,
         }
     }
 }
@@ -2336,7 +2334,6 @@ impl NetworkSink {
         self.pending.result = Writable::Done;
         self.pending.run();
         self.source.close(None);
-        self.cancel = true;
         self.finalize();
     }
 
@@ -2522,16 +2519,7 @@ impl NetworkSink {
         if self.task.is_some() && !self.done {
             // we need to wait for the task to end
             self.end_promise = JSPromiseStrong::init(self.global_this());
-            let value = self.end_promise.value();
-            if !self.ended {
-                self.ended = true;
-                // we need to send EOF
-                if let Some(task) = self.task_ref() {
-                    let _ = task.write_bytes(b"", true);
-                }
-                self.source.close(None);
-            }
-            return bun_sys::Result::Ok(value);
+            return bun_sys::Result::Ok(self.end_promise.value());
         }
         // task already detached
         bun_sys::Result::Ok(JSValue::js_number(0.0))


### PR DESCRIPTION
### What

Two pieces of dead code in `NetworkSink`:

- `cancel` was set in `abort()` and never read anywhere in the tree.
- In `end_from_js`, `self.end(None)` runs first and always leaves `ended` set (it returns early when it already was, otherwise it sets it, and nothing ever clears it), so the `if !self.ended { ... send EOF ... }` block below could not execute.

Both removed; `end_from_js` now just creates the end promise and returns it on that path. No behaviour change.

Related: #36770 folds the same flags into a state enum as part of a larger change; this PR is only the removal of the dead parts.

### Verification

`bun bd test test/js/bun/s3/s3.test.ts test/js/bun/s3/s3-stream-cancel-leak.test.ts test/js/bun/s3/s3-connection-close.test.ts` passes, including the local-server upload cases that go through `NetworkSink`.
