### PR TITLE
node:fs: release the { signal } of readFile/writeFile on the JS thread, not on the pool

### DIFF
--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -115,7 +115,7 @@ impl AbortSignal {
         WebCore__AbortSignal__decrementPendingActivity(self)
     }
 
-    /// This function is not threadsafe. aborted is a boolean, not an atomic!
+    /// Readable from any thread (an atomic load); whoever calls it keeps the signal alive.
     pub fn aborted(&self) -> bool {
         WebCore__AbortSignal__aborted(self)
     }

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -86,7 +86,8 @@ public:
     void signalAbort(JSC::JSGlobalObject* globalObject, CommonAbortReason reason);
     void signalAbort(JSC::JSValue reason);
 
-    bool aborted() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::Aborted); }
+    // Readable from any thread (thread-pool work polls it); the caller keeps the signal alive.
+    bool aborted() const { return flags() & static_cast<uint8_t>(AbortSignalFlags::Aborted); }
     void markAborted(JSC::JSValue reason);
     void runAbortSteps();
 
@@ -102,8 +103,8 @@ public:
     }
 
     bool hasActiveTimeoutTimer() const { return m_timeout != nullptr; }
-    bool hasAbortEventListener() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener); }
-    bool isFiringEventListeners() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners); }
+    bool hasAbortEventListener() const { return flags() & static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener); }
+    bool isFiringEventListeners() const { return flags() & static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners); }
 
     // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
@@ -147,7 +148,7 @@ public:
         m_timeoutObserverCount.fetch_sub(1, std::memory_order_relaxed);
     }
     bool hasPendingActivity() const { return pendingActivityCount > 0; }
-    bool isDependent() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::Dependent); }
+    bool isDependent() const { return flags() & static_cast<uint8_t>(AbortSignalFlags::Dependent); }
 
     size_t memoryCost() const;
 
@@ -166,31 +167,19 @@ private:
     void releaseSourceObserverCounts();
     void cancelTimer();
 
-    void applyFlags(uint8_t flags) { m_flags |= flags; }
-    void setIsDependent(bool isDependent)
+    // Written on the owning thread only; also read by GC marker threads (JSAbortSignalOwner) and by thread-pool work (aborted()).
+    uint8_t flags() const { return m_flags.load(std::memory_order_relaxed); }
+    void applyFlags(uint8_t bits) { m_flags.fetch_or(bits, std::memory_order_relaxed); }
+    void setFlag(AbortSignalFlags flag, bool on)
     {
-        if (isDependent) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::Dependent);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::Dependent);
-        }
+        if (on)
+            m_flags.fetch_or(static_cast<uint8_t>(flag), std::memory_order_relaxed);
+        else
+            m_flags.fetch_and(static_cast<uint8_t>(~static_cast<uint8_t>(flag)), std::memory_order_relaxed);
     }
-    void setHasAbortEventListener(bool hasAbortEventListener)
-    {
-        if (hasAbortEventListener) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener);
-        }
-    }
-    void setIsFiringEventListeners(bool isFiringEventListeners)
-    {
-        if (isFiringEventListeners) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners);
-        }
-    }
+    void setIsDependent(bool isDependent) { setFlag(AbortSignalFlags::Dependent, isDependent); }
+    void setHasAbortEventListener(bool hasAbortEventListener) { setFlag(AbortSignalFlags::HasAbortEventListener, hasAbortEventListener); }
+    void setIsFiringEventListeners(bool isFiringEventListeners) { setFlag(AbortSignalFlags::IsFiringEventListeners, isFiringEventListeners); }
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return AbortSignalEventTargetInterfaceType; }
@@ -219,7 +208,7 @@ private:
     std::atomic<uint32_t> m_timeoutObserverCount { 0 };
     uint32_t m_algorithmIdentifier { 0 };
     AbortSignalTimeout m_timeout { nullptr };
-    uint8_t m_flags { 0 };
+    std::atomic<uint8_t> m_flags { 0 };
 };
 
 WebCoreOpaqueRoot root(AbortSignal*);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -143,11 +143,6 @@ type BlobSizeType = u64;
 /// `maxInt(u52)` == 2^52 - 1.
 const BLOB_SIZE_MAX: u64 = (1u64 << 52) - 1;
 
-/// `webcore.RefPtr<AbortSignal>` — JSC's intrusive ref-counted pointer.
-/// Backed by `bun_ptr::ExternalShared<AbortSignal>` (alias re-exported
-/// from `bun_jsc`): `Clone` → `ref()`, `Drop` → `unref()`, `Deref` → `&AbortSignal`.
-use bun_jsc::AbortSignalRef;
-
 // Wired to the real sibling modules under `super::` (rather than a
 // `bun_jsc::node` re-export shim) so this file compiles standalone.
 use super::stat::Stats;
@@ -467,11 +462,6 @@ pub(crate) const DEFAULT_PERMISSION: Mode = sys::S::IRUSR as Mode
 #[cfg(not(unix))]
 // Windows does not have permissions
 pub(crate) const DEFAULT_PERMISSION: Mode = 0;
-
-// `AbortSignalRef` (= `ExternalShared<AbortSignal>`) implements `Deref`, so
-// `signal.pending_activity_ref()` / `signal.aborted()` resolve directly to the
-// `&AbortSignal` inherent methods — the former `AbortSignalRefExt` shim with
-// per-call `unsafe { self.as_ref() }` is gone. `unref()` is handled by `Drop`.
 
 /// All async FS functions are run in a thread pool, but some implementations may
 /// decide to do something slightly different. For example, reading a file has
@@ -1019,6 +1009,10 @@ mod _async_tasks {
         fn signal(&self) -> Option<&AbortSignal> {
             None
         }
+        /// For the job's JS side; the arguments keep only the pointer they poll.
+        fn take_signal(&mut self) -> Option<args::SignalHold> {
+            None
+        }
     }
 
     /// Forward [`FsArgument`] to the inherent `from_js` / `to_thread_safe`
@@ -1075,7 +1069,7 @@ mod _async_tasks {
     );
     // `ReadFile`/`WriteFile` carry an `AbortSignal` field — opt them in so the
     // `const _ = assert!(…::HAVE_ABORT_SIGNAL)` invariants in `async_` hold and
-    // `signal()` exposes it to `AsyncFSTask::run_from_js_thread`.
+    // `signal()` / `take_signal()` expose it to the async entry points.
     impl FsArgument for args::ReadFile {
         const HAVE_ABORT_SIGNAL: bool = true;
         #[inline]
@@ -1088,7 +1082,11 @@ mod _async_tasks {
         }
         #[inline]
         fn signal(&self) -> Option<&AbortSignal> {
-            self.signal.as_deref()
+            self.signal.as_ref().map(args::Signal::get)
+        }
+        #[inline]
+        fn take_signal(&mut self) -> Option<args::SignalHold> {
+            self.signal.as_mut().and_then(args::Signal::take_hold)
         }
     }
     impl FsArgument for args::WriteFile {
@@ -1103,7 +1101,11 @@ mod _async_tasks {
         }
         #[inline]
         fn signal(&self) -> Option<&AbortSignal> {
-            self.signal.as_deref()
+            self.signal.as_ref().map(args::Signal::get)
+        }
+        #[inline]
+        fn take_signal(&mut self) -> Option<args::SignalHold> {
+            self.signal.as_mut().and_then(args::Signal::take_hold)
         }
     }
     impl FsArgument for args::AppendFile {
@@ -1119,7 +1121,11 @@ mod _async_tasks {
         }
         #[inline]
         fn signal(&self) -> Option<&AbortSignal> {
-            self.0.signal.as_deref()
+            FsArgument::signal(&self.0)
+        }
+        #[inline]
+        fn take_signal(&mut self) -> Option<args::SignalHold> {
+            FsArgument::take_signal(&mut self.0)
         }
     }
 
@@ -1242,6 +1248,8 @@ mod _async_tasks {
     pub struct AsyncFSJs {
         pub(crate) promise: JSPromiseStrong,
         pub(crate) tracker: AsyncTaskTracker,
+        /// readFile/writeFile/appendFile's `{ signal }`, released with the rest of the JS side.
+        pub(crate) signal: Option<args::SignalHold>,
     }
 
     impl<R: FsReturn + 'static, A: FsArgument + 'static, const F: NodeFSFunctionEnum>
@@ -1292,7 +1300,7 @@ mod _async_tasks {
             promise_value.ensure_still_alive();
 
             if Self::HAVE_ABORT_SIGNAL {
-                if let Some(signal) = this.args.signal() {
+                if let Some(signal) = js.signal.as_ref().map(args::SignalHold::signal) {
                     if let Some(abort_error) = signal.node_abort_error_if_aborted(global_object) {
                         return Ok(promise.reject(global_object, Ok(abort_error))?);
                     }
@@ -1323,13 +1331,14 @@ mod _async_tasks {
         pub(crate) fn create(
             global_object: &JSGlobalObject,
             _binding: &Binding,
-            args: A,
+            mut args: A,
             vm: &mut VirtualMachine,
         ) -> JSValue {
             let tracker = AsyncTaskTracker::init(vm);
             tracker.did_schedule(global_object);
             let promise = JSPromiseStrong::init(global_object);
             let value = promise.value();
+            let signal = args.take_signal();
             bun_jsc::Job::<Self>::schedule(
                 &global_object.js_thread(),
                 Self {
@@ -1338,7 +1347,11 @@ mod _async_tasks {
                     // may be niche-optimised; never construct an all-zero `Result`.
                     result: Err(sys::Error::default()),
                 },
-                AsyncFSJs { promise, tracker },
+                AsyncFSJs {
+                    promise,
+                    tracker,
+                    signal,
+                },
             );
             value
         }
@@ -2402,7 +2415,11 @@ mod _async_tasks {
                     pending_err: None,
                     pending_err_mutex: bun_threading::Mutex::default(),
                 },
-                AsyncFSJs { promise, tracker },
+                AsyncFSJs {
+                    promise,
+                    tracker,
+                    signal: None,
+                },
             );
             value
         }
@@ -4033,6 +4050,61 @@ pub mod args {
         }
     }
 
+    /// `{ signal }`: the operation polls `aborted()` through the pointer; the hold is JS-thread state.
+    pub struct Signal {
+        ptr: bun_jsc::JsPtr<AbortSignal>,
+        /// `None` once an async call moved it onto the job's JS side ([`FsArgument::take_signal`]).
+        hold: Option<SignalHold>,
+    }
+    impl Signal {
+        /// JS thread; `None` if `value` is not an `AbortSignal`.
+        fn from_js(value: JSValue) -> Option<Self> {
+            let ptr = NonNull::new(AbortSignal::from_js(value)?)?;
+            // SAFETY: `hold` protects the wrapper that owns the signal until it is
+            // released on the JS thread (with the arguments, or the job's JS side),
+            // and the wrapper is only finalized by a later GC or the VM's destruction,
+            // i.e. after any body still polling through this pointer has finished.
+            let ptr = unsafe { bun_jsc::JsPtr::new(ptr) };
+            Some(Self {
+                ptr,
+                hold: Some(SignalHold::new(value, ptr)),
+            })
+        }
+        pub(crate) fn get(&self) -> &AbortSignal {
+            AbortSignal::opaque_ref(self.ptr.as_ptr())
+        }
+        pub(crate) fn aborted(&self) -> bool {
+            self.get().aborted()
+        }
+        pub(crate) fn take_hold(&mut self) -> Option<SignalHold> {
+            self.hold.take()
+        }
+    }
+
+    /// Keeps `{ signal }` alive and counted as pending activity while an operation uses it; JS thread only.
+    #[derive(bun_jsc::JsAffine)]
+    pub struct SignalHold {
+        signal: bun_jsc::JsPtr<AbortSignal>,
+        _wrapper: bun_jsc::Protected,
+    }
+    impl SignalHold {
+        fn new(wrapper: JSValue, signal: bun_jsc::JsPtr<AbortSignal>) -> Self {
+            AbortSignal::opaque_ref(signal.as_ptr()).pending_activity_ref();
+            Self {
+                signal,
+                _wrapper: bun_jsc::Protected::new(wrapper),
+            }
+        }
+        pub(crate) fn signal(&self) -> &AbortSignal {
+            AbortSignal::opaque_ref(self.signal.as_ptr())
+        }
+    }
+    impl Drop for SignalHold {
+        fn drop(&mut self) {
+            self.signal().pending_activity_unref();
+        }
+    }
+
     /// Asynchronously reads the entire contents of a file.
     /// @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
     /// If a file descriptor is provided, the underlying file will _not_ be closed automatically.
@@ -4045,7 +4117,7 @@ pub mod args {
         pub(crate) max_size: Option<BlobSizeType>,
         pub(crate) limit_size_for_javascript: bool,
         pub(crate) flag: FileSystemFlags,
-        pub(crate) signal: Option<AbortSignalRef>,
+        pub(crate) signal: Option<Signal>,
     }
     impl Default for ReadFile {
         fn default() -> Self {
@@ -4060,19 +4132,10 @@ pub mod args {
             }
         }
     }
-    impl Drop for ReadFile {
-        fn drop(&mut self) {
-            // Release the AbortSignal ref taken in `from_js`.
-            if let Some(signal) = self.signal.take() {
-                signal.pending_activity_unref();
-            }
-        }
-    }
     impl Unprotect for ReadFile {
         #[inline]
         fn unprotect(&mut self) {
             self.path.unprotect();
-            // Signal unref handled by `Drop` (idempotent via `.take()`).
         }
     }
     impl ReadFile {
@@ -4080,7 +4143,7 @@ pub mod args {
             self.path.to_thread_safe();
         }
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<ReadFile> {
-            // `Drop` on `path` covers every
+            // `Drop` on `path` (and `signal`) covers every
             // `?`-propagated JsError below.
             let path = PathOrFileDescriptor::from_js(ctx, arguments)?.ok_or_else(|| {
                 ctx.throw_invalid_arguments(format_args!(
@@ -4089,11 +4152,7 @@ pub mod args {
             })?;
             let mut encoding = Encoding::Buffer;
             let mut flag = FileSystemFlags::R;
-            let mut abort_signal = scopeguard::guard(None::<AbortSignalRef>, |s| {
-                if let Some(signal) = s {
-                    signal.pending_activity_unref(); /* unref via Drop */
-                }
-            });
+            let mut signal: Option<Signal> = None;
             if let Some(arg) = arguments.next() {
                 arguments.eat();
                 if arg.is_string() {
@@ -4104,9 +4163,8 @@ pub mod args {
                         flag = FileSystemFlags::from_js(ctx, flag_)?.unwrap_or(flag);
                     }
                     if let Some(value) = arg.get_truthy(ctx, "signal")? {
-                        if let Some(signal) = AbortSignal::ref_from_js(value) {
-                            signal.pending_activity_ref();
-                            *abort_signal = Some(signal);
+                        if let Some(parsed) = Signal::from_js(value) {
+                            signal = Some(parsed);
                         } else {
                             return Err(ctx.throw_invalid_argument_type_value(
                                 b"signal",
@@ -4117,21 +4175,17 @@ pub mod args {
                     }
                 }
             }
-            let abort_signal = scopeguard::ScopeGuard::into_inner(abort_signal);
             Ok(ReadFile {
                 path,
                 encoding,
                 flag,
                 limit_size_for_javascript: true,
-                signal: abort_signal,
+                signal,
                 ..Default::default()
             })
         }
         pub(crate) fn aborted(&self) -> bool {
-            if let Some(signal) = &self.signal {
-                return signal.aborted();
-            }
-            false
+            self.signal.as_ref().is_some_and(Signal::aborted)
         }
     }
 
@@ -4143,15 +4197,7 @@ pub mod args {
         /// Encoded at the time of construction.
         pub(crate) data: StringOrBuffer,
         pub(crate) dirfd: FD,
-        pub(crate) signal: Option<AbortSignalRef>,
-    }
-    impl Drop for WriteFile {
-        fn drop(&mut self) {
-            // Release the AbortSignal ref taken in `from_js`.
-            if let Some(signal) = self.signal.take() {
-                signal.pending_activity_unref();
-            }
-        }
+        pub(crate) signal: Option<Signal>,
     }
     impl WriteFile {
         pub(crate) fn to_thread_safe(&mut self) {
@@ -4163,7 +4209,6 @@ pub mod args {
         fn unprotect(&mut self) {
             self.file.unprotect();
             self.data.unprotect();
-            // Signal unref handled by `Drop` (idempotent via `.take()`).
         }
     }
     impl WriteFile {
@@ -4178,7 +4223,7 @@ pub mod args {
             arguments: &mut ArgumentsSlice,
             default_flag: FileSystemFlags,
         ) -> JsResult<WriteFile> {
-            // `Drop` on `path` covers every
+            // `Drop` on `path` (and `signal`) covers every
             // `?`-propagated JsError below.
             let path = PathOrFileDescriptor::from_js(ctx, arguments)?.ok_or_else(|| {
                 ctx.throw_invalid_arguments(format_args!(
@@ -4191,11 +4236,7 @@ pub mod args {
             let mut encoding = Encoding::Buffer;
             let mut flag = default_flag;
             let mut mode: Mode = DEFAULT_PERMISSION;
-            let mut abort_signal = scopeguard::guard(None::<AbortSignalRef>, |s| {
-                if let Some(signal) = s {
-                    signal.pending_activity_unref(); /* unref via Drop */
-                }
-            });
+            let mut signal: Option<Signal> = None;
             let mut flush = false;
             if data_value.is_string() {
                 encoding = Encoding::Utf8;
@@ -4213,9 +4254,8 @@ pub mod args {
                         mode = node::mode_from_js(ctx, mode_)?.unwrap_or(mode);
                     }
                     if let Some(value) = arg.get_truthy(ctx, "signal")? {
-                        if let Some(signal) = AbortSignal::ref_from_js(value) {
-                            signal.pending_activity_ref();
-                            *abort_signal = Some(signal);
+                        if let Some(parsed) = Signal::from_js(value) {
+                            signal = Some(parsed);
                         } else {
                             return Err(ctx.throw_invalid_argument_type_value(
                                 b"signal",
@@ -4241,22 +4281,18 @@ pub mod args {
             let is_async = arguments.will_be_async;
             let data = StringOrBuffer::from_js_with_encoding_maybe_async(ctx, data_value, encoding, is_async, allow_string_object)?
                 .ok_or_else(|| validators::throw_err_invalid_arg_type_with_message(ctx, format_args!("The \"data\" argument must be of type string or an instance of Buffer, TypedArray, or DataView")))?;
-            let abort_signal = scopeguard::ScopeGuard::into_inner(abort_signal);
             Ok(WriteFile {
                 file: path,
                 flag,
                 mode,
                 data,
                 dirfd: FD::cwd(),
-                signal: abort_signal,
+                signal,
                 flush,
             })
         }
         pub(crate) fn aborted(&self) -> bool {
-            if let Some(signal) = &self.signal {
-                return signal.aborted();
-            }
-            false
+            self.signal.as_ref().is_some_and(Signal::aborted)
         }
     }
 

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -86,11 +86,10 @@ fn read_from_blob(
         _ => return Err(ReadFromBlobError::NotAFile),
     };
     let mut fs = node_fs::NodeFS::default();
-    // `ReadFile` has a `Drop` impl (releases its `signal` ref), so functional
-    // record update from `..Default::default()` would partially move out of a
-    // `Drop` type. Mutate-after-default instead.
-    let mut read_args = node_fs::args::ReadFile::default();
-    read_args.path = file.pathlike.clone();
+    let read_args = node_fs::args::ReadFile {
+        path: file.pathlike.clone(),
+        ..Default::default()
+    };
     let maybe = fs.read_file_with_options(
         &read_args,
         node_fs::Flavor::Sync,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4021,12 +4021,13 @@ impl FormDataContext<'_> {
                             // `NodeFS` (it is stateless aside from a path scratch
                             // buffer; a per-VM cache would be purely a perf reuse).
                             let mut node_fs = crate::node::fs::NodeFS::default();
-                            // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
-                            let mut rf_args = crate::node::fs::args::ReadFile::default();
-                            rf_args.encoding = crate::node::types::Encoding::Buffer;
-                            rf_args.path = file.pathlike.clone();
-                            rf_args.offset = blob.offset.get();
-                            rf_args.max_size = Some(blob.size.get());
+                            let rf_args = crate::node::fs::args::ReadFile {
+                                encoding: crate::node::types::Encoding::Buffer,
+                                path: file.pathlike.clone(),
+                                offset: blob.offset.get(),
+                                max_size: Some(blob.size.get()),
+                                ..Default::default()
+                            };
                             let res = node_fs.read_file(&rf_args, crate::node::fs::Flavor::Sync);
                             match res {
                                 Err(err) => {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1791,12 +1791,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // with an `Fd` path only touches `self.sync_error_buf` for
             // path-variant inputs, so a fresh `NodeFS` is sufficient here.
             let mut node_fs = node::fs::NodeFS::default();
-            // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
-            let mut rf_args = node::fs::args::ReadFile::default();
-            rf_args.encoding = Encoding::Buffer;
-            rf_args.path = PathOrFileDescriptor::Fd(*opened_fd);
-            rf_args.offset = blob_offset;
-            rf_args.max_size = Some(blob_size);
+            let rf_args = node::fs::args::ReadFile {
+                encoding: Encoding::Buffer,
+                path: PathOrFileDescriptor::Fd(*opened_fd),
+                offset: blob_offset,
+                max_size: Some(blob_size),
+                ..Default::default()
+            };
             let res = node_fs.read_file(&rf_args, node::fs::Flavor::Sync);
 
             // Eagerly close before constructing the (potentially large) JS

--- a/test/js/node/fs/abort-signal-read-write-file-worker-teardown-fixture.ts
+++ b/test/js/node/fs/abort-signal-read-write-file-worker-teardown-fixture.ts
@@ -7,7 +7,10 @@
 // 2. A worker queues operations with { signal } behind them and is terminated,
 //    tearing its VM down while they are still queued.
 // 3. Close the write ends: the pool drains and frees the dead worker's jobs.
-import { closeSync, openSync, promises } from "node:fs";
+//    Jobs released that way never run, so none of the worker's writes may have
+//    produced a file; a count above zero means they were not queued behind the
+//    parked threads after all and the run proved nothing.
+import { closeSync, openSync, promises, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { Worker } from "node:worker_threads";
 
@@ -58,4 +61,6 @@ console.log("worker torn down");
 
 for (const fd of writeEnds) closeSync(fd);
 await Promise.all(parked);
-console.log("pool drained");
+const inputs = new Set(["data.txt", "fifo-a", "fifo-b"]);
+const workerWrites = readdirSync(dir).filter(name => !inputs.has(name)).length;
+console.log(`pool drained, worker writes that ran: ${workerWrites}`);

--- a/test/js/node/fs/abort-signal-read-write-file-worker-teardown-fixture.ts
+++ b/test/js/node/fs/abort-signal-read-write-file-worker-teardown-fixture.ts
@@ -1,0 +1,61 @@
+// Spawned by promises.test.js with UV_THREADPOOL_SIZE=2 (see the test for what
+// this checks).
+//
+// 1. Park both pool threads in a readFile() of a FIFO each. open("w") on a
+//    FIFO returns once the reader has it open, so after that both threads are
+//    inside those reads until the write ends are closed.
+// 2. A worker queues operations with { signal } behind them and is terminated,
+//    tearing its VM down while they are still queued.
+// 3. Close the write ends: the pool drains and frees the dead worker's jobs.
+import { closeSync, openSync, promises } from "node:fs";
+import { join } from "node:path";
+import { Worker } from "node:worker_threads";
+
+const dir = process.argv[2];
+const fifos = [join(dir, "fifo-a"), join(dir, "fifo-b")];
+
+const parked = fifos.map(fifo => promises.readFile(fifo));
+const writeEnds = fifos.map(fifo => openSync(fifo, "w"));
+console.log("pool parked");
+
+const worker = new Worker(
+  `
+  const fs = require("node:fs");
+  const { parentPort, workerData: dir } = require("node:worker_threads");
+  const ignore = () => {};
+  const keep = [];
+  for (let i = 0; i < 4; i++) {
+    // Aborted after the operations were queued: the reason is a JS value the
+    // signal holds through a GC handle.
+    const aborted = new AbortController();
+    // A JS abort listener registered on the signal.
+    const listened = new AbortController();
+    listened.signal.addEventListener("abort", ignore);
+    // Owns a timer on this worker's event loop.
+    const timeout = AbortSignal.timeout(60_000);
+    for (const signal of [aborted.signal, listened.signal, timeout]) {
+      fs.promises.readFile(dir + "/data.txt", { signal }).catch(ignore);
+      fs.promises.writeFile(dir + "/write-" + i + ".txt", "x", { signal }).catch(ignore);
+      fs.promises.appendFile(dir + "/append-" + i + ".txt", "x", { signal }).catch(ignore);
+      fs.readFile(dir + "/data.txt", { signal }, ignore);
+      fs.writeFile(dir + "/cb-write-" + i + ".txt", "x", { signal }, ignore);
+    }
+    aborted.abort(new Error("aborted after queueing"));
+    keep.push(aborted, listened, timeout);
+  }
+  parentPort.postMessage("queued");
+  `,
+  { eval: true, workerData: dir },
+);
+
+const { promise: queued, resolve, reject } = Promise.withResolvers<void>();
+worker.once("message", () => resolve());
+worker.once("error", reject);
+worker.once("exit", code => reject(new Error(`worker exited with code ${code} before queueing its operations`)));
+await queued;
+await worker.terminate();
+console.log("worker torn down");
+
+for (const fd of writeEnds) closeSync(fd);
+await Promise.all(parked);
+console.log("pool drained");

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -1,4 +1,6 @@
-import { tempDir, tempDirWithFiles } from "harness";
+import { heapStats } from "bun:jsc";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkfifo } from "mkfifo";
 import { join } from "path";
 const assert = require("assert");
 const os = require("os");
@@ -551,3 +553,82 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     expectNodeAbortError(writeErr, signal.reason);
   });
 });
+
+// Every entry point taking { signal } keeps the signal alive (GC protection on
+// the wrapper) and counted as pending activity only until it has finished. A
+// leaked protection pins every wrapper; a leaked pending-activity count still
+// pins the ones with a JS abort listener and the timeout ones (pending activity
+// counts as observing the timeout), so either shows up as uncollectable wrappers.
+test("readFile/writeFile/appendFile release their signal once they have finished", async () => {
+  await using dir = tempDir("fs-signal-release", { "f.txt": "hello" });
+  const file = join(dir, "f.txt");
+  const out = join(dir, "out.txt");
+  const liveSignals = () => {
+    Bun.gc(true);
+    return heapStats().objectTypeCounts.AbortSignal ?? 0;
+  };
+  const before = liveSignals();
+
+  const iterations = 10;
+  for (let i = 0; i < iterations; i++) {
+    const plain = new AbortController().signal;
+    const listened = new AbortController().signal;
+    listened.addEventListener("abort", () => {});
+    const timeout = AbortSignal.timeout(60_000);
+    for (const signal of [plain, listened, timeout]) {
+      await fsPromises.readFile(file, { signal });
+      await fsPromises.writeFile(out, "x", { signal });
+      await fsPromises.appendFile(out, "x", { signal });
+      await new Promise((resolve, reject) => fs.readFile(file, { signal }, err => (err ? reject(err) : resolve())));
+      await new Promise((resolve, reject) =>
+        fs.writeFile(out, "x", { signal }, err => (err ? reject(err) : resolve())),
+      );
+      fs.readFileSync(file, { signal });
+      fs.writeFileSync(out, "x", { signal });
+    }
+  }
+
+  // The weakest leak pins two signals per iteration; a healthy run keeps at most
+  // the last iteration's three alive.
+  expect(liveSignals() - before).toBeLessThan(iterations);
+});
+
+// A readFile/writeFile/appendFile with { signal } is on the thread pool while
+// pending. When the worker that started it is torn down while it is still
+// queued, the pool thread that later frees the job must not be what releases
+// the signal: its refcount, abort listeners, reason and the timer of
+// AbortSignal.timeout() all belong to the JS thread that is gone by then.
+// Release builds die on WebCore's thread check, ASAN builds on the freed GC
+// handles. The fixture parks the whole (two-thread) pool on FIFOs first so the
+// worker's operations are guaranteed to still be queued when it is terminated.
+// Starting and tearing down a worker alone takes ~3s on a debug build.
+test.skipIf(isWindows)(
+  "signals of operations still queued on the pool when their worker is torn down",
+  async () => {
+    using dir = tempDir("fs-signal-worker-teardown", { "data.txt": "data" });
+    mkfifo(join(String(dir), "fifo-a"));
+    mkfifo(join(String(dir), "fifo-b"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "abort-signal-read-write-file-worker-teardown-fixture.ts"), String(dir)],
+      env: {
+        ...bunEnv,
+        UV_THREADPOOL_SIZE: "2",
+        // JSC/WebCore memory is libpas-backed and invisible to ASAN otherwise.
+        // Leak detection stays off: under Malloc=1 LSan reports WTF's
+        // process-lifetime allocations.
+        Malloc: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+      stdout: "pool parked\nworker torn down\npool drained\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  30_000,
+);

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -471,6 +471,34 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     }
   });
 
+  // The operation itself has to keep the signal's wrapper alive (it shows up as
+  // a protected AbortSignal while in flight): the reason is only reachable
+  // through the wrapper, so if the caller keeps nothing and a GC runs before the
+  // operation settles, the rejection would lose its cause. Nothing here may hold
+  // the controller, the signal or the reason, or the GC would not be the one
+  // deciding.
+  test("readFile aborted while in flight keeps its reason when the caller holds nothing", async () => {
+    await using dir = tempDir("fs-abort-readfile-gc", { "f.txt": "hello" });
+    const protectedSignals = () => heapStats().protectedObjectTypeCounts.AbortSignal ?? 0;
+    const protectedBefore = protectedSignals();
+    function startAndAbort() {
+      const ac = new AbortController();
+      const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
+      ac.abort(new Error("stop"));
+      return promise;
+    }
+    const promise = startAndAbort();
+    expect(protectedSignals() - protectedBefore).toBe(1);
+    Bun.gc(true);
+    Bun.gc(true);
+    const outcome = await promise.then(
+      () => "resolved",
+      err => ({ code: err.code, cause: err.cause?.message }),
+    );
+    expect(outcome).toEqual({ code: "ABORT_ERR", cause: "stop" });
+    expect(protectedSignals()).toBe(protectedBefore);
+  });
+
   // abort() with no reason stores the signal's lazily-created DOMException in a
   // common-reason slot; the cause must still be that exact object, not a copy.
   test("readFile aborted while in flight with the default abort reason", async () => {
@@ -558,7 +586,8 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
 // the wrapper) and counted as pending activity only until it has finished. A
 // leaked protection pins every wrapper; a leaked pending-activity count still
 // pins the ones with a JS abort listener and the timeout ones (pending activity
-// counts as observing the timeout), so either shows up as uncollectable wrappers.
+// counts as observing the timeout), so either shows up as uncollectable wrappers;
+// the protection is also counted directly.
 test("readFile/writeFile/appendFile release their signal once they have finished", async () => {
   await using dir = tempDir("fs-signal-release", { "f.txt": "hello" });
   const file = join(dir, "f.txt");
@@ -567,7 +596,9 @@ test("readFile/writeFile/appendFile release their signal once they have finished
     Bun.gc(true);
     return heapStats().objectTypeCounts.AbortSignal ?? 0;
   };
+  const protectedSignals = () => heapStats().protectedObjectTypeCounts.AbortSignal ?? 0;
   const before = liveSignals();
+  const protectedBefore = protectedSignals();
 
   const iterations = 10;
   for (let i = 0; i < iterations; i++) {
@@ -588,6 +619,7 @@ test("readFile/writeFile/appendFile release their signal once they have finished
     }
   }
 
+  expect(protectedSignals()).toBe(protectedBefore);
   // The weakest leak pins two signals per iteration; a healthy run keeps at most
   // the last iteration's three alive.
   expect(liveSignals() - before).toBeLessThan(iterations);
@@ -625,7 +657,7 @@ test.skipIf(isWindows)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
-      stdout: "pool parked\nworker torn down\npool drained\n",
+      stdout: "pool parked\nworker torn down\npool drained, worker writes that ran: 0\n",
       stderr: "",
       exitCode: 0,
     });


### PR DESCRIPTION
### Symptom

`fs.readFile` / `fs.promises.readFile` / `writeFile` / `appendFile` called with `{ signal }` inside a worker that is torn down (terminate(), process.exit(), uncaught error) while those operations are still queued on the thread pool crash the process once the pool gets to them. Same thing on the main thread under `BUN_DESTRUCT_VM_ON_EXIT=1`. Affects every platform (these ops use `AsyncFSTask` everywhere).

Repro: `test/js/node/fs/abort-signal-read-write-file-worker-teardown-fixture.ts`, run with `UV_THREADPOOL_SIZE=2`. It parks both pool threads in a `readFile()` of a FIFO (the `open("w")` handshake proves they are inside those reads), has a worker queue readFile/writeFile/appendFile calls with three kinds of signals behind them, terminates the worker, then closes the FIFOs. On main, a debug build dies with both of these at once (one per pool thread):

```
ASSERTION FAILED: Thread::mayBeGCThread()
src/jsc/bindings/webcore/EventListenerMap.h(77) : void WebCore::EventListenerMap::releaseAssertOrSetThreadUID()

panic: VirtualMachine.get() called with no VM on this thread
```

with the stack `<bun_runtime::node::fs::args::ReadFile as Drop>::drop` -> `ExternalShared<AbortSignal>::drop` -> `WebCore__AbortSignal__unref` -> `WebCore::AbortSignal::~AbortSignal()` on a pool thread. The first is a `RELEASE_ASSERT`, so release builds die the same way for a signal that has abort listeners.

### Cause

`args::ReadFile` / `args::WriteFile` owned the `AbortSignalRef` (and the pending-activity count), and the arguments are part of the job's off-thread half. `job.rs` releases a job's JS side on the VM's own thread at teardown and leaves the off-thread half to whoever holds it; for a job still queued on the pool that is a pool thread, after the VM, its heap and the signal's wrapper are gone. The job's ref is the last one by then, so `~AbortSignal()` runs on the pool thread against a dead VM:

- a signal with abort listeners: `~EventTarget` trips `EventListenerMap`'s thread check (release assert), and each `JSEventListener` releases a `JSC::Weak` into the freed heap;
- an aborted signal: `m_reason` releases a `JSC::Weak` into the freed heap (heap corruption in release);
- `AbortSignal.timeout()`: `cancelTimer()` -> `AbortSignal__Timeout__deinit` resolves the VM through the calling thread's thread-local, which a pool thread does not have;
- in every case the non-atomic refcount is decremented off its thread.

### Fix

The arguments keep only a pointer to the signal, and the only thing the operation does with it is poll `aborted()`. The flags byte behind `aborted()` is `std::atomic` now (relaxed; GC marker threads were already reading it through `JSAbortSignalOwner`), so the pool's poll is a plain atomic load instead of the racy byte read it was before.

Keeping the signal alive while the operation is pending is `args::SignalHold`: GC protection on the wrapper plus the pending-activity count the code already took (it is what marks a timeout signal as observed). It is taken when the arguments are parsed and released on the JS thread in every case: a synchronous call drops it with the arguments, and `AsyncFSTask::create` moves it onto the job's JS side (`AsyncFSJs.signal`), which the completion releases, or `JobList::release_all_js` at teardown, same as the promise. The off-thread half of a job freed after its VM is gone holds nothing of the signal any more. No allocation, no listener.

Why the retention is a protection on the wrapper rather than a ref of our own held on the JS side: teardown releases the JS sides (`release_all_js`) before `VmHandle::close()` waits for bodies still running on the pool. Unprotecting only makes the wrapper collectible, and nothing collects it before the VM is destroyed, which happens after those bodies have finished, so a body still polling keeps reading a live signal; that is the same thing every other job's off-thread pointers rely on. Dropping what might be the last ref at that point would free the signal under a running body (a signal whose wrapper was already collected mid-operation, e.g. a throwaway controller).

`ReadFile`/`WriteFile` no longer need a `Drop` impl; the three `ReadFile::default()`-then-assign sites that existed because of it are struct literals now (clippy's `field_reassign_with_default` fires on them otherwise).

### Tests

In `test/js/node/fs/promises.test.js`:

- "signals of operations still queued on the pool when their worker is torn down" (POSIX; the FIFO setup makes the queued state deterministic, and the fixture reports how many of the worker's writes ran, which must be 0 since released jobs never run: without `UV_THREADPOOL_SIZE=2` it reports 12, so a run that did not actually park the pool fails instead of passing vacuously). Fails on main as above (a release build of main dies in ~170ms), passes with the fix. Runs the child with `Malloc=1` so the heap side is visible to ASAN as well.
- "readFile aborted while in flight keeps its reason when the caller holds nothing" (all platforms): a readFile whose controller, signal and reason are referenced by nothing else. While it is in flight exactly one AbortSignal is protected (`heapStats().protectedObjectTypeCounts`), after two GCs the rejection still carries its cause, and afterwards the protection is gone. Fails on main: nothing is protected, and on a release build of main the cause also comes back `undefined` (20/20; the reason is only reachable through the wrapper, which nothing kept alive).
- "readFile/writeFile/appendFile release their signal once they have finished": plain, listener-bearing and timeout signals through all seven signal-taking entry points (promise, callback and sync forms); afterwards the protected count is back at its baseline and a GC plus a wrapper count checks the pending activity (a count that is never released pins two of the three per iteration; verified by temporarily removing the unref: 51 live against a bound of 25 at the time). Passes before and after; it guards the release side of the new ownership.

Also green locally on the debug/ASAN build: `fs.test.ts`, `promises.test.js`, `test/js/web/abort/`, the fetch abort tests, `worker-refused-completion.test.ts`, the Node `test-fs-{promises-,}readfile*` / `writefile*` files; `cargo clippy -p bun_runtime`, clang-format on the header, and a `cargo check` of the Windows target.

Related but different: #36259 and #35021 add more `aborted()` polls between chunks and compose with this. #36983 / #37170 / #34154 predate #37075's job model and address in-flight or blocked work; #37170's refused-post disposal also leaks the signal ref with `ManuallyDrop` instead of releasing it, which this supersedes (its signal arm can be dropped on rebase).
