### PR TITLE
dns: add the loopback family AI_ADDRCONFIG filters out of localhost lookups

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -297,6 +297,7 @@ export function getJS2NativeRust() {
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_getRuntimeDefaultResultOrderOption",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__Resolver_newResolver",
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting",
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isLocalhostNameForTesting",
   ]);
 
   const srcRoot = path.resolve(import.meta.dir, "..");

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -737,17 +737,14 @@ export const stringsInternals = {
   ) => string,
 };
 
-/**
- * Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order.
- * `firstFamily` is what the loopback-name path passes to keep AI_ADDRCONFIG's family at the head of the list.
- */
+/** Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order. */
 export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.seedCacheForTesting", 3) as (
   hostname: string,
   addresses: string[],
   firstFamily?: 4 | 6,
 ) => number[];
 
-/** The names the connect-path resolver exempts from AI_ADDRCONFIG's loopback filtering ("localhost" and below). */
+/** The names the connect-path resolver treats as loopback names ("localhost" and below); see `add_filtered_loopback_family`. */
 export const dnsIsLocalhostName = $newRustFunction(
   "runtime/dns_jsc/dns.rs",
   "internal.isLocalhostNameForTesting",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -737,11 +737,22 @@ export const stringsInternals = {
   ) => string,
 };
 
-/** Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order. */
-export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.seedCacheForTesting", 2) as (
+/**
+ * Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order.
+ * `firstFamily` is what the loopback-name path passes to keep AI_ADDRCONFIG's family at the head of the list.
+ */
+export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.seedCacheForTesting", 3) as (
   hostname: string,
   addresses: string[],
+  firstFamily?: 4 | 6,
 ) => number[];
+
+/** The names the connect-path resolver exempts from AI_ADDRCONFIG's loopback filtering ("localhost" and below). */
+export const dnsIsLocalhostName = $newRustFunction(
+  "runtime/dns_jsc/dns.rs",
+  "internal.isLocalhostNameForTesting",
+  1,
+) as (hostname: string) => boolean;
 
 export const fetchH2Internals = {
   liveCounts: $newRustFunction("http/H2Client.rs", "TestingAPIs.liveCounts", 0) as () => {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2398,9 +2398,10 @@ pub mod internal {
         hints_copy
     }
 
-    /// "localhost" or a name under it (RFC 6761 §6.3), as `normalize_dns_name` special-cases for `dns.lookup`.
+    /// "localhost" or a name under it, with or without the root dot (RFC 6761 §6.3).
     fn is_localhost_name(host: &[u8]) -> bool {
         const LOCALHOST: &[u8] = b"localhost";
+        let host = host.strip_suffix(b".").unwrap_or(host);
         let Some(prefix_len) = host.len().checked_sub(LOCALHOST.len()) else {
             return false;
         };

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2398,8 +2398,7 @@ pub mod internal {
         hints_copy
     }
 
-    /// "localhost" or a name under it (RFC 6761 §6.3), the same set `normalize_dns_name`
-    /// special-cases for `dns.lookup`.
+    /// "localhost" or a name under it (RFC 6761 §6.3), as `normalize_dns_name` special-cases for `dns.lookup`.
     fn is_localhost_name(host: &[u8]) -> bool {
         const LOCALHOST: &[u8] = b"localhost";
         let Some(prefix_len) = host.len().checked_sub(LOCALHOST.len()) else {
@@ -2410,8 +2409,7 @@ pub mod internal {
             && (prefix.is_empty() || prefix.ends_with(b"."))
     }
 
-    /// `bun:internal-for-testing`: [`is_localhost_name`]. What it changes about a
-    /// real lookup is only observable on a host where AI_ADDRCONFIG filters loopback.
+    /// `bun:internal-for-testing`: [`is_localhost_name`], whose effect on a real lookup only shows on a host where AI_ADDRCONFIG filters loopback.
     pub(crate) fn is_localhost_name_for_testing(
         global: &JSGlobalObject,
         frame: &CallFrame,
@@ -2424,23 +2422,7 @@ pub mod internal {
         Ok(JSValue::js_boolean(is_localhost_name(hostname.slice())))
     }
 
-    /// glibc's AI_ADDRCONFIG judges each family by the machine's non-loopback
-    /// addresses, so where ::1 is the only IPv6 address (a container, typically) it
-    /// drops the `::1 localhost` line of /etc/hosts even though ::1 is up, and a
-    /// listener bound to the name sits exactly there (`bsd_create_listen_socket`
-    /// prefers that line). macOS libinfo exempts localhost from its equivalent
-    /// filter and musl's AI_ADDRCONFIG probes loopback itself; for glibc, a loopback
-    /// name whose filtered answer holds a single family gets the unfiltered answer.
-    ///
-    /// Returns the filtered answer's family so it stays at the head of the list:
-    /// the other loopback family is only ever an extra candidate, and a consumer
-    /// that takes just the first entry (`us_quic_connect_result`) connects where it
-    /// did before. `AF_UNSPEC` when the answer was left alone.
-    ///
-    /// # Safety
-    /// `*addrinfo` must be the non-null list a successful `getaddrinfo()` call with
-    /// `hints`, `host_ptr` and `service` returned; on return it is again a list the
-    /// caller owns and frees.
+    /// glibc's AI_ADDRCONFIG drops a family present only on loopback, so a localhost name answered with one family gets the unfiltered list; returns the answered family to keep at the head, else `AF_UNSPEC`.
     #[cfg(not(windows))]
     unsafe fn add_filtered_loopback_family(
         hints: &mut AddrInfo,
@@ -2451,7 +2433,9 @@ pub mod internal {
         if hints.ai_family != netc::AF_UNSPEC {
             return netc::AF_UNSPEC;
         }
-        // SAFETY: `*addrinfo` is a getaddrinfo()-owned list per the contract above.
+        // SAFETY: the caller passes the non-null list a successful getaddrinfo() with
+        // `hints`, `host_ptr` and `service` returned, and frees whatever list is left
+        // in `*addrinfo` on return.
         let filtered_family = unsafe { (**addrinfo).ai_family };
         let mut node = *addrinfo;
         while !node.is_null() {
@@ -2573,11 +2557,7 @@ pub mod internal {
     // Pack getaddrinfo results into one allocation with address families
     // interleaved (RFC 8305 §4) so an unroutable family can never fill all
     // CONCURRENT_CONNECTIONS parallel connect attempts. See #4938 / #33278.
-    //
-    // `first_family` takes index 0 and the even slots; `AF_UNSPEC` means the
-    // family the list itself starts with. The slot arithmetic below is a
-    // bijection for any split, including one where `first_family` matches no
-    // entry at all.
+    // `first_family` takes index 0 and the even slots (AF_UNSPEC: the list's own leading family); the slot arithmetic is a bijection for any split.
     fn process_results(info: *mut AddrInfo, first_family: c_int) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
         let mut n_first: usize = 0;
@@ -2940,9 +2920,8 @@ pub mod internal {
 
     /// `bun:internal-for-testing`: seed the connect-path DNS cache for `hostname`
     /// by running `addresses` through the real [`process_results`] interleave and
-    /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it. The
-    /// optional `firstFamily` (4 or 6) is what `add_filtered_loopback_family`
-    /// passes for a loopback name.
+    /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it.
+    /// The optional `firstFamily` (4 or 6) is what `add_filtered_loopback_family` passes for a loopback name.
     pub(crate) fn seed_cache_for_testing(
         global: &JSGlobalObject,
         frame: &CallFrame,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2400,7 +2400,6 @@ pub mod internal {
 
     /// "localhost" or a name under it (RFC 6761 §6.3), the same set `normalize_dns_name`
     /// special-cases for `dns.lookup`.
-    #[cfg(not(windows))]
     fn is_localhost_name(host: &[u8]) -> bool {
         const LOCALHOST: &[u8] = b"localhost";
         let Some(prefix_len) = host.len().checked_sub(LOCALHOST.len()) else {
@@ -2409,6 +2408,75 @@ pub mod internal {
         let (prefix, label) = host.split_at(prefix_len);
         strings::eql_case_insensitive_ascii(label, LOCALHOST, true)
             && (prefix.is_empty() || prefix.ends_with(b"."))
+    }
+
+    /// `bun:internal-for-testing`: [`is_localhost_name`]. What it changes about a
+    /// real lookup is only observable on a host where AI_ADDRCONFIG filters loopback.
+    pub(crate) fn is_localhost_name_for_testing(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let hostname = frame.argument(0);
+        if !hostname.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!("expected (hostname: string)")));
+        }
+        let hostname = hostname.to_slice(global)?;
+        Ok(JSValue::js_boolean(is_localhost_name(hostname.slice())))
+    }
+
+    /// glibc's AI_ADDRCONFIG judges each family by the machine's non-loopback
+    /// addresses, so where ::1 is the only IPv6 address (a container, typically) it
+    /// drops the `::1 localhost` line of /etc/hosts even though ::1 is up, and a
+    /// listener bound to the name sits exactly there (`bsd_create_listen_socket`
+    /// prefers that line). macOS libinfo exempts localhost from its equivalent
+    /// filter and musl's AI_ADDRCONFIG probes loopback itself; for glibc, a loopback
+    /// name whose filtered answer holds a single family gets the unfiltered answer.
+    ///
+    /// Returns the filtered answer's family so it stays at the head of the list:
+    /// the other loopback family is only ever an extra candidate, and a consumer
+    /// that takes just the first entry (`us_quic_connect_result`) connects where it
+    /// did before. `AF_UNSPEC` when the answer was left alone.
+    ///
+    /// # Safety
+    /// `*addrinfo` must be the non-null list a successful `getaddrinfo()` call with
+    /// `hints`, `host_ptr` and `service` returned; on return it is again a list the
+    /// caller owns and frees.
+    #[cfg(not(windows))]
+    unsafe fn add_filtered_loopback_family(
+        hints: &mut AddrInfo,
+        host_ptr: *const c_char,
+        service: *const c_char,
+        addrinfo: &mut *mut AddrInfo,
+    ) -> c_int {
+        if hints.ai_family != netc::AF_UNSPEC {
+            return netc::AF_UNSPEC;
+        }
+        // SAFETY: `*addrinfo` is a getaddrinfo()-owned list per the contract above.
+        let filtered_family = unsafe { (**addrinfo).ai_family };
+        let mut node = *addrinfo;
+        while !node.is_null() {
+            // SAFETY: walking the same list.
+            unsafe {
+                if (*node).ai_family != filtered_family {
+                    return netc::AF_UNSPEC;
+                }
+                node = (*node).ai_next;
+            }
+        }
+
+        hints.ai_flags &= !netc::AI_ADDRCONFIG;
+        let mut unfiltered: *mut AddrInfo = ptr::null_mut();
+        // SAFETY: FFI getaddrinfo with the caller's still-valid host/service
+        // pointers; `hints`/`unfiltered` are live locals.
+        if unsafe { libc::getaddrinfo(host_ptr, service, &raw const *hints, &raw mut unfiltered) }
+            != 0
+        {
+            return netc::AF_UNSPEC;
+        }
+        // SAFETY: `*addrinfo` came from getaddrinfo() and nothing else points into it.
+        unsafe { bun_dns::freeaddrinfo(*addrinfo) };
+        *addrinfo = unfiltered;
+        filtered_family
     }
 
     // `Request` is passed opaquely to usockets and round-tripped back into
@@ -2505,11 +2573,16 @@ pub mod internal {
     // Pack getaddrinfo results into one allocation with address families
     // interleaved (RFC 8305 §4) so an unroutable family can never fill all
     // CONCURRENT_CONNECTIONS parallel connect attempts. See #4938 / #33278.
-    fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
+    //
+    // `first_family` takes index 0 and the even slots; `AF_UNSPEC` means the
+    // family the list itself starts with. The slot arithmetic below is a
+    // bijection for any split, including one where `first_family` matches no
+    // entry at all.
+    fn process_results(info: *mut AddrInfo, first_family: c_int) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
         let mut n_first: usize = 0;
-        let first_family = if info.is_null() {
-            netc::AF_UNSPEC
+        let first_family = if first_family != netc::AF_UNSPEC || info.is_null() {
+            first_family
         } else {
             // SAFETY: info is a live addrinfo node; freed by caller after we return.
             unsafe { (*info).ai_family }
@@ -2587,9 +2660,9 @@ pub mod internal {
         results
     }
 
-    fn after_result(req: *mut Request, info: *mut AddrInfo, err: c_int) {
+    fn after_result(req: *mut Request, info: *mut AddrInfo, err: c_int, first_family: c_int) {
         let results: Option<Box<[ResultEntry]>> = if !info.is_null() {
-            let res = process_results(info);
+            let res = process_results(info, first_family);
             // ws2_32!getaddrinfo-allocated on Windows — free via the matching
             // ws2_32!freeaddrinfo (NOT uv_freeaddrinfo: different allocator).
             // `.cast()` is identity on POSIX, libuv_sys→ws2_32 addrinfo on Windows.
@@ -2658,7 +2731,7 @@ pub mod internal {
                 &wsa_hints,
                 &mut addrinfo,
             );
-            after_result(req, addrinfo.cast(), err);
+            after_result(req, addrinfo.cast(), err, netc::AF_UNSPEC);
         }
         #[cfg(not(windows))]
         // SAFETY: FFI getaddrinfo; `req.key.host` is the owned NUL-terminated host
@@ -2668,27 +2741,26 @@ pub mod internal {
             let mut hints = get_hints();
             let host = (*req).key.host.as_ref();
 
-            // glibc's AI_ADDRCONFIG only counts non-loopback interface addresses, so on
-            // a machine whose only IPv6 address is ::1 (a container, typically) it drops
-            // the `::1 localhost` line of /etc/hosts even though ::1 is up, while a
-            // listener bound to the name (bsd_create_listen_socket prefers that line)
-            // sits exactly there. Loopback names get the unfiltered answer, which is
-            // what macOS libinfo and musl already return for them.
-            if host.is_some_and(|h| is_localhost_name(h.as_bytes())) {
-                hints.ai_flags &= !netc::AI_ADDRCONFIG;
-            }
-
             let host_ptr = host
                 .map(|h| h.as_ptr().cast::<c_char>())
                 .unwrap_or(ptr::null());
             let mut err = libc::getaddrinfo(host_ptr, service, &raw const hints, &raw mut addrinfo);
 
-            // optional fallback
-            if err == netc::EAI_NONAME && (hints.ai_flags & netc::AI_ADDRCONFIG) != 0 {
-                hints.ai_flags &= !netc::AI_ADDRCONFIG;
-                err = libc::getaddrinfo(host_ptr, service, &raw const hints, &raw mut addrinfo);
+            let mut first_family = netc::AF_UNSPEC;
+            if (hints.ai_flags & netc::AI_ADDRCONFIG) != 0 {
+                if err == netc::EAI_NONAME {
+                    // optional fallback
+                    hints.ai_flags &= !netc::AI_ADDRCONFIG;
+                    err = libc::getaddrinfo(host_ptr, service, &raw const hints, &raw mut addrinfo);
+                } else if err == 0
+                    && !addrinfo.is_null()
+                    && host.is_some_and(|h| is_localhost_name(h.as_bytes()))
+                {
+                    first_family =
+                        add_filtered_loopback_family(&mut hints, host_ptr, service, &mut addrinfo);
+                }
             }
-            after_result(req, addrinfo, err);
+            after_result(req, addrinfo, err, first_family);
         }
     }
 
@@ -2816,7 +2888,7 @@ pub mod internal {
             unsafe { (*base.add(i)).ai_next = base.add(i + 1) };
         }
 
-        let results = process_results(nodes.as_mut_ptr());
+        let results = process_results(nodes.as_mut_ptr(), netc::AF_UNSPEC);
         after_result_entries(req, Some(results), 0);
     }
 
@@ -2868,7 +2940,9 @@ pub mod internal {
 
     /// `bun:internal-for-testing`: seed the connect-path DNS cache for `hostname`
     /// by running `addresses` through the real [`process_results`] interleave and
-    /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it.
+    /// storing the result, so a real `fetch()` / `Bun.connect()` consumes it. The
+    /// optional `firstFamily` (4 or 6) is what `add_filtered_loopback_family`
+    /// passes for a loopback name.
     pub(crate) fn seed_cache_for_testing(
         global: &JSGlobalObject,
         frame: &CallFrame,
@@ -2876,7 +2950,7 @@ pub mod internal {
         let args = frame.arguments();
         if args.len() < 2 || !args[0].is_string() || !args[1].is_array() {
             return Err(global.throw_invalid_arguments(format_args!(
-                "expected (hostname: string, addresses: string[])"
+                "expected (hostname: string, addresses: string[], firstFamily?: 4 | 6)"
             )));
         }
         let hostname_slice = args[0].to_slice(global)?;
@@ -2887,6 +2961,16 @@ pub mod internal {
                 global.throw_invalid_arguments(format_args!("addresses must have 1..=64 entries"))
             );
         }
+        let first_family = match frame.argument(2) {
+            v if v.is_undefined() => netc::AF_UNSPEC,
+            v if v.is_int32() && v.as_int32() == 4 => netc::AF_INET,
+            v if v.is_int32() && v.as_int32() == 6 => netc::AF_INET6,
+            _ => {
+                return Err(
+                    global.throw_invalid_arguments(format_args!("firstFamily must be 4 or 6"))
+                );
+            }
+        };
 
         let mut addrs: Vec<SockaddrStorage> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
         let mut nodes: Vec<AddrInfo> = (0..len).map(|_| bun_core::ffi::zeroed()).collect();
@@ -2932,7 +3016,7 @@ pub mod internal {
             unsafe { (*base.add(i)).ai_next = base.add(i + 1) };
         }
 
-        let results = process_results(nodes.as_mut_ptr());
+        let results = process_results(nodes.as_mut_ptr(), first_family);
 
         let out = JSValue::create_empty_array(global, results.len())?;
         for (i, entry) in (0u32..).zip(results.iter()) {
@@ -6122,4 +6206,8 @@ export_host_fn!(
 export_host_fn!(
     internal::seed_cache_for_testing,
     "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_seedCacheForTesting"
+);
+export_host_fn!(
+    internal::is_localhost_name_for_testing,
+    "JS2Rust___src_runtime_dns_jsc_dns_rs__internal_isLocalhostNameForTesting"
 );

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2398,6 +2398,19 @@ pub mod internal {
         hints_copy
     }
 
+    /// "localhost" or a name under it (RFC 6761 §6.3), the same set `normalize_dns_name`
+    /// special-cases for `dns.lookup`.
+    #[cfg(not(windows))]
+    fn is_localhost_name(host: &[u8]) -> bool {
+        const LOCALHOST: &[u8] = b"localhost";
+        let Some(prefix_len) = host.len().checked_sub(LOCALHOST.len()) else {
+            return false;
+        };
+        let (prefix, label) = host.split_at(prefix_len);
+        strings::eql_case_insensitive_ascii(label, LOCALHOST, true)
+            && (prefix.is_empty() || prefix.ends_with(b"."))
+    }
+
     // `Request` is passed opaquely to usockets and round-tripped back into
     // Rust; the C side never dereferences fields, so layout is irrelevant.
     #[allow(improper_ctypes)]
@@ -2653,11 +2666,19 @@ pub mod internal {
         unsafe {
             let mut addrinfo: *mut AddrInfo = ptr::null_mut();
             let mut hints = get_hints();
+            let host = (*req).key.host.as_ref();
 
-            let host_ptr = (*req)
-                .key
-                .host
-                .as_ref()
+            // glibc's AI_ADDRCONFIG only counts non-loopback interface addresses, so on
+            // a machine whose only IPv6 address is ::1 (a container, typically) it drops
+            // the `::1 localhost` line of /etc/hosts even though ::1 is up, while a
+            // listener bound to the name (bsd_create_listen_socket prefers that line)
+            // sits exactly there. Loopback names get the unfiltered answer, which is
+            // what macOS libinfo and musl already return for them.
+            if host.is_some_and(|h| is_localhost_name(h.as_bytes())) {
+                hints.ai_flags &= !netc::AI_ADDRCONFIG;
+            }
+
+            let host_ptr = host
                 .map(|h| h.as_ptr().cast::<c_char>())
                 .unwrap_or(ptr::null());
             let mut err = libc::getaddrinfo(host_ptr, service, &raw const hints, &raw mut addrinfo);

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -1,6 +1,11 @@
 import { dns } from "bun";
+import { dnsCacheSeed, dnsIsLocalhostName } from "bun:internal-for-testing";
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+
+// What the system says "localhost" is, unfiltered: the JS-facing lookup passes no
+// AI_ADDRCONFIG, so this is the same /etc/hosts content the listeners below bind.
+const localhostHasV6Loopback = (await dns.lookup("localhost").catch(() => [])).some(({ address }) => address === "::1");
 
 // The DNS cache is process-global, so this runs in its own process to get
 // clean counters. Docs promise that a failed connection evicts the host's
@@ -40,67 +45,107 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
   });
 });
 
-// A listener given a hostname binds one of the name's addresses (the `::1
-// localhost` line of /etc/hosts when there is one), so a connect to the same name
-// has to try every address the name has. The connect side resolves through the
-// internal DNS cache, which used to pass AI_ADDRCONFIG for every name; glibc's
-// AI_ADDRCONFIG ignores loopback when deciding which families are configured, so
-// on a machine whose only IPv6 address is ::1 (a container) "localhost" resolved
-// to 127.0.0.1 alone and the listener on ::1 was unreachable by name.
-describe.concurrent("connecting to the hostname a listener was bound to", () => {
-  test("fetch()", async () => {
+// The connect-path resolver (fetch(), Bun.connect(), WebSocket) passes
+// AI_ADDRCONFIG to getaddrinfo(). glibc judges each family by the machine's
+// non-loopback addresses, so on a host whose only IPv6 address is ::1 (a
+// container, typically) it drops the `::1 localhost` line of /etc/hosts, while a
+// listener bound to the name "localhost" (or to ::1) sits exactly there. For
+// localhost names the resolver now adds the filtered-out loopback family behind
+// the family AI_ADDRCONFIG did answer with.
+//
+// Which names get this, and how the merged list is ordered, are checked
+// directly below because a real lookup only shows the difference on such a host.
+// The end-to-end tests after that fail without the fix on such a host and are
+// plain regression coverage everywhere else.
+describe("loopback names and AI_ADDRCONFIG", () => {
+  test("names that are exempt from the filter", () => {
+    const names = [
+      "localhost",
+      "LOCALHOST",
+      "app.localhost",
+      "a.b.LocalHost",
+      "notlocalhost",
+      "localhost.example",
+      "localhost2",
+      "127.0.0.1",
+      "",
+    ];
+    expect(Object.fromEntries(names.map(name => [name, dnsIsLocalhostName(name)]))).toEqual({
+      "localhost": true,
+      "LOCALHOST": true,
+      "app.localhost": true,
+      "a.b.LocalHost": true,
+      "notlocalhost": false,
+      "localhost.example": false,
+      "localhost2": false,
+      "127.0.0.1": false,
+      "": false,
+    });
+  });
+
+  test("the family AI_ADDRCONFIG answered with stays at the head of the unfiltered list", () => {
+    // /etc/hosts lists ::1 first; AI_ADDRCONFIG had answered with IPv4 only, so
+    // consumers that take the first entry keep connecting to 127.0.0.1 and ::1
+    // is added behind it. Symmetric for an IPv6-only answer, and unchanged
+    // (the list's own order) when no family is forced.
+    expect({
+      v4Answered: dnsCacheSeed("addrconfig-v4.invalid", ["::1", "127.0.0.1"], 4),
+      v6Answered: dnsCacheSeed("addrconfig-v6.invalid", ["127.0.0.1", "::1"], 6),
+      unforced: dnsCacheSeed("addrconfig-unforced.invalid", ["::1", "127.0.0.1"]),
+    }).toEqual({
+      v4Answered: [4, 6],
+      v6Answered: [6, 4],
+      unforced: [6, 4],
+    });
+  });
+
+  test.concurrent("fetch() reaches a server listening on the name it connects to", async () => {
     await using server = Bun.serve({ port: 0, hostname: "localhost", fetch: () => new Response("ok") });
     const response = await fetch(`http://localhost:${server.port}/`);
     expect(await response.text()).toBe("ok");
   });
 
-  // getaddrinfo() is case-insensitive, so the exemption has to be too.
-  test.each(["localhost", "LOCALHOST"])("Bun.connect({ hostname: %j })", async hostname => {
-    using listener = Bun.listen({
-      port: 0,
-      hostname: "localhost",
-      socket: {
-        open(socket) {
-          socket.end("hello");
-        },
-        data() {},
-      },
+  // Only meaningful where the system resolver maps localhost to ::1 at all.
+  describe.skipIf(!localhostHasV6Loopback)("a server on ::1 is reachable through the name", () => {
+    test.concurrent("fetch()", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "::1",
+        fetch: (request, server) => new Response(server.requestIP(request)!.address),
+      });
+      const response = await fetch(`http://localhost:${server.port}/`);
+      expect(await response.text()).toBe("::1");
     });
-    const { promise, resolve } = Promise.withResolvers<string>();
-    using socket = await Bun.connect({
-      hostname,
-      port: listener.port,
-      socket: {
-        data(_socket, data) {
-          resolve(data.toString());
-        },
-      },
-    });
-    expect(await promise).toBe("hello");
-    expect(socket.remoteAddress).toBeOneOf(["127.0.0.1", "::1"]);
-  });
 
-  test("new WebSocket()", async () => {
-    await using server = Bun.serve({
-      port: 0,
-      hostname: "localhost",
-      fetch(request, server) {
-        return server.upgrade(request) ? undefined : new Response(null, { status: 400 });
-      },
-      websocket: {
-        open(ws) {
-          ws.send("hello");
-        },
-        message() {},
-      },
+    // getaddrinfo() is case-insensitive, so the exemption has to be too.
+    test.concurrent.each(["localhost", "LOCALHOST"])("Bun.connect({ hostname: %j })", async hostname => {
+      using listener = Bun.listen({ port: 0, hostname: "::1", socket: { data() {} } });
+      using socket = await Bun.connect({ hostname, port: listener.port, socket: { data() {} } });
+      expect(socket.remoteAddress).toBe("::1");
     });
-    const { promise, resolve, reject } = Promise.withResolvers<string>();
-    const ws = new WebSocket(`ws://localhost:${server.port}/`);
-    ws.onmessage = event => resolve(String(event.data));
-    ws.onclose = event => reject(new Error(`closed before any message: ${event.code} ${event.reason}`));
-    expect(await promise).toBe("hello");
-    ws.onclose = null;
-    ws.close();
+
+    test.concurrent("new WebSocket()", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "::1",
+        fetch(request, server) {
+          return server.upgrade(request) ? undefined : new Response(null, { status: 400 });
+        },
+        websocket: {
+          open(ws) {
+            ws.send(ws.remoteAddress);
+          },
+          message() {},
+        },
+      });
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const ws = new WebSocket(`ws://localhost:${server.port}/`);
+      ws.onmessage = event => resolve(String(event.data));
+      ws.onclose = event => reject(new Error(`closed before any message: ${event.code} ${event.reason}`));
+      expect(await promise).toBe("::1");
+      ws.onclose = null;
+      ws.close();
+    });
   });
 });
 

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -59,28 +59,21 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
 // plain regression coverage everywhere else.
 describe("loopback names and AI_ADDRCONFIG", () => {
   test("names that get the filtered loopback family added back", () => {
-    const names = [
-      "localhost",
-      "LOCALHOST",
-      "app.localhost",
-      "a.b.LocalHost",
-      "notlocalhost",
-      "localhost.example",
-      "localhost2",
-      "127.0.0.1",
-      "",
-    ];
-    expect(Object.fromEntries(names.map(name => [name, dnsIsLocalhostName(name)]))).toEqual({
+    const expected = {
       "localhost": true,
       "LOCALHOST": true,
+      "localhost.": true,
       "app.localhost": true,
+      "app.localhost.": true,
       "a.b.LocalHost": true,
       "notlocalhost": false,
       "localhost.example": false,
       "localhost2": false,
+      "localhost..": false,
       "127.0.0.1": false,
       "": false,
-    });
+    };
+    expect(Object.fromEntries(Object.keys(expected).map(name => [name, dnsIsLocalhostName(name)]))).toEqual(expected);
   });
 
   test("the family AI_ADDRCONFIG answered with stays at the head of the unfiltered list", () => {

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -40,6 +40,70 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
   });
 });
 
+// A listener given a hostname binds one of the name's addresses (the `::1
+// localhost` line of /etc/hosts when there is one), so a connect to the same name
+// has to try every address the name has. The connect side resolves through the
+// internal DNS cache, which used to pass AI_ADDRCONFIG for every name; glibc's
+// AI_ADDRCONFIG ignores loopback when deciding which families are configured, so
+// on a machine whose only IPv6 address is ::1 (a container) "localhost" resolved
+// to 127.0.0.1 alone and the listener on ::1 was unreachable by name.
+describe.concurrent("connecting to the hostname a listener was bound to", () => {
+  test("fetch()", async () => {
+    await using server = Bun.serve({ port: 0, hostname: "localhost", fetch: () => new Response("ok") });
+    const response = await fetch(`http://localhost:${server.port}/`);
+    expect(await response.text()).toBe("ok");
+  });
+
+  // getaddrinfo() is case-insensitive, so the exemption has to be too.
+  test.each(["localhost", "LOCALHOST"])("Bun.connect({ hostname: %j })", async hostname => {
+    using listener = Bun.listen({
+      port: 0,
+      hostname: "localhost",
+      socket: {
+        open(socket) {
+          socket.end("hello");
+        },
+        data() {},
+      },
+    });
+    const { promise, resolve } = Promise.withResolvers<string>();
+    using socket = await Bun.connect({
+      hostname,
+      port: listener.port,
+      socket: {
+        data(_socket, data) {
+          resolve(data.toString());
+        },
+      },
+    });
+    expect(await promise).toBe("hello");
+    expect(socket.remoteAddress).toBeOneOf(["127.0.0.1", "::1"]);
+  });
+
+  test("new WebSocket()", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "localhost",
+      fetch(request, server) {
+        return server.upgrade(request) ? undefined : new Response(null, { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.send("hello");
+        },
+        message() {},
+      },
+    });
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const ws = new WebSocket(`ws://localhost:${server.port}/`);
+    ws.onmessage = event => resolve(String(event.data));
+    ws.onclose = event => reject(new Error(`closed before any message: ${event.code} ${event.reason}`));
+    expect(await promise).toBe("hello");
+    ws.onclose = null;
+    ws.close();
+  });
+});
+
 describe("dns.prefetch", () => {
   it("should prefetch", async () => {
     // A local server keeps the test off the external network. "localhost" is a

--- a/test/js/bun/dns/dns-prefetch.test.ts
+++ b/test/js/bun/dns/dns-prefetch.test.ts
@@ -58,7 +58,7 @@ test("a failed connect evicts the host's DNS cache entry", async () => {
 // The end-to-end tests after that fail without the fix on such a host and are
 // plain regression coverage everywhere else.
 describe("loopback names and AI_ADDRCONFIG", () => {
-  test("names that are exempt from the filter", () => {
+  test("names that get the filtered loopback family added back", () => {
     const names = [
       "localhost",
       "LOCALHOST",
@@ -117,7 +117,7 @@ describe("loopback names and AI_ADDRCONFIG", () => {
       expect(await response.text()).toBe("::1");
     });
 
-    // getaddrinfo() is case-insensitive, so the exemption has to be too.
+    // getaddrinfo() is case-insensitive, so the name check has to be too.
     test.concurrent.each(["localhost", "LOCALHOST"])("Bun.connect({ hostname: %j })", async hostname => {
       using listener = Bun.listen({ port: 0, hostname: "::1", socket: { data() {} } });
       using socket = await Bun.connect({ hostname, port: listener.port, socket: { data() {} } });


### PR DESCRIPTION
### What

On a Linux/glibc machine whose only IPv6 address is `::1` (the default inside a container; `/etc/hosts` still carries Docker's `::1 localhost` line), listening on the name `localhost` and connecting to the name `localhost` from the same process fails:

```js
using server = Bun.serve({ port: 0, hostname: "localhost", fetch: () => new Response("ok") });
await fetch(`http://localhost:${server.port}/`);
// TypeError: Unable to connect. Is the computer able to access the url?  code: "ConnectionRefused"

await Bun.connect({ hostname: "localhost", port, socket: { data() {} } });
// error: Failed to connect  code: "ECONNREFUSED"

new WebSocket(`ws://localhost:${port}/`);
// close 1006 "Failed to connect"
```

The listener is bound to `::1` (`ss` shows it there); every native client only ever tries `127.0.0.1`. `test/js/web/fetch/fetch-preconnect.test.ts` is a ready-made reproducer: 11 of its 14 tests fail in such a container, on the released build as well as on main; `test/js/bun/http/bun-serve-html-entry.test.ts` (`bun ./index.html` binds `localhost`) fails 5 of 7 the same way. #36543 and #35160 worked around the same thing test by test.

### Cause

Two different views of the same `/etc/hosts`:

- The listen side (`bsd_create_listen_socket` in `packages/bun-usockets/src/bsd.c`) calls `getaddrinfo()` with `AI_PASSIVE` and, like upstream uSockets, prefers the AF_INET6 entry. `localhost` therefore binds `::1`.
- The connect side (`internal::work_pool_callback` in `src/runtime/dns_jsc/dns.rs`, which backs `fetch()`, `Bun.connect()`, the WebSocket client, `bun install`, ...) calls `getaddrinfo()` with `AI_ADDRCONFIG`. glibc implements that flag by checking whether any *non-loopback* address of the family is configured, so with no IPv6 on `eth0` the `::1` entry is filtered out and the name resolves to `127.0.0.1` only. The TCP connect path is happy to try every address it is given (`start_connections` opens up to 4 in parallel and advances on failure); it just never sees `::1`.

`AI_ADDRCONFIG` itself is worth keeping: on an IPv4-only machine it is what stops glibc from sending AAAA queries for every real hostname. Its "is this family configured" heuristic is just meaningless for names that resolve to loopback.

### Fix

`work_pool_callback` resolves with `AI_ADDRCONFIG` exactly as before. If the name is `localhost` or a name under it (ASCII case-insensitive like `getaddrinfo()`, with or without the root dot; `normalize_dns_name` in this file already special-cases the same names for `dns.lookup`) and the answer contains a single family, it resolves once more without the flag and packs that answer with the originally answered family first (`process_results` takes the leading family as a parameter now). So:

- dual-stack hosts (anything with a non-loopback IPv6 address, i.e. most dev machines and CI): the first answer already has both families, nothing changes, no second call;
- the affected hosts: the list goes from `[127.0.0.1]` to `[127.0.0.1, ::1]`. Entry 0 is what it was before, so anything that only takes the first entry (the QUIC client in `us_quic_connect_result` commits to one address) connects exactly where it did; the TCP path gains `::1` as a parallel candidate and reaches the listener;
- real hostnames: untouched, including the `EAI_NONAME` retry from #19753;
- `BUN_FEATURE_FLAG_DISABLE_IPV6` / `DISABLE_IPV4`: the second call is skipped when a family is forced.

The second `getaddrinfo()` is an `/etc/hosts` read, once per cache entry, only for localhost names and only on hosts where the first answer was single-family. The only behavioral cost is on those hosts when the server is on `127.0.0.1`: one extra `connect()` to `::1` per new connection, refused synchronously by the kernel, in parallel with the one that succeeds.

Why this is the right thing to do even though Node (v26.3.0 checked on the same container) fails the same way here: Bun's other builds already return `::1` for `localhost` on such a host. macOS libinfo exempts `localhost` from its equivalent of `AI_ADDRCONFIG` (noted in `dns_sd.rs`), musl's `AI_ADDRCONFIG` decides per family by probing the loopback address, and the Windows path never sets the flag. glibc was the only build where Bun's own `localhost` listener was unreachable from Bun's own clients. Browsers, curl, Python and Go all reach a `::1`-bound `localhost` server in the same container.

Not changed: `node:net` / `node:http` clients. `lookupAndConnect` in `src/js/node/net.ts` adds `dns.ADDRCONFIG` itself, exactly as Node's does, and keeps failing here exactly as Node does; that is a Node compat question and out of scope.

Found along the way and left for a separate fix: the QUIC client never falls back to the second resolved address, so on any dual-stack host (where `localhost` already resolves to `[::1, 127.0.0.1]`) an `http3` fetch by name to a `127.0.0.1`-bound server times out today. This PR keeps that behavior identical rather than fixing or worsening it (verified below).

### Tests

`test/js/bun/dns/dns-prefetch.test.ts` (existing home of the internal resolver's tests):

- Deterministic on every platform: `dnsIsLocalhostName` (new `bun:internal-for-testing` hook over the predicate) pins which names qualify (`localhost`, `LOCALHOST`, `localhost.`, `app.localhost`, `app.localhost.`, `a.b.LocalHost`) and which do not (`notlocalhost`, `localhost.example`, `localhost2`, `localhost..`, `127.0.0.1`, `""`); `dnsCacheSeed` gained the optional leading-family argument and a test pins the merge order (`["::1","127.0.0.1"]` with IPv4 answered first packs as `[4, 6]`, the mirror case as `[6, 4]`, unforced keeps list order).
- End to end: `fetch()` against a server bound to the name; and, where the system resolver maps `localhost` to `::1` at all (skipped otherwise), servers bound to `::1` reached through the name by `fetch()` (body is `server.requestIP()`), `Bun.connect()` with `"localhost"` and `"LOCALHOST"` (`remoteAddress`), and `new WebSocket()` (server echoes `ws.remoteAddress`), all asserting `"::1"`. On the affected hosts these five fail without the fix; elsewhere they are regression coverage for trying `::1` at all.

```
# container with `::1 localhost` in /etc/hosts and no IPv6 on eth0
USE_SYSTEM_BUN=1 bun test test/js/bun/dns/dns-prefetch.test.ts   # 5 end-to-end tests fail (ConnectionRefused / ECONNREFUSED / close 1006); hook tests cannot load
bun bd test test/js/bun/dns/dns-prefetch.test.ts                  # 9 pass
bun bd test test/js/web/fetch/fetch-preconnect.test.ts            # 14 pass (11 failed before)
bun bd test test/js/bun/http/bun-serve-html-entry.test.ts         # 7 pass (5 failed before)
```

Also run on the debug build: `test/js/bun/dns/`, `test/js/bun/net/socket.test.ts`, `test/js/web/websocket/websocket.test.js`, `test/js/web/fetch/fetch-http3-client.test.ts`, `test/js/web/fetch/fetch.test.ts`. Remaining failures there need the public internet, an IPv6 literal through this container's HTTP proxy, or are debug-build `gc()` timeouts; they fail the same way on the released build.

H3 check (server `http3: true`, `fetch(..., { protocol: "http3" })` by the name `localhost`): bound to `127.0.0.1`, released build 200 and this PR 200; bound to `::1`, released build times out and this PR times out the same way. An earlier revision of this PR that simply dropped the flag put `::1` first and turned the first case into a timeout, which is why the answered family is kept at the head.
