### PR TITLE
jsc: check for exceptions before using a stored constructEmptyArray result

### DIFF
--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -919,8 +919,11 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__upsertBunStringArray(
         } else {
             // Create new array with both values
             JSC::JSArray* array = JSC::constructEmptyArray(global, nullptr, 2);
+            RETURN_IF_EXCEPTION(scope, {});
             array->putDirectIndex(global, 0, existingValue);
+            RETURN_IF_EXCEPTION(scope, {});
             array->putDirectIndex(global, 1, newValue);
+            RETURN_IF_EXCEPTION(scope, {});
             target->putDirect(vm, id, array, 0);
         }
     } else {

--- a/src/jsc/bindings/ProcessBindingHTTPParser.cpp
+++ b/src/jsc/bindings/ProcessBindingHTTPParser.cpp
@@ -7,8 +7,7 @@ namespace Bun {
 
 using namespace JSC;
 
-// Lazy property builder: exceptions must not propagate into
-// reifyStaticProperty, which performs no exception check.
+// reifyStaticProperty, which calls the builders below, does not check for exceptions.
 static JSArray* constructMethodsArray(VM& vm, JSGlobalObject* globalObject, unsigned length)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/src/jsc/bindings/ProcessBindingHTTPParser.cpp
+++ b/src/jsc/bindings/ProcessBindingHTTPParser.cpp
@@ -1,16 +1,33 @@
 #include "ProcessBindingHTTPParser.h"
 #include "ZigGlobalObject.h"
+#include "JavaScriptCore/TopExceptionScope.h"
 #include "llhttp/llhttp.h"
 
 namespace Bun {
 
 using namespace JSC;
 
+// Lazy property builder: exceptions must not propagate into
+// reifyStaticProperty, which performs no exception check.
+static JSArray* constructMethodsArray(VM& vm, JSGlobalObject* globalObject, unsigned length)
+{
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSArray* methods = constructEmptyArray(globalObject, nullptr, length);
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return nullptr;
+    }
+    return methods;
+}
+
 static JSValue ProcessBindingHTTPParser_methods(VM& vm, JSObject* binding)
 {
     JSGlobalObject* globalObject = binding->globalObject();
 
-    JSArray* methods = constructEmptyArray(globalObject, nullptr, 35);
+    JSArray* methods = constructMethodsArray(vm, globalObject, 35);
+    if (!methods) [[unlikely]]
+        return jsUndefined();
 
     int index = 0;
 #define FOR_EACH_METHOD(num, name, string) \
@@ -25,7 +42,9 @@ static JSValue ProcessBindingHTTPParser_allMethods(VM& vm, JSObject* binding)
 {
     JSGlobalObject* globalObject = binding->globalObject();
 
-    JSArray* methods = constructEmptyArray(globalObject, nullptr, 47);
+    JSArray* methods = constructMethodsArray(vm, globalObject, 47);
+    if (!methods) [[unlikely]]
+        return jsUndefined();
 
     int index = 0;
 #define FOR_EACH_METHOD(num, name, string) \

--- a/src/jsc/bindings/ProcessBindingHTTPParser.cpp
+++ b/src/jsc/bindings/ProcessBindingHTTPParser.cpp
@@ -7,26 +7,13 @@ namespace Bun {
 
 using namespace JSC;
 
-// reifyStaticProperty, which calls the builders below, does not check for exceptions.
-static JSArray* constructMethodsArray(VM& vm, JSGlobalObject* globalObject, unsigned length)
-{
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    JSArray* methods = constructEmptyArray(globalObject, nullptr, length);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        return nullptr;
-    }
-    return methods;
-}
-
 static JSValue ProcessBindingHTTPParser_methods(VM& vm, JSObject* binding)
 {
     JSGlobalObject* globalObject = binding->globalObject();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    JSArray* methods = constructMethodsArray(vm, globalObject, 35);
-    if (!methods) [[unlikely]]
-        return jsUndefined();
+    JSArray* methods = constructEmptyArray(globalObject, nullptr, 35);
+    RETURN_IF_EXCEPTION(scope, {});
 
     int index = 0;
 #define FOR_EACH_METHOD(num, name, string) \
@@ -40,10 +27,10 @@ static JSValue ProcessBindingHTTPParser_methods(VM& vm, JSObject* binding)
 static JSValue ProcessBindingHTTPParser_allMethods(VM& vm, JSObject* binding)
 {
     JSGlobalObject* globalObject = binding->globalObject();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    JSArray* methods = constructMethodsArray(vm, globalObject, 47);
-    if (!methods) [[unlikely]]
-        return jsUndefined();
+    JSArray* methods = constructEmptyArray(globalObject, nullptr, 47);
+    RETURN_IF_EXCEPTION(scope, {});
 
     int index = 0;
 #define FOR_EACH_METHOD(num, name, string) \

--- a/src/jsc/bindings/ProcessBindingUV.cpp
+++ b/src/jsc/bindings/ProcessBindingUV.cpp
@@ -153,20 +153,30 @@ JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFra
 JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
-    auto map = JSC::JSMap::create(vm, globalObject->mapStructure());
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* map = JSC::JSMap::create(vm, globalObject->mapStructure());
 
-    // Inlining each of these via macros costs like 300 KB.
-    const auto putProperty = [](JSC::VM& vm, JSC::JSMap* map, JSC::JSGlobalObject* globalObject, ASCIILiteral name, int value, ASCIILiteral desc) -> void {
-        auto arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);
-        // RETURN_IF_EXCEPTION
-        arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(name)));
-        arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(desc)));
-        map->set(globalObject, JSC::jsNumber(value), arr);
+    struct Entry {
+        ASCIILiteral name;
+        int value;
+        ASCIILiteral desc;
+    };
+    static constexpr Entry entries[] = {
+#define ENTRY(name, desc) { #name##_s, UV_##name, desc##_s },
+        BUN_UV_ERRNO_MAP(ENTRY)
+#undef ENTRY
     };
 
-#define PUT_PROPERTY(name, desc) putProperty(vm, map, globalObject, #name##_s, UV_##name, desc##_s);
-    BUN_UV_ERRNO_MAP(PUT_PROPERTY)
-#undef PUT_PROPERTY
+    for (const auto& [name, value, desc] : entries) {
+        auto* arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);
+        RETURN_IF_EXCEPTION(scope, {});
+        arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(name)));
+        RETURN_IF_EXCEPTION(scope, {});
+        arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(desc)));
+        RETURN_IF_EXCEPTION(scope, {});
+        map->set(globalObject, JSC::jsNumber(value), arr);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
 
     return JSValue::encode(map);
 }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2685,7 +2685,7 @@ impl DevServer {
         // TODO: lazy structure caching since we are making these objects a lot
         let global = self.vm().global();
         let params_js_value = if self.router.match_slow(pathname, &mut params).is_some() {
-            params.to_js(global)
+            params.to_js(global)?
         } else {
             JSValue::NULL
         };
@@ -6758,7 +6758,7 @@ fn new_route_params_for_bundle_promise(
             route_index.get()
         )));
     }
-    let params_js_value = params.to_js(global);
+    let params_js_value = params.to_js(global)?;
 
     // SAFETY: `dev_ptr` is live; `framework_bundle` points into
     // `(*dev_ptr).route_bundles[route_bundle_index].data` and its reborrow is

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1210,11 +1210,11 @@ impl MatchedParams {
 
     /// Convert the matched params to a JavaScript object
     /// Returns null if there are no params
-    pub fn to_js(&self, global: &JSGlobalObject) -> JSValue {
+    pub fn to_js(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         let params_array = self.params.const_slice();
 
         if params_array.is_empty() {
-            return JSValue::NULL;
+            return Ok(JSValue::NULL);
         }
 
         // Create a JavaScript object with params
@@ -1223,14 +1223,9 @@ impl MatchedParams {
             let key_str = bun_core::String::clone_utf8(param.key.slice());
             let value_str = bun_core::String::clone_utf8(param.value.slice());
 
-            obj.put_bun_string_one_or_array(
-                global,
-                &key_str,
-                value_str.to_js(global).expect("unreachable"),
-            )
-            .expect("unreachable");
+            obj.put_bun_string_one_or_array(global, &key_str, value_str.to_js(global)?)?;
         }
-        obj
+        Ok(obj)
     }
 }
 

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1220,8 +1220,10 @@ impl MatchedParams {
         // Create a JavaScript object with params
         let obj = JSValue::create_empty_object(global, params_array.len());
         for param in params_array {
-            let key_str = bun_core::String::clone_utf8(param.key.slice());
-            let value_str = bun_core::String::clone_utf8(param.value.slice());
+            let key_str =
+                bun_core::OwnedString::new(bun_core::String::clone_utf8(param.key.slice()));
+            let value_str =
+                bun_core::OwnedString::new(bun_core::String::clone_utf8(param.value.slice()));
 
             obj.put_bun_string_one_or_array(global, &key_str, value_str.to_js(global)?)?;
         }
@@ -1867,7 +1869,9 @@ impl JSFrameworkRouter {
                         JSValue::create_empty_object(global, params_out.params.len() as usize);
                     for param in params_out.params.slice() {
                         // key/value borrow from `path`/pattern, both live here (RawSlice invariant)
-                        let value_str = bun_core::String::clone_utf8(param.value.slice());
+                        let value_str = bun_core::OwnedString::new(bun_core::String::clone_utf8(
+                            param.value.slice(),
+                        ));
                         params_obj.put(global, param.key.slice(), value_str.to_js(global)?);
                     }
                     params_obj

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -1,6 +1,6 @@
 import { frameworkRouterInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 const { parseRoutePattern, FrameworkRouter } = frameworkRouterInternals;
@@ -131,5 +131,54 @@ test("discovers from filesystem paths", () => {
         children: [],
       },
     ],
+  });
+});
+
+test("match() releases the param strings it creates", async () => {
+  using dir = tempDir("fsr-params-leak", {
+    "[a]/[b]/[c]/[d].tsx": "1",
+  });
+
+  // Each matched param value is copied into a WTF string that the JS string
+  // then refs; the copy's own ref has to be released or every match leaks all
+  // four values (4 x 256 KiB here, about 200 MiB over the measured loop).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      /* js */ `
+        const { frameworkRouterInternals } = require("bun:internal-for-testing");
+        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const router = new frameworkRouterInternals.FrameworkRouter({ root: ${JSON.stringify(String(dir))}, style: "nextjs-pages" });
+        const segment = Buffer.alloc(256 * 1024, "x").toString();
+        const url = "/" + segment + "/" + segment + "/" + segment + "/" + segment;
+        const lengths = {};
+        for (const [name, value] of Object.entries(router.match(url).params)) lengths[name] = value.length;
+        console.log(JSON.stringify(lengths));
+        for (let i = 0; i < 20; i++) router.match(url);
+        Bun.gc(true);
+        const before = rss();
+        for (let i = 0; i < 200; i++) router.match(url);
+        Bun.gc(true);
+        const growthMB = (rss() - before) / 1024 / 1024;
+        if (growthMB > 64) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      // Under ASAN freed allocations sit in the quarantine (default
+      // quarantine_size_mb=256) instead of leaving RSS, which would hide the
+      // difference between releasing and leaking. Ignored by non-ASAN builds.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: '{"a":262144,"b":262144,"c":262144,"d":262144}\n',
+    stderr: "",
+    exitCode: 0,
   });
 });

--- a/test/internal/source-lints/construct-empty-array-unchecked.test.ts
+++ b/test/internal/source-lints/construct-empty-array-unchecked.test.ts
@@ -1,0 +1,207 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// JSC::constructEmptyArray (JSGlobalObjectInlines.h) returns nullptr with an
+// exception pending when it throws out of memory, and also when its internal
+// RETURN_IF_EXCEPTION services a VM trap: a worker.terminate() or vm timeout
+// that arrives while the caller runs first surfaces there. A caller that stores
+// the result and uses it before checking the scope dereferences null.
+// BUN_JSC_validateExceptionChecks does not catch this: putDirectIndex into a
+// pre-sized array and putDirect(vm, ..) open no ThrowScope, so a check anywhere
+// later in the function satisfies the validator with the dereference before it.
+//
+// The tree's shape is a check as the very next statement:
+//   JSArray* array = constructEmptyArray(globalObject, nullptr, 2);
+//   RETURN_IF_EXCEPTION(scope, {});
+// Lazy property builders, which cannot propagate, branch on scope.exception()
+// instead (Process_stubEmptyArray in BunProcess.cpp). This lint accepts those
+// two forms, or a null test of the result. It models the stored-result flavor
+// only; passing the call inline as an argument is a different shape.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const cxxSources = globAllSources().cxx;
+
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `ident = [JSC::]constructEmptyArray(...);` whether `ident` is being declared
+// or assigned; the argument list may span lines. `(?!=)` keeps `==` out.
+const STORED_CALL = /\b(\w+)\s*=(?!=)\s*(?:JSC::)?constructEmptyArray\s*\([^;]*\)\s*;/g;
+
+// Blank out comments but keep every newline so reported line numbers hold.
+function stripComments(content: string): string {
+  return content.replace(/\/\*[\s\S]*?\*\//g, c => c.replace(/[^\n]/g, " ")).replace(/\/\/.*$/gm, "");
+}
+
+// The first line of code executed after the statement ending at `from`.
+// Closing braces and preprocessor directives execute nothing, so a check that
+// follows them still counts.
+function nextStatement(stripped: string, from: number): string {
+  let i = from;
+  for (;;) {
+    while (i < stripped.length && /\s/.test(stripped[i]!)) i++;
+    if (stripped[i] === "}") {
+      i++;
+      continue;
+    }
+    if (stripped[i] === "#") {
+      const eol = stripped.indexOf("\n", i);
+      i = eol === -1 ? stripped.length : eol;
+      continue;
+    }
+    break;
+  }
+  const eol = stripped.indexOf("\n", i);
+  return stripped.slice(i, eol === -1 ? stripped.length : eol).trim();
+}
+
+function isExceptionCheck(statement: string, ident: string): boolean {
+  if (/^(?:CLEAR_AND_)?RETURN_IF_EXCEPTION\w*\s*\(/.test(statement)) return true;
+  if (!/^if\s*\(/.test(statement)) return false;
+  return /\.exception\(\)/.test(statement) || new RegExp(String.raw`!\s*${ident}\b`).test(statement);
+}
+
+function scanSource(content: string): { line: number; ident: string; next: string }[] {
+  const stripped = stripComments(content);
+  const found: { line: number; ident: string; next: string }[] = [];
+  for (const m of stripped.matchAll(STORED_CALL)) {
+    const ident = m[1]!;
+    const next = nextStatement(stripped, m.index! + m[0].length);
+    if (isExceptionCheck(next, ident)) continue;
+    const line = stripped.slice(0, m.index!).split("\n").length;
+    found.push({ line, ident, next });
+  }
+  return found;
+}
+
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of cxxSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  for (const { line, ident, next } of scanSource(await file(abs).text())) {
+    offenders.push(
+      `${source}:${line}: \`${ident} = constructEmptyArray(..)\` is not followed by an exception check (next statement: \`${next}\`) → ` +
+        `add RETURN_IF_EXCEPTION(scope, ..) right after it, or branch on scope.exception() in a lazy property builder`,
+    );
+  }
+}
+
+// Self-test fixtures: the scanner must fire on each unchecked shape and stay
+// quiet on each shape the tree uses for the check, so a regex that silently
+// matches nothing cannot pass the tree-wide test below.
+const detects: { label: string; ident: string; line: number; cpp: string }[] = [
+  {
+    label: "a dereference on the next line",
+    ident: "array",
+    line: 2,
+    cpp: `void f() {\n    JSC::JSArray* array = JSC::constructEmptyArray(global, nullptr, 2);\n    array->putDirectIndex(global, 0, existingValue);\n    RETURN_IF_EXCEPTION(scope, {});\n}\n`,
+  },
+  {
+    label: "an unrelated statement before the use",
+    ident: "methods",
+    line: 2,
+    cpp: `void f() {\n    JSArray* methods = constructEmptyArray(globalObject, nullptr, 35);\n\n    int index = 0;\n    methods->putDirectIndex(globalObject, index++, value);\n}\n`,
+  },
+  {
+    label: "a comment standing in for the check",
+    ident: "arr",
+    line: 2,
+    cpp: `void f() {\n    auto arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);\n    // RETURN_IF_EXCEPTION\n    arr->putDirectIndex(globalObject, 0, name);\n}\n`,
+  },
+  {
+    label: "assignment to an existing variable",
+    ident: "result",
+    line: 3,
+    cpp: `void f() {\n    JSArray* result = nullptr;\n    result = constructEmptyArray(globalObject, nullptr, 0);\n    result->push(globalObject, value);\n}\n`,
+  },
+  {
+    label: "an argument list spanning lines",
+    ident: "raw",
+    line: 2,
+    cpp: `void f() {\n    JSC::JSArray* raw = JSC::constructEmptyArray(globalObject, nullptr, static_cast<unsigned>(\n        count * 2));\n    raw->putDirectIndex(globalObject, 0, value);\n}\n`,
+  },
+  {
+    label: "a non-branching assertion",
+    ident: "array",
+    line: 2,
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    scope.assertNoExceptionExceptTermination();\n    array->push(globalObject, value);\n}\n`,
+  },
+];
+const ignores: { label: string; cpp: string }[] = [
+  {
+    label: "RETURN_IF_EXCEPTION on the next line",
+    cpp: `void f() {\n    JSC::JSArray* array = JSC::constructEmptyArray(global, nullptr, 2);\n    RETURN_IF_EXCEPTION(scope, {});\n    array->putDirectIndex(global, 0, existingValue);\n}\n`,
+  },
+  {
+    label: "RETURN_IF_EXCEPTION with another scope name and return value",
+    cpp: `void f() {\n    JSC::JSArray* array = constructEmptyArray(lexicalGlobalObject, nullptr, count);\n    RETURN_IF_EXCEPTION(throwScope, jsUndefined());\n    return array;\n}\n`,
+  },
+  {
+    label: "a check on the same line",
+    cpp: `void f() {\n    auto* values = constructEmptyArray(globalObject, nullptr, 0); RETURN_IF_EXCEPTION(scope, {});\n    return values;\n}\n`,
+  },
+  {
+    label: "the lazy property builder shape",
+    cpp: `void f() {\n    JSC::JSArray* array = JSC::constructEmptyArray(processObject->globalObject(), nullptr);\n    if (auto* exception = scope.exception()) [[unlikely]] {\n        (void)scope.tryClearException();\n        return JSC::jsUndefined();\n    }\n    return array;\n}\n`,
+  },
+  {
+    label: "a combined null and scope test",
+    cpp: `void f() {\n    auto* rawHeaders = JSC::constructEmptyArray(globalObject, nullptr, headers.size() * 2);\n    if (!rawHeaders || scope.exception()) [[unlikely]] {\n        return;\n    }\n    rawHeaders->push(globalObject, value);\n}\n`,
+  },
+  {
+    label: "a null test of the result",
+    cpp: `void f() {\n    val = JSC::constructEmptyArray(globalObject(), nullptr, 0);\n    if (!val) return {};\n    this->calls.set(vm(), this, val);\n}\n`,
+  },
+  {
+    label: "a check after the block that assigned the result",
+    cpp: `void f() {\n    if (!array) {\n        array = constructEmptyArray(globalObject, nullptr);\n    }\n    RETURN_IF_EXCEPTION(scope, {});\n    array->push(globalObject, value);\n}\n`,
+  },
+  {
+    label: "a check after a preprocessor directive",
+    cpp: `void f() {\n#if OS(WINDOWS)\n    JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);\n#endif\n    RETURN_IF_EXCEPTION(scope, {});\n    return keyArray;\n}\n`,
+  },
+  {
+    label: "the call used inline rather than stored, which this lint does not model",
+    cpp: `void f() {\n    return JSValue::encode(JSC::constructEmptyArray(globalObject, nullptr));\n}\n`,
+  },
+  {
+    label: "a comparison rather than an assignment",
+    cpp: `void f() {\n    if (array == constructEmptyArray(globalObject, nullptr)) {\n    }\n    array->push(globalObject, value);\n}\n`,
+  },
+  {
+    label: "an offending shape inside a block comment",
+    cpp: `void f() {\n    /*\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    array->push(globalObject, value);\n    */\n}\n`,
+  },
+];
+
+for (const { label, ident, line, cpp } of detects) {
+  test(`detects ${label}`, () => {
+    expect(scanSource(cpp)).toEqual([{ line, ident, next: expect.any(String) }]);
+  });
+}
+for (const { label, cpp } of ignores) {
+  test(`ignores ${label}`, () => {
+    expect(scanSource(cpp)).toEqual([]);
+  });
+}
+
+test("scans a non-empty set of tracked C++ sources", () => {
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("every stored constructEmptyArray result is exception-checked before use", () => {
+  expect(offenders).toEqual([]);
+});

--- a/test/internal/source-lints/construct-empty-array-unchecked.test.ts
+++ b/test/internal/source-lints/construct-empty-array-unchecked.test.ts
@@ -17,9 +17,13 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   JSArray* array = constructEmptyArray(globalObject, nullptr, 2);
 //   RETURN_IF_EXCEPTION(scope, {});
 // Lazy property builders, which cannot propagate, branch on scope.exception()
-// instead (Process_stubEmptyArray in BunProcess.cpp). This lint accepts those
-// two forms, or a null test of the result. It models the stored-result flavor
-// only; passing the call inline as an argument is a different shape.
+// instead (Process_stubEmptyArray in BunProcess.cpp). This lint requires the
+// statements following every stored call to be checks of the scope or of the
+// result, ending in one that leaves the function or loop body (a check that
+// only asserts or logs does not protect the use after it); returning the
+// result untouched also counts, since the caller then holds the same contract.
+// It models the stored-result flavor only; passing the call inline as an
+// argument is a different shape.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const cxxSources = globAllSources().cxx;
@@ -38,46 +42,129 @@ const tracked: Set<string> | null = (() => {
 // or assigned; the argument list may span lines. `(?!=)` keeps `==` out.
 const STORED_CALL = /\b(\w+)\s*=(?!=)\s*(?:JSC::)?constructEmptyArray\s*\([^;]*\)\s*;/g;
 
-// Blank out comments but keep every newline so reported line numbers hold.
-function stripComments(content: string): string {
-  return content.replace(/\/\*[\s\S]*?\*\//g, c => c.replace(/[^\n]/g, " ")).replace(/\/\/.*$/gm, "");
+// Blank out comments and the contents of string and character literals (so
+// braces and parens inside them do not take part in matching below), keeping
+// every newline so reported line numbers hold.
+function stripForScan(content: string): string {
+  let out = "";
+  let i = 0;
+  const blank = (end: number) => {
+    out += content.slice(i, end).replace(/[^\n]/g, " ");
+    i = end;
+  };
+  while (i < content.length) {
+    const rest = content.slice(i, i + 2);
+    if (rest === "//") {
+      const eol = content.indexOf("\n", i);
+      blank(eol === -1 ? content.length : eol);
+    } else if (rest === "/*") {
+      const close = content.indexOf("*/", i + 2);
+      blank(close === -1 ? content.length : close + 2);
+    } else if (rest[0] === '"' || (rest[0] === "'" && !/\w/.test(content[i - 1] ?? ""))) {
+      const quote = rest[0]!;
+      let j = i + 1;
+      while (j < content.length && content[j] !== quote && content[j] !== "\n") j += content[j] === "\\" ? 2 : 1;
+      out += quote;
+      i++;
+      blank(j);
+      if (content[j] === quote) {
+        out += quote;
+        i++;
+      }
+    } else {
+      out += content[i]!;
+      i++;
+    }
+  }
+  return out;
 }
 
-// The first line of code executed after the statement ending at `from`.
-// Closing braces and preprocessor directives execute nothing, so a check that
-// follows them still counts.
-function nextStatement(stripped: string, from: number): string {
+// Index just past the bracket matching the opener at `open`.
+function closeOf(text: string, open: number): number {
+  const [opener, closer] = text[open] === "(" ? ["(", ")"] : ["{", "}"];
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === opener) depth++;
+    else if (text[i] === closer && --depth === 0) return i + 1;
+  }
+  return text.length;
+}
+
+type Statement = { condition: string; body: string; end: number; display: string };
+
+// The next statement executed after `from`: closing braces and preprocessor
+// directives run nothing and are skipped. An `if` is split into its condition
+// and its body (a braced block or a single statement); anything else is a
+// single line with an empty condition.
+function nextStatement(stripped: string, from: number): Statement {
+  const lineEnd = (at: number) => {
+    const eol = stripped.indexOf("\n", at);
+    return eol === -1 ? stripped.length : eol;
+  };
   let i = from;
   for (;;) {
     while (i < stripped.length && /\s/.test(stripped[i]!)) i++;
-    if (stripped[i] === "}") {
-      i++;
-      continue;
-    }
-    if (stripped[i] === "#") {
-      const eol = stripped.indexOf("\n", i);
-      i = eol === -1 ? stripped.length : eol;
-      continue;
-    }
-    break;
+    if (stripped[i] === "}") i++;
+    else if (stripped[i] === "#") i = lineEnd(i);
+    else break;
   }
-  const eol = stripped.indexOf("\n", i);
-  return stripped.slice(i, eol === -1 ? stripped.length : eol).trim();
+  const firstLine = stripped.slice(i, lineEnd(i)).trim();
+  const display = firstLine === "" ? "<end of file>" : firstLine;
+  if (!/^if\s*\(/.test(firstLine)) {
+    return { condition: "", body: firstLine, end: lineEnd(i), display };
+  }
+  const conditionEnd = closeOf(stripped, stripped.indexOf("(", i));
+  let bodyStart = conditionEnd;
+  for (;;) {
+    while (bodyStart < stripped.length && /\s/.test(stripped[bodyStart]!)) bodyStart++;
+    if (!stripped.startsWith("[[", bodyStart)) break;
+    const attributeEnd = stripped.indexOf("]]", bodyStart);
+    bodyStart = attributeEnd === -1 ? stripped.length : attributeEnd + 2;
+  }
+  let end: number;
+  if (stripped[bodyStart] === "{") end = closeOf(stripped, bodyStart);
+  else {
+    const semicolon = stripped.indexOf(";", bodyStart);
+    end = semicolon === -1 ? stripped.length : semicolon + 1;
+  }
+  return { condition: stripped.slice(i, conditionEnd), body: stripped.slice(bodyStart, end), end, display };
 }
 
-function isExceptionCheck(statement: string, ident: string): boolean {
-  if (/^(?:CLEAR_AND_)?RETURN_IF_EXCEPTION\w*\s*\(/.test(statement)) return true;
-  if (!/^if\s*\(/.test(statement)) return false;
-  return /\.exception\(\)/.test(statement) || new RegExp(String.raw`!\s*${ident}\b`).test(statement);
+// `return x;`, `return JSValue::encode(x);`, or the RELEASE_AND_RETURN forms of
+// the same: the unexamined result goes straight back to the caller.
+function handsOff(statement: string, ident: string): boolean {
+  const value = String.raw`(?:${ident}|(?:JSC::)?JSValue::encode\s*\(\s*${ident}\s*\))`;
+  return new RegExp(String.raw`^(?:return\s+${value}|RELEASE_AND_RETURN\s*\(\s*\w+\s*,\s*${value}\s*\))\s*;`).test(
+    statement,
+  );
+}
+
+// Returns the statement that fails the rule, or null when the result is
+// protected before anything else runs.
+function unprotectedUse(stripped: string, from: number, ident: string): string | null {
+  const resultTest = new RegExp(String.raw`!\s*${ident}\s*(?:\)|\|\||&&)`);
+  for (;;) {
+    const statement = nextStatement(stripped, from);
+    if (statement.condition === "") {
+      if (/^(?:CLEAR_AND_)?RETURN_IF_EXCEPTION\w*\s*\(/.test(statement.body)) return null;
+      return handsOff(statement.body, ident) ? null : statement.display;
+    }
+    if (!/\.exception\(\)/.test(statement.condition) && !resultTest.test(statement.condition)) return statement.display;
+    if (/\b(?:return|goto|break|continue)\b|\bRELEASE_AND_RETURN\b/.test(statement.body)) return null;
+    // A check that does not leave (an assertion, a log line): the statement
+    // after it still has to protect the result.
+    if (statement.end <= from) return statement.display;
+    from = statement.end;
+  }
 }
 
 function scanSource(content: string): { line: number; ident: string; next: string }[] {
-  const stripped = stripComments(content);
+  const stripped = stripForScan(content);
   const found: { line: number; ident: string; next: string }[] = [];
   for (const m of stripped.matchAll(STORED_CALL)) {
     const ident = m[1]!;
-    const next = nextStatement(stripped, m.index! + m[0].length);
-    if (isExceptionCheck(next, ident)) continue;
+    const next = unprotectedUse(stripped, m.index! + m[0].length, ident);
+    if (next === null) continue;
     const line = stripped.slice(0, m.index!).split("\n").length;
     found.push({ line, ident, next });
   }
@@ -102,42 +189,76 @@ for (const abs of cxxSources) {
 // Self-test fixtures: the scanner must fire on each unchecked shape and stay
 // quiet on each shape the tree uses for the check, so a regex that silently
 // matches nothing cannot pass the tree-wide test below.
-const detects: { label: string; ident: string; line: number; cpp: string }[] = [
+const detects: { label: string; ident: string; line: number; next: string; cpp: string }[] = [
   {
     label: "a dereference on the next line",
     ident: "array",
     line: 2,
+    next: "array->putDirectIndex(global, 0, existingValue);",
     cpp: `void f() {\n    JSC::JSArray* array = JSC::constructEmptyArray(global, nullptr, 2);\n    array->putDirectIndex(global, 0, existingValue);\n    RETURN_IF_EXCEPTION(scope, {});\n}\n`,
   },
   {
     label: "an unrelated statement before the use",
     ident: "methods",
     line: 2,
+    next: "int index = 0;",
     cpp: `void f() {\n    JSArray* methods = constructEmptyArray(globalObject, nullptr, 35);\n\n    int index = 0;\n    methods->putDirectIndex(globalObject, index++, value);\n}\n`,
   },
   {
     label: "a comment standing in for the check",
     ident: "arr",
     line: 2,
+    next: "arr->putDirectIndex(globalObject, 0, name);",
     cpp: `void f() {\n    auto arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);\n    // RETURN_IF_EXCEPTION\n    arr->putDirectIndex(globalObject, 0, name);\n}\n`,
   },
   {
     label: "assignment to an existing variable",
     ident: "result",
     line: 3,
+    next: "result->push(globalObject, value);",
     cpp: `void f() {\n    JSArray* result = nullptr;\n    result = constructEmptyArray(globalObject, nullptr, 0);\n    result->push(globalObject, value);\n}\n`,
   },
   {
     label: "an argument list spanning lines",
     ident: "raw",
     line: 2,
+    next: "raw->putDirectIndex(globalObject, 0, value);",
     cpp: `void f() {\n    JSC::JSArray* raw = JSC::constructEmptyArray(globalObject, nullptr, static_cast<unsigned>(\n        count * 2));\n    raw->putDirectIndex(globalObject, 0, value);\n}\n`,
   },
   {
     label: "a non-branching assertion",
     ident: "array",
     line: 2,
+    next: "scope.assertNoExceptionExceptTermination();",
     cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    scope.assertNoExceptionExceptTermination();\n    array->push(globalObject, value);\n}\n`,
+  },
+  {
+    label: "a check whose branch only logs",
+    ident: "array",
+    line: 2,
+    next: "array->push(globalObject, value);",
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    if (scope.exception()) [[unlikely]] {\n        dataLogLn("allocation failed");\n    }\n    array->push(globalObject, value);\n}\n`,
+  },
+  {
+    label: "a null test that dereferences the result",
+    ident: "array",
+    line: 2,
+    next: "if (!array->length())",
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    if (!array->length())\n        return;\n}\n`,
+  },
+  {
+    label: "a return that dereferences the result",
+    ident: "array",
+    line: 2,
+    next: "return array->length();",
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    return array->length();\n}\n`,
+  },
+  {
+    label: "a return that passes the result on",
+    ident: "array",
+    line: 2,
+    next: "return wrap(globalObject, array);",
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    return wrap(globalObject, array);\n}\n`,
   },
 ];
 const ignores: { label: string; cpp: string }[] = [
@@ -159,11 +280,19 @@ const ignores: { label: string; cpp: string }[] = [
   },
   {
     label: "a combined null and scope test",
-    cpp: `void f() {\n    auto* rawHeaders = JSC::constructEmptyArray(globalObject, nullptr, headers.size() * 2);\n    if (!rawHeaders || scope.exception()) [[unlikely]] {\n        return;\n    }\n    rawHeaders->push(globalObject, value);\n}\n`,
+    cpp: `void f() {\n    auto* rawHeaders = JSC::constructEmptyArray(globalObject, nullptr, headers.size() * 2);\n    if (!rawHeaders || scope.exception()) [[unlikely]] {\n        scope.clearExceptionExceptTermination();\n        return;\n    }\n    rawHeaders->push(globalObject, value);\n}\n`,
   },
   {
-    label: "a null test of the result",
-    cpp: `void f() {\n    val = JSC::constructEmptyArray(globalObject(), nullptr, 0);\n    if (!val) return {};\n    this->calls.set(vm(), this, val);\n}\n`,
+    label: "a brace-less branch that jumps out",
+    cpp: `void f() {\n    JSArray* outArray = constructEmptyArray(globalObject, nullptr, length);\n    if (scope.exception()) [[unlikely]]\n        goto error;\n    outArray->push(globalObject, value);\nerror:\n    return;\n}\n`,
+  },
+  {
+    label: "an assertion on the result followed by the real test",
+    cpp: `void f() {\n    val = JSC::constructEmptyArray(globalObject(), nullptr, 0);\n    if (!val) ASSERT_PENDING_EXCEPTION(globalObject());\n    if (!val) return {};\n    this->calls.set(vm(), this, val);\n}\n`,
+  },
+  {
+    label: "a branch whose message contains braces and parens",
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    if (!array) {\n        throwTypeError(globalObject, scope, "expected {} or ()"_s);\n        return {};\n    }\n    array->push(globalObject, value);\n}\n`,
   },
   {
     label: "a check after the block that assigned the result",
@@ -172,6 +301,18 @@ const ignores: { label: string; cpp: string }[] = [
   {
     label: "a check after a preprocessor directive",
     cpp: `void f() {\n#if OS(WINDOWS)\n    JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);\n#endif\n    RETURN_IF_EXCEPTION(scope, {});\n    return keyArray;\n}\n`,
+  },
+  {
+    label: "returning the result untouched",
+    cpp: `void f() {\n    JSArray* result = constructEmptyArray(globalObject, nullptr);\n    return result;\n}\n`,
+  },
+  {
+    label: "returning the encoded result untouched",
+    cpp: `void f() {\n    JSArray* result = constructEmptyArray(globalObject, nullptr);\n    return JSC::JSValue::encode(result);\n}\n`,
+  },
+  {
+    label: "releasing the scope and returning the result untouched",
+    cpp: `void f() {\n    auto* array = constructEmptyArray(globalObject, nullptr, 0);\n    RELEASE_AND_RETURN(scope, JSValue::encode(array));\n}\n`,
   },
   {
     label: "the call used inline rather than stored, which this lint does not model",
@@ -185,11 +326,15 @@ const ignores: { label: string; cpp: string }[] = [
     label: "an offending shape inside a block comment",
     cpp: `void f() {\n    /*\n    auto* array = constructEmptyArray(globalObject, nullptr);\n    array->push(globalObject, value);\n    */\n}\n`,
   },
+  {
+    label: "an offending shape inside a string literal",
+    cpp: `void f() {\n    return jsString(vm, "auto* array = constructEmptyArray(globalObject, nullptr); array->push(globalObject, value);"_s);\n}\n`,
+  },
 ];
 
-for (const { label, ident, line, cpp } of detects) {
+for (const { label, ident, line, next, cpp } of detects) {
   test(`detects ${label}`, () => {
-    expect(scanSource(cpp)).toEqual([{ line, ident, next: expect.any(String) }]);
+    expect(scanSource(cpp)).toEqual([{ line, ident, next }]);
   });
 }
 for (const { label, cpp } of ignores) {

--- a/test/internal/source-lints/construct-empty-array-unchecked.test.ts
+++ b/test/internal/source-lints/construct-empty-array-unchecked.test.ts
@@ -16,14 +16,15 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // The tree's shape is a check as the very next statement:
 //   JSArray* array = constructEmptyArray(globalObject, nullptr, 2);
 //   RETURN_IF_EXCEPTION(scope, {});
-// Lazy property builders, which cannot propagate, branch on scope.exception()
-// instead (Process_stubEmptyArray in BunProcess.cpp). This lint requires the
-// statements following every stored call to be checks of the scope or of the
-// result, ending in one that leaves the function or loop body (a check that
-// only asserts or logs does not protect the use after it); returning the
-// result untouched also counts, since the caller then holds the same contract.
-// It models the stored-result flavor only; passing the call inline as an
-// argument is a different shape.
+// (under a TopExceptionScope in static-table PropertyCallback builders, whose
+// callers in Lookup.cpp propagate an empty result; constructVersions in
+// BunProcess.cpp is one). A few builders branch on scope.exception() and
+// report instead. This lint requires the statements following every stored
+// call to be checks of the scope or of the result, ending in one that leaves
+// the function or loop body (a check that only asserts or logs does not
+// protect the use after it); returning the result untouched also counts,
+// since the caller then holds the same contract. It models the stored-result
+// flavor only; passing the call inline as an argument is a different shape.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const cxxSources = globAllSources().cxx;
@@ -181,7 +182,7 @@ for (const abs of cxxSources) {
   for (const { line, ident, next } of scanSource(await file(abs).text())) {
     offenders.push(
       `${source}:${line}: \`${ident} = constructEmptyArray(..)\` is not followed by an exception check (next statement: \`${next}\`) → ` +
-        `add RETURN_IF_EXCEPTION(scope, ..) right after it, or branch on scope.exception() in a lazy property builder`,
+        `add RETURN_IF_EXCEPTION(scope, ..) right after it`,
     );
   }
 }
@@ -275,7 +276,7 @@ const ignores: { label: string; cpp: string }[] = [
     cpp: `void f() {\n    auto* values = constructEmptyArray(globalObject, nullptr, 0); RETURN_IF_EXCEPTION(scope, {});\n    return values;\n}\n`,
   },
   {
-    label: "the lazy property builder shape",
+    label: "a branch on the scope that returns",
     cpp: `void f() {\n    JSC::JSArray* array = JSC::constructEmptyArray(processObject->globalObject(), nullptr);\n    if (auto* exception = scope.exception()) [[unlikely]] {\n        (void)scope.tryClearException();\n        return JSC::jsUndefined();\n    }\n    return array;\n}\n`,
   },
   {


### PR DESCRIPTION
### What

`JSC::constructEmptyArray` returns `nullptr` with an exception pending in two cases: `JSArray::tryCreate` failed and it threw out of memory, or its own `RETURN_IF_EXCEPTION` (JSGlobalObjectInlines.h) fired. That macro goes through `vm.hasExceptionsAfterHandlingTraps()`, so a `worker.terminate()` (or a `vm` timeout) whose trap is first serviced inside the call also produces the null return. Three builders in the tree stored the result and dereferenced it before checking the scope:

* `JSC__JSValue__upsertBunStringArray` (BunString.cpp), in the branch that turns a repeated key into a two element array. Its only caller is `MatchedParams::to_js` (bake `FrameworkRouter.rs`), reached for every dev server request whose catch-all route (`pages/[...slug].tsx`) matches two or more segments. Out of memory or termination applies here.
* `process.binding('http_parser').methods` and `.allMethods` (ProcessBindingHTTPParser.cpp). These are static-table `PropertyCallback` builders, evaluated once per global; `node:http` reads both at load. JSC defers termination around these callbacks (Lookup.cpp, `JSObject::reifyAllStaticProperties`), so out of memory is the only failure that reaches them.
* `process.binding('uv').getErrorMap()` (ProcessBindingUV.cpp), where the window is wide enough to hit on demand. #37441 fixes that one with a runtime test; its hunk is included here unchanged so the lint below passes on this branch. The two PRs merge cleanly in either order.

The crash is the same in all three: `panic: Segmentation fault at address 0x4` (member call on a null `JSC::JSObject` at the first `putDirectIndex`).

`BUN_JSC_validateExceptionChecks=1` does not flag the first two sites. `putDirectIndex` into a pre-sized array and `putDirect(vm, ..)` open no ThrowScope, so the `RETURN_IF_EXCEPTION` at the end of `upsertBunStringArray` satisfies the validator while the dereference sits before it, and the http_parser builders had no scope at all.

### Fix

* BunString.cpp: `RETURN_IF_EXCEPTION` after `constructEmptyArray` and after each `putDirectIndex`, the shape every other stored `constructEmptyArray` in the tree uses (84 of 88 sites; the other four are the ones above).
* ProcessBindingHTTPParser.cpp: a `TopExceptionScope` and `RETURN_IF_EXCEPTION(scope, {})`, as `constructVersions` in BunProcess.cpp does. `reifyStaticProperty` leaves the property unreified when a builder returns empty and both of its callers propagate the exception, so the access throws the out of memory error and a later access retries. The `putDirectIndex` calls that follow cannot throw: the arrays are pre-sized to the 35 and 47 entries of the two method maps.
* FrameworkRouter.rs: `MatchedParams::to_js` returns `JsResult` instead of `.expect("unreachable")` on a result that is reachable (and already was, via the `getIfPropertyExists` check and `array->push`). Both DevServer callers already return `JsResult`, and the early return takes the same path as the `compute_arguments_for_framework_request` error a few lines below. Re-auditing that loop for the new early returns turned up that the two `clone_utf8` copies per param were never released on any path (`toJS` and `upsertBunStringArray` take their own references; the Zig version had a `defer deref()` on each), so every params object leaked its keys and values. They are now `OwnedString`s, and the same one-line fix is applied to the `match()` binding in the same file, which had the same leak.

### Test

There is no reliable runtime reproduction for the BunString or http_parser crashes: the termination has to be observed between the preceding exception check and the one inside `constructEmptyArray`, and the http_parser builders run once per global and only fail on out of memory. The fix is instead pinned by a source lint, `test/internal/source-lints/construct-empty-array-unchecked.test.ts`: after every stored `constructEmptyArray` call, the following statements have to be checks of the scope or of the result ending in one that leaves (`RETURN_IF_EXCEPTION`, or an `if` on `scope.exception()` / `!result` whose body returns or jumps), or a plain return of the result. Comments do not count, which is what the old `// RETURN_IF_EXCEPTION` line in ProcessBindingUV.cpp relied on, and neither does a branch that only asserts or logs. It has fixtures for each detected and accepted shape, and on `main` it reports exactly the four sites listed above:

<details>
<summary>lint output on main</summary>

```
src/jsc/bindings/BunString.cpp:921: `array = constructEmptyArray(..)` is not followed by an exception check (next statement: `array->putDirectIndex(global, 0, existingValue);`)
src/jsc/bindings/ProcessBindingHTTPParser.cpp:13: `methods = constructEmptyArray(..)` is not followed by an exception check (next statement: `int index = 0;`)
src/jsc/bindings/ProcessBindingHTTPParser.cpp:28: `methods = constructEmptyArray(..)` is not followed by an exception check (next statement: `int index = 0;`)
src/jsc/bindings/ProcessBindingUV.cpp:160: `arr = constructEmptyArray(..)` is not followed by an exception check (next statement: `arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(name)));`)
```

</details>

This covers the stored-result flavor only; #37296 adds a lint for the inline argument flavor of the same contract.

The leak has a regression test in `test/bake/framework-router.test.ts`: 200 `match()` calls with four 256 KiB params grow RSS by 204 MB on the current release and by 12 MB on the fixed ASAN debug build (quarantine disabled for the measurement, as the other RSS tests do), against a 64 MB bound. `MatchedParams::to_js` itself is only reachable through a dev server request, so the production site is covered by the identical one-line change rather than a test.

Success paths were run on the debug build with `BUN_JSC_validateExceptionChecks=1`: `test/bake/dev/ssg-pages-router.test.ts -t catch-all` (exercises the put, new-array and push branches of `upsertBunStringArray` through `MatchedParams::to_js`), `test/bake/framework-router.test.ts`, `test/js/node/process-binding.test.ts`, `test/js/node/http/node-http-parser.test.ts`, `test-uv-errmap.js` and `test-http-parser-lazy-loaded.js`; `methods.length`, `allMethods.length` and `getErrorMap().size` are unchanged (35, 47, 85).
