### PR TITLE
cron: remove the Done and Failed states of RegisterState and RemoveState

### DIFF
--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -251,8 +251,6 @@ enum RegisterState {
     BootingOut,
     #[cfg(target_os = "macos")]
     Bootstrapping,
-    Done,
-    Failed,
 }
 
 // Forward as raw ptr — `maybe_finished` (via `CronJobBase`) may free `this`.
@@ -422,11 +420,6 @@ impl CronJobBase for CronRegisterJob {
     unsafe fn finish(this: *mut Self) {
         // SAFETY: caller transfers the unique Box<Self> leaked in cron_register.
         let mut job = unsafe { bun_core::heap::take(this) };
-        job.state = if job.err_msg.is_some() {
-            RegisterState::Failed
-        } else {
-            RegisterState::Done
-        };
         job.poll.unref(bun_io::js_vm_ctx());
         let ev = VirtualMachine::get().event_loop_mut();
         ev.enter();
@@ -1084,8 +1077,6 @@ enum RemoveState {
     ReadingCrontab,
     InstallingCrontab,
     BootingOut,
-    Done,
-    Failed,
 }
 
 // Forward as raw ptr — `maybe_finished` (via `CronJobBase`) may free `this`.
@@ -1233,11 +1224,6 @@ impl CronJobBase for CronRemoveJob {
     unsafe fn finish(this: *mut Self) {
         // SAFETY: caller transfers the unique Box<Self> leaked in cron_remove.
         let mut job = unsafe { bun_core::heap::take(this) };
-        job.state = if job.err_msg.is_some() {
-            RemoveState::Failed
-        } else {
-            RemoveState::Done
-        };
         job.poll.unref(bun_io::js_vm_ctx());
         let ev = VirtualMachine::get().event_loop_mut();
         ev.enter();


### PR DESCRIPTION
### What

`RegisterState` and `RemoveState` each had `Done` and `Failed` variants that `finish()` assigned immediately before dropping the job. Nothing reads `state` after that point (the `Drop` impls do not touch it), so the two variants were write-only.

### Fix

Remove the variants and the assignments. The remaining `_` arms in `advance_state` are still reachable on every platform. No behaviour change.

### Verification

`bun bd test test/js/bun/cron/cron.test.ts` passes locally (the crontab-backed cases are skipped here and are covered by CI); `cargo check -p bun_runtime` also passes for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`, which compile the platform-specific variant sets.
