### PR TITLE
http: don't pool a connection when bytes trail a bodyless response

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3773,12 +3773,8 @@ impl<'a> HTTPClient<'a> {
         }
 
         if should_continue == ShouldContinue::Finished {
-            // The message ended with its header block, so whatever follows it
-            // in this packet was never requested (RFC 9112 section 6.3). As
-            // with the Content-Length overshoot in handle_response_body, the
-            // response is still delivered, but the connection's framing can't
-            // be trusted any more: close it instead of pooling it. do_redirect
-            // honours this flag too via is_keep_alive_possible.
+            // Nothing is pipelined, so leftover bytes desynchronize the socket
+            // (RFC 9112 section 6.3). Has to stay ahead of do_redirect.
             if !to_read.is_empty() {
                 self.state.flags.allow_keepalive = false;
             }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3773,8 +3773,6 @@ impl<'a> HTTPClient<'a> {
         }
 
         if should_continue == ShouldContinue::Finished {
-            // Nothing is pipelined, so leftover bytes desynchronize the socket
-            // (RFC 9112 section 6.3). Has to stay ahead of do_redirect.
             if !to_read.is_empty() {
                 self.state.flags.allow_keepalive = false;
             }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3773,6 +3773,15 @@ impl<'a> HTTPClient<'a> {
         }
 
         if should_continue == ShouldContinue::Finished {
+            // The message ended with its header block, so whatever follows it
+            // in this packet was never requested (RFC 9112 section 6.3). As
+            // with the Content-Length overshoot in handle_response_body, the
+            // response is still delivered, but the connection's framing can't
+            // be trusted any more: close it instead of pooling it. do_redirect
+            // honours this flag too via is_keep_alive_possible.
+            if !to_read.is_empty() {
+                self.state.flags.allow_keepalive = false;
+            }
             if self.state.flags.is_redirect_pending {
                 self.do_redirect::<IS_SSL>(ctx, socket);
                 return;

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3254,6 +3254,140 @@ it("does not reuse a keep-alive connection whose response carried more bytes tha
   }
 });
 
+it("does not reuse a keep-alive connection when bytes follow a response that ended at its header block", async () => {
+  // A 204/304, a Content-Length: 0 response, any response to HEAD, and a followed
+  // 3xx are complete once their header block is in. Bytes after that in the same
+  // packet are the bodyless counterpart of the Content-Length overshoot above: the
+  // connection's framing can no longer be trusted, so the response is delivered but
+  // the connection must be closed instead of going back to the pool (this includes
+  // the redirect path, which pools the socket before following the Location).
+  // Without trailing bytes each of these responses must still be pooled and reused.
+  const injected = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected";
+  const responses: Record<string, { head: string; junk: string }> = {
+    "/204": { head: "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n", junk: injected },
+    "/304": { head: 'HTTP/1.1 304 Not Modified\r\nETag: "x"\r\nConnection: keep-alive\r\n\r\n', junk: injected },
+    "/empty": { head: "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n", junk: injected },
+    // Answered with HEAD: Content-Length describes the GET body, nothing may follow.
+    // The junk variant sends that body anyway.
+    "/head": { head: "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\n", junk: "hello" },
+    "/303": {
+      head: "HTTP/1.1 303 See Other\r\nLocation: /legit\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n",
+      junk: injected,
+    },
+  };
+  const legit =
+    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\nConnection: keep-alive\r\n\r\nlegit!";
+
+  let connections = 0;
+  const sockets: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    connections++;
+    sockets.push(socket);
+    socket.on("error", () => {});
+    let buffered = "";
+    socket.on("data", data => {
+      buffered += data.toString("latin1");
+      while (true) {
+        const headerEnd = buffered.indexOf("\r\n\r\n");
+        if (headerEnd === -1) return;
+        const head = buffered.slice(0, headerEnd);
+        // Consume the request body (the redirect case is a POST) before answering, so
+        // body bytes are never mistaken for the next request.
+        let requestEnd = headerEnd + 4;
+        if (/^transfer-encoding:.*\bchunked\b/im.test(head)) {
+          const terminator = buffered.indexOf("0\r\n\r\n", requestEnd);
+          if (terminator === -1) return;
+          requestEnd = terminator + 5;
+        } else {
+          requestEnd += Number(/^content-length:\s*(\d+)/im.exec(head)?.[1] ?? 0);
+          if (buffered.length < requestEnd) return;
+        }
+        buffered = buffered.slice(requestEnd);
+
+        const target = head.split("\r\n")[0].split(" ")[1];
+        const [path, query] = target.split("?");
+        const response = responses[path];
+        if (response) {
+          socket.write(response.head + (query === "junk" ? response.junk : ""));
+        } else {
+          socket.write(legit);
+        }
+      }
+    });
+  });
+  // 127.0.0.1 explicitly: counting connections requires the server to listen on the
+  // address fetch() connects to.
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+  const origin = `http://127.0.0.1:${port}`;
+
+  const cases: { path: string; init?: () => RequestInit }[] = [
+    { path: "/204" },
+    { path: "/304" },
+    { path: "/empty" },
+    { path: "/head", init: () => ({ method: "HEAD" }) },
+    // The redirect path only pools the socket once the upload is known to be
+    // complete, which today is the case for streamed bodies, so a streamed POST is
+    // what exercises that path's pooling decision.
+    {
+      path: "/303",
+      init: () => ({
+        method: "POST",
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("payload"));
+            controller.close();
+          },
+        }),
+      }),
+    },
+  ];
+
+  try {
+    // Warm the pool with one clean connection so every case below starts out
+    // reusing a pooled socket.
+    expect(await (await fetch(`${origin}/legit`)).text()).toBe("legit!");
+    expect(connections).toBe(1);
+
+    const results: { request: string; status: number; body: string; newConnections: number }[] = [];
+    for (const { path, init } of cases) {
+      for (const junk of [true, false]) {
+        const before = connections;
+        const response = await fetch(`${origin}${path}${junk ? "?junk" : ""}`, init?.());
+        const body = await response.text();
+        // The follow-up request must never be served by the connection that
+        // carried the mis-framed response (and whatever else it may still deliver),
+        // while a cleanly framed bodyless response must keep its connection pooled.
+        const followUp = await fetch(`${origin}/legit`);
+        expect(await followUp.text()).toBe("legit!");
+        results.push({
+          request: `${path}${junk ? " + trailing bytes" : ""}`,
+          status: response.status,
+          body,
+          newConnections: connections - before,
+        });
+      }
+    }
+
+    expect(results).toEqual([
+      { request: "/204 + trailing bytes", status: 204, body: "", newConnections: 1 },
+      { request: "/204", status: 204, body: "", newConnections: 0 },
+      { request: "/304 + trailing bytes", status: 304, body: "", newConnections: 1 },
+      { request: "/304", status: 304, body: "", newConnections: 0 },
+      { request: "/empty + trailing bytes", status: 200, body: "", newConnections: 1 },
+      { request: "/empty", status: 200, body: "", newConnections: 0 },
+      { request: "/head + trailing bytes", status: 200, body: "", newConnections: 1 },
+      { request: "/head", status: 200, body: "", newConnections: 0 },
+      // The redirect is still followed; only the hop to /legit needs the new connection.
+      { request: "/303 + trailing bytes", status: 200, body: "legit!", newConnections: 1 },
+      { request: "/303", status: 200, body: "legit!", newConnections: 0 },
+    ]);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    server.close();
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/16682
 it("an explicit numeric `timeout` extends the socket idle deadline past the default", async () => {
   // The child runs with a 1s idle default (BUN_CONFIG_HTTP_IDLE_TIMEOUT=1) and

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3195,73 +3195,11 @@ it("releases interim 1xx response bytes as they are parsed while waiting for the
   }
 }, 60_000);
 
-it("does not reuse a keep-alive connection whose response carried more bytes than its Content-Length", async () => {
-  // Surplus bytes past the declared Content-Length mean the connection's framing can
-  // no longer be trusted: anything still buffered on (or later delivered to) that
-  // socket would be parsed as the response to whichever request next reuses it from
-  // the keep-alive pool. The mis-framed response itself is still delivered (truncated
-  // to its declared length), but the connection must be closed instead of pooled.
-  let connections = 0;
-  const sockets: net.Socket[] = [];
-  const server = net.createServer(socket => {
-    connections++;
-    sockets.push(socket);
-    let buffered = "";
-    socket.on("data", data => {
-      buffered += data.toString("latin1");
-      while (true) {
-        const headerEnd = buffered.indexOf("\r\n\r\n");
-        if (headerEnd === -1) break;
-        const head = buffered.slice(0, headerEnd);
-        buffered = buffered.slice(headerEnd + 4);
-        const path = head.split("\r\n")[0].split(" ")[1];
-        if (path === "/overshoot") {
-          // Declares 5 body bytes but sends those 5 plus a complete pipelined
-          // "injected" response that the declared framing never accounted for.
-          socket.write(
-            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nhello" +
-              "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected",
-          );
-        } else {
-          socket.write(
-            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\nConnection: keep-alive\r\n\r\nlegit!",
-          );
-        }
-      }
-    });
-  });
-  await once(server.listen(0, "localhost"), "listening");
-  const { port } = server.address() as AddressInfo;
-
-  try {
-    // The mis-framed response is still delivered, truncated to its declared length.
-    const first = await fetch(`http://localhost:${port}/overshoot`);
-    expect(await first.text()).toBe("hello");
-
-    // The follow-up request must go out on a fresh connection, so it can never be
-    // answered by the leftover "injected" bytes on the desynchronized socket.
-    const second = await fetch(`http://localhost:${port}/after`);
-    expect(await second.text()).toBe("legit!");
-    expect(connections).toBe(2);
-
-    // A correctly framed keep-alive response is still pooled and reused.
-    const third = await fetch(`http://localhost:${port}/again`);
-    expect(await third.text()).toBe("legit!");
-    expect(connections).toBe(2);
-  } finally {
-    for (const socket of sockets) socket.destroy();
-    server.close();
-  }
-});
-
 it("does not reuse a keep-alive connection when bytes follow a response that ended at its header block", async () => {
-  // A 204/304, a Content-Length: 0 response, any response to HEAD, and a followed
-  // 3xx are complete once their header block is in. Bytes after that in the same
-  // packet are the bodyless counterpart of the Content-Length overshoot above: the
-  // connection's framing can no longer be trusted, so the response is delivered but
-  // the connection must be closed instead of going back to the pool (this includes
-  // the redirect path, which pools the socket before following the Location).
-  // Without trailing bytes each of these responses must still be pooled and reused.
+  // Bodyless counterpart of the Content-Length overshoot test below. Each of these
+  // responses is complete once its header block is in (the followed 3xx through the
+  // redirect path, which pools the socket itself), so trailing bytes must cost the
+  // connection while the same responses without them must still be pooled.
   const injected = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected";
   const responses: Record<string, { head: string; junk: string }> = {
     "/204": { head: "HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n", junk: injected },
@@ -3355,9 +3293,7 @@ it("does not reuse a keep-alive connection when bytes follow a response that end
         const before = connections;
         const response = await fetch(`${origin}${path}${junk ? "?junk" : ""}`, init?.());
         const body = await response.text();
-        // The follow-up request must never be served by the connection that
-        // carried the mis-framed response (and whatever else it may still deliver),
-        // while a cleanly framed bodyless response must keep its connection pooled.
+        // newConnections counts what this response plus the follow-up request opened.
         const followUp = await fetch(`${origin}/legit`);
         expect(await followUp.text()).toBe("legit!");
         results.push({
@@ -3382,6 +3318,65 @@ it("does not reuse a keep-alive connection when bytes follow a response that end
       { request: "/303 + trailing bytes", status: 200, body: "legit!", newConnections: 1 },
       { request: "/303", status: 200, body: "legit!", newConnections: 0 },
     ]);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    server.close();
+  }
+});
+
+it("does not reuse a keep-alive connection whose response carried more bytes than its Content-Length", async () => {
+  // Surplus bytes past the declared Content-Length mean the connection's framing can
+  // no longer be trusted: anything still buffered on (or later delivered to) that
+  // socket would be parsed as the response to whichever request next reuses it from
+  // the keep-alive pool. The mis-framed response itself is still delivered (truncated
+  // to its declared length), but the connection must be closed instead of pooled.
+  let connections = 0;
+  const sockets: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    connections++;
+    sockets.push(socket);
+    let buffered = "";
+    socket.on("data", data => {
+      buffered += data.toString("latin1");
+      while (true) {
+        const headerEnd = buffered.indexOf("\r\n\r\n");
+        if (headerEnd === -1) break;
+        const head = buffered.slice(0, headerEnd);
+        buffered = buffered.slice(headerEnd + 4);
+        const path = head.split("\r\n")[0].split(" ")[1];
+        if (path === "/overshoot") {
+          // Declares 5 body bytes but sends those 5 plus a complete pipelined
+          // "injected" response that the declared framing never accounted for.
+          socket.write(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nhello" +
+              "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected",
+          );
+        } else {
+          socket.write(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\nConnection: keep-alive\r\n\r\nlegit!",
+          );
+        }
+      }
+    });
+  });
+  await once(server.listen(0, "localhost"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    // The mis-framed response is still delivered, truncated to its declared length.
+    const first = await fetch(`http://localhost:${port}/overshoot`);
+    expect(await first.text()).toBe("hello");
+
+    // The follow-up request must go out on a fresh connection, so it can never be
+    // answered by the leftover "injected" bytes on the desynchronized socket.
+    const second = await fetch(`http://localhost:${port}/after`);
+    expect(await second.text()).toBe("legit!");
+    expect(connections).toBe(2);
+
+    // A correctly framed keep-alive response is still pooled and reused.
+    const third = await fetch(`http://localhost:${port}/again`);
+    expect(await third.text()).toBe("legit!");
+    expect(connections).toBe(2);
   } finally {
     for (const socket of sockets) socket.destroy();
     server.close();


### PR DESCRIPTION
### Repro

Raw server that appends a second, unrequested response to a bodyless one:

```js
import net from "net"; import { once } from "events";
let connections = 0;
const injected = "HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\ninjected";
const server = net.createServer(sock => { connections++; let buf = "";
  sock.on("data", d => { buf += d; let i;
    while ((i = buf.indexOf("\r\n\r\n")) !== -1) { const path = buf.slice(0, i).split(" ")[1]; buf = buf.slice(i + 4);
      if (path === "/204") sock.write("HTTP/1.1 204 No Content\r\nConnection: keep-alive\r\n\r\n" + injected);
      else if (path === "/cl0") sock.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n" + injected);
      else if (path === "/head") sock.write("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nhello");
      else sock.write("HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: keep-alive\r\n\r\nlegit!"); } }); });
await once(server.listen(0, "127.0.0.1"), "listening");
const port = server.address().port, out = [];
for (const [path, init] of [["/204"], ["/legit"], ["/cl0"], ["/legit"], ["/head", { method: "HEAD" }], ["/legit"]]) {
  const r = await fetch(`http://127.0.0.1:${port}${path}`, init); await r.text(); out.push([path, r.status, connections]); }
console.log(JSON.stringify(out));
```

Connections column before (bun 1.4.0): `1,1,1,1,1,1`, every `/legit` is sent on the connection that just misbehaved. After: `1,2,2,3,3,4`. Same thing for a followed redirect: a streamed POST answered with `303` + `Content-Length: 0` + trailing bytes had its `GET` hop sent on the same connection.

### Cause

`handle_on_data_headers` (src/http/lib.rs): when `handle_response_metadata` returns `ShouldContinue::Finished` (HEAD response, 204/304, `Content-Length: 0`, or a redirect being followed) the remaining bytes of the packet in `to_read` were dropped on the floor and `progress_update` / `do_redirect` released the socket to the keep-alive pool as usual.

The rest of this class: a body longer than its `Content-Length` already clears `allow_keepalive` in `handle_response_body`, data arriving later on an idle pooled socket already gets the socket evicted in `HTTPContext::on_data`, and bytes after the terminating chunk of a chunked body are fixed in #37436. This PR covers the header-block-terminated responses. #37436 introduces an `on_bytes_past_response_end` helper for the Content-Length and chunked sites; whichever of the two PRs lands second should route this check through it too. The two PRs apply independently in either order (checked with `git apply --check` of #37436 on top of this branch).

### Fix

In the `Finished` branch, clear `state.flags.allow_keepalive` when `to_read` is not empty, before the redirect check so `do_redirect` (which goes through `is_keep_alive_possible` as well) makes the same decision. The response is still delivered exactly as before; the only change is that the connection is closed instead of pooled.

Why closing is the right call: RFC 9112 section 6.3 lets a client discard data left over after a complete response but says it must not be processed as a separate response. We only ever see the part of that data that happened to share a packet with the header block; whatever else the server is going to send would be parsed as the reply to the next request that picks this socket out of the pool. The connection has no trustworthy message boundary any more, which is the same reasoning as the existing Content-Length overshoot rule. Node destroys the socket in this situation too (the leftover bytes fail to parse as a response or are rejected as a double response). The cost is only paid by servers that are mis-framing, and for them it is one extra connection.

`HTTPContext::on_data` tolerates a bare `0\r\n\r\n` arriving later on an idle pooled socket (a 2022 drive-by for servers that send a chunk terminator after a bodyless chunked response). This change does not special-case that sequence when it arrives in the same packet: such a server still gets its response delivered, it just does not get connection reuse. The idle-socket tolerance itself is left as is.

### Verification

New test in test/js/web/fetch/fetch.test.ts, placed just ahead of the Content-Length overshoot one (#37436 adds its test right after it). It drives 204, 304, `Content-Length: 0`, HEAD and a followed 303 (via a streamed POST, the request shape whose redirect hop currently reuses the pooled socket) through the server above, each once with trailing bytes and once clean, and checks that the trailing-bytes variants cost exactly one new connection for the follow-up request while the clean variants still reuse theirs. Without the fix the five trailing-bytes rows report 0 new connections; with it the whole table matches.

Also ran fetch-keepalive, fetch-redirect, fetch-connection-header, content-length, fetch-url-after-redirect and the proxy tests against the debug build; the only failures are the pre-existing ones caused by this container resolving `localhost` to `::1` / setting `NO_PROXY`, identical with the release binary.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->