### PR TITLE
uws: run the close gate in HttpResponse::cork() when the cork slot was lost

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -871,38 +871,35 @@ public:
             Super::cork();
             handler();
 
-            /* If we're no longer in a cork slot, either: (a) the handler wrote
-             * large data that triggered an internal uncork, (b) our empty slot
-             * was stolen by another request during an await, or (c) we were
-             * upgraded to a WebSocket (upgrade path transferred the slot). In
-             * all cases our data (if any) was already flushed; nothing to do.
-             * The upgrade case is handled by HttpContext's uncork or the drain
-             * loop. */
-            if (loopData->findCorkSlot(this) == LoopData::INVALID_CORK_SLOT) {
+            /* The handler may have closed this socket (an end that reached a
+             * close gate, an abort, an upgrade that relocated the socket); its
+             * ext is destructed then, so there is nothing to flush or to gate. */
+            if (us_socket_is_closed((us_socket_t *) this)) {
                 return this;
             }
 
-            /* Timeout on uncork failure, since most writes will succeed while corked */
-            auto [written, failed] = Super::uncork();
+            /* We may have lost our cork slot during the handler: a write larger
+             * than the cork buffer uncorked us, another socket borrowed the slot
+             * while it was still empty, or JS run by the handler corked two
+             * other sockets and AsyncSocket::cork() force-flushed ours as the
+             * LRU slot. Our bytes are out in every case, but the close gate
+             * below must still run: an end that does not gate itself
+             * (uws_res_end_without_body) relies on it, and outside the parser
+             * there is no later one. (If the forced flush hit backpressure,
+             * HttpContext::onWritable's gate closes once it drains.) */
+            if (loopData->findCorkSlot(this) != LoopData::INVALID_CORK_SLOT) {
+                /* Timeout on uncork failure, since most writes will succeed while corked */
+                auto [written, failed] = Super::uncork();
 
-            if (written > 0 || failed) {
-                /* For now we only have one single timeout so let's use it */
-                /* This behavior should equal the behavior in HttpContext when uncorking fails */
-                this->resetTimeout();
+                if (written > 0 || failed) {
+                    /* For now we only have one single timeout so let's use it */
+                    /* This behavior should equal the behavior in HttpContext when uncorking fails */
+                    this->resetTimeout();
+                }
             }
 
             /* If we have no backbuffer and we are connection close and we responded fully then close */
-            HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
-            if (httpResponseData->shouldCloseConnection()) {
-                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                    if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
-                        ((AsyncSocket<SSL> *) this)->shutdown();
-                        /* We need to force close after sending FIN since we want to hinder
-                        * clients from keeping to send their huge data */
-                        ((AsyncSocket<SSL> *) this)->close();
-                    }
-                }
-            }
+            closeIfDoneAndMarked(getHttpResponseData());
         } else {
             /* We are already corked, or can't cork so let's just call the handler */
             handler();

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -98,7 +98,15 @@ public:
 
     /* Shutdown+close when the connection is marked to close (Connection:
      * close, peer FIN, close-when-idle), the response is complete and every
-     * outgoing byte has been flushed. Returns true when the socket was closed. */
+     * outgoing byte has been flushed. Returns true when the socket was closed.
+     *
+     * Where it runs: HttpContext::onData's tail for the socket being parsed;
+     * cork() after its handler, for everything rendered through it (the only
+     * gate an end that does not gate itself, uws_res_end_without_body, gets);
+     * internalEnd, for ends reached outside cork() on a socket uws_res_write
+     * corked by itself (the loop's leftover-cork drain flushes but never
+     * closes); HttpContext::onWritable once a backpressured tail drains; and
+     * uws_res_close_if_done_and_marked after the uncorked ends on Bun's side. */
     bool closeIfDoneAndMarked(HttpResponseData<SSL> *httpResponseData) {
         if (httpResponseData->shouldCloseConnection()) {
             if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
@@ -212,13 +220,14 @@ public:
                 }
             } else if (!keepCorked) {
                 this->uncork();
-                /* That uncork released our cork slot, so the cork() wrapper's
-                 * post-uncork close gate will not run. When THIS socket is the
-                 * one being parsed, onData's post-parse gate closes it once
-                 * the buffer is fully consumed; any other socket (an async
-                 * handler completing, possibly inside another socket's parse
-                 * window via a drained microtask) gets no later gate, so close
-                 * here. */
+                /* The cork we just released may not be cork()'s at all: a
+                 * streaming body's uws_res_write corks the socket by itself,
+                 * and an end on such a socket (an async handler completing,
+                 * possibly inside another socket's parse window via a drained
+                 * microtask) gets no later gate unless THIS socket is the one
+                 * being parsed, which onData's tail closes once the buffer is
+                 * consumed. Inside cork() this just closes first; the wrapper
+                 * then finds the socket closed. */
                 if (HttpContext<SSL>::fromSocket((us_socket_t *) this)->getSocketContextData()->parsingSocket != (us_socket_t *) this
                     && closeIfDoneAndMarked(httpResponseData)) {
                     return true;
@@ -279,9 +288,9 @@ public:
                     closeIfDoneAndMarked(httpResponseData);
                 }  else if (!keepCorked) {
                     this->uncork();
-                    /* Same as the chunked arm above: the cork slot is gone, so
-                     * run the close gate here unless THIS socket is the one
-                     * being parsed (then onData's post-parse gate handles it). */
+                    /* Same as the chunked arm above: the cork may have been the
+                     * socket's own, so gate here unless THIS socket is the one
+                     * being parsed (then onData's tail handles it). */
                     if (HttpContext<SSL>::fromSocket((us_socket_t *) this)->getSocketContextData()->parsingSocket != (us_socket_t *) this) {
                         closeIfDoneAndMarked(httpResponseData);
                     }
@@ -867,7 +876,6 @@ public:
      /* Corks the response if possible. Leaves already corked socket be. */
     HttpResponse *cork(MoveOnlyFunction<void()> &&handler) {
         if (!Super::isCorked()) {
-            LoopData *loopData = Super::getLoopData();
             Super::cork();
             handler();
 
@@ -878,27 +886,24 @@ public:
                 return this;
             }
 
-            /* We may have lost our cork slot during the handler: a write larger
-             * than the cork buffer uncorked us, another socket borrowed the slot
-             * while it was still empty, or JS run by the handler corked two
-             * other sockets and AsyncSocket::cork() force-flushed ours as the
-             * LRU slot. Our bytes are out in every case, but the close gate
-             * below must still run: an end that does not gate itself
-             * (uws_res_end_without_body) relies on it, and outside the parser
-             * there is no later one. (If the forced flush hit backpressure,
-             * HttpContext::onWritable's gate closes once it drains.) */
-            if (loopData->findCorkSlot(this) != LoopData::INVALID_CORK_SLOT) {
-                /* Timeout on uncork failure, since most writes will succeed while corked */
-                auto [written, failed] = Super::uncork();
+            /* uncork() is a no-op if the handler cost us our slot: a write
+             * larger than the cork buffer uncorked us, another socket borrowed
+             * the still-empty slot, or JS run by the handler corked two other
+             * sockets and AsyncSocket::cork() force-flushed ours as the LRU
+             * slot. Our bytes are out in every case. Otherwise, timeout on
+             * uncork failure, since most writes will succeed while corked. */
+            auto [written, failed] = Super::uncork();
 
-                if (written > 0 || failed) {
-                    /* For now we only have one single timeout so let's use it */
-                    /* This behavior should equal the behavior in HttpContext when uncorking fails */
-                    this->resetTimeout();
-                }
+            if (written > 0 || failed) {
+                /* For now we only have one single timeout so let's use it */
+                /* This behavior should equal the behavior in HttpContext when uncorking fails */
+                this->resetTimeout();
             }
 
-            /* If we have no backbuffer and we are connection close and we responded fully then close */
+            /* Whether or not the slot survived: for an end that does not gate
+             * itself (uws_res_end_without_body) this is the only gate outside
+             * the parser. A forced flush that hit backpressure is left to
+             * HttpContext::onWritable. */
             closeIfDoneAndMarked(getHttpResponseData());
         } else {
             /* We are already corked, or can't cork so let's just call the handler */

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1354,7 +1354,7 @@ extern "C"
    * sendfile path): closes the socket when the connection is marked to close
    * (Connection: close, peer FIN, close-when-idle), the response is complete,
    * and every outgoing byte has been flushed. Corked responses are left to the
-   * cork() wrapper's own post-uncork gate. */
+   * gate HttpResponse::cork() runs after its handler. */
   void uws_res_close_if_done_and_marked(int ssl, uws_res_r res)
   {
     /* A callback upstream of this gate may already have closed the socket;
@@ -1423,9 +1423,9 @@ extern "C"
       /* No close gate here: callers (FileResponseStream::finish,
        * DevServer/HTMLBundle error paths) keep using the response after this
        * returns, so closing inside this call would destruct the ext under
-       * them. Corked callers get the cork() wrapper's post-uncork gate;
-       * uncorked ones run uws_res_close_if_done_and_marked themselves once
-       * they are done with the response. */
+       * them. Corked callers get the gate HttpResponse::cork() runs after its
+       * handler; uncorked ones run uws_res_close_if_done_and_marked themselves
+       * once they are done with the response. */
     }
     else
     {

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1420,12 +1420,8 @@ extern "C"
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone(uwsRes);
       uwsRes->resetTimeout();
-      /* No close gate here: callers (FileResponseStream::finish,
-       * DevServer/HTMLBundle error paths) keep using the response after this
-       * returns, so closing inside this call would destruct the ext under
-       * them. Corked callers get the gate HttpResponse::cork() runs after its
-       * handler; uncorked ones run uws_res_close_if_done_and_marked themselves
-       * once they are done with the response. */
+      /* Callers keep using the response after this returns, so the close gate
+       * must not run here; closeIfDoneAndMarked() lists who runs it instead. */
     }
     else
     {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1393,6 +1393,7 @@ test("a Connection: close response still closes when its cork slot is evicted wh
     new WebSocket(`ws://127.0.0.1:${server.port}/ws`),
     new WebSocket(`ws://127.0.0.1:${server.port}/ws`),
   ];
+  for (const ws of wsClients) ws.onerror = event => bothOpen.reject(new Error(`websocket client ${event.type}`));
   await bothOpen.promise;
 
   let received = "";

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1347,6 +1347,89 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
   });
 });
 
+test("a Connection: close response still closes when its cork slot is evicted while it completes", async () => {
+  // A 304 from an async handler completes through the no-body end path, whose
+  // only close gate is the one at the end of HttpResponse::cork(). Ending the
+  // response rejects the unread request body, and that rejection handler runs
+  // in the microtask drain the end performs while the response still holds its
+  // cork slot. Corking two other sockets from there fills both of the loop's
+  // cork slots, so the second cork() force-flushes the response's slot (LRU).
+  // cork() used to treat its missing slot as "nothing left to do" and skip the
+  // gate, so the 304 reached the client but the connection was never shut
+  // down: a client reading until EOF hung until idleTimeout.
+  const wsServerSide: ServerWebSocket<unknown>[] = [];
+  const bothOpen = Promise.withResolvers<void>();
+  let evicted = false;
+  using server = Bun.serve<unknown>({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 255,
+    websocket: {
+      open(ws) {
+        if (wsServerSide.push(ws) === 2) bothOpen.resolve();
+      },
+      message() {},
+    },
+    async fetch(req, server) {
+      if (new URL(req.url).pathname === "/ws") {
+        if (server.upgrade(req)) return;
+        return new Response(null, { status: 400 });
+      }
+      const [b, c] = wsServerSide;
+      req.text().catch(() => {
+        b.cork(() => {
+          b.send("b");
+          c.cork(() => c.send("c"));
+        });
+        evicted = true;
+      });
+      // Leave the parser's dispatch (uws corks the socket itself there) so the
+      // response below is rendered through HttpResponse::cork().
+      await Bun.sleep(0);
+      return new Response(null, { status: 304 });
+    },
+  });
+  const wsClients = [
+    new WebSocket(`ws://127.0.0.1:${server.port}/ws`),
+    new WebSocket(`ws://127.0.0.1:${server.port}/ws`),
+  ];
+  await bothOpen.promise;
+
+  let received = "";
+  const shutDown = Promise.withResolvers<void>();
+  using client = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    socket: {
+      data(_socket, chunk) {
+        received += chunk.toString();
+      },
+      end() {
+        shutDown.resolve();
+      },
+      close() {
+        shutDown.resolve();
+      },
+      error(_socket, error) {
+        shutDown.reject(error);
+      },
+    },
+  });
+  // The body never arrives, so the request body is still pending when the
+  // response completes.
+  client.write("POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nContent-Length: 10\r\n\r\n");
+  // Only the server ever shuts this connection down (the client does not hang
+  // up and idleTimeout is out of reach), so the runner timeout is the stall
+  // bound for the missing close.
+  await shutDown.promise;
+  for (const ws of wsClients) ws.close();
+
+  expect({ evicted, statusLine: received.slice(0, received.indexOf("\r\n")) }).toEqual({
+    evicted: true,
+    statusLine: "HTTP/1.1 304 Not Modified",
+  });
+});
+
 test("should be able to await server.stop(true) with keep alive", async () => {
   const { promise, resolve } = Promise.withResolvers();
   const ready = Promise.withResolvers();

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1348,15 +1348,16 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
 });
 
 test("a Connection: close response still closes when its cork slot is evicted while it completes", async () => {
-  // A 304 from an async handler completes through the no-body end path, whose
-  // only close gate is the one at the end of HttpResponse::cork(). Ending the
-  // response rejects the unread request body, and that rejection handler runs
-  // in the microtask drain the end performs while the response still holds its
-  // cork slot. Corking two other sockets from there fills both of the loop's
-  // cork slots, so the second cork() force-flushes the response's slot (LRU).
-  // cork() used to treat its missing slot as "nothing left to do" and skip the
-  // gate, so the 304 reached the client but the connection was never shut
-  // down: a client reading until EOF hung until idleTimeout.
+  // A 304 from an async handler completes through the no-body end path; its
+  // close check on the Bun side is skipped while the socket is corked, which
+  // leaves the gate at the end of HttpResponse::cork() as the only one. Ending
+  // the response rejects the unread request body, and that rejection handler
+  // runs in the microtask drain the end performs while the response still
+  // holds its cork slot. Corking two other sockets from there fills both of the
+  // loop's cork slots, so the second cork() force-flushes the response's slot
+  // (LRU). cork() used to treat its missing slot as "nothing left to do" and
+  // skip the gate, so the 304 reached the client but the connection was never
+  // shut down: a client reading until EOF hung until idleTimeout.
   const wsServerSide: ServerWebSocket<unknown>[] = [];
   const bothOpen = Promise.withResolvers<void>();
   let evicted = false;
@@ -1396,33 +1397,12 @@ test("a Connection: close response still closes when its cork slot is evicted wh
   for (const ws of wsClients) ws.onerror = event => bothOpen.reject(new Error(`websocket client ${event.type}`));
   await bothOpen.promise;
 
-  let received = "";
-  const shutDown = Promise.withResolvers<void>();
-  using client = await Bun.connect({
-    hostname: "127.0.0.1",
-    port: server.port,
-    socket: {
-      data(_socket, chunk) {
-        received += chunk.toString();
-      },
-      end() {
-        shutDown.resolve();
-      },
-      close() {
-        shutDown.resolve();
-      },
-      error(_socket, error) {
-        shutDown.reject(error);
-      },
-    },
-  });
   // The body never arrives, so the request body is still pending when the
   // response completes.
-  client.write("POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nContent-Length: 10\r\n\r\n");
-  // Only the server ever shuts this connection down (the client does not hang
-  // up and idleTimeout is out of reach), so the runner timeout is the stall
-  // bound for the missing close.
-  await shutDown.promise;
+  const received = await requestUntilServerCloses(
+    server.port,
+    "POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nContent-Length: 10\r\n\r\n",
+  );
   for (const ws of wsClients) ws.close();
 
   expect({ evicted, statusLine: received.slice(0, received.indexOf("\r\n")) }).toEqual({
@@ -1430,6 +1410,72 @@ test("a Connection: close response still closes when its cork slot is evicted wh
     statusLine: "HTTP/1.1 304 Not Modified",
   });
 });
+
+test("a Connection: close streaming response ended on a socket its own body write corked still closes", async () => {
+  // Companion of the test above for the other gate: nothing below completes
+  // inside HttpResponse::cork(). flush() writes the chunk through uws_res_write,
+  // which corks the socket by itself, and end() then completes the response on
+  // that socket. The loop's leftover-cork drain only flushes, so internalEnd's
+  // own close check is what has to shut the connection down.
+  using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    idleTimeout: 255,
+    async fetch() {
+      await Bun.sleep(0);
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            // pull() is first invoked by the render, inside cork(); produce
+            // the body only once that (and the loop's cork drain) is over.
+            await Bun.sleep(0);
+            controller.write("x");
+            controller.flush();
+            await controller.end();
+          },
+        }),
+      );
+    },
+  });
+
+  const received = await requestUntilServerCloses(
+    server.port,
+    "GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+  );
+
+  expect(received).toMatch(/^HTTP\/1\.1 200 OK\r\n[^]*\r\n\r\n1\r\nx\r\n0\r\n\r\n$/);
+});
+
+// Writes one request and returns everything received once the server shuts
+// the connection down. The client itself never half-closes before that (a
+// client FIN would make the server close the connection for its own reasons),
+// and the callers' servers put idleTimeout out of reach, so a missing
+// server-side close stalls here until the runner timeout.
+async function requestUntilServerCloses(port: number, request: string): Promise<string> {
+  let received = "";
+  const shutDown = Promise.withResolvers<string>();
+  using client = await Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    socket: {
+      data(_socket, chunk) {
+        received += chunk.toString();
+      },
+      end() {
+        shutDown.resolve(received);
+      },
+      close() {
+        shutDown.resolve(received);
+      },
+      error(_socket, error) {
+        shutDown.reject(error);
+      },
+    },
+  });
+  client.write(request);
+  return await shutDown.promise;
+}
 
 test("should be able to await server.stop(true) with keep alive", async () => {
   const { promise, resolve } = Promise.withResolvers();


### PR DESCRIPTION
Follow-up to #37074, from review: `HttpResponse::cork()` returned early when the socket no longer held a cork slot after the handler ran (`HttpResponse.h`, the `findCorkSlot(this) == INVALID_CORK_SLOT` return), which skipped the `shouldCloseConnection()` gate at the end of the wrapper.

## Repro

The slot is also lost when JS run by the handler corks two other sockets: `AsyncSocket::cork()` (`AsyncSocket.h`, "Both slots hold data from other sockets") force-uncorks the least recently used slot, which is the one belonging to the response being rendered. A response that completes through a path with no gate of its own (`uws_res_end_without_body`: HEAD, 304, the bodiless node:http ends) on a socket outside the parser (any async handler) was then never shut down. The bytes reach the client, but a `Connection: close` / HTTP/1.0 client (nginx with `proxy_http_version 1.0`, for instance) waits for EOF until `idleTimeout`.

Reproducible from JS without nginx: an async handler answering a `Connection: close` POST whose body never arrives with a 304. Ending the response rejects the unread body, and that rejection handler runs in the microtask drain the end performs while the response still holds its slot:

```js
req.text().catch(() => {
  wsB.cork(() => {
    wsB.send("b");
    wsC.cork(() => wsC.send("c")); // both slots full: evicts the response's slot
  });
});
await Bun.sleep(0);
return new Response(null, { status: 304 });
```

Before: the client receives `HTTP/1.1 304 Not Modified` and the connection stays open (canary and a `main` debug build both hang until idleTimeout; dropping the `wsC.cork` line makes it close in ~50ms). After: the connection is shut down right after the response.

## Fix

`cork()` now bails only if the handler closed the socket (its ext is destructed then; a closed socket never holds a slot, so that is the case the early return was actually protecting), then uncorks (`AsyncSocket::uncork()` is already a no-op without a slot, same shape as `HttpContext::onData` and `WebSocket::cork`) and runs `closeIfDoneAndMarked()` either way. A forced flush that hit backpressure leaves the gate to `HttpContext::onWritable`, as before.

The gates #37074 added to `internalEnd`'s corked paths were justified with "the wrapper's gate will not run", which this makes untrue. They are still needed, for a different reason: a streaming body's `uws_res_write` corks the socket on its own, outside any `cork()` frame, and the loop's leftover-cork drain only flushes. The comments now say that, `closeIfDoneAndMarked()` lists the gate sites once, and the two "post-uncork gate" cross-references in `libuwsockets.cpp` are reworded.

## Verification

Two tests in `test/js/bun/http/bun-server.test.ts`, both waiting for the server's FIN on a raw socket:

- "a Connection: close response still closes when its cork slot is evicted while it completes": the scenario above. Times out on the current build, passes in well under 100ms with the fix (25/25 reruns).
- "a Connection: close streaming response ended on a socket its own body write corked still closes": pins `internalEnd`'s corked-path gates. Checked that it is the gate being pinned by temporarily disabling those two gates: this test stalls while the eviction test still passes; with the gates back both pass.

`bun-server.test.ts`, `serve.test.ts`, `websocket-server.test.ts`, `request-smuggling.test.ts`, `bun-serve-static.test.ts`, `bun-serve-file.test.ts`, `bun-serve-headers.test.ts`, `tls-keepalive.test.ts`, `node-http-nested-cork.test.ts`, `node-http-server-socket-end-drain.test.ts`, `node-http-pinned-write.test.ts`, `node-http-backpressure.test.ts`, `websocket-server-upgrade-reentrant.test.ts` on a debug build. The remaining local failures are environmental: the tests that connect to `localhost` (refused in this container), `requestIP v6`, the privileged-port and `/bun:info` tests fail the same way on an unmodified release build here, and the few timeouts were subprocess-spawning tests run concurrently under the debug build that pass when run alone. The first revision of this PR (fix + eviction test) was green across all 190 CI jobs.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->