### PR TITLE
compile: drop -baseline from android and freebsd --target values

### DIFF
--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -238,10 +238,7 @@ impl CompileTarget {
         }
     }
 
-    /// Whether a separate `-baseline` package is published for this target
-    /// (see `platforms` in packages/bun-release/src/platform.ts). Only the x64
-    /// builds of macOS, Windows and glibc/musl Linux have one; arm64, Android
-    /// and FreeBSD ship a single binary.
+    /// Mirrors the `-baseline` entries of `platforms` in packages/bun-release/src/platform.ts.
     fn has_baseline_package(&self) -> bool {
         self.arch == Architecture::X64
             && match self.os {
@@ -339,8 +336,6 @@ impl CompileTarget {
             let _ = found_arch;
         }
 
-        // Otherwise the download URL and cache name would point at a package
-        // that does not exist; "-baseline" resolves to the one binary there is.
         if this.baseline && !this.has_baseline_package() {
             this.baseline = false;
         }

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -245,7 +245,10 @@ impl CompileTarget {
     fn has_baseline_package(&self) -> bool {
         self.arch == Architecture::X64
             && match self.os {
-                OperatingSystem::Linux => self.libc != Libc::Android,
+                OperatingSystem::Linux => match self.libc {
+                    Libc::Default | Libc::Musl => true,
+                    Libc::Android => false,
+                },
                 OperatingSystem::Mac | OperatingSystem::Windows => true,
                 OperatingSystem::Freebsd | OperatingSystem::Wasm => false,
             }

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -238,6 +238,19 @@ impl CompileTarget {
         }
     }
 
+    /// Whether a separate `-baseline` package is published for this target
+    /// (see `platforms` in packages/bun-release/src/platform.ts). Only the x64
+    /// builds of macOS, Windows and glibc/musl Linux have one; arm64, Android
+    /// and FreeBSD ship a single binary.
+    fn has_baseline_package(&self) -> bool {
+        self.arch == Architecture::X64
+            && match self.os {
+                OperatingSystem::Linux => self.libc != Libc::Android,
+                OperatingSystem::Mac | OperatingSystem::Windows => true,
+                OperatingSystem::Freebsd | OperatingSystem::Wasm => false,
+            }
+    }
+
     pub fn try_from(input_: &[u8]) -> Result<CompileTarget, ParseError> {
         let mut this = CompileTarget::default();
         let input = strings::trim(input_, b" \t\r");
@@ -323,8 +336,9 @@ impl CompileTarget {
             let _ = found_arch;
         }
 
-        // there is no baseline arm64.
-        if this.baseline && this.arch == Architecture::Arm64 {
+        // Otherwise the download URL and cache name would point at a package
+        // that does not exist; "-baseline" resolves to the one binary there is.
+        if this.baseline && !this.has_baseline_package() {
             this.baseline = false;
         }
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -189,6 +189,110 @@ describe("compiled binary validity", () => {
   });
 });
 
+// A separate `-baseline` package is only published for x64 darwin, windows and glibc/musl linux
+// (packages/bun-release/src/platform.ts). Everything else ships one binary, so `-baseline` has to
+// resolve to it; asking npm for bun-linux-x64-android-baseline or bun-freebsd-x64-baseline 404s.
+//
+// The tarball URL is pointed at a local server that always 404s, so the binary a target resolved to
+// shows up in the "not available for download" message without touching the network. The pinned
+// -v1.2.3 keeps the target from ever being the running bun (which is used as-is, nothing to download)
+// and keeps the expected names independent of the version under test.
+describe("compile target -baseline resolution", () => {
+  const downloadError = /Target platform '([^']+)' is not available for download/;
+
+  function serve404() {
+    return Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => new Response("not found", { status: 404 }),
+    });
+  }
+
+  function envFor(server: Bun.Server, dir: string) {
+    return {
+      ...bunEnv,
+      BUN_COMPILE_TARGET_TARBALL_URL: server.url.href,
+      BUN_INSTALL_CACHE_DIR: join(dir, "cache"),
+    };
+  }
+
+  test.concurrent.each([
+    // [--target, binary it resolves to]
+    ["bun-linux-x64-android-baseline-v1.2.3", "bun-linux-x64-android-v1.2.3"],
+    ["bun-linux-x64-baseline-android-v1.2.3", "bun-linux-x64-android-v1.2.3"],
+    ["bun-freebsd-x64-baseline-v1.2.3", "bun-freebsd-x64-v1.2.3"],
+    ["bun-freebsd-baseline-v1.2.3", "bun-freebsd-x64-v1.2.3"],
+    ["bun-linux-arm64-musl-baseline-v1.2.3", "bun-linux-aarch64-musl-v1.2.3"],
+    // These do publish a -baseline package, so the suffix is kept.
+    ["bun-linux-x64-musl-baseline-v1.2.3", "bun-linux-x64-musl-baseline-v1.2.3"],
+    ["bun-darwin-x64-baseline-v1.2.3", "bun-darwin-x64-baseline-v1.2.3"],
+    ["bun-windows-x64-baseline-v1.2.3", "bun-windows-x64-baseline-v1.2.3"],
+  ])("bun build --compile --target=%s downloads %s", async (target, resolved) => {
+    using dir = tempDir("build-compile-baseline-cli", {
+      "app.js": `console.log("unreachable");`,
+    });
+    using server = serve404();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", `--target=${target}`, "app.js", "--outfile", "app"],
+      env: envFor(server, String(dir)),
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toMatch(downloadError);
+    expect({ resolved: stderr.match(downloadError)![1], exitCode }).toEqual({ resolved, exitCode: 1 });
+  });
+
+  test.concurrent("Bun.build resolves the same way", async () => {
+    using dir = tempDir("build-compile-baseline-api", {
+      "app.js": `console.log("unreachable");`,
+      "build.js": `
+        const targets = ["bun-linux-x64-android-baseline-v1.2.3", "bun-freebsd-x64-baseline-v1.2.3"];
+        const resolved = {};
+        for (const target of targets) {
+          const result = await Bun.build({
+            entrypoints: ["./app.js"],
+            compile: { target, outfile: "./app" },
+            throw: false,
+          });
+          resolved[target] = { success: result.success, logs: result.logs.map(log => log.message) };
+        }
+        console.log(JSON.stringify(resolved));
+      `,
+    });
+    using server = serve404();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.js"],
+      env: envFor(server, String(dir)),
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "bun-linux-x64-android-baseline-v1.2.3": {
+        success: false,
+        logs: [
+          "Target platform 'bun-linux-x64-android-v1.2.3' is not available for download. Check if this version of Bun supports this target.",
+        ],
+      },
+      "bun-freebsd-x64-baseline-v1.2.3": {
+        success: false,
+        logs: [
+          "Target platform 'bun-freebsd-x64-v1.2.3' is not available for download. Check if this version of Bun supports this target.",
+        ],
+      },
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
 if (isLinux) {
   describe("ELF section", () => {
     test("compiled binary runs with execute-only permissions", async () => {

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -223,7 +223,9 @@ describe("compile target -baseline resolution", () => {
     ["bun-freebsd-x64-baseline-v1.2.3", "bun-freebsd-x64-v1.2.3"],
     ["bun-freebsd-baseline-v1.2.3", "bun-freebsd-x64-v1.2.3"],
     ["bun-linux-arm64-musl-baseline-v1.2.3", "bun-linux-aarch64-musl-v1.2.3"],
-    // These do publish a -baseline package, so the suffix is kept.
+    // These do publish a -baseline package, so the suffix is kept. A linux target without a libc
+    // segment inherits the libc of the bun running the build, and CI runs this file on alpine too.
+    ["bun-linux-x64-baseline-v1.2.3", isMusl ? "bun-linux-x64-musl-baseline-v1.2.3" : "bun-linux-x64-baseline-v1.2.3"],
     ["bun-linux-x64-musl-baseline-v1.2.3", "bun-linux-x64-musl-baseline-v1.2.3"],
     ["bun-darwin-x64-baseline-v1.2.3", "bun-darwin-x64-baseline-v1.2.3"],
     ["bun-windows-x64-baseline-v1.2.3", "bun-windows-x64-baseline-v1.2.3"],


### PR DESCRIPTION
### Repro

```
$ echo 'console.log(1)' > app.js
$ bun build --compile --target=bun-linux-x64-android-baseline app.js --outfile out
Target platform 'bun-linux-x64-android-baseline-v1.4.0' is not available for download. Check if this version of Bun supports this target.

$ bun build --compile --target=bun-freebsd-x64-baseline app.js --outfile out
Target platform 'bun-freebsd-x64-baseline-v1.4.0' is not available for download. Check if this version of Bun supports this target.
```

Same result for `bun-linux-x64-baseline-android` and through `Bun.build({ compile: { target } })`. Reproduced with bun 1.4.0. The message blames the target, but `bun-linux-x64-android` and `bun-freebsd-x64` are published and build fine; it is the `-baseline` variant that does not exist.

### Cause

`CompileTarget::try_from` (`src/options_types/compile_target.rs`) accepts the `baseline` segment for any target and only clears it for arm64 ("there is no baseline arm64"). The Android and FreeBSD builds have never had a baseline variant either: `packages/bun-release/src/platform.ts` publishes exactly `bun-linux-{x64,aarch64}-android` and `bun-freebsd-{x64,aarch64}`, and the only `-baseline` packages are `bun-darwin-x64-baseline`, `bun-linux-x64-baseline`, `bun-linux-x64-musl-baseline` and `bun-windows-x64-baseline`. With the flag left set, `to_npm_registry_url_with_url` builds `@oven/bun-linux-x64-android-baseline` / `@oven/bun-freebsd-x64-baseline`, the registry 404s, and the cache file name (`Display`) carries the same bogus suffix.

### Fix

`has_baseline_package()` encodes which targets publish a separate `-baseline` package (x64 on macOS, Windows and glibc/musl Linux) as exhaustive matches over the os and libc enums, so a future variant has to state its answer, and `try_from` clears `baseline` whenever it is false. That covers arm64 exactly as before and adds Android and FreeBSD. Because the normalization happens at parse time, the download URL, the cache file name, the error messages and `is_default()` (an Android or FreeBSD x64 host asked for its own target with `-baseline` now uses the running binary, like arm64 hosts already do) all agree.

Why resolve rather than reject: `-baseline` is a selector between published packages, and the existing contract, both for arm64 in this parser and in the docs, is that where only one package exists the selector resolves to it (`bun-darwin-arm64-baseline` has always built the arm64 binary, and is part of the `CompileTarget` type). Android and FreeBSD are the remaining targets with exactly one package at every version, so the same rule applies at every version. Targets that do publish the alias keep it: for versions pinned with `-vX.Y.Z` before the x64 builds were unified, `bun-linux-x64-baseline` and `bun-linux-x64` are different binaries, so clearing the flag for them would be wrong.

Parse errors are unchanged: `bun-linux-x64-android-baseline-bogus` still reports `bogus`, and `bun-darwin-x64-android-baseline` is still rejected because android requires linux.

### Verification

New `compile target -baseline resolution` block in `test/bundler/bun-build-compile.test.ts`. It points `BUN_COMPILE_TARGET_TARBALL_URL` at a local `Bun.serve` that always returns 404 (and `BUN_INSTALL_CACHE_DIR` at a temp dir), so the binary a target resolved to is visible in the "not available for download" message without any network access; targets are pinned to `-v1.2.3` so none of them is ever the running bun.

- `bun build --compile` with `bun-linux-x64-android-baseline`, `bun-linux-x64-baseline-android`, `bun-freebsd-x64-baseline` and `bun-freebsd-baseline` resolve to `bun-linux-x64-android` / `bun-freebsd-x64`; `bun-linux-arm64-musl-baseline` keeps resolving to the aarch64 build.
- `bun-linux-x64-baseline` (resolving to the musl package on musl hosts, since a libc-less Linux target inherits the host libc), `bun-linux-x64-musl-baseline`, `bun-darwin-x64-baseline` and `bun-windows-x64-baseline` still keep the suffix.
- `Bun.build` with the android and freebsd targets reports the same resolved names in `result.logs`.

Without the `src/` change the four android/freebsd CLI cases and the `Bun.build` case fail (received `...-android-baseline-v1.2.3` / `...-freebsd-x64-baseline-v1.2.3`); with it the whole file passes under `bun bd test`.
