### PR TITLE
fetch: report early rejections as unhandled rejections

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -190,10 +190,7 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
         Err(_) => {
             let err =
                 global_this.create_error_instance(format_args!("failed to fetch the data URL"));
-            return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            );
+            return JSPromise::rejected_promise(global_this, err).to_js();
         }
     };
     let blob = Blob::init(data, global_this);
@@ -365,7 +362,7 @@ fn reject_on_exception(
             }
         },
     };
-    Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
+    Ok(JSPromise::rejected_promise(global_this, err).to_js())
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -403,12 +400,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::MISSING_ARGS,
             format_args!("{FETCH_ERROR_NO_ARGS}"),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     let mut headers: Option<Headers> = None;
@@ -559,12 +551,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::INVALID_URL,
             format_args!("{FETCH_ERROR_BLANK_URL}"),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     if url_str.has_prefix_comptime(b"data:") {
@@ -575,12 +562,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             Ok(d) => d,
             Err(_) => {
                 let err = ctx.create_error_instance(format_args!("failed to fetch the data URL"));
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        err,
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
         };
         let mut data_url = data_url;
@@ -600,12 +582,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 jsc::ErrorCode::INVALID_URL,
                 format_args!("fetch() URL is invalid"),
             );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
         }
     };
     let mut url_proxy_buffer = owned_url.into_href().into_vec();
@@ -1019,11 +996,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                 jsc::ErrorCode::INVALID_ARG_VALUE,
                                 format_args!("fetch() proxy URL is invalid"),
                             );
-                            return Ok(
-                                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                    global_this, err,
-                                ),
-                            );
+                            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
                         }
                         let mut buffer: Vec<u8> = Vec::with_capacity(url_proxy_buffer.len());
                         buffer.extend_from_slice(&url_proxy_buffer);
@@ -1059,9 +1032,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                         format_args!("fetch() proxy URL is invalid"),
                                     );
                                     return Ok(
-                                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                            global_this, err,
-                                        ),
+                                        JSPromise::rejected_promise(global_this, err).to_js()
                                     );
                                 }
                                 let mut buffer: Vec<u8> =
@@ -1143,12 +1114,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     jsc::ErrorCode::INVALID_ARG_TYPE,
                     format_args!("signal is not of type AbortSignal."),
                 );
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        err,
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
 
             if global_this.has_exception() {
@@ -1177,12 +1143,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     jsc::ErrorCode::INVALID_ARG_TYPE,
                     format_args!("signal is not of type AbortSignal."),
                 );
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        err,
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
         }
 
@@ -1414,12 +1375,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::INVALID_ARG_VALUE,
             format_args!("{FETCH_ERROR_PROXY_UNIX}"),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     if global_this.has_exception() {
@@ -1477,12 +1433,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             bstr::BStr::new(url_path_decoded)
                         ),
                     );
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err,
-                        ),
-                    );
+                    return Ok(JSPromise::rejected_promise(global_this, err).to_js());
                 }
             }
 
@@ -1593,12 +1544,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 jsc::ErrorCode::INVALID_ARG_VALUE,
                 format_args!("protocol must be http:, https: or s3:"),
             );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
         }
     }
 
@@ -1610,12 +1556,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::INVALID_ARG_VALUE,
             format_args!("{FETCH_ERROR_UNEXPECTED_BODY}"),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     // Fetch spec step 11: reject synchronously for a pre-aborted signal. Runs
@@ -1631,12 +1572,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 }
             }
             body.detach();
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    reason,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, reason).to_js());
         }
     }
 
@@ -1674,11 +1610,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 old.detach();
                 break 'prepare_body;
             }
-            let rejected_value =
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    global_this.create_error_instance(format_args!("Failed to start s3 stream")),
-                );
+            let rejected_value = JSPromise::rejected_promise(
+                global_this,
+                global_this.create_error_instance(format_args!("Failed to start s3 stream")),
+            )
+            .to_js();
             // HTTPRequestBody has no Drop impl, so a bare `drop(body)` would
             // leak the S3 Blob.Store ref.
             body.detach();
@@ -1710,11 +1646,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let opened_fd = match opened_fd_res {
                 Err(err) => {
                     let err_js = err.to_js(global_this);
-                    let rejected_value =
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err_js,
-                        );
+                    let rejected_value = JSPromise::rejected_promise(global_this, err_js).to_js();
                     return Ok(rejected_value);
                 }
                 Ok(fd) => fd,
@@ -1806,10 +1738,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             match res {
                 Err(err) => {
                     let rejected_value =
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err.to_js(global_this),
-                        );
+                        JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js();
                     body.detach();
                     return Ok(rejected_value);
                 }
@@ -1898,14 +1827,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // `defer body.ReadableStream.deinit()` → Drop on `body` scope exit.
 
             if method != Method::PUT && method != Method::POST {
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        global_this.create_error_instance(format_args!(
-                            "Only POST and PUT do support body when using S3"
-                        )),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(
+                    global_this,
+                    global_this.create_error_instance(format_args!(
+                        "Only POST and PUT do support body when using S3"
+                    )),
+                )
+                .to_js());
             }
             let promise = jsc::JSPromiseStrong::init(global_this);
             let promise_value = promise.value();
@@ -1979,12 +1907,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         ) {
             Ok(r) => r,
             Err(sign_err) => {
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        s3::get_js_sign_error(sign_err.into(), global_this),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(
+                    global_this,
+                    s3::get_js_sign_error(sign_err.into(), global_this),
+                )
+                .to_js());
             }
         };
         // `defer result.deinit()` → Drop.

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -234,7 +234,7 @@ test("missing file throws the expected error", async () => {
         proxy: "http://localhost:3000",
       });
       expect(Bun.peek.status(resp)).toBe("rejected");
-      expect(async () => await resp).toThrow("no such file or directory");
+      expect(resp).rejects.toThrow("no such file or directory");
     }
   });
   Bun.gc(true);

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -237,5 +237,8 @@ test("missing file throws the expected error", async () => {
       expect(resp).rejects.toThrow("no such file or directory");
     }
   });
+  // The rejection tracker keeps each promise alive until the end of the tick
+  // (a microtask is not enough), so yield one before forcing the collection.
+  await Bun.sleep(0);
   Bun.gc(true);
 });

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -251,9 +251,12 @@ describe.concurrent("fetch() early rejections are reported when unhandled", () =
     expect(exitCode).toBe(0);
   });
 
+  // Before the rejection was registered, handling it still reached the tracker's
+  // "handled" side, which emitted a spurious rejectionHandled event.
   test("a rejection that is handled is not reported", async () => {
     const { stdout, stderr, exitCode } = await runUnhandled(`
       process.on("unhandledRejection", () => console.log("unhandledRejection fired"));
+      process.on("rejectionHandled", () => console.log("rejectionHandled fired"));
       fetch("gopher://example.com/").catch(err => console.log("caught:", err.message));
     `);
     expect(stdout).toBe("caught: protocol must be http:, https: or s3:\n");

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -1,5 +1,7 @@
 import { TCPSocketListener } from "bun";
 import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 let server;
 let requestCount = 0;
@@ -136,6 +138,127 @@ describe("fetch() rejects instead of throwing synchronously when option conversi
         } as any),
       `${name}-BOOM`,
     );
+  });
+});
+
+// Every early exit in fetch() (bad arguments, unsupported scheme, unresolvable
+// blob:, pre-aborted signal, unreadable Bun.file() body, ...) returns an already
+// rejected promise. Those promises used to be created without notifying the VM,
+// so when nothing handled them the process printed nothing and exited 0.
+describe.concurrent("fetch() early rejections are reported when unhandled", () => {
+  async function runUnhandled(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const cases: [name: string, code: string, expectedStderr: string][] = [
+    ["no arguments", `fetch()`, "fetch() expects a string but received no arguments"],
+    ["blank url", `fetch("")`, "fetch() URL must not be a blank string"],
+    ["invalid url", `fetch("not a url")`, "fetch() URL is invalid"],
+    ["unsupported protocol", `fetch("gopher://example.com/")`, "protocol must be http:, https: or s3:"],
+    [
+      "revoked blob: url",
+      `const url = URL.createObjectURL(new Blob(["x"])); URL.revokeObjectURL(url); fetch(url);`,
+      "Failed to resolve blob:",
+    ],
+    ["data: url without a comma", `fetch("data:text/plain")`, "failed to fetch the data URL"],
+    ["data: url with invalid base64", `fetch("data:text/plain;base64,@@@")`, "failed to fetch the data URL"],
+    ["url toString() throws", `fetch({ toString() { throw new Error("UBOOM"); } })`, "UBOOM"],
+    [
+      "GET with a body",
+      `fetch("http://127.0.0.1:1/", { body: "x" })`,
+      "fetch() request with GET/HEAD method cannot have body",
+    ],
+    [
+      "proxy combined with unix",
+      `fetch("http://127.0.0.1:1/", { proxy: "http://127.0.0.1:1/", unix: "/tmp/fetch-args.sock" })`,
+      "fetch() cannot use a proxy with a unix socket",
+    ],
+    ["invalid proxy url", `fetch("http://127.0.0.1:1/", { proxy: "not a url" })`, "fetch() proxy URL is invalid"],
+    [
+      "invalid proxy.url",
+      `fetch("http://127.0.0.1:1/", { proxy: { url: "not a url" } })`,
+      "fetch() proxy URL is invalid",
+    ],
+    [
+      "init.signal is not an AbortSignal",
+      `fetch("http://127.0.0.1:1/", { signal: 1 })`,
+      "signal is not of type AbortSignal",
+    ],
+    [
+      "input.signal is not an AbortSignal",
+      `fetch({ url: "http://127.0.0.1:1/", signal: 1 })`,
+      "signal is not of type AbortSignal",
+    ],
+    [
+      "already aborted signal",
+      `fetch("http://127.0.0.1:1/", { signal: AbortSignal.abort() })`,
+      "The operation was aborted",
+    ],
+    [
+      "s3: request signing fails",
+      `fetch("s3://bucket/key", { method: "PATCH", s3: { accessKeyId: "a", secretAccessKey: "b" } })`,
+      "Method must be GET, PUT, DELETE or HEAD when using s3:// protocol",
+    ],
+    [
+      "s3: ReadableStream body with a non-upload method",
+      `fetch("s3://bucket/key", { method: "DELETE", body: new ReadableStream() })`,
+      "Only POST and PUT do support body when using S3",
+    ],
+  ];
+
+  test.each(cases)("%s", async (_name, code, expectedStderr) => {
+    const { stderr, exitCode } = await runUnhandled(code);
+    expect(stderr).toContain(expectedStderr);
+    expect(exitCode).toBe(1);
+  });
+
+  test("Bun.file() body that does not exist", async () => {
+    using dir = tempDir("fetch-unhandled-body", {});
+    const missing = JSON.stringify(join(String(dir), "missing.bin"));
+    const { stderr, exitCode } = await runUnhandled(
+      `fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(${missing}) })`,
+    );
+    expect(stderr).toContain("ENOENT");
+    expect(exitCode).toBe(1);
+  });
+
+  test("Bun.file() body that is a directory", async () => {
+    using dir = tempDir("fetch-unhandled-body", {});
+    const directory = JSON.stringify(String(dir));
+    const { stderr, exitCode } = await runUnhandled(
+      `fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(${directory}) })`,
+    );
+    expect(stderr).toContain("EISDIR");
+    expect(exitCode).toBe(1);
+  });
+
+  test("the rejection is delivered to process.on('unhandledRejection')", async () => {
+    const { stdout, stderr, exitCode } = await runUnhandled(`
+      process.on("unhandledRejection", (reason, promise) => {
+        console.log(promise === returned, reason.code, reason.message);
+      });
+      const returned = fetch("gopher://example.com/");
+    `);
+    expect(stdout).toBe("true ERR_INVALID_ARG_VALUE protocol must be http:, https: or s3:\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a rejection that is handled is not reported", async () => {
+    const { stdout, stderr, exitCode } = await runUnhandled(`
+      process.on("unhandledRejection", () => console.log("unhandledRejection fired"));
+      fetch("gopher://example.com/").catch(err => console.log("caught:", err.message));
+    `);
+    expect(stdout).toBe("caught: protocol must be http:, https: or s3:\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

When `fetch()` rejects before it ever touches the network and nothing handles that rejection, Bun prints nothing and exits 0:

```sh
$ bun -e 'fetch("gopher://example.com/")'; echo "exit=$?"
exit=0
$ bun -e 'const u = URL.createObjectURL(new Blob(["x"])); URL.revokeObjectURL(u); fetch(u)'; echo "exit=$?"
exit=0
```

The error exists (`.catch()` receives `TypeError: protocol must be http:, https: or s3:` and `Failed to resolve blob:...`), it is just never reported. `process.on("unhandledRejection")` listeners do not run either. Node reports both as unhandled rejections and exits 1, and so does Bun for every other rejected promise, including the ones `fetch()` produces later on from the network path.

The handled side is off too: because the tracker never saw the rejection, attaching a handler (`fetch("gopher://example.com/").catch(...)`) makes it look like a late handler for an already reported rejection, so `process` emits a spurious `rejectionHandled` event, and `--unhandled-rejections=warn` prints `PromiseRejectionHandledWarning` for a rejection that was handled synchronously.

**Cause:** every early exit in `fetch_impl` (`src/runtime/webcore/fetch.rs`) builds its promise with `JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm`. That helper (`JSC__JSPromise__rejectedPromiseValue`) sets the promise's rejected flag and result slot directly and never calls `promiseRejectionTracker`, which is exactly what its doc comment in `src/jsc/JSPromise.rs` warns about. The affected exits are: no arguments, blank URL, unparsable URL, `data:` URLs that fail to parse or decode, invalid `proxy` (string and object form), `signal` that is not an `AbortSignal` (init and input object form), `proxy` combined with `unix`, unresolvable `blob:` URL, unsupported scheme, GET/HEAD with a body, already aborted signal, a `Bun.file()` body that fails to open or read, s3 signing errors, a stream body with a non-upload method on s3, and `reject_on_exception`, which turns any exception thrown while converting the arguments into a rejection.

**Fix:** build them with `JSPromise::rejected_promise(global, err).to_js()` instead. That goes through `JSC::JSPromise::rejectedPromise`, so the rejection is registered with the tracker like a `Promise.reject()` from JS. It is the helper `Body.rs`, `streams.rs`, `s3/client.rs` and `ErrorCode::reject()` already use for the same purpose. The change is the same one line at each of the 20 call sites in `fetch.rs`; no messages or error types change.

### Why this is the right behavior

The promise is handed straight back to the caller, so the usual rules apply: attaching a handler synchronously (`.catch()`, `await`, `expect(...).rejects`) removes it from the pending list before anything is reported, and only a rejection nobody handles by the end of the tick is reported. That is what the network-path rejections from the same `fetch()` call already do, so callers no longer get different reporting depending on how far `fetch()` got before failing. It also matches Node for these inputs. `bun:test`'s `expect(fn).toThrow()` captures rejections produced during `fn` through its own scope, so the existing `fetch-args.test.ts` tests that assert on these errors via `toThrow` still pass unchanged.

One existing test needed updating: `test/js/bun/http/fetch-file-upload.test.ts` ("missing file throws the expected error") creates 1000 rejected `fetch()` promises and then asserts on each with `expect(async () => await resp).toThrow(...)`. `toThrow()` drains the rejections that are still pending when it is called, so with the promises now registered the first assertion reported the rest as unhandled (the same thing happens today if `resp` is a plain `Promise.reject()`). The test now uses `expect(resp).rejects.toThrow(...)`, which marks the promise handled as part of the assertion. That was the only failure in the full CI run of the first commit. Review then pointed out that the tracker keeps the 1000 promises alive until the end of the tick, which would have turned the trailing `Bun.gc(true)` into a no-op; verified with `heapStats()` (1000 promises and 1000 errors still live at that point, and still live after a bare `await`, since the list is drained after the microtask queue), so the test now yields one event loop turn with `await Bun.sleep(0)` before the forced collection, after which the counts are back to zero.

The other users of the deprecated helper (`Bun.write`, `server.fetch()`, `Bun.resolve()`, ...) have the same problem and are being handled separately; #37425 adds a new `file:` rejection that already uses `rejected_promise`.

### How did you verify your code works?

New `describe` block in `test/js/web/fetch/fetch-args.test.ts`. It spawns `bun -e` for 19 of the 20 exits above (the remaining one, "Failed to start s3 stream", needs an internal stream creation failure that I could not trigger from JS) and checks that the error reaches stderr and the process exits 1. Two more tests check that a `process.on("unhandledRejection")` listener receives the rejection with the returned promise, and that a rejection handled with `.catch()` is neither reported nor followed by a `rejectionHandled` event. All 21 fail on the current release (empty stderr and exit 0 for the first twenty, the spurious `rejectionHandled` for the last one); all pass with this change, together with the rest of `fetch-args.test.ts`.

Also ran `fetch.test.ts`, `fetch.stream.test.ts`, `fetch-redirect.test.ts`, `fetch.unix.test.ts`, `client-fetch.test.ts`, `blob.test.ts`, the `node-fetch` and `undici` shim tests with the debug build. The only failures are the same ones the unmodified build has in this environment (localhost connections refused, `(with gc)` tests and a few compression tests exceeding their timeout under the debug build when the whole file runs; they pass in isolation).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/fetch-file-upload.test.ts

<!-- robobun:evidence:end -->
