### PR TITLE
install: pin that .. tarball entries are clamped to the package root in both extractors

### DIFF
--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -10,7 +10,7 @@ import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { createGzip, gzipSync } from "node:zlib";
 
 setDefaultTimeout(1000 * 60 * 5);
@@ -375,6 +375,76 @@ describe("streaming tarball extraction", () => {
       expect([path, got.equals(body)]).toEqual([path, true]);
     }
     expect(existsSync(join(pkgRoot, longName))).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+
+  // Both extractors strip the leading `package/` and hand the rest to
+  // normalize_buf_t, which drops every `..` that would climb above the root
+  // of a relative path. The buffered extractor (Archiver::extract_to_dir) has
+  // nothing else between an entry name and openat(extraction_dir, ...); the
+  // streaming one (TarballStream) has a leading-`..` check behind it that the
+  // clamp makes unreachable. Pin the clamp for both so a normalizer change
+  // cannot quietly turn these entries into writes outside the extraction dir.
+  test.each([
+    ["streaming", {}],
+    ["buffered", { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" }],
+  ] as const)("entries that climb above the package root with .. are clamped to it (%s)", async (label, env) => {
+    const climbing = [
+      "../climb-1.txt",
+      "../../../climb-3.txt",
+      "nested/../../climb-nested.txt",
+      "a/b/../../../climb-ab.txt",
+    ];
+    const built = buildTarball([...entries, ...climbing.map(path => ({ path, body: Buffer.from(`${path}\n`) }))]);
+    expect(built.tgz.length).toBeGreaterThan(2 * 1024 * 1024);
+
+    await using reg = await makeRegistry(built.tgz, built.shasum, built.integrity, chunkBytes);
+    const registry = reg.url;
+
+    using dir = tempDir("streaming-extract-dotdot", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry } }),
+    });
+    // Entries are extracted into a directory under BUN_TMPDIR and the tree is
+    // then renamed into the cache (which runInstall keeps under `dir`). Bury
+    // the temp dir deeper than the longest `..` chain above climbs, so an
+    // entry that did escape still lands somewhere the walk below can see.
+    const tmp = join(String(dir), "t1", "t2", "t3", "bun-tmp");
+    mkdirSync(tmp, { recursive: true });
+
+    const { stderr, exitCode } = await runInstall(String(dir), { ...env, BUN_TMPDIR: tmp, TMPDIR: tmp });
+    expect(stderr).not.toContain("error:");
+    if (label === "streaming") {
+      expect(stderr).toContain("] Streamed ");
+    } else {
+      expect(stderr).toContain("] Extracted to ");
+    }
+    expect(reg.tarballHits).toBe(1);
+
+    // The clamp keeps the basename: every climbing entry ends up directly in
+    // the package root, next to the regular entries.
+    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+    const climbed = (await readdirSorted(pkgRoot)).filter(name => name.startsWith("climb-"));
+    expect(climbed).toEqual(["climb-1.txt", "climb-3.txt", "climb-ab.txt", "climb-nested.txt"]);
+    expect(readFileSync(join(pkgRoot, "climb-ab.txt"), "utf8")).toBe("a/b/../../../climb-ab.txt\n");
+    expect(readFileSync(join(pkgRoot, "index.js"), "utf8")).toBe("module.exports = 'ok';\n");
+
+    // The property that matters: every copy of a climbing entry anywhere under
+    // `dir` (node_modules, the cache, the temp dir) sits in a directory that
+    // is a stream-pkg package root. An escaped entry would have bun-tmp, one
+    // of the t* directories, .cache or `dir` itself as its parent.
+    const isStreamPkgRoot = (directory: string) => {
+      const manifest = join(directory, "package.json");
+      return existsSync(manifest) && JSON.parse(readFileSync(manifest, "utf8")).name === "stream-pkg";
+    };
+    const strays = readdirSync(String(dir), { recursive: true, withFileTypes: true })
+      .filter(entry => entry.name.startsWith("climb-") && !isStreamPkgRoot(entry.parentPath))
+      .map(entry => relative(String(dir), join(entry.parentPath, entry.name)));
+    expect(strays).toEqual([]);
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### What

Both tarball extractors strip the first path component of an entry (`package/`, or the repo directory for GitHub tarballs) and run the remainder through `normalize_buf_t`. For a relative input that normalizes with `ALLOW_ABOVE_ROOT = false` (`resolve_path.rs`, the `!is_absolute` arms of `normalize_buf_t`), so `../x`, `../../../x` and `a/b/../../../x` all come out as `x` and are written into the package root.

- `Archiver::extract_to_dir` (buffered path) relies on that clamp alone: nothing else sits between the entry name and `openat(extraction_dir, ...)`.
- `TarballStream` (streaming path) has an additional leading-`..` check, but its comment said the normalizer "leaves a leading `..` on a relative input", which is not what happens; the check is unreachable today.

Neither extractor had a test for `..` entry names (the existing traversal tests cover symlink targets), so a normalizer change would have reopened traversal in the buffered extractor without anything failing.

### Change

Test only. `bun-install-streaming-extract.test.ts` gets a `test.each` over the streaming and buffered extractors (`BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL` for the latter, with the `] Streamed ` / `] Extracted to ` verbose lines asserted so each case proves which extractor ran). Each case installs a tarball containing `../climb-1.txt`, `../../../climb-3.txt`, `nested/../../climb-nested.txt` and `a/b/../../../climb-ab.txt`. `BUN_TMPDIR` is pointed at `dir/t1/t2/t3/bun-tmp`, deeper than the longest chain climbs, and the cache already lives under `dir`, so an escaping entry has to land inside the test directory. The test asserts the four files are in `node_modules/stream-pkg/` with their contents, and that every `climb-*` file anywhere under `dir` has a directory whose `package.json` is stream-pkg's as its parent.

### Verification

```
bun bd test test/cli/install/bun-install-streaming-extract.test.ts
```

Both new cases pass. Planting a stray `t1/climb-decoy.txt` before the walk makes the containment assertion fail with that path, so the detector is live; an earlier version that keyed on the parent directory name failed on the cache layout (`.cache/stream-pkg/1.0.0@@127.0.0.1@@@1/`), which is why it checks for the package manifest instead.

No runtime change. The comment above the streaming extractor's check in `TarballStream.rs` still describes the normalizer incorrectly; I left it alone here so this PR stays test only, and the test's own comment records what actually happens. It is a one-line fix to fold into whatever next touches that file.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-install-streaming-extract.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-install-streaming-extract.test.ts
bun test v1.4.0 (ac4b7334f)

test/cli/install/bun-install-streaming-extract.test.ts:
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (streaming) [987.86ms]
(pass) streaming tarball extraction > extracts a drip-fed tarball correctly (buffered) [495.24ms]
(pass) streaming tarball extraction > streaming extract succeeds when the first chunk is smaller than the gzip header [396.26ms]
(pass) streaming tarball extraction > streaming extract skips an entry whose pathname is longer than the path buffer [814.58ms]
(pass) streaming tarball extraction > entries that climb above the package root with .. are clamped to it (streaming) [760.57ms]
(pass) streaming tarball extraction > entries that climb above the package root with .. are clamped to it (buffered) [732.83ms]
(pass) streaming tarball extraction > tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path [427.53ms]
(pass) streaming tarball extraction > streaming rejects a tarball whose integrity does not match [372.77ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (default) [688.83ms]
(pass) streaming tarball extraction > drain threshold holds off extraction until enough bytes arrive (override) [533.33ms]
(pass) buffered extract: damaged-block retry resets header state (upstream semantics) [199.51ms]
(pass) buffered extract does not hold the decompressed local tarball in memory [1575.26ms]

 12 pass
 0 fail
 477 expect() calls
Ran 12 tests across 1 file. [17.48s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../install/bun-install-streaming-extract.test.ts  | 72 +++++++++++++++++++++-
 1 file changed, 71 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
test/cli/install/bun-install-streaming-extract.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->