### PR TITLE
fetch: pool the redirecting connection when the request went out in one write

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1586,6 +1586,24 @@ impl<'a> HTTPClient<'a> {
         !self.request_body().is_empty()
     }
 
+    /// Whether the whole request, headers and body (or the chunked
+    /// terminator of a streamed body), has been handed to the socket. Every
+    /// write path sets `request_stage = Done` at that point: `on_writable`
+    /// for Bytes bodies (direct or through a proxy tunnel) and Sendfile
+    /// bodies, `write_to_stream` for Stream bodies.
+    ///
+    /// A response can complete before this happens: a server may answer a
+    /// large PUT (413, or a 200 that ignores the body) or redirect a streaming
+    /// POST (303) while the upload is still going out. A socket in that state
+    /// must be closed rather than pooled (RFC 9112 section 9.3): a reuse would
+    /// write the next request's line and headers into the tail of this
+    /// request's body. The keep-alive release in `do_redirect` and in
+    /// `send_progress_update_without_stage_check` both gate on this.
+    #[inline]
+    fn is_request_fully_sent(&self) -> bool {
+        self.state.request_stage == RequestStage::Done
+    }
+
     #[inline]
     fn request_body(&self) -> &[u8] {
         // `request_body` is a `RawSlice` into `original_request_body` (sibling
@@ -2577,13 +2595,6 @@ impl<'a> HTTPClient<'a> {
             self.flags.is_streaming_request_body = false;
         }
 
-        // There is no struct copy-back
-        // (`sync_progress_from` skips owned fields) and the original retains
-        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
-        // clone was created via `ptr::read`). Dropping it here would
-        // double-free when the original later runs `clear_data()`. Forget the
-        // clone's view; the original is the sole owner.
-        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         // TODO: what we do with stream body?
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
@@ -2612,7 +2623,7 @@ impl<'a> HTTPClient<'a> {
             bun_core::scoped_log!(fetch, "close the tunnel");
             self.close_proxy_tunnel(true);
             GenHttpContext::<IS_SSL>::close_socket(socket);
-        } else if self.state.request_stage == RequestStage::Done
+        } else if self.is_request_fully_sent()
             && self.is_keep_alive_possible()
             && !socket.is_closed_or_has_error()
             // A direct TLS socket verified against a Host-header override
@@ -2621,10 +2632,6 @@ impl<'a> HTTPClient<'a> {
             // can no longer compute the correct pool key. Close it instead.
             && (!IS_SSL || self.http_proxy.is_some() || self.hostname.is_none())
         {
-            // request_stage == .done: a 303 to a streaming POST can arrive before
-            // the chunked upload's terminating 0\r\n\r\n is written. Pooling that
-            // socket would let the next request's bytes land inside what the
-            // server is still parsing as the previous chunked body.
             bun_core::scoped_log!(fetch, "Keep-Alive release in redirect");
             debug_assert!(!self.connected_url.hostname.is_empty());
             Self::ssl_ctx_mut(ctx).release_socket(
@@ -2647,6 +2654,20 @@ impl<'a> HTTPClient<'a> {
         // connected_url was the last borrower of the previous hop's URL buffer
         // (handleResponseMetadata already repointed this.url at the new one).
         self.prev_redirect = Vec::new();
+
+        // The redirect target is reached over TCP, so the unix socket path is
+        // dropped here. This has to stay below the pool/close decision above:
+        // is_keep_alive_possible() reads it to keep a unix-socket connection
+        // out of the pool, where it would be keyed by connected_url's
+        // hostname and handed to a later TCP request for that host.
+        //
+        // There is no struct copy-back
+        // (`sync_progress_from` skips owned fields) and the original retains
+        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
+        // clone was created via `ptr::read`). Dropping it here would
+        // double-free when the original later runs `clear_data()`. Forget the
+        // clone's view; the original is the sole owner.
+        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
 
         // Deferred until after the pool/close decision above — see
         // `InternalStateFlags::clear_hostname_on_redirect`.
@@ -3318,16 +3339,17 @@ impl<'a> HTTPClient<'a> {
                 let try_sending_more_data = result.try_sending_more_data;
 
                 if has_sent_headers && has_sent_body {
-                    if self.flags.proxy_tunneling {
-                        self.state.request_stage = RequestStage::ProxyHandshake;
+                    // `has_sent_body` is only ever true for a Bytes body (see
+                    // send_initial_request_payload), so the whole request has
+                    // been written: mark the request side Done here just like
+                    // the Body arm below does for a body that needed more than
+                    // one write. The keep-alive gates in do_redirect and
+                    // send_progress_update_without_stage_check rely on this.
+                    self.state.request_stage = if self.flags.proxy_tunneling {
+                        RequestStage::ProxyHandshake
                     } else {
-                        self.state.request_stage = RequestStage::Body;
-                        if self.flags.is_streaming_request_body {
-                            // lets signal to start streaming the body
-                            let ctx = self.get_ssl_ctx::<IS_SSL>();
-                            self.progress_update::<IS_SSL>(ctx, socket);
-                        }
-                    }
+                        RequestStage::Done
+                    };
                     return;
                 }
 
@@ -4144,12 +4166,13 @@ impl<'a> HTTPClient<'a> {
 
         if is_done {
             self.unregister_abort_tracker();
-            // is_done is response-driven. A server can reply early (HTTP 413)
-            // with keep-alive while request_stage is still .proxy_body or the
-            // tunnel still has buffered encrypted writes. Pooling that tunnel
-            // would leave the connection mid-request on the inner TLS stream;
-            // adopt() resetting write_buffer doesn't restore a clean HTTP/1.1
-            // boundary. Only pool a tunnel whose request side is fully drained.
+            // is_done is response-driven; see `is_request_fully_sent` for why
+            // a socket whose request is still going out must not be pooled.
+            //
+            // A tunnel additionally has to have flushed its encrypted writes:
+            // pooling it with a non-empty write_buffer would leave the
+            // connection mid-request on the inner TLS stream, and adopt()
+            // resetting write_buffer doesn't restore a clean HTTP/1.1 boundary.
             //
             // Also check wrapper liveness: a close-delimited body (no
             // Content-Length, no Transfer-Encoding — RFC 7230 §3.3.3 rule 7)
@@ -4157,8 +4180,7 @@ impl<'a> HTTPClient<'a> {
             // socket is still alive. Pooling that dead wrapper would hang the
             // next request (proxy.write() → error.ConnectionClosed, swallowed).
             let tunnel_poolable = if let Some(t) = self.proxy_tunnel.as_deref() {
-                self.state.request_stage == RequestStage::Done
-                    && t.write_buffer.is_empty()
+                t.write_buffer.is_empty()
                     && t.wrapper
                         .as_ref()
                         .map(|w| {
@@ -4169,32 +4191,6 @@ impl<'a> HTTPClient<'a> {
                 true
             };
 
-            // The same early-reply hazard
-            // described above for tunnels applies to direct connections — a
-            // server may answer (200, Content-Length: 0) before a large PUT
-            // body has finished writing (e.g. S3 multipart UploadPart against
-            // a mock that ignores req.body). Pooling that socket lets the next
-            // request's bytes interleave with the previous body's tail on the
-            // wire, which the server then mis-parses. The redirect path
-            // (do_redirect) already gates on request_stage == Done for exactly
-            // this reason; mirror that gate here for the non-redirect
-            // completion path. `request_stage` alone is insufficient for
-            // byte-buffer bodies because a fully-sent small request parks at
-            // `.body` (see on_writable), so check the unsent slice instead.
-            //
-            // For a Stream the socket carries an incomplete chunked message
-            // (no terminating 0\r\n\r\n), so a pooled reuse writes the next
-            // request's line and credential headers INTO that body (RFC 9112
-            // section 9.3: the client must close instead). Both of
-            // write_to_stream's stream-complete exits set request_stage =
-            // Done, so Done is the reliable signal for Stream and Sendfile.
-            let request_side_drained = match &self.state.original_request_body {
-                HTTPRequestBody::Bytes(_) => self.state.request_body.is_empty(),
-                HTTPRequestBody::Stream(_) | HTTPRequestBody::Sendfile(_) => {
-                    self.state.request_stage == RequestStage::Done
-                }
-            };
-
             // The uSockets paused bit survives `state.reset()`; never hand a
             // paused socket back to the pool.
             if core::mem::take(&mut self.state.flags.receive_paused)
@@ -4203,10 +4199,10 @@ impl<'a> HTTPClient<'a> {
                 let _ = socket.resume_stream();
             }
 
-            if self.is_keep_alive_possible()
+            if self.is_request_fully_sent()
+                && self.is_keep_alive_possible()
                 && !socket.is_closed_or_has_error()
                 && tunnel_poolable
-                && request_side_drained
             {
                 bun_core::scoped_log!(fetch, "release socket");
                 // Hand the client's strong ref straight to the pool: `release_socket`

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1586,19 +1586,7 @@ impl<'a> HTTPClient<'a> {
         !self.request_body().is_empty()
     }
 
-    /// Whether the whole request, headers and body (or the chunked
-    /// terminator of a streamed body), has been handed to the socket. Every
-    /// write path sets `request_stage = Done` at that point: `on_writable`
-    /// for Bytes bodies (direct or through a proxy tunnel) and Sendfile
-    /// bodies, `write_to_stream` for Stream bodies.
-    ///
-    /// A response can complete before this happens: a server may answer a
-    /// large PUT (413, or a 200 that ignores the body) or redirect a streaming
-    /// POST (303) while the upload is still going out. A socket in that state
-    /// must be closed rather than pooled (RFC 9112 section 9.3): a reuse would
-    /// write the next request's line and headers into the tail of this
-    /// request's body. The keep-alive release in `do_redirect` and in
-    /// `send_progress_update_without_stage_check` both gate on this.
+    /// Pooling a socket whose request is still going out would land the next request inside this one's body.
     #[inline]
     fn is_request_fully_sent(&self) -> bool {
         self.state.request_stage == RequestStage::Done
@@ -2595,6 +2583,15 @@ impl<'a> HTTPClient<'a> {
             self.flags.is_streaming_request_body = false;
         }
 
+        // Decided before unix_socket_path is forgotten below: a unix-socket connection must not be pooled.
+        let keep_alive_possible = self.is_keep_alive_possible();
+        // There is no struct copy-back
+        // (`sync_progress_from` skips owned fields) and the original retains
+        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
+        // clone was created via `ptr::read`). Dropping it here would
+        // double-free when the original later runs `clear_data()`. Forget the
+        // clone's view; the original is the sole owner.
+        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         // TODO: what we do with stream body?
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
@@ -2623,8 +2620,8 @@ impl<'a> HTTPClient<'a> {
             bun_core::scoped_log!(fetch, "close the tunnel");
             self.close_proxy_tunnel(true);
             GenHttpContext::<IS_SSL>::close_socket(socket);
-        } else if self.is_request_fully_sent()
-            && self.is_keep_alive_possible()
+        } else if keep_alive_possible
+            && self.is_request_fully_sent()
             && !socket.is_closed_or_has_error()
             // A direct TLS socket verified against a Host-header override
             // (get_tls_hostname) must not be pooled here: this.url has already
@@ -2654,20 +2651,6 @@ impl<'a> HTTPClient<'a> {
         // connected_url was the last borrower of the previous hop's URL buffer
         // (handleResponseMetadata already repointed this.url at the new one).
         self.prev_redirect = Vec::new();
-
-        // The redirect target is reached over TCP, so the unix socket path is
-        // dropped here. This has to stay below the pool/close decision above:
-        // is_keep_alive_possible() reads it to keep a unix-socket connection
-        // out of the pool, where it would be keyed by connected_url's
-        // hostname and handed to a later TCP request for that host.
-        //
-        // There is no struct copy-back
-        // (`sync_progress_from` skips owned fields) and the original retains
-        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
-        // clone was created via `ptr::read`). Dropping it here would
-        // double-free when the original later runs `clear_data()`. Forget the
-        // clone's view; the original is the sole owner.
-        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
 
         // Deferred until after the pool/close decision above — see
         // `InternalStateFlags::clear_hostname_on_redirect`.
@@ -3339,12 +3322,7 @@ impl<'a> HTTPClient<'a> {
                 let try_sending_more_data = result.try_sending_more_data;
 
                 if has_sent_headers && has_sent_body {
-                    // `has_sent_body` is only ever true for a Bytes body (see
-                    // send_initial_request_payload), so the whole request has
-                    // been written: mark the request side Done here just like
-                    // the Body arm below does for a body that needed more than
-                    // one write. The keep-alive gates in do_redirect and
-                    // send_progress_update_without_stage_check rely on this.
+                    // has_sent_body is only ever true for a Bytes body, so the whole request is out.
                     self.state.request_stage = if self.flags.proxy_tunneling {
                         RequestStage::ProxyHandshake
                     } else {
@@ -4166,13 +4144,12 @@ impl<'a> HTTPClient<'a> {
 
         if is_done {
             self.unregister_abort_tracker();
-            // is_done is response-driven; see `is_request_fully_sent` for why
-            // a socket whose request is still going out must not be pooled.
-            //
-            // A tunnel additionally has to have flushed its encrypted writes:
-            // pooling it with a non-empty write_buffer would leave the
-            // connection mid-request on the inner TLS stream, and adopt()
-            // resetting write_buffer doesn't restore a clean HTTP/1.1 boundary.
+            // is_done is response-driven. A server can reply early (HTTP 413)
+            // with keep-alive while request_stage is still .proxy_body or the
+            // tunnel still has buffered encrypted writes. Pooling that tunnel
+            // would leave the connection mid-request on the inner TLS stream;
+            // adopt() resetting write_buffer doesn't restore a clean HTTP/1.1
+            // boundary. Only pool a tunnel whose request side is fully drained.
             //
             // Also check wrapper liveness: a close-delimited body (no
             // Content-Length, no Transfer-Encoding — RFC 7230 §3.3.3 rule 7)

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -368,3 +368,187 @@ test("a completed streaming POST keeps its connection in the keep-alive pool", a
     exitCode: 0,
   });
 });
+
+// Raw HTTP/1.1 server for the redirect tests below, bound to 127.0.0.1 (the
+// address fetch() dials). Every request is answered on the connection it came
+// in on, so `connections` is exactly how many times bun dialed.
+//   /302, /303, /307  bodyless redirect to /legit on a reusable connection
+//   /302-close        the same 302 with Connection: close
+//   /302-body         a 302 that carries a body
+//   anything else     200 whose body is "<method>:<request body length>"
+const redirectServer = `
+  import net from "node:net";
+  let connections = 0;
+  const server = net.createServer(sock => {
+    connections++;
+    sock.on("error", () => {});
+    let buf = "";
+    sock.on("data", d => {
+      buf += d.toString("latin1");
+      while (true) {
+        const end = buf.indexOf("\\r\\n\\r\\n");
+        if (end === -1) return;
+        const head = buf.slice(0, end);
+        const len = Number(/^content-length:\\s*(\\d+)/im.exec(head)?.[1] ?? 0);
+        if (buf.length < end + 4 + len) return;
+        buf = buf.slice(end + 4 + len);
+        const [method, path] = head.split(" ");
+        const redirect = {
+          "/302": "302 Found",
+          "/302-close": "302 Found",
+          "/302-body": "302 Found",
+          "/303": "303 See Other",
+          "/307": "307 Temporary Redirect",
+        }[path];
+        if (!redirect) {
+          const body = method + ":" + len;
+          sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: " + body.length + "\\r\\n\\r\\n" + body);
+        } else if (path === "/302-close") {
+          sock.end("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n");
+        } else if (path === "/302-body") {
+          sock.write("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 5\\r\\n\\r\\nmoved");
+        } else {
+          sock.write("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\n\\r\\n");
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await new Promise(r => server.on("listening", r));
+  const origin = "http://127.0.0.1:" + server.address().port;
+`;
+
+// A bodyless 3xx on a keep-alive connection leaves that connection as reusable
+// as any other completed exchange, so the hop (and every later fetch) should
+// ride on it: four redirected fetches, one connection. This used to hold only
+// for streamed request bodies; a request whose headers and body went out in a
+// single write was never considered finished by the redirect path, so each
+// redirect closed the connection and dialed again for the hop (5 connections
+// here, one per redirect plus the first). Subprocess so the pool is private to
+// the test.
+test.concurrent.each([
+  ["GET -> 302", "/302", "{}", "GET:0", 1],
+  ["POST -> 303 (hop is a bodyless GET)", "/303", '{ method: "POST", body: "payload" }', "GET:0", 1],
+  ["POST -> 307 (hop resends the body)", "/307", '{ method: "POST", body: "payload" }', "POST:7", 1],
+  // Not reusable, so every fetch dials once more for the hop; the hop's own
+  // connection is pooled and carries the next fetch's 3xx.
+  ["GET -> 302 with Connection: close", "/302-close", "{}", "GET:0", 5],
+  ["GET -> 302 carrying a body", "/302-body", "{}", "GET:0", 5],
+])("redirect keep-alive: %s", async (_, path, init, hopBody, connections) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      ${redirectServer}
+      const results = [];
+      for (let i = 0; i < 4; i++) {
+        const res = await fetch(origin + ${JSON.stringify(path)}, ${init});
+        results.push(res.status, res.redirected, await res.text());
+      }
+      console.log(JSON.stringify({ results, connections }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: { results: Array(4).fill([200, true, hopBody]).flat(), connections },
+    exitCode: 0,
+  });
+});
+
+// What the pooling above must not relax: a response (redirect or final) that
+// arrives while the request body is still going out leaves the connection
+// mid-message. The next request has to dial a new connection; written onto the
+// old one, its request line would land inside the unfinished upload, which the
+// server below reports with a 299. The stream body never ends, and the byte
+// body is far larger than the loopback socket buffers, so in both cases the
+// reply is processed with part of the body still unsent.
+test.concurrent.each([
+  [
+    "303 while a ReadableStream body is still open",
+    "HTTP/1.1 303 See Other\r\nLocation: /legit\r\nContent-Length: 0\r\n\r\n",
+    "new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(4)); return new Promise(() => {}); } })",
+    [200, "GET:0"],
+  ],
+  [
+    "303 while a 64 MiB byte body is still being written",
+    "HTTP/1.1 303 See Other\r\nLocation: /legit\r\nContent-Length: 0\r\n\r\n",
+    "new Uint8Array(64 * 1024 * 1024)",
+    [200, "GET:0"],
+  ],
+  [
+    "200 while a 64 MiB byte body is still being written",
+    "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+    "new Uint8Array(64 * 1024 * 1024)",
+    [200, ""],
+  ],
+])("a connection answered early (%s) is not pooled", async (_, earlyReply, body, first) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      let connections = 0;
+      const server = net.createServer(sock => {
+        connections++;
+        sock.on("error", () => {});
+        let buf = "";
+        let answeredEarly = false;
+        sock.on("data", d => {
+          const chunk = d.toString("latin1");
+          if (answeredEarly) {
+            // Only the rest of the upload may follow the early reply.
+            if (chunk.includes("GET /legit ")) {
+              sock.write("HTTP/1.1 299 Poisoned\\r\\nContent-Length: 0\\r\\n\\r\\n");
+            }
+            return;
+          }
+          buf += chunk;
+          const end = buf.indexOf("\\r\\n\\r\\n");
+          if (end === -1) return;
+          const head = buf.slice(0, end);
+          buf = "";
+          if (head.startsWith("POST /upload ")) {
+            answeredEarly = true;
+            sock.write(${JSON.stringify(earlyReply)});
+          } else {
+            const len = Number(/^content-length:\\s*(\\d+)/im.exec(head)?.[1] ?? 0);
+            const res = head.split(" ")[0] + ":" + len;
+            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: " + res.length + "\\r\\n\\r\\n" + res);
+          }
+        });
+      });
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const origin = "http://127.0.0.1:" + server.address().port;
+
+      const res1 = await fetch(origin + "/upload", { method: "POST", duplex: "half", body: ${body} });
+      const first = [res1.status, await res1.text()];
+      const res2 = await fetch(origin + "/legit");
+      const second = [res2.status, await res2.text()];
+      console.log(JSON.stringify({ first, second, connections }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    // The 303 rows' hop and the 200 row's follow-up fetch each dial the second
+    // connection; the follow-up in the 303 rows then reuses the hop's.
+    result: { first, second: [200, "GET:0"], connections: 2 },
+    exitCode: 0,
+  });
+});

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tls } from "harness";
+import { bunEnv, bunExe, isWindows, tls } from "harness";
 
 test("keepalive", async () => {
   using server = Bun.serve({
@@ -467,88 +467,103 @@ test.concurrent.each([
 // arrives while the request body is still going out leaves the connection
 // mid-message. The next request has to dial a new connection; written onto the
 // old one, its request line would land inside the unfinished upload, which the
-// server below reports with a 299. The stream body never ends, and the byte
-// body is far larger than the loopback socket buffers, so in both cases the
-// reply is processed with part of the body still unsent.
-test.concurrent.each([
+// server below reports with a 299. The stream body never ends. The byte body
+// is far larger than the loopback socket buffers on Linux and macOS, so bun
+// gets the reply with most of it still unsent; Windows' loopback accepts the
+// whole 64 MiB into kernel buffers at once, even with the peer not reading, so
+// there the request really is fully sent and reusing the connection is
+// legitimate (the server then sees the full body followed by the request).
+const earlyReplyCases: [
+  label: string,
+  earlyReply: string,
+  body: string,
+  first: [number, string],
+  onWindows: boolean,
+][] = [
   [
     "303 while a ReadableStream body is still open",
     "HTTP/1.1 303 See Other\r\nLocation: /legit\r\nContent-Length: 0\r\n\r\n",
     "new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(4)); return new Promise(() => {}); } })",
     [200, "GET:0"],
+    true,
   ],
   [
     "303 while a 64 MiB byte body is still being written",
     "HTTP/1.1 303 See Other\r\nLocation: /legit\r\nContent-Length: 0\r\n\r\n",
     "new Uint8Array(64 * 1024 * 1024)",
     [200, "GET:0"],
+    false,
   ],
   [
     "200 while a 64 MiB byte body is still being written",
     "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
     "new Uint8Array(64 * 1024 * 1024)",
     [200, ""],
+    false,
   ],
-])("a connection answered early (%s) is not pooled", async (_, earlyReply, body, first) => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      import net from "node:net";
-      let connections = 0;
-      const server = net.createServer(sock => {
-        connections++;
-        sock.on("error", () => {});
-        let buf = "";
-        let answeredEarly = false;
-        sock.on("data", d => {
-          const chunk = d.toString("latin1");
-          if (answeredEarly) {
-            // Only the rest of the upload may follow the early reply.
-            if (chunk.includes("GET /legit ")) {
-              sock.write("HTTP/1.1 299 Poisoned\\r\\nContent-Length: 0\\r\\n\\r\\n");
+];
+for (const [label, earlyReply, body, first, onWindows] of earlyReplyCases) {
+  test.concurrent.skipIf(isWindows && !onWindows)(`a connection answered early (${label}) is not pooled`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import net from "node:net";
+        let connections = 0;
+        const server = net.createServer(sock => {
+          connections++;
+          sock.on("error", () => {});
+          let buf = "";
+          let answeredEarly = false;
+          sock.on("data", d => {
+            const chunk = d.toString("latin1");
+            if (answeredEarly) {
+              // Only the rest of the upload may follow the early reply.
+              if (chunk.includes("GET /legit ")) {
+                sock.write("HTTP/1.1 299 Poisoned\\r\\nContent-Length: 0\\r\\n\\r\\n");
+              }
+              return;
             }
-            return;
-          }
-          buf += chunk;
-          const end = buf.indexOf("\\r\\n\\r\\n");
-          if (end === -1) return;
-          const head = buf.slice(0, end);
-          buf = "";
-          if (head.startsWith("POST /upload ")) {
-            answeredEarly = true;
-            sock.write(${JSON.stringify(earlyReply)});
-          } else {
-            const len = Number(/^content-length:\\s*(\\d+)/im.exec(head)?.[1] ?? 0);
-            const res = head.split(" ")[0] + ":" + len;
-            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: " + res.length + "\\r\\n\\r\\n" + res);
-          }
+            buf += chunk;
+            const end = buf.indexOf("\\r\\n\\r\\n");
+            if (end === -1) return;
+            const head = buf.slice(0, end);
+            buf = "";
+            if (head.startsWith("POST /upload ")) {
+              answeredEarly = true;
+              sock.write(${JSON.stringify(earlyReply)});
+            } else {
+              const len = Number(/^content-length:\\s*(\\d+)/im.exec(head)?.[1] ?? 0);
+              const res = head.split(" ")[0] + ":" + len;
+              sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: " + res.length + "\\r\\n\\r\\n" + res);
+            }
+          });
         });
-      });
-      server.listen(0, "127.0.0.1");
-      await new Promise(r => server.on("listening", r));
-      const origin = "http://127.0.0.1:" + server.address().port;
+        server.listen(0, "127.0.0.1");
+        await new Promise(r => server.on("listening", r));
+        const origin = "http://127.0.0.1:" + server.address().port;
 
-      const res1 = await fetch(origin + "/upload", { method: "POST", duplex: "half", body: ${body} });
-      const first = [res1.status, await res1.text()];
-      const res2 = await fetch(origin + "/legit");
-      const second = [res2.status, await res2.text()];
-      console.log(JSON.stringify({ first, second, connections }));
-      process.exit(0);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+        const res1 = await fetch(origin + "/upload", { method: "POST", duplex: "half", body: ${body} });
+        const first = [res1.status, await res1.text()];
+        const res2 = await fetch(origin + "/legit");
+        const second = [res2.status, await res2.text()];
+        console.log(JSON.stringify({ first, second, connections }));
+        process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-  expect({ result, exitCode }).toEqual({
-    // The 303 rows' hop and the 200 row's follow-up fetch each dial the second
-    // connection; the follow-up in the 303 rows then reuses the hop's.
-    result: { first, second: [200, "GET:0"], connections: 2 },
-    exitCode: 0,
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({
+      // The 303 rows' hop and the 200 row's follow-up fetch each dial the second
+      // connection; the follow-up in the 303 rows then reuses the hop's.
+      result: { first, second: [200, "GET:0"], connections: 2 },
+      exitCode: 0,
+    });
   });
-});
+}

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -244,3 +244,32 @@ it("handle redirect to non-unix", async () => {
     expect(await response.text()).toBe("world");
   }
 });
+
+// Following a redirect hands a reusable connection to the keep-alive pool,
+// keyed by the request URL's host and port. A unix-socket connection is not
+// reusable that way: the request URL below names the TCP server, so pooling
+// the unix connection would serve the TCP hop (and any later fetch of that
+// host:port) from the unix server.
+it("does not pool the unix-socket connection whose redirect is being followed", async () => {
+  startServer({
+    fetch(req) {
+      return new Response(`tcp ${new URL(req.url).pathname}`);
+    },
+  });
+  const path = startServerUnix({
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname === "/hello") {
+        return new Response(null, { status: 302, headers: { Location: "/world" } });
+      }
+      return new Response(`unix ${pathname}`);
+    },
+  });
+
+  const results: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    const response = await fetch(`http://127.0.0.1:${server.port}/hello`, { unix: path });
+    results.push(`${response.status} ${response.redirected} ${await response.text()}`);
+  }
+  expect(results).toEqual(Array(5).fill("200 true tcp /world"));
+});


### PR DESCRIPTION
### Repro

A raw server on 127.0.0.1 that counts connections and answers `/302` with `HTTP/1.1 302 Found`, `Location: /legit`, `Content-Length: 0` on a keep-alive connection, and everything else with a small 200:

```js
for (let i = 0; i < 4; i++) {
  const res = await fetch(origin + "/302");
  console.log(await res.text(), connections);
}
```

On bun 1.4.0 (and a debug build of main) this prints connection counts 2, 3, 4, 5: every followed redirect closes the connection that carried the 3xx and dials a new one for the hop. With `BUN_DEBUG_fetch=1` a debug build logs `doRedirect` four times and `Keep-Alive release in redirect` zero times. The same happens for `POST -> 307` (body resent) and `POST -> 303`. The count should stay at 1.

### Cause

`do_redirect` only releases the socket to the pool when `request_stage == Done` (gate added in #29766, shipped in 1.3.14, so that a 303 answering a still-uploading streamed POST is not pooled mid-chunked-body). But `on_writable`'s initial-payload arm sets `request_stage = Body` when the headers and the byte body went out in that first write and returns; nothing advances it to `Done` unless a further writable event happens to fire. So for an ordinary GET, or any request that fits in one write, the gate is never true. Before #29766 these connections were pooled. `send_progress_update_without_stage_check` had been working around the same parking with a separate "unsent slice is empty" check for byte bodies.

### Fix

* `on_writable`: when the initial write sent both headers and body (only possible for a byte body, see `send_initial_request_payload`), set `request_stage = Done`, which is what the `Body` arm already does for a body that needs more than one write and what `write_to_stream` does for streams. The `is_streaming_request_body` branch that used to sit there was unreachable (`has_sent_body` is never true for a stream body).
* Both keep-alive release sites (`do_redirect` and `send_progress_update_without_stage_check`) now gate on one helper, `is_request_fully_sent()` (`request_stage == Done`), so the byte-body special case in the progress-update path goes away. For byte bodies this is the same as the old check whenever the headers had been fully written, and stricter (close instead of pool) if a response completes while the request head itself is still partially unsent, which is the right call for that connection too. Stream and sendfile bodies are unchanged: both already required `Done`.
* `do_redirect` forgot `unix_socket_path` before making the pool/close decision, which `is_keep_alive_possible()` reads to keep unix-socket connections out of the pool. That was harmless while the gate never passed; with the gate fixed it would pool the unix connection under the request URL's host:port and the TCP hop to that host:port would be served by the unix server (verified both ways: the new `fetch.unix` test fails with `"unix /world"` instead of `"tcp /world"` if only the gate is fixed). `do_redirect` now takes the keep-alive decision before the path is forgotten.

Scope: this only changes bodyless (`Content-Length: 0`) 3xx responses. A 3xx with a body already has `allow_keepalive` cleared in `handle_response_metadata` because the body is discarded rather than read, and `Connection: close` is honoured on any status, so those still close. The proxy-tunnel and TLS Host-override exclusions in `do_redirect` are unchanged.

### Tests

`test/js/web/fetch/fetch-keepalive.test.ts`:
* `redirect keep-alive:` `GET -> 302`, `POST -> 303`, `POST -> 307`: four redirected fetches use one connection (fail before the fix with 5 connections, on both the release binary and a debug build of main); `302 + Connection: close` and `302 carrying a body` still dial once per fetch.
* `a connection answered early (...) is not pooled`: a 303 arriving while a ReadableStream body is still open, a 303 arriving while a 64 MiB byte body is still being written, and a 200 doing the same (the non-redirect release site) all make the next request dial a new connection, and the server confirms nothing was written into the unfinished upload. There was no test for the streamed-303 hazard #29766's gate exists for, nor for the byte-body early-reply check in the progress-update path. The two byte-body cases are skipped on Windows: its loopback accepts the whole 64 MiB into kernel buffers at once even with the peer not reading (checked on a Windows box: after the early reply the server can still read all 64 MiB followed by the next request), so there the request really is fully sent and reuse is legitimate; the scenario only exists where the socket buffers bound the upload.

`test/js/web/fetch/fetch.unix.test.ts`: the unix-socket connection whose redirect is being followed is not handed to the TCP hop.

Also ran the fetch, client-fetch, fetch-redirect, fetch-tcp-keepalive, proxy (tunnel pooling), node-http, body/stream and a few install suites against the debug build; the remaining failures there reproduce identically on the unmodified binary in this environment (`NO_PROXY`/localhost binding, and ASAN timeouts on tests that are close to 5s on main as well).
