### PR TITLE
fetch: do not pool a connection after bytes past the last chunk

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4655,6 +4655,24 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
+    /// `undecoded` is the non-negative return of `phr_decode_chunked`: bytes
+    /// that followed the terminating chunk and trailer section. Requests are
+    /// never pipelined, so those bytes belong to no request of ours; as with
+    /// the Content-Length overshoot in `handle_response_body`, the framing of
+    /// the connection can no longer be trusted and it must not be pooled.
+    fn on_last_chunk(&mut self, undecoded: isize) {
+        debug_assert!(undecoded >= 0);
+        self.state.flags.received_last_chunk = true;
+        if undecoded > 0 {
+            bun_core::scoped_log!(
+                fetch,
+                "{} bytes after the last chunk, disabling keep-alive",
+                undecoded
+            );
+            self.state.flags.allow_keepalive = false;
+        }
+    }
+
     fn handle_response_body_chunked_encoding_from_multiple_packets(
         &mut self,
         incoming_data: &[u8],
@@ -4721,7 +4739,7 @@ impl<'a> HTTPClient<'a> {
             }
             // Done
             _ => {
-                self.state.flags.received_last_chunk = true;
+                self.on_last_chunk(pret);
                 // Move the
                 // bytes out so no `&` into self.state aliases the `&mut self.state` call.
                 let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
@@ -4799,7 +4817,7 @@ impl<'a> HTTPClient<'a> {
             }
             // Done
             _ => {
-                self.state.flags.received_last_chunk = true;
+                self.on_last_chunk(pret);
                 self.handle_response_body_from_single_packet(buffer)?;
                 debug_assert!(self.state.decoded_body.list.as_ptr() != buffer.as_ptr());
                 self.report_progress(buffer.len());

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3773,6 +3773,13 @@ impl<'a> HTTPClient<'a> {
         }
 
         if should_continue == ShouldContinue::Finished {
+            // The response ends with its header block (HEAD, 204/304,
+            // Content-Length: 0). Skipped when reuse is already off, which
+            // includes the redirect case whose discarded 3xx body may be in
+            // `to_read`.
+            if self.state.flags.allow_keepalive {
+                self.on_bytes_past_response_end(to_read.len());
+            }
             if self.state.flags.is_redirect_pending {
                 self.do_redirect::<IS_SSL>(ctx, socket);
                 return;
@@ -4526,6 +4533,24 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
+    /// `count` bytes arrived after the point where the response's framing
+    /// (Content-Length, the terminating chunk, or a header block that cannot
+    /// be followed by a body) says the response ends. Requests are never
+    /// pipelined, so they belong to no request of ours and the connection's
+    /// framing can no longer be trusted: it must be closed, not pooled, or
+    /// they (and whatever the origin sends next) would be read as the reply to
+    /// the next request that reuses it.
+    fn on_bytes_past_response_end(&mut self, count: usize) {
+        if count > 0 {
+            bun_core::scoped_log!(
+                fetch,
+                "{} bytes past the end of the response, disabling keep-alive",
+                count
+            );
+            self.state.flags.allow_keepalive = false;
+        }
+    }
+
     pub(crate) fn handle_response_body(
         &mut self,
         incoming_data: &[u8],
@@ -4533,10 +4558,9 @@ impl<'a> HTTPClient<'a> {
     ) -> crate::Result<bool> {
         debug_assert!(self.state.transfer_encoding == Encoding::Identity);
         let content_length = self.state.content_length;
-        if let Some(len) = content_length
-            && incoming_data.len() > len.saturating_sub(self.state.total_body_received)
-        {
-            self.state.flags.allow_keepalive = false;
+        if let Some(len) = content_length {
+            let remaining = len.saturating_sub(self.state.total_body_received);
+            self.on_bytes_past_response_end(incoming_data.len().saturating_sub(remaining));
         }
         // is it exactly as much as we need?
         if is_only_buffer
@@ -4655,22 +4679,12 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
-    /// `undecoded` is the non-negative return of `phr_decode_chunked`: bytes
-    /// that followed the terminating chunk and trailer section. Requests are
-    /// never pipelined, so those bytes belong to no request of ours; as with
-    /// the Content-Length overshoot in `handle_response_body`, the framing of
-    /// the connection can no longer be trusted and it must not be pooled.
+    /// `undecoded` is the non-negative return of `phr_decode_chunked`: the
+    /// number of bytes that followed the terminating chunk and trailer section.
     fn on_last_chunk(&mut self, undecoded: isize) {
         debug_assert!(undecoded >= 0);
         self.state.flags.received_last_chunk = true;
-        if undecoded > 0 {
-            bun_core::scoped_log!(
-                fetch,
-                "{} bytes after the last chunk, disabling keep-alive",
-                undecoded
-            );
-            self.state.flags.allow_keepalive = false;
-        }
+        self.on_bytes_past_response_end(undecoded.unsigned_abs());
     }
 
     fn handle_response_body_chunked_encoding_from_multiple_packets(

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3773,13 +3773,6 @@ impl<'a> HTTPClient<'a> {
         }
 
         if should_continue == ShouldContinue::Finished {
-            // The response ends with its header block (HEAD, 204/304,
-            // Content-Length: 0). Skipped when reuse is already off, which
-            // includes the redirect case whose discarded 3xx body may be in
-            // `to_read`.
-            if self.state.flags.allow_keepalive {
-                self.on_bytes_past_response_end(to_read.len());
-            }
             if self.state.flags.is_redirect_pending {
                 self.do_redirect::<IS_SSL>(ctx, socket);
                 return;
@@ -4533,15 +4526,9 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
-    /// `count` bytes arrived after the point where the response's framing
-    /// (Content-Length, the terminating chunk, or a header block that cannot
-    /// be followed by a body) says the response ends. Requests are never
-    /// pipelined, so they belong to no request of ours and the connection's
-    /// framing can no longer be trusted: it must be closed, not pooled, or
-    /// they (and whatever the origin sends next) would be read as the reply to
-    /// the next request that reuses it.
+    /// Nothing is pipelined, so bytes past the framed end of a response desynchronize the socket.
     fn on_bytes_past_response_end(&mut self, count: usize) {
-        if count > 0 {
+        if count > 0 && self.state.flags.allow_keepalive {
             bun_core::scoped_log!(
                 fetch,
                 "{} bytes past the end of the response, disabling keep-alive",
@@ -4679,12 +4666,11 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
-    /// `undecoded` is the non-negative return of `phr_decode_chunked`: the
-    /// number of bytes that followed the terminating chunk and trailer section.
-    fn on_last_chunk(&mut self, undecoded: isize) {
-        debug_assert!(undecoded >= 0);
+    /// `bytes_after_terminator` is the non-negative return of `phr_decode_chunked`.
+    fn on_last_chunk(&mut self, bytes_after_terminator: isize) {
+        debug_assert!(bytes_after_terminator >= 0);
         self.state.flags.received_last_chunk = true;
-        self.on_bytes_past_response_end(undecoded.unsigned_abs());
+        self.on_bytes_past_response_end(bytes_after_terminator.unsigned_abs());
     }
 
     fn handle_response_body_chunked_encoding_from_multiple_packets(

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3254,15 +3254,40 @@ it("does not reuse a keep-alive connection whose response carried more bytes tha
   }
 });
 
-// A complete extra response appended after the end of a legitimate one. Nothing we sent
-// asked for it, so a client that keeps the connection would read it (or whatever the
-// origin sends next) as the reply to the next request it pools onto that socket.
-const INJECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected";
+it("does not reuse a keep-alive connection whose chunked response carried bytes past the terminating chunk", async () => {
+  // The chunked analogue of the Content-Length overshoot above: anything the origin
+  // sends after the zero-length chunk that ends the body belongs to no request of ours,
+  // so the connection's framing can no longer be trusted. The response itself is still
+  // delivered, but the connection must be closed instead of being returned to the
+  // keep-alive pool, where the next request to reuse it would be answered by whatever
+  // followed the terminator.
+  const injected = Buffer.from(
+    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected",
+    "latin1",
+  );
+  const chunkedResponse = (payload: Buffer, headers: string = "") =>
+    Buffer.concat([
+      Buffer.from(
+        `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n${headers}Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n` +
+          `${payload.length.toString(16)}\r\n`,
+        "latin1",
+      ),
+      payload,
+      Buffer.from("\r\n0\r\n\r\n", "latin1"),
+    ]);
+  // The chunked decoder runs in one of two modes depending on whether a packet fits the
+  // 16 KiB scratch buffer and on the content encoding; one overshoot per combination.
+  const largeBody = Buffer.alloc(64 * 1024, "x").toString();
+  const responses: Record<string, Buffer> = {
+    "/legit": chunkedResponse(Buffer.from("legit!")),
+    "/overshoot": Buffer.concat([chunkedResponse(Buffer.from("hello")), injected]),
+    "/overshoot-large": Buffer.concat([chunkedResponse(Buffer.from(largeBody)), injected]),
+    "/overshoot-gzip": Buffer.concat([
+      chunkedResponse(gzipSync(Buffer.from("hello")), "Content-Encoding: gzip\r\n"),
+      injected,
+    ]),
+  };
 
-// Serves canned raw HTTP/1.1 responses keyed by request line ("GET /path") and counts
-// accepted connections, which is how the tests below observe whether fetch() pooled the
-// previous connection or closed it.
-async function rawResponseServer(responses: Record<string, string | Buffer>) {
   let connections = 0;
   const sockets: net.Socket[] = [];
   const server = net.createServer(socket => {
@@ -3275,123 +3300,40 @@ async function rawResponseServer(responses: Record<string, string | Buffer>) {
       while (true) {
         const headerEnd = buffered.indexOf("\r\n\r\n");
         if (headerEnd === -1) break;
-        const [method, path] = buffered.slice(0, headerEnd).split("\r\n")[0].split(" ");
+        const head = buffered.slice(0, headerEnd);
         buffered = buffered.slice(headerEnd + 4);
-        socket.write(responses[`${method} ${path}`]);
+        const path = head.split("\r\n")[0].split(" ")[1];
+        socket.write(responses[path]);
       }
     });
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
   const { port } = server.address() as AddressInfo;
-  return {
-    // Issues the requests one after another and records the connection count once each
-    // response has been read, by which point its socket has either been pooled or closed.
-    async run(requests: string[]) {
-      const results: Array<[request: string, body: string, connections: number]> = [];
-      for (const request of requests) {
-        const [method, path] = request.split(" ");
-        const response = await fetch(`http://127.0.0.1:${port}${path}`, { method });
-        results.push([request, await response.text(), connections]);
-      }
-      return results;
-    },
-    [Symbol.dispose]() {
-      for (const socket of sockets) socket.destroy();
-      server.close();
-    },
-  };
-}
 
-it("does not reuse a keep-alive connection whose chunked response carried bytes past the terminating chunk", async () => {
-  // The chunked analogue of the Content-Length overshoot above: the response itself is
-  // still delivered, but the connection must be closed instead of pooled.
-  const chunkedResponse = (payload: Buffer, headers: string = "") =>
-    Buffer.concat([
-      Buffer.from(
-        `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n${headers}Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n` +
-          `${payload.length.toString(16)}\r\n`,
-        "latin1",
-      ),
-      payload,
-      Buffer.from("\r\n0\r\n\r\n", "latin1"),
+  try {
+    const results: Array<[path: string, body: string, connections: number]> = [];
+    for (const path of ["/overshoot", "/legit", "/overshoot-large", "/legit", "/overshoot-gzip", "/legit", "/legit"]) {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`);
+      const body = await response.text();
+      results.push([path, body === largeBody ? "<large body>" : body, connections]);
+    }
+    // Every mis-framed response is still delivered in full, the request following each
+    // one has to open a new connection, and a correctly framed chunked response is still
+    // pooled (each overshoot after the first, and the final request, reuse the connection
+    // that carried the preceding /legit response).
+    expect(results).toEqual([
+      ["/overshoot", "hello", 1],
+      ["/legit", "legit!", 2],
+      ["/overshoot-large", "<large body>", 2],
+      ["/legit", "legit!", 3],
+      ["/overshoot-gzip", "hello", 3],
+      ["/legit", "legit!", 4],
+      ["/legit", "legit!", 4],
     ]);
-  const injected = Buffer.from(INJECTED_RESPONSE, "latin1");
-  // The chunked decoder runs in one of two modes depending on whether a packet fits the
-  // 16 KiB scratch buffer and on the content encoding; one overshoot per combination.
-  const largeBody = Buffer.alloc(64 * 1024, "x").toString();
-  using server = await rawResponseServer({
-    "GET /legit": chunkedResponse(Buffer.from("legit!")),
-    "GET /overshoot": Buffer.concat([chunkedResponse(Buffer.from("hello")), injected]),
-    "GET /overshoot-large": Buffer.concat([chunkedResponse(Buffer.from(largeBody)), injected]),
-    "GET /overshoot-gzip": Buffer.concat([
-      chunkedResponse(gzipSync(Buffer.from("hello")), "Content-Encoding: gzip\r\n"),
-      injected,
-    ]),
-  });
-
-  const results = await server.run([
-    "GET /overshoot",
-    "GET /legit",
-    "GET /overshoot-large",
-    "GET /legit",
-    "GET /overshoot-gzip",
-    "GET /legit",
-    "GET /legit",
-  ]);
-  // Every mis-framed response is still delivered in full, the request following each
-  // one has to open a new connection, and a correctly framed chunked response is still
-  // pooled (each overshoot after the first, and the final request, reuse the connection
-  // that carried the preceding /legit response).
-  for (const result of results) if (result[1] === largeBody) result[1] = "<large body>";
-  expect(results).toEqual([
-    ["GET /overshoot", "hello", 1],
-    ["GET /legit", "legit!", 2],
-    ["GET /overshoot-large", "<large body>", 2],
-    ["GET /legit", "legit!", 3],
-    ["GET /overshoot-gzip", "hello", 3],
-    ["GET /legit", "legit!", 4],
-    ["GET /legit", "legit!", 4],
-  ]);
-});
-
-it("does not reuse a keep-alive connection when bytes follow a response that cannot have a body", async () => {
-  // A 204, a Content-Length: 0 response and any response to HEAD end with their header
-  // block (RFC 9112 section 6.3), so bytes after it are the same framing violation as
-  // above, just without a body decoder in the way to notice them.
-  using server = await rawResponseServer({
-    "GET /legit": "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: keep-alive\r\n\r\nlegit!",
-    "GET /no-content": "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n" + INJECTED_RESPONSE,
-    "GET /empty": "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n" + INJECTED_RESPONSE,
-    // A body on a HEAD response is itself the violation: it is not part of the message.
-    "HEAD /head": "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nhello",
-    "GET /no-content-ok": "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n",
-    "HEAD /head-ok": "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\n",
-  });
-
-  const results = await server.run([
-    "GET /no-content",
-    "GET /legit",
-    "GET /empty",
-    "GET /legit",
-    "HEAD /head",
-    "GET /legit",
-    "GET /no-content-ok",
-    "HEAD /head-ok",
-    "GET /legit",
-  ]);
-  // Same trajectory as the chunked case; the two well-formed bodiless responses at the
-  // end must still be pooled and reused.
-  expect(results).toEqual([
-    ["GET /no-content", "", 1],
-    ["GET /legit", "legit!", 2],
-    ["GET /empty", "", 2],
-    ["GET /legit", "legit!", 3],
-    ["HEAD /head", "", 3],
-    ["GET /legit", "legit!", 4],
-    ["GET /no-content-ok", "", 4],
-    ["HEAD /head-ok", "", 4],
-    ["GET /legit", "legit!", 4],
-  ]);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    server.close();
+  }
 });
 
 // https://github.com/oven-sh/bun/issues/16682

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3254,40 +3254,15 @@ it("does not reuse a keep-alive connection whose response carried more bytes tha
   }
 });
 
-it("does not reuse a keep-alive connection whose chunked response carried bytes past the terminating chunk", async () => {
-  // The chunked analogue of the Content-Length overshoot above: anything the origin
-  // sends after the zero-length chunk that ends the body belongs to no request of ours,
-  // so the connection's framing can no longer be trusted. The response itself is still
-  // delivered, but the connection must be closed instead of being returned to the
-  // keep-alive pool, where the next request to reuse it would be answered by whatever
-  // followed the terminator.
-  const injected = Buffer.from(
-    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected",
-    "latin1",
-  );
-  const chunkedResponse = (payload: Buffer, headers: string = "") =>
-    Buffer.concat([
-      Buffer.from(
-        `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n${headers}Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n` +
-          `${payload.length.toString(16)}\r\n`,
-        "latin1",
-      ),
-      payload,
-      Buffer.from("\r\n0\r\n\r\n", "latin1"),
-    ]);
-  // The chunked decoder runs in one of two modes depending on whether a packet fits the
-  // 16 KiB scratch buffer and on the content encoding; one overshoot per combination.
-  const largeBody = Buffer.alloc(64 * 1024, "x").toString();
-  const responses: Record<string, Buffer> = {
-    "/legit": chunkedResponse(Buffer.from("legit!")),
-    "/overshoot": Buffer.concat([chunkedResponse(Buffer.from("hello")), injected]),
-    "/overshoot-large": Buffer.concat([chunkedResponse(Buffer.from(largeBody)), injected]),
-    "/overshoot-gzip": Buffer.concat([
-      chunkedResponse(gzipSync(Buffer.from("hello")), "Content-Encoding: gzip\r\n"),
-      injected,
-    ]),
-  };
+// A complete extra response appended after the end of a legitimate one. Nothing we sent
+// asked for it, so a client that keeps the connection would read it (or whatever the
+// origin sends next) as the reply to the next request it pools onto that socket.
+const INJECTED_RESPONSE = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected";
 
+// Serves canned raw HTTP/1.1 responses keyed by request line ("GET /path") and counts
+// accepted connections, which is how the tests below observe whether fetch() pooled the
+// previous connection or closed it.
+async function rawResponseServer(responses: Record<string, string | Buffer>) {
   let connections = 0;
   const sockets: net.Socket[] = [];
   const server = net.createServer(socket => {
@@ -3300,40 +3275,123 @@ it("does not reuse a keep-alive connection whose chunked response carried bytes 
       while (true) {
         const headerEnd = buffered.indexOf("\r\n\r\n");
         if (headerEnd === -1) break;
-        const head = buffered.slice(0, headerEnd);
+        const [method, path] = buffered.slice(0, headerEnd).split("\r\n")[0].split(" ");
         buffered = buffered.slice(headerEnd + 4);
-        const path = head.split("\r\n")[0].split(" ")[1];
-        socket.write(responses[path]);
+        socket.write(responses[`${method} ${path}`]);
       }
     });
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
   const { port } = server.address() as AddressInfo;
+  return {
+    // Issues the requests one after another and records the connection count once each
+    // response has been read, by which point its socket has either been pooled or closed.
+    async run(requests: string[]) {
+      const results: Array<[request: string, body: string, connections: number]> = [];
+      for (const request of requests) {
+        const [method, path] = request.split(" ");
+        const response = await fetch(`http://127.0.0.1:${port}${path}`, { method });
+        results.push([request, await response.text(), connections]);
+      }
+      return results;
+    },
+    [Symbol.dispose]() {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    },
+  };
+}
 
-  try {
-    const results: Array<[path: string, body: string, connections: number]> = [];
-    for (const path of ["/overshoot", "/legit", "/overshoot-large", "/legit", "/overshoot-gzip", "/legit", "/legit"]) {
-      const response = await fetch(`http://127.0.0.1:${port}${path}`);
-      const body = await response.text();
-      results.push([path, body === largeBody ? "<large body>" : body, connections]);
-    }
-    // Every mis-framed response is still delivered in full, the request following each
-    // one has to open a new connection, and a correctly framed chunked response is still
-    // pooled (each overshoot after the first, and the final request, reuse the connection
-    // that carried the preceding /legit response).
-    expect(results).toEqual([
-      ["/overshoot", "hello", 1],
-      ["/legit", "legit!", 2],
-      ["/overshoot-large", "<large body>", 2],
-      ["/legit", "legit!", 3],
-      ["/overshoot-gzip", "hello", 3],
-      ["/legit", "legit!", 4],
-      ["/legit", "legit!", 4],
+it("does not reuse a keep-alive connection whose chunked response carried bytes past the terminating chunk", async () => {
+  // The chunked analogue of the Content-Length overshoot above: the response itself is
+  // still delivered, but the connection must be closed instead of pooled.
+  const chunkedResponse = (payload: Buffer, headers: string = "") =>
+    Buffer.concat([
+      Buffer.from(
+        `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n${headers}Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n` +
+          `${payload.length.toString(16)}\r\n`,
+        "latin1",
+      ),
+      payload,
+      Buffer.from("\r\n0\r\n\r\n", "latin1"),
     ]);
-  } finally {
-    for (const socket of sockets) socket.destroy();
-    server.close();
-  }
+  const injected = Buffer.from(INJECTED_RESPONSE, "latin1");
+  // The chunked decoder runs in one of two modes depending on whether a packet fits the
+  // 16 KiB scratch buffer and on the content encoding; one overshoot per combination.
+  const largeBody = Buffer.alloc(64 * 1024, "x").toString();
+  using server = await rawResponseServer({
+    "GET /legit": chunkedResponse(Buffer.from("legit!")),
+    "GET /overshoot": Buffer.concat([chunkedResponse(Buffer.from("hello")), injected]),
+    "GET /overshoot-large": Buffer.concat([chunkedResponse(Buffer.from(largeBody)), injected]),
+    "GET /overshoot-gzip": Buffer.concat([
+      chunkedResponse(gzipSync(Buffer.from("hello")), "Content-Encoding: gzip\r\n"),
+      injected,
+    ]),
+  });
+
+  const results = await server.run([
+    "GET /overshoot",
+    "GET /legit",
+    "GET /overshoot-large",
+    "GET /legit",
+    "GET /overshoot-gzip",
+    "GET /legit",
+    "GET /legit",
+  ]);
+  // Every mis-framed response is still delivered in full, the request following each
+  // one has to open a new connection, and a correctly framed chunked response is still
+  // pooled (each overshoot after the first, and the final request, reuse the connection
+  // that carried the preceding /legit response).
+  for (const result of results) if (result[1] === largeBody) result[1] = "<large body>";
+  expect(results).toEqual([
+    ["GET /overshoot", "hello", 1],
+    ["GET /legit", "legit!", 2],
+    ["GET /overshoot-large", "<large body>", 2],
+    ["GET /legit", "legit!", 3],
+    ["GET /overshoot-gzip", "hello", 3],
+    ["GET /legit", "legit!", 4],
+    ["GET /legit", "legit!", 4],
+  ]);
+});
+
+it("does not reuse a keep-alive connection when bytes follow a response that cannot have a body", async () => {
+  // A 204, a Content-Length: 0 response and any response to HEAD end with their header
+  // block (RFC 9112 section 6.3), so bytes after it are the same framing violation as
+  // above, just without a body decoder in the way to notice them.
+  using server = await rawResponseServer({
+    "GET /legit": "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: keep-alive\r\n\r\nlegit!",
+    "GET /no-content": "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n" + INJECTED_RESPONSE,
+    "GET /empty": "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n" + INJECTED_RESPONSE,
+    // A body on a HEAD response is itself the violation: it is not part of the message.
+    "HEAD /head": "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nhello",
+    "GET /no-content-ok": "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n",
+    "HEAD /head-ok": "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\n",
+  });
+
+  const results = await server.run([
+    "GET /no-content",
+    "GET /legit",
+    "GET /empty",
+    "GET /legit",
+    "HEAD /head",
+    "GET /legit",
+    "GET /no-content-ok",
+    "HEAD /head-ok",
+    "GET /legit",
+  ]);
+  // Same trajectory as the chunked case; the two well-formed bodiless responses at the
+  // end must still be pooled and reused.
+  expect(results).toEqual([
+    ["GET /no-content", "", 1],
+    ["GET /legit", "legit!", 2],
+    ["GET /empty", "", 2],
+    ["GET /legit", "legit!", 3],
+    ["HEAD /head", "", 3],
+    ["GET /legit", "legit!", 4],
+    ["GET /no-content-ok", "", 4],
+    ["HEAD /head-ok", "", 4],
+    ["GET /legit", "legit!", 4],
+  ]);
 });
 
 // https://github.com/oven-sh/bun/issues/16682

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3254,6 +3254,88 @@ it("does not reuse a keep-alive connection whose response carried more bytes tha
   }
 });
 
+it("does not reuse a keep-alive connection whose chunked response carried bytes past the terminating chunk", async () => {
+  // The chunked analogue of the Content-Length overshoot above: anything the origin
+  // sends after the zero-length chunk that ends the body belongs to no request of ours,
+  // so the connection's framing can no longer be trusted. The response itself is still
+  // delivered, but the connection must be closed instead of being returned to the
+  // keep-alive pool, where the next request to reuse it would be answered by whatever
+  // followed the terminator.
+  const injected = Buffer.from(
+    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected",
+    "latin1",
+  );
+  const chunkedResponse = (payload: Buffer, headers: string = "") =>
+    Buffer.concat([
+      Buffer.from(
+        `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n${headers}Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n` +
+          `${payload.length.toString(16)}\r\n`,
+        "latin1",
+      ),
+      payload,
+      Buffer.from("\r\n0\r\n\r\n", "latin1"),
+    ]);
+  // The chunked decoder runs in one of two modes depending on whether a packet fits the
+  // 16 KiB scratch buffer and on the content encoding; one overshoot per combination.
+  const largeBody = Buffer.alloc(64 * 1024, "x").toString();
+  const responses: Record<string, Buffer> = {
+    "/legit": chunkedResponse(Buffer.from("legit!")),
+    "/overshoot": Buffer.concat([chunkedResponse(Buffer.from("hello")), injected]),
+    "/overshoot-large": Buffer.concat([chunkedResponse(Buffer.from(largeBody)), injected]),
+    "/overshoot-gzip": Buffer.concat([
+      chunkedResponse(gzipSync(Buffer.from("hello")), "Content-Encoding: gzip\r\n"),
+      injected,
+    ]),
+  };
+
+  let connections = 0;
+  const sockets: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    connections++;
+    sockets.push(socket);
+    socket.on("error", () => {});
+    let buffered = "";
+    socket.on("data", data => {
+      buffered += data.toString("latin1");
+      while (true) {
+        const headerEnd = buffered.indexOf("\r\n\r\n");
+        if (headerEnd === -1) break;
+        const head = buffered.slice(0, headerEnd);
+        buffered = buffered.slice(headerEnd + 4);
+        const path = head.split("\r\n")[0].split(" ")[1];
+        socket.write(responses[path]);
+      }
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const results: Array<[path: string, body: string, connections: number]> = [];
+    for (const path of ["/overshoot", "/legit", "/overshoot-large", "/legit", "/overshoot-gzip", "/legit", "/legit"]) {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`);
+      const body = await response.text();
+      results.push([path, body === largeBody ? "<large body>" : body, connections]);
+    }
+    // Every mis-framed response is still delivered in full, the request following each
+    // one has to open a new connection, and a correctly framed chunked response is still
+    // pooled (each overshoot after the first, and the final request, reuse the connection
+    // that carried the preceding /legit response).
+    expect(results).toEqual([
+      ["/overshoot", "hello", 1],
+      ["/legit", "legit!", 2],
+      ["/overshoot-large", "<large body>", 2],
+      ["/legit", "legit!", 3],
+      ["/overshoot-gzip", "hello", 3],
+      ["/legit", "legit!", 4],
+      ["/legit", "legit!", 4],
+    ]);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    server.close();
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/16682
 it("an explicit numeric `timeout` extends the socket idle deadline past the default", async () => {
   // The child runs with a 1s idle default (BUN_CONFIG_HTTP_IDLE_TIMEOUT=1) and


### PR DESCRIPTION
### Repro

A server answers with a chunked body and keeps sending after the terminator, in the same packet:

```
HTTP/1.1 200 OK
Transfer-Encoding: chunked
Connection: keep-alive

5
hello
0

HTTP/1.1 200 OK
Content-Length: 8

injected
```

On the released build the response is delivered as `hello` and the socket still goes back into the keep-alive pool: seven requests against such a server (identity, a 64 KiB body and a gzip body, each followed by a well framed one) all ride a single TCP connection.

### Cause

`phr_decode_chunked` returns a non-negative count once it has seen the terminating chunk and trailer section, and that count is the number of bytes left over in the packet. Both `handle_response_body_chunked_encoding_from_single_packet` and `_from_multiple_packets` truncate those bytes away and leave `allow_keepalive` untouched, so the connection is released to the pool even though its framing can no longer be trusted. The Content-Length path already handles its equivalent: `handle_response_body` clears `allow_keepalive` when more bytes than the declared length arrive.

### Fix

The Content-Length overshoot check moves into a small `on_bytes_past_response_end(count)` helper, and both chunked decoders now report the leftover count to it (via `on_last_chunk`, which also sets `received_last_chunk`), so `progress_update` closes the socket instead of pooling it. Requests are never pipelined, so bytes past the terminator can only come from a mis-framed or hostile origin; the response itself is still delivered unchanged, only connection reuse is lost. Bytes arriving in a later packet were already covered: the pool terminates an idle socket on unexpected data.

The remaining member of this class, bytes following a response that ends at its header block (HEAD, 204/304, `Content-Length: 0`, followed 3xx), is fixed separately in #37438; it can call the same helper once one of the two lands.

### Verification

New test in `test/js/web/fetch/fetch.test.ts`, next to the Content-Length overshoot test. It sends one overshoot per decoder (small identity: single-packet path, 64 KiB identity: multi-packet path, small gzip: single-packet compressed path) and checks via the server's connection counter that the request after each overshoot opens a fresh connection while the correctly framed chunked responses in between are still pooled and reused. With `BUN_DEBUG_fetch=1` the three overshoots each log `72 bytes past the end of the response, disabling keep-alive`, two from `...FromSinglePacket` and one from `...FromMultiplePackets`; the existing Content-Length overshoot test logs the same line through the shared helper.

Fails on the released build (every step reports connection count 1), passes with this change. `fetch-gzip`, `fetch-retry-chunked`, `fetch-keepalive`, `fetch-redirect` and the proxy tests still pass; the remaining failures in `fetch.test.ts` locally are the pre-existing ones (tests binding a `net` server to `localhost`, which resolves to `::1` in this environment while `fetch` hardcodes `localhost` to `127.0.0.1`, plus debug-build timeouts) and are identical without the change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->