### PR TITLE
bake: remap server-side stack frames against the server chunk prefix

### DIFF
--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -1687,14 +1687,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         debug_assert!(matches!(SIDE, Side::Client));
         debug_assert!(self.current_chunk_len > 0);
         let kind = options.kind;
-
-        let runtime: bake::HmrRuntime = match kind {
-            ChunkKind::InitialResponse => bake::get_hmr_runtime(Side::Client),
-            ChunkKind::HmrChunk => bake::HmrRuntime {
-                code: bun_core::ZStr::from_static(b"self[Symbol.for(\"bun:hmr\")]({\n\0"),
-                line_count: 1,
-            },
-        };
+        let runtime = kind.prefix(SIDE);
 
         let mut end_list: Vec<u8> = Vec::with_capacity(256);
         // SAFETY: see `owner()`.
@@ -1802,13 +1795,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         debug_assert!(matches!(SIDE, Side::Server));
         debug_assert!(self.current_chunk_len > 0);
 
-        let runtime: bake::HmrRuntime = match options.kind {
-            ChunkKind::InitialResponse => bake::get_hmr_runtime(Side::Server),
-            ChunkKind::HmrChunk => bake::HmrRuntime {
-                code: bun_core::ZStr::from_static(b"({\0"),
-                line_count: 0,
-            },
-        };
+        let runtime = options.kind.prefix(SIDE);
         // Server `.InitialResponse` is unreachable per spec; only HmrChunk hits
         // the end-builder.
         let end: &[u8] = b"})";

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -17,7 +17,7 @@ use bun_collections::{HashMap, StringArrayHashMap, bit_set::DynamicBitSet};
 use bun_sys::FdExt as _;
 
 use super::jsc;
-use super::{Graph, Side};
+use super::{Graph, HmrRuntime, Side, get_hmr_runtime};
 
 // ─── submodules ──────────────────────────────────────────────────────────────
 pub(crate) mod error_report_request;
@@ -60,6 +60,22 @@ pub enum FileKind {
 pub enum ChunkKind {
     InitialResponse = 0,
     HmrChunk = 1,
+}
+
+impl ChunkKind {
+    /// What `IncrementalGraph::take_js_bundle` emits ahead of the module code.
+    /// `source_map_store::Entry::join_vlq` offsets the chunk's mappings by its
+    /// `line_count`, so both sides of that agreement come from here.
+    pub(crate) fn prefix(self, side: Side) -> HmrRuntime {
+        const CLIENT_HMR_CHUNK: HmrRuntime =
+            HmrRuntime::from_static(b"self[Symbol.for(\"bun:hmr\")]({\n\0");
+        const SERVER_HMR_CHUNK: HmrRuntime = HmrRuntime::from_static(b"({\0");
+        match (self, side) {
+            (ChunkKind::InitialResponse, _) => get_hmr_runtime(side),
+            (ChunkKind::HmrChunk, Side::Client) => CLIENT_HMR_CHUNK,
+            (ChunkKind::HmrChunk, Side::Server) => SERVER_HMR_CHUNK,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -11,8 +11,8 @@ use bun_core::string_joiner::StringJoiner;
 use bun_core::{Timespec, TimespecMockMode};
 use bun_sourcemap::{self as source_map, SourceMapState};
 
+use crate::bake::Side;
 use crate::bake::dev_server_body::map_log;
-use crate::bake::{self, Side};
 use crate::timer::EventLoopTimerState;
 
 use super::{ChunkKind, DevServer, EventLoopTimer, Magic, TimerTag, packed_map};
@@ -249,16 +249,7 @@ impl Entry {
         j: &mut StringJoiner<'a>,
         side: Side,
     ) -> crate::Result<()> {
-        let _ = side;
         let map_files = self.files.as_slice();
-
-        // Only the line count of the prefix matters here; the literal has
-        // exactly one '\n'.
-        const HMR_CHUNK_PREFIX: &[u8] = b"self[Symbol.for(\"bun:hmr\")]({\n";
-        let runtime_line_count: u32 = match kind {
-            ChunkKind::InitialResponse => bake::get_hmr_runtime(Side::Client).line_count,
-            ChunkKind::HmrChunk => bun_core::strings::count_char(HMR_CHUNK_PREFIX, b'\n') as u32,
-        };
 
         let mut prev_end_state = SourceMapState {
             generated_line: 0,
@@ -268,9 +259,9 @@ impl Entry {
             original_column: 0,
         };
 
-        // The runtime.line_count counts newlines (e.g., 2941 for a 2942-line file).
-        // The runtime ends at line 2942 with })({ so modules start after that.
-        let mut lines_between: u32 = runtime_line_count;
+        // `line_count` counts the prefix's newlines, which is the 0-based
+        // generated line the first module starts on.
+        let mut lines_between: u32 = kind.prefix(side).line_count;
 
         // Join all of the mappings together.
         for (i, file) in map_files.iter().enumerate() {

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -598,6 +598,20 @@ pub(crate) struct HmrRuntime {
     pub(crate) code: &'static bun_core::ZStr,
     pub(crate) line_count: u32,
 }
+impl HmrRuntime {
+    /// `code` is a literal including its trailing NUL (`b"({\0"`).
+    pub(crate) const fn from_static(code: &'static [u8]) -> Self {
+        let code = bun_core::ZStr::from_static(code);
+        let bytes = code.as_bytes();
+        let mut line_count = 0;
+        let mut i = 0;
+        while i < bytes.len() {
+            line_count += (bytes[i] == b'\n') as u32;
+            i += 1;
+        }
+        Self { code, line_count }
+    }
+}
 pub(crate) use bake_body::get_hmr_runtime;
 // (Former `__bun_bake_get_hmr_runtime` link-time bridge deleted —
 // `bun_bundler::bake_types::get_hmr_runtime` now loads the codegen bytes

--- a/test/bake/dev/server-sourcemap.test.ts
+++ b/test/bake/dev/server-sourcemap.test.ts
@@ -1,6 +1,25 @@
 import { expect } from "bun:test";
 import { isASAN } from "harness";
-import { devTest } from "../bake-harness";
+import { Dev, devTest } from "../bake-harness";
+
+/**
+ * Matches a remapped stack frame such as `at myFunc (/abs/pages/a.tsx:7:13)`,
+ * with `line`/`column` being 1-based positions in the fixture source. `\w*`
+ * tolerates the bundler renaming a symbol (`doSomething` prints as
+ * `doSomething2`).
+ */
+function frame(fn: string, file: string, line: number, column: number) {
+  const path = file
+    .split("/")
+    .map(RegExp.escape)
+    .join(String.raw`[/\\]`);
+  return new RegExp(String.raw`\bat ${fn}\w* \(.*${path}:${line}:${column}\)`);
+}
+
+/** Dev server output so far, without the ANSI codes interleaved in stack frames. */
+function output(dev: Dev) {
+  return dev.output.lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+}
 
 devTest("server-side source maps show correct error lines", {
   files: {
@@ -27,30 +46,19 @@ export async function getStaticPaths() {
   },
   framework: "react",
   async test(dev) {
-    // Make a request that will trigger the error
-    await dev.fetch("/test-error").catch(() => {});
+    await Promise.all([
+      dev.fetch("/test-error").catch(() => {}),
+      dev.output.waitForLine(/Test error for source maps!/),
+    ]);
 
-    // The output we saw shows the stack trace with correct source mapping
-    // We need to check that the error shows the right file:line:column
-    const lines = dev.output.lines.join("\n");
-
-    // Check that we got the error
-    expect(lines).toContain("Test error for source maps!");
-
-    // Check that the stack trace shows correct file and line numbers
-    // The source maps are working if we see the correct patterns
-    // We need to check for the patterns because ANSI codes might be embedded
-    // Strip ANSI codes for cleaner checking
-    const cleanLines = lines.replace(/\x1b\[[0-9;]*m/g, "");
-
-    const hasCorrectThrowLine = cleanLines.includes("myFunc") && cleanLines.includes("6:16");
-    // const hasCorrectCallLine = cleanLines.includes("MyPage") && cleanLines.includes("2") && cleanLines.includes("3");
-    const hasCorrectFileName = cleanLines.includes("pages/[...slug].tsx");
-
-    expect(hasCorrectThrowLine).toBe(true);
-    // TODO: renable this when async stacktraces are enabled?
-    // expect(hasCorrectCallLine).toBe(true);
-    expect(hasCorrectFileName).toBe(true);
+    const out = output(dev);
+    // Line 7 is `  throw new Error(...)`. The async component rejects and React
+    // reads `error.stack` before the error is printed; that rendering puts
+    // construct frames at the callee (`Error`), whereas the sync pages below
+    // are printed at the `new` keyword.
+    expect(out).toMatch(frame("myFunc", "pages/[...slug].tsx", 7, 13));
+    // Line 2 is `  myFunc();`.
+    expect(out).toMatch(frame("MyPage", "pages/[...slug].tsx", 2, 3));
   },
   timeoutMultiplier: 2, // Give more time for the test
 });
@@ -95,16 +103,11 @@ export async function getStaticPaths() {
 
     await Promise.all([dev.fetch("/error-page").catch(() => {}), dev.output.waitForLine(/HMR error test/)]);
 
-    // Check source map points to correct lines after HMR
-    const lines = dev.output.lines.join("\n");
-    // Strip ANSI codes for cleaner checking
-    const cleanLines = lines.replace(/\x1b\[[0-9;]*m/g, "");
-
-    const hasCorrectThrowLine = cleanLines.includes("throwError") && cleanLines.includes("6:1");
-    const hasCorrectCallLine = cleanLines.includes("ErrorPage") && cleanLines.includes("1:16");
-
-    expect(hasCorrectThrowLine).toBe(true);
-    expect(hasCorrectCallLine).toBe(true);
+    const out = output(dev);
+    // Line 7 is `  throw new Error(...)`, reported at the `new` keyword.
+    expect(out).toMatch(frame("throwError", "pages/error-page.tsx", 7, 9));
+    // Line 2 is `  throwError();`.
+    expect(out).toMatch(frame("ErrorPage", "pages/error-page.tsx", 2, 3));
   },
 });
 
@@ -134,18 +137,13 @@ function helperFunction() {
   async test(dev) {
     await Promise.all([dev.fetch("/nested").catch(() => {}), dev.output.waitForLine(/Nested error/)]);
 
-    // Check that stack trace shows both files with correct lines
-    const lines = dev.output.lines.join("\n");
-    // Strip ANSI codes for cleaner checking
-    const cleanLines = lines.replace(/\x1b\[[0-9;]*m/g, "");
-
-    const hasUtilsThrowLine = cleanLines.includes("helperFunction") && cleanLines.includes("5:1");
-    const hasUtilsCallLine = cleanLines.includes("doSomething2") && cleanLines.includes("1:28");
-    const hasPageCallLine = cleanLines.includes("NestedPage") && cleanLines.includes("3:38");
-
-    expect(hasUtilsThrowLine).toBe(true);
-    expect(hasUtilsCallLine).toBe(true);
-    expect(hasPageCallLine).toBe(true);
+    const out = output(dev);
+    // lib/utils.ts line 6 is `  throw new Error(...)`, reported at the `new` keyword.
+    expect(out).toMatch(frame("helperFunction", "lib/utils.ts", 6, 9));
+    // lib/utils.ts line 2 is `  return helperFunction();`.
+    expect(out).toMatch(frame("doSomething", "lib/utils.ts", 2, 10));
+    // pages/nested.tsx line 4 is `  const result = doSomething();`.
+    expect(out).toMatch(frame("NestedPage", "pages/nested.tsx", 4, 18));
   },
 });
 
@@ -190,13 +188,9 @@ devTest("server-side source maps stay correct across repeated reloads", {
         dev.output.waitForLine(new RegExp(`Churn error ${name}`)),
       ]);
 
-      // Strip ANSI codes; they interleave within stack-frame lines.
-      const cleanLines = dev.output.lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
-      // The throwing function is declared on line 6 + i of round i's version
-      // of the source file; frames remap to the declaration position (see the
-      // `helperFunction`/`5:1` expectation above). `\w*` tolerates bundler
-      // symbol renaming (see `doSomething2` above).
-      expect(cleanLines).toMatch(new RegExp(`at churn${name}\\w* \\(.*pages[/\\\\]churn\\.tsx:${6 + i}:1\\)`));
+      // Round i's version of the file has its `  throw new Error(...)` on
+      // line 7 + i.
+      expect(output(dev)).toMatch(frame(`churn${name}`, "pages/churn.tsx", 7 + i, 9));
     }
   },
   timeoutMultiplier: 2,


### PR DESCRIPTION
### What does this PR do?

Stack traces for server-side code running in the bake dev server (framework mode, where route modules are evaluated on the server) point at the wrong line. With this route module:

```tsx
// pages/error-page.tsx
export default function ErrorPage() {
  throwError();                        // line 2
  return <div />;
}

function throwError() {                // line 6
  throw new Error("HMR error test");   // line 7
}
```

a request prints

```
6 | function throwError() {
    ^
error: HMR error test
      at throwError (pages/error-page.tsx:6:1)
      at ErrorPage (pages/error-page.tsx:1:16)
```

and with this change it prints

```
7 |   throw new Error("HMR error test");
            ^
error: HMR error test
      at throwError (pages/error-page.tsx:7:9)
      at ErrorPage (pages/error-page.tsx:2:3)
```

`test/bake/dev/server-sourcemap.test.ts` had the wrong positions baked into its expectations (`6:16`, `6:1`, `5:1`, `1:28`, `3:38`, and the churn test's `6 + i`), with a comment rationalizing them as "frames remap to the declaration position". This has been the behavior since server source maps were added; the client side is not affected.

### Cause

The server HMR chunk and its source map disagree about what precedes the module code.

* `IncrementalGraph::take_js_bundle_to_list_server` emits a server `HmrChunk` as `({` + modules + `})`. The prefix contains no newline, so the first module starts on generated line 0.
* `source_map_store::Entry::join_vlq` ignored its `side` argument (`let _ = side;`) and, for every `HmrChunk`, started the mappings after the line count of the *client* prefix, `self[Symbol.for("bun:hmr")]({\n`, i.e. on generated line 1.

So the map for the server chunk is shifted down by one generated line relative to the code. A frame on generated line `L` is looked up at map line `L`, which holds the mappings recorded for generated line `L - 1`, so every frame reports the original position of the previous generated line. For ordinary code that is the line above the statement; the column is whichever mapping on that line happens to precede the frame's generated column (hence `6:16`, the `(` of `function myFunc(`, or `3:38`, the `{` of the function declaration). In denser code it can be further off: a `react-server-dom` frame in the same chunk moved from `3971:15` (a `try {` line) to `3972:20`, the actual `Component(props, void 0)` call.

The client chunks use the same function but with the client prefix, which is why `test/bake/dev/sourcemap.test.ts` (exact positions for the initial response and an HMR chunk) passes before and after.

### Fix

`ChunkKind::prefix(side)` returns the code a chunk of that kind starts with on that side (the full HMR runtime for `InitialResponse`, the one-line client wrapper or the bare `({` for `HmrChunk`). Both `take_js_bundle_to_list*` and `join_vlq` take it from there, and `HmrRuntime::from_static` derives `line_count` from the literal, so the emitted code and the map cannot disagree again. `join_vlq`'s `side` parameter is now used; `render_json` was already being called with `Side::Server` for server chunks.

### Verification

`test/bake/dev/server-sourcemap.test.ts` now asserts the full remapped frames (`at fn (.../file:line:col)`) for the throw site and for each caller, across the initial bundle, an HMR update, a throw in an imported non-page module, and four successive reloads. Without the change in `src/` all four tests fail with the positions shown above (`6:16` / `1:1`, `6:1` / `1:16`, `5:1` / `1:28` / `3:38`, `6 + i:1`); with it they pass.

Also run: `test/bake/dev/sourcemap.test.ts` (client maps, unchanged behavior) and `test/bake/dev/html.test.ts` (the `/_bun/report_error` remapping path, which renders client maps through the same function); `cargo clippy -p bun_runtime` is clean.

Note on columns: in the first test the page component is `async`, so React reads `error.stack` before the error is printed, and that rendering currently places a construct frame at the callee (`Error`, `7:13`) where the printer places it at the `new` keyword (`7:9`, what the other tests see). #37396 makes the two agree; once it lands, that one expectation becomes `7:9` (its current version of this file will conflict with this change either way).

While looking at this I also noticed that after any hot update, frames from modules loaded by an earlier server patch stop remapping (every patch is registered under `bake://server.patch.js`, so the newest patch's map replaces the older ones; visible as `at react-stack-bottom-frame (bake://server.patch.js:3242:29)` in the HMR test output). That is a separate problem and is not addressed here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/server-sourcemap.test.ts
bun test v1.4.0 (178906144)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-O6wHS9
bun add v1.4.0 (178906144)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [244.00ms]
bun install v1.4.0 (178906144)

Checked 6 installs across 7 packages (no changes) [100.00ms]
[0;30mdev|[0m Started development server: http://localhost:39561
[0;30mdev|[0m [32mBundled page in 1920ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSO
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-LMzvrB
bun add v1.4.0-canary.1 (9008ae7ab)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [10.00ms]
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 6 installs across 7 packages (no changes) [1.00ms]
[0;30mdev|[0m Started development server: http://localhost:38961
[0;30mdev|[0m [32mBundled page in 51ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSON[0m[3m[1m.stringify[0m(params)}[0m<[0m/h1>[0m[2m;[0m
[0;30mdev|[0m [0m[1m4 |[0m }
[0;30mdev|[0m [0m[1m5 |[0m 
[0;30mdev|[0m [0m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/server-sourcemap.test.ts
bun test v1.4.0 (178906144)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-fA4VAw
bun add v1.4.0 (178906144)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [174.00ms]
bun install v1.4.0 (178906144)

Checked 6 installs across 7 packages (no changes) [100.00ms]
[0;30mdev|[0m Started development server: http://localhost:43795
[0;30mdev|[0m [32mBundled page in 1945ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSON[0m[3m[1m.stringify[0m(params)}[0m<[0m/h1>[0m[2m;[0m
[0;30mdev|[0m [0m[1m4 |[0m }
[0;30mdev|[0m [0m[1m5 |[0m 

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     178906144a
  features     baseline

22 deps, 107 codegen, 1176 objects in 805ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [14.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1238] gen bindgenv2
[4/1238] gen ErrorCode+*.h
[5/1238] fetch picohttpparser
[picohttpparser] up to date
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [14.00ms]
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/Process
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/dev_server/incremental_graph.rs |  17 +---
 src/runtime/bake/dev_server/mod.rs               |  18 +++-
 src/runtime/bake/dev_server/source_map_store.rs  |  17 +---
 src/runtime/bake/mod.rs                          |  14 ++++
 test/bake/dev/server-sourcemap.test.ts           | 102 +++++++++++------------
 5 files changed, 85 insertions(+), 83 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/runtime/bake/dev_server/incremental_graph.rs      1      2      0
src/runtime/bake/dev_server/mod.rs                    1      2      0
src/runtime/bake/dev_server/source_map_store.rs       2      4      0
src/runtime/bake/mod.rs                               1      1      0
test/bake/dev/server-sourcemap.test.ts                5     11      0
```

</details>

**self-review** · no surviving concerns

26 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->