### PR TITLE
docs: state what directory routes do with symlinks off Linux and with dotfiles

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -206,7 +206,9 @@ Bun.serve({
 });
 ```
 
-Bun percent-decodes the part of the request URL after the prefix once and opens it relative to `dir`. Bun rejects non-canonical paths with `404`, so the served path is always the path the router matched. A path is non-canonical if it contains `.`, `..`, empty segments, `%2F`, or a `%XX` sequence encoding a character that may appear literally in a path segment. On Linux the open uses `openat2(RESOLVE_IN_ROOT)`, so the kernel clamps symlinks that would escape `dir`.
+Bun percent-decodes the part of the request URL after the prefix once and opens it relative to `dir`. Bun rejects non-canonical paths with `404`, so the served path is always the path the router matched. A path is non-canonical if it contains a segment that is exactly `.` or `..`, an empty segment, `%2F`, or a `%XX` sequence encoding a character that may appear literally in a path segment. On Linux the open uses `openat2(RESOLVE_IN_ROOT)`, so the kernel clamps symlinks that would escape `dir`. Where `openat2` is unavailable (kernels before 5.6, or a seccomp policy that blocks it), and on macOS and Windows, Bun follows symlinks wherever they point, so a symlink inside `dir` publishes its target even when the target is outside `dir`.
+
+Bun does not filter dotfiles: it serves any regular file under `dir`, including a `.env` file or the contents of a `.git` directory. Point `dir` at a directory that contains only files meant to be public.
 
 <Info>
   Routing is case-sensitive, but filesystems on macOS and Windows are case-insensitive by default. As a result, a

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -584,11 +584,16 @@ declare module "bun" {
      *
      * The route path **must** end in `/*`. The part of the request URL after
      * the prefix is percent-decoded once and opened relative to `dir`.
-     * Non-canonical paths (containing `.`, `..`, empty segments, `%2F`, or a
-     * `%XX` sequence encoding a character that may appear literally in a path
-     * segment) are rejected with `404` so the served path is always the path
-     * the router matched. On Linux the open uses `openat2(RESOLVE_IN_ROOT)`,
-     * so symlinks that would escape `dir` are clamped by the kernel. Routing
+     * Non-canonical paths (a segment that is exactly `.` or `..`, an empty
+     * segment, `%2F`, or a `%XX` sequence encoding a character that may appear
+     * literally in a path segment) are rejected with `404` so the served path
+     * is always the path the router matched. On Linux the open uses
+     * `openat2(RESOLVE_IN_ROOT)`, so symlinks that would escape `dir` are
+     * clamped by the kernel; where `openat2` is unavailable (kernels before
+     * 5.6, or seccomp), and on macOS and Windows, symlinks are followed
+     * wherever they point, including outside `dir`. Dotfiles are not
+     * filtered: any regular file under `dir` (a `.env` file, the contents of
+     * `.git/`) is served, so `dir` should contain only public files. Routing
      * is case-sensitive but filesystems on macOS and Windows are not by
      * default: do not place access-controlled content inside `dir` and rely
      * on an overlapping route to gate it.

--- a/test/js/bun/http/serve-directory-routes.test.ts
+++ b/test/js/bun/http/serve-directory-routes.test.ts
@@ -434,6 +434,27 @@ describe("Bun.serve() directory routes", () => {
     expect(exitCode).toBe(0);
   });
 
+  // Documented in docs/runtime/http/routing.mdx and serve.d.ts: there is no
+  // dotfile filter, only `.` and `..` segments are rejected.
+  it("serves dotfiles and files inside dot-directories", async () => {
+    using dir = tempDir("serve-dir-dotfiles", {
+      "public/.env": "KEY=value",
+      "public/.git/config": "[core]",
+    });
+
+    server = serve({
+      port: 0,
+      routes: { "/static/*": { dir: join(String(dir), "public") } },
+      fetch: () => new Response("fallback", { status: 404 }),
+    });
+
+    const env = await fetch(`${server.url}static/.env`);
+    expect({ status: env.status, body: await env.text() }).toEqual({ status: 200, body: "KEY=value" });
+
+    const config = await fetch(`${server.url}static/.git/config`);
+    expect({ status: config.status, body: await config.text() }).toEqual({ status: 200, body: "[core]" });
+  });
+
   it("percent-decodes file names", async () => {
     using dir = tempDir("serve-dir-pct", {
       "public/hello world.txt": "hi",


### PR DESCRIPTION
### What

`DirectoryRoute::open_beneath` (`src/runtime/server/DirectoryRoute.rs`) uses `openat2(RESOLVE_IN_ROOT)` only on Linux, and `bun_sys::openat2_in_root` itself falls back to plain `openat` when the kernel or a seccomp policy does not provide `openat2` (Bun's minimum kernel is 5.1, `openat2` is 5.6+). On macOS and Windows it is always a plain `openat`. In all of those cases a symlink inside the served tree is followed wherever it points, including outside `dir`. `resolve_subpath` rejects `.` and `..` segments and nothing else, so dotfiles (`.env`, `.git/config`) are served on every platform.

The docs (`docs/runtime/http/routing.mdx`) and the `DirectoryRouteOptions` JSDoc only described the Linux behavior, and their "paths containing `.`" wording could be read as if dotfiles were rejected.

### Change

- Both texts now say what happens off Linux (and on Linux without `openat2`), that dotfiles are not filtered, and describe the rejected segments precisely.
- `test/js/bun/http/serve-directory-routes.test.ts` gets a test for the dotfile behavior as documented, next to the existing Linux `RESOLVE_IN_ROOT` test.

No runtime change. If a dotfile filter or `O_NOFOLLOW_ANY` on Darwin is wanted, that is a behavior change with its own trade-offs (`O_NOFOLLOW_ANY` would also refuse symlinks that stay inside `dir`, which `RESOLVE_IN_ROOT` allows) and should be its own PR; this only makes the current behavior explicit.

### Verification

```
bun bd test test/js/bun/http/serve-directory-routes.test.ts   # 31 pass
bun test test/integration/bun-types/bun-types.test.ts          # 14 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-directory-routes.test.ts

<!-- robobun:evidence:end -->
