### PR TITLE
Bun.build: resolve metafile paths like compile.outfile and type the string/object forms

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1772,7 +1772,8 @@ interface BuildConfig {
   /**
    * Generate a metafile describing the build. `true` exposes it as
    * `BuildOutput.metafile`; a string or an object also writes it to disk.
-   * Relative paths are resolved against `outdir`.
+   * Relative paths are resolved against `outdir`, or against the working
+   * directory when there is no `outdir`.
    *
    * @default false
    */

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1366,33 +1366,35 @@ bun build ./src/index.ts --outdir ./dist --metafile ./dist/meta.json --metafile-
 
 #### `metafile` option formats
 
-In the JavaScript API, `metafile` accepts several forms:
+In the JavaScript API, `metafile` accepts several forms. Every form makes the metafile available as `result.metafile`; the string and object forms also write it to disk:
 
 ```ts title="build.ts" icon="/icons/typescript.svg"
-// Boolean — include metafile in the result object
+// Boolean: include the metafile in the result object
 await Bun.build({
   entrypoints: ["./src/index.ts"],
   outdir: "./dist",
   metafile: true,
 });
 
-// String — write JSON metafile to a specific path
+// String: also write the JSON metafile to ./dist/meta.json
 await Bun.build({
   entrypoints: ["./src/index.ts"],
   outdir: "./dist",
-  metafile: "./dist/meta.json",
+  metafile: "meta.json",
 });
 
-// Object — specify separate paths for JSON and markdown output
+// Object: also write JSON and/or markdown to ./dist/meta.json and ./dist/meta.md
 await Bun.build({
   entrypoints: ["./src/index.ts"],
   outdir: "./dist",
   metafile: {
-    json: "./dist/meta.json",
-    markdown: "./dist/meta.md",
+    json: "meta.json",
+    markdown: "meta.md",
   },
 });
 ```
+
+These paths are resolved like `compile.outfile`: a relative path is relative to `outdir` (or to the working directory when there is no `outdir`), and an absolute path is used as-is. The written files are also included in `result.outputs`, with a `kind` of `"metafile-json"` or `"metafile-markdown"`. The `--metafile` and `--metafile-md` CLI flags, like every other CLI path, are relative to the working directory.
 
 The metafile structure contains:
 
@@ -1434,11 +1436,11 @@ interface BuildOutput {
   outputs: BuildArtifact[];
   success: boolean;
   logs: Array<object>; // see docs for details
-  metafile?: BuildMetafile; // only when metafile: true
+  metafile?: BuildMetafile; // only when the metafile option is set
 }
 
 interface BuildArtifact extends Blob {
-  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode";
+  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode" | "metafile-json" | "metafile-markdown";
   path: string;
   loader: Loader;
   hash: string | null;
@@ -1767,6 +1769,15 @@ interface BuildConfig {
    */
   tsconfig?: string;
 
+  /**
+   * Generate a metafile describing the build. `true` exposes it as
+   * `BuildOutput.metafile`; a string or an object also writes it to disk.
+   * Relative paths are resolved against `outdir`.
+   *
+   * @default false
+   */
+  metafile?: boolean | string | { json?: string; markdown?: string };
+
   outdir?: string;
 }
 
@@ -1774,13 +1785,14 @@ interface BuildOutput {
   outputs: BuildArtifact[];
   success: boolean;
   logs: Array<BuildMessage | ResolveMessage>;
+  metafile?: BuildMetafile; // only when the metafile option is set
 }
 
 interface BuildArtifact extends Blob {
   path: string;
   loader: Loader;
   hash: string | null;
-  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode";
+  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode" | "metafile-json" | "metafile-markdown";
   sourcemap: BuildArtifact | null;
 }
 

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1345,7 +1345,7 @@ Generate metadata about the build in a structured format. The metafile describes
   </Tab>
   <Tab title="CLI">
     ```bash terminal icon="terminal"
-    bun build ./src/index.ts --outdir ./dist --metafile ./dist/meta.json
+    bun build ./src/index.ts --outdir ./dist --metafile=./dist/meta.json
     ```
   </Tab>
 </Tabs>
@@ -1355,14 +1355,16 @@ Generate metadata about the build in a structured format. The metafile describes
 Use `--metafile-md` to generate a markdown metafile, which is LLM-friendly and readable in the terminal:
 
 ```bash terminal icon="terminal"
-bun build ./src/index.ts --outdir ./dist --metafile-md ./dist/meta.md
+bun build ./src/index.ts --outdir ./dist --metafile-md=./dist/meta.md
 ```
 
 Both `--metafile` and `--metafile-md` can be used together:
 
 ```bash terminal icon="terminal"
-bun build ./src/index.ts --outdir ./dist --metafile ./dist/meta.json --metafile-md ./dist/meta.md
+bun build ./src/index.ts --outdir ./dist --metafile=./dist/meta.json --metafile-md=./dist/meta.md
 ```
+
+The path is optional and must be attached with `=`. `bun build ./src/index.ts --outdir ./dist --metafile` writes `meta.json` (and `--metafile-md` writes `meta.md`) in the working directory; a bare `--metafile ./dist/meta.json` would treat `./dist/meta.json` as another entry point. Paths given to these flags are relative to the working directory, not to `--outdir`.
 
 #### `metafile` option formats
 
@@ -1394,7 +1396,7 @@ await Bun.build({
 });
 ```
 
-These paths are resolved like `compile.outfile`: a relative path is relative to `outdir` (or to the working directory when there is no `outdir`), and an absolute path is used as-is. The written files are also included in `result.outputs`, with a `kind` of `"metafile-json"` or `"metafile-markdown"`. The `--metafile` and `--metafile-md` CLI flags, like every other CLI path, are relative to the working directory.
+These paths are resolved like `compile.outfile`: a relative path is relative to `outdir` (or to the working directory when there is no `outdir`), and an absolute path is used as-is. The written files are also included in `result.outputs` (including with `compile`), with a `kind` of `"metafile-json"` or `"metafile-markdown"`. Unlike the CLI flags above, these paths are resolved against `outdir`.
 
 The metafile structure contains:
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3150,13 +3150,26 @@ declare module "bun" {
     files?: Record<string, string | Blob | NodeJS.TypedArray | ArrayBufferLike>;
 
     /**
-     * Generate a JSON file containing metadata about the build.
+     * Generate metadata about the build: every input and output file, its size,
+     * and the imports between them. Use it for bundle analysis, visualization,
+     * or integration with other tools.
      *
-     * The metafile contains information about inputs, outputs, imports, and exports
-     * which can be used for bundle analysis, visualization, or integration with
-     * other tools.
+     * `true`, a string, or an object makes the metafile available as
+     * {@link BuildOutput.metafile}. A string or an object also writes it to disk:
      *
-     * When `true`, the metafile JSON string is included in the {@link BuildOutput.metafile} property.
+     * - `true`: only expose it as {@link BuildOutput.metafile}
+     * - `string`: also write the JSON metafile to this path
+     * - `{ json?: string; markdown?: string }`: also write the JSON metafile and/or a
+     *   markdown report of the module graph to these paths
+     *
+     * Paths are resolved like {@link CompileBuildOptions.outfile}: a relative path is
+     * relative to {@link BuildConfig.outdir} (or to the working directory when there is
+     * no `outdir`), an absolute path is used as-is. Files written this way are also
+     * included in {@link BuildOutput.outputs} with a {@link BuildArtifact.kind} of
+     * `"metafile-json"` or `"metafile-markdown"`.
+     *
+     * The `bun build --metafile <path>` and `--metafile-md <path>` CLI flags resolve
+     * their paths relative to the working directory.
      *
      * @default false
      *
@@ -3168,18 +3181,47 @@ declare module "bun" {
      *   metafile: true,
      * });
      *
-     * // Write metafile to disk for analysis
-     * if (result.metafile) {
-     *   await Bun.write('./dist/meta.json', result.metafile);
+     * for (const [path, output] of Object.entries(result.metafile!.outputs)) {
+     *   console.log(`${path}: ${output.bytes} bytes`);
      * }
+     * ```
      *
-     * // Parse and analyze the metafile
-     * const meta = JSON.parse(result.metafile!);
-     * console.log('Input files:', Object.keys(meta.inputs));
-     * console.log('Output files:', Object.keys(meta.outputs));
+     * @example
+     * ```ts
+     * // Writes ./dist/meta.json
+     * await Bun.build({
+     *   entrypoints: ['./src/index.ts'],
+     *   outdir: './dist',
+     *   metafile: 'meta.json',
+     * });
+     * ```
+     *
+     * @example
+     * ```ts
+     * // Writes ./dist/meta.json and ./dist/meta.md
+     * await Bun.build({
+     *   entrypoints: ['./src/index.ts'],
+     *   outdir: './dist',
+     *   metafile: {
+     *     json: 'meta.json',
+     *     markdown: 'meta.md',
+     *   },
+     * });
      * ```
      */
-    metafile?: boolean;
+    metafile?:
+      | boolean
+      | string
+      | {
+          /**
+           * Path to write the JSON metafile to.
+           */
+          json?: string;
+          /**
+           * Path to write a markdown report of the module graph to.
+           */
+          markdown?: string;
+        };
 
     outdir?: string;
 
@@ -3809,7 +3851,11 @@ declare module "bun" {
     path: string;
     loader: Loader;
     hash: string | null;
-    kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode";
+    /**
+     * `"metafile-json"` and `"metafile-markdown"` are the files written when
+     * {@link BuildConfig.metafile} is a string or an object.
+     */
+    kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode" | "metafile-json" | "metafile-markdown";
     sourcemap: BuildArtifact | null;
   }
 
@@ -3828,7 +3874,7 @@ declare module "bun" {
      * - **outputs**: every generated file with its byte size, the inputs that
      *   contributed to it, imports between chunks, and exports
      *
-     * Only present when {@link BuildConfig.metafile} is `true`.
+     * Only present when {@link BuildConfig.metafile} is `true`, a string, or an object.
      *
      * Use it for bundle size analysis, inspecting the dependency graph, or as
      * input to bundle analyzer tools.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3168,8 +3168,8 @@ declare module "bun" {
      * included in {@link BuildOutput.outputs} with a {@link BuildArtifact.kind} of
      * `"metafile-json"` or `"metafile-markdown"`.
      *
-     * The `bun build --metafile <path>` and `--metafile-md <path>` CLI flags resolve
-     * their paths relative to the working directory.
+     * The `bun build --metafile=<path>` and `--metafile-md=<path>` CLI flags resolve
+     * their paths relative to the working directory instead.
      *
      * @default false
      *

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5137,27 +5137,23 @@ pub mod bv2_impl {
                 _ => None,
             };
 
-            // Write metafile outputs to disk and add them as OutputFiles.
-            // Metafile paths are relative to outdir, like all other output files.
-            // `LinkerContext::resolver()` wraps the `*mut Resolver` backref deref.
-            let outdir = &self.linker.resolver().opts.output_dir;
-            if !self.linker.options.metafile_json_path.is_empty() {
+            let json_path = self.linker.options.metafile_json_path;
+            if !json_path.is_empty() {
                 if let Some(mf) = &metafile {
-                    write_metafile_output(
+                    self.write_metafile_output(
                         &mut output_files,
-                        outdir,
-                        self.linker.options.metafile_json_path,
+                        json_path,
                         mf,
                         crate::options::OutputKind::MetafileJson,
                     )?;
                 }
             }
-            if !self.linker.options.metafile_markdown_path.is_empty() {
+            let markdown_path = self.linker.options.metafile_markdown_path;
+            if !markdown_path.is_empty() {
                 if let Some(md) = &metafile_markdown {
-                    write_metafile_output(
+                    self.write_metafile_output(
                         &mut output_files,
-                        outdir,
-                        self.linker.options.metafile_markdown_path,
+                        markdown_path,
                         md,
                         crate::options::OutputKind::MetafileMarkdown,
                     )?;
@@ -5170,64 +5166,66 @@ pub mod bv2_impl {
                 metafile_markdown,
             })
         }
-    }
 
-    /// Writes a metafile (JSON or markdown) to disk and appends it to the output_files list.
-    /// Metafile paths are relative to outdir, like all other output files.
-    fn write_metafile_output(
-        output_files: &mut Vec<options::OutputFile>,
-        outdir: &[u8],
-        file_path: &[u8],
-        content: &[u8],
-        output_kind: crate::options::OutputKind,
-    ) -> Result<(), Error> {
-        if !outdir.is_empty() {
-            // Open the output directory and write the metafile relative to it,
-            // routed through `bun_sys::File`.
-            let mut buf = bun_paths::path_buffer_pool::get();
-            let joined = bun_paths::resolve_path::join_string_buf::<
-                bun_paths::resolve_path::platform::Auto,
-            >(&mut buf.0[..], &[outdir, file_path]);
-            // Create parent directories if needed (relative to outdir).
-            let parent = bun_paths::resolve_path::dirname::<bun_paths::resolve_path::platform::Loose>(
-                joined,
-            );
-            if !parent.is_empty() {
-                let _ = bun_sys::mkdir_recursive(parent);
+        /// Writes a metafile (JSON or markdown) requested through a `metafile`
+        /// path to disk and appends it to `output_files`.
+        ///
+        /// The path is resolved the same way as `compile.outfile`: a relative
+        /// path is relative to `outdir` (or to the working directory when there
+        /// is no `outdir`), an absolute path is used as-is. The resolved path is
+        /// stored as the output path so the `BuildArtifact` reports the file that
+        /// was actually written.
+        fn write_metafile_output(
+            &mut self,
+            output_files: &mut Vec<options::OutputFile>,
+            file_path: &[u8],
+            content: &[u8],
+            output_kind: crate::options::OutputKind,
+        ) -> Result<(), Error> {
+            let dest_path: Box<[u8]> = {
+                let mut buf = bun_paths::path_buffer_pool::get();
+                Box::from(bun_paths::resolve_path::join_abs_string_buf::<
+                    bun_paths::platform::Auto,
+                >(
+                    self.transpiler.fs().top_level_dir,
+                    &mut buf[..],
+                    &[&*self.transpiler.options.output_dir, file_path],
+                ))
+            };
+
+            if let Err(err) = bun_sys::File::make_open(
+                &dest_path,
+                bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
+                0o664,
+            )
+            .and_then(|file| file.write_all(content))
+            {
+                self.linker.log_mut().add_sys_error(
+                    &err,
+                    format_args!("writing metafile {}", bun_core::fmt::quote(&dest_path)),
+                );
+                return Err(Error::WriteFailed);
             }
-            let mut zbuf = bun_paths::path_buffer_pool::get();
-            let joined_z = bun_paths::resolve_path::z(joined, &mut zbuf);
-            match bun_sys::File::write_file(bun_core::Fd::cwd(), joined_z, content) {
-                Ok(()) => {}
-                Err(err) => {
-                    bun_core::warn!(
-                        "Failed to write metafile to '{}': {}",
-                        bstr::BStr::new(file_path),
-                        err
-                    );
-                }
-            }
+
+            let is_json = output_kind == crate::options::OutputKind::MetafileJson;
+            output_files.push(options::OutputFile::init(crate::output_file::Options {
+                loader: if is_json { Loader::Json } else { Loader::File },
+                input_loader: if is_json { Loader::Json } else { Loader::File },
+                input_path: Box::<[u8]>::from(if is_json {
+                    b"metafile.json".as_slice()
+                } else {
+                    b"metafile.md".as_slice()
+                }),
+                output_path: dest_path,
+                data: crate::output_file::OptionsData::Saved(content.len()),
+                output_kind,
+                is_executable: false,
+                side: None,
+                entry_point_index: None,
+                ..Default::default()
+            }));
+            Ok(())
         }
-
-        // Add as OutputFile so it appears in result.outputs
-        let is_json = output_kind == crate::options::OutputKind::MetafileJson;
-        output_files.push(options::OutputFile::init(crate::output_file::Options {
-            loader: if is_json { Loader::Json } else { Loader::File },
-            input_loader: if is_json { Loader::Json } else { Loader::File },
-            input_path: Box::<[u8]>::from(if is_json {
-                b"metafile.json".as_slice()
-            } else {
-                b"metafile.md".as_slice()
-            }),
-            output_path: Box::<[u8]>::from(file_path),
-            data: crate::output_file::OptionsData::Saved(content.len()),
-            output_kind,
-            is_executable: false,
-            side: None,
-            entry_point_index: None,
-            ..Default::default()
-        }));
-        Ok(())
     }
 
     impl<'a> BundleV2<'a> {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5175,15 +5175,21 @@ pub mod bv2_impl {
             content: &[u8],
             output_kind: crate::options::OutputKind,
         ) -> Result<(), Error> {
-            let dest_path: Box<[u8]> = {
+            let dest_path: Option<Box<[u8]>> = {
                 let mut buf = bun_paths::path_buffer_pool::get();
-                Box::from(bun_paths::resolve_path::join_abs_string_buf::<
-                    bun_paths::platform::Auto,
-                >(
+                bun_paths::resolve_path::join_abs_string_buf_checked::<bun_paths::platform::Auto>(
                     self.transpiler.fs().top_level_dir,
                     &mut buf[..],
                     &[&*self.transpiler.options.output_dir, file_path],
-                ))
+                )
+                .map(Box::from)
+            };
+            let Some(dest_path) = dest_path else {
+                self.linker.log_mut().add_sys_error(
+                    &bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open),
+                    format_args!("writing metafile {}", bun_core::fmt::quote(file_path)),
+                );
+                return Err(Error::WriteFailed);
             };
 
             if let Err(err) = bun_sys::File::make_open(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5167,9 +5167,7 @@ pub mod bv2_impl {
             })
         }
 
-        /// Resolves `file_path` like `compile.outfile` (against `outdir`, else the
-        /// working directory; absolute paths as-is), writes the metafile there and
-        /// appends it to `output_files`.
+        /// Resolved like `compile.outfile`: against `outdir`, else the cwd; absolute paths as-is.
         fn write_metafile_output(
             &mut self,
             output_files: &mut Vec<options::OutputFile>,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5167,14 +5167,9 @@ pub mod bv2_impl {
             })
         }
 
-        /// Writes a metafile (JSON or markdown) requested through a `metafile`
-        /// path to disk and appends it to `output_files`.
-        ///
-        /// The path is resolved the same way as `compile.outfile`: a relative
-        /// path is relative to `outdir` (or to the working directory when there
-        /// is no `outdir`), an absolute path is used as-is. The resolved path is
-        /// stored as the output path so the `BuildArtifact` reports the file that
-        /// was actually written.
+        /// Resolves `file_path` like `compile.outfile` (against `outdir`, else the
+        /// working directory; absolute paths as-is), writes the metafile there and
+        /// appends it to `output_files`.
         fn write_metafile_output(
             &mut self,
             output_files: &mut Vec<options::OutputFile>,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -461,13 +461,20 @@ impl JSBundleCompletionTask {
         }
 
         // Write external sourcemap files next to the compiled executable and
-        // keep them in the output array. Destroy all other non-entry-point files.
+        // keep them, plus the metafiles the bundler wrote, in the output array. Destroy the rest.
         // With --splitting, there can be multiple sourcemap files (one per chunk).
         let mut kept: usize = 0;
         // Swap-compact in place via index iteration so each loop body holds
         // at most one `&mut` into `output_files`.
         for i in 0..output_files.len() {
             let keep_this = if i == entry_point_index {
+                true
+            } else if matches!(result, CompileResult::Success)
+                && matches!(
+                    output_files[i].output_kind,
+                    OutputKind::MetafileJson | OutputKind::MetafileMarkdown
+                )
+            {
                 true
             } else if matches!(result, CompileResult::Success)
                 && output_files[i].output_kind == OutputKind::Sourcemap

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync } from "node:fs";
+import { join, relative } from "node:path";
 
 // Type definitions for metafile structure
 interface MetafileImport {
@@ -799,8 +801,142 @@ describe("Bun.build metafile option variants", () => {
   });
 });
 
-// CLI tests for --metafile-md
-import { bunEnv, bunExe } from "harness";
+describe("Bun.build metafile paths", () => {
+  const files = {
+    "entry.js": `import { foo } from "./foo.js"; console.log(foo);`,
+    "foo.js": `export const foo = "hello";`,
+  };
+
+  function metafileOutputs(result: Awaited<ReturnType<typeof Bun.build>>, root: string) {
+    return result.outputs
+      .filter(output => output.kind.startsWith("metafile-"))
+      .map(output => ({ kind: output.kind, path: relative(root, output.path) }));
+  }
+
+  test.concurrent("relative paths are resolved against outdir", async () => {
+    using dir = tempDir("metafile-path-outdir", files);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      outdir: `${dir}/dist`,
+      metafile: { json: "meta/graph.json", markdown: "meta/graph.md" },
+    });
+
+    expect(metafileOutputs(result, String(dir))).toEqual([
+      { kind: "metafile-json", path: join("dist", "meta", "graph.json") },
+      { kind: "metafile-markdown", path: join("dist", "meta", "graph.md") },
+    ]);
+    expect(readdirSync(`${dir}/dist/meta`).sort()).toEqual(["graph.json", "graph.md"]);
+  });
+
+  test.concurrent("an absolute string path is written there, not under outdir", async () => {
+    using dir = tempDir("metafile-path-absolute-string", files);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      outdir: `${dir}/dist`,
+      metafile: `${dir}/report/meta.json`,
+    });
+
+    expect(metafileOutputs(result, String(dir))).toEqual([
+      { kind: "metafile-json", path: join("report", "meta.json") },
+    ]);
+    expect(readdirSync(`${dir}/dist`)).toEqual(["entry.js"]);
+    const written = JSON.parse(await Bun.file(`${dir}/report/meta.json`).text());
+    expect(Object.keys(written.outputs)).toEqual(Object.keys(result.metafile!.outputs));
+  });
+
+  test.concurrent("absolute json and markdown paths are written there, not under outdir", async () => {
+    using dir = tempDir("metafile-path-absolute-object", files);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      outdir: `${dir}/dist`,
+      metafile: { json: `${dir}/report/meta.json`, markdown: `${dir}/report/meta.md` },
+    });
+
+    expect(metafileOutputs(result, String(dir))).toEqual([
+      { kind: "metafile-json", path: join("report", "meta.json") },
+      { kind: "metafile-markdown", path: join("report", "meta.md") },
+    ]);
+    expect(readdirSync(`${dir}/dist`)).toEqual(["entry.js"]);
+    expect(readdirSync(`${dir}/report`).sort()).toEqual(["meta.json", "meta.md"]);
+    expect(await Bun.file(`${dir}/report/meta.md`).text()).toContain("# Bundle Analysis Report");
+  });
+
+  test.concurrent("the artifacts read back the files that were written", async () => {
+    using dir = tempDir("metafile-path-artifact-contents", files);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      metafile: { json: `${dir}/report/meta.json`, markdown: `${dir}/report/meta.md` },
+    });
+
+    const [json, markdown] = result.outputs.filter(output => output.kind.startsWith("metafile-"));
+    expect(await json.json()).toEqual(result.metafile);
+    expect(await markdown.text()).toBe(await Bun.file(`${dir}/report/meta.md`).text());
+  });
+
+  test.concurrent("without outdir, relative paths are resolved against the working directory", async () => {
+    using dir = tempDir("metafile-path-cwd", {
+      ...files,
+      "build-fixture.ts": `
+        const withOutdir = await Bun.build({
+          entrypoints: ["./entry.js"],
+          outdir: "./dist",
+          metafile: "meta.json",
+        });
+        const withoutOutdir = await Bun.build({
+          entrypoints: ["./entry.js"],
+          metafile: { json: "report/meta.json", markdown: "report/meta.md" },
+        });
+        const paths = (result: Bun.BuildOutput) =>
+          result.outputs.filter(output => output.kind.startsWith("metafile-")).map(output => output.path);
+        console.log(JSON.stringify([...paths(withOutdir), ...paths(withoutOutdir)]));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build-fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const paths: string[] = JSON.parse(stdout);
+    expect(paths.map(path => relative(String(dir), path))).toEqual([
+      join("dist", "meta.json"),
+      join("report", "meta.json"),
+      join("report", "meta.md"),
+    ]);
+    expect(exitCode).toBe(0);
+
+    expect(readdirSync(`${dir}/dist`).sort()).toEqual(["entry.js", "meta.json"]);
+    expect(readdirSync(`${dir}/report`).sort()).toEqual(["meta.json", "meta.md"]);
+    expect(JSON.parse(await Bun.file(`${dir}/report/meta.json`).text())).toHaveProperty("inputs");
+  });
+
+  test.concurrent("a metafile that cannot be written fails the build", async () => {
+    using dir = tempDir("metafile-path-unwritable", {
+      ...files,
+      "not-a-dir": "",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      outdir: `${dir}/dist`,
+      metafile: `${dir}/not-a-dir/meta.json`,
+      throw: false,
+    });
+
+    expect(result.logs.map(log => log.message)).toEqual([expect.stringContaining("writing metafile")]);
+    expect(result.logs[0].message).toContain("meta.json");
+    expect(result.success).toBe(false);
+  });
+});
 
 describe("bun build --metafile-md", () => {
   test("generates markdown metafile with default name", async () => {

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { readdirSync } from "node:fs";
 import { join, relative } from "node:path";
 
@@ -952,6 +952,38 @@ describe("Bun.build metafile paths", () => {
     expect(result.logs.map(log => log.message)).toEqual([expect.stringContaining("writing metafile")]);
     expect(result.logs[0].message).toContain("meta.json");
     expect(result.success).toBe(false);
+  });
+
+  test.concurrent("a metafile path longer than the path buffer fails the build", async () => {
+    using dir = tempDir("metafile-path-too-long", files);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      metafile: { markdown: Buffer.alloc(100_000, "a").toString() },
+      throw: false,
+    });
+
+    expect(result.logs.map(log => log.message)).toEqual([expect.stringContaining("writing metafile")]);
+    expect(result.success).toBe(false);
+  });
+
+  test.concurrent("with compile, the written metafiles stay in result.outputs", async () => {
+    using dir = tempDir("metafile-path-compile", files);
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      outdir: `${dir}/dist`,
+      compile: { outfile: "app" },
+      metafile: { json: "meta.json", markdown: "meta.md" },
+    });
+
+    expect(result.outputs.map(output => output.kind)).toEqual(["entry-point", "metafile-json", "metafile-markdown"]);
+    expect(metafileOutputs(result, String(dir))).toEqual([
+      { kind: "metafile-json", path: join("dist", "meta.json") },
+      { kind: "metafile-markdown", path: join("dist", "meta.md") },
+    ]);
+    expect(readdirSync(`${dir}/dist`).sort()).toEqual([isWindows ? "app.exe" : "app", "meta.json", "meta.md"]);
+    expect(await result.outputs[1].json()).toEqual(result.metafile);
   });
 });
 

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -799,6 +799,23 @@ describe("Bun.build metafile option variants", () => {
     expect(metafile.inputs).toBeDefined();
     expect(metafile.outputs).toBeDefined();
   });
+
+  test("metafile: {} provides the metafile object without writing any files", async () => {
+    using dir = tempDir("metafile-empty-object", {
+      "test.js": `export const a = 1;`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/test.js`],
+      outdir: `${dir}/dist`,
+      metafile: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(Object.keys(result.metafile as Metafile)).toEqual(["inputs", "outputs"]);
+    expect(result.outputs.map(output => output.kind)).toEqual(["entry-point"]);
+    expect(readdirSync(`${dir}/dist`)).toEqual(["test.js"]);
+  });
 });
 
 describe("Bun.build metafile paths", () => {

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -963,7 +963,9 @@ describe("Bun.build metafile paths", () => {
       throw: false,
     });
 
-    expect(result.logs.map(log => log.message)).toEqual([expect.stringContaining("writing metafile")]);
+    expect(result.logs.map(log => log.message)).toEqual([
+      expect.stringContaining("File name too long: writing metafile"),
+    ]);
     expect(result.success).toBe(false);
   });
 

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -66,3 +66,32 @@ Bun.build({
     },
   ],
 });
+
+// BuildConfig.metafile accepts every form the runtime accepts: a boolean, a path
+// for the JSON metafile, or separate paths for the JSON and markdown metafiles.
+expectAssignable<Bun.BuildConfig["metafile"]>(true);
+expectAssignable<Bun.BuildConfig["metafile"]>("meta.json");
+expectAssignable<Bun.BuildConfig["metafile"]>({ json: "meta.json" });
+expectAssignable<Bun.BuildConfig["metafile"]>({ markdown: "meta.md" });
+expectAssignable<Bun.BuildConfig["metafile"]>({ json: "meta.json", markdown: "meta.md" });
+// @ts-expect-error - only json and markdown can be written
+expectAssignable<Bun.BuildConfig["metafile"]>({ yaml: "meta.yaml" });
+
+Bun.build({
+  entrypoints: ["hey"],
+  outdir: "out",
+  metafile: "meta.json",
+});
+
+Bun.build({
+  entrypoints: ["hey"],
+  outdir: "out",
+  metafile: { json: "meta.json", markdown: "meta.md" },
+}).then(result => {
+  expectType(result.metafile).is<Bun.BuildMetafile | undefined>();
+  for (const output of result.outputs) {
+    if (output.kind === "metafile-json" || output.kind === "metafile-markdown") {
+      expectType(output.path).is<string>();
+    }
+  }
+});

--- a/test/integration/bun-types/fixture/build.ts
+++ b/test/integration/bun-types/fixture/build.ts
@@ -74,6 +74,8 @@ expectAssignable<Bun.BuildConfig["metafile"]>("meta.json");
 expectAssignable<Bun.BuildConfig["metafile"]>({ json: "meta.json" });
 expectAssignable<Bun.BuildConfig["metafile"]>({ markdown: "meta.md" });
 expectAssignable<Bun.BuildConfig["metafile"]>({ json: "meta.json", markdown: "meta.md" });
+// An empty object only exposes result.metafile, the same as `true`.
+expectAssignable<Bun.BuildConfig["metafile"]>({});
 // @ts-expect-error - only json and markdown can be written
 expectAssignable<Bun.BuildConfig["metafile"]>({ yaml: "meta.yaml" });
 


### PR DESCRIPTION
### What does this PR do?

`Bun.build({ metafile })` accepts `boolean | string | { json?, markdown? }` at runtime (the string and object forms write the metafile to disk), but the types only allowed `boolean`, and the path handling behind the string and object forms had three bugs.

```ts
// bun 1.4.0, cwd = /tmp/x, /tmp/x/app.js exists
await Bun.build({ entrypoints: ["./app.js"], outdir: "./dist", metafile: "/tmp/x/meta.json" });
// writes /tmp/x/dist/tmp/x/meta.json, while result.outputs[1].path says /tmp/x/meta.json

await Bun.build({ entrypoints: ["./app.js"], metafile: "meta.json" });
// writes nothing, but result.outputs still contains a "metafile-json" artifact;
// await result.outputs[1].text() -> ENOENT

await Bun.build({ entrypoints: ["./app.js"], outdir: "./dist", metafile: "not-a-dir/meta.json" });
// (dist/not-a-dir is a file) prints a warning, resolves with success: true, no metafile on disk

// and in a .ts file, following docs/bundler/index.mdx:
metafile: "./dist/meta.json"
// error TS2322: Type 'string' is not assignable to type 'boolean | undefined'.
```

The docs example for the string/object forms also repeated the outdir in the path (`outdir: "./dist", metafile: "./dist/meta.json"`), which produces `dist/dist/meta.json`.

### Cause

`write_metafile_output` in `src/bundler/bundle_v2.rs` (only used by the `Bun.build` path; `bun build --metafile` writes its file itself in `build_command.rs`) built the destination with `join_string_buf`, i.e. `path.join(outdir, metafile)`: an absolute metafile path gets appended under outdir. It skipped the write entirely when there was no outdir but still pushed a `Saved` output file, and it swallowed write errors with a warning. The `OutputFile` kept the user's string as its path, so `BuildArtifact.path` (computed with `path.resolve` semantics in the completion task) could disagree with where the file went.

### Fix

`write_metafile_output` now resolves the path with `join_abs_string_buf_checked` against `top_level_dir` and `outdir`, which is exactly how `compile.outfile` is resolved in `js_bundle_completion_task.rs`: a relative path is relative to `outdir`, relative to the working directory when there is no `outdir`, and an absolute path is used as-is. It writes with the same `File::make_open` the CLI uses, stores the resolved path on the output file (so `BuildArtifact.path` is the file that was written, and the artifact is readable), and a failed write becomes a build error (`Not a directory: writing metafile "/tmp/x/dist/not-a-dir/meta.json"`) like any other output file write failure.

Two related holes found in review are closed in the same function and its consumer: a metafile path that does not fit the path buffer used to panic inside the unchecked join (the process aborts, `throw: false` or not); the checked join turns it into `File name too long: writing metafile "..."`. And with `compile` set, the file was written but `do_compilation` dropped the artifact while compacting `output_files` down to the executable and its sourcemaps, so the "also included in `result.outputs`" contract the docs make was false there; the compaction now keeps the two metafile kinds too (they are already excluded from the embedded graph by `is_file_in_standalone_mode`).

Relative paths stay outdir-relative on purpose. That is what the existing tests in `test/bundler/metafile.test.ts` assert, it is how every other path `Bun.build` produces works (`naming`, `compile.outfile` with an `outdir`, and the artifact `.path` formula), and changing it would silently move files for anyone already using `metafile: "meta.json"`. So the docs example is the thing that changes (`metafile: "meta.json"`), and both the docs and the JSDoc now say how paths are resolved, including that the CLI flags are cwd-relative. The CLI itself is unchanged, but its docs examples used `--metafile ./dist/meta.json`, and `--metafile`/`--metafile-md` only take a value with `=` (the space form makes the path an extra entry point and the build fails), so the examples now use `--metafile=./dist/meta.json` and say so.

Types: `BuildConfig.metafile` is widened to what the runtime accepts, `BuildArtifact.kind` gains `"metafile-json" | "metafile-markdown"` (the kinds the written files show up as in `result.outputs`), and `BuildOutput.metafile` no longer says it is only present for `true`. The type widening is the same change as #27055, credited in the commit; this PR also covers the runtime and docs side. #37421 rewrites the example in the same `metafile` JSDoc block, so whichever of the two lands second needs a trivial conflict resolution there.

### How did you verify your code works?

`test/bundler/metafile.test.ts`, new `Bun.build metafile paths` block: absolute string path, absolute json + markdown paths, artifacts reading back the written files without an outdir, relative paths without an outdir (spawned with `cwd` set, checks both `outdir` and cwd resolution), an unwritable path failing the build, an over-long path failing the build, `compile` keeping the metafile artifacts, a pin that relative paths still resolve against `outdir`, and (in the variants block) `metafile: {}` writing nothing. All but the two pins fail on the released bun and pass with this change; the whole file (53 tests) passes with `bun bd test`, as do `bun-build-compile.test.ts` and `bun-build-compile-sourcemap.test.ts`, which exercise the changed compaction loop.

`test/integration/bun-types/fixture/build.ts` asserts every `metafile` form is assignable and narrows `output.kind` to the metafile kinds; `bun test test/integration/bun-types/bun-types.test.ts` reports 8 diagnostics in it without the `bun.d.ts` change and passes with it (tsc and tsgo).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/metafile.test.ts

<!-- robobun:evidence:end -->