### PR TITLE
fetch: reject file: URLs whose path cannot be read

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -225,6 +225,42 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// file: URLs
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The `Response` for a `file:` URL wraps a blob that opens the file lazily, so
+/// `fetch()` itself has to check the path; otherwise a path that cannot be read
+/// still gets a 200 and the error only surfaces from the body reader. Returns
+/// the JS error for `fetch()` to reject with.
+///
+/// Only conditions under which the read is certain to fail are checked (the
+/// path does not stat, or is a directory). `stat` rather than an eager `open`:
+/// opening a FIFO or a device has side effects, and nothing here needs the fd.
+/// Files embedded in a standalone executable come back as byte-backed blobs,
+/// which have nothing on disk to check.
+fn file_url_unreadable_error(file_blob: &Blob, global_this: &JSGlobalObject) -> Option<JSValue> {
+    let store = file_blob.store()?;
+    let blob::store::Data::File(file) = &store.data else {
+        return None;
+    };
+    let PathOrFileDescriptor::Path(path) = &file.pathlike else {
+        return None;
+    };
+
+    let mut path_buf = bun_paths::path_buffer_pool::get();
+    let err = match bun_sys::stat(path.slice_z(&mut path_buf)) {
+        Ok(stat) if bun_sys::S::ISDIR(stat.st_mode as bun_sys::Mode) => {
+            bun_sys::Error::from_code(bun_sys::E::EISDIR, bun_sys::Tag::read)
+        }
+        Ok(_) => return None,
+        Err(err) => err,
+    };
+    // `stat` attached the scratch copy of the path (`\\?\`-prefixed on
+    // Windows); report the path as the blob holds it.
+    Some(err.with_path(path.slice()).to_js(global_this))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Bun__fetchPreconnect
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -1553,8 +1589,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 }
             };
 
-            url_string = jsc::URL::file_url_from_string(BunString::borrow_utf8(temp_file_path));
-
             // `find_or_create_file_from_path` is typed against the
             // `crate::webcore::node_types` stub (until it's swapped to a
             // re-export of `crate::node::types`); construct that variant here.
@@ -1564,7 +1598,17 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 )),
             );
 
-            break 'blob Blob::find_or_create_file_from_path(&mut pathlike, global_this, true);
+            let file_blob = Blob::find_or_create_file_from_path(&mut pathlike, global_this, true);
+
+            if let Some(err) = file_url_unreadable_error(&file_blob, global_this) {
+                return Ok(JSPromise::rejected_promise(global_this, err).to_js());
+            }
+
+            // A bare +1 ref that only `Response::init` below releases, so it is
+            // created after the early return above.
+            url_string = jsc::URL::file_url_from_string(BunString::borrow_utf8(temp_file_path));
+
+            break 'blob file_blob;
         };
 
         let response = bun_core::heap::into_raw(Box::new(Response::init(

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -224,19 +224,10 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
     )
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// file: URLs
-// ──────────────────────────────────────────────────────────────────────────
-
-/// The body blob opens the file lazily, so this is where `fetch("file:...")`
-/// learns that the path cannot be read. Returns the rejection value, a
-/// `TypeError` like every other `fetch()` failure (`ValueError::SystemTypeError`).
-///
-/// `stat`, not `open`: opening a FIFO or a device has side effects and the fd
-/// is not needed. Non-file stores (files embedded in a standalone executable)
-/// have nothing on disk to check.
+/// The `TypeError` for `fetch("file:...")` to reject with when the blob's path cannot be read.
 fn file_url_unreadable_error(file_blob: &Blob, global_this: &JSGlobalObject) -> Option<JSValue> {
     let store = file_blob.store()?;
+    // A file embedded in a standalone executable comes back as a byte store; nothing to check.
     let blob::store::Data::File(file) = &store.data else {
         return None;
     };
@@ -245,6 +236,7 @@ fn file_url_unreadable_error(file_blob: &Blob, global_this: &JSGlobalObject) -> 
     };
 
     let mut path_buf = bun_paths::path_buffer_pool::get();
+    // `stat`, not `open`: opening a FIFO or a device has side effects, and the fd is not needed.
     let err = match bun_sys::stat(path.slice_z(&mut path_buf)) {
         Ok(stat) if bun_sys::S::ISDIR(stat.st_mode as bun_sys::Mode) => {
             bun_sys::Error::from_code(bun_sys::E::EISDIR, bun_sys::Tag::read)

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -228,17 +228,13 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
 // file: URLs
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The `Response` for a `file:` URL wraps a blob that opens the file lazily, so
-/// `fetch()` itself has to check the path; otherwise a path that cannot be read
-/// still gets a 200 and the error only surfaces from the body reader. Returns
-/// the error for `fetch()` to reject with: the system error as a `TypeError`,
-/// the shape every other `fetch()` rejection has (see `ValueError::SystemTypeError`).
+/// The body blob opens the file lazily, so this is where `fetch("file:...")`
+/// learns that the path cannot be read. Returns the rejection value, a
+/// `TypeError` like every other `fetch()` failure (`ValueError::SystemTypeError`).
 ///
-/// Only conditions under which the read is certain to fail are checked (the
-/// path does not stat, or is a directory). `stat` rather than an eager `open`:
-/// opening a FIFO or a device has side effects, and nothing here needs the fd.
-/// Files embedded in a standalone executable come back as byte-backed blobs,
-/// which have nothing on disk to check.
+/// `stat`, not `open`: opening a FIFO or a device has side effects and the fd
+/// is not needed. Non-file stores (files embedded in a standalone executable)
+/// have nothing on disk to check.
 fn file_url_unreadable_error(file_blob: &Blob, global_this: &JSGlobalObject) -> Option<JSValue> {
     let store = file_blob.store()?;
     let blob::store::Data::File(file) = &store.data else {
@@ -256,8 +252,7 @@ fn file_url_unreadable_error(file_blob: &Blob, global_this: &JSGlobalObject) -> 
         Ok(_) => return None,
         Err(err) => err,
     };
-    // `stat` attached the scratch copy of the path (`\\?\`-prefixed on
-    // Windows); report the path as the blob holds it.
+    // Report the blob's path, not the `\\?\`-prefixed scratch copy `stat` attached.
     let system_error: jsc::SystemError = err.with_path(path.slice()).to_system_error().into();
     Some(system_error.to_type_error_instance(global_this))
 }
@@ -1606,8 +1601,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 return Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
 
-            // A bare +1 ref that only `Response::init` below releases, so it is
-            // created after the early return above.
+            // +1 ref released only by `Response::init`: must stay after the early return.
             url_string = jsc::URL::file_url_from_string(BunString::borrow_utf8(temp_file_path));
 
             break 'blob file_blob;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -231,7 +231,8 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
 /// The `Response` for a `file:` URL wraps a blob that opens the file lazily, so
 /// `fetch()` itself has to check the path; otherwise a path that cannot be read
 /// still gets a 200 and the error only surfaces from the body reader. Returns
-/// the JS error for `fetch()` to reject with.
+/// the error for `fetch()` to reject with: the system error as a `TypeError`,
+/// the shape every other `fetch()` rejection has (see `ValueError::SystemTypeError`).
 ///
 /// Only conditions under which the read is certain to fail are checked (the
 /// path does not stat, or is a directory). `stat` rather than an eager `open`:
@@ -257,7 +258,8 @@ fn file_url_unreadable_error(file_blob: &Blob, global_this: &JSGlobalObject) -> 
     };
     // `stat` attached the scratch copy of the path (`\\?\`-prefixed on
     // Windows); report the path as the blob holds it.
-    Some(err.with_path(path.slice()).to_js(global_this))
+    let system_error: jsc::SystemError = err.with_path(path.slice()).to_system_error().into();
+    Some(system_error.to_type_error_instance(global_this))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -316,6 +316,21 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "Hello, world!" },
   });
+  // fetch() rejects a file: URL whose path is not on disk. An embedded file
+  // only exists inside the executable, so it has to keep resolving.
+  itBundled("compile/FetchFileURLOfEmbeddedFile", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import { pathToFileURL } from "node:url";
+        import embedded from './foo.file' with {type: "file"};
+        const response = await fetch(pathToFileURL(embedded));
+        console.log(response.status, (await response.text()).trim());
+      `,
+      "/foo.file": `abcd`,
+    },
+    run: { stdout: "200 abcd" },
+  });
   itBundled("compile/WorkerRelativePathNoExtension", {
     backend: "cli",
     compile: true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -301,12 +301,18 @@ describe("bundler", () => {
     },
   });
   // https://github.com/oven-sh/bun/issues/8697
+  // Also covers fetch() of the embedded file's file: URL: fetch() rejects a
+  // file: URL whose path is not on disk, and an embedded file only exists
+  // inside the executable, so it has to keep resolving.
   itBundled("compile/EmbeddedFileOutfile", {
     compile: true,
     files: {
       "/entry.ts": /* js */ `
+        import { pathToFileURL } from "node:url";
         import bar from './foo.file' with {type: "file"};
         if ((await Bun.file(bar).text()).trim() !== "abcd") throw "fail";
+        const response = await fetch(pathToFileURL(bar));
+        if (response.status !== 200 || (await response.text()).trim() !== "abcd") throw "fetch fail";
         console.log("Hello, world!");
       `,
       "/foo.file": /* js */ `
@@ -315,21 +321,6 @@ describe("bundler", () => {
     },
     outfile: "dist/out",
     run: { stdout: "Hello, world!" },
-  });
-  // fetch() rejects a file: URL whose path is not on disk. An embedded file
-  // only exists inside the executable, so it has to keep resolving.
-  itBundled("compile/FetchFileURLOfEmbeddedFile", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        import { pathToFileURL } from "node:url";
-        import embedded from './foo.file' with {type: "file"};
-        const response = await fetch(pathToFileURL(embedded));
-        console.log(response.status, (await response.text()).trim());
-      `,
-      "/foo.file": `abcd`,
-    },
-    run: { stdout: "200 abcd" },
   });
   itBundled("compile/WorkerRelativePathNoExtension", {
     backend: "cli",

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -549,14 +549,19 @@ test.concurrent(
       // Blob body is never read, so the Response is the only thing created.
       await fetch(url);
     }
-    for (let i = 0; i < 200; i++) await hit();
+    // Warm up until the heap and allocator have reached their steady state, so
+    // the baseline is not taken while they are still growing.
+    for (let i = 0; i < 2000; i++) {
+      await hit();
+      if ((i & 255) === 0) Bun.gc(true);
+    }
     Bun.gc(true);
     const baseline = rss();
 
     const ITERS = 20000;
     for (let i = 0; i < ITERS; i++) {
       await hit();
-      if ((i & 1023) === 0) Bun.gc(true);
+      if ((i & 255) === 0) Bun.gc(true);
     }
     Bun.gc(true);
     const final = rss();
@@ -567,9 +572,11 @@ test.concurrent(
       finalMB: (final / 1024 / 1024) | 0,
       deltaMB: Math.round(deltaMB * 10) / 10,
     }));
-    // ~0.85 KiB × 20000 ≈ 17 MiB raw leak (measured ~26 MiB on debug+ASAN)
-    // when the extra ref is dropped on the floor; ~11 MiB noise with the fix.
-    if (deltaMB > 20) {
+    // Each leaked impl is ~0.9 KiB, so 20000 of them are ~17 MiB raw. Leaking vs
+    // fixed: 26-27 vs 8-10 MiB on debug+ASAN (extra ref re-added), 19-21 vs ~2 MiB
+    // on a release build (leak approximated by retaining one equal-sized string
+    // per call).
+    if (deltaMB > ${isASAN ? 18 : 12}) {
       throw new Error("fetch(file://) leaked " + deltaMB.toFixed(1) + " MB over " + ITERS + " iterations");
     }
   `;

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tls as COMMON_CERT, gc, isASAN, isCI, isDebug } from "harness";
+import { bunEnv, bunExe, tls as COMMON_CERT, gc, isASAN, isCI, isDebug, tempDir } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import net from "node:net";
@@ -526,28 +526,36 @@ test.concurrent(
   async () => {
     // The leaked impl is "file://<resolved abs path>", and fetch_impl decodes
     // url.path into a stack PathBuffer that is 1024 bytes on macOS/BSD, 4096 on
-    // Linux, ~98 KiB on Windows. Use a ~900-byte path so decode_into succeeds on
-    // every platform and url_string is actually assigned, with enough iterations
-    // for the small per-call leak to show in RSS.
+    // Linux, ~98 KiB on Windows. Use a ~850-byte path so decode_into succeeds on
+    // every platform, with enough iterations for the small per-call leak to
+    // show in RSS. The file has to exist: fetch() rejects for a path that does
+    // not stat before url_string is ever created.
+    using dir = tempDir("fetch-file-url-leak", {});
     const script = /* js */ `
-    const pad = Buffer.alloc(900, "a").toString();
-    // Windows strips the leading "/" then asserts is_absolute_windows() in
-    // PosixToWinNormalizer under debug_assertions, which needs a drive letter.
-    const prefix = process.platform === "win32" ? "file:///C:/" : "file:///";
+    import { mkdirSync, writeFileSync } from "node:fs";
+    import { join } from "node:path";
+    import { pathToFileURL } from "node:url";
+
+    const component = Buffer.alloc(200, "a").toString();
+    const parent = join(process.cwd(), component, component, component, component);
+    mkdirSync(parent, { recursive: true });
+    const file = join(parent, "file.txt");
+    writeFileSync(file, "hello");
+    const url = pathToFileURL(file).href;
+
     const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
-    async function hit(i) {
-      // Fresh path per iteration so each leaked ref pins a distinct impl.
-      // The file does not exist; the Response is created (with url_string set)
-      // and the lazy Blob body is never read, so no fs I/O happens.
-      await fetch(prefix + i + pad);
+    async function hit() {
+      // Every call builds a fresh url_string impl for the Response. The lazy
+      // Blob body is never read, so the Response is the only thing created.
+      await fetch(url);
     }
-    for (let i = 0; i < 200; i++) { try { await hit(-i); } catch {} }
+    for (let i = 0; i < 200; i++) await hit();
     Bun.gc(true);
     const baseline = rss();
 
     const ITERS = 20000;
     for (let i = 0; i < ITERS; i++) {
-      try { await hit(i); } catch {}
+      await hit();
       if ((i & 1023) === 0) Bun.gc(true);
     }
     Bun.gc(true);
@@ -559,8 +567,8 @@ test.concurrent(
       finalMB: (final / 1024 / 1024) | 0,
       deltaMB: Math.round(deltaMB * 10) / 10,
     }));
-    // ~0.9 KiB × 20000 ≈ 18 MiB raw leak (measured ~32 MiB on debug+ASAN)
-    // when the extra ref is dropped on the floor; ~12 MiB noise with the fix.
+    // ~0.85 KiB × 20000 ≈ 17 MiB raw leak (measured ~26 MiB on debug+ASAN)
+    // when the extra ref is dropped on the floor; ~11 MiB noise with the fix.
     if (deltaMB > 20) {
       throw new Error("fetch(file://) leaked " + deltaMB.toFixed(1) + " MB over " + ITERS + " iterations");
     }
@@ -568,6 +576,7 @@ test.concurrent(
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--smol", "-e", script],
+      cwd: String(dir),
       env: {
         ...bunEnv,
         ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1793,9 +1793,23 @@ it("fetch() file:// works", async () => {
 });
 
 describe.concurrent("fetch() file:// that cannot be read", () => {
+  const isRoot = !isWindows && process.getuid?.() === 0;
   // The file: branch keeps the URL's forward slashes in the path it reports,
   // which only differs from path.join() on Windows.
   const reportedPath = (p: string) => (isWindows ? p.replaceAll("\\", "/") : p);
+
+  async function rejection(input: string | URL | Request): Promise<unknown> {
+    const error = await fetch(input).then(
+      () => {
+        throw new Error("fetch() resolved");
+      },
+      (error: unknown) => error,
+    );
+    // Every fetch() failure is a TypeError (a network error in fetch spec
+    // terms); the system error fields ride along on it.
+    expect(error).toBeInstanceOf(TypeError);
+    return error;
+  }
 
   it("rejects with ENOENT when the file does not exist", async () => {
     using dir = tempDir("fetch-file-url", { "exists.txt": "exists" });
@@ -1803,7 +1817,7 @@ describe.concurrent("fetch() file:// that cannot be read", () => {
     const url = pathToFileURL(missing);
 
     for (const input of [url.href, url, new Request(url)]) {
-      await expect(fetch(input)).rejects.toMatchObject({
+      expect(await rejection(input)).toMatchObject({
         code: "ENOENT",
         syscall: "stat",
         path: reportedPath(missing),
@@ -1818,14 +1832,60 @@ describe.concurrent("fetch() file:// that cannot be read", () => {
   it("rejects with EISDIR when the path is a directory", async () => {
     using dir = tempDir("fetch-file-url-dir", {});
 
-    await expect(fetch(pathToFileURL(String(dir)))).rejects.toMatchObject({
+    expect(await rejection(pathToFileURL(String(dir)))).toMatchObject({
       code: "EISDIR",
       syscall: "read",
       path: reportedPath(String(dir)),
     });
   });
 
-  it.skipIf(isWindows)("still resolves for special files such as /dev/null", async () => {
+  it.skipIf(isWindows || isRoot)("rejects with EACCES when a parent directory cannot be searched", async () => {
+    using dir = tempDir("fetch-file-url-eacces", { "locked/file.txt": "secret" });
+    const locked = join(String(dir), "locked");
+    const file = join(locked, "file.txt");
+
+    chmodSync(locked, 0o000);
+    try {
+      expect(await rejection(pathToFileURL(file))).toMatchObject({
+        code: "EACCES",
+        syscall: "stat",
+        path: reportedPath(file),
+      });
+    } finally {
+      chmodSync(locked, 0o755);
+    }
+  });
+
+  it.skipIf(isWindows || isRoot)("leaves a permission check on the file itself to the body read", async () => {
+    // Only what stat() reports is checked before the Response is created.
+    // access(2) can disagree with open(2), so a file that stats but cannot be
+    // opened still resolves and the open error comes from the body, as before.
+    using dir = tempDir("fetch-file-url-mode", { "file.txt": "secret" });
+    const file = join(String(dir), "file.txt");
+    chmodSync(file, 0o000);
+
+    const response = await fetch(pathToFileURL(file));
+    expect(response.status).toBe(200);
+    await expect(response.text()).rejects.toMatchObject({
+      code: "EACCES",
+      syscall: "open",
+      path: reportedPath(file),
+    });
+  });
+
+  it.skipIf(isWindows)("resolves for a FIFO without opening it", async () => {
+    using dir = tempDir("fetch-file-url-fifo", {});
+    const fifo = join(String(dir), "pipe");
+    mkfifo(fifo);
+
+    // Nothing ever writes to the pipe, so an implementation that opened the
+    // path up front instead of stat()ing it would block here. The body is
+    // deliberately left unread.
+    const response = await fetch(pathToFileURL(fifo));
+    expect(response.status).toBe(200);
+  });
+
+  it.skipIf(isWindows)("resolves for a character device", async () => {
     const response = await fetch("file:///dev/null");
     expect([response.status, await response.text()]).toEqual([200, ""]);
   });
@@ -1843,7 +1903,7 @@ describe.concurrent("fetch() file:// that cannot be read", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stdout).toBe("");
-    expect(stderr).toContain("ENOENT");
+    expect(stderr).toContain("TypeError: ENOENT");
     expect(stderr).toContain(reportedPath(missing));
     expect(exitCode).toBe(1);
   });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -16,6 +16,7 @@ import {
   isWindows,
   rss,
   runFixtureMaxRSS,
+  tempDir,
   tls,
   tmpdirSync,
   withoutAggressiveGC,
@@ -27,6 +28,7 @@ import type { AddressInfo } from "net";
 import net from "net";
 import { join } from "path";
 import { Readable } from "stream";
+import { pathToFileURL } from "url";
 import { gzipSync } from "zlib";
 
 const tmp_dir = tmpdirSync();
@@ -1789,6 +1791,64 @@ it("fetch() file:// works", async () => {
   expect(fileResponseText).toEqual(bunFileText);
   gc(true);
 });
+
+describe.concurrent("fetch() file:// that cannot be read", () => {
+  // The file: branch keeps the URL's forward slashes in the path it reports,
+  // which only differs from path.join() on Windows.
+  const reportedPath = (p: string) => (isWindows ? p.replaceAll("\\", "/") : p);
+
+  it("rejects with ENOENT when the file does not exist", async () => {
+    using dir = tempDir("fetch-file-url", { "exists.txt": "exists" });
+    const missing = join(String(dir), "missing.txt");
+    const url = pathToFileURL(missing);
+
+    for (const input of [url.href, url, new Request(url)]) {
+      await expect(fetch(input)).rejects.toMatchObject({
+        code: "ENOENT",
+        syscall: "stat",
+        path: reportedPath(missing),
+      });
+    }
+
+    // A sibling that does exist is unaffected.
+    const response = await fetch(pathToFileURL(join(String(dir), "exists.txt")));
+    expect([response.status, await response.text()]).toEqual([200, "exists"]);
+  });
+
+  it("rejects with EISDIR when the path is a directory", async () => {
+    using dir = tempDir("fetch-file-url-dir", {});
+
+    await expect(fetch(pathToFileURL(String(dir)))).rejects.toMatchObject({
+      code: "EISDIR",
+      syscall: "read",
+      path: reportedPath(String(dir)),
+    });
+  });
+
+  it.skipIf(isWindows)("still resolves for special files such as /dev/null", async () => {
+    const response = await fetch("file:///dev/null");
+    expect([response.status, await response.text()]).toEqual([200, ""]);
+  });
+
+  it("reports the rejection as unhandled when nothing catches it", async () => {
+    using dir = tempDir("fetch-file-url-unhandled", {});
+    const missing = join(String(dir), "missing.txt");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `fetch(${JSON.stringify(pathToFileURL(missing).href)});`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("ENOENT");
+    expect(stderr).toContain(reportedPath(missing));
+    expect(exitCode).toBe(1);
+  });
+});
+
 it("cloned response headers are independent before accessing", () => {
   const response = new Response("hello", {
     headers: {


### PR DESCRIPTION
### What does this PR do?

`fetch()` of a `file:` URL resolved with a 200 `Response` no matter what the path pointed at. The error only showed up when the body was read:

```js
const res = await fetch("file:///definitely/missing/file");
console.log(res.status, res.ok); // 200 true
await res.text();                // ENOENT: no such file or directory, open '/definitely/missing/file'
```

Same thing for a directory (`fetch("file:///tmp")` is a 200, `.text()` throws EISDIR).

**Cause:** the `file:` branch of `fetch_impl` (`src/runtime/webcore/fetch.rs`) builds the `Response` around a `Bun.file()`-style blob, which does not touch the file until it is read, and hardcodes `status_code: 200`. Nothing in between looks at the disk.

**Fix:** after the blob is created, `stat` the path and reject the `fetch()` promise instead of building the `Response`:

- path does not stat (ENOENT, ENOTDIR, EACCES on a parent directory, ELOOP, ...): reject with that error (`code`, `syscall: "stat"`, `path`, `errno`)
- path is a directory: reject with EISDIR (`syscall: "read"`, the error the body read would have produced)
- anything else, including FIFOs and character devices like `/dev/null`, keeps resolving as before

The rejection is the system error materialized as a `TypeError` (`SystemError::to_type_error_instance`), which is the shape every other `fetch()` rejection has had since #35855 (`ValueError::SystemTypeError`): `err instanceof TypeError` holds, and `err.code === "ENOENT"` checks that today run against the `.text()` error keep working.

The check only runs for path-backed file blobs. Files embedded in a standalone executable come back from `find_or_create_file_from_path` as byte-backed blobs and do not exist on disk, so they are left alone (covered by a new compile test).

### Why this shape

- Rejecting rather than returning a 404 `Response` is what `fetch()` already does for an unresolvable `blob:` URL a few lines up, what Deno does for a missing `file:` URL, and what the Fetch spec asks for when a `file:` fetch cannot be served (a network error, which is a `TypeError` at the JS level). `fetch()` has no status to map ENOTDIR, ELOOP or EISDIR onto anyway. This also mirrors the upload direction in the same function, where `fetch(url, { body: Bun.file(missing) })` already rejects with the open error up front.
- `stat` rather than an eager `open`: nothing here needs the fd (the body reader opens the path itself, and a path-backed store is what keeps `response.clone()` working), and opening a FIFO or a device just to close it again has side effects, or blocks when a FIFO has no writer. `stat` has none of that. There is a FIFO test that blocks under an eager blocking open.
- Only failures that guarantee the read would fail are checked. A permission failure on the file's own mode bits is deliberately not pre-checked: `access(2)` can disagree with `open(2)` (real vs effective ids, NFS), and a pre-flight must never reject a file the read would have succeeded on. That case still resolves and the EACCES still comes from the body read, exactly as today; a test pins that boundary from both sides.
- The check is synchronous, like `Bun.file().size`/`.exists()` and the `open`/`fstat` that `Bun.serve` does when rendering a file-backed `Response`. It is one `stat` of a local path.
- The rejection is created with `JSPromise::rejected_promise`, so an uncaught `fetch("file:///missing")` is reported as an unhandled rejection (tested). The older helper used by the other early exits in this function suppresses that reporting; switching those call sites is tracked separately.
- `url_string` is a bare +1 ref that only `Response::init` releases, so it is now created after the check. The existing leak test for that ref (`fetch-leak.test.ts`) fetched a path that does not exist, which no longer reaches the code it guards, so it now fetches a file that does exist. While there, its flat 20 MiB bound (over a ~17 MiB raw signal) was replaced by a longer warm-up and an `isASAN`-branched bound like the other tests in that file. Measured with `url_string.clone()` temporarily re-added vs fixed: 26-27 vs 8-10 MiB on debug+ASAN (bound 18); on the release build ~2 MiB fixed and 19-21 MiB with the leak approximated by retaining one equal-sized string per call (bound 12).
- The new early return drops the request body the same way the existing resolving return in this branch (and most other early exits in `fetch_impl`) already does; `HTTPRequestBody` has no `Drop`, so a body passed to a `file:` fetch is retained today regardless of this change. That is a separate pre-existing leak and is being handled on its own.

### How did you verify your code works?

New tests in `test/js/web/fetch/fetch.test.ts` (`fetch() file:// that cannot be read`), every rejection also asserted to be a `TypeError`:

- ENOENT for a string, `URL` and `Request` input (a sibling that exists still resolves)
- EISDIR for a directory
- EACCES reported by `stat` for a file under a mode 000 directory (skipped on Windows and as root)
- a mode 000 file still resolves and `.text()` rejects with the EACCES from `open` (skipped on Windows and as root)
- a FIFO with no writer resolves without the body being read (skipped on Windows)
- `/dev/null` resolves with an empty body (skipped on Windows)
- an uncaught rejection prints `TypeError: ENOENT ...` and exits 1

The ENOENT, EISDIR, EACCES-from-stat and uncaught cases fail on the current release (`fetch()` resolves) and pass with this change; the other three pass on both and pin the boundary. I ran the block both as root and as an unprivileged user so the two permission tests executed.

`compile/EmbeddedFileOutfile` in `test/bundler/bundler_compile.test.ts` (which already builds an executable with an embedded file) now also checks that `fetch(pathToFileURL(embeddedPath))` returns the embedded contents; I confirmed by hand that the `/$bunfs/...` path involved does not exist on disk.

Also run locally with the debug build: the pre-existing `fetch() file:// works` test, the updated leak test, `cargo clippy -p bun_runtime`. The rest of `fetch.test.ts` has the same failures with and without this change in my environment (localhost connections refused, and `(with gc)` tests exceeding their timeout under the debug build).
