### PR TITLE
repl: drop Key variants that were decoded but never handled

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -95,7 +95,6 @@ enum Key {
     CtrlL,
     CtrlN,
     CtrlP,
-    CtrlR,
     CtrlT,
     CtrlU,
     CtrlW,
@@ -108,8 +107,6 @@ enum Key {
     Delete,
     Home,
     End,
-    PageUp,
-    PageDown,
     ArrowUp,
     ArrowDown,
     ArrowRight,
@@ -146,7 +143,6 @@ impl Key {
             12 => Key::CtrlL,
             14 => Key::CtrlN,
             16 => Key::CtrlP,
-            18 => Key::CtrlR,
             20 => Key::CtrlT,
             21 => Key::CtrlU,
             23 => Key::CtrlW,
@@ -1097,11 +1093,9 @@ impl<'a> Repl<'a> {
                         if fourth == b'~' {
                             break 'blk match third {
                                 b'1' => Key::Home,
-                                b'2' => Key::Unknown, // insert
                                 b'3' => Key::Delete,
                                 b'4' => Key::End,
-                                b'5' => Key::PageUp,
-                                b'6' => Key::PageDown,
+                                // insert / page up / page down: consumed, not bound
                                 _ => Key::Unknown,
                             };
                         } else if fourth == b';' {
@@ -2160,7 +2154,7 @@ impl<'a> Repl<'a> {
                     let _ = self.line_editor.insert_slice(&bytes[..len]);
                     self.refresh_line();
                 }
-                _ => {}
+                Key::Escape | Key::Unknown => {}
             }
         }
 


### PR DESCRIPTION
### What

`Key::CtrlR`, `Key::PageUp` and `Key::PageDown` were produced by the decoder and then fell into the `_ => {}` arm of the dispatch loop.

### Fix

Remove the three variants. Byte 18 and the `ESC [ 5 ~` / `ESC [ 6 ~` sequences now decode to `Key::Unknown` like insert already did, so they are still consumed rather than inserted as text. With them gone the dispatch match can name the two keys it intentionally ignores (`Escape`, `Unknown`) instead of using a wildcard, so adding a decoded key without handling it no longer compiles. No behaviour change.

### Verification

`bun bd test test/js/bun/repl/repl.test.ts` passes.
