### PR TITLE
bun-types: fix Bun.build JSDoc examples that do not type-check (compile, metafile, loader)

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3150,13 +3150,15 @@ declare module "bun" {
     files?: Record<string, string | Blob | NodeJS.TypedArray | ArrayBufferLike>;
 
     /**
-     * Generate a JSON file containing metadata about the build.
+     * Generate metadata about the build.
      *
      * The metafile contains information about inputs, outputs, imports, and exports
      * which can be used for bundle analysis, visualization, or integration with
      * other tools.
      *
-     * When `true`, the metafile JSON string is included in the {@link BuildOutput.metafile} property.
+     * When `true`, the metafile is returned as the {@link BuildOutput.metafile}
+     * object (a {@link BuildMetafile}, not a JSON string); serialize it with
+     * `JSON.stringify` to write it to disk.
      *
      * @default false
      *
@@ -3168,15 +3170,13 @@ declare module "bun" {
      *   metafile: true,
      * });
      *
-     * // Write metafile to disk for analysis
      * if (result.metafile) {
-     *   await Bun.write('./dist/meta.json', result.metafile);
-     * }
+     *   console.log('Input files:', Object.keys(result.metafile.inputs));
+     *   console.log('Output files:', Object.keys(result.metafile.outputs));
      *
-     * // Parse and analyze the metafile
-     * const meta = JSON.parse(result.metafile!);
-     * console.log('Input files:', Object.keys(meta.inputs));
-     * console.log('Output files:', Object.keys(meta.outputs));
+     *   // Write the metafile to disk for analysis tools
+     *   await Bun.write('./dist/meta.json', JSON.stringify(result.metafile));
+     * }
      * ```
      */
     metafile?: boolean;
@@ -3186,8 +3186,12 @@ declare module "bun" {
     /**
      * Create a standalone executable or self-contained HTML.
      *
-     * When `true`, creates an executable for the current platform.
-     * When a target string, creates an executable for that platform.
+     * When `true`, creates an executable for the current platform. When a
+     * {@link Bun.Build.CompileTarget} string such as `"bun-linux-x64"`,
+     * cross-compiles for that platform. Both name the executable after the
+     * entrypoint; pass a {@link CompileBuildOptions} object to choose the output
+     * path (`outfile` lives in that object, `Bun.build()` has no top-level
+     * `outfile`) and other executable options.
      *
      * When used with `target: "browser"`, produces self-contained HTML files
      * with all scripts, styles, and assets inlined. All `<script>` tags become
@@ -3197,20 +3201,25 @@ declare module "bun" {
      *
      * @example
      * ```ts
-     * // Create executable for current platform
+     * // Create an executable for the current platform
      * await Bun.build({
      *   entrypoints: ['./app.js'],
-     *   compile: {
-     *     target: 'linux-x64',
-     *   },
-     *   outfile: './my-app'
+     *   compile: true,
      * });
      *
      * // Cross-compile for Linux x64
      * await Bun.build({
      *   entrypoints: ['./app.js'],
-     *   compile: 'linux-x64',
-     *   outfile: './my-app'
+     *   compile: 'bun-linux-x64',
+     * });
+     *
+     * // Cross-compile and choose the output path
+     * await Bun.build({
+     *   entrypoints: ['./app.js'],
+     *   compile: {
+     *     target: 'bun-linux-x64',
+     *     outfile: './my-app',
+     *   },
      * });
      *
      * // Produce self-contained HTML

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3188,10 +3188,12 @@ declare module "bun" {
      *
      * When `true`, creates an executable for the current platform. When a
      * {@link Bun.Build.CompileTarget} string such as `"bun-linux-x64"`,
-     * cross-compiles for that platform. Both name the executable after the
-     * entrypoint; pass a {@link CompileBuildOptions} object to choose the output
-     * path (`outfile` lives in that object, `Bun.build()` has no top-level
-     * `outfile`) and other executable options.
+     * cross-compiles for that platform. Both derive the executable's name from
+     * the entrypoint (`app.ts` becomes `app`, or `app.exe` for Windows targets;
+     * an `index.*` entrypoint uses its directory's name instead). Pass a
+     * {@link CompileBuildOptions} object to set the output path explicitly
+     * (`outfile` lives in that object, `Bun.build()` has no top-level `outfile`)
+     * or any of the other executable options.
      *
      * When used with `target: "browser"`, produces self-contained HTML files
      * with all scripts, styles, and assets inlined. All `<script>` tags become
@@ -3988,8 +3990,8 @@ declare module "bun" {
    *   entrypoints: ['./src/index.tsx'],
    *   outdir: './dist',
    *   loader: {
-   *     '.png': 'dataurl',
-   *     '.svg': 'file',
+   *     '.png': 'file',
+   *     '.svg': 'text',
    *     '.txt': 'text',
    *     '.json': 'json'
    *   },

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -112,6 +112,66 @@ async function createIsolatedFixture(packages?: string[]): Promise<string> {
   return fixtureDir;
 }
 
+// Runs on debug builds too: spawning tsc over a file or two is cheap, unlike the
+// in-process LanguageService runs in `typeTest`.
+async function tsc(name: string, files: Record<string, string>) {
+  const checkDir = join(TEMP_DIR, name);
+  const tsconfig = structuredClone(sourceTsconfig);
+  tsconfig.include = Object.keys(files);
+  tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+  await mkdir(checkDir, { recursive: true });
+  await makeTree(checkDir, { ...files, "tsconfig.json": JSON.stringify(tsconfig, null, 2) });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+    env: bunEnv,
+    cwd: checkDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+/**
+ * The fenced code blocks of every `@example` tag on the members of the named
+ * interfaces in a bun-types declaration file, as one `.ts` file per example.
+ * Each file starts with a comment pointing back at the tag it came from.
+ */
+function jsdocExamples(declarationFile: string, interfaceNames: string[]): Record<string, string> {
+  const path = join(BUN_TYPES_PACKAGE_ROOT, declarationFile);
+  const source = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true);
+  const examples: Record<string, string> = {};
+
+  function visit(node: ts.Node) {
+    if (!ts.isInterfaceDeclaration(node) || !interfaceNames.includes(node.name.text)) {
+      ts.forEachChild(node, visit);
+      return;
+    }
+
+    for (const member of node.members) {
+      if (!member.name || !ts.isIdentifier(member.name)) continue;
+
+      let index = 0;
+      for (const tag of ts.getJSDocTags(member)) {
+        if (tag.tagName.text !== "example") continue;
+
+        const fence = /^```\w*\n([\s\S]*?)^```/m.exec(ts.getTextOfJSDocComment(tag.comment) ?? "");
+        if (!fence) continue;
+
+        const { line } = source.getLineAndCharacterOfPosition(tag.getStart());
+        examples[`${node.name.text}.${member.name.text}.${index++}.ts`] =
+          `// packages/bun-types/${declarationFile}:${line + 1}\n${fence[1]}\n`;
+      }
+    }
+  }
+
+  visit(source);
+  return examples;
+}
+
 function typeTest(name: string, config: TypeTestConfig) {
   // This file only tests the bun-types .d.ts, not bun's own code. Driving the
   // TypeScript LanguageService in-process under a debug build is ~40x slower,
@@ -358,37 +418,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
   describe("Bun.mmap", () => {
     test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      const result = await tsc("mmap-options-check", {
         "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
            view satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
       });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
+      expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
     });
+  });
+
+  describe("Bun.build", () => {
+    // The @example blocks are what editors show on hover, so they have to be
+    // valid against the types they document. The `compile` examples used to
+    // pass targets without the "bun-" prefix and put `outfile` at the top
+    // level, neither of which the types (or the runtime) accept.
+    //
+    // Explicit timeout: parsing the 10k-line bun.d.ts in-process takes a few
+    // seconds on a debug build (well under 1s on release).
+    test("JSDoc examples type-check against the declared types", async () => {
+      const examples = jsdocExamples("bun.d.ts", ["BuildConfig", "CompileBuildOptions", "BuildOutput"]);
+      expect(Object.keys(examples)).toContain("BuildConfig.compile.0.ts");
+
+      const result = await tsc("build-jsdoc-examples-check", examples);
+
+      expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    }, 30_000);
   });
 
   describe("Test Globals", () => {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -146,6 +146,44 @@ const EXAMPLE_FENCE_EXTENSIONS: Record<string, string> = {
 };
 
 /**
+ * The source text of each declaration of `name` in a .d.ts file, together with
+ * the JSDoc in front of it, and the 0-based line the text starts on.
+ *
+ * Sliced out of the file by hand instead of parsing the whole file: the
+ * TypeScript parser needs several seconds for the 10k lines of bun.d.ts on a
+ * debug build, and only a few declarations are of interest. An `interface`
+ * runs until the closing brace on the same indentation as its header; for a
+ * function, type alias or variable only the JSDoc in front of it matters, so
+ * the header line itself is enough.
+ */
+function declarationSlices(text: string, name: string): { line: number; text: string }[] {
+  const headers = text.matchAll(
+    new RegExp(
+      String.raw`^([ \t]*)(?:export\s+)?(?:declare\s+)?(?:interface|type|function|const|var)\s+${name}\b.*$`,
+      "gm",
+    ),
+  );
+
+  const slices = Array.from(headers, header => {
+    const [headerLine, indent] = header;
+    const before = text.slice(0, header.index);
+    const start = /\*\/\s*$/.test(before) ? before.lastIndexOf("/**") : header.index;
+
+    let end = header.index + headerLine.length;
+    if (headerLine.trimEnd().endsWith("{")) {
+      const close = text.indexOf(`\n${indent}}`, end);
+      if (close === -1) throw new Error(`Could not find the end of ${headerLine.trim()}`);
+      end = close + indent.length + 2;
+    }
+
+    return { line: text.slice(0, start).split("\n").length - 1, text: text.slice(start, end) };
+  });
+
+  if (slices.length === 0) throw new Error(`No declaration of ${name} found`);
+  return slices;
+}
+
+/**
  * The fenced code blocks of every `@example` tag on the named declarations in a
  * bun-types declaration file (the members of an interface, or a function
  * itself), as one source file per block, named `<declaration>.<n>.<ext>`.
@@ -153,17 +191,16 @@ const EXAMPLE_FENCE_EXTENSIONS: Record<string, string> = {
  * A tag whose fence cannot be parsed is an error, not a silently skipped example.
  */
 function jsdocExamples(declarationFile: string, declarationNames: string[]): Record<string, string> {
-  const path = join(BUN_TYPES_PACKAGE_ROOT, declarationFile);
-  const source = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true);
+  const text = readFileSync(join(BUN_TYPES_PACKAGE_ROOT, declarationFile), "utf8");
   const examples: Record<string, string> = {};
   const counters = new Map<string, number>();
 
-  function collect(key: string, host: ts.Node) {
+  function collect(key: string, host: ts.Node, snippet: ts.SourceFile, firstLine: number) {
     for (const tag of ts.getJSDocTags(host)) {
       if (tag.tagName.text !== "example") continue;
 
-      const { line } = source.getLineAndCharacterOfPosition(tag.getStart());
-      const location = `packages/bun-types/${declarationFile}:${line + 1}`;
+      const { line } = snippet.getLineAndCharacterOfPosition(tag.getStart());
+      const location = `packages/bun-types/${declarationFile}:${firstLine + line + 1}`;
       const comment = ts.getTextOfJSDocComment(tag.comment) ?? "";
       const fences = Array.from(comment.matchAll(/^[ \t]*```([^\n]*)\n([\s\S]*?)^[ \t]*```/gm));
       if (fences.length === 0 && comment.includes("```")) {
@@ -181,20 +218,24 @@ function jsdocExamples(declarationFile: string, declarationNames: string[]): Rec
     }
   }
 
-  function visit(node: ts.Node) {
-    if (ts.isInterfaceDeclaration(node) && declarationNames.includes(node.name.text)) {
-      for (const member of node.members) {
-        const memberName = member.name?.getText(source).replace(/[^\w$.]/g, "") || ts.SyntaxKind[member.kind];
-        collect(`${node.name.text}.${memberName}`, member);
+  for (const name of declarationNames) {
+    for (const slice of declarationSlices(text, name)) {
+      const snippet = ts.createSourceFile(declarationFile, slice.text, ts.ScriptTarget.Latest, true);
+
+      for (const statement of snippet.statements) {
+        if (!ts.isInterfaceDeclaration(statement)) {
+          collect(name, statement, snippet, slice.line);
+          continue;
+        }
+
+        for (const member of statement.members) {
+          const memberName = member.name?.getText(snippet).replace(/[^\w$.]/g, "") || ts.SyntaxKind[member.kind];
+          collect(`${name}.${memberName}`, member, snippet, slice.line);
+        }
       }
-    } else if (ts.isFunctionDeclaration(node) && node.name && declarationNames.includes(node.name.text)) {
-      collect(node.name.text, node);
-    } else {
-      ts.forEachChild(node, visit);
     }
   }
 
-  visit(source);
   return examples;
 }
 
@@ -461,15 +502,13 @@ describe("@types/bun integration test", () => {
     // The @example blocks are what editors show on hover, so they have to be
     // valid against the types they document. The `compile` examples used to
     // pass targets without the "bun-" prefix and put `outfile` at the top
-    // level, and a `build()` example used a loader `Loader` does not have;
-    // none of it type-checked, and none of it worked at runtime either.
-    //
-    // Explicit timeout: parsing the 10k-line bun.d.ts in-process takes a few
-    // seconds on a debug build (well under 1s on release).
+    // level (the runtime rejects the former and ignores the latter), and a
+    // `build()` example used a loader that `Loader` does not have because the
+    // bundler does not implement it yet.
     test("JSDoc examples type-check against the declared types", async () => {
       const examples = jsdocExamples("bun.d.ts", ["build", "BuildConfig", "CompileBuildOptions", "BuildOutput"]);
-      // The examples this test was added for; guards against the walk above
-      // quietly matching nothing.
+      // The examples this test was added for; guards against the extraction
+      // above quietly matching nothing.
       expect(Object.keys(examples)).toEqual(
         expect.arrayContaining(["build.3.ts", "BuildConfig.compile.0.ts", "BuildConfig.metafile.0.ts"]),
       );
@@ -477,7 +516,7 @@ describe("@types/bun integration test", () => {
       const result = await tsc("build-jsdoc-examples-check", examples);
 
       expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
-    }, 30_000);
+    });
   });
 
   describe("Test Globals", () => {

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -135,36 +135,62 @@ async function tsc(name: string, files: Record<string, string>) {
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
+// File extension to type-check a fenced @example block as, by the fence's
+// language tag. Fences in other languages (json, sh, ...) are not examples of
+// the types and are left out.
+const EXAMPLE_FENCE_EXTENSIONS: Record<string, string> = {
+  "": "ts",
+  ts: "ts",
+  typescript: "ts",
+  tsx: "tsx",
+};
+
 /**
- * The fenced code blocks of every `@example` tag on the members of the named
- * interfaces in a bun-types declaration file, as one `.ts` file per example.
+ * The fenced code blocks of every `@example` tag on the named declarations in a
+ * bun-types declaration file (the members of an interface, or a function
+ * itself), as one source file per block, named `<declaration>.<n>.<ext>`.
  * Each file starts with a comment pointing back at the tag it came from.
+ * A tag whose fence cannot be parsed is an error, not a silently skipped example.
  */
-function jsdocExamples(declarationFile: string, interfaceNames: string[]): Record<string, string> {
+function jsdocExamples(declarationFile: string, declarationNames: string[]): Record<string, string> {
   const path = join(BUN_TYPES_PACKAGE_ROOT, declarationFile);
   const source = ts.createSourceFile(path, readFileSync(path, "utf8"), ts.ScriptTarget.Latest, true);
   const examples: Record<string, string> = {};
+  const counters = new Map<string, number>();
+
+  function collect(key: string, host: ts.Node) {
+    for (const tag of ts.getJSDocTags(host)) {
+      if (tag.tagName.text !== "example") continue;
+
+      const { line } = source.getLineAndCharacterOfPosition(tag.getStart());
+      const location = `packages/bun-types/${declarationFile}:${line + 1}`;
+      const comment = ts.getTextOfJSDocComment(tag.comment) ?? "";
+      const fences = Array.from(comment.matchAll(/^[ \t]*```([^\n]*)\n([\s\S]*?)^[ \t]*```/gm));
+      if (fences.length === 0 && comment.includes("```")) {
+        throw new Error(`${location}: could not parse the code fence of this @example`);
+      }
+
+      for (const [, info, code] of fences) {
+        const extension = EXAMPLE_FENCE_EXTENSIONS[info.trim().split(/\s+/, 1)[0]!];
+        if (!extension) continue;
+
+        const index = counters.get(key) ?? 0;
+        counters.set(key, index + 1);
+        examples[`${key}.${index}.${extension}`] = `// ${location}\n${code}\n`;
+      }
+    }
+  }
 
   function visit(node: ts.Node) {
-    if (!ts.isInterfaceDeclaration(node) || !interfaceNames.includes(node.name.text)) {
-      ts.forEachChild(node, visit);
-      return;
-    }
-
-    for (const member of node.members) {
-      if (!member.name || !ts.isIdentifier(member.name)) continue;
-
-      let index = 0;
-      for (const tag of ts.getJSDocTags(member)) {
-        if (tag.tagName.text !== "example") continue;
-
-        const fence = /^```\w*\n([\s\S]*?)^```/m.exec(ts.getTextOfJSDocComment(tag.comment) ?? "");
-        if (!fence) continue;
-
-        const { line } = source.getLineAndCharacterOfPosition(tag.getStart());
-        examples[`${node.name.text}.${member.name.text}.${index++}.ts`] =
-          `// packages/bun-types/${declarationFile}:${line + 1}\n${fence[1]}\n`;
+    if (ts.isInterfaceDeclaration(node) && declarationNames.includes(node.name.text)) {
+      for (const member of node.members) {
+        const memberName = member.name?.getText(source).replace(/[^\w$.]/g, "") || ts.SyntaxKind[member.kind];
+        collect(`${node.name.text}.${memberName}`, member);
       }
+    } else if (ts.isFunctionDeclaration(node) && node.name && declarationNames.includes(node.name.text)) {
+      collect(node.name.text, node);
+    } else {
+      ts.forEachChild(node, visit);
     }
   }
 
@@ -435,13 +461,18 @@ describe("@types/bun integration test", () => {
     // The @example blocks are what editors show on hover, so they have to be
     // valid against the types they document. The `compile` examples used to
     // pass targets without the "bun-" prefix and put `outfile` at the top
-    // level, neither of which the types (or the runtime) accept.
+    // level, and a `build()` example used a loader `Loader` does not have;
+    // none of it type-checked, and none of it worked at runtime either.
     //
     // Explicit timeout: parsing the 10k-line bun.d.ts in-process takes a few
     // seconds on a debug build (well under 1s on release).
     test("JSDoc examples type-check against the declared types", async () => {
-      const examples = jsdocExamples("bun.d.ts", ["BuildConfig", "CompileBuildOptions", "BuildOutput"]);
-      expect(Object.keys(examples)).toContain("BuildConfig.compile.0.ts");
+      const examples = jsdocExamples("bun.d.ts", ["build", "BuildConfig", "CompileBuildOptions", "BuildOutput"]);
+      // The examples this test was added for; guards against the walk above
+      // quietly matching nothing.
+      expect(Object.keys(examples)).toEqual(
+        expect.arrayContaining(["build.3.ts", "BuildConfig.compile.0.ts", "BuildConfig.metafile.0.ts"]),
+      );
 
       const result = await tsc("build-jsdoc-examples-check", examples);
 


### PR DESCRIPTION
### What does this PR do?

The `@example` blocks on `BuildConfig.compile` in `packages/bun-types/bun.d.ts` do not work as written:

```ts
await Bun.build({ entrypoints: ['./app.js'], compile: { target: 'linux-x64' }, outfile: './my-app' });
await Bun.build({ entrypoints: ['./app.js'], compile: 'linux-x64', outfile: './my-app' });
```

- Both targets throw at runtime on bun 1.4.0: `Expected compile target to start with 'bun-', got linux-x64` (`compile_target_from_js` in `src/bundler_jsc/options_jsc.rs`). They also fail `tsc`: `Type '"linux-x64"' is not assignable to type 'CompileTarget | undefined'` (TS2322).
- The top-level `outfile` is ignored by the runtime (`CompileOptions::from_js` in `src/runtime/api/JSBundler.rs` only reads `outfile` from the compile object; with `compile: true, outfile: "./x"` the executable is still written under the entrypoint's name) and is an excess property for `BuildConfig` (TS2353).
- The first example is labelled "current platform" but pins a target.

The examples have been like this since they were added in #21915; `outfile` has always lived in `CompileBuildOptions`, in both the types and the runtime. The block now shows the three forms the runtime and types accept (`compile: true`, `compile: "bun-linux-x64"`, `compile: { target, outfile }`), matching `docs/bundler/executables.mdx`, and the prose says where `outfile` goes and how the default name is derived (`app.ts` -> `app`, `.exe` appended for Windows targets, `index.*` uses the directory name; see the `outfile` derivation in `JSBundler.rs` and the `.exe` handling in `js_bundle_completion_task.rs`).

The new test found two more examples in the same API with the same problem, fixed here as well:

- `BuildConfig.metafile` described `BuildOutput.metafile` as a JSON string and called `JSON.parse` / `Bun.write` on it, but it is a `BuildMetafile` object (`typeof result.metafile === "object"` at runtime, and that is how `BuildOutput.metafile` is declared). The example now uses the object. Widening `BuildConfig.metafile` to the string / `{ json, markdown }` forms the runtime accepts is a separate type change and is tracked separately.
- One of the 16 examples on `Bun.build()` itself mapped `.png` to the `dataurl` loader. `Loader` has no such member (TS2322), and at runtime that loader currently bundles the import to `""`; #36327 implements it and adds the `Loader` members in the same change. Until then the example uses `file` / `text`.

### Why

The `.d.ts` JSDoc is what editors show on hover, so examples there need to be valid against the types they sit on and against the runtime. Every rewritten example was run as written against bun 1.4.0: the four `compile` builds produce `./app`, `./app`, `./my-app` and `./index.html`; the metafile example prints the input/output keys and writes `dist/meta.json`; the loader example emits the `.png` as an asset and inlines the `.svg` / `.txt` as strings with `react` left external.

### Test

`test/integration/bun-types/bun-types.test.ts` gets a `Bun.build > JSDoc examples type-check against the declared types` case. It slices the declarations of `build()`, `BuildConfig`, `CompileBuildOptions` and `BuildOutput` out of `bun.d.ts` (the leading JSDoc, plus the body for interfaces), parses those with the TypeScript API, writes the fenced block of every `@example` to its own file (26 today, each headed with the `bun.d.ts` line it came from) and runs `tsc` over them against the packed types. Only the slices are parsed because parsing the whole 10k-line file takes several seconds on a debug build; the case costs about the same as the neighbouring `Bun.mmap` one. The extractor fails loudly on a fence it cannot parse rather than dropping the example, and the test asserts the three keys this PR fixes are among the extracted files so the extraction cannot quietly match nothing. The tsc launch is shared with the existing `Bun.mmap` case through a small `tsc()` helper (the same extraction #37398 makes, so whichever lands second has a trivial rebase).

With `packages/` at main and this test, it fails with:

```
BuildConfig.compile.0.ts(6,5): error TS2322: Type '"linux-x64"' is not assignable to type 'CompileTarget | undefined'.
BuildConfig.compile.0.ts(14,3): error TS2322: Type '"linux-x64"' is not assignable to type 'boolean | CompileBuildOptions | CompileTarget | undefined'.
BuildConfig.metafile.0.ts(10,39): error TS2769: No overload matches this call.
BuildConfig.metafile.0.ts(14,25): error TS2345: Argument of type 'BuildMetafile' is not assignable to parameter of type 'string'.
build.3.ts(6,5): error TS2322: Type '"dataurl"' is not assignable to type 'Loader'.
```

With this branch the file passes under both `bun bd test` and the release binary.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (74cfef5a9)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.91ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1481.47ms]
513 |         expect.arrayContaining(["build.3.ts", "BuildConfig.compile.0.ts", "BuildConfig.metafile.0.ts"]),
514 |       );
515 | 
516 |       const result = await tsc("build-jsdoc-examples-check", examples);
517 | 
518 |       expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 1,
    "stderr": "",
-   "stdout": "",
+   "stdout": 
+ "BuildConfig.compile.0.ts(6,5): error TS2322: Type '"linux-x64"' is not assignable to type 'CompileTarge
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (c2615715d)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.24ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [3464.72ms]
(pass) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts [845.02ms]
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [84.91ms]
513 |         expect.arrayContaining(["build.3.ts", "BuildConfig.compile.0.ts", "BuildConfig.metafile.0.ts"]),
514 |       );
515 | 
516 |       const result = await tsc("build-jsdoc-examples-check", examples);
517 | 
518 |       expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 1,
    "stderr": "",
-   "stdout": "",
+   "stdout": 
+ "BuildConfig.compile.0.ts(6,5): error TS2322: Type '"linux-x64"' is not assignable to type 'CompileTarget | undefined'.
+ BuildConfig.compile.0.ts(14,3): error TS2322: Type '"linux-x64"' is not assignable to type 'boolean | CompileBuildOptions | Compil
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (74cfef5a9)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.77ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1469.77ms]
(pass) @types/bun integration test > Bun.build > JSDoc examples type-check against the declared types [2556.33ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation produces type errors for inva
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 764ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9752ms)
Bundle modules (62ms)
Postprocesss modules (82ms)
Bundle Functions (941ms)
Generate Code (32ms)

[10.88s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_js_printer 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts                  |  51 ++++----
 test/integration/bun-types/bun-types.test.ts | 170 +++++++++++++++++++++++----
 2 files changed, 180 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/bun.d.ts                       9      9      0
test/integration/bun-types/bun-types.test.ts      8     10      0
```

</details>

**root cause** · written by the author bot

The JSDoc examples on `BuildConfig.compile` in bun.d.ts used bare `'linux-x64'` target strings, which the runtime rejects because compile targets must start with `bun-` and which are not assignable to `Bun.Build.CompileTarget`, and the examples also mislabelled a pinned target as "current platform" and placed `outfile` at the top level of `Bun.build` rather than inside the compile object. The fix rewrites those examples (along with similarly stale examples on `metafile` and a `build()` overload) to use `compile: true` for the current platform, `bun-linux-x64` for cross-compilation, and `com…

<!-- robobun:evidence:end -->