### PR TITLE
http: clear the request stream drain callback under the buffer mutex

### DIFF
--- a/src/http/ThreadSafeStreamBuffer.rs
+++ b/src/http/ThreadSafeStreamBuffer.rs
@@ -9,8 +9,7 @@ pub struct ThreadSafeStreamBuffer {
     pub(crate) mutex: Mutex,
     /// Intrusive atomic refcount. Starts at 2: 1 for main thread and 1 for http thread.
     pub(crate) ref_count: bun_ptr::ThreadSafeRefCount<ThreadSafeStreamBuffer>,
-    /// Called by the HTTP thread when the buffer drains before the end chunk.
-    /// Guarded by `mutex`, like `buffer`.
+    /// Called by the http thread when the buffer drains; guarded by `mutex`, like `buffer`.
     callback: Option<Callback>,
 }
 

--- a/src/http/ThreadSafeStreamBuffer.rs
+++ b/src/http/ThreadSafeStreamBuffer.rs
@@ -9,12 +9,8 @@ pub struct ThreadSafeStreamBuffer {
     pub(crate) mutex: Mutex,
     /// Intrusive atomic refcount. Starts at 2: 1 for main thread and 1 for http thread.
     pub(crate) ref_count: bun_ptr::ThreadSafeRefCount<ThreadSafeStreamBuffer>,
-    /// Invoked by the HTTP thread (`report_drain`) once everything buffered
-    /// has been written out and the end chunk has not been sent yet.
-    ///
-    /// Guarded by `mutex`, like `buffer`: `report_drain` reads it under the
-    /// lock on the HTTP thread while the JS thread may be clearing it in
-    /// `clear_drain_callback` for a request that is still in flight.
+    /// Called by the HTTP thread when the buffer drains before the end chunk.
+    /// Guarded by `mutex`, like `buffer`.
     callback: Option<Callback>,
 }
 
@@ -106,18 +102,14 @@ impl ThreadSafeStreamBuffer {
         self.callback = Some(Callback::init(callback, context));
     }
 
-    /// Main thread. The HTTP thread may still be flushing this buffer (and
-    /// about to `report_drain`) when the JS side tears the request down, so
-    /// the callback can only be cleared under the same lock that
-    /// `report_drain` reads it under; once this returns it can no longer fire.
+    /// Main thread; the request may still be in flight on the http thread.
     pub fn clear_drain_callback(&mut self) {
         let _guard = self.mutex.lock_guard();
         self.callback = None;
     }
 
     /// This is exclusively called from the http thread.
-    /// The caller must hold the lock (`acquire`/`lock`); it is what keeps
-    /// `callback` from being cleared out from under this read.
+    /// Buffer must be acquired before calling this.
     pub(crate) fn report_drain(&self) {
         debug_assert!(self.mutex.is_held_by_current_thread());
         if self.buffer.is_empty() {

--- a/src/http/ThreadSafeStreamBuffer.rs
+++ b/src/http/ThreadSafeStreamBuffer.rs
@@ -9,9 +9,13 @@ pub struct ThreadSafeStreamBuffer {
     pub(crate) mutex: Mutex,
     /// Intrusive atomic refcount. Starts at 2: 1 for main thread and 1 for http thread.
     pub(crate) ref_count: bun_ptr::ThreadSafeRefCount<ThreadSafeStreamBuffer>,
-    /// callback will be called passing the context for the http callback
-    /// this is used to report when the buffer is drained and only if end chunk was not sent/reported
-    pub(crate) callback: Option<Callback>,
+    /// Invoked by the HTTP thread (`report_drain`) once everything buffered
+    /// has been written out and the end chunk has not been sent yet.
+    ///
+    /// Guarded by `mutex`, like `buffer`: `report_drain` reads it under the
+    /// lock on the HTTP thread while the JS thread may be clearing it in
+    /// `clear_drain_callback` for a request that is still in flight.
+    callback: Option<Callback>,
 }
 
 pub struct Callback {
@@ -102,13 +106,20 @@ impl ThreadSafeStreamBuffer {
         self.callback = Some(Callback::init(callback, context));
     }
 
+    /// Main thread. The HTTP thread may still be flushing this buffer (and
+    /// about to `report_drain`) when the JS side tears the request down, so
+    /// the callback can only be cleared under the same lock that
+    /// `report_drain` reads it under; once this returns it can no longer fire.
     pub fn clear_drain_callback(&mut self) {
+        let _guard = self.mutex.lock_guard();
         self.callback = None;
     }
 
     /// This is exclusively called from the http thread.
-    /// Buffer should be acquired before calling this.
+    /// The caller must hold the lock (`acquire`/`lock`); it is what keeps
+    /// `callback` from being cleared out from under this read.
     pub(crate) fn report_drain(&self) {
+        debug_assert!(self.mutex.is_held_by_current_thread());
         if self.buffer.is_empty() {
             if let Some(callback) = &self.callback {
                 callback.call();

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -450,10 +450,8 @@ impl FetchTasklet {
         }
         if let Some(buffer) = self.request_body_streaming_buffer.take() {
             // SAFETY: intrusive-refcounted heap allocation from `ThreadSafeStreamBuffer::new`;
-            // this side holds one of the two initial refs. The HTTP thread may still own its
-            // ref and be flushing (`start_request_stream` gets here with the request in
-            // flight); `clear_drain_callback` takes the buffer's mutex, so after it returns
-            // the HTTP thread can no longer call back into this tasklet through the buffer.
+            // this side holds one of the two initial refs. The HTTP thread may still be using
+            // its ref; `clear_drain_callback` synchronises with it through the buffer's mutex.
             unsafe { (*buffer.as_ptr()).clear_drain_callback() };
             ThreadSafeStreamBuffer::deref(buffer);
         }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -386,9 +386,9 @@ impl FetchTasklet {
     /// shared with the HTTP thread (mutex-guarded internally).
     #[inline]
     pub(crate) fn stream_buffer_mut<'r>(&self) -> Option<&'r mut ThreadSafeStreamBuffer> {
-        // SAFETY: see doc comment — counted ref keeps pointee live; mutex
-        // inside `ThreadSafeStreamBuffer` serialises cross-thread `buffer`
-        // access, and `callback` is main-thread-only.
+        // SAFETY: see doc comment — counted ref keeps pointee live; the mutex
+        // inside `ThreadSafeStreamBuffer` serialises every cross-thread access
+        // (`buffer` and the drain callback alike).
         self.request_body_streaming_buffer
             .map(|p| unsafe { &mut *p.as_ptr() })
     }
@@ -450,8 +450,10 @@ impl FetchTasklet {
         }
         if let Some(buffer) = self.request_body_streaming_buffer.take() {
             // SAFETY: intrusive-refcounted heap allocation from `ThreadSafeStreamBuffer::new`;
-            // this side holds one of the two initial refs. Mutex guards cross-thread access
-            // to `buffer`, and `callback` is only touched on the main thread (here).
+            // this side holds one of the two initial refs. The HTTP thread may still own its
+            // ref and be flushing (`start_request_stream` gets here with the request in
+            // flight); `clear_drain_callback` takes the buffer's mutex, so after it returns
+            // the HTTP thread can no longer call back into this tasklet through the buffer.
             unsafe { (*buffer.as_ptr()).clear_drain_callback() };
             ThreadSafeStreamBuffer::deref(buffer);
         }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -386,9 +386,9 @@ impl FetchTasklet {
     /// shared with the HTTP thread (mutex-guarded internally).
     #[inline]
     pub(crate) fn stream_buffer_mut<'r>(&self) -> Option<&'r mut ThreadSafeStreamBuffer> {
-        // SAFETY: see doc comment — counted ref keeps pointee live; the mutex
-        // inside `ThreadSafeStreamBuffer` serialises every cross-thread access
-        // (`buffer` and the drain callback alike).
+        // SAFETY: see doc comment: the counted ref keeps the pointee live, and the
+        // mutex inside `ThreadSafeStreamBuffer` serialises every cross-thread
+        // access (`buffer` and the drain callback alike).
         self.request_body_streaming_buffer
             .map(|p| unsafe { &mut *p.as_ptr() })
     }
@@ -449,9 +449,9 @@ impl FetchTasklet {
             JSSink::<FetchRequestBodySink>::detach(&mut sink.source, &self.global_this);
         }
         if let Some(buffer) = self.request_body_streaming_buffer.take() {
-            // SAFETY: intrusive-refcounted heap allocation from `ThreadSafeStreamBuffer::new`;
-            // this side holds one of the two initial refs. The HTTP thread may still be using
-            // its ref; `clear_drain_callback` synchronises with it through the buffer's mutex.
+            // SAFETY: intrusive-refcounted heap allocation from `ThreadSafeStreamBuffer::new`; this
+            // side holds one of the two initial refs. The HTTP thread may still be using its ref;
+            // `clear_drain_callback` synchronises with it through the buffer's mutex.
             unsafe { (*buffer.as_ptr()).clear_drain_callback() };
             ThreadSafeStreamBuffer::deref(buffer);
         }

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -79,6 +79,48 @@ test
     expect(exitCode).toBe(0);
   });
 
+// A direct stream's pull() runs synchronously inside start_request_stream, and
+// that only happens once the HTTP thread has sent the headers and asked for the
+// body. Writing and then throwing from it tears the request down (clear_sink)
+// while the HTTP thread is still flushing the bytes just written and reporting
+// the buffer drained, so the JS side clears the buffer's drain callback at the
+// same moment the HTTP thread reads it; both have to go through the buffer's
+// mutex. Every iteration has to reject with pull's own error, and clearing the
+// callback must not deadlock against the HTTP thread holding the buffer.
+test.concurrent("request body pull() that writes and then throws rejects the fetch while the upload is in flight", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      // Only answer once the client has torn the upload down, so the rejection
+      // below can only come from pull()'s error, never from a response.
+      await req.arrayBuffer().catch(() => {});
+      return new Response("unreachable");
+    },
+  });
+
+  const iterations = 50;
+  // Several chunks over the sink's 16 KiB high water mark, so the HTTP thread
+  // is woken and has something to flush (and report drained) while pull()
+  // throws on the JS thread.
+  const chunk = Buffer.alloc(64 * 1024, "x");
+  let pulls = 0;
+
+  for (let i = 0; i < iterations; i++) {
+    const error = new Error(`pull ${i}`);
+    const body = new ReadableStream({
+      type: "direct",
+      pull(controller) {
+        pulls++;
+        for (let j = 0; j < 4; j++) controller.write(chunk);
+        throw error;
+      },
+    });
+    await expect(fetch(server.url, { method: "POST", body })).rejects.toBe(error);
+  }
+
+  expect(pulls).toBe(iterations);
+});
+
 test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "fetch-abort-stream-body-fixture.ts")],

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -87,39 +87,42 @@ test
 // same moment the HTTP thread reads it; both have to go through the buffer's
 // mutex. Every iteration has to reject with pull's own error, and clearing the
 // callback must not deadlock against the HTTP thread holding the buffer.
-test.concurrent("request body pull() that writes and then throws rejects the fetch while the upload is in flight", async () => {
-  await using server = Bun.serve({
-    port: 0,
-    async fetch(req) {
-      // Only answer once the client has torn the upload down, so the rejection
-      // below can only come from pull()'s error, never from a response.
-      await req.arrayBuffer().catch(() => {});
-      return new Response("unreachable");
-    },
-  });
-
-  const iterations = 50;
-  // Several chunks over the sink's 16 KiB high water mark, so the HTTP thread
-  // is woken and has something to flush (and report drained) while pull()
-  // throws on the JS thread.
-  const chunk = Buffer.alloc(64 * 1024, "x");
-  let pulls = 0;
-
-  for (let i = 0; i < iterations; i++) {
-    const error = new Error(`pull ${i}`);
-    const body = new ReadableStream({
-      type: "direct",
-      pull(controller) {
-        pulls++;
-        for (let j = 0; j < 4; j++) controller.write(chunk);
-        throw error;
+test.concurrent(
+  "request body pull() that writes and then throws rejects the fetch while the upload is in flight",
+  async () => {
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        // Only answer once the client has torn the upload down, so the rejection
+        // below can only come from pull()'s error, never from a response.
+        await req.arrayBuffer().catch(() => {});
+        return new Response("unreachable");
       },
     });
-    await expect(fetch(server.url, { method: "POST", body })).rejects.toBe(error);
-  }
 
-  expect(pulls).toBe(iterations);
-});
+    const iterations = 50;
+    // Several chunks over the sink's 16 KiB high water mark, so the HTTP thread
+    // is woken and has something to flush (and report drained) while pull()
+    // throws on the JS thread.
+    const chunk = Buffer.alloc(64 * 1024, "x");
+    let pulls = 0;
+
+    for (let i = 0; i < iterations; i++) {
+      const error = new Error(`pull ${i}`);
+      const body = new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          pulls++;
+          for (let j = 0; j < 4; j++) controller.write(chunk);
+          throw error;
+        },
+      });
+      await expect(fetch(server.url, { method: "POST", body })).rejects.toBe(error);
+    }
+
+    expect(pulls).toBe(iterations);
+  },
+);
 
 test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {
   await using proc = Bun.spawn({


### PR DESCRIPTION
### What does this PR do?

Fixes a data race on `ThreadSafeStreamBuffer.callback` (the streaming request body's drain callback) between the HTTP thread and the JS thread.

**Cause.** The HTTP thread reads `callback` in `report_drain()` while holding the buffer mutex (`src/http/lib.rs` `write_to_stream`, and the h2/h3 `drain_send_body`). The JS thread cleared it in `clear_drain_callback()` without the mutex; the comments in `FetchTasklet` claimed the field was main-thread-only. `FetchTasklet::start_request_stream` calls `clear_sink()` when `assign_to_stream` fails, and at that point the request is still in flight: the HTTP thread still owns its ref on the buffer and may be flushing the bytes that were just written, so the unlocked write of `None` raced the locked read. `Option<Callback>` is two words (fn pointer + context), so a stale or torn read calls `on_write_request_data_drain(tasklet)` during teardown. Today the tasklet is still referenced on that path (the HTTP side releases its ref only after the abort completes), so the worst case is a spurious resume task, but nothing in the code enforces that. The other caller, `deinit` -> `clear_data` -> `clear_sink`, is already ordered after the HTTP thread's last access by the tasklet refcount release.

A user-reachable way onto that path is a direct stream request body whose `pull()` writes and then throws synchronously:

```ts
await fetch(url, {
  method: "POST",
  body: new ReadableStream({
    type: "direct",
    pull(controller) {
      for (let i = 0; i < 4; i++) controller.write(chunk); // wakes the HTTP thread
      throw error; // assign_to_stream fails -> write_end_request -> clear_sink
    },
  }),
});
```

**Fix.** `clear_drain_callback` takes the buffer mutex, so it is serialised against `report_drain`; once it returns the HTTP thread can no longer call back into the tasklet through the buffer. The field is now private so every access goes through the locked accessors, and `report_drain` debug-asserts that the caller holds the lock (it already had to, per its doc comment). The stale comments in `FetchTasklet` are corrected.

### How did you verify your code works?

New test in `test/js/web/fetch/fetch-abort-stream-body.test.ts` drives the snippet above 50 times against a server that does not answer until the upload is torn down, and checks that every fetch rejects with `pull()`'s own error, that `pull()` ran every time (it only runs once the HTTP thread has asked for the body, so the teardown really happens in flight), and, with the fix, that clearing the callback does not deadlock against the HTTP thread holding the buffer. There is no thread sanitizer build, so this test is regression coverage of the path rather than a detector for the race itself; it also passes on the unfixed build.

To confirm the window is actually hit, I temporarily logged both accesses in a debug build and ran the same scenario 500 times:

<details>
<summary>Observed interleavings (temporary instrumentation, not part of the PR)</summary>

Per request, in logging order (`drain` = HTTP thread `report_drain`, `clear` = JS thread `clear_drain_callback`):

```
 298  drain > drain > drain > clear
 161  drain > drain > clear
  28  drain > drain > drain > drain > clear
   7  drain > clear
   3  clear > drain            <- HTTP thread read the field after the JS thread cleared it
   3  drain > clear > drain    <- same
```

500/500 requests had the HTTP thread reading the callback in the same window as the JS-side clear; in 6 the read landed after the clear (with the fix it observes `None`; before it was an unsynchronised read of a field being written).

</details>

Also ran under the debug build: `fetch-abort-stream-body.test.ts`, `fetch-http2-client.test.ts`, `fetch-http3-client.test.ts` (their streaming request body tests exercise the new `report_drain` assertion on h1, h2 and h3), `body.test.ts`, `fetch-cyclic-reference.test.ts`, `fetch-keepalive.test.ts`. `fetch-backpressure.test.ts`'s four `h3 receive backpressure` cases time out locally when the whole file runs, identically on unmodified main (they send no request body, so they do not touch this code); they pass in isolation.

A larger follow-up could make the mutex own `buffer` and `callback` outright (`Guarded<_>`), which would also remove the `&mut ThreadSafeStreamBuffer` both threads currently hold at once; this PR only closes the race.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-abort-stream-body.test.ts

<!-- robobun:evidence:end -->