### PR TITLE
test: isolate proxy tests from ambient proxy environment variables

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -128,6 +128,64 @@ export function bunExe() {
   return process.execPath;
 }
 
+/**
+ * The environment variables the HTTP client, WebSocket and S3 read to pick a
+ * proxy or bypass one. `bunEnv` keeps whatever the host has set in them (the
+ * harness itself needs them to reach the network on proxied machines), so a
+ * test that runs its own proxy against localhost has to clear them: NO_PROXY
+ * applies to an explicit `proxy:` option too, and a proxied host typically
+ * lists localhost in it.
+ */
+export const PROXY_ENV_KEYS = [
+  "NO_PROXY",
+  "no_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+] as const;
+
+/**
+ * Clears {@link PROXY_ENV_KEYS} in this process for in-process fetch /
+ * WebSocket / S3 calls. Call it from `beforeAll` and pass the result to
+ * {@link restoreProxyEnv} in `afterAll`; subprocesses are unaffected (`bunEnv`
+ * was captured at import), spread {@link proxyFreeEnv} into their env instead.
+ */
+export function clearProxyEnv(): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {};
+  for (const key of PROXY_ENV_KEYS) {
+    saved[key] = process.env[key];
+    // Assign rather than delete: only an assignment reaches the native env
+    // loader the HTTP client reads from. An empty value disables the
+    // proxy/bypass.
+    process.env[key] = "";
+  }
+  return saved;
+}
+
+export function restoreProxyEnv(saved: Record<string, string | undefined>) {
+  for (const key of PROXY_ENV_KEYS) {
+    process.env[key] = saved[key] ?? "";
+  }
+}
+
+/**
+ * Spread after `bunEnv` in a child's env to start it without any proxy
+ * configuration: `{ ...bunEnv, ...proxyFreeEnv, NO_PROXY: "localhost" }`.
+ * `Bun.spawn` drops `undefined` entries, so the variables are absent in the
+ * child rather than blank; that matters on Windows, where environment names
+ * are case-insensitive and a blank `HTTP_PROXY` would collide with the
+ * `http_proxy` a test sets next to it.
+ */
+export const proxyFreeEnv = {
+  NO_PROXY: undefined,
+  no_proxy: undefined,
+  HTTP_PROXY: undefined,
+  http_proxy: undefined,
+  HTTPS_PROXY: undefined,
+  https_proxy: undefined,
+} as const;
+
 export function nodeExe(): string | null {
   return which("node") || null;
 }

--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -19,48 +19,10 @@ import zlib from "node:zlib";
 import { once } from "node:events";
 import { tls as tlsCert } from "harness";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Environment hygiene: ambient HTTP_PROXY / NO_PROXY on CI hosts will reroute
-// or bypass localhost fetches and silently turn every assertion here into a
-// false positive. Importers of this module get the cleared env (and a
-// restorer) for free.
-// ─────────────────────────────────────────────────────────────────────────────
-
-export const PROXY_ENV_KEYS = [
-  "NO_PROXY",
-  "no_proxy",
-  "HTTP_PROXY",
-  "http_proxy",
-  "HTTPS_PROXY",
-  "https_proxy",
-] as const;
-
-export function clearProxyEnv(): Record<string, string | undefined> {
-  const saved: Record<string, string | undefined> = {};
-  for (const key of PROXY_ENV_KEYS) {
-    saved[key] = process.env[key];
-    // Assign "" rather than delete: the native env loader only observes
-    // assignments. An empty value disables the proxy/bypass.
-    process.env[key] = "";
-  }
-  return saved;
-}
-
-export function restoreProxyEnv(saved: Record<string, string | undefined>) {
-  for (const key of PROXY_ENV_KEYS) {
-    process.env[key] = saved[key] ?? "";
-  }
-}
-
-/** Env override for subprocess fixtures: wipes every proxy-relevant key. */
-export const proxyFreeEnv = {
-  NO_PROXY: undefined,
-  no_proxy: undefined,
-  HTTP_PROXY: undefined,
-  http_proxy: undefined,
-  HTTPS_PROXY: undefined,
-  https_proxy: undefined,
-} as const;
+// Environment hygiene: ambient HTTP_PROXY / NO_PROXY would reroute or bypass
+// the localhost fetches in every stress file, so they all clear the env in
+// beforeAll/afterAll with these.
+export { PROXY_ENV_KEYS, clearProxyEnv, proxyFreeEnv, restoreProxyEnv } from "harness";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Adversarial proxy

--- a/test/js/bun/http/proxy.test.js
+++ b/test/js/bun/http/proxy.test.js
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, gc } from "harness";
+import { bunEnv, bunExe, clearProxyEnv, gc, proxyFreeEnv, restoreProxyEnv } from "harness";
 import path from "path";
-import { clearProxyEnv, proxyFreeEnv, restoreProxyEnv } from "./proxy-stress-helpers";
 
 // Forwards an absolute-form request to its target and marks the response so
 // tests can tell it went through the proxy.
@@ -20,10 +19,9 @@ async function forward(request) {
 }
 
 let proxy, auth_proxy, server;
-// The in-process tests fetch localhost through an explicit `proxy:`, and
-// NO_PROXY applies to explicit proxies too; the proxies' upstream fetch()
-// would likewise honor an ambient HTTP_PROXY. `bunEnv` was captured before
-// this runs, so the subprocess tests spread `proxyFreeEnv` on top of it.
+// Cleared for the in-process fetches through the proxies below and for the
+// proxies' own upstream fetch(), which would otherwise follow an ambient
+// HTTP_PROXY. The subprocess tests spread `proxyFreeEnv` themselves.
 let savedProxyEnv;
 beforeAll(() => {
   savedProxyEnv = clearProxyEnv();

--- a/test/js/bun/http/proxy.test.js
+++ b/test/js/bun/http/proxy.test.js
@@ -2,9 +2,31 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, gc } from "harness";
 import path from "path";
+import { clearProxyEnv, proxyFreeEnv, restoreProxyEnv } from "./proxy-stress-helpers";
+
+// Forwards an absolute-form request to its target and marks the response so
+// tests can tell it went through the proxy.
+async function forward(request) {
+  const response = await fetch(request.url, {
+    method: request.method,
+    body: await request.text(),
+  });
+  const headers = new Headers(response.headers);
+  headers.set("x-proxy-used", "1");
+  return new Response(response.body, {
+    status: response.status,
+    headers,
+  });
+}
 
 let proxy, auth_proxy, server;
+// The in-process tests fetch localhost through an explicit `proxy:`, and
+// NO_PROXY applies to explicit proxies too; the proxies' upstream fetch()
+// would likewise honor an ambient HTTP_PROXY. `bunEnv` was captured before
+// this runs, so the subprocess tests spread `proxyFreeEnv` on top of it.
+let savedProxyEnv;
 beforeAll(() => {
+  savedProxyEnv = clearProxyEnv();
   proxy = Bun.serve({
     port: 0,
     async fetch(request) {
@@ -15,17 +37,7 @@ beforeAll(() => {
 
       // simple http proxy
       if (request.url.startsWith("http://")) {
-        const response = await fetch(request.url, {
-          method: request.method,
-          body: await request.text(),
-        });
-        // Add marker header to indicate request went through proxy
-        const headers = new Headers(response.headers);
-        headers.set("x-proxy-used", "1");
-        return new Response(response.body, {
-          status: response.status,
-          headers,
-        });
+        return await forward(request);
       }
 
       // no TLS support here
@@ -54,10 +66,7 @@ beforeAll(() => {
 
       // simple http proxy
       if (request.url.startsWith("http://")) {
-        return await fetch(request.url, {
-          method: request.method,
-          body: await request.text(),
-        });
+        return await forward(request);
       }
 
       // no TLS support here
@@ -80,6 +89,7 @@ afterAll(() => {
   server.stop(true);
   proxy.stop(true);
   auth_proxy.stop(true);
+  restoreProxyEnv(savedProxyEnv);
 });
 
 const test = process.env.PROXY_URL ? it : it.skip;
@@ -116,38 +126,40 @@ describe.concurrent(() => {
     expect(result.data).toBe(data);
   });
 
-  describe("proxy non-TLS", async () => {
+  describe("proxy non-TLS", () => {
     let url;
     let auth_proxy_url;
     let proxy_url;
-    const requests = [
-      () => [new Request(url), auth_proxy_url],
-      () => [
+    const requests = {
+      "GET Request through auth proxy": () => [new Request(url), auth_proxy_url],
+      "POST Request through auth proxy": () => [
         new Request(url, {
           method: "POST",
           body: "Hello, World",
         }),
         auth_proxy_url,
       ],
-      () => [url, auth_proxy_url],
-      () => [new Request(url), proxy_url],
-      () => [
+      "GET url through auth proxy": () => [url, auth_proxy_url],
+      "GET Request through proxy": () => [new Request(url), proxy_url],
+      "POST Request through proxy": () => [
         new Request(url, {
           method: "POST",
           body: "Hello, World",
         }),
         proxy_url,
       ],
-      () => [url, proxy_url],
-    ];
+      "GET url through proxy": () => [url, proxy_url],
+    };
     beforeAll(() => {
       url = `http://localhost:${server.port}`;
       auth_proxy_url = `http://squid_user:ASD123%40123asd@localhost:${auth_proxy.port}`;
       proxy_url = `localhost:${proxy.port}`;
     });
 
-    for (let callback of requests) {
-      test(async () => {
+    // These only need the in-process servers, so they are not gated on
+    // PROXY_URL like the httpbin tests above.
+    for (const [name, callback] of Object.entries(requests)) {
+      it(name, async () => {
         const [request, proxy] = callback();
         gc();
         const response = await fetch(request, { verbose: true, proxy });
@@ -155,6 +167,7 @@ describe.concurrent(() => {
         const text = await response.text();
         gc();
         expect(text).toBe("Hello, World");
+        expect(response.headers.get("x-proxy-used")).toBe("1");
       });
     }
   });
@@ -231,6 +244,7 @@ describe.concurrent(() => {
       cmd: [bunExe(), "-e", `await fetch("${localServer.url}")`],
       env: {
         ...bunEnv,
+        ...proxyFreeEnv,
         http_proxy: http_proxy,
         https_proxy: https_proxy,
       },
@@ -259,6 +273,7 @@ describe.concurrent(() => {
       cmd: [bunExe(), "-e", `fetch("http://localhost:1").catch(() => {})`],
       env: {
         ...bunEnv,
+        ...proxyFreeEnv,
         http_proxy: "http://127.0.0.1:1",
         NO_PROXY: no_proxy,
       },
@@ -287,6 +302,7 @@ describe.concurrent(() => {
         ],
         env: {
           ...bunEnv,
+          ...proxyFreeEnv,
           http_proxy: `http://localhost:${proxy.port}`,
           NO_PROXY: `localhost:${server.port}`,
         },
@@ -318,6 +334,7 @@ describe.concurrent(() => {
         ],
         env: {
           ...bunEnv,
+          ...proxyFreeEnv,
           http_proxy: `http://localhost:${proxy.port}`,
           NO_PROXY: `localhost:${differentPort}`,
         },
@@ -348,6 +365,7 @@ describe.concurrent(() => {
         ],
         env: {
           ...bunEnv,
+          ...proxyFreeEnv,
           http_proxy: `http://localhost:${proxy.port}`,
           NO_PROXY: `localhost`,
         },
@@ -379,6 +397,7 @@ describe.concurrent(() => {
         ],
         env: {
           ...bunEnv,
+          ...proxyFreeEnv,
           http_proxy: `http://localhost:${proxy.port}`,
           NO_PROXY: `example.com, localhost:${differentPort}, localhost:${server.port}`,
         },

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1753,6 +1753,13 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
   // process environment at startup. A dead proxy that immediately closes
   // connections is used so that if NO_PROXY doesn't work, the fetch fails
   // with a connection error.
+  //
+  // Start the child from a proxy-free env: a non-empty lowercase `no_proxy`
+  // inherited through bunEnv would take precedence over the NO_PROXY each
+  // test sets.
+  const noProxyEnv = { ...bunEnv };
+  for (const k of PROXY_ENV_KEYS) delete noProxyEnv[k];
+
   let deadProxyPort: number;
   let deadProxy: ReturnType<typeof Bun.listen>;
 
@@ -1781,7 +1788,7 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
         "-e",
         `const resp = await fetch("http://localhost:${httpServer.port}", { proxy: "http://127.0.0.1:${deadProxyPort}" }); console.log(resp.status);`,
       ],
-      env: { ...bunEnv, NO_PROXY: "localhost" },
+      env: { ...noProxyEnv, NO_PROXY: "localhost" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1799,7 +1806,7 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
         "-e",
         `const resp = await fetch("http://localhost:${httpServer.port}", { proxy: "http://127.0.0.1:${deadProxyPort}" }); console.log(resp.status);`,
       ],
-      env: { ...bunEnv, NO_PROXY: `localhost:${httpServer.port}` },
+      env: { ...noProxyEnv, NO_PROXY: `localhost:${httpServer.port}` },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1818,7 +1825,7 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
         "-e",
         `try { await fetch("http://localhost:${httpServer.port}", { proxy: "http://127.0.0.1:${deadProxyPort}" }); process.exit(1); } catch { process.exit(0); }`,
       ],
-      env: { ...bunEnv, NO_PROXY: "other.com" },
+      env: { ...noProxyEnv, NO_PROXY: "other.com" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1864,16 +1871,9 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
           process.exit(0);
         `,
       ],
-      // Strip inherited NO_PROXY/no_proxy so the first fetch reliably
-      // hits the dead proxy. Setting to "" wouldn't work — isNoProxy
-      // checks lowercase first and an empty no_proxy would mask the
-      // runtime-set uppercase NO_PROXY.
-      env: (() => {
-        const e = { ...bunEnv };
-        delete e.NO_PROXY;
-        delete e.no_proxy;
-        return e;
-      })(),
+      // No inherited NO_PROXY/no_proxy, so the first fetch reliably hits the
+      // dead proxy.
+      env: noProxyEnv,
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, clearProxyEnv, isASAN, PROXY_ENV_KEYS, restoreProxyEnv, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
 import net from "node:net";
@@ -139,24 +139,13 @@ let httpsServer: Server;
 let httpProxyServer: { server: net.Server; url: string; log: string[] };
 let httpsProxyServer: { server: net.Server; url: string; log: string[] };
 
-// Tests in this file that call fetch() in-process expect the explicit `proxy`
-// option to be honored against localhost targets. An ambient NO_PROXY /
-// HTTP_PROXY / HTTPS_PROXY in the environment (as some CI/dev containers set)
-// would make those localhost fetches bypass the proxy and the assertions fail.
-// Clear them for the duration of this file; subprocess-based tests below pass
-// their own explicit `env` and are unaffected.
-//
-// Assign "" rather than `delete`: the HTTP client reads these via getenv, and
-// (matching Node semantics) only an assignment propagates to it — a `delete`
-// leaves the native value stale. An empty value disables the proxy/bypass.
-const savedProxyEnv: Record<string, string | undefined> = {};
-const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"];
+// The in-process fetches below expect the explicit `proxy` option to be
+// honored against localhost targets; subprocess-based tests pass their own
+// proxy-free `env`.
+let savedProxyEnv: ReturnType<typeof clearProxyEnv>;
 
 beforeAll(async () => {
-  for (const key of PROXY_ENV_KEYS) {
-    savedProxyEnv[key] = process.env[key];
-    process.env[key] = "";
-  }
+  savedProxyEnv = clearProxyEnv();
 
   httpServer = Bun.serve({
     port: 0,
@@ -190,11 +179,7 @@ afterAll(() => {
   httpsServer.stop();
   httpProxyServer.server.close();
   httpsProxyServer.server.close();
-
-  for (const key of PROXY_ENV_KEYS) {
-    // Restore the prior value; an absent var maps back to "" (see note above).
-    process.env[key] = savedProxyEnv[key] ?? "";
-  }
+  restoreProxyEnv(savedProxyEnv);
 });
 
 for (const proxy_tls of [false, true]) {
@@ -1244,7 +1229,7 @@ for (const scheme of ["http", "https"] as const) {
         ...bunEnv,
         // The explicit per-request proxy must not be bypassed or rerouted
         // by ambient proxy configuration on CI hosts; clear them in the
-        // spawn env so the child starts clean (see PROXY_ENV_KEYS above).
+        // spawn env so the child starts clean.
         NO_PROXY: undefined,
         no_proxy: undefined,
         HTTP_PROXY: undefined,

--- a/test/js/first_party/ws/ws-proxy.test.ts
+++ b/test/js/first_party/ws/ws-proxy.test.ts
@@ -11,6 +11,15 @@ const { HttpsProxyAgent } = require("https-proxy-agent") as {
   HttpsProxyAgent: typeof HttpsProxyAgentType;
 };
 
+// The tunneling tests connect to 127.0.0.1 through an explicit proxy and
+// expect the proxy to be hit. NO_PROXY applies to explicit proxies too, so an
+// ambient NO_PROXY covering loopback would make them bypass the proxy (same
+// as in ../../web/websocket/websocket-proxy.test.ts).
+const prevNoProxy = process.env.NO_PROXY;
+const prevNoProxyLower = process.env.no_proxy;
+process.env.NO_PROXY = "";
+process.env.no_proxy = "";
+
 // HTTP CONNECT proxy server for WebSocket tunneling
 let proxy: net.Server;
 let authProxy: net.Server;
@@ -89,6 +98,8 @@ afterAll(() => {
   httpsProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
+  if (prevNoProxy !== undefined) process.env.NO_PROXY = prevNoProxy;
+  if (prevNoProxyLower !== undefined) process.env.no_proxy = prevNoProxyLower;
 });
 
 describe("ws package proxy API", () => {

--- a/test/js/first_party/ws/ws-proxy.test.ts
+++ b/test/js/first_party/ws/ws-proxy.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { gc, tls as tlsCerts } from "harness";
+import { clearProxyEnv, gc, restoreProxyEnv, tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
 import net from "net";
 import tls from "tls";
@@ -10,15 +10,6 @@ import { createConnectProxy, createTLSConnectProxy, startProxy } from "../../web
 const { HttpsProxyAgent } = require("https-proxy-agent") as {
   HttpsProxyAgent: typeof HttpsProxyAgentType;
 };
-
-// The tunneling tests connect to 127.0.0.1 through an explicit proxy and
-// expect the proxy to be hit. NO_PROXY applies to explicit proxies too, so an
-// ambient NO_PROXY covering loopback would make them bypass the proxy (same
-// as in ../../web/websocket/websocket-proxy.test.ts).
-const prevNoProxy = process.env.NO_PROXY;
-const prevNoProxyLower = process.env.no_proxy;
-process.env.NO_PROXY = "";
-process.env.no_proxy = "";
 
 // HTTP CONNECT proxy server for WebSocket tunneling
 let proxy: net.Server;
@@ -31,8 +22,13 @@ let authProxyPort: number;
 let httpsProxyPort: number;
 let wsPort: number;
 let wssPort: number;
+// The tunneling tests connect to 127.0.0.1 through an explicit proxy and
+// assert on the proxy's response; an ambient NO_PROXY would bypass it.
+let savedProxyEnv: ReturnType<typeof clearProxyEnv>;
 
 beforeAll(async () => {
+  savedProxyEnv = clearProxyEnv();
+
   // Create HTTP CONNECT proxy
   proxy = createConnectProxy();
   proxyPort = await startProxy(proxy);
@@ -98,8 +94,7 @@ afterAll(() => {
   httpsProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
-  if (prevNoProxy !== undefined) process.env.NO_PROXY = prevNoProxy;
-  if (prevNoProxyLower !== undefined) process.env.no_proxy = prevNoProxyLower;
+  restoreProxyEnv(savedProxyEnv);
 });
 
 describe("ws package proxy API", () => {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as harness from "harness";
-import { tls as tlsCerts } from "harness";
+import { clearProxyEnv, proxyFreeEnv, restoreProxyEnv, tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
 import net from "net";
 import tls from "tls";
@@ -17,16 +17,6 @@ const bunExe = harness.bunExe;
 const bunEnv = harness.bunEnv;
 const isDockerEnabled = harness.isDockerEnabled;
 
-// The in-process WebSocket tests below pass an explicit `proxy:` option targeting
-// 127.0.0.1 and expect the proxy to be hit. NO_PROXY applies to explicit proxies
-// too, so an ambient NO_PROXY=localhost,127.0.0.1,... would bypass the proxy and
-// break those assertions. The NO_PROXY test block further down spawns subprocesses
-// with an explicit env, so clearing the runner's value here doesn't affect it.
-const prevNoProxy = process.env.NO_PROXY;
-const prevNoProxyLower = process.env.no_proxy;
-process.env.NO_PROXY = "";
-process.env.no_proxy = "";
-
 // HTTP CONNECT proxy server for WebSocket tunneling
 let proxy: net.Server;
 let authProxy: net.Server;
@@ -36,8 +26,14 @@ let proxyPort: number;
 let authProxyPort: number;
 let wsPort: number;
 let wssPort: number;
+// The in-process tests connect to 127.0.0.1 through an explicit proxy and
+// assert on the proxy's response; an ambient NO_PROXY would bypass it. The
+// NO_PROXY block further down spawns subprocesses and sets up its own env.
+let savedProxyEnv: ReturnType<typeof clearProxyEnv>;
 
 beforeAll(async () => {
+  savedProxyEnv = clearProxyEnv();
+
   // Create HTTP CONNECT proxy
   proxy = createConnectProxy();
   proxyPort = await startProxy(proxy);
@@ -98,8 +94,7 @@ afterAll(() => {
   authProxy?.close();
   wsServer?.stop(true);
   wssServer?.stop(true);
-  if (prevNoProxy !== undefined) process.env.NO_PROXY = prevNoProxy;
-  if (prevNoProxyLower !== undefined) process.env.no_proxy = prevNoProxyLower;
+  restoreProxyEnv(savedProxyEnv);
 });
 
 describe("WebSocket proxy API", () => {
@@ -774,7 +769,7 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
          ws.onopen = () => { ws.close(); process.exit(0); };
          ws.onerror = () => { process.exit(1); };`,
       ],
-      env: { ...bunEnv, NO_PROXY: "127.0.0.1" },
+      env: { ...bunEnv, ...proxyFreeEnv, NO_PROXY: "127.0.0.1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -793,7 +788,7 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
          ws.onopen = () => { ws.close(); process.exit(0); };
          ws.onerror = () => { process.exit(1); };`,
       ],
-      env: { ...bunEnv, NO_PROXY: `127.0.0.1:${wsPort}` },
+      env: { ...bunEnv, ...proxyFreeEnv, NO_PROXY: `127.0.0.1:${wsPort}` },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -814,7 +809,7 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
          ws.onopen = () => { process.exit(1); };
          ws.onerror = () => { process.exit(0); };`,
       ],
-      env: { ...bunEnv, NO_PROXY: "other.host.com" },
+      env: { ...bunEnv, ...proxyFreeEnv, NO_PROXY: "other.host.com" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -833,7 +828,7 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
          ws.onopen = () => { ws.close(); process.exit(0); };
          ws.onerror = () => { process.exit(1); };`,
       ],
-      env: { ...bunEnv, NO_PROXY: "*" },
+      env: { ...bunEnv, ...proxyFreeEnv, NO_PROXY: "*" },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/websocket/websocket-syscall-fault.test.ts
+++ b/test/js/web/websocket/websocket-syscall-fault.test.ts
@@ -1,6 +1,6 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
+import { bunEnv, bunExe, tls as certs, isWindows, proxyFreeEnv } from "harness";
 import crypto from "node:crypto";
 import tls from "node:tls";
 import { createConnectProxy, startProxy } from "./proxy-test-utils";
@@ -27,7 +27,9 @@ async function runWSClient(
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],
-    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", NODE_TLS_REJECT_UNAUTHORIZED: "0", CA: certs.cert },
+    // proxyFreeEnv: the CONNECT proxy test below must not be bypassed by an
+    // ambient NO_PROXY covering 127.0.0.1.
+    env: { ...bunEnv, ...proxyFreeEnv, BUN_DEBUG_QUIET_LOGS: "1", NODE_TLS_REJECT_UNAUTHORIZED: "0", CA: certs.cert },
     stderr: "pipe",
     stdout: "pipe",
   });


### PR DESCRIPTION
## Problem

Running the proxy tests on a machine whose environment already carries proxy settings (proxied CI / dev containers typically ship `NO_PROXY=localhost,127.0.0.1,::1,0.0.0.0` together with `HTTP_PROXY`/`HTTPS_PROXY`) fails tests that have nothing to do with the runtime:

```
$ bun test test/js/bun/http/proxy.test.js
(fail) proxy non-TLS auth can fail                          # status 200 instead of 407
(fail) simultaneous proxy auth failures should not hang     # [200 x5] instead of [407 x5]

$ bun test test/js/first_party/ws/ws-proxy.test.ts
(fail) ws package through HTTP CONNECT proxy > proxy auth failure returns error
(fail) ws package through HTTP CONNECT proxy > proxy wrong credentials returns error
(fail) ws package through HTTPS proxy (TLS proxy) > ws:// through HTTPS proxy fails without CA certificate
```

Same result on the released 1.4.0 and on a debug build of main; both files pass as soon as the variables are unset, so this is test environment hygiene only.

The subprocess variant of the same problem shows up with the other common ambient value, a lowercase `no_proxy`:

```
$ no_proxy=localhost,127.0.0.1 bun test test/js/bun/http/proxy.test.ts
(fail) NO_PROXY with explicit proxy option > NO_PROXY non-match does not bypass explicit proxy
$ no_proxy=localhost,127.0.0.1 bun test test/js/web/websocket/websocket-proxy.test.ts
(fail) WebSocket NO_PROXY bypass > NO_PROXY not matching still uses proxy (auth fails)
```

## Cause

These tests connect to a loopback origin through an explicit `proxy:` option and assert on what the proxy does (407 / 403 / TLS failure). `NO_PROXY` applies to explicit proxies as well (#26608), so an ambient `NO_PROXY` covering loopback sends the request straight to the origin, which answers 200. `proxy.test.js` and `ws-proxy.test.ts` never cleared the variables; `proxy.test.ts`, `websocket-proxy.test.ts` and the `proxy-stress-*` files already did.

The subprocess tests are exposed through `bunEnv`, which is a copy of `process.env`: the NO_PROXY blocks in `proxy.test.ts` and `websocket-proxy.test.ts` set uppercase `NO_PROXY` on top of it, but the env loader reads a non-empty lowercase `no_proxy` first, so an inherited lowercase value wins over the one the test sets. The `test proxy env` cases in `proxy.test.js` set `http_proxy=""`, which falls through to an inherited uppercase `HTTP_PROXY`, and the in-process proxies' own upstream `fetch()` would use an ambient `HTTP_PROXY` too. `websocket-syscall-fault.test.ts` spawns its CONNECT proxy client with plain `bunEnv`, so under an ambient `NO_PROXY` that regression test passes while connecting directly instead of through the tunnel it exists to cover.

`websocket-proxy.test.ts` also cleared `NO_PROXY` in the module body but restored it in `afterAll`. With `bun test -t <pattern>` over several files, a file whose tests are all filtered out runs neither hook, so the blanked value leaked into every later file in that process (reproduced: a later file's plain loopback `fetch()` got routed to the ambient proxy). The first revision of this branch copied that shape into `ws-proxy.test.ts`; both now clear in `beforeAll`.

## Fix

- `clearProxyEnv()` / `restoreProxyEnv()` / `proxyFreeEnv` / `PROXY_ENV_KEYS` move from `proxy-stress-helpers.ts` into `harness` so files outside `test/js/bun/http` can use them; the stress helpers re-export them for their seven existing importers. `clearProxyEnv` assigns `""` because only an assignment to `process.env` reaches the native env loader (a `delete` leaves the old value in effect, checked on both the released and a debug build); `proxyFreeEnv` removes the keys from a child env rather than blanking them because the child environment is case-insensitive on Windows.
- `proxy.test.js`: clear in `beforeAll`, restore in `afterAll`, `...proxyFreeEnv` in the six subprocess envs.
- `ws-proxy.test.ts`, `websocket-proxy.test.ts`: clear in `beforeAll`, restore in `afterAll`; the four NO_PROXY children in `websocket-proxy.test.ts` start from a proxy-free env.
- `proxy.test.ts`: replaces its private copy of the clear/restore logic with the shared one; the `NO_PROXY with explicit proxy option` children start from a proxy-free env (the fourth test in that block already built one inline and now shares it).
- `websocket-syscall-fault.test.ts`: `...proxyFreeEnv` in the client env.

While registering the six `proxy non-TLS` cases in `proxy.test.js` I noticed they have been skipped since #25884: the refactor registered them through the `PROXY_URL`-gated `test` alias that exists for the two httpbin tests, although they only use the in-process servers. They are registered unconditionally again, named, and both test proxies now mark forwarded responses with `x-proxy-used` so the cases check the proxy was really used rather than only that a body came back (the origin returns the same body either way).

Intentionally not touched: `test/cli/install/bun-install-proxy.test.ts` sets uppercase `HTTP(S)_PROXY` on top of `bunEnv` for a docker-gated install from the real registry through squid; only an ambient lowercase `http_proxy` could interfere with it, and it cannot be run here. The S3 tests also fail in a proxied environment, but for a runtime reason (the S3 client ignores `NO_PROXY`, #32045, fix in #32046).

Per file rather than globally in `bunEnv` / `test/preload.ts` on purpose: `bunEnv` cannot carry blank values (the Windows case-collision above would break every test that sets one spelling on top of it), removing the keys from `bunEnv` would not reach in-process requests (the preload removes variables with `delete`, which the env loader does not observe), and the harness itself relies on the ambient settings to reach the network on proxied machines (`nodeExeMatchingAbi` downloads through `bunEnv`). A preload that blanks the variables in-process while dropping them from `bunEnv` would cover the whole tree at once, but it changes the environment of every test process and is a separate decision; this PR keeps the existing per-file convention and makes the helpers shared so the remaining sites are a grep for `...bunEnv` next to a proxy variable.

## Verification

With the container's ambient `NO_PROXY`/`HTTP_PROXY`/`HTTPS_PROXY`, on main (debug build): `proxy.test.js` 14 pass / 8 skip / 2 fail, `ws-proxy.test.ts` 16 pass / 3 fail; with `no_proxy=localhost,127.0.0.1,::1` added, `proxy.test.ts` and `websocket-proxy.test.ts` fail one test each as shown above. With this branch, in that environment: `proxy.test.js` 22 pass / 2 skip (the httpbin tests), `ws-proxy.test.ts` 19 pass, `websocket-proxy.test.ts` 31 pass / 4 skip (docker), `proxy.test.ts` 68 pass, `websocket-syscall-fault.test.ts` 15 pass, `proxy-stress-errors.test.ts` 53 pass through the re-export; the same with the lowercase `no_proxy` added, with all variables unset, and with an ambient `HTTP_PROXY` pointing at a closed port and no `NO_PROXY`. Without the `beforeAll` clear, the six re-enabled cases fail in the proxied environment along with the original two. `bun test -t zzz <ws-proxy.test.ts> <file in another directory>` now leaves the later file's `NO_PROXY` untouched; with the module-scope shape it saw `""`. CI has none of these variables set, so for CI this is behavior-neutral (the first revision's build passed on every lane); the hygiene only matters in proxied environments, which is where the failures were observed.
