### PR TITLE
bake: give every server HMR patch its own source URL so older patches keep remapping

### DIFF
--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -15,6 +15,7 @@
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/JSModuleNamespaceObject.h"
 #include "ImportMetaObject.h"
+#include <atomic>
 
 namespace Bake {
 
@@ -84,7 +85,12 @@ extern "C" JSC::EncodedJSValue BakeLoadServerHmrPatchWithSourceMap(GlobalObject*
   JSC::VM&vm = global->vm();
   auto scope = DECLARE_THROW_SCOPE(vm);
 
-  String string = "bake://server.patch.js"_s;
+  // The VM's source map table is keyed by this URL. Modules that later hot
+  // updates do not re-bundle keep running the patch that loaded them, so each
+  // patch needs its own entry instead of replacing the previous patch's map.
+  // Process-wide counter: every dev server in the process shares the VM's table.
+  static std::atomic<unsigned> patchCount { 0 };
+  String string = makeString("bake://server.patch."_s, patchCount++, ".js"_s);
   JSC::SourceOrigin origin = JSC::SourceOrigin(WTF::URL(string));
   
   // Use DevServerSourceProvider with the source map JSON

--- a/test/bake/dev/server-sourcemap.test.ts
+++ b/test/bake/dev/server-sourcemap.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "bun:test";
 import { isASAN } from "harness";
-import { devTest } from "../bake-harness";
+import path from "node:path";
+import { Dev, devTest, minimalFramework } from "../bake-harness";
 
 devTest("server-side source maps show correct error lines", {
   files: {
@@ -105,6 +106,11 @@ export async function getStaticPaths() {
 
     expect(hasCorrectThrowLine).toBe(true);
     expect(hasCorrectCallLine).toBe(true);
+    // react-server-dom was loaded by the initial bundle and is not part of the
+    // update, so its frame still has to remap through the initial bundle's map.
+    expect(cleanLines).toMatch(
+      /at react-stack-bottom-frame \(.*react-server-dom-webpack-server\.node\.unbundled\.development\.js:\d+:\d+\)/,
+    );
   },
 });
 
@@ -149,12 +155,12 @@ function helperFunction() {
   },
 });
 
-// Each round re-registers the file's source provider over the previous one
-// and re-materializes the parsed map from it, so stack remapping must stay
-// correct through repeated provider replacement, not just the first install.
+// Each round evaluates a new server patch, which registers its own source
+// provider next to the ones of the earlier rounds, so the frame must be
+// remapped through the map of the round that actually loaded the code.
 // `filler` comment lines shift the throwing function down one line per round,
-// so a stale map from an earlier round would remap the frame to the wrong
-// line and fail that round's assertion.
+// so remapping through any earlier round's map would report the wrong line
+// and fail that round's assertion.
 function churnPage(name: string, filler: number) {
   const fillerLines = Array.from({ length: filler }, (_, n) => `// filler ${n}\n`).join("");
   return `export default function ChurnPage() {
@@ -200,6 +206,70 @@ devTest("server-side source maps stay correct across repeated reloads", {
     }
   },
   timeoutMultiplier: 2,
+});
+
+function withFillerLines(source: string, count: number) {
+  return Array.from({ length: count }, (_, n) => `// filler ${n}\n`).join("") + source;
+}
+
+const throwingLib = `export function boom() {
+  throw new Error("boom");
+}`;
+
+const throwingRoute = `import { boom } from "../lib/boom";
+export default function (req, meta) {
+  boom();
+  return new Response("unreachable");
+}`;
+
+// Requests "/" and returns the three synchronous user frames of its error
+// (lib/boom.ts, routes/index.ts, the framework's minimal.server.ts) from the
+// JSON payload of the dev error page, reduced to the file (last two path
+// segments) and line. A frame that did not remap keeps its raw `bake://` URL.
+async function fetchErrorFrames(dev: Dev): Promise<{ file: string; line: number }[]> {
+  const response = await dev.fetch("/");
+  expect(response.status).toBe(500);
+  const html = await response.text();
+  const payload = JSON.parse(/<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/.exec(html)![1]);
+  const { message, stack } = payload.problems.exceptions[0];
+  expect(message).toBe("boom");
+  return stack.frames.slice(0, 3).map(({ file, position }: any) => ({
+    file: path.isAbsolute(file) ? file.split(/[\\/]/).slice(-2).join("/") : file,
+    line: position.line,
+  }));
+}
+
+// Each server hot update is evaluated as one patch whose source map only covers
+// the files in that update. Files that are not part of an update keep running
+// the code of the patch that loaded them, so their frames must still remap
+// through that patch's map once newer patches have been loaded. Lines are
+// compared relative to the first round: prepending filler lines to a file
+// moves its frame by exactly that many lines, but only when the frame is
+// remapped through the map of the patch that loaded the file's current code.
+devTest("server-side source maps keep working for modules loaded by an earlier patch", {
+  framework: minimalFramework,
+  files: {
+    "lib/boom.ts": throwingLib,
+    "routes/index.ts": throwingRoute,
+  },
+  async test(dev) {
+    const [lib, route, framework] = await fetchErrorFrames(dev);
+    expect([lib.file, route.file, framework.file]).toEqual([
+      "lib/boom.ts",
+      "routes/index.ts",
+      "bake/minimal.server.ts",
+    ]);
+
+    // Re-bundles only the route; lib/boom.ts and minimal.server.ts stay in the
+    // initial patch.
+    await dev.write("routes/index.ts", withFillerLines(throwingRoute, 3));
+    const routeAfterUpdate = { file: route.file, line: route.line + 3 };
+    expect(await fetchErrorFrames(dev)).toEqual([lib, routeAfterUpdate, framework]);
+
+    // Re-bundles only the lib; the route keeps running the previous patch.
+    await dev.write("lib/boom.ts", withFillerLines(throwingLib, 2));
+    expect(await fetchErrorFrames(dev)).toEqual([{ file: lib.file, line: lib.line + 2 }, routeAfterUpdate, framework]);
+  },
 });
 
 // ~DevServerSourceProvider ran after the Zig::GlobalObject cell was swept.


### PR DESCRIPTION
### Repro

Dev server with a server-side framework (`minimalFramework` from the bake test harness is enough), `lib/boom.ts` throwing and `routes/index.ts` importing and calling it. The first request prints the stack correctly:

```
at boom2 (<root>/lib/boom.ts:1:8)
at routes_default (<root>/routes/index.ts:2:8)
at render (test/bake/minimal.server.ts:7:3)
```

After a hot update that only touches `routes/index.ts` (so `lib/boom.ts` and the framework entry are not re-bundled), the same request prints:

```
at boom2 (bake://server.patch.js:42:13)
at routes_default (<root>/routes/index.ts:5:8)
at render (<root>/routes/index.ts:4:1)
```

`boom2` is printed raw and `render`, which lives in `minimal.server.ts`, is attributed to a file of the new patch. With `framework: "react"` the same thing happens to every react-server-dom frame after the first hot update (`at react-stack-bottom-frame (bake://server.patch.js:3054:29)`). The dev error page embeds the same wrong frames in its JSON payload, and `error.stack` goes through the same lookup.

### Cause

`BakeLoadServerHmrPatchWithSourceMap` (`src/runtime/bake/BakeSourceProvider.cpp`) evaluated every server patch under the same URL, `bake://server.patch.js`. Each patch's `DevServerSourceProvider` registers itself in the VM's `SavedSourceMap` keyed by that URL, and `put_source_provider` replaces the existing entry, so after the second patch every frame with that URL, whichever patch it actually belongs to, is remapped through the newest patch's map. Modules that a hot update does not re-bundle keep running the code of the patch that loaded them (`replaceModules` only swaps the updated module ids), so that code is live for the whole session while its map is gone after the first unrelated update. Lines past the end of the newer map print raw; lines inside it get attributed to one of the newer patch's files.

### Fix

Each patch gets its own URL, `bake://server.patch.<n>.js`, from a counter, so each patch keeps its own table entry. The entry is removed when the patch's provider is destroyed, which is what `~DevServerSourceProvider` already does (`remove_source_provider` compares the provider identity, so with unique keys the removal now actually hits instead of being a no-op on the replaced entry). This mirrors the client side, where every hot update chunk already gets its own `/_bun/client/<id>.js.map`.

Why a counter and not the dev server's own bundle generation: the table is per VM and every dev server in a process shares it, so two dev servers would collide on the same generation number. A content hash (what the client uses for its ids) would reintroduce the collision for identical re-bundles, which is exactly the case where two live patches must stay distinct.

Memory: a patch's entry (and its lazily parsed mappings, once a frame from it has been looked up) now lives as long as the patch's code, rather than one bundle round. The source map JSON itself was already retained for that long by the provider; this only keeps it reachable through the table.

`BakeLoadServerHmrPatch` (the variant without a source map) is left as is. It is unreachable: `receive_chunk` pushes a `current_chunk_source_maps` entry (a real map or a line count) for every server chunk it adds to `current_chunk_code`, so whenever there is a patch to load there is also a map and the `else` branch in `finalize_bundle` never runs. It also uses the production `Bake::SourceProvider`, which registers under its URL too but never has a dev server map to offer and, unlike `DevServerSourceProvider`, has no destructor that unregisters it; giving that path unique URLs would only accumulate entries. Removing the dead variant and fixing that class's unregistration are separate changes.

### Verification

`test/bake/dev/server-sourcemap.test.ts`:
- new case (`minimalFramework`, three requests): update only the route, then update only the lib, and check all three frames each time. The route frame has to move by the number of lines prepended to it, the lib frame has to stay put and then move once the lib itself is updated, and the framework frame has to keep pointing at `minimal.server.ts`. Lines are asserted relative to the first round because the absolute numbers are the subject of a separate dev server source map fix.
- the existing react HMR case additionally checks that the `react-stack-bottom-frame` frame still remaps after the update.

Without the fix, both cases fail (`bake://server.patch.js:42` and `routes/index.ts:4` show up in the first one's diff); with it the file passes, including the ASAN destructor case, as do `test/bake/dev/sourcemap.test.ts`, `bundle.test.ts`, `react-response.test.ts` and `test/bake/deinitialization.test.ts` on a debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/server-sourcemap.test.ts
bun test v1.4.0 (dbba65cbb)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-jQ5tAf
bun add v1.4.0 (dbba65cbb)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [439.00ms]
bun install v1.4.0 (dbba65cbb)

Checked 6 installs across 7 packages (no changes) [218.00ms]
[0;30mdev|[0m Started development server: http://localhost:39035
[0;30mdev|[0m [32mBundled page in 3201ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSO
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-HUdORi
bun add v1.4.0-canary.1 (9008ae7ab)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [28.00ms]
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 6 installs across 7 packages (no changes) [6.00ms]
[0;30mdev|[0m Started development server: http://localhost:33149
[0;30mdev|[0m [32mBundled page in 90ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSON[0m[3m[1m.stringify[0m(params)}[0m<[0m/h1>[0m[2m;[0m
[0;30mdev|[0m [0m[1m4 |[0m }
[0;30mdev|[0m [0m[1m5 |[0m 
[0;30mdev|[0m [0m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/server-sourcemap.test.ts
bun test v1.4.0 (dbba65cbb)

test/bake/dev/server-sourcemap.test.ts:
Dev server testing directory: /tmp/bun-dev-test-8BjQIB
bun add v1.4.0 (dbba65cbb)
Resolving dependencies
Resolved, downloaded and extracted [0]
Saved lockfile

installed react@0.0.0-experimental-603e6108-20241029
installed react-dom@0.0.0-experimental-603e6108-20241029
installed react-server-dom-bun@0.0.0-experimental-603e6108-20241029
installed react-refresh@0.0.0-experimental-603e6108-20241029

6 packages installed [134.00ms]
bun install v1.4.0 (dbba65cbb)

Checked 6 installs across 7 packages (no changes) [97.00ms]
[0;30mdev|[0m Started development server: http://localhost:46027
[0;30mdev|[0m [32mBundled page in 3496ms[0m[2m:[0m pages/[...slug].tsx [2m+ 2 more[0m
[0;30mdev|[0m [0m[1m1 |[0m [0m[35mexport[0m [0m[35mdefault[0m [0m[35masync[0m [0m[35mfunction[0m MyPage(params) {
[0;30mdev|[0m [0m[1m2 |[0m   myFunc()[0m[2m;[0m
[0;30mdev|[0m [0m[1m3 |[0m   [0m[35mreturn[0m [0m<[0mh1>{JSON
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     dbba65cbba
  features     baseline

22 deps, 107 codegen, 1176 objects in 934ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen .bind.ts → GeneratedBindings.cpp
[3/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [23.00ms]
[4/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [3.00ms]
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[8/1238] fetch zlib
[zlib] up to date
[9/1238] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTP
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/BakeSourceProvider.cpp |  8 +++-
 test/bake/dev/server-sourcemap.test.ts  | 82 ++++++++++++++++++++++++++++++---
 2 files changed, 83 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/bake/BakeSourceProvider.cpp      2      6      0
test/bake/dev/server-sourcemap.test.ts       3      7      0
```

</details>

**self-review** · no surviving concerns

33 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->