### PR TITLE
test: serve the h3 receive-backpressure bodies from an idle process

### DIFF
--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -1,8 +1,8 @@
 // Receive-side backpressure: a stalled `res.body.getReader()` must stop the
 // HTTP thread from buffering the entire response in memory.
-import { describe, expect, test } from "bun:test";
+import type { Subprocess } from "bun";
+import { afterAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, forEachLine, isASAN, isDebug, isWindows, tls } from "harness";
-import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createSecureServer } from "node:http2";
@@ -16,6 +16,15 @@ const COUNT = 256; // 16 MiB
 const TOTAL = CHUNK * COUNT;
 
 type Kind = "h1" | "h1-chunked" | "h1-gzip" | "h1-tls" | "h2" | "h3";
+
+// serve("h3") registers its subprocess here before waiting for the URL, so a
+// server that never reports one (the test times out inside serve(), and its
+// `await using` never binds) is still reaped. These tests are concurrent, so
+// the runner does not kill a timed-out test's children itself.
+const h3Servers: Subprocess[] = [];
+afterAll(() => {
+  for (const proc of h3Servers) proc.kill();
+});
 
 async function serve(kind: Kind, count = COUNT): Promise<{ url: string; sent: () => number } & AsyncDisposable> {
   let sent = 0;
@@ -93,6 +102,7 @@ async function serve(kind: Kind, count = COUNT): Promise<{ url: string; sent: ()
       stdout: "pipe",
       stderr: "pipe",
     });
+    h3Servers.push(proc);
     const stderr = proc.stderr.text();
     const { value: url, done } = await forEachLine(proc.stdout).next();
     if (done) throw new Error(`h3 server exited ${await proc.exited}: ${await stderr}`);
@@ -107,7 +117,10 @@ async function serve(kind: Kind, count = COUNT): Promise<{ url: string; sent: ()
   }
 
   // h1 / h1-chunked / h1-gzip / h1-tls
-  const gz = kind === "h1-gzip" ? gzipSync(randomBytes(CHUNK * count)) : null;
+  // Stored blocks (level 0) keep the wire the same size as the body, which is
+  // what makes the gzip variant stream like the others; actually compressing
+  // 16 MiB took ~2 s of this busy process's main thread under a debug build.
+  const gz = kind === "h1-gzip" ? gzipSync(Buffer.alloc(CHUNK * count, 65), { level: 0 }) : null;
   const handler = (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => {
     res.on("error", () => {});
     if (gz) {

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -117,9 +117,9 @@ async function serve(kind: Kind, count = COUNT): Promise<{ url: string; sent: ()
   }
 
   // h1 / h1-chunked / h1-gzip / h1-tls
-  // Stored blocks (level 0) keep the wire the same size as the body, which is
-  // what makes the gzip variant stream like the others; actually compressing
-  // 16 MiB took ~2 s of this busy process's main thread under a debug build.
+  // Stored blocks (level 0) put a body-sized stream on the wire (asserted via
+  // sent() by the drain test) without the ~2 s a debug build spent actually
+  // compressing 16 MiB on this busy main thread.
   const gz = kind === "h1-gzip" ? gzipSync(Buffer.alloc(CHUNK * count, 65), { level: 0 }) : null;
   const handler = (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => {
     res.on("error", () => {});
@@ -269,6 +269,10 @@ for (const kind of ["h1", "h1-chunked", "h1-gzip", "h1-tls", "h2", "h3"] as Kind
         await using server = await serve(kind);
         const { peak, total, exitCode } = await spawnClient(server.url, kind, script);
         expect({ peakMB: peak >> 20, total }).toEqual({ peakMB: expect.any(Number), total: TOTAL });
+        // A compressible gzip body would arrive as one small packet and be
+        // decoded without the transport ever pausing; the variant only tests
+        // anything if the wire carried about as many bytes as the body.
+        if (kind === "h1-gzip") expect(server.sent()).toBeGreaterThanOrEqual(TOTAL);
         expect(exitCode).toBe(0);
       });
     }

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -1,7 +1,7 @@
 // Receive-side backpressure: a stalled `res.body.getReader()` must stop the
 // HTTP thread from buffering the entire response in memory.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, tls } from "harness";
+import { bunEnv, bunExe, forEachLine, isASAN, isDebug, isWindows, tls } from "harness";
 import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:http";
@@ -56,24 +56,54 @@ async function serve(kind: Kind, count = COUNT): Promise<{ url: string; sent: ()
   }
 
   if (kind === "h3") {
-    const srv = Bun.serve({
-      port: 0,
-      tls,
-      http3: true,
-      http1: false,
-      fetch() {
-        let i = 0;
-        return new Response(
-          new ReadableStream({
-            pull(ctrl) {
-              if (i++ < count) ctrl.enqueue(payload);
-              else ctrl.close();
+    // Bun.serve({ http3 }) runs lsquic on the event loop of the process that
+    // created it. In this file that loop is also draining the 1 GiB bodies of
+    // the concurrent "server stops writing" tests, and a userspace transport
+    // only makes progress once per loop iteration (at most about a cwnd of
+    // packets), so served from here the 16 MiB body took 11-13 s under
+    // debug/ASAN, past the 5 s test timeout. The TCP servers are unaffected
+    // because the kernel moves their bytes. Serve h3 from an idle process.
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          const payload = Buffer.alloc(${CHUNK}, 65);
+          const server = Bun.serve({
+            port: 0,
+            tls: ${JSON.stringify(tls)},
+            http3: true,
+            http1: false,
+            fetch() {
+              let i = 0;
+              return new Response(
+                new ReadableStream({
+                  pull(ctrl) {
+                    if (i++ < ${count}) ctrl.enqueue(payload);
+                    else ctrl.close();
+                  },
+                }),
+              );
             },
-          }),
-        );
-      },
+          });
+          console.log(server.url.href);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    return { url: String(srv.url), sent: () => sent, [Symbol.asyncDispose]: () => srv.stop(true) };
+    const lines = forEachLine(proc.stdout);
+    const { value: url, done } = await lines.next();
+    if (done) throw new Error(`h3 server exited ${await proc.exited}: ${await proc.stderr.text()}`);
+    return {
+      url,
+      sent: () => sent,
+      [Symbol.asyncDispose]: async () => {
+        proc.kill();
+        await proc.exited;
+      },
+    };
   }
 
   // h1 / h1-chunked / h1-gzip / h1-tls

--- a/test/js/web/fetch/fetch-backpressure.test.ts
+++ b/test/js/web/fetch/fetch-backpressure.test.ts
@@ -93,15 +93,15 @@ async function serve(kind: Kind, count = COUNT): Promise<{ url: string; sent: ()
       stdout: "pipe",
       stderr: "pipe",
     });
-    const lines = forEachLine(proc.stdout);
-    const { value: url, done } = await lines.next();
-    if (done) throw new Error(`h3 server exited ${await proc.exited}: ${await proc.stderr.text()}`);
+    const stderr = proc.stderr.text();
+    const { value: url, done } = await forEachLine(proc.stdout).next();
+    if (done) throw new Error(`h3 server exited ${await proc.exited}: ${await stderr}`);
     return {
       url,
       sent: () => sent,
       [Symbol.asyncDispose]: async () => {
         proc.kill();
-        await proc.exited;
+        await Promise.all([proc.exited, stderr]);
       },
     };
   }


### PR DESCRIPTION
### Problem

Running the whole of `test/js/web/fetch/fetch-backpressure.test.ts` under a debug/ASAN build fails the four `fetch() h3 receive backpressure > stalled {getReader(), pipeTo(), for await, no consumer} drains the full body` cases at the 5 s default timeout, 3/3 runs here (16-core linux-x64 container, unmodified main). Every h1 / h1-chunked / h1-gzip / h1-tls / h2 variant of the same parameterised test passes in 1.4-3.7 s in the same run, and the h3 cases pass in ~2 s when run with `-t "h3 receive backpressure"`.

```
(fail) fetch() h3 receive backpressure > stalled getReader() drains the full body [5082.84ms]
(fail) fetch() h3 receive backpressure > stalled pipeTo() drains the full body [5022.32ms]
(fail) fetch() h3 receive backpressure > stalled for await drains the full body [5072.87ms]
(fail) fetch() h3 receive backpressure > stalled no consumer drains the full body [5116.57ms]
```

### Cause

The test's h1/h2 servers and its h3 server all live in the test process, whose event loop is concurrently draining the 1 GiB bodies of the three "server stops writing while the reader is stalled" cases plus the `Readable.fromWeb` one (each ~25 s under ASAN). For the TCP servers that does not matter: once `res.write()` hands bytes to the kernel they flow regardless of what the loop is doing. `Bun.serve({ http3 })` runs lsquic on that loop, so the QUIC connection only makes progress once per loop iteration (at most about a cwnd of packets each time), and with the loop this busy the 16 MiB body crawls. Instrumenting the test showed the h3 cases taking 11.0-12.8 s end to end under the file's load versus 1.5-3.5 s for every TCP kind; with an idle loop the same transfer takes ~0.2 s.

So the timeout measures how busy the test process is, not whether the client's receive-backpressure resume path drains the body, which is what the test is for.

### Fix

Serve the h3 body from a spawned `bun -e` process whose loop has nothing else to do, the same way the client under test is already a spawned process. The server prints its URL on stdout; disposal kills it. Its stderr is drained from spawn, and the subprocess is registered in a module-level list before the URL is awaited and reaped in `afterAll`, so a server that never reports a URL cannot outlive the file (these tests are concurrent, and the runner only kills a timed-out test's children for sequential tests). The in-process h1/h2 servers and the `sent()` based pause tests are unchanged (the h3 branch never counted `sent`).

The h1-gzip variant of the same tests was the next tightest case: it spent ~2 s (debug build) gzipping 16 MiB of random bytes on the same busy main thread, ran at 3.5-3.7 s under the file's load, and went over 5 s in one run here while the host was under extra contention. It now gzips a constant payload with stored blocks (level 0), which keeps the property the variant needs (a wire the size of the body, so it streams like the other kinds) and brings it to ~1.8 s. Because that property now rests on one option, the drain test asserts it through the server's existing `sent()` wire-byte counter: with `level: 0` the wire is 16,779,789 bytes; without it the same body gzips to 16,329 bytes, arrives in a single packet and the old assertions still passed, whereas the new one fails with `Received: 16329`.

While looking at this I also found two runtime-side reasons an h3 server on a busy loop is slower than it needs to be (lsquic's adaptive congestion control picks BBRv1 whenever the first RTT sample is inflated by loop latency and then never grows cwnd past the initial window, and the QUIC UDP sockets use the kernel default receive buffer so cwnd-sized bursts drop packets). Neither makes this test pass by itself (the h3 cases still took 11-13 s with Cubic forced), so they are being handled separately and this PR is only the test.

### Verification

`bun bd test test/js/web/fetch/fetch-backpressure.test.ts` (debug + ASAN): 43 pass / 1 skip in seven full-file runs across the commits, h3 cases at 2.0-2.35 s (in line with the h2 cases) and h1-gzip at 1.8-1.9 s; no server processes left behind afterwards. Two copies of the file running concurrently still pass with the h3 cases at 2.1-2.4 s. Before the change the same command failed the four h3 cases in 3/3 runs. The reaping hook was checked with a copy of the file whose server never prints its URL: with the hook nothing is left after the file, without it one server survives.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->