### PR TITLE
Error.prepareStackTrace: index source URLs by visible frame, not by JSC frame

### DIFF
--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -39,8 +39,7 @@ void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encountere
         }
     }
 
-    // Initialize "this" and "function" (and set the "IsStrict" flag if needed).
-    // JSC::StackFrame does not record the receiver, so getThis() is always undefined.
+    // JSC::StackFrame has no receiver, so getThis() is always undefined.
     m_thisValue.set(vm, this, JSC::jsUndefined());
     if (isStrictFrame) {
         m_function.set(vm, this, JSC::jsUndefined());

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -20,7 +20,7 @@ namespace Zig {
 
 const JSC::ClassInfo CallSite::s_info = { "CallSite"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(CallSite) };
 
-void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStackFrame& stackFrame, bool encounteredStrictFrame)
+void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encounteredStrictFrame)
 {
     Base::finishCreation(vm);
 
@@ -39,20 +39,13 @@ void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStac
         }
     }
 
-    // Initialize "this" and "function" (and set the "IsStrict" flag if needed)
-    JSC::CallFrame* callFrame = stackFrame.callFrame();
+    // Initialize "this" and "function" (and set the "IsStrict" flag if needed).
+    // JSC::StackFrame does not record the receiver, so getThis() is always undefined.
+    m_thisValue.set(vm, this, JSC::jsUndefined());
     if (isStrictFrame) {
-        m_thisValue.set(vm, this, JSC::jsUndefined());
         m_function.set(vm, this, JSC::jsUndefined());
         m_flags |= static_cast<unsigned int>(Flags::IsStrict);
     } else {
-        if (callFrame && callFrame->thisValue()) {
-            // We know that we're not in strict mode
-            m_thisValue.set(vm, this, callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::sloppy()));
-        } else {
-            m_thisValue.set(vm, this, JSC::jsUndefined());
-        }
-
         m_function.set(vm, this, stackFrame.callee());
     }
 

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -48,7 +48,7 @@ public:
     {
         auto& vm = JSC::getVM(globalObject);
         CallSite* callSite = new (NotNull, JSC::allocateCell<CallSite>(vm)) CallSite(vm, structure);
-        callSite->finishCreation(vm, globalObject, stackFrame, encounteredStrictFrame);
+        callSite->finishCreation(vm, stackFrame, encounteredStrictFrame);
         return callSite;
     }
 
@@ -101,7 +101,7 @@ private:
     {
     }
 
-    void finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStackFrame& stackFrame, bool encounteredStrictFrame);
+    void finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encounteredStrictFrame);
 
     DECLARE_VISIT_CHILDREN;
 };

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -94,7 +94,7 @@ bool isImplementationVisibilityPrivate(const JSC::StackFrame& frame)
     return implementationVisibility != ImplementationVisibility::Public;
 }
 
-JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames)
+JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames, WTF::Vector<const JSC::StackFrame*>& visibleFrames)
 {
     WTF::Vector<JSCStackFrame> newFrames;
 
@@ -104,9 +104,12 @@ JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::St
     }
 
     newFrames.reserveInitialCapacity(frameCount);
+    visibleFrames.reserveInitialCapacity(frameCount);
     for (size_t i = 0; i < frameCount; i++) {
-        if (!isImplementationVisibilityPrivate(existingFrames.at(i))) {
-            newFrames.constructAndAppend(vm, existingFrames.at(i));
+        const JSC::StackFrame& frame = existingFrames.at(i);
+        if (!isImplementationVisibilityPrivate(frame)) {
+            newFrames.constructAndAppend(vm, frame);
+            visibleFrames.append(&frame);
         }
     }
 
@@ -180,27 +183,6 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
 
     if (stackTrace.size() > stackTraceLimit)
         stackTrace.shrink(stackTraceLimit);
-}
-
-JSCStackTrace JSCStackTrace::getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue)
-{
-    const WTF::Vector<JSC::StackFrame>* jscStackTrace = nullptr;
-
-    JSC::Exception* currentException = DECLARE_TOP_EXCEPTION_SCOPE(vm).exception();
-    if (currentException && currentException->value() == thrownValue) {
-        jscStackTrace = &currentException->stack();
-    } else {
-        JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(thrownValue);
-        if (error) {
-            jscStackTrace = error->stackTrace();
-        }
-    }
-
-    if (!jscStackTrace) {
-        return JSCStackTrace();
-    }
-
-    return fromExisting(vm, *jscStackTrace);
 }
 
 static bool isVisibleBuiltinFunction(JSC::CodeBlock* codeBlock)

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -182,27 +182,6 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
         stackTrace.shrink(stackTraceLimit);
 }
 
-JSCStackTrace JSCStackTrace::getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue)
-{
-    const WTF::Vector<JSC::StackFrame>* jscStackTrace = nullptr;
-
-    JSC::Exception* currentException = DECLARE_TOP_EXCEPTION_SCOPE(vm).exception();
-    if (currentException && currentException->value() == thrownValue) {
-        jscStackTrace = &currentException->stack();
-    } else {
-        JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(thrownValue);
-        if (error) {
-            jscStackTrace = error->stackTrace();
-        }
-    }
-
-    if (!jscStackTrace) {
-        return JSCStackTrace();
-    }
-
-    return fromExisting(vm, *jscStackTrace);
-}
-
 static bool isVisibleBuiltinFunction(JSC::CodeBlock* codeBlock)
 {
     if (!codeBlock->ownerExecutable()) {

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -94,7 +94,7 @@ bool isImplementationVisibilityPrivate(const JSC::StackFrame& frame)
     return implementationVisibility != ImplementationVisibility::Public;
 }
 
-JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames, WTF::Vector<const JSC::StackFrame*>& visibleFrames)
+JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames)
 {
     WTF::Vector<JSCStackFrame> newFrames;
 
@@ -104,12 +104,9 @@ JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::St
     }
 
     newFrames.reserveInitialCapacity(frameCount);
-    visibleFrames.reserveInitialCapacity(frameCount);
     for (size_t i = 0; i < frameCount; i++) {
-        const JSC::StackFrame& frame = existingFrames.at(i);
-        if (!isImplementationVisibilityPrivate(frame)) {
-            newFrames.constructAndAppend(vm, frame);
-            visibleFrames.append(&frame);
+        if (!isImplementationVisibilityPrivate(existingFrames.at(i))) {
+            newFrames.constructAndAppend(vm, existingFrames.at(i));
         }
     }
 
@@ -185,6 +182,27 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
         stackTrace.shrink(stackTraceLimit);
 }
 
+JSCStackTrace JSCStackTrace::getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue)
+{
+    const WTF::Vector<JSC::StackFrame>* jscStackTrace = nullptr;
+
+    JSC::Exception* currentException = DECLARE_TOP_EXCEPTION_SCOPE(vm).exception();
+    if (currentException && currentException->value() == thrownValue) {
+        jscStackTrace = &currentException->stack();
+    } else {
+        JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(thrownValue);
+        if (error) {
+            jscStackTrace = error->stackTrace();
+        }
+    }
+
+    if (!jscStackTrace) {
+        return JSCStackTrace();
+    }
+
+    return fromExisting(vm, *jscStackTrace);
+}
+
 static bool isVisibleBuiltinFunction(JSC::CodeBlock* codeBlock)
 {
     if (!codeBlock->ownerExecutable()) {
@@ -195,57 +213,9 @@ static bool isVisibleBuiltinFunction(JSC::CodeBlock* codeBlock)
     return !Zig::sourceURL(source).isEmpty();
 }
 
-JSCStackFrame::JSCStackFrame(JSC::VM& vm, JSC::StackVisitor& visitor)
-    : m_vm(vm)
-    , m_codeBlock(nullptr)
-    , m_bytecodeIndex(JSC::BytecodeIndex())
-    , m_sourceURL()
-    , m_functionName()
-    , m_isWasmFrame(false)
-    , m_isAsync(false)
-    , m_sourcePositionsState(SourcePositionsState::NotCalculated)
-{
-    m_callee = visitor->callee().asCell();
-    m_callFrame = visitor->callFrame();
-
-    if (auto* codeBlock = visitor->codeBlock()) {
-        auto codeType = codeBlock->codeType();
-        if (codeType == JSC::FunctionCode || codeType == JSC::EvalCode) {
-            m_isFunctionOrEval = true;
-        }
-    }
-
-    // Based on JSC's GetStackTraceFunctor (Interpreter.cpp)
-    if (visitor->isNativeCalleeFrame()) {
-        auto* nativeCallee = visitor->callee().asNativeCallee();
-        switch (nativeCallee->category()) {
-        case NativeCallee::Category::Wasm: {
-            m_wasmFunctionIndexOrName = visitor->wasmFunctionIndexOrName();
-            m_isWasmFrame = true;
-            break;
-        }
-        case NativeCallee::Category::InlineCache: {
-            break;
-        }
-        }
-    } else if (auto* codeBlock = visitor->codeBlock()) {
-        auto* unlinkedCodeBlock = codeBlock->unlinkedCodeBlock();
-        if (!unlinkedCodeBlock->isBuiltinFunction() || isVisibleBuiltinFunction(codeBlock)) {
-            m_codeBlock = codeBlock;
-            m_bytecodeIndex = visitor->bytecodeIndex();
-        }
-    }
-
-    if (!m_bytecodeIndex && visitor->hasLineAndColumnInfo()) {
-        auto lineColumn = visitor->computeLineAndColumn();
-        m_sourcePositions = { OrdinalNumber::fromOneBasedInt(lineColumn.line), OrdinalNumber::fromOneBasedInt(lineColumn.column) };
-        m_sourcePositionsState = SourcePositionsState::Calculated;
-    }
-}
-
 JSCStackFrame::JSCStackFrame(JSC::VM& vm, const JSC::StackFrame& frame)
     : m_vm(vm)
-    , m_callFrame(nullptr)
+    , m_stackFrame(&frame)
     , m_codeBlock(nullptr)
     , m_bytecodeIndex(JSC::BytecodeIndex())
     , m_sourceURL()

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -179,27 +179,13 @@ public:
 
     WTF::Vector<JSCStackFrame>&& frames() { return WTF::move(m_frames); }
 
-    static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames);
+    /* Skips private-visibility frames. JSC only omits them from `existingFrames` itself while
+     * Options::showPrivateScriptsInStackTraces() is off (debug builds turn it on), so the result can be
+     * shorter than `existingFrames`. `visibleFrames` receives the JSC::StackFrame behind each returned
+     * frame at the same index, pointing into `existingFrames`. */
+    static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames, WTF::Vector<const JSC::StackFrame*>& visibleFrames);
 
     static void getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit);
-
-    /* In JSC, JSC::Exception points to the actual value that was thrown, usually
-     * a JSC::ErrorInstance (but could be any JSValue). In v8, on the other hand,
-     * TryCatch::Exception returns the thrown value, and we follow the same rule in jscshim.
-     * This is a problem, since JSC::Exception is the one that holds the stack trace.
-     * ErrorInstances might also hold the stack trace (until the error properties are
-     * "materialized" and it is no longer needed). So, to try to get the stack trace for a thrown JSValue,
-     * we'll try two things:
-     * - If the current JSC (vm) exception points to our value, it means our value is probably the current
-     *   exception and we could take the stack trace from the vm's current JSC::Exception. The downside
-     *   of doing this is that we'll get the last stack trace of the thrown value, meaning that if the value
-     *   was thrown, stored in the api and than re-thrown, we'll get the latest stack trace and not the one
-     *   that was available when we stored it. For now it'll do.
-     * - If that failed and our thrown value is a JSC::ErrorInstance, we'll try to use it's stack trace,
-     *   if it currently has one.
-     *
-     * Return value must remain stack allocated */
-    static JSCStackTrace getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue);
 
 private:
     JSCStackTrace(WTF::Vector<JSCStackFrame>& frames)

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -176,9 +176,7 @@ public:
 
     WTF::Vector<JSCStackFrame>&& frames() { return WTF::move(m_frames); }
 
-    /* Skips private-visibility frames, which JSC only leaves in `existingFrames` while
-     * Options::showPrivateScriptsInStackTraces() is on (debug builds), so the result can be shorter
-     * than `existingFrames`; reach the JSC frame through JSCStackFrame::stackFrame(), not by index. */
+    // Drops private-visibility frames (present when Options::showPrivateScriptsInStackTraces() is on), so the result does not index like existingFrames.
     static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames);
 
     static void getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit);

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -16,8 +16,7 @@ using namespace WebCore;
 
 namespace Zig {
 
-/* JSCStackFrame is an alternative to JSC::StackFrame, which provides the following advantages\changes:
- * - Also hold the call frame (ExecState). This is mainly used by CallSite to get "this value".
+/* JSCStackFrame is a view over a JSC::StackFrame, which provides the following advantages\changes:
  * - More detailed and v8 compatible "source offsets" calculations: JSC::StackFrame only provides the
  *   line number and column numbers. It's column calculation seems to be different than v8's column.
  *   According to v8's unit tests, it seems that their column number points to the beginning of
@@ -46,10 +45,9 @@ public:
 
 private:
     JSC::VM& m_vm;
+    // Points into the vector this frame was built from (JSCStackTrace::fromExisting).
+    const JSC::StackFrame* m_stackFrame;
     JSC::JSCell* m_callee { nullptr };
-
-    // May be null
-    JSC::CallFrame* m_callFrame;
 
     // May be null
     JSC::CodeBlock* m_codeBlock { nullptr };
@@ -77,11 +75,10 @@ private:
     SourcePositionsState m_sourcePositionsState;
 
 public:
-    JSCStackFrame(JSC::VM& vm, JSC::StackVisitor& visitor);
     JSCStackFrame(JSC::VM& vm, const JSC::StackFrame& frame);
 
+    const JSC::StackFrame& stackFrame() const { return *m_stackFrame; }
     JSC::JSCell* callee() const { return m_callee; }
-    JSC::CallFrame* callFrame() const { return m_callFrame; }
     JSC::CodeBlock* codeBlock() const { return m_codeBlock; }
 
     intptr_t sourceID() const;
@@ -179,13 +176,30 @@ public:
 
     WTF::Vector<JSCStackFrame>&& frames() { return WTF::move(m_frames); }
 
-    /* Skips private-visibility frames. JSC only omits them from `existingFrames` itself while
-     * Options::showPrivateScriptsInStackTraces() is off (debug builds turn it on), so the result can be
-     * shorter than `existingFrames`. `visibleFrames` receives the JSC::StackFrame behind each returned
-     * frame at the same index, pointing into `existingFrames`. */
-    static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames, WTF::Vector<const JSC::StackFrame*>& visibleFrames);
+    /* Skips private-visibility frames, which JSC only leaves in `existingFrames` while
+     * Options::showPrivateScriptsInStackTraces() is on (debug builds), so the result can be shorter
+     * than `existingFrames`; reach the JSC frame through JSCStackFrame::stackFrame(), not by index. */
+    static JSCStackTrace fromExisting(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& existingFrames);
 
     static void getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit);
+
+    /* In JSC, JSC::Exception points to the actual value that was thrown, usually
+     * a JSC::ErrorInstance (but could be any JSValue). In v8, on the other hand,
+     * TryCatch::Exception returns the thrown value, and we follow the same rule in jscshim.
+     * This is a problem, since JSC::Exception is the one that holds the stack trace.
+     * ErrorInstances might also hold the stack trace (until the error properties are
+     * "materialized" and it is no longer needed). So, to try to get the stack trace for a thrown JSValue,
+     * we'll try two things:
+     * - If the current JSC (vm) exception points to our value, it means our value is probably the current
+     *   exception and we could take the stack trace from the vm's current JSC::Exception. The downside
+     *   of doing this is that we'll get the last stack trace of the thrown value, meaning that if the value
+     *   was thrown, stored in the api and than re-thrown, we'll get the latest stack trace and not the one
+     *   that was available when we stored it. For now it'll do.
+     * - If that failed and our thrown value is a JSC::ErrorInstance, we'll try to use it's stack trace,
+     *   if it currently has one.
+     *
+     * Return value must remain stack allocated */
+    static JSCStackTrace getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue);
 
 private:
     JSCStackTrace(WTF::Vector<JSCStackFrame>& frames)

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -181,24 +181,6 @@ public:
 
     static void getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit);
 
-    /* In JSC, JSC::Exception points to the actual value that was thrown, usually
-     * a JSC::ErrorInstance (but could be any JSValue). In v8, on the other hand,
-     * TryCatch::Exception returns the thrown value, and we follow the same rule in jscshim.
-     * This is a problem, since JSC::Exception is the one that holds the stack trace.
-     * ErrorInstances might also hold the stack trace (until the error properties are
-     * "materialized" and it is no longer needed). So, to try to get the stack trace for a thrown JSValue,
-     * we'll try two things:
-     * - If the current JSC (vm) exception points to our value, it means our value is probably the current
-     *   exception and we could take the stack trace from the vm's current JSC::Exception. The downside
-     *   of doing this is that we'll get the last stack trace of the thrown value, meaning that if the value
-     *   was thrown, stored in the api and than re-thrown, we'll get the latest stack trace and not the one
-     *   that was available when we stored it. For now it'll do.
-     * - If that failed and our thrown value is a JSC::ErrorInstance, we'll try to use it's stack trace,
-     *   if it currently has one.
-     *
-     * Return value must remain stack allocated */
-    static JSCStackTrace getStackTraceForThrownValue(JSC::VM& vm, JSC::JSValue thrownValue);
-
 private:
     JSCStackTrace(WTF::Vector<JSCStackFrame>& frames)
         : m_frames(WTF::move(frames))

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -432,9 +432,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // Everything below is indexed per CallSite; `stackFrames` may still hold private frames that get none.
-    WTF::Vector<const JSC::StackFrame*> visibleFrames;
-    JSCStackTrace stackTrace = JSCStackTrace::fromExisting(vm, stackFrames, visibleFrames);
+    JSCStackTrace stackTrace = JSCStackTrace::fromExisting(vm, stackFrames);
 
     // Note: we cannot use tryCreateUninitializedRestricted here because we cannot allocate memory inside initializeIndex()
     MarkedArgumentBuffer callSites;
@@ -456,7 +454,8 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
 
     for (int i = 0; i < n; i++) {
         ZigStackFrame& frame = remappedFrames[i];
-        const JSC::StackFrame& stackFrame = *visibleFrames[i];
+        JSCStackFrame& visibleFrame = stackTrace.at(i);
+        const JSC::StackFrame& stackFrame = visibleFrame.stackFrame();
         sourceURLs[i] = Zig::sourceURL(vm, stackFrame);
         didRemap[i] = false;
         frame.position.line_zero_based = -1;
@@ -480,7 +479,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
         }
 
         if (globalObjectForFrame == globalObject) {
-            if (JSCStackFrame::SourcePositions* sourcePositions = stackTrace.at(i).getSourcePositions()) {
+            if (JSCStackFrame::SourcePositions* sourcePositions = visibleFrame.getSourcePositions()) {
                 frame.position.line_zero_based = sourcePositions->line.zeroBasedInt();
                 frame.position.column_zero_based = sourcePositions->column.zeroBasedInt();
             }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -432,7 +432,9 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSCStackTrace stackTrace = JSCStackTrace::fromExisting(vm, stackFrames);
+    // Everything below is indexed per CallSite; `stackFrames` may still hold private frames that get none.
+    WTF::Vector<const JSC::StackFrame*> visibleFrames;
+    JSCStackTrace stackTrace = JSCStackTrace::fromExisting(vm, stackFrames, visibleFrames);
 
     // Note: we cannot use tryCreateUninitializedRestricted here because we cannot allocate memory inside initializeIndex()
     MarkedArgumentBuffer callSites;
@@ -454,7 +456,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
 
     for (int i = 0; i < n; i++) {
         ZigStackFrame& frame = remappedFrames[i];
-        auto& stackFrame = stackFrames.at(i);
+        const JSC::StackFrame& stackFrame = *visibleFrames[i];
         sourceURLs[i] = Zig::sourceURL(vm, stackFrame);
         didRemap[i] = false;
         frame.position.line_zero_based = -1;

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,7 +1,7 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
 import { afterEach, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -1120,4 +1120,77 @@ test("lazy error-info materialization does not store an empty stack value when t
     signalCode: null,
   });
   expect(exitCode).toBe(0);
+});
+
+test("Error.prepareStackTrace call sites keep their own file when a hidden frame is on the stack", async () => {
+  // A bound function call is a frame with private implementation visibility. JSC omits it from the
+  // trace unless showPrivateScriptsInStackTraces is on (debug builds turn it on); Bun then has to
+  // drop it while building the CallSites, and the frames after it must keep their own file.
+  using dir = tempDir("prepare-stack-trace-hidden-frame", {
+    "main.cjs": [
+      `const { outer, viaAsyncLocalStorage } = require("./callers.cjs");`,
+      `function inner() {`,
+      `  const error = new Error("boom");`,
+      `  return error;`,
+      `}`,
+      `function main() {`,
+      `  const error = outer(inner.bind(null));`,
+      `  return error;`,
+      `}`,
+      `const { basename } = require("node:path");`,
+      `const wanted = new Set(["inner", "outer", "main", "run", "viaAsyncLocalStorage"]);`,
+      `Error.prepareStackTrace = (_error, callSites) =>`,
+      `  callSites`,
+      `    .filter(callSite => wanted.has(callSite.getFunctionName()))`,
+      `    .map(callSite => ({`,
+      `      name: callSite.getFunctionName(),`,
+      `      file: basename(callSite.getFileName()),`,
+      `      line: callSite.getLineNumber(),`,
+      `    }));`,
+      `console.log(JSON.stringify({ bound: main().stack, asyncLocalStorage: viaAsyncLocalStorage(inner.bind(null)).stack }));`,
+    ].join("\n"),
+    "callers.cjs": [
+      `const { AsyncLocalStorage } = require("node:async_hooks");`,
+      `exports.outer = function outer(callback) {`,
+      `  const error = callback();`,
+      `  return error;`,
+      `};`,
+      `const storage = new AsyncLocalStorage();`,
+      `exports.viaAsyncLocalStorage = function viaAsyncLocalStorage(callback) {`,
+      `  const error = storage.run("store", callback);`,
+      `  return error;`,
+      `};`,
+    ].join("\n"),
+  });
+
+  const results = await Promise.all(
+    ["0", "1"].map(async showPrivateScriptsInStackTraces => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.cjs"],
+        cwd: String(dir),
+        env: { ...bunEnv, BUN_JSC_showPrivateScriptsInStackTraces: showPrivateScriptsInStackTraces },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { showPrivateScriptsInStackTraces, callSites: stdout && JSON.parse(stdout), stderr, exitCode };
+    }),
+  );
+
+  const expected = {
+    bound: [
+      { name: "inner", file: "main.cjs", line: 3 },
+      { name: "outer", file: "callers.cjs", line: 3 },
+      { name: "main", file: "main.cjs", line: 7 },
+    ],
+    asyncLocalStorage: [
+      { name: "inner", file: "main.cjs", line: 3 },
+      { name: "run", file: "node:async_hooks", line: expect.any(Number) },
+      { name: "viaAsyncLocalStorage", file: "callers.cjs", line: 8 },
+    ],
+  };
+  expect(results).toEqual([
+    { showPrivateScriptsInStackTraces: "0", callSites: expected, stderr: "", exitCode: 0 },
+    { showPrivateScriptsInStackTraces: "1", callSites: expected, stderr: "", exitCode: 0 },
+  ]);
 });


### PR DESCRIPTION
## Repro

`main.cjs`:

```js
const { outer } = require("./callers.cjs");
function inner() {
  const error = new Error("boom");
  return error;
}
function main() {
  const error = outer(inner.bind(null));
  return error;
}
Error.prepareStackTrace = (_error, callSites) =>
  callSites.map(c => `${c.getFunctionName() || "<anonymous>"} ${c.getFileName()}:${c.getLineNumber()}`).join("\n");
console.log(main().stack);
```

`callers.cjs`:

```js
exports.outer = function outer(callback) {
  const error = callback();
  return error;
};
```

```
$ bun main.cjs
inner /tmp/x/main.cjs:3
outer /tmp/x/callers.cjs:2
main /tmp/x/main.cjs:7
<anonymous> /tmp/x/main.cjs:12

$ BUN_JSC_showPrivateScriptsInStackTraces=1 bun main.cjs     # same output as any debug build, where the option is on by default
inner /tmp/x/main.cjs:3
outer [native code]:3
main /tmp/x/callers.cjs:7
<anonymous> /tmp/x/main.cjs:12
```

`outer` and `main` report the file of the frame above them (`[native code]` is the bound function call), and because the remap then runs against the wrong file, `outer` keeps its generated line. `<anonymous>` only looks right because `main` lives in the same file.

The same happens with `AsyncLocalStorage#run(store, boundFn)`: `run` reports `[native code]` and the frame below it reports `node:async_hooks`. That is how the bake dev server hits it: react-server-dom calls components through `componentStorage.run(..., callComponentInDEV)`, a bound function, and builds the error's `.stack` through its own `Error.prepareStackTrace`, so a debug-build dev server prints

```
at run ([native code]:198:29)
at renderFunctionComponent (node:async_hooks:1272:198)
```

## Cause

`computeErrorInfoWithPrepareStackTrace` (`src/jsc/bindings/FormatStackTraceForJS.cpp`) builds the CallSites from `JSCStackTrace::fromExisting`, which skips frames with private implementation visibility (a bound function call is one, `VM::getBoundFunction` marks it private), but it then looked up each CallSite's source URL and owning global object in the unfiltered `JSC::StackFrame` vector at the same index. Once one private frame is in that vector, every CallSite after it is paired with the previous JSC frame.

JSC itself only keeps private frames in the vector while `Options::showPrivateScriptsInStackTraces()` is on, which Bun turns on in debug builds (`ZigGlobalObject.cpp`) and which `BUN_JSC_showPrivateScriptsInStackTraces=1` turns on in release builds. With it off, `fromExisting` filters nothing and the two lists happen to line up, which is why the release default is unaffected. The mismatch dates back to #5802.

## Fix

`JSCStackFrame` now keeps a pointer to the `JSC::StackFrame` it was built from, and the prepareStackTrace loop reads the JSC frame through the same `JSCStackFrame` the CallSite came from, so the pairing holds by construction instead of through a second index-aligned list. The per-frame logic (`Zig::sourceURL`, the node:vm global object check, the remap) is unchanged, so frames that were already lined up produce exactly the same CallSites as before, and the CallSite list now comes out the same whether or not JSC kept the private frames, which is what `fromExisting`'s filtering is for.

Making that pointer unconditional means removing `JSCStackFrame`'s other constructor, the one taking a `StackVisitor`, which has had no callers since #19238. The call-frame pointer only that constructor populated goes with it: it has been null for every frame since then, so `CallSite#getThis()` already returns `undefined` for every frame (a `JSC::StackFrame` carries no receiver), and `CallSite::finishCreation` now says so directly and drops the `globalObject` parameter it only needed for that path. No behavior changes there.

`JSCStackTrace::getStackTraceForThrownValue`, the only other user of `fromExisting`, is deleted as well: it had no callers, and it built a trace over a vector owned by a `JSC::Exception` or `ErrorInstance`, which the frames would now point into.

The other code that walks these vectors (`formatStackTrace` for the default `.stack` string, `populateStackTrace` in `ZigException.cpp`, and `getFramesForCaller`, which filters the vector in place before it gets here) each works on one list, so this was the only site pairing two of them.

## Verification

New test in `test/js/node/v8/capture-stack-trace.test.js`: a two-file fixture covering both the plain bound call and `AsyncLocalStorage#run` with a bound callback, run with `BUN_JSC_showPrivateScriptsInStackTraces` set to `0` and to `1`, asserting both runs report the same file and line for every named CallSite. Before the fix the `1` run (and therefore any debug build) reports `outer` at `[native code]`, `main` in `callers.cjs`, `run` at `[native code]` and `viaAsyncLocalStorage` in `node:async_hooks`; the `0` run pins the release behavior that must not change.

```
USE_SYSTEM_BUN=1 bun test test/js/node/v8/capture-stack-trace.test.js -t "hidden frame"   # fails as above
bun bd test test/js/node/v8/capture-stack-trace.test.js                                      # 44 pass
```

Also passing on the debug build: `test/js/bun/sourcemap`, `test/js/bun/util/reportError.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/node/util/util.test.js`, `test/js/web/workers/structured-clone.test.ts`, `test/regression/issue/{013880,fix-bindings-stack-trace,prepare-stack-trace-crash}.test.ts`, and the `node:test` prepareStackTrace / getCallSites / shadow realm parallel tests (these cover `getThis`/`getFunction` on strict and sloppy frames). `test/js/bun/util/inspect-error.test.js` "Error inside minified file" fails on debug builds with and without this change (the private `require` frame shows up in the default `.stack` path, which this PR does not touch).

Two nearby issues seen while reproducing are already owned by open PRs and are left alone here: #37388 (`new Error()` minified to `Error()` becomes a tail call in strict code and drops the creating frame) and #36602 (printing an error whose `.stack` was already materialized source-maps the non-top frames a second time, #15859).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (ba050a44e)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [14.74ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.55ms]
(pass) capture stack trace [6.77ms]
(pass) capture stack trace with message [7.10ms]
(pass) capture stack trace with constructor [5.18ms]
(pass) capture stack trace limit [22.46ms]
(pass) prepare stack trace [11.14ms]
(pass) capture stack trace second argument [17.41ms]
(pass) capture stack trace edge cases [11.19ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [21.72ms]
(pass) prepare stack trace call sites [11.83ms]
(pass) sanity check [12.35ms]
(pass) CallFrame isEval works as expected [7.12ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.65ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [9.51ms]
(pass) CallFrame.p.isConstructor [3.46ms]
(pass) CallFrame.p.isNative [2.94ms]
(pass) return non-strings from Error.prepareStackTrace [3.31ms]
(pass) CallF
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.15ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.10ms]
(pass) capture stack trace [0.06ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.07ms]
(pass) capture stack trace limit [0.21ms]
(pass) prepare stack trace [0.11ms]
(pass) capture stack trace second argument [0.16ms]
(pass) capture stack trace edge cases [0.10ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.28ms]
(pass) prepare stack trace call sites [0.14ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.09ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.09ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.11ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.25ms]
(pass) Error.prepareStackTrace inside a node:vm works [2.04ms]
(pass) Error.captureStackTrace i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (ba050a44e)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.45ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.42ms]
(pass) capture stack trace [6.91ms]
(pass) capture stack trace with message [7.18ms]
(pass) capture stack trace with constructor [5.14ms]
(pass) capture stack trace limit [21.90ms]
(pass) prepare stack trace [11.15ms]
(pass) capture stack trace second argument [17.52ms]
(pass) capture stack trace edge cases [10.76ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [20.78ms]
(pass) prepare stack trace call sites [11.73ms]
(pass) sanity check [12.59ms]
(pass) CallFrame isEval works as expected [7.05ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.82ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.69ms]
(pass) CallFrame.p.isConstructor [3.52ms]
(pass) CallFrame.p.isNative [2.82ms]
(pass) return non-strings from Error.prepareStackTrace [3.24ms]
(pass) CallF
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 714ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/24] gen cpp.rs (cppbind)
[2/24] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/CallSite.cpp               | 14 ++----
 src/jsc/bindings/CallSite.h                 |  4 +-
 src/jsc/bindings/ErrorStackTrace.cpp        | 71 +--------------------------
 src/jsc/bindings/ErrorStackTrace.h          | 30 ++----------
 src/jsc/bindings/FormatStackTraceForJS.cpp  |  5 +-
 test/js/node/v8/capture-stack-trace.test.js | 75 ++++++++++++++++++++++++++++-
 6 files changed, 88 insertions(+), 111 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/CallSite.cpp                    2      3      0
src/jsc/bindings/CallSite.h                      1      2      0
src/jsc/bindings/ErrorStackTrace.cpp             6      4      0
src/jsc/bindings/ErrorStackTrace.h               5      8      0
src/jsc/bindings/FormatStackTraceForJS.cpp       5      6      0
test/js/node/v8/capture-stack-trace.test.js      3      4      0
```

</details>

<!-- robobun:evidence:end -->