### PR TITLE
toml: index table keys so large tables parse in linear time

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -168,6 +168,7 @@ impl TOML {
             bump,
             stack_check: StackCheck::init(),
             meta: HashMap::default(),
+            keys: HashMap::default(),
             block: 0,
         };
         match parser.parse_root() {
@@ -1443,6 +1444,14 @@ struct Parser<'a, 'log> {
     stack_check: StackCheck,
     /// Keyed by `E::Object::as_ptr()` / `E::Array::as_ptr()` addresses.
     meta: HashMap<usize, Meta>,
+    /// `(table address, key text)` → the key's value, for every key
+    /// `insert_key` has added. Duplicate checks and dotted/header navigation
+    /// look up here rather than scanning the table's property list, which
+    /// made a table with n keys cost O(n²). Key text is always valid UTF-8
+    /// (the document is validated up front and escapes decode to UTF-8), so
+    /// byte equality is key equality whether the stored key EString ended up
+    /// 8-bit or UTF-16.
+    keys: HashMap<(usize, &'a [u8]), Expr>,
     /// Current definition block: bumped per table header and per inline table.
     block: u32,
 }
@@ -1516,11 +1525,7 @@ impl<'a, 'log> Parser<'a, 'log> {
         let mut cur: *mut E::Object = root;
         for (i, seg) in path.iter().enumerate() {
             let last = i + 1 == path.len();
-            // SAFETY: `cur` always points at an E::Object inside the AST store,
-            // created earlier in this parse; the store lives in `self.bump`.
-            let cur_obj: &mut E::Object = unsafe { &mut *cur };
-            let existing = cur_obj.as_property(seg.text).map(|q| q.expr);
-            match existing {
+            match self.get_key(cur, seg.text) {
                 None => {
                     if last && is_aot {
                         let array = self.new_array(seg.pos, Kind::AotArray);
@@ -1667,9 +1672,7 @@ impl<'a, 'log> Parser<'a, 'log> {
     ) -> PResult<()> {
         let mut cur = table;
         for seg in &path[..path.len() - 1] {
-            // SAFETY: `cur` points at a live E::Object in the AST store.
-            let cur_obj: &mut E::Object = unsafe { &mut *cur };
-            match cur_obj.as_property(seg.text).map(|q| q.expr) {
+            match self.get_key(cur, seg.text) {
                 None => {
                     let (expr, ptr) = self.new_table(seg.pos, Kind::Dotted);
                     self.insert_key(cur, *seg, expr)?;
@@ -1842,23 +1845,28 @@ impl<'a, 'log> Parser<'a, 'log> {
         Ok(ptr)
     }
 
+    /// The value stored under `key` in `table`, if any.
+    fn get_key(&self, table: *mut E::Object, key: &'a [u8]) -> Option<Expr> {
+        self.keys.get(&(table as usize, key)).copied()
+    }
+
     fn insert_key(&mut self, obj: *mut E::Object, seg: KeySeg<'a>, value: Expr) -> PResult<()> {
-        // SAFETY: `obj` points at a live E::Object in the AST store.
-        let obj: &mut E::Object = unsafe { &mut *obj };
-        // The duplicate check must use the UTF-8 key bytes: `as_property`
-        // compares correctly against both 8-bit and UTF-16 stored keys.
-        if obj.as_property(seg.text).is_some() {
+        let slot = self.keys.get_or_put((obj as usize, seg.text))?;
+        if slot.found_existing {
             return Err(self
                 .scanner
                 .err_keyed(seg.pos, "Cannot redefine key", seg.text, ""));
         }
+        *slot.value_ptr = value;
+
         let key_loc = loc_of(seg.pos);
         let key_expr = if seg.text.is_ascii() {
             Expr::init(E::String::init(seg.text), key_loc)
         } else {
             Expr::init(E::String::init_re_encode_utf8(seg.text, self.bump), key_loc)
         };
-        obj.append_property(key_expr, value);
+        // SAFETY: `obj` points at a live E::Object in the AST store.
+        unsafe { (*obj).append_property(key_expr, value) };
         Ok(())
     }
 }

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -1,5 +1,6 @@
 import { TOML } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // Hand-written coverage beyond the official conformance suite
 // (toml-test-suite.test.ts): the JS-facing API surface, JS value mapping,
@@ -144,6 +145,15 @@ describe("JS value mapping", () => {
     expect(o[composed]).toBe(1);
     expect(o[decomposed]).toBe(2);
     expect(Object.keys(o)).toHaveLength(2);
+  });
+
+  test("non-ASCII keys are the same key whether spelled literally or escaped", () => {
+    expect(syntaxError('"é" = 1\n"\\u00E9" = 2').message).toBe("TOML Parse error: Cannot redefine key 'é'");
+    expect(syntaxError('[tbl]\n"日本" = 1\n"\\u65E5\\u672C" = 2').message).toBe(
+      "TOML Parse error: Cannot redefine key '日本'",
+    );
+    // The same spelling in different tables is not a duplicate.
+    expect(TOML.parse('[a]\n"é" = 1\n[b]\n"\\u00E9" = 2')).toEqual({ a: { é: 1 }, b: { é: 2 } });
   });
 
   test("non-ASCII and astral-plane content round-trips", () => {
@@ -454,7 +464,7 @@ describe("robustness", () => {
     expect((TOML.parse(`a = "${long}"`) as any).a).toBe(long);
   });
 
-  test("a table with many keys preserves every entry", () => {
+  test("a table with many keys preserves every entry and still rejects duplicates", () => {
     const n = 1000;
     let doc = "";
     for (let i = 0; i < n; i++) doc += `key_${i} = ${i}\n`;
@@ -462,7 +472,47 @@ describe("robustness", () => {
     expect(Object.keys(o)).toHaveLength(n);
     expect(o.key_0).toBe(0);
     expect(o[`key_${n - 1}`]).toBe(n - 1);
+
+    expect(syntaxError(doc + "key_0 = 1").message).toBe("TOML Parse error: Cannot redefine key 'key_0'");
+    expect(syntaxError(doc + `key_${n - 1} = 1`).message).toBe(`TOML Parse error: Cannot redefine key 'key_${n - 1}'`);
+    expect(syntaxError(doc + "[key_0]").message).toBe("TOML Parse error: Cannot redefine key 'key_0' as a table");
+    expect(syntaxError(doc + "key_0.x = 1").message).toBe("TOML Parse error: Cannot redefine key 'key_0'");
   });
+
+  // Inserting a key used to scan the whole table for a duplicate, and dotted
+  // keys and headers rescanned it to find their parent, so a table with n
+  // keys cost O(n^2): this document took 150s in a release build. n is sized
+  // so that cannot finish inside the spawn timeout, while the indexed parser
+  // needs ~12s even under debug+ASAN. The document is built with spread+join
+  // because per-line JS work is slower than the parse itself on debug builds.
+  test("a table with many keys parses in linear time", async () => {
+    const n = 200_000;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const n = ${n};
+         const doc = "k" + [...Array(n).keys()].join(" = 1\\nk") + " = 1\\n";
+         const o = Bun.TOML.parse(doc);
+         console.log(JSON.stringify({ keys: Object.keys(o).length, first: o.k0, last: o["k" + (n - 1)] }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Debug builds may log benign noise on stderr; only real failures count.
+    const failures = /error|panic|assert|abort/i.test(stderr) ? stderr : "";
+    expect({ stdout: stdout.trim(), stderr: failures, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: JSON.stringify({ keys: n, first: 1, last: 1 }),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 90_000);
 
   test("values survive garbage collection", () => {
     const doc = 'a = "héllo wörld 🌍"\nb = [1, 2.5, true, "x"]\n[t]\nc = 1979-05-27\n';


### PR DESCRIPTION
### What does this PR do?

`Bun.TOML.parse` (and importing a `.toml` file) was quadratic in the number of keys per table.

```js
const n = 200_000;
const doc = "k" + [...Array(n).keys()].join(" = 1\nk") + " = 1\n";
console.time("toml"); Bun.TOML.parse(doc); console.timeEnd("toml");
```

Before (release build, 1.4.0): 20k keys ~1s, 50k ~6s, 100k ~25s, 200k ~150s, roughly 4x per doubling. `Bun.YAML.parse` / `Bun.JSONC.parse` handle the same number of keys in tens of milliseconds. Every table shape was affected (root keys, `[t]` keys, dotted keys, inline tables, and N distinct `[tN]` headers, which paid for two scans per header); only `[[a]]` x N was linear.

Cause: `insert_key` in `src/parsers/toml.rs` checked for a duplicate with `E::Object::as_property`, a linear scan over the table's property list, and `navigate_header` / `assign_path` used the same scan to find the parent table for each path segment. Inserting the n-th key into a table therefore cost O(n).

Fix: the parser keeps one `HashMap<(table address, key text), value>` that `insert_key` populates, and the duplicate check and the header/dotted-key navigation look up in it. Key text is validated UTF-8 (escapes decode to UTF-8 as well), so byte equality is the same key identity the `as_property` comparison had for both 8-bit and UTF-16 stored keys; the error messages are unchanged.

After: the 200k-key document parses in ~12s under a debug+ASAN build, the same per-key cost as `Bun.YAML.parse` of the equivalent document on that build, so the remaining time is the shared AST-to-JS conversion, not the parser.

### How did you verify your code works?

- `test/js/bun/toml/toml.test.ts`: new "parses in linear time" test spawns a parse of 200k keys with a 60s kill timeout. It fails against the unfixed parser (killed at 60s; the release build needs ~150s) and passes with the fix (~11s under debug+ASAN).
- The "many keys" test now also checks that a duplicate key, a `[header]`, and a dotted key colliding with an existing key are still rejected after 1000 keys, which exercises all three lookup sites through the index, plus a test that a non-ASCII key spelled literally and as a `\u` escape is still detected as a duplicate (and is not one across tables).
- `bun bd test test/js/bun/toml/` (hand-written tests and the 708-case conformance suite), `test/js/bun/resolve/toml`, and `test/config/bunfig` all pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/toml/toml.test.ts
bun test v1.4.0 (c5bfc1e0b)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [2.75ms]
(pass) input types > Buffer [1.89ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.27ms]
(pass) input types > DataView [4.00ms]
(pass) input types > ArrayBuffer [1.92ms]
(pass) input types > SharedArrayBuffer [2.68ms]
(pass) input types > Blob parses synchronously [2.01ms]
(pass) input types > DataView over a SharedArrayBuffer [2.86ms]
(pass) input types > non-string values are coerced via toString [6.28ms]
(pass) input types > null and undefined throw [6.15ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [5.56ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [3.94ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [2.25ms]
(pass) JS value mapping > returns a plain object with Object.prototype [2.02ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [4.35ms]

... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [0.08ms]
(pass) input types > Buffer [0.03ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [0.03ms]
(pass) input types > DataView [0.05ms]
(pass) input types > ArrayBuffer [0.03ms]
(pass) input types > SharedArrayBuffer [0.06ms]
(pass) input types > Blob parses synchronously [0.04ms]
(pass) input types > DataView over a SharedArrayBuffer [0.04ms]
(pass) input types > non-string values are coerced via toString [0.10ms]
(pass) input types > null and undefined throw [0.05ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [0.06ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [0.04ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [0.02ms]
(pass) JS value mapping > returns a plain object with Object.prototype [0.02ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [0.05ms]
(pass) JS value mapping > __proto__ table becomes an own property [0.03ms]
(pass) JS value mapping > constructor and prototype keys are plain data propert
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/toml/toml.test.ts
bun test v1.4.0 (c5bfc1e0b)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [2.66ms]
(pass) input types > Buffer [1.92ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.63ms]
(pass) input types > DataView [3.74ms]
(pass) input types > ArrayBuffer [1.96ms]
(pass) input types > SharedArrayBuffer [2.69ms]
(pass) input types > Blob parses synchronously [2.10ms]
(pass) input types > DataView over a SharedArrayBuffer [2.89ms]
(pass) input types > non-string values are coerced via toString [6.18ms]
(pass) input types > null and undefined throw [6.09ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [4.64ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [3.53ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [2.28ms]
(pass) JS value mapping > returns a plain object with Object.prototype [1.96ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [4.44ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c5bfc1e0bb
  features     baseline

22 deps, 107 codegen, 1176 objects in 1252ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen bindgenv2
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [13.00ms]
[3/1238] gen ErrorCode+*.h
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1238] fetch picohttpparser
[picohttpparser] up to date
[6/1238] gen .bind.ts → GeneratedBindings.cpp
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] fetch zlib
[zlib] up to date
[9/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [16.00ms]
[11/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/parsers/toml.rs           | 36 ++++++++++++++++++-----------
 test/js/bun/toml/toml.test.ts | 54 +++++++++++++++++++++++++++++++++++++++++--
 2 files changed, 74 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/parsers/toml.rs                4      6      0
test/js/bun/toml/toml.test.ts      4      5      0
```

</details>

<!-- robobun:evidence:end -->