### PR TITLE
error: gate the <parse> stack frame on the parser having recorded a location, not on sourceURL

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,9 +3,9 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-// Preview build of https://github.com/oven-sh/WebKit/pull/407 (parser SyntaxErrors are
-// flagged as such before their stack is formatted). Replace with the main sha once it lands.
-export const WEBKIT_VERSION = "autobuild-preview-pr-407-deb6bcb2";
+// Preview build of https://github.com/oven-sh/WebKit/pull/407 (ErrorInstance::hasParseLocation()).
+// Replace with the main sha once it lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-407-f6d8e2a0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,9 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "447082ab6897278727b44e1ba3c326ae6e1504c3";
+// Preview build of https://github.com/oven-sh/WebKit/pull/407 (parser SyntaxErrors are
+// flagged as such before their stack is formatted). Replace with the main sha once it lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-407-deb6bcb2";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,7 +177,12 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            if (err->errorType() == ErrorType::SyntaxError && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
+            // The synthetic <parse> frame shows the source JSC's parser rejected, which it
+            // records on the error via addErrorInfo(). A SyntaxError from user code, JSON.parse,
+            // RegExp, etc. records no sourceURL, so there is no parse location to show.
+            // (isParseError() is not usable here: ParserError::toErrorObject sets it only after
+            // addErrorInfo() has already materialized .stack.)
+            if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:
                 // /* empty comment */

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,8 +177,7 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // Only JSC's parser records a sourceURL on the error (addErrorInfo); it is the location
-            // this frame shows. isParseError() is set after addErrorInfo() has already formatted .stack.
+            // Only parser errors record a sourceURL (addErrorInfo); it is what the <parse> frame shows.
             if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -198,15 +198,12 @@ WTF::String formatStackTrace(
                 String sourceURLForFrame = err->sourceURL();
 
                 // If it's not a Zig::GlobalObject, don't bother source-mapping it.
-                if (globalObject && !sourceURLForFrame.isEmpty()) {
-                    // https://github.com/oven-sh/bun/issues/3595
-                    if (!sourceURLForFrame.isEmpty()) {
-                        remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
-                        // This ensures the lifetime of the sourceURL is accounted for correctly
-                        Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
+                if (globalObject) {
+                    remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
+                    // This ensures the lifetime of the sourceURL is accounted for correctly
+                    Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
 
-                        sourceURLForFrame = remappedFrame.source_url.toWTFString();
-                    }
+                    sourceURLForFrame = remappedFrame.source_url.toWTFString();
                 }
 
                 // there is always a newline before each stack frame line, ensuring that the name + message

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,9 +177,7 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // The <parse> frame shows the URL and line addErrorInfo() recorded for a source JSC's parser rejected.
-            // A sourceURL alone doesn't mean that (structured clones and errors whose frames GC already flushed
-            // have one too), and a parser error for a source without a URL (new Function) has nothing to show.
+            // Where the parser failed, as recorded by addErrorInfo(); a source with no URL (new Function) has nothing to show.
             if (err->hasParseLocation() && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,11 +177,8 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // The synthetic <parse> frame shows the source JSC's parser rejected, which it
-            // records on the error via addErrorInfo(). A SyntaxError from user code, JSON.parse,
-            // RegExp, etc. records no sourceURL, so there is no parse location to show.
-            // (isParseError() is not usable here: ParserError::toErrorObject sets it only after
-            // addErrorInfo() has already materialized .stack.)
+            // Only JSC's parser records a sourceURL on the error (addErrorInfo); it is the location
+            // this frame shows. isParseError() is set after addErrorInfo() has already formatted .stack.
             if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -178,9 +178,9 @@ WTF::String formatStackTrace(
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
             // The <parse> frame shows the URL and line addErrorInfo() recorded for a source JSC's parser rejected.
-            // Having a sourceURL alone doesn't mean that (structured clones and errors whose frames GC already
-            // flushed have one too), so require the parser's flag; sources without a URL have nothing to show.
-            if (err->errorType() == ErrorType::SyntaxError && err->isParseError() && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
+            // A sourceURL alone doesn't mean that (structured clones and errors whose frames GC already flushed
+            // have one too), and a parser error for a source without a URL (new Function) has nothing to show.
+            if (err->hasParseLocation() && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:
                 // /* empty comment */

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -177,8 +177,10 @@ WTF::String formatStackTrace(
 
     if (errorInstance) {
         if (JSC::ErrorInstance* err = dynamicDowncast<JSC::ErrorInstance>(errorInstance)) {
-            // Only parser errors record a sourceURL (addErrorInfo); it is what the <parse> frame shows.
-            if (err->errorType() == ErrorType::SyntaxError && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
+            // The <parse> frame shows the URL and line addErrorInfo() recorded for a source JSC's parser rejected.
+            // Having a sourceURL alone doesn't mean that (structured clones and errors whose frames GC already
+            // flushed have one too), so require the parser's flag; sources without a URL have nothing to show.
+            if (err->errorType() == ErrorType::SyntaxError && err->isParseError() && !err->sourceURL().isEmpty() && (stackTrace.isEmpty() || stackTrace.at(0).sourceURL(vm) != err->sourceURL())) {
                 // There appears to be an off-by-one error.
                 // The following reproduces the issue:
                 // /* empty comment */

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,7 +1,8 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
+import vm from "node:vm";
 
 test("name property is used for function calls in Error.stack", () => {
   function WRONG() {
@@ -148,4 +149,143 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// When JSC's parser rejects a source it records that source's URL and line on the
+// SyntaxError, and .stack renders them as a synthetic "at <parse> (url:line)" frame.
+// Every other SyntaxError has no such location and must format like node's: the
+// header followed by the real frames.
+describe("SyntaxError .stack", () => {
+  test("new SyntaxError() has no <parse> frame", () => {
+    const err = new SyntaxError("user made");
+    expect(normalizeBunSnapshot(err.stack!)).toMatchInlineSnapshot(`
+      "SyntaxError: user made
+          at <anonymous> (file:NN:NN)"
+    `);
+  });
+
+  const caught = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (e) {
+      return e as Error;
+    }
+    throw new Error("expected fn to throw");
+  };
+
+  test.each([
+    ["SyntaxError() called without new", () => SyntaxError("user made")],
+    ["a SyntaxError subclass", () => new (class MySyntaxError extends SyntaxError {})("user made")],
+    ["JSON.parse()", () => caught(() => JSON.parse("{"))],
+    ["new RegExp()", () => caught(() => new RegExp("[a-0]"))],
+  ])("%s has no <parse> frame", (_, make) => {
+    const stack = make().stack!;
+    expect(stack).not.toContain("<parse>");
+    // The real frames are still there; the outermost one is this test callback.
+    expect(stack.split("\n").at(-1)).toMatch(/^    at .*stack\.test\.ts:\d+:\d+\)?$/);
+  });
+
+  test("Error.captureStackTrace() on a SyntaxError adds no <parse> frame", () => {
+    const err = new SyntaxError("captured");
+    Error.captureStackTrace(err);
+    expect(normalizeBunSnapshot(err.stack!)).toMatchInlineSnapshot(`
+      "SyntaxError: captured
+          at <anonymous> (file:NN:NN)"
+    `);
+  });
+
+  test("a SyntaxError with no frames at all is just the header", () => {
+    const err = new SyntaxError("no frames");
+    // Math.max is not on the stack, so every frame is dropped.
+    Error.captureStackTrace(err, Math.max);
+    expect(err.stack).toBe("SyntaxError: no frames");
+  });
+
+  test("Bun.inspect() of a SyntaxError whose .stack was already read shows the real frame", () => {
+    const err = new SyntaxError("inspected");
+    // Once .stack is materialized the printer works from the string instead of the frames.
+    void err.stack;
+    const printed = Bun.inspect(err);
+    expect(printed).toContain("SyntaxError: inspected");
+    expect(printed).not.toContain("<parse>");
+    expect(printed).toMatch(/stack\.test\.ts:\d+:\d+/);
+  });
+
+  test("an uncaught SyntaxError whose .stack was already read still reports where it was created", async () => {
+    using dir = tempDir("syntax-error-stack", {
+      "index.js": ['const err = new SyntaxError("boom");', "void err.stack;", "throw err;", ""].join("\n"),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("SyntaxError: boom");
+    expect(stderr).not.toContain("<parse>");
+    expect(stderr).toMatch(/index\.js:1:\d+/);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a parser SyntaxError keeps its <parse> frame", () => {
+    const err = caught(() => new vm.Script("\n\n/[a-0]/", { filename: "my-script.js" }));
+    expect(err.stack!.split("\n")).toContain("    at <parse> (my-script.js:3)");
+  });
+
+  test("a parser SyntaxError in a source without a URL has no <parse> frame", () => {
+    // There is no file to point at, so an "at <parse> (:4)" line would only be noise.
+    const stack = caught(() => new Function("{")).stack!;
+    expect(stack).not.toContain("<parse>");
+    expect(stack.split("\n").at(-1)).toMatch(/^    at .*stack\.test\.ts:\d+:\d+\)?$/);
+  });
+
+  test("a parser SyntaxError from importing a module keeps its <parse> frame", async () => {
+    // Bun's transpiler accepts these modules; JSC's parser rejects the regex. A top-level
+    // await import() fails while no JS frame is on the stack, so the errors only get frames
+    // (and a .stack) from Error.captureStackTrace.
+    const badModule = ["module.exports = 1;", '"".match(/[a-0]/);', ""].join("\n");
+    using dir = tempDir("parse-error-import", {
+      "bad-a.cjs": badModule,
+      "bad-b.cjs": badModule,
+      "index.mjs": `
+        let a, b;
+        try {
+          await import("./bad-a.cjs");
+        } catch (e) {
+          a = e;
+        }
+        try {
+          await import("./bad-b.cjs");
+        } catch (e) {
+          b = e;
+        }
+        // Math.max is not on the stack, so no frames are captured for a.
+        Error.captureStackTrace(a, Math.max);
+        Error.captureStackTrace(b);
+        console.log(JSON.stringify([a.stack, b.stack]));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const [noFrames, withFrames] = JSON.parse(stdout) as [string, string];
+    expect(noFrames.split("\n")).toEqual([
+      expect.stringMatching(/^SyntaxError: /),
+      expect.stringMatching(/^    at <parse> \(.*bad-a\.cjs:\d+\)$/),
+    ]);
+    expect(withFrames.split("\n").slice(0, 3)).toEqual([
+      expect.stringMatching(/^SyntaxError: /),
+      expect.stringMatching(/^    at <parse> \(.*bad-b\.cjs:\d+\)$/),
+      expect.stringMatching(/^    at .*index\.mjs:\d+:\d+\)?$/),
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -222,7 +222,8 @@ describe("SyntaxError .stack", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toContain("SyntaxError: boom");
     expect(stderr).not.toContain("<parse>");
     expect(stderr).toMatch(/index\.js:1:\d+/);
@@ -235,10 +236,17 @@ describe("SyntaxError .stack", () => {
   });
 
   test("a parser SyntaxError in a source without a URL has no <parse> frame", () => {
-    // There is no file to point at, so an "at <parse> (:4)" line would only be noise.
-    const stack = caught(() => new Function("{")).stack!;
+    // There is no file to point at, so an "at <parse> (:1)" line would only be noise.
+    // Not new Function("{") or eval: those materialize .stack from inside JSC's own parse-error
+    // path, which never checks for an exception from the stack hook, so they abort under
+    // BUN_JSC_validateExceptionChecks (see #30823). node:vm's path checks.
+    const stack = caught(() => vm.compileFunction("{")).stack!;
     expect(stack).not.toContain("<parse>");
     expect(stack.split("\n").at(-1)).toMatch(/^    at .*stack\.test\.ts:\d+:\d+\)?$/);
+
+    // The same source with a URL keeps the frame.
+    const named = caught(() => vm.compileFunction("{", [], { filename: "named.js" })).stack!;
+    expect(named.split("\n")).toContain("    at <parse> (named.js:1)");
   });
 
   test("a parser SyntaxError from importing a module keeps its <parse> frame", async () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -2,6 +2,7 @@ import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -153,8 +154,7 @@ test("Async functions frame should be included in stack trace", async () => {
 
 // When JSC's parser rejects a source it records that source's URL and line on the
 // SyntaxError, and .stack renders them as a synthetic "at <parse> (url:line)" frame.
-// Every other SyntaxError has no such location and must format like node's: the
-// header followed by the real frames.
+// Every other SyntaxError must format like node's: the header followed by the real frames.
 describe("SyntaxError .stack", () => {
   test("new SyntaxError() has no <parse> frame", () => {
     const err = new SyntaxError("user made");
@@ -228,6 +228,67 @@ describe("SyntaxError .stack", () => {
     expect(stderr).not.toContain("<parse>");
     expect(stderr).toMatch(/index\.js:1:\d+/);
     expect(exitCode).toBe(1);
+  });
+
+  // A SyntaxError can carry a sourceURL without coming from the parser: structured clone
+  // recreates an error with its original's line/column/sourceURL, and a GC that collects a
+  // function on the error's stack records the first frame's position on the error instead.
+  // When such an error later gets frames from Error.captureStackTrace(), that location must
+  // not be rendered as a <parse> frame. The cases below capture from a different file than
+  // the one recorded, since a frame from the recorded file would hide the <parse> line anyway.
+  const stackLines = (err: Error) => err.stack!.split("\n");
+
+  test("a structured clone of a SyntaxError captured from another file gets no <parse> frame", () => {
+    const original = new SyntaxError("cloned");
+    expect((structuredClone(original) as any).sourceURL).toEndWith("stack.test.ts");
+
+    const clone = structuredClone(original);
+    const captureElsewhere = new vm.Script("err => Error.captureStackTrace(err)", {
+      filename: "capture-site.js",
+    }).runInThisContext();
+    captureElsewhere(clone);
+    expect(stackLines(clone).slice(0, 3)).toEqual([
+      "SyntaxError: cloned",
+      expect.stringMatching(/^    at .*capture-site\.js:1:\d+\)?$/),
+      expect.stringMatching(/^    at .*stack\.test\.ts:\d+:\d+\)?$/),
+    ]);
+  });
+
+  test("a SyntaxError posted by a worker gets no <parse> frame when the parent captures a stack for it", async () => {
+    using dir = tempDir("worker-syntax-error", {
+      "worker.js": 'postMessage(new SyntaxError("made in worker"));\n',
+    });
+    const worker = new Worker(pathToFileURL(join(String(dir), "worker.js")).href);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<SyntaxError>();
+      worker.onmessage = event => resolve(event.data);
+      worker.onerror = reject;
+      const err = await promise;
+      Error.captureStackTrace(err);
+      expect(stackLines(err).slice(0, 2)).toEqual([
+        "SyntaxError: made in worker",
+        expect.stringMatching(/^    at .*stack\.test\.ts:\d+:\d+\)?$/),
+      ]);
+    } finally {
+      worker.terminate();
+    }
+  });
+
+  test("a SyntaxError whose frames were collected by GC gets no <parse> frame when captured again", () => {
+    // Nothing but the error refers to the function that created it, so a full GC collects the
+    // function and flushes the error's frames, recording gc-me.js as the error's sourceURL.
+    // A few rounds in case a stale pointer on the native stack keeps the function alive once.
+    for (let i = 0; i < 4; i++) {
+      const err: SyntaxError = new vm.Script('(() => new SyntaxError("collected"))()', {
+        filename: "gc-me.js",
+      }).runInThisContext();
+      Bun.gc(true);
+      Error.captureStackTrace(err);
+      expect(stackLines(err).slice(0, 2)).toEqual([
+        "SyntaxError: collected",
+        expect.stringMatching(/^    at .*stack\.test\.ts:\d+:\d+\)?$/),
+      ]);
+    }
   });
 
   test("a parser SyntaxError keeps its <parse> frame", () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -274,18 +274,27 @@ describe("SyntaxError .stack", () => {
     }
   });
 
-  test("a SyntaxError whose frames were collected by GC gets no <parse> frame when captured again", () => {
+  test.each([
+    ["new SyntaxError()", '(() => new SyntaxError("collected"))()', /^SyntaxError: collected$/],
+    // JSC flags a syntax error in eval code as a parse error but records no location for it, so
+    // once GC has recorded one it must not be rendered either. (Unlike new Function(), eval's
+    // parse-error path does not materialize .stack, so it is fine under BUN_JSC_validateExceptionChecks.)
+    ["eval()", '(() => { try { eval("{"); } catch (e) { return e; } })()', /^SyntaxError: /],
+    ["indirect eval", '(() => { try { (0, eval)("{"); } catch (e) { return e; } })()', /^SyntaxError: /],
+  ])("a SyntaxError from %s whose frames GC collected gets no <parse> frame when captured", (_, source, header) => {
     // Nothing but the error refers to the function that created it, so a full GC collects the
     // function and flushes the error's frames, recording gc-me.js as the error's sourceURL.
     // A few rounds in case a stale pointer on the native stack keeps the function alive once.
     for (let i = 0; i < 4; i++) {
-      const err: SyntaxError = new vm.Script('(() => new SyntaxError("collected"))()', {
-        filename: "gc-me.js",
-      }).runInThisContext();
+      const err: SyntaxError = new vm.Script(source, { filename: "gc-me.js" }).runInThisContext();
+      // The VM holds on to the most recently thrown exception, frames included, until the next throw.
+      try {
+        throw new Error("displaces the eval error as the VM's last exception");
+      } catch {}
       Bun.gc(true);
       Error.captureStackTrace(err);
       expect(stackLines(err).slice(0, 2)).toEqual([
-        "SyntaxError: collected",
+        expect.stringMatching(header),
         expect.stringMatching(/^    at .*stack\.test\.ts:\d+:\d+\)?$/),
       ]);
     }
@@ -298,8 +307,8 @@ describe("SyntaxError .stack", () => {
 
   test("a parser SyntaxError in a source without a URL has no <parse> frame", () => {
     // There is no file to point at, so an "at <parse> (:1)" line would only be noise.
-    // Not new Function("{") or eval: those materialize .stack from inside JSC's own parse-error
-    // path, which never checks for an exception from the stack hook, so they abort under
+    // Not new Function("{"): it materializes .stack from inside JSC's own parse-error path, which
+    // never checks for an exception from the stack hook, so it aborts under
     // BUN_JSC_validateExceptionChecks (see #30823). node:vm's path checks.
     const stack = caught(() => vm.compileFunction("{")).stack!;
     expect(stack).not.toContain("<parse>");


### PR DESCRIPTION
Stacked on #37386 (its four commits come first; the change here is the last commit). Pairs with oven-sh/WebKit#407, pinned here as a preview build; once that lands I will replace `WEBKIT_VERSION` with the main sha.

### What does this PR do?

#37386 stops `.stack` from giving every SyntaxError a fabricated `at <parse> (:0)` line by only emitting the `<parse>` frame when the error records a `sourceURL`, which is what JSC's `addErrorInfo()` leaves on a parser error. A `sourceURL` is not unique to parser errors though. A SyntaxError that has one for another reason still gets the frame as soon as it is given frames from a different file:

```js
// a.js
export const clone = structuredClone(new SyntaxError("made in a.js"));

// b.js
import { clone } from "./a.js";
Error.captureStackTrace(clone);
console.log(clone.stack);
```

```
# bun 1.4.0, and #37386
SyntaxError: made in a.js
    at <parse> (/tmp/clone/a.js:1)
    at /tmp/clone/b.js:2:7

# node
SyntaxError: made in a.js
    at file:///tmp/clone/b.js:2:7
```

The realistic shape is an error `postMessage`d by a worker that the parent then `captureStackTrace`s. Two ways an error that never had a parser location ends up with a `sourceURL`:

- Structured clone (`structuredClone`, `postMessage`) recreates the error through the `ErrorInstance::create` overload that takes the original's line/column/sourceURL (`SerializedScriptValue.cpp`), so every clone records the file its original was created in.
- GC: when a function on an error's stack is collected, `ErrorInstance::finalizeUnconditionally` flushes the frames to a string and records the first frame's URL on the error. A `new SyntaxError()` created inside a function that has since been collected shows the same `<parse>` line when captured afterwards, and so does a syntax error thrown by `eval()` (which JSC does flag as a parse error, but records no location for), no cloning involved: `at <parse> (gc-me.js:1)` in the new tests.

A plain `.stack` read on a clone was already fine (it returns the serialized stack string) and still is. Only errors that get frames installed after the fact are affected, and those all go through this one formatter.

### Fix

The thing the frame renders is the location `addErrorInfo()` recorded, so that is what the formatter should test for. oven-sh/WebKit#407 adds a Bun-only bit to `ErrorInstance`, set by `addErrorInfo()` right where it records the line and sourceURL (before it materializes the stack through our hook), exposed as `hasParseLocation()`. Clones, GC-flushed errors and eval parse errors never get it; every parser error for a named source does. `formatStackTrace()` now checks that instead of the error type. The `sourceURL` check stays so parser errors for URL-less sources (`new Function`, `vm.compileFunction` without a filename) keep formatting without a frame, as #37386 made them.

JSC's existing `isParseError()` does not work for this, which is why the engine change is needed: `ParserError::toErrorObject()` sets it only after `addErrorInfo()` has already formatted the stack (#37386 verified that gating on it dropped the frame for every parser error), and it is also set for eval-code syntax errors, which have no location to show and would still pick up the GC-recorded one. The first revision of this PR gated on it with the ordering fixed and review turned up exactly that eval case, so the discriminator is now a dedicated bit.

Parser errors are unaffected: the existing guards in `stack.test.ts` (`vm.Script` and `vm.compileFunction` with a filename, `import()` of modules JSC rejects with and without captured frames) pass against the new build, and an `import()` of an ESM module JSC rejects still prints `at <parse> (bad.mjs:2)`.

The clone deserializer is deliberately left alone: a clone carrying its original's `line`/`column`/`sourceURL` is correct and observable (`structuredClone(err).sourceURL`). The formatter was reading the wrong signal.

### Tests

Added to the `SyntaxError .stack` block in `test/js/bun/test/stack.test.ts`:

- `structuredClone()` of a SyntaxError, then `Error.captureStackTrace()` run from a `vm.Script` with a different filename
- a SyntaxError posted by a `Worker`, then `captureStackTrace`d by the parent
- a SyntaxError created by `new SyntaxError()`, `eval("{")` and `(0, eval)("{")` inside a `vm.Script` function that `Bun.gc(true)` collects, then `captureStackTrace`d (the eval rows need the VM's last-thrown exception displaced first, since it keeps a caught error's frames alive)

Each fails with the `<parse>` line in place of the real first frame on the released build (`USE_SYSTEM_BUN=1 bun test test/js/bun/test/stack.test.ts`) and on a debug build with the preview WebKit but `src/` at #37386's state; the two eval rows also fail against the first revision of this PR. With this change the file passes (`bun bd test test/js/bun/test/stack.test.ts`), including under `BUN_JSC_validateExceptionChecks=1`.

Also run against the debug build: `test/js/node/v8/capture-stack-trace.test.js`, `test/js/node/vm/vm.test.ts`, `test/js/node/vm/vm-sourceUrl.test.ts`, `test/js/web/workers/structured-clone.test.ts`, `test/js/node/worker_threads/worker_threads.test.ts`, all passing. `test/js/bun/util/inspect-error.test.js` has two minified-file snapshot failures that reproduce on a pristine `main` debug build (an extra builtin `require` frame, tracked separately) and are unrelated.

### Notes for the reviewer

- `WEBKIT_VERSION` points at `autobuild-preview-pr-407-f6d8e2a0`. The preview is branched from WebKit `main` (723cea6c), so relative to the current pin (447082ab) it also contains oven-sh/WebKit#405, the same delta #37352 bumps to. Not meant to merge with the preview tag; the order is WebKit#407, pin swap here, then #37386 and this.
- #36634 changes how the location inside this branch is remapped for real parser errors; it does not touch the condition and composes with this.
