### PR TITLE
proxy: match bare IPv6 NO_PROXY entries against bracketed URL hosts

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -864,24 +864,11 @@ impl Loader {
     }
 }
 
-/// Returns true if a request to `hostname` should bypass the proxy according
-/// to `no_proxy_text`, the value of `NO_PROXY` (syntax per
-/// https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/).
-/// `host` is `hostname` plus `:port` when the URL carries one; entries with a
-/// port are matched against it. Both come straight from the URL, so an IPv6
-/// literal arrives bracketed (`http://[::1]/` gives `[::1]` and `[::1]:8080`).
-///
-/// Shared by the env-backed [`Loader::is_no_proxy`] (WebSocket, install,
-/// upgrade, ...) and `bun_http::ProxySettings`, which matches fetch's hop-0
-/// and redirect targets against a captured copy of the value.
+/// `hostname` comes from the URL (an IPv6 literal arrives as `[::1]`); `host` adds its `:port`.
 pub fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> bool {
     if hostname.is_empty() {
         return false;
     }
-    // NO_PROXY lists conventionally write an IPv6 address bare
-    // (`NO_PROXY=localhost,127.0.0.1,::1`: the form curl, Go and node:http
-    // read), while undici reads the bracketed form. Accept both by comparing
-    // the address with the brackets removed from each side.
     let ipv6_hostname = strip_ipv6_brackets(hostname);
 
     for item in strings::split(no_proxy_text, b",") {
@@ -899,9 +886,7 @@ pub fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> b
             }
         }
 
-        // `host:port` has a single colon; a bare IPv6 literal (`::1`,
-        // `2001:db8::1`) has several and carries no port; a bracketed IPv6
-        // literal carries a port only as `[...]:port`.
+        // One colon is host:port; more is a bare IPv6 address, which only takes a port bracketed.
         let has_port = if strings::starts_with_char(entry, b'[') {
             strings::index_of(entry, b"]:").is_some()
         } else {
@@ -916,8 +901,7 @@ pub fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> b
         }
 
         if let Some(address) = ipv6_hostname {
-            // An address has no domain suffix to match on: only the same
-            // address, written with or without brackets, bypasses.
+            // Entries spell the address bare (`::1`, as curl and Go read it) or `[::1]`; no suffix.
             let entry = strip_ipv6_brackets(entry).unwrap_or(entry);
             if strings::eql_case_insensitive_ascii(address, entry, true) {
                 return true;

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -345,82 +345,16 @@ impl Loader {
     /// Returns true if the given hostname/host should bypass the proxy
     /// according to the NO_PROXY / no_proxy environment variable.
     pub fn is_no_proxy(&self, hostname: Option<&[u8]>, host: Option<&[u8]>) -> bool {
-        // NO_PROXY filter
-        // See the syntax at https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
-        let Some(hn) = hostname else { return false };
-
+        let Some(hostname) = hostname else {
+            return false;
+        };
         let Some(no_proxy_text) = self.get_lower_then_upper(b"no_proxy", b"NO_PROXY") else {
             return false;
         };
         if Self::is_emptyish(no_proxy_text) {
             return false;
         }
-
-        for no_proxy_item in strings::split(no_proxy_text, b",") {
-            let mut no_proxy_entry = strings::trim(no_proxy_item, &strings::WHITESPACE_CHARS);
-            if no_proxy_entry.is_empty() {
-                continue;
-            }
-            if no_proxy_entry == b"*" {
-                return true;
-            }
-            // strips .
-            if strings::starts_with_char(no_proxy_entry, b'.') {
-                no_proxy_entry = &no_proxy_entry[1..];
-                if no_proxy_entry.is_empty() {
-                    continue;
-                }
-            }
-
-            // Determine if entry contains a port or is an IPv6 address
-            // IPv6 addresses contain multiple colons (e.g., "::1", "2001:db8::1")
-            // Bracketed IPv6 with port: "[::1]:8080"
-            // Host with port: "localhost:8080" (single colon)
-            let colon_count = strings::count_char(no_proxy_entry, b':');
-            let is_bracketed_ipv6 = strings::starts_with_char(no_proxy_entry, b'[');
-            let has_port = 'blk: {
-                if is_bracketed_ipv6 {
-                    // Bracketed IPv6: check for "]:port" pattern
-                    if strings::index_of(no_proxy_entry, b"]:").is_some() {
-                        break 'blk true;
-                    }
-                    break 'blk false;
-                } else if colon_count == 1 {
-                    // Single colon means host:port (not IPv6)
-                    break 'blk true;
-                }
-                // Multiple colons without brackets = bare IPv6 literal (no port)
-                break 'blk false;
-            };
-
-            if has_port {
-                // Entry has a port, do exact match against host:port
-                if let Some(h) = host {
-                    if strings::eql_case_insensitive_ascii(h, no_proxy_entry, true) {
-                        return true;
-                    }
-                }
-            } else {
-                // Entry is hostname/IPv6 only, match exact or dot-boundary suffix (case-insensitive)
-                let entry_len = no_proxy_entry.len();
-                if hn.len() == entry_len {
-                    if strings::eql_case_insensitive_ascii(hn, no_proxy_entry, true) {
-                        return true;
-                    }
-                } else if hn.len() > entry_len
-                    && hn[hn.len() - entry_len - 1] == b'.'
-                    && strings::eql_case_insensitive_ascii(
-                        &hn[hn.len() - entry_len..],
-                        no_proxy_entry,
-                        true,
-                    )
-                {
-                    return true;
-                }
-            }
-        }
-
-        false
+        no_proxy_matches(no_proxy_text, hostname, host.unwrap_or(b""))
     }
 
     pub fn load_ccache_path(&mut self, fs: &bun_paths::fs::FileSystem) {
@@ -928,6 +862,94 @@ impl Loader {
             .put(file_path, bun_ast::Source::default())?;
         Ok(())
     }
+}
+
+/// Returns true if a request to `hostname` should bypass the proxy according
+/// to `no_proxy_text`, the value of `NO_PROXY` (syntax per
+/// https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/).
+/// `host` is `hostname` plus `:port` when the URL carries one; entries with a
+/// port are matched against it. Both come straight from the URL, so an IPv6
+/// literal arrives bracketed (`http://[::1]/` gives `[::1]` and `[::1]:8080`).
+///
+/// Shared by the env-backed [`Loader::is_no_proxy`] (WebSocket, install,
+/// upgrade, ...) and `bun_http::ProxySettings`, which matches fetch's hop-0
+/// and redirect targets against a captured copy of the value.
+pub fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> bool {
+    if hostname.is_empty() {
+        return false;
+    }
+    // NO_PROXY lists conventionally write an IPv6 address bare
+    // (`NO_PROXY=localhost,127.0.0.1,::1`: the form curl, Go and node:http
+    // read), while undici reads the bracketed form. Accept both by comparing
+    // the address with the brackets removed from each side.
+    let ipv6_hostname = strip_ipv6_brackets(hostname);
+
+    for item in strings::split(no_proxy_text, b",") {
+        let mut entry = strings::trim(item, &strings::WHITESPACE_CHARS);
+        if entry.is_empty() {
+            continue;
+        }
+        if entry == b"*" {
+            return true;
+        }
+        if strings::starts_with_char(entry, b'.') {
+            entry = &entry[1..];
+            if entry.is_empty() {
+                continue;
+            }
+        }
+
+        // `host:port` has a single colon; a bare IPv6 literal (`::1`,
+        // `2001:db8::1`) has several and carries no port; a bracketed IPv6
+        // literal carries a port only as `[...]:port`.
+        let has_port = if strings::starts_with_char(entry, b'[') {
+            strings::index_of(entry, b"]:").is_some()
+        } else {
+            strings::count_char(entry, b':') == 1
+        };
+
+        if has_port {
+            if strings::eql_case_insensitive_ascii(host, entry, true) {
+                return true;
+            }
+            continue;
+        }
+
+        if let Some(address) = ipv6_hostname {
+            // An address has no domain suffix to match on: only the same
+            // address, written with or without brackets, bypasses.
+            let entry = strip_ipv6_brackets(entry).unwrap_or(entry);
+            if strings::eql_case_insensitive_ascii(address, entry, true) {
+                return true;
+            }
+            continue;
+        }
+
+        let entry_len = entry.len();
+        if hostname.len() == entry_len {
+            if strings::eql_case_insensitive_ascii(hostname, entry, true) {
+                return true;
+            }
+        } else if hostname.len() > entry_len
+            && hostname[hostname.len() - entry_len - 1] == b'.'
+            && strings::eql_case_insensitive_ascii(
+                &hostname[hostname.len() - entry_len..],
+                entry,
+                true,
+            )
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// `[::1]` -> `::1`; `None` when `s` is not a bracketed IPv6 literal.
+fn strip_ipv6_brackets(s: &[u8]) -> Option<&[u8]> {
+    s.strip_prefix(b"[")?
+        .strip_suffix(b"]")
+        .filter(|address| !address.is_empty())
 }
 
 /// Shared post-open tail of `load_env_file` / `load_env_file_dynamic`:

--- a/src/dotenv/lib.rs
+++ b/src/dotenv/lib.rs
@@ -8,7 +8,7 @@ pub use error::{Error, Result};
 pub use env_loader::{
     DirEntryKeys, DirEntryProbe, DotEnvBehavior, DotEnvFileSuffix, HAS_NO_CLEAR_SCREEN_CLI_FLAG,
     HashTable, HashTableValue, INSTANCE, Loader, Map, NullDelimitedEnvMap, S3Credentials,
-    StdEnvMapWrapper, instance, set_instance,
+    StdEnvMapWrapper, instance, no_proxy_matches, set_instance,
 };
 
 /// `dotenv::map::{HashTable, Entry}` namespace expected by `install_jsc::ini_jsc` et al.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -720,68 +720,11 @@ impl ProxySettings {
         if href.is_empty() {
             return None;
         }
-        if no_proxy_matches(&self.no_proxy, url.hostname, url.host) {
+        if bun_dotenv::no_proxy_matches(&self.no_proxy, url.hostname, url.host) {
             return None;
         }
         Some(href)
     }
-}
-
-/// Returns true if the given hostname/host should bypass the proxy according
-/// to the supplied `no_proxy` list. Runs on the HTTP thread from a captured
-/// copy of the env value; see https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/.
-fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> bool {
-    if hostname.is_empty() {
-        return false;
-    }
-    for item in strings::split(no_proxy_text, b",") {
-        let mut entry = strings::trim(item, &strings::WHITESPACE_CHARS);
-        if entry.is_empty() {
-            continue;
-        }
-        if entry == b"*" {
-            return true;
-        }
-        if strings::starts_with_char(entry, b'.') {
-            entry = &entry[1..];
-            if entry.is_empty() {
-                continue;
-            }
-        }
-
-        // IPv6 literals contain multiple colons (e.g., "::1"); bracketed IPv6
-        // with port is "[::1]:8080"; host:port has a single colon.
-        let colon_count = strings::count_char(entry, b':');
-        let has_port = if strings::starts_with_char(entry, b'[') {
-            strings::index_of(entry, b"]:").is_some()
-        } else {
-            colon_count == 1
-        };
-
-        if has_port {
-            if strings::eql_case_insensitive_ascii(host, entry, true) {
-                return true;
-            }
-        } else {
-            let entry_len = entry.len();
-            if hostname.len() == entry_len {
-                if strings::eql_case_insensitive_ascii(hostname, entry, true) {
-                    return true;
-                }
-            } else if hostname.len() > entry_len
-                && hostname[hostname.len() - entry_len - 1] == b'.'
-                && strings::eql_case_insensitive_ascii(
-                    &hostname[hostname.len() - entry_len..],
-                    entry,
-                    true,
-                )
-            {
-                return true;
-            }
-        }
-    }
-
-    false
 }
 
 // TODO: reduce the size of this struct

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
-import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, hasIPv6Loopback, isASAN, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
 describe.concurrent("bun info", () => {
@@ -431,3 +431,72 @@ test.skipIf(!isASAN)(
   },
   30_000,
 );
+
+describe.concurrent.skipIf(!hasIPv6Loopback())("NO_PROXY matches a registry on [::1] with or without brackets", () => {
+  // The package manager resolves the proxy for the registry URL as written in
+  // the config (Loader::get_http_proxy_for), a different entry point than
+  // fetch's. The proxy knows no packages, so `bun info` only succeeds when
+  // NO_PROXY sends the manifest request directly to the registry.
+  let registry: ReturnType<typeof Bun.serve>;
+  let proxy: ReturnType<typeof Bun.serve>;
+
+  beforeAll(() => {
+    const manifest = JSON.stringify({
+      name: "v6pkg",
+      "dist-tags": { latest: "0.0.1" },
+      versions: {
+        "0.0.1": {
+          name: "v6pkg",
+          version: "0.0.1",
+          dist: { tarball: "http://localhost/v6pkg-0.0.1.tgz", shasum: "0".repeat(40) },
+        },
+      },
+      time: { "0.0.1": "2020-01-01T00:00:00.000Z" },
+    });
+    registry = Bun.serve({
+      hostname: "::1",
+      port: 0,
+      fetch: () => new Response(manifest, { headers: { "content-type": "application/json" } }),
+    });
+    proxy = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response(null, { status: 404 }) });
+  });
+
+  afterAll(() => {
+    registry.stop(true);
+    proxy.stop(true);
+  });
+
+  const direct = { stdout: "v6pkg", stderr: "", exitCode: 0 };
+  const proxied = { stdout: "", stderr: expect.stringContaining("404 Not Found"), exitCode: 1 };
+
+  test.each([
+    ["::1", direct],
+    ["localhost,127.0.0.1,::1", direct],
+    ["[::1]", direct],
+    ["::2", proxied],
+  ])("NO_PROXY=%s", async (noProxy, expected) => {
+    const dir = tempDirWithFiles("bun-info-no-proxy-v6", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry: `http://[::1]:${registry.port}/` } }),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "info", "v6pkg", "name"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache"),
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+        no_proxy: undefined,
+        http_proxy: `http://127.0.0.1:${proxy.port}`,
+        NO_PROXY: noProxy,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual(expected);
+  });
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1661,6 +1661,26 @@ export function isIPv4() {
   return isIP("IPv4");
 }
 
+let ipv6Loopback: boolean | undefined;
+
+/**
+ * Whether a server can bind `::1`. Unlike {@link isIPv6}, which reports
+ * interface addresses and is pinned to false on BuildKite Linux, this only
+ * asks for the IPv6 loopback, which is all a test talking to `[::1]` needs
+ * and is what IPv6-disabled containers lack.
+ */
+export function hasIPv6Loopback(): boolean {
+  if (ipv6Loopback === undefined) {
+    try {
+      using _listener = Bun.listen({ hostname: "::1", port: 0, socket: { data() {} } });
+      ipv6Loopback = true;
+    } catch {
+      ipv6Loopback = false;
+    }
+  }
+  return ipv6Loopback;
+}
+
 let glibcVersion: string | undefined;
 
 export function getGlibcVersion() {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, hasIPv6Loopback, isASAN, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
 import net from "node:net";
@@ -2164,7 +2164,7 @@ describe("http_proxy/NO_PROXY re-evaluated per redirect hop", () => {
   });
 });
 
-describe.concurrent("NO_PROXY matches an IPv6 literal target with or without brackets", () => {
+describe.concurrent.skipIf(!hasIPv6Loopback())("NO_PROXY matches an IPv6 literal with or without brackets", () => {
   // The URL hands the matcher the bracketed hostname ("[::1]" for
   // http://[::1]/), while NO_PROXY lists conventionally hold the bare address
   // (NO_PROXY=localhost,127.0.0.1,::1 is what curl, Go and node:http read).

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -2164,6 +2164,110 @@ describe("http_proxy/NO_PROXY re-evaluated per redirect hop", () => {
   });
 });
 
+describe.concurrent("NO_PROXY matches an IPv6 literal target with or without brackets", () => {
+  // The URL hands the matcher the bracketed hostname ("[::1]" for
+  // http://[::1]/), while NO_PROXY lists conventionally hold the bare address
+  // (NO_PROXY=localhost,127.0.0.1,::1 is what curl, Go and node:http read).
+  // Bun used to match only the bracketed spelling; both must work.
+  //
+  // The proxy answers every request itself, so the body of the subprocess's
+  // fetch says which route it took.
+  let origin: Server; // on ::1
+  let redirector: Server; // on 127.0.0.1, 302 -> origin
+  let proxy: ReturnType<typeof Bun.listen>;
+
+  beforeAll(() => {
+    origin = Bun.serve({ hostname: "::1", port: 0, fetch: () => new Response("direct") });
+    redirector = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: `http://[::1]:${origin.port}/`, Connection: "close" },
+        }),
+    });
+    proxy = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(s) {
+          s.write("HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\nproxied");
+          s.flush();
+          s.end();
+        },
+        error() {},
+        close() {},
+        drain() {},
+      },
+    });
+  });
+
+  afterAll(() => {
+    origin.stop(true);
+    redirector.stop(true);
+    proxy.stop(true);
+  });
+
+  async function route(noProxy: string, opts: { url?: string; explicitProxyOption?: boolean } = {}) {
+    const proxyUrl = `http://127.0.0.1:${proxy.port}`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        opts.explicitProxyOption
+          ? `console.log(await (await fetch(process.env.U, { proxy: process.env.P })).text())`
+          : `console.log(await (await fetch(process.env.U)).text())`,
+      ],
+      env: {
+        ...bunEnv,
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+        no_proxy: undefined,
+        http_proxy: opts.explicitProxyOption ? undefined : proxyUrl,
+        NO_PROXY: noProxy,
+        U: opts.url ?? `http://[::1]:${origin.port}/`,
+        P: proxyUrl,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error("stderr:", stderr);
+    expect(exitCode).toBe(0);
+    return stdout.trim();
+  }
+
+  test.each([
+    ["::1", "direct"],
+    ["localhost,127.0.0.1,::1,0.0.0.0", "direct"],
+    ["127.0.0.1, ::1", "direct"],
+    ["[::1]", "direct"],
+    ["[::1]:ORIGIN_PORT", "direct"],
+    ["::2", "proxied"],
+    ["[::1]:1", "proxied"],
+    // Without brackets the whole entry is the address (this one is ::1:1),
+    // so a port can only be attached to the bracketed form.
+    ["::1:ORIGIN_PORT", "proxied"],
+    // Domain-suffix matching does not apply to an address.
+    ["1", "proxied"],
+  ])("NO_PROXY=%s sends http://[::1]/ %s", async (entry, expected) => {
+    expect(await route(entry.replace("ORIGIN_PORT", String(origin.port)))).toBe(expected);
+  });
+
+  test("bare address also bypasses an explicit fetch({ proxy }) option", async () => {
+    expect(await route("::1", { explicitProxyOption: true })).toBe("direct");
+  });
+
+  test("bare address also applies to a redirect into the IPv6 host", async () => {
+    // Hop 1 to 127.0.0.1 is exempt either way; hop 2 is re-resolved against
+    // the redirect target http://[::1]/ on the HTTP thread.
+    expect(await route("127.0.0.1,::1", { url: `http://127.0.0.1:${redirector.port}/` })).toBe("direct");
+    expect(await route("127.0.0.1,::2", { url: `http://127.0.0.1:${redirector.port}/` })).toBe("proxied");
+  });
+});
+
 test("non-200 CONNECT response from proxy is surfaced and its Location header is not followed", async () => {
   // RFC 9110 §9.3.6: a non-2xx response to CONNECT means the tunnel was not
   // established. The proxy's response must be returned to the caller, but a

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, hasIPv6Loopback, isASAN, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, hasIPv6Loopback, isASAN, isWindows, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
 import net from "node:net";
@@ -2173,11 +2173,13 @@ describe.concurrent.skipIf(!hasIPv6Loopback())("NO_PROXY matches an IPv6 literal
   // The proxy answers every request itself, so the body of the subprocess's
   // fetch says which route it took.
   let origin: Server; // on ::1
+  let origin4: Server; // on 127.0.0.1, reached as the v4-mapped address [::ffff:7f00:1]
   let redirector: Server; // on 127.0.0.1, 302 -> origin
   let proxy: ReturnType<typeof Bun.listen>;
 
   beforeAll(() => {
     origin = Bun.serve({ hostname: "::1", port: 0, fetch: () => new Response("direct") });
+    origin4 = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("direct") });
     redirector = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
@@ -2205,6 +2207,7 @@ describe.concurrent.skipIf(!hasIPv6Loopback())("NO_PROXY matches an IPv6 literal
 
   afterAll(() => {
     origin.stop(true);
+    origin4.stop(true);
     redirector.stop(true);
     proxy.stop(true);
   });
@@ -2254,6 +2257,17 @@ describe.concurrent.skipIf(!hasIPv6Loopback())("NO_PROXY matches an IPv6 literal
     ["1", "proxied"],
   ])("NO_PROXY=%s sends http://[::1]/ %s", async (entry, expected) => {
     expect(await route(entry.replace("ORIGIN_PORT", String(origin.port)))).toBe(expected);
+  });
+
+  // URLs serialize IPv6 hex digits in lowercase; entries are compared to them
+  // case-insensitively. Windows sockets are IPv6-only by default, so only the
+  // other platforms can reach a v4-mapped address.
+  test.skipIf(isWindows).each([
+    ["::FFFF:7F00:1", "direct"],
+    ["[::ffff:7f00:1]", "direct"],
+    ["::ffff:7f00:2", "proxied"],
+  ])("NO_PROXY=%s sends http://[::ffff:7f00:1]/ %s", async (entry, expected) => {
+    expect(await route(entry, { url: `http://[::ffff:7f00:1]:${origin4.port}/` })).toBe(expected);
   });
 
   test("bare address also bypasses an explicit fetch({ proxy }) option", async () => {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -843,7 +843,7 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
     expect(exitCode).toBe(0);
   });
 
-  describe("IPv6 literal target", () => {
+  describe.skipIf(!harness.hasIPv6Loopback())("IPv6 literal target", () => {
     // ws://[::1]/ hands the matcher the bracketed host "[::1]"; NO_PROXY lists
     // conventionally hold the bare address (NO_PROXY=localhost,127.0.0.1,::1),
     // and Bun used to match only the bracketed spelling. Same setup as above:

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -842,4 +842,62 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
     if (exitCode !== 0) console.error("stderr:", stderr);
     expect(exitCode).toBe(0);
   });
+
+  describe("IPv6 literal target", () => {
+    // ws://[::1]/ hands the matcher the bracketed host "[::1]"; NO_PROXY lists
+    // conventionally hold the bare address (NO_PROXY=localhost,127.0.0.1,::1),
+    // and Bun used to match only the bracketed spelling. Same setup as above:
+    // bypassing authProxy is the only way the socket can open.
+    let wsServer6: ReturnType<typeof Bun.serve>;
+
+    beforeAll(() => {
+      wsServer6 = Bun.serve({
+        hostname: "::1",
+        port: 0,
+        fetch(req, server) {
+          if (server.upgrade(req)) return;
+          return new Response("Expected WebSocket", { status: 400 });
+        },
+        websocket: { message() {} },
+      });
+    });
+
+    afterAll(() => {
+      wsServer6?.stop(true);
+    });
+
+    async function route(noProxy: string): Promise<"direct" | "proxied"> {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const ws = new WebSocket(process.env.WS_URL, { proxy: process.env.WS_PROXY });
+           ws.onopen = () => { console.log("direct"); ws.close(); process.exit(0); };
+           ws.onerror = () => { console.log("proxied"); process.exit(0); };`,
+        ],
+        env: {
+          ...bunEnv,
+          no_proxy: undefined,
+          NO_PROXY: noProxy,
+          WS_URL: `ws://[::1]:${wsServer6.port}`,
+          WS_PROXY: `http://127.0.0.1:${authProxyPort}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) console.error("stderr:", stderr);
+      expect(exitCode).toBe(0);
+      return stdout.trim() as "direct" | "proxied";
+    }
+
+    test.each([
+      ["::1", "direct"],
+      ["localhost,127.0.0.1,::1", "direct"],
+      ["[::1]", "direct"],
+      ["::2", "proxied"],
+    ])("NO_PROXY=%s connects ws://[::1]/ %s", async (entry, expected) => {
+      expect(await route(entry)).toBe(expected);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

With a proxy configured, a `NO_PROXY` entry holding a bare IPv6 address does not exempt requests to that address. Only the bracketed spelling does:

```js
// proxy on 127.0.0.1 answers everything itself with 599; origin on ::1 answers 200
process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
for (const np of ["::1", "[::1]", "localhost,::1", "*"]) {
  process.env.NO_PROXY = np;
  console.log(np, (await fetch(`http://[::1]:${originPort}/`)).status);
}
```

```
::1            599   <- sent through the proxy
[::1]          200
localhost,::1  599   <- sent through the proxy
*              200
```

`new WebSocket("ws://[::1]:port", { proxy })` behaves the same way, and so does anything else that goes through the env loader (`bun install` against an IPv6 registry, `bun upgrade`, `bun create`).

The bare form is the one people actually write: `NO_PROXY=localhost,127.0.0.1,::1` is what curl, Go (docker and friends), pip and Node's `node:http` proxy support read, and it is the value typical proxied CI / dev containers ship with. Bun's own `node:http` port already accepts it (it compares the unbracketed host), so `http.get("http://[::1]/")` bypassed the proxy while `fetch("http://[::1]/")` in the same process did not.

## Cause

Both NO_PROXY matchers, `Loader::is_no_proxy` in `src/dotenv/env_loader.rs` (WebSocket via `Bun__isNoProxy`, install, upgrade, create) and its copy `no_proxy_matches` in `src/http/lib.rs` (fetch hop 0 and redirect hops, added in #33651), compare the hostname exactly as the URL parser hands it over. For an IPv6 literal that is the bracketed string `[::1]`, so the entry only matches when it is written with brackets too.

## Fix

The two copies are folded into one `bun_dotenv::no_proxy_matches`, which `Loader::is_no_proxy` and `bun_http::ProxySettings::resolve` both call. When the URL hostname is a bracketed IPv6 literal, the brackets are removed from it and from the entry before comparing, so `::1` and `[::1]` both match `http://[::1]/`. Accepting both is a strict superset of what Bun accepted before (undici's `EnvHttpProxyAgent` reads the bracketed form, so existing `[::1]` entries keep working) and adds the form the rest of the ecosystem reads; an entry with two or more colons, bracketed or not, cannot mean anything other than an IPv6 address, so nothing that previously matched changes meaning.

Two deliberate details:

- An address entry is matched exactly, never as a domain suffix: there is no `.`-boundary suffix semantic for an address (curl does address matching only for IP targets as well). Previously the suffix rule was applied to the bracketed string; with a canonical IPv6 serialization it could never match, so no observable behavior is lost.
- `[::1]:8080` still matches the URL's `host` (`[::1]:8080`) as before. A bare entry never carries a port, because `::1:8080` is itself a valid IPv6 address; curl and Go read it the same way.

Matching stays textual, as before and as in Node's `http` and undici: an entry has to use the same spelling as the URL host (`::1` for `http://[::1]/`, which is also what the WHATWG serialization produces for fetch and WebSocket; `bun install` compares against the registry URL as written). Address-level comparison of alternative spellings such as `0:0:0:0:0:0:0:1` would be a separate change.

## Tests

All IPv6 blocks are gated on a new `harness.hasIPv6Loopback()`, a bind probe of `::1`. `isIPv6()` was not used because it is pinned to false on BuildKite Linux even though the loopback binds there (`bun-server.test.ts` binds `::1` unconditionally on every lane), so it would have skipped these tests on the lanes that matter.

`test/js/bun/http/proxy.test.ts`, new block "NO_PROXY matches an IPv6 literal with or without brackets": a subprocess fetches `http://[::1]:<origin>/` with `http_proxy` pointing at a proxy that answers every request itself, so the response body says which route was taken. Rows: `::1`, `localhost,127.0.0.1,::1,0.0.0.0`, `127.0.0.1, ::1`, `[::1]`, `[::1]:<port>` go direct; `::2`, `[::1]:1`, `::1:<port>`, `1` still go through the proxy. Three rows against `http://[::ffff:7f00:1]/` (the v4-mapped loopback, reaching an origin on 127.0.0.1; skipped on Windows, whose sockets are IPv6-only by default) give the address compare hex digits in both cases: `::FFFF:7F00:1` and `[::ffff:7f00:1]` go direct, `::ffff:7f00:2` does not. Two more tests cover the explicit `fetch(url, { proxy })` option and a 302 from 127.0.0.1 into `http://[::1]/` (the redirect re-evaluation path in `bun_http`).

`test/js/web/websocket/websocket-proxy.test.ts`, new "IPv6 literal target" rows in the existing NO_PROXY block: `ws://[::1]:<port>` with an explicit auth-requiring proxy and `NO_PROXY` set to `::1`, `localhost,127.0.0.1,::1`, `[::1]` (connects) and `::2` (407 from the proxy). This is the `Bun__isNoProxy` entry point into the env loader.

`test/cli/install/bun-info.test.ts`, new block: `bun info` against a registry on `[::1]` with `http_proxy` pointing at a proxy that 404s everything, for `NO_PROXY` = `::1`, `localhost,127.0.0.1,::1`, `[::1]` (prints the package name) and `::2` (fails with the proxy's 404). This is the `Loader::get_http_proxy_for` entry point, which install, audit, upgrade and create share and which neither fetch nor WebSocket goes through.

On the released binary the bare-form rows fail (6 in proxy.test.ts, 2 in websocket-proxy.test.ts, 2 in bun-info.test.ts) and the bracketed and negative rows pass; with this change all three files pass in full.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/proxy.test.ts

<!-- robobun:evidence:end -->