### PR TITLE
Fix crash when a property lookup throws while an object is being formatted

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -319,9 +319,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -331,9 +328,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5671,7 +5672,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from "getPrototypeOf" proxy traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -467,6 +467,80 @@ describe("crash testing", () => {
   }
 });
 
+describe("exceptions thrown while walking properties", () => {
+  // Each case crashed the process before the walk cleared the exception, so
+  // they run in a subprocess.
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent("a throwing Proxy trap in the prototype chain skips only that property", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      {
+        const proto = new Proxy(
+          { a: 1, b: 2, c: 3 },
+          {
+            get(target, key, receiver) {
+              if (key === "a") throw new Error("boom");
+              return Reflect.get(target, key, receiver);
+            },
+          },
+        );
+        console.log(Bun.inspect(Object.create(proto)));
+      }
+      {
+        const proto = new Proxy(
+          { a: 1 },
+          {
+            getPrototypeOf() {
+              throw new Error("boom");
+            },
+          },
+        );
+        console.log(Bun.inspect(Object.create(proto)));
+      }
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        b: 2,
+        c: 3,
+      }
+      {
+        a: 1,
+      }
+      "
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("a throwing lazy property initializer skips only that property", async () => {
+    // The builtin behind Bun.$ calls the global Symbol, so clobbering it makes
+    // that lazy property throw when it is first reified.
+    const { stdout, stderr, exitCode } = await run(`
+      globalThis.Symbol = NaN;
+      let threw = false;
+      try {
+        Bun.$;
+      } catch {
+        threw = true;
+      }
+      const inspected = Bun.inspect(Bun);
+      console.log(threw, inspected.includes("Archive:"), inspected.includes("version:"));
+    `);
+    expect(stdout).toBe("true true true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("possibly formatted emojis log", () => {
   expect(Bun.inspect("✔")).toBe('"✔"');
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -468,8 +468,9 @@ describe("crash testing", () => {
 });
 
 describe("exceptions thrown while walking properties", () => {
-  // Each case crashed the process before the walk cleared the exception, so
-  // they run in a subprocess.
+  // Before the walk cleared these exceptions the process crashed (or, in the
+  // second case, a debug build asserted), and the second case replaces a
+  // global, so each case runs in a subprocess.
   async function run(fixture) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
@@ -522,20 +523,24 @@ describe("exceptions thrown while walking properties", () => {
   });
 
   it.concurrent("a throwing lazy property initializer skips only that property", async () => {
-    // The builtin behind Bun.$ calls the global Symbol, so clobbering it makes
-    // that lazy property throw when it is first reified.
+    // The builtin behind Bun.$ calls the global Symbol("cwd"), so making that
+    // one call throw makes Bun.$ (and nothing else on Bun) fail to reify while
+    // Bun is formatted. The properties listed after it must still be printed.
     const { stdout, stderr, exitCode } = await run(`
-      globalThis.Symbol = NaN;
-      let threw = false;
-      try {
-        Bun.$;
-      } catch {
-        threw = true;
-      }
+      globalThis.Symbol = new Proxy(Symbol, {
+        apply(target, thisArg, args) {
+          if (args[0] === "cwd") throw new Error("boom");
+          return Reflect.apply(target, thisArg, args);
+        },
+      });
       const inspected = Bun.inspect(Bun);
-      console.log(threw, inspected.includes("Archive:"), inspected.includes("version:"));
+      console.log(
+        inspected.includes("\\n  $: "),
+        inspected.includes("\\n  Archive: "),
+        inspected.includes("\\n  version: "),
+      );
     `);
-    expect(stdout).toBe("true true true\n");
+    expect(stdout).toBe("false true true\n");
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### What

Fixes a crash in the object property walk used by `Bun.inspect`, `console.log` and the `expect()` failure messages (`JSC__JSValue__forEachPropertyImpl` in `src/jsc/bindings/bindings.cpp`), found by the fuzzer. The crash needs a property lookup that throws while the object is being formatted.

Release builds segfault (`Segmentation fault at address 0x5`) on either of these:

```js
const proto = new Proxy({ a: 1, b: 2, c: 3 }, {
  get(t, k, r) { if (k === "a") throw new Error("boom"); return Reflect.get(t, k, r); },
});
Bun.inspect(Object.create(proto));

const proto2 = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("boom"); } });
Bun.inspect(Object.create(proto2));
```

Debug builds additionally abort with `releaseAssertNoException` on the fuzzer's case, which is a lazy property on the `Bun` object throwing while `Bun` is formatted (the shell builtin behind `Bun.$` calls the global `Symbol`, which a previous REPRL script had replaced). In release builds that case silently drops every property of `Bun` that comes after the throwing one.

### Root cause

In the slow path of the walk, a `getPropertySlot` that returned false was skipped with `continue` before the `CLEAR_IF_EXCEPTION` that follows it. JSC reports a throwing Proxy trap or a throwing static lazy property initializer exactly that way (returns false, exception pending), so the exception stayed on the VM:

* every later lookup on the object fails early because of the stale exception (the silently dropped properties in release, the assertion in debug when the next lazy initializer returns a value with an exception still pending),
* when the walk moves to the next prototype, `getPrototype()` bails out and returns the empty `JSValue`, and `.getObject()` on it dereferences null (an empty `JSValue` passes `isCell()`, and `JSCell::getObject` reads the type byte at offset 5). A Proxy whose `getPrototypeOf` trap throws reaches this line directly, without a stale exception.

### Fix

`bindings.cpp`: clear the exception after `getPropertySlot` regardless of its result (this is what the ordered variant `JSC__JSValue__forEachPropertyOrdered` already does), and check the value returned by `getPrototype` before calling `getObject()` on it, ending the walk if the trap threw.

Not in this PR: `napi_get_all_property_names` (`src/jsc/bindings/napi.cpp`, the descriptor filter loop) has the same `getPrototype().getObject()` chain and also ignores a throwing `getOwnPropertyDescriptor` right before it. It is only reachable from a native addon and needs its own addon-based test, so it is being fixed separately.

`BunObject.cpp`: `defaultBunSQLObject` / `constructBunSQLObject` had a debug-only block that passed a load failure of the SQL module to `reportUncaughtExceptionAtEventLoop` while the exception was still pending on the VM. Every other caller clears the exception first. The report runs `process.get("_fatalException")`, which reifies a static property on `process` with the exception pending and trips the `Structure::storedPrototype` assertion, so `globalThis.Symbol = NaN; Bun.sql` aborted debug builds, and so did the fuzzer's case once the walk got past `Bun.$`. The exception is propagated to the caller right below this block anyway (`Bun.sql` throws it), so the block is removed rather than reordered.

### Tests

Two tests added to `test/js/bun/util/inspect.test.js` under "exceptions thrown while walking properties", both spawning a subprocess because the unfixed binary dies:

* the two Proxy cases above. On the unfixed build the subprocess segfaults; fixed, the throwing property is skipped and the others are printed.
* the fuzzer's case, reduced to one property: a Proxy around `Symbol` makes only the `Symbol("cwd")` call in the shell builtin throw, so `Bun.$` fails to reify while `Bun.inspect(Bun)` runs. Unfixed release prints `false false true` (`Archive`, the property after `$`, is missing), unfixed debug aborts; fixed, it prints `false true true`. Verified on Linux and Windows (an earlier version of this test replaced `Symbol` entirely, which also broke loading `node:util`; Windows needs that to format `process.env`, and a lazy initializer failing there hits an unrelated pre-existing abort, so the test failed on the Windows lanes of the first CI run).

Also ran the full `inspect.test.js`, `BunObject.test.ts`, `mock-fn.test.js` and `sql/adapter-override.test.ts` against the debug build, and the repros with `BUN_JSC_validateExceptionChecks=1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->