### PR TITLE
xml: collapse Step::Done and Step::Continue into one variant

### DIFF
--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -598,8 +598,8 @@ impl<U: Unit> core::fmt::Display for KindDisplay<'_, U> {
 
 /// See `Parser::content_step`.
 enum Step {
-    Done,
-    Continue,
+    /// One content item was consumed (a child opened or the element closed).
+    Handled,
     Slow,
 }
 
@@ -3819,8 +3819,8 @@ impl<'a, 'log, U: Unit, S: Sink<'a, U>> Parser<'a, 'log, U, S> {
             // through `next_content`'s tokens.
             if self.scanner.in_document() && self.scanner.idx.is_some() {
                 match self.content_step(name, frame)? {
+                    Step::Handled => continue,
                     Step::Slow => {}
-                    _ => continue,
                 }
             }
             self.advance_content()?;
@@ -3981,7 +3981,7 @@ impl<'a, 'log, U: Unit, S: Sink<'a, U>> Parser<'a, 'log, U, S> {
             };
             let end_frame = sc.frame_id;
             self.close_element(name, frame, end_name, stop, end_frame)?;
-            return Ok(Step::Done);
+            return Ok(Step::Handled);
         }
         sc.pos = stop + 1;
         sc.tag_degraded = false;
@@ -3993,7 +3993,7 @@ impl<'a, 'log, U: Unit, S: Sink<'a, U>> Parser<'a, 'log, U, S> {
             spaced: false,
         };
         self.open_element()?;
-        Ok(Step::Continue)
+        Ok(Step::Handled)
     }
 
     /// The attributes of the start tag of `element`, streamed to the sink:


### PR DESCRIPTION
### What

`content_step` returned `Step::Done` after closing the element and `Step::Continue` after opening a child, but `parse_tree` handled both with the same `_ => continue` arm, so the distinction carried nothing.

### Fix

One `Step::Handled` variant; the match in `parse_tree` is now exhaustive without a wildcard. No behaviour change.

### Verification

`bun bd test test/js/bun/xml/xml.test.ts test/js/bun/xml/xml-test-suite.test.ts` passes.
