### PR TITLE
test(bundler): compile each outfile case in its own test

### DIFF
--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -50,41 +50,27 @@ describe("Bun.build compile", () => {
       }),
     ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-invalid-platform"`);
   });
-  test("compile with relative outfile paths", async () => {
-    using dir = tempDir("build-compile-relative-paths", {
-      "app.js": `console.log("Testing relative paths");`,
-    });
 
-    // Test 1: Nested forward slash path
-    const result1 = await Bun.build({
-      entrypoints: [join(dir + "", "app.js")],
-      compile: {
-        outfile: join(dir + "", "output/nested/app1"),
-      },
-    });
-    expect(result1.success).toBe(true);
-    expect(result1.outputs[0].path).toContain(join("output", "nested", isWindows ? "app1.exe" : "app1"));
+  // One compile per test: each compile copies the whole bun binary (~1 GB under debug+ASAN),
+  // which by itself takes a good part of the default per-test timeout.
+  test.each(["output/nested/app1", "app2", "a/b/c/d/app3"])(
+    "compile writes the executable to outfile %s",
+    async relativeOutfile => {
+      using dir = tempDir("build-compile-outfile", {
+        "app.js": `console.log("Testing outfile paths");`,
+      });
+      const outfile = join(String(dir), relativeOutfile);
 
-    // Test 2: Current directory relative path
-    const result2 = await Bun.build({
-      entrypoints: [join(dir + "", "app.js")],
-      compile: {
-        outfile: join(dir + "", "app2"),
-      },
-    });
-    expect(result2.success).toBe(true);
-    expect(result2.outputs[0].path).toEndWith(isWindows ? "app2.exe" : "app2");
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "app.js")],
+        compile: { outfile },
+      });
 
-    // Test 3: Deeply nested path
-    const result3 = await Bun.build({
-      entrypoints: [join(dir + "", "app.js")],
-      compile: {
-        outfile: join(dir + "", "a/b/c/d/app3"),
-      },
-    });
-    expect(result3.success).toBe(true);
-    expect(result3.outputs[0].path).toContain(join("a", "b", "c", "d", isWindows ? "app3.exe" : "app3"));
-  });
+      expect(result.success).toBe(true);
+      expect(result.outputs.map(output => output.path)).toEqual([isWindows ? `${outfile}.exe` : outfile]);
+      expect(await Bun.file(result.outputs[0].path).exists()).toBe(true);
+    },
+  );
 
   test("compile with embedded resources uses correct module prefix", async () => {
     using dir = tempDir("build-compile-embedded-resources", {


### PR DESCRIPTION
### What

`test/bundler/bun-build-compile.test.ts` "compile with relative outfile paths" ran three `Bun.build({ compile: { outfile } })` calls inside one test. Every compile copies and rewrites the whole bun binary, which is about 1 GB with a debug+ASAN build and takes roughly 2.5s there (every single-compile test in the file reports 2.4s to 2.9s), so the test needed 7s or more of a 5s default per-test budget. On the unmodified file, `bun bd test test/bundler/bun-build-compile.test.ts` at 9fcdea80b1:

```
(fail) Bun.build compile > compile with relative outfile paths [5523.70ms]
  ^ this test timed out after 5000ms.
(pass) Bun.build compile > compile with embedded resources uses correct module prefix [5227.91ms]
```

The failure is intermittent (the session that reported it saw it in about 1 run in 3, with the passing runs taking 7.0s to 7.2s). The compile step runs on the JS thread inside the bundle completion task (`do_compilation` is called from `JSBundleCompletionTask::on_complete`), so the timeout can only be observed between compiles: when the first two compiles add up to more than 5s the test fails after the second one, otherwise the third compile starts and the test finishes late but passes. The third compile of a timed-out run also keeps going and slows down the next test, which is why "embedded resources" shows 5.2s above and 2.5s once this is fixed.

This only affects the 5s default used by a plain `bun test` / `bun bd test` run; the CI runner passes a much larger `--timeout`, and with a release binary each compile takes about 0.13s.

### Fix

Turn the three cases into a `test.each`, so every test does exactly one compile, the same shape as the rest of the file. The per-test timeout is left at the default rather than raised: the workload per test is what was out of proportion.

While rewriting the assertion, the three `toContain` / `toEndWith` checks on the reported path become an exact comparison against the outfile that was passed in (`.exe` appended on Windows; with no `outdir` the artifact path is the outfile verbatim), and each case also checks that the executable exists at that path, which is what the nested `output/nested/` and `a/b/c/d/` cases are there to prove. Nothing else in the file changes.

### Verification

`bun bd test test/bundler/bun-build-compile.test.ts` (debug+ASAN), two runs, 14 pass / 1 skip each, about 40s per run:

```
(pass) Bun.build compile > compile writes the executable to outfile output/nested/app1 [2567.03ms]
(pass) Bun.build compile > compile writes the executable to outfile app2 [2576.66ms]
(pass) Bun.build compile > compile writes the executable to outfile a/b/c/d/app3 [2590.81ms]
(pass) Bun.build compile > compile with embedded resources uses correct module prefix [2501.16ms]
```

The same file also passes with a release bun on Linux (`USE_SYSTEM_BUN=1`) and on Windows Server 2019 x64 (release bun 1.4.0, where the exact path assertion exercises the `.exe` branch).

Related: #37389 raises this test's timeout to 60s as a side change of an unrelated fix; whichever lands second drops or rebases a one-line hunk. #37397 fixes the neighbouring "embedded resources" test in the same file and does not overlap with this hunk.
