### PR TITLE
bake: unregister Bake::SourceProvider from the source map table when it is destroyed

### DIFF
--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -260,8 +260,8 @@ pub fn get_verbose_fetch_value() -> i32 {
     }
 }
 
-// `Bun__addBakeSourceProviderSourceMap` / `Bun__addDevServerSourceProvider` /
-// `Bun__removeDevServerSourceProvider` live in
+// `Bun__{add,remove}BakeSourceProviderSourceMap` /
+// `Bun__{add,remove}DevServerSourceProvider` live in
 // `bun_runtime::bake::source_provider_exports` (their callers are bake's C++
 // source providers; LAYERING).
 

--- a/src/runtime/bake/BakeSourceProvider.h
+++ b/src/runtime/bake/BakeSourceProvider.h
@@ -9,6 +9,7 @@ namespace Bake {
 class SourceProvider;
 
 extern "C" void Bun__addBakeSourceProviderSourceMap(void* bun_vm, SourceProvider* opaque_source_provider, BunString* specifier);
+extern "C" void Bun__removeBakeSourceProviderSourceMap(void* bun_vm, SourceProvider* opaque_source_provider, BunString* specifier);
 
 class SourceProvider final : public JSC::StringSourceProvider {
 public:
@@ -20,15 +21,16 @@ public:
         const TextPosition& startPosition,
         JSC::SourceProviderSourceType sourceType)
     {
-        auto provider = adoptRef(*new SourceProvider(source, sourceOrigin, WTF::move(sourceURL), startPosition, sourceType));
-        auto* zigGlobalObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+        void* bunVM = uncheckedDowncast<Zig::GlobalObject>(globalObject)->bunVM();
+        auto provider = adoptRef(*new SourceProvider(bunVM, source, sourceOrigin, WTF::move(sourceURL), startPosition, sourceType));
         auto specifier = Bun::toString(provider->sourceURL());
-        Bun__addBakeSourceProviderSourceMap(zigGlobalObject->bunVM(), provider.ptr(), &specifier);
+        Bun__addBakeSourceProviderSourceMap(bunVM, provider.ptr(), &specifier);
         return provider;
     }
 
 private:
     SourceProvider(
+        void* bunVM,
         const String& source,
         const JSC::SourceOrigin& sourceOrigin,
         String&& sourceURL,
@@ -41,8 +43,20 @@ private:
               WTF::move(sourceURL),
               startPosition,
               sourceType)
+        , m_bunVM(bunVM)
     {
     }
+
+    ~SourceProvider()
+    {
+        auto specifier = Bun::toString(sourceURL());
+        Bun__removeBakeSourceProviderSourceMap(m_bunVM, this, &specifier);
+    }
+
+    // The Rust VirtualMachine rather than the Zig::GlobalObject: this
+    // destructor runs from JSC's sweep, possibly after the global object cell
+    // itself has been swept (see DevServerSourceProvider).
+    void* m_bunVM;
 };
 
 } // namespace Bake

--- a/src/runtime/bake/source_provider_exports.rs
+++ b/src/runtime/bake/source_provider_exports.rs
@@ -1,9 +1,9 @@
 //! Rust side of `BakeSourceProvider.h` / `DevServerSourceProvider.h`: the
 //! FFI bindings and `SourceProvider` impls for bake's two C++ source
-//! providers, plus the host exports that register them with the VM's
-//! `SavedSourceMap` so stack remapping can resolve dev-server /
-//! bake-production output. `bun_sourcemap` sees these only as erased
-//! `AnySourceProvider` handles.
+//! providers, plus the host exports that register them with (and, from their
+//! destructors, remove them from) the VM's `SavedSourceMap` so stack remapping
+//! can resolve dev-server / bake-production output. `bun_sourcemap` sees these
+//! only as erased `AnySourceProvider` handles.
 //!
 //! `#[unsafe(no_mangle)] extern "C"` thunks are emitted by
 //! `src/codegen/generate-host-exports.ts` from the `// HOST_EXPORT(Sym, c)`
@@ -18,8 +18,8 @@ use bun_sourcemap::parsed_source_map::AnySourceProvider;
 use bun_sourcemap::{SourceContentPtr, SourceProvider};
 
 bun_opaque::opaque_ffi! {
-    /// Opaque handle to the C++ `Bake::SourceProvider` for production-build
-    /// sources (`BakeSourceProvider.cpp`).
+    /// Opaque handle to the C++ `Bake::SourceProvider` (`BakeSourceProvider.h`),
+    /// registered from its `create()` and unregistered from its destructor.
     pub(crate) struct BakeSourceProvider;
     /// Opaque handle to the C++ `Bake::DevServerSourceProvider`
     /// (`DevServerSourceProvider.cpp`).
@@ -139,6 +139,17 @@ pub fn add_bake_source_provider_source_map(
         ),
         slice.slice(),
     );
+}
+
+// HOST_EXPORT(Bun__removeBakeSourceProviderSourceMap, c)
+pub fn remove_bake_source_provider_source_map(
+    vm: &mut VirtualMachine,
+    opaque_source_provider: *mut c_void,
+    specifier: &BunString,
+) {
+    let slice = specifier.to_utf8();
+    vm.source_mappings
+        .remove_source_provider(opaque_source_provider, slice.slice());
 }
 
 // HOST_EXPORT(Bun__addDevServerSourceProvider, c)

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import path from "node:path";
 
 test("dev server deinitializes itself", () => {
@@ -13,3 +13,104 @@ test("dev server deinitializes itself", () => {
   // The child runs a whole `bun test` suite (nine GC-heavy cases plus leak
   // reporting at exit), which takes longer than the 5s default under ASAN.
 }, 60_000);
+
+// Every framework dev server evaluates the server runtime through its own
+// Bake::SourceProvider, registered in the VM's source map table under the one
+// key "bake://server-runtime.js", so the table points at whichever server
+// started last. Once that server is torn down and its provider freed, the
+// next stack trace through a surviving server's runtime looks the map up via
+// the table entry, so the provider must have removed itself by then. Malloc=1
+// puts JSC's allocations under the system malloc so ASAN sees the read of the
+// freed provider instead of bmalloc quietly handing back the stale memory.
+test.skipIf(!isASAN)(
+  "tearing down one dev server does not leave its server runtime source provider registered for another",
+  async () => {
+    using dir = tempDir("bake-deinit-source-provider", {
+      "server.ts": `
+        export function render(req, meta) {
+          return meta.pageModule.default(req, meta);
+        }
+        export function registerClientReference(value, file, uid) {
+          return { value, file, uid };
+        }
+      `,
+      "routes/index.ts": `
+        export default function () {
+          return new Response(new Error("probe").stack);
+        }
+      `,
+      "fixture.ts": `
+        import { getDevServerDeinitCount } from "bun:internal-for-testing";
+        import path from "node:path";
+
+        const serverEntryPoint = path.join(import.meta.dir, "server.ts");
+        const framework = {
+          fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint }],
+          serverComponents: {
+            separateSSRGraph: false,
+            serverRuntimeImportSource: serverEntryPoint,
+            serverRegisterClientReferenceExport: "registerClientReference",
+          },
+        };
+        const start = () => Bun.serve({ port: 0, app: { framework } });
+
+        async function collect(isDone) {
+          for (let i = 0; i < 200 && !isDone(); i++) {
+            Bun.gc(true);
+            await new Promise(resolve => setTimeout(resolve, 1));
+          }
+          if (!isDone()) throw new Error("dev server was not deinitialized");
+        }
+
+        const survivor = start();
+
+        // Started second, so its provider replaces the survivor's table entry.
+        // Stopped inside its own function so nothing on the stack keeps it alive.
+        const deinitsBefore = getDevServerDeinitCount();
+        const survivorDebugHooks = globalThis.DEBUG;
+        (function startAndStop() {
+          start().stop(true);
+        })();
+        // Debug builds of the server runtime publish globalThis.DEBUG, whose
+        // ASSERT is a function of whichever runtime ran last and so would keep
+        // the second server's provider alive (release builds compile it out).
+        // Put the survivor's back; it is the one that keeps handling requests.
+        globalThis.DEBUG = survivorDebugHooks;
+        await collect(() => getDevServerDeinitCount() > deinitsBefore);
+        // Deinit dropped the dev server's references to the runtime's
+        // functions; a few more collections sweep them and free the provider.
+        for (let i = 0; i < 5; i++) {
+          Bun.gc(true);
+          await new Promise(resolve => setTimeout(resolve, 1));
+        }
+
+        const response = await fetch(survivor.url);
+        const stack = await response.text();
+        survivor.stop(true);
+        console.log("status:", response.status);
+        console.log("runtime frame:", stack.includes("bake://server-runtime.js"));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        Malloc: "1",
+        // detect_leaks=0: Malloc=1 exposes JSC's process-lifetime startup
+        // allocations to LSAN; this test is about the use-after-free.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("AddressSanitizer");
+    // The runtime frame is what sends the stack trace through the table entry.
+    expect(stdout).toEndWith("status: 200\nruntime frame: true\n");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
### Repro

Two framework dev servers in one process. Stop the one that started last, let it be collected, then format any stack trace that passes through the surviving server's runtime (every request does; the fixture's route returns `new Error().stack`). On an ASAN build with `Malloc=1`:

```
ERROR: AddressSanitizer: heap-use-after-free
    #0 WTF::Ref<WTF::StringImpl>::get()
    #1 JSC::StringSourceProvider::source()
    #2 BakeSourceProvider__getSourceSlice                      src/runtime/bake/BakeSourceProvider.cpp
    #3 <BakeSourceProvider as bun_sourcemap::SourceProvider>::get_source_slice   src/runtime/bake/source_provider_exports.rs
    #4 bun_sourcemap::get_source_map_impl
    #7 <SavedSourceMap>::get_with_content                      src/jsc/SavedSourceMap.rs
    #10 <VirtualMachine>::remap_stack_frame_positions
    #13 Bun::formatStackTrace                                  src/jsc/bindings/FormatStackTraceForJS.cpp
    #20 JSC::ErrorInstance::materializeErrorInfoIfNeeded

freed by thread T0 here:
    ...
    #12 Bake::SourceProvider::~SourceProvider()
    #16 JSC::UnlinkedSourceCode::~UnlinkedSourceCode()
    #18 JSC::ScriptExecutable::~ScriptExecutable()
    #20 JSC::FunctionExecutable::destroy(JSC::JSCell*)
    (GC sweep)

previously allocated by thread T0 here:
    ...
    #11 Bake::SourceProvider::create(...)
    #12 BakeLoadInitialServerCode                             src/runtime/bake/BakeSourceProvider.cpp
```

Without ASAN this is a silent read of freed memory while printing an error (or reading `error.stack`) in the dev server.

### Cause

`Bake::SourceProvider::create` (`src/runtime/bake/BakeSourceProvider.h`) registers the provider in the VM's `SavedSourceMap` via `Bun__addBakeSourceProviderSourceMap`. `put_source_provider` stores the raw pointer and documents that the owner unregisters it before it is freed, but `Bake::SourceProvider` had no destructor and no remove export existed, so the entry outlived the provider. `Zig::SourceProvider` and `Bake::DevServerSourceProvider` both unregister themselves from their destructors; this class was the odd one out since the registration was added in #20745.

The dev server makes the stale entry easy to hit: `BakeLoadInitialServerCode` creates one of these providers per dev server, always under the key `bake://server-runtime.js`, so the table points at whichever server started last. That provider is kept alive only by the runtime's functions, which the dev server holds through `Strong`s and releases in its `Drop`. Stop that server, collect, and the entry dangles; the surviving server's `handleRequest` frames carry the same URL and are looked up through it on the next stack trace.

### Fix

`Bake::SourceProvider` stores the Rust `VirtualMachine*` at construction and its destructor removes the entry through a new `Bun__removeBakeSourceProviderSourceMap` export, which is the same `remove_source_provider` call the other two provider classes make. It stores the VM pointer rather than the global object for the reason #34035 fixed in `DevServerSourceProvider`: the destructor runs from JSC's sweep (and from `~VM` under `BUN_DESTRUCT_VM_ON_EXIT`), when the global object cell may already be gone. `SavedSourceMap` is torn down in `VirtualMachine::destroy`, after the JSC VM, which is the ordering the other two destructors already rely on.

This is the right place for the fix rather than, say, checking liveness at lookup time: the table holds a borrowed pointer by design, and the only party that knows when the provider dies is the provider. `remove_source_provider` compares the stored pointer against the dying provider, so the paths where several providers share one key stay correct on their own: a dying older runtime provider does not remove a newer server's entry, and under `bake://server.patch.js` a `Bake::SourceProvider` (the `BakeLoadServerHmrPatch` fallback) and `DevServerSourceProvider`s (the normal path) can replace each other freely. It also handles the case where the table has already materialized a `ParsedSourceMap` from the provider (production builds, where `get_external_data` succeeds), since that branch checks the map's underlying provider.

Registering the runtime and the map-less patch in dev is still pointless (no map can ever be found for them, so the first lookup fails and drops the entry); that is unchanged here, and with this fix it is merely useless rather than unsafe.

### Verification

New ASAN-only case in `test/bake/deinitialization.test.ts` runs the scenario above in a child with `Malloc=1`. One detail the fixture has to handle: debug builds of the server runtime publish `globalThis.DEBUG`, whose `ASSERT` is a function from whichever runtime ran last and would keep the dead server's provider alive (release builds compile that out), so the fixture puts the survivor's object back before collecting.

- `bun bd test test/bake/deinitialization.test.ts` without the `src/` change: the new case fails with the `heap-use-after-free` above; with it, both cases pass.
- `test/bake/dev/server-sourcemap.test.ts` (5 tests, including the `BUN_DESTRUCT_VM_ON_EXIT=1` + `Malloc=1` teardown case, which now also runs the new destructor for the runtime provider during `~VM`) passes.
- `test/bake/dev/production.test.ts` (9 tests) passes both normally and with `BUN_DESTRUCT_VM_ON_EXIT=1 Malloc=1` in the environment.
- `cargo clippy -p bun_runtime -p bun_jsc` and clang-format are clean.
