### PR TITLE
http: widen the per-request id to 64 bits

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -62,6 +62,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "ffi.rs": "runtime/ffi/ffi.rs",
   "h2_frame_parser.rs": "runtime/api/bun/h2_frame_parser.rs",
   "hosted_git_info.rs": "install/hosted_git_info.rs",
+  "http/AsyncHTTP.rs": "http/AsyncHTTP.rs",
   "http/H2Client.rs": "http/H2Client.rs",
   "http/H3Client.rs": "http/H3Client.rs",
   "ini.rs": "ini/ini.rs",

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -46,7 +46,7 @@ pub struct AsyncHTTP<'a> {
 
     pub client: HTTPClient<'a>,
     pub err: Option<crate::Error>,
-    pub async_http_id: u32,
+    pub async_http_id: u64,
 
     pub elapsed: u64,
 
@@ -68,6 +68,15 @@ unsafe impl bun_threading::Linked for AsyncHTTP<'static> {
 
 pub(crate) static ACTIVE_REQUESTS_COUNT: AtomicUsize = AtomicUsize::new(0);
 pub static MAX_SIMULTANEOUS_REQUESTS: AtomicUsize = AtomicUsize::new(256);
+
+/// `bun:internal-for-testing`: advance the id counter by `count` and return
+/// the id the next signalled request will be given, so a test can hold two
+/// live requests more than 2^32 ids apart without issuing that many requests.
+pub fn skip_ids_for_testing(count: u64) -> u64 {
+    crate::ASYNC_HTTP_ID_MONOTONIC
+        .fetch_add(count, Ordering::Relaxed)
+        .wrapping_add(count)
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // helpers
@@ -151,7 +160,7 @@ fn make_client<'a>(
     header_buf: &'a [u8],
     hostname: Option<&'a [u8]>,
     signals: Signals,
-    async_http_id: u32,
+    async_http_id: u64,
     http_proxy: Option<URL<'a>>,
     proxy_headers: Option<Headers>,
     redirect_type: FetchRedirect,

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -408,7 +408,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
     /// misses: a request parked in `PendingConnect.waiters` (coalesced
     /// onto a leader's in-flight TLS connect) never registered a socket,
     /// so it can only be found by scanning here.
-    pub(crate) fn abort_pending_h2_waiter(&mut self, async_http_id: u32) -> bool {
+    pub(crate) fn abort_pending_h2_waiter(&mut self, async_http_id: u64) -> bool {
         if !SSL {
             return false;
         }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -122,7 +122,7 @@ pub struct HttpThread {
 
     pub(crate) queued_shutdowns: Vec<ShutdownMessage>,
     pub(crate) queued_writes: Vec<WriteMessage>,
-    pub(crate) queued_receive_resumes: Vec<u32>,
+    pub(crate) queued_receive_resumes: Vec<u64>,
     pub(crate) queued_cert_check_resumes: Vec<CertCheckResumeMessage>,
 
     pub(crate) queued_shutdowns_lock: Mutex,
@@ -256,7 +256,7 @@ impl RequestBodyBuffer {
 }
 
 pub struct WriteMessage {
-    pub(crate) async_http_id: u32,
+    pub(crate) async_http_id: u64,
     pub(crate) kind: WriteMessageType,
 }
 
@@ -268,13 +268,13 @@ pub enum WriteMessageType {
 }
 
 pub struct ShutdownMessage {
-    pub(crate) async_http_id: u32,
+    pub(crate) async_http_id: u64,
 }
 
 /// The JS thread's `checkServerIdentity` callback approved the peer
 /// certificate; un-park the connection so the request is written.
 pub struct CertCheckResumeMessage {
-    pub(crate) async_http_id: u32,
+    pub(crate) async_http_id: u64,
 }
 
 pub struct LibdeflateState {
@@ -622,7 +622,7 @@ impl HttpThread {
         }
     }
 
-    fn abort_pending_h2_waiter(&mut self, async_http_id: u32) -> bool {
+    fn abort_pending_h2_waiter(&mut self, async_http_id: u64) -> bool {
         if self.https_context.abort_pending_h2_waiter(async_http_id) {
             return true;
         }
@@ -960,7 +960,7 @@ impl HttpThread {
         }
     }
 
-    pub fn schedule_receive_resume(&mut self, async_http_id: u32) {
+    pub fn schedule_receive_resume(&mut self, async_http_id: u64) {
         {
             let _guard = self.queued_receive_resumes_lock.lock_guard();
             if self.queued_receive_resumes.last() == Some(&async_http_id) {
@@ -975,7 +975,7 @@ impl HttpThread {
         self.schedule_shutdown_by_id(http.async_http_id);
     }
 
-    pub fn schedule_shutdown_by_id(&mut self, async_http_id: u32) {
+    pub fn schedule_shutdown_by_id(&mut self, async_http_id: u64) {
         bun_core::scoped_log!(HTTPThread, "scheduleShutdown {}", async_http_id);
         {
             let _guard = self.queued_shutdowns_lock.lock_guard();
@@ -1201,7 +1201,7 @@ fn start_queued_task(
 /// Borrow the HTTP-thread abort tracker. PORTING.md §Global mutable state:
 /// HTTP-thread-only, per-statement reborrow.
 #[inline]
-fn abort_tracker() -> &'static mut ArrayHashMap<u32, uws::AnySocket> {
+fn abort_tracker() -> &'static mut ArrayHashMap<u64, uws::AnySocket> {
     crate::abort_tracker()
 }
 

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -68,7 +68,7 @@ pub struct ClientSession {
     /// (`stream_body_by_http_id` / `resume_receive_by_http_id` /
     /// `drain_response_body_by_http_id` / `abort_by_http_id`) resolve in O(1)
     /// instead of scanning every live stream on the session.
-    pub(crate) by_http_id: ArrayHashMap<u32, *mut Stream>,
+    pub(crate) by_http_id: ArrayHashMap<u64, *mut Stream>,
     pub(crate) next_stream_id: u31,
     /// Stream id whose CONTINUATION sequence is in progress; 0 = none.
     pub(crate) expecting_continuation: u31,
@@ -572,14 +572,14 @@ impl ClientSession {
     /// stream pointer (owned by `self.streams`) so callers can re-borrow
     /// `&mut self` afterwards without an outstanding shared borrow.
     #[inline]
-    fn stream_for_http_id(&self, async_http_id: u32) -> Option<*mut Stream> {
+    fn stream_for_http_id(&self, async_http_id: u64) -> Option<*mut Stream> {
         self.by_http_id.get(&async_http_id).copied()
     }
 
     /// HTTP-thread wake-up from `scheduleResponseBodyDrain`: JS just enabled
     /// `response_body_streaming`, so flush any body bytes that arrived between
     /// metadata delivery and `getReader()`.
-    pub(crate) fn drain_response_body_by_http_id(&mut self, async_http_id: u32) {
+    pub(crate) fn drain_response_body_by_http_id(&mut self, async_http_id: u64) {
         let _guard = self.ref_scope();
         let Some(stream) = self.stream_for_http_id(async_http_id) else {
             return;
@@ -589,7 +589,7 @@ impl ClientSession {
         }
     }
 
-    pub(crate) fn resume_receive_by_http_id(&mut self, async_http_id: u32) {
+    pub(crate) fn resume_receive_by_http_id(&mut self, async_http_id: u64) {
         let _guard = self.ref_scope();
         if self.stream_for_http_id(async_http_id).is_none() {
             return;
@@ -604,7 +604,7 @@ impl ClientSession {
 
     /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
     /// end-of-body) are available in the ThreadSafeStreamBuffer.
-    pub(crate) fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) {
+    pub(crate) fn stream_body_by_http_id(&mut self, async_http_id: u64, ended: bool) {
         let _guard = self.ref_scope();
         let Some(stream) = self.stream_for_http_id(async_http_id) else {
             return;
@@ -868,7 +868,7 @@ impl ClientSession {
 
     /// Called from the HTTP thread's shutdown queue when a fetch on this
     /// session is aborted. RST_STREAMs that one request; siblings continue.
-    pub(crate) fn abort_by_http_id(&mut self, async_http_id: u32) {
+    pub(crate) fn abort_by_http_id(&mut self, async_http_id: u64) {
         // Find the index via a raw-ptr field read first, then swap_remove, so
         // no `&mut HTTPClient` is held across the Vec mutation and no `&mut`
         // is materialised during iteration.

--- a/src/http/h2_client/Stream.rs
+++ b/src/http/h2_client/Stream.rs
@@ -23,7 +23,7 @@ pub struct Stream {
     /// session's `by_http_id` index can be maintained after `client` has been
     /// cleared (terminal delivery nulls `client` before `remove_stream`).
     /// `None` for clients without an abort-signal store (not indexed).
-    pub(crate) async_http_id: Option<u32>,
+    pub(crate) async_http_id: Option<u64>,
     // BACKREF: weak back-pointer, cleared before terminal callbacks.
     // Lifetime-erased — the stream never reads borrowed fields through this.
     pub(crate) client: Option<NonNull<HTTPClient<'static>>>,
@@ -122,7 +122,7 @@ impl Drop for Stream {
 impl Stream {
     pub(crate) fn new(
         id: u32,
-        async_http_id: Option<u32>,
+        async_http_id: Option<u64>,
         client: Option<NonNull<HTTPClient<'static>>>,
         send_window: i32,
     ) -> Box<Self> {

--- a/src/http/h3_client/ClientContext.rs
+++ b/src/http/h3_client/ClientContext.rs
@@ -195,7 +195,7 @@ impl ClientContext {
         session.registry_index = u32::MAX;
     }
 
-    pub(crate) fn abort_by_http_id(async_http_id: u32) -> bool {
+    pub(crate) fn abort_by_http_id(async_http_id: u64) -> bool {
         let Some(this) = Self::get() else {
             return false;
         };
@@ -213,7 +213,7 @@ impl ClientContext {
         false
     }
 
-    pub(crate) fn stream_body_by_http_id(async_http_id: u32, ended: bool) {
+    pub(crate) fn stream_body_by_http_id(async_http_id: u64, ended: bool) {
         let Some(this) = Self::get() else {
             return;
         };
@@ -227,7 +227,7 @@ impl ClientContext {
         }
     }
 
-    pub(crate) fn resume_receive_by_http_id(async_http_id: u32) {
+    pub(crate) fn resume_receive_by_http_id(async_http_id: u64) {
         let Some(this) = Self::get() else {
             return;
         };

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -123,7 +123,7 @@ impl ClientSession {
         }
     }
 
-    pub(crate) fn stream_body_by_http_id(&mut self, async_http_id: u32, ended: bool) -> bool {
+    pub(crate) fn stream_body_by_http_id(&mut self, async_http_id: u64, ended: bool) -> bool {
         for &stream_ptr in self.pending.iter() {
             let stream = stream_mut(stream_ptr);
             let Some(client) = stream.client else {
@@ -144,7 +144,7 @@ impl ClientSession {
         false
     }
 
-    pub(crate) fn resume_receive_by_http_id(&mut self, async_http_id: u32) -> bool {
+    pub(crate) fn resume_receive_by_http_id(&mut self, async_http_id: u64) -> bool {
         for &stream_ptr in self.pending.iter() {
             let stream = stream_mut(stream_ptr);
             let Some(client) = stream.client else {
@@ -252,7 +252,7 @@ impl ClientSession {
         // `host` drops here (was `defer bun.default_allocator.free(host)`).
     }
 
-    pub(crate) fn abort_by_http_id(&mut self, async_http_id: u32) -> bool {
+    pub(crate) fn abort_by_http_id(&mut self, async_http_id: u64) -> bool {
         // `fail` mutates `pending`, so it cannot be called while the iterator
         // holds `&self.pending`, and only one entry can match — so locate
         // first via raw-ptr reads, then act.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -182,7 +182,7 @@ pub use bun_http_types::{ETag, MimeType};
 
 use bun_core::MutableString;
 use bun_http_types::FetchRedirect::CommonAbortReason;
-use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -241,7 +241,12 @@ impl Default for Flags {
 
 // ───────────────────────────── globals ─────────────────────────────
 
-pub(crate) static ASYNC_HTTP_ID_MONOTONIC: AtomicU32 = AtomicU32::new(0);
+/// Next `async_http_id`. The id keys the abort tracker and every JS-thread ->
+/// HTTP-thread message for a request, so it must stay unique for the life of
+/// the process; a 32-bit counter wraps within the lifetime of a busy process.
+/// Starts at 1: 0 marks requests without a signal store, which are never
+/// looked up by id.
+pub(crate) static ASYNC_HTTP_ID_MONOTONIC: AtomicU64 = AtomicU64::new(1);
 
 /// Set once at startup from `--experimental-http2-fetch` (before the HTTP
 /// thread spawns) and then only read on that thread.
@@ -865,7 +870,7 @@ pub struct HTTPClient<'a> {
     /// `HTTPContext.pending_h2_connects` Vec — not an owned Box.
     pub(crate) pending_h2: Option<NonNull<h2::PendingConnect>>,
     pub(crate) signals: Signals,
-    pub(crate) async_http_id: u32,
+    pub(crate) async_http_id: u64,
     pub(crate) hostname: Option<&'a [u8]>,
     pub(crate) unix_socket_path: ZigStringSlice,
     /// `fetch({ compress })` — when set, the body is compressed lazily at
@@ -982,7 +987,7 @@ pub(crate) fn http_thread_mut() -> &'static mut HTTPThread {
 // TODO: this needs to be freed when Worker Threads are implemented
 // HTTP-thread-only; `RacyCell` is the alias-safe static cell.
 pub(crate) static SOCKET_ASYNC_HTTP_ABORT_TRACKER: bun_core::RacyCell<
-    Option<bun_collections::ArrayHashMap<u32, bun_uws::AnySocket>>,
+    Option<bun_collections::ArrayHashMap<u64, bun_uws::AnySocket>>,
 > = bun_core::RacyCell::new(None);
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1201,7 +1206,7 @@ impl<const SSL: bool> SocketTimeout for HttpSocket<SSL> {
 /// `*mut` API imposed, now centralized here so 5 call sites drop their
 /// `unsafe` block).
 #[inline]
-fn abort_tracker() -> &'static mut ArrayHashMap<u32, uws::AnySocket> {
+fn abort_tracker() -> &'static mut ArrayHashMap<u64, uws::AnySocket> {
     // SAFETY: same single-thread invariant as http_thread(). Every call site
     // is a per-statement reborrow (audited in r3); no two `&mut` overlap.
     unsafe { (*SOCKET_ASYNC_HTTP_ABORT_TRACKER.get()).get_or_insert_with(ArrayHashMap::new) }

--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -1,5 +1,5 @@
-//! JSC bridges for `bun.http.{Headers,H2Client,H3Client}`. Keeps `src/http/`
-//! free of JSC types.
+//! JSC bridges for `bun.http.{Headers,AsyncHTTP,H2Client,H3Client}`. Keeps
+//! `src/http/` free of JSC types.
 
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
@@ -145,6 +145,22 @@ pub fn to_fetch_headers(
     .ok_or(JsError::Thrown)
 }
 
+struct AsyncHTTPTestingAPIs;
+
+impl AsyncHTTPTestingAPIs {
+    /// `skipIds(count)`: see `bun_http::async_http::skip_ids_for_testing`.
+    fn skip_ids(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let [count] = frame.arguments_as_array::<1>();
+        if !count.is_number() {
+            return Err(global.throw_invalid_arguments(format_args!("skipIds expects a number")));
+        }
+        let count = count.to_int64().max(0) as u64;
+        Ok(JSValue::js_number_from_uint64(
+            bun_http::async_http::skip_ids_for_testing(count),
+        ))
+    }
+}
+
 struct H2TestingAPIs;
 
 impl H2TestingAPIs {
@@ -196,9 +212,14 @@ impl H3TestingAPIs {
     }
 }
 
-/// Free-fn aliases of [`H2TestingAPIs::live_counts`] /
-/// [`H3TestingAPIs::quic_live_counts`] so `bun_runtime::dispatch::js2native`
-/// can `pub use` them (associated fns aren't importable items).
+/// Free-fn aliases of [`AsyncHTTPTestingAPIs::skip_ids`] /
+/// [`H2TestingAPIs::live_counts`] / [`H3TestingAPIs::quic_live_counts`] so
+/// `bun_runtime::dispatch::js2native` can `pub use` them (associated fns
+/// aren't importable items).
+#[inline]
+pub fn async_http_skip_ids(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    AsyncHTTPTestingAPIs::skip_ids(global, frame)
+}
 #[inline]
 pub fn h2_live_counts(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     H2TestingAPIs::live_counts(global, frame)

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -743,6 +743,16 @@ export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal
   addresses: string[],
 ) => number[];
 
+export const fetchRequestIdInternals = {
+  /**
+   * Advance the counter that hands out per-request ids (the key the JS thread
+   * uses to abort / resume / write to a request on the HTTP thread) by `count`
+   * and return the id the next request will be given. Lets a test hold two
+   * live requests 2**32 ids apart without issuing 2**32 requests.
+   */
+  skipIds: $newRustFunction("http/AsyncHTTP.rs", "TestingAPIs.skipIds", 1) as (count: number) => number,
+};
+
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -58,6 +58,7 @@ pub use bun_sys_jsc::error_jsc::TestingAPIs::sys_error_name_from_libuv as sys_er
 pub use bun_sys_jsc::error_jsc::TestingAPIs::translate_nt_status_to_e as sys_sys_testing_ap_is_translate_nt_status_to_e;
 pub use bun_sys_jsc::error_jsc::TestingAPIs::translate_uv_error_to_e as sys_sys_testing_ap_is_translate_uv_error_to_e;
 
+pub use bun_http_jsc::headers_jsc::async_http_skip_ids as http_async_http_testing_ap_is_skip_ids;
 pub use bun_http_jsc::headers_jsc::h2_live_counts as http_h2_client_testing_ap_is_live_counts;
 pub use bun_http_jsc::headers_jsc::h3_quic_live_counts as http_h3_client_testing_ap_is_quic_live_counts;
 

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -42,7 +42,7 @@ pub struct S3HttpDownloadStreamingTask {
     /// Captured once on the main thread before the request is queued so the cancel
     /// path can call `schedule_shutdown_by_id` without dereferencing `http` (which
     /// `update_state` overwrites on the HTTP thread under `mutex`).
-    pub(crate) async_http_id: u32,
+    pub(crate) async_http_id: u64,
 }
 
 // Hot-dispatch tag for `ConcurrentTask::from`.

--- a/test/js/web/fetch/fetch-abort-id-routing.test.ts
+++ b/test/js/web/fetch/fetch-abort-id-routing.test.ts
@@ -1,0 +1,46 @@
+// Every fetch() is given an id that the JS thread uses to find the request's
+// socket on the HTTP thread (abort, request-body writes, receive resumes). The
+// id counter is 64-bit, so two requests that are alive at the same time can
+// never share an id. This test puts two live requests exactly 2**32 ids apart
+// (identical in their low 32 bits) and checks that aborting one leaves the
+// other alone.
+
+import { fetchRequestIdInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+test("requests whose ids agree in their low 32 bits are aborted independently", async () => {
+  const bothRequestsArrived = Promise.withResolvers<void>();
+  let requestsArrived = 0;
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      if (++requestsArrived === 2) bothRequestsArrived.resolve();
+      // Hold both responses open; each request ends only when the client aborts it.
+      return new Promise<Response>(() => {});
+    },
+  });
+
+  const idOfA = fetchRequestIdInternals.skipIds(0);
+  const controllerA = new AbortController();
+  const a = fetch(server.url, { signal: controllerA.signal });
+  // `a` took one id; skipping the rest of the 2**32 block puts `b` exactly 2**32 ids after it.
+  expect(fetchRequestIdInternals.skipIds(2 ** 32 - 1)).toBe(idOfA + 2 ** 32);
+  const controllerB = new AbortController();
+  const b = fetch(server.url, { signal: controllerB.signal });
+  const settle = (name: string, promise: Promise<Response>) =>
+    promise.then(
+      () => `${name} resolved`,
+      (e: { name: string }) => `${name} rejected: ${e.name}`,
+    );
+  const aSettled = settle("a", a);
+  const bSettled = settle("b", b);
+
+  await bothRequestsArrived.promise;
+
+  controllerA.abort();
+  expect(await Promise.race([aSettled, bSettled])).toBe("a rejected: AbortError");
+  expect(Bun.peek.status(b)).toBe("pending");
+
+  controllerB.abort();
+  expect(await bSettled).toBe("b rejected: AbortError");
+});


### PR DESCRIPTION
Hardening of the id that the JS thread uses to reach a request's socket on the HTTP thread (abort, request-body writes, receive resumes, cert-check resumes).

### Cause

`ASYNC_HTTP_ID_MONOTONIC` was a `u32`, and the id was stored and compared as `u32` at every hop: `AsyncHTTP`/`HTTPClient`, the abort tracker map, the `Shutdown`/`Write`/`CertCheckResume`/receive-resume queues, the h2 `by_http_id` index and pending-connect scans, the h3 session scans, and the S3 download task. A long-lived process that issues enough requests eventually hands a new request an id that a still-running request is using, and from then on the two are routed as one: `abort_tracker().put()` replaces the older entry, messages for either request land on whichever socket is registered, and the completion of one removes the other's entry. The counter also started at 0, which is the same value unsignalled requests (preconnect, `send_sync`) carry, so the very first signalled request shared its id with those in the paths that compare ids directly.

### Fix

The id is `u64` everywhere it is stored or compared, and the counter starts at 1 so 0 only ever means "no signal store" (such requests are never looked up by id). No `as` casts were needed anywhere, so a future narrowing at any hop would fail to compile rather than silently truncate.

### Test

`test/js/web/fetch/fetch-abort-id-routing.test.ts` holds two requests open against a local server, with the second one exactly `2**32` ids after the first (via a new `fetchRequestIdInternals.skipIds` hook in `bun:internal-for-testing`; it advances the counter and returns the next id), then aborts them one at a time and checks that only the aborted request settles each time.

With ids truncated to 32 bits (simulated locally by masking the counter) the test fails at the first abort with `Received: "b rejected: AbortError"`: aborting the first request tore down the second. On the current release the test fails because the hook does not exist. With this change it passes, as do the existing h1/h2/h3 abort, streaming-upload and receive-backpressure suites that exercise the other id-keyed paths (`fetch-abort-*.test.ts`, `fetch-http2-client.test.ts`, `fetch-http3-client.test.ts`, `fetch-backpressure.test.ts`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-abort-id-routing.test.ts
bun test v1.4.0 (36209fad8)

test/js/web/fetch/fetch-abort-id-routing.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'fetchRequestIdInternals' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [2.42s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/web/fetch/fetch-abort-id-routing.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'fetchRequestIdInternals' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [162.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-abort-id-routing.test.ts
bun test v1.4.0 (36209fad8)

test/js/web/fetch/fetch-abort-id-routing.test.ts:
(pass) requests whose ids agree in their low 32 bits are aborted independently [68.89ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [2.61s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 847ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (10020ms)
Bundle modules (41ms)
Postprocesss modules (234ms)
Bundle Functions (909ms)
Generate Code (43ms)

[11.26s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/generate-js2native.ts                |  1 +
 src/http/AsyncHTTP.rs                            | 13 +++++--
 src/http/HTTPContext.rs                          |  2 +-
 src/http/HTTPThread.rs                           | 16 ++++-----
 src/http/h2_client/ClientSession.rs              | 12 +++----
 src/http/h2_client/Stream.rs                     |  4 +--
 src/http/h3_client/ClientContext.rs              |  6 ++--
 src/http/h3_client/ClientSession.rs              |  6 ++--
 src/http/lib.rs                                  | 15 +++++---
 src/http_jsc/headers_jsc.rs                      | 31 +++++++++++++---
 src/js/internal-for-testing.ts                   | 10 ++++++
 src/runtime/dispatch_js2native.rs                |  1 +
 src/runtime/webcore/s3/download_stream.rs        |  2 +-
 test/js/web/fetch/fetch-abort-id-routing.test.ts | 46 ++++++++++++++++++++++++
 14 files changed, 129 insertions(+), 36 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/codegen/generate-js2native.ts                     1      1      0
src/http/AsyncHTTP.rs                                 2      5      0
src/http/HTTPContext.rs                               1      1      0
src/http/HTTPThread.rs                                4      8      0
src/http/h2_client/ClientSession.rs                   3      6      0
src/http/h2_client/Stream.rs                          1      2      0
src/http/h3_client/ClientContext.rs                   1      3      0
src/http/h3_client/ClientSession.rs                   2      3      0
src/http/lib.rs                                       6      5      0
src/http_jsc/headers_jsc.rs                           1      4      0
src/js/internal-for-testing.ts                        1      1      0
src/runtime/dispatch_js2native.rs                     1      1      0
src/runtime/webcore/s3/download_stream.rs             1      1      0
test/js/web/fetch/fetch-abort-id-routing.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->