### PR TITLE
process.binding('uv'): fix segfault when worker.terminate() lands inside getErrorMap()

### DIFF
--- a/src/jsc/bindings/ProcessBindingUV.cpp
+++ b/src/jsc/bindings/ProcessBindingUV.cpp
@@ -153,20 +153,30 @@ JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFra
 JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
-    auto map = JSC::JSMap::create(vm, globalObject->mapStructure());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* map = JSC::JSMap::create(vm, globalObject->mapStructure());
 
-    // Inlining each of these via macros costs like 300 KB.
-    const auto putProperty = [](JSC::VM& vm, JSC::JSMap* map, JSC::JSGlobalObject* globalObject, ASCIILiteral name, int value, ASCIILiteral desc) -> void {
-        auto arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);
-        // RETURN_IF_EXCEPTION
-        arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(name)));
-        arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(desc)));
-        map->set(globalObject, JSC::jsNumber(value), arr);
+    struct Entry {
+        ASCIILiteral name;
+        int value;
+        ASCIILiteral desc;
+    };
+    static constexpr Entry entries[] = {
+#define ENTRY(name, desc) { #name##_s, UV_##name, desc##_s },
+        BUN_UV_ERRNO_MAP(ENTRY)
+#undef ENTRY
     };
 
-#define PUT_PROPERTY(name, desc) putProperty(vm, map, globalObject, #name##_s, UV_##name, desc##_s);
-    BUN_UV_ERRNO_MAP(PUT_PROPERTY)
-#undef PUT_PROPERTY
+    for (const auto& [name, value, desc] : entries) {
+        auto* arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);
+        RETURN_IF_EXCEPTION(scope, {});
+        arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(name)));
+        RETURN_IF_EXCEPTION(scope, {});
+        arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(desc)));
+        RETURN_IF_EXCEPTION(scope, {});
+        map->set(globalObject, JSC::jsNumber(value), arr);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
 
     return JSValue::encode(map);
 }

--- a/test/js/node/process-binding.test.ts
+++ b/test/js/node/process-binding.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
 describe("process.binding", () => {
   test("process.binding('constants')", () => {
     /* @ts-ignore */
@@ -28,4 +31,47 @@ describe("process.binding", () => {
     expect(map).toBeDefined();
     expect(map.get(uv.UV_EISCONN)).toEqual(["EISCONN", "socket is already connected"]);
   });
+
+  // A pending worker.terminate() surfaces inside getErrorMap() at one of its ~85 array allocations.
+  // This used to segfault the whole process, hence the subprocess. The timeout covers booting four
+  // workers on debug and ASAN builds.
+  const workerTerminateTimeout = 20_000;
+  test(
+    "process.binding('uv').getErrorMap() survives worker.terminate() landing mid-call",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("node:worker_threads");
+            const source = \`
+              const { parentPort } = require("node:worker_threads");
+              const uv = process.binding("uv");
+              parentPort.postMessage("busy");
+              for (;;) uv.getErrorMap();
+            \`;
+            const exitCodes = [];
+            for (let i = 0; i < 4; i++) {
+              const worker = new Worker(source, { eval: true });
+              worker.on("message", () => worker.terminate());
+              worker.on("exit", code => {
+                exitCodes.push(code);
+                if (exitCodes.length === 4) console.log(JSON.stringify(exitCodes));
+              });
+            }
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[1,1,1,1]\n");
+      expect(exitCode).toBe(0);
+    },
+    workerTerminateTimeout,
+  );
 });


### PR DESCRIPTION
### Crash

Calling `worker.terminate()` while the worker is inside `process.binding("uv").getErrorMap()` segfaults the whole process. Reproduces on the current release build every time (20 of 20 runs with a single worker):

```js
const { Worker, isMainThread, parentPort } = require("worker_threads");
if (isMainThread) {
  const w = new Worker(__filename);
  w.on("message", () => w.terminate());
  w.on("exit", code => console.log("worker exited", code));
} else {
  const uv = process.binding("uv");
  parentPort.postMessage("busy");
  for (;;) uv.getErrorMap();
}
```

```
panic: Segmentation fault at address 0x4
```

Under UBSan the first frame is `ProcessBindingUV.cpp:162: member call on null pointer of type 'JSC::JSObject'` in `Bun::ProcessBindingUV::jsGetErrorMap`. Besides direct `process.binding("uv")` users, `internal/fs/watch.ts` calls this binding on its error path.

### Cause

`jsGetErrorMap` built each `[name, message]` entry in a `void` lambda:

```cpp
auto arr = JSC::constructEmptyArray(globalObject, nullptr, 2);
// RETURN_IF_EXCEPTION
arr->putDirectIndex(globalObject, 0, ...);
```

`constructEmptyArray` returns null after its own `RETURN_IF_EXCEPTION` (or when it throws out of memory), and `RETURN_IF_EXCEPTION` also services VM traps (`ExceptionScope.h` goes through `vm.hasExceptionsAfterHandlingTraps()`), so the `notifyNeedTermination()` issued by `terminate()` materializes as a pending termination exception inside one of the ~85 `constructEmptyArray` calls per `getErrorMap()`. The lambda then dereferenced the null array. `JSMap::set` can throw too (it materializes and grows the storage) and was unchecked as well.

### Fix

Replace the lambda with a `constexpr` table built from the same `BUN_UV_ERRNO_MAP` list and a plain loop in the host function, with a `RETURN_IF_EXCEPTION` after `constructEmptyArray`, each `putDirectIndex` and `JSMap::set` (the shape `createPatternFilledArray` in JSC and the other `constructEmptyArray` callers in this tree use; REVIEW.md also asks for no check macros inside lambdas). The termination now propagates like any other exception and the worker exits with code 1. The map contents and iteration order are byte-identical to before (compared the JSON of `[...getErrorMap()]` from the release build and this build, 85 entries).

### Test

`test/js/node/process-binding.test.ts` gains a case that spawns bun, starts four workers that loop on `getErrorMap()`, terminates each on its first message and expects `[1,1,1,1]` with an empty stderr and exit code 0. Without the fix the child segfaults (10 of 10 runs on the release build); with the fix it passes on the debug build. `BUN_JSC_validateExceptionChecks=1` is clean on the new loop, and `test/js/node/test/parallel/test-uv-errmap.js` and `test/js/node/watch/fs.watch.test.ts` still pass.

While auditing for the same shape I found two more hoisted-but-unchecked `constructEmptyArray` results (`ProcessBindingHTTPParser.cpp` `methods`/`allMethods` lazy builders, and `JSC__JSValue__upsertBunStringArray` in `BunString.cpp`). They have much narrower windows and are being handled separately; this PR only changes `ProcessBindingUV.cpp`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process-binding.test.ts
bun test v1.4.0 (d1185a71e)

test/js/node/process-binding.test.ts:
(pass) process.binding > process.binding('constants') [12.84ms]
(pass) process.binding > process.binding('uv') [19.35ms]
66 |         stdout: "pipe",
67 |         stderr: "pipe",
68 |       });
69 | 
70 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
71 |       expect(stderr).toBe("");
                          ^
error: expect(received).toBe(expected)

- ""
+ "../../src/jsc/bindings/ProcessBindingUV.cpp:162:14: runtime error: member call on null pointer of type 'JSC::JSObject'
+ SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../src/jsc/bindings/ProcessBindingUV.cpp:162:14 
+ "

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/node/process-binding.test.ts:71:22)
(fail) process.binding > process.binding('uv').getErrorMap() survives worker.terminate() landing mid-call [3784.05ms]

 2 pass
 1 fail
 16 expect() calls
Ran 3 tests a
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/process-binding.test.ts:
(pass) process.binding > process.binding('constants') [0.18ms]
(pass) process.binding > process.binding('uv') [0.23ms]
66 |         stdout: "pipe",
67 |         stderr: "pipe",
68 |       });
69 | 
70 |       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
71 |       expect(stderr).toBe("");
                          ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Canary v1.4.0-canary.1 (9008ae7ab) Linux x64
+ Linux Kernel v6.17.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "-e" "\n            const { Worker } = require(\"node:worker_threads\");\n            const source = `\n              const { parentPort } = require(\"node:worker_threads\");\n"...
+ Features: Bun.stderr(8) Bun.stdin(8) Bun.stdout(8) bunfig jsc tsconfig workers_spawned(4) 
+ Builtins: "bun:main" "node:worker_threads" 
+ 
+ Elapsed: 61ms | User: 160ms | Sys: 20ms
+ RSS: 60.31 MB | Peak: 55.82 MB | Commit: 120.98 MB | Faults: 0 | Machine: 34.36 GB

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process-binding.test.ts
bun test v1.4.0 (d1185a71e)

test/js/node/process-binding.test.ts:
(pass) process.binding > process.binding('constants') [11.75ms]
(pass) process.binding > process.binding('uv') [38.40ms]
(pass) process.binding > process.binding('uv').getErrorMap() survives worker.terminate() landing mid-call [4600.59ms]

 3 pass
 0 fail
 18 expect() calls
Ran 3 tests across 1 file. [7.47s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 935ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/82] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/82] gen cpp.rs (cppbind)
[3/82] gen JS modules (bundle-modules)
Preprocess modules (12995ms)
Bundle modules (57ms)
Postprocesss modules (184ms)
Bundle Functions (769ms)
Generate Code (33ms)

[14.06s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/70] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ProcessBindingUV.cpp | 30 +++++++++++++++--------
 test/js/node/process-binding.test.ts  | 46 +++++++++++++++++++++++++++++++++++
 2 files changed, 66 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/ProcessBindingUV.cpp      1      1      0
test/js/node/process-binding.test.ts       3      6      0
```

</details>

<!-- robobun:evidence:end -->