### PR TITLE
usockets: take every SCM_RIGHTS descriptor off an IPC message and close the extras

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -943,6 +943,68 @@ ssize_t bsd_recvmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct msghdr *msg, int flags) {
         return ret;
     }
 }
+
+ssize_t bsd_recv_ipc(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags, LIBUS_SOCKET_DESCRIPTOR *received_fd) {
+    /* The protocol attaches one descriptor per message, but take room for more
+     * (64, like libuv): a descriptor the control buffer has no room for is
+     * dropped by Linux, while macOS still installs it in this process and then
+     * truncates the control message, so it leaks. */
+    char control[CMSG_SPACE(64 * sizeof(int))];
+    struct iovec iov;
+    struct msghdr msg;
+    memset(&msg, 0, sizeof(msg));
+    iov.iov_base = buf;
+    iov.iov_len = length;
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = control;
+    msg.msg_controllen = sizeof(control);
+#if defined(MSG_CMSG_CLOEXEC)
+    flags |= MSG_CMSG_CLOEXEC;
+#endif
+
+    *received_fd = LIBUS_SOCKET_ERROR;
+    ssize_t ret = bsd_recvmsg(fd, &msg, flags);
+    /* Descriptors only ever ride along with data. A 0 may also be a fault
+     * injected by bsd_recvmsg, which leaves msg (and control) uninitialized. */
+    if (ret <= 0) {
+        return ret;
+    }
+
+    /* On MSG_CTRUNC a cmsg_len still describes the untruncated message, so the
+     * walk is bounded by what the kernel actually copied out. */
+    const unsigned char *control_end = (const unsigned char *) msg.msg_control + msg.msg_controllen;
+    for (struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+        /* Darwin's CMSG_NXTHDR returns the same header again for cmsg_len 0. */
+        if (cmsg->cmsg_len < CMSG_LEN(0)) {
+            break;
+        }
+        if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+            continue;
+        }
+        const unsigned char *data = CMSG_DATA(cmsg);
+        const unsigned char *end = (const unsigned char *) cmsg + cmsg->cmsg_len;
+        if (end > control_end) {
+            end = control_end;
+        }
+        for (; end - data >= (ptrdiff_t) sizeof(int); data += sizeof(int)) {
+            int passed_fd;
+            memcpy(&passed_fd, data, sizeof(int));
+            if (*received_fd == LIBUS_SOCKET_ERROR) {
+                *received_fd = passed_fd;
+            } else {
+                close(passed_fd);
+            }
+        }
+    }
+
+#if !defined(MSG_CMSG_CLOEXEC)
+    if (*received_fd != LIBUS_SOCKET_ERROR) {
+        fcntl(*received_fd, F_SETFD, fcntl(*received_fd, F_GETFD) | FD_CLOEXEC);
+    }
+#endif
+    return ret;
+}
 #endif
 
 #if !defined(_WIN32)

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -217,6 +217,12 @@ LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd
 ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags);
 #if !defined(_WIN32)
 ssize_t bsd_recvmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct msghdr *msg, int flags);
+/* bsd_recv() for an IPC socket (the us_socket_ipc_write_fd peer). When the bytes
+ * returned came with SCM_RIGHTS descriptors, the first one is stored in
+ * *received_fd, made close-on-exec, and every other one is closed: the protocol
+ * attaches at most one descriptor per message. *received_fd is LIBUS_SOCKET_ERROR
+ * when no descriptor was received. */
+ssize_t bsd_recv_ipc(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags, LIBUS_SOCKET_DESCRIPTOR *received_fd);
 #endif
 ssize_t bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length);
 #if !defined(_WIN32)

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -685,32 +685,13 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     int length;
                     #if !defined(_WIN32)
                     if(s->flags.is_ipc) {
-                        struct msghdr msg = {0};
-                        struct iovec iov = {0};
-                        char cmsg_buf[CMSG_SPACE(sizeof(int))];
+                        LIBUS_SOCKET_DESCRIPTOR received_fd;
+                        length = bsd_recv_ipc(us_poll_fd(&s->p), loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, LIBUS_RECV_BUFFER_LENGTH, recv_flags, &received_fd);
 
-                        iov.iov_base = loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING;
-                        iov.iov_len = LIBUS_RECV_BUFFER_LENGTH;
-
-                        msg.msg_flags = 0;
-                        msg.msg_iov = &iov;
-                        msg.msg_iovlen = 1;
-                        msg.msg_name = NULL;
-                        msg.msg_namelen = 0;
-                        msg.msg_controllen = CMSG_LEN(sizeof(int));
-                        msg.msg_control = cmsg_buf;
-
-                        length = bsd_recvmsg(us_poll_fd(&s->p), &msg, recv_flags);
-
-                        // Extract file descriptor if present
-                        if (length > 0 && msg.msg_controllen > 0) {
-                            struct cmsghdr *cmsg_ptr = CMSG_FIRSTHDR(&msg);
-                            if (cmsg_ptr && cmsg_ptr->cmsg_level == SOL_SOCKET && cmsg_ptr->cmsg_type == SCM_RIGHTS) {
-                                int fd = *(int *)CMSG_DATA(cmsg_ptr);
-                                s = us_dispatch_fd(s, fd);
-                                if (!s || us_socket_is_closed(s)) {
-                                    break;
-                                }
+                        if (received_fd != LIBUS_SOCKET_ERROR) {
+                            s = us_dispatch_fd(s, received_fd);
+                            if (!s || us_socket_is_closed(s)) {
+                                break;
                             }
                         }
                     }else{

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
+import { dlopen } from "bun:ffi";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gcTick, isWindows } from "harness";
+import { bunEnv, bunExe, gcTick, isWindows, libcPathForDlopen, tempDir } from "harness";
 import path from "path";
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
@@ -260,3 +261,132 @@ it.skipIf(isWindows)("advanced serialization advertises wire format version 2", 
   expect(JSON.parse(stdout.trim())).toEqual([1, 2, 0, 0, 0]);
   expect(exitCode).toBe(0);
 });
+
+// The peer hand-rolls the sendmsg(2) so it can attach three descriptors to one
+// NODE_HANDLE message, which neither Bun nor libuv ever do. The receiver (this
+// test process) has to use the first one and close the others. The peer keeps
+// the far ends of the two extras, so EOF on those proves we closed our copies;
+// that part can only fail on macOS, where descriptors that do not fit the
+// receiver's control buffer are installed anyway and leak (Linux drops them in
+// the kernel). The close-on-exec check covers both platforms.
+const scmRightsPeerSource = `
+const { dlopen, FFIType, ptr } = require("bun:ffi");
+const isDarwin = process.platform === "darwin";
+const libc = dlopen(process.env.LIBC_PATH, {
+  socket: { args: [FFIType.int, FFIType.int, FFIType.int], returns: FFIType.int },
+  socketpair: { args: [FFIType.int, FFIType.int, FFIType.int, FFIType.ptr], returns: FFIType.int },
+  sendmsg: { args: [FFIType.int, FFIType.ptr, FFIType.int], returns: FFIType.i64_fast },
+  recv: { args: [FFIType.int, FFIType.ptr, FFIType.u64, FFIType.int], returns: FFIType.i64_fast },
+  close: { args: [FFIType.int], returns: FFIType.int },
+});
+const AF_UNIX = 1, AF_INET = 2, SOCK_STREAM = 1, SOCK_DGRAM = 2;
+const SOL_SOCKET = isDarwin ? 0xffff : 1;
+const SCM_RIGHTS = 1;
+const MSG_DONTWAIT = isDarwin ? 0x80 : 0x40;
+
+function socketpair() {
+  const fds = new Int32Array(2);
+  if (libc.symbols.socketpair(AF_UNIX, SOCK_STREAM, 0, fds) !== 0) throw new Error("socketpair() failed");
+  return fds;
+}
+
+// fds[0] is the handle the message describes; the receiver must close the rest.
+const udp = libc.symbols.socket(AF_INET, SOCK_DGRAM, 0);
+if (udp < 0) throw new Error("socket() failed");
+const [extraA, keptA] = socketpair();
+const [extraB, keptB] = socketpair();
+const fds = [udp, extraA, extraB];
+
+const payload = Buffer.from(JSON.stringify({ cmd: "NODE_HANDLE", type: "dgram.Native", message: { hello: "handle" } }) + "\\n");
+
+// struct cmsghdr: Linux { size_t len; int level; int type; } (data 8-aligned),
+// Darwin { socklen_t len; int level; int type; } (data 4-aligned). Both are
+// little-endian, so 32-bit writes into a zeroed buffer fill the wider fields too.
+const cmsgHeader = isDarwin ? 12 : 16;
+const cmsgAlign = isDarwin ? 4 : 8;
+const cmsgLen = cmsgHeader + 4 * fds.length;
+const cmsgSpace = cmsgHeader + Math.ceil((4 * fds.length) / cmsgAlign) * cmsgAlign;
+const control = new Uint8Array(cmsgSpace);
+const controlView = new DataView(control.buffer);
+controlView.setUint32(0, cmsgLen, true);
+controlView.setInt32(isDarwin ? 4 : 8, SOL_SOCKET, true);
+controlView.setInt32(isDarwin ? 8 : 12, SCM_RIGHTS, true);
+fds.forEach((fd, i) => controlView.setInt32(cmsgHeader + 4 * i, fd, true));
+
+// struct iovec { void *base; size_t len; } is the same on both.
+const iov = new Uint8Array(16);
+const iovView = new DataView(iov.buffer);
+iovView.setBigUint64(0, BigInt(ptr(payload)), true);
+iovView.setUint32(8, payload.byteLength, true);
+
+// struct msghdr: name @0, namelen @8, iov @16, iovlen @24 (size_t on Linux, int
+// on Darwin), control @32, controllen @40 (size_t on Linux, socklen_t on Darwin
+// followed by flags @44), flags @48 on Linux. Zeroed buffer, so the narrower
+// Darwin fields and the padding come out right from the same 32-bit writes.
+const msg = new Uint8Array(56);
+const msgView = new DataView(msg.buffer);
+msgView.setBigUint64(16, BigInt(ptr(iov)), true);
+msgView.setUint32(24, 1, true);
+msgView.setBigUint64(32, BigInt(ptr(control)), true);
+msgView.setUint32(40, control.byteLength, true);
+
+// Bun put the IPC channel on fd 3 (no other extra stdio).
+const sent = libc.symbols.sendmsg(3, msg, 0);
+if (sent !== payload.byteLength) throw new Error("sendmsg() returned " + sent);
+// Drop our copies: from here on only the receiver keeps extraA/extraB open, so
+// EOF on keptA/keptB means the receiver closed them.
+for (const fd of fds) libc.symbols.close(fd);
+
+// Nothing is ever written on these pairs, so recv() is 0 (EOF) once every copy
+// of the far end is closed and -1 (EAGAIN) while the receiver still holds one.
+process.on("message", () => {
+  const probe = new Uint8Array(1);
+  const state = fd => (libc.symbols.recv(fd, probe, 1, MSG_DONTWAIT) === 0 ? "closed" : "open");
+  process.send({ extras: [state(keptA), state(keptB)] });
+});
+`;
+
+it.skipIf(isWindows)(
+  "a NODE_HANDLE message carrying several descriptors delivers the first and closes the rest",
+  async () => {
+    using dir = tempDir("ipc-scm-rights", { "peer.js": scmRightsPeerSource });
+    const { promise, resolve, reject } = Promise.withResolvers<{ message: unknown; handle: any; peer: unknown }>();
+    let first: { message: unknown; handle: any } | undefined;
+    await using child = spawn({
+      cmd: [bunExe(), "peer.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, LIBC_PATH: libcPathForDlopen() },
+      stdio: ["ignore", "inherit", "inherit"],
+      serialization: "json",
+      ipc(message, subprocess, handle) {
+        if (!first) {
+          first = { message, handle };
+          // By the time the handle reaches us the receive path has already dealt
+          // with the other descriptors, so the peer can check its ends now.
+          subprocess.send("probe");
+        } else {
+          resolve({ ...first, peer: message });
+        }
+      },
+      onExit(_subprocess, exitCode, signalCode) {
+        reject(new Error(`peer exited (${exitCode}, ${signalCode}) before reporting`));
+      },
+    });
+    const { message, handle, peer } = await promise;
+
+    // `handle` is the dgram wrap Bun built around the first descriptor, so
+    // handle.fd is that descriptor as received into this process.
+    const F_GETFD = 1;
+    const FD_CLOEXEC = 1;
+    const libc = dlopen(libcPathForDlopen(), { fcntl: { args: ["int", "int"], returns: "int" } });
+    const fdFlags = libc.symbols.fcntl(handle.fd, F_GETFD);
+    libc.close();
+    handle.close();
+
+    expect({ message, peer, cloexec: fdFlags & FD_CLOEXEC }).toEqual({
+      message: { hello: "handle" },
+      peer: { extras: ["closed", "closed"] },
+      cloexec: FD_CLOEXEC,
+    });
+  },
+);


### PR DESCRIPTION
### What

`loop.c`'s IPC receive path (`packages/bun-usockets/src/loop.c`, the `is_ipc` branch) had two problems in how it picked up `SCM_RIGHTS` descriptors:

- `msg.msg_controllen` was set to `CMSG_LEN(sizeof(int))` rather than the size of `cmsg_buf` (`CMSG_SPACE`).
- Only the first descriptor of an `SCM_RIGHTS` array was read. Anything else attached to the message was left open in the receiving process.

On Linux the kernel only installs as many descriptors as fit in the control buffer and drops the rest (`MSG_CTRUNC`), so nothing leaked there. On macOS `unp_externalize` installs every descriptor into the process first and `recvit` truncates the control message afterwards, so with the one-descriptor buffer a message carrying N descriptors leaked N-1 of them with no way to find out their numbers.

The protocol itself (`us_socket_ipc_write_fd`, libuv's `uv_write2`) only ever attaches one descriptor per message, so this needs a misbehaving peer. Low severity, but the receive path should not depend on it.

### Fix

The `recvmsg` moved into `bsd_recv_ipc()` in `bsd.c`:

- control buffer sized for 64 descriptors (the count libuv uses), `msg_controllen = sizeof(control)`
- walks every `SCM_RIGHTS` cmsg; the walk is bounded by `msg_controllen` because after `MSG_CTRUNC` macOS leaves the untruncated `cmsg_len` in the header
- the first descriptor goes to `us_dispatch_fd`, every other one is `close()`d
- received descriptors are made close-on-exec (`MSG_CMSG_CLOEXEC`, `fcntl` fallback where that flag does not exist). libuv does the same in `uv__recvmsg`, and every other descriptor usockets creates is already `FD_CLOEXEC`; until now a received one was not until something adopted it. Easy to drop if you would rather keep this change to the two items above.

`loop.c` now just calls the helper and dispatches the descriptor it returns. Nothing changes on the Rust side: `on_fd` still gets at most one descriptor per message.

### Test

`test/js/bun/spawn/spawn.ipc.test.ts`: a child uses `bun:ffi` to `sendmsg` one json-mode `NODE_HANDLE` line on the IPC channel with three descriptors attached (a UDP socket plus one end of each of two socketpairs), then closes its copies. The test process receives it and checks that:

- the handle built from the first descriptor arrives with the message,
- that descriptor has `FD_CLOEXEC` set (fails before this change on both platforms),
- the child's far ends of the two extras read EOF, i.e. the receiver closed them. This assertion can only fail on macOS, where the extras used to leak; on Linux the kernel was already dropping them, which is also why the test passes both ways there without the cloexec check.

Before, on Linux:

```
-   "cloexec": 1,
+   "cloexec": 0,
```

Verified with an `LD_PRELOAD` shim logging `recvmsg`/`close` in the receiver on Linux. Before: `recvmsg(...) -> 1 fds: 8 (MSG_CTRUNC)`. After: `recvmsg(flags=MSG_DONTWAIT|MSG_CMSG_CLOEXEC) -> 3 fds: 9 11 12`, then `close(11)`, `close(12)`, and fd 9 delivered as the handle. The macOS leak itself is from reading xnu's `soreceive`/`recvit`; I have not run the failing case on a Mac, CI's darwin lanes run the new test against the fixed build.

Also ran the cluster shared-dgram tests (the real one-descriptor traffic through this path), `child_process` IPC tests, the socket fault-injection tests and a few `bun test --parallel` tests (its coordinator channel is an `is_ipc` socket too); all pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.ipc.test.ts

<!-- robobun:evidence:end -->