### PR TITLE
quic: set SO_RCVBUF/SO_SNDBUF on the HTTP/3 UDP sockets

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -872,19 +872,20 @@ void us_quic_set_socket_buffer_size_for_testing(int bytes) {
  * the old value cannot be restored afterwards, so what the request actually
  * yields is measured on a throwaway socket first and a socket that already
  * has at least that much is left alone. Best effort: any failure leaves the
- * socket at its default. */
-static void us_quic_set_socket_buffers(struct us_udp_socket_t *udp) {
+ * socket at its default. Called once ls->local is known so the probe uses the
+ * family the kernel just accepted for the real socket. */
+static void us_quic_set_socket_buffers(us_quic_listen_socket_t *ls) {
     int request = __atomic_load_n(&us_quic_socket_buffer_request, __ATOMIC_SEQ_CST);
     if (request <= 0) return;
-    LIBUS_SOCKET_DESCRIPTOR probe = bsd_create_socket(AF_INET, SOCK_DGRAM, 0, NULL);
+    LIBUS_SOCKET_DESCRIPTOR probe = bsd_create_socket(ls->local.ss_family, SOCK_DGRAM, 0, NULL);
     if (probe == LIBUS_SOCKET_ERROR) return;
     for (int is_recv = 0; is_recv <= 1; is_recv++) {
         int granted = 0, current = 0;
         if (bsd_socket_buffer_size(probe, is_recv, request, &granted) != 0 ||
             bsd_socket_buffer_size(probe, is_recv, 0, &granted) != 0 ||
-            us_udp_socket_buffer_size(udp, is_recv, 0, &current) != 0 ||
+            us_udp_socket_buffer_size(ls->udp, is_recv, 0, &current) != 0 ||
             current >= granted) continue;
-        us_udp_socket_buffer_size(udp, is_recv, request, &current);
+        us_udp_socket_buffer_size(ls->udp, is_recv, request, &current);
     }
     bsd_close_socket(probe);
 }
@@ -905,11 +906,11 @@ us_quic_listen_socket_t *us_quic_socket_context_listen(
         host, (unsigned short) port, flags, &err, ls);
     if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
-    us_quic_set_socket_buffers(ls->udp);
 
     /* Record actual bound address — packet_in needs sa_local. */
     socklen_t sl = sizeof(ls->local);
     getsockname(us_poll_fd((struct us_poll_t *) ls->udp), (struct sockaddr *) &ls->local, &sl);
+    us_quic_set_socket_buffers(ls);
 
     ls->next = ctx->listeners;
     ctx->listeners = ls;
@@ -1264,9 +1265,9 @@ static us_quic_listen_socket_t *us_quic_client_endpoint(us_quic_socket_context_t
     }
     if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
-    us_quic_set_socket_buffers(ls->udp);
     socklen_t sl = sizeof(ls->local);
     getsockname(us_poll_fd((struct us_poll_t *) ls->udp), (struct sockaddr *) &ls->local, &sl);
+    us_quic_set_socket_buffers(ls);
     ls->next = ctx->listeners;
     ctx->listeners = ls;
     ctx->client_udp = ls;

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -849,6 +849,28 @@ static void us_quic_set_dontfrag(struct us_udp_socket_t *udp) {
     (void) on;
 }
 
+/* Kernel default UDP socket buffers are sized for request/response datagram
+ * traffic: Linux net.core.rmem_default (208 KiB) queues fewer than 100
+ * full-size QUIC packets once skb overhead is charged, Windows defaults to
+ * 64 KiB. lsquic sends up to a cwnd per engine tick and one socket carries
+ * every connection, so the tail of any larger burst is dropped by the
+ * receiving socket before lsquic sees it, every burst becomes a loss event,
+ * and throughput settles at about one socket buffer per RTT. 4 MiB is in line
+ * with other QUIC stacks and below macOS's default kern.ipc.maxsockbuf.
+ * Linux clamps the request to net.core.{r,w}mem_max (then doubles it), so an
+ * untuned host gets 2x the default and a tuned one the full amount. Best
+ * effort: a failure, or a default that is already this large, leaves the
+ * socket as is. */
+#define US_QUIC_SOCKET_BUFFER_SIZE (4 * 1024 * 1024)
+
+static void us_quic_set_socket_buffers(struct us_udp_socket_t *udp) {
+    for (int is_recv = 0; is_recv <= 1; is_recv++) {
+        int size = 0;
+        if (us_udp_socket_buffer_size(udp, is_recv, 0, &size) == 0 && size >= US_QUIC_SOCKET_BUFFER_SIZE) continue;
+        us_udp_socket_buffer_size(udp, is_recv, US_QUIC_SOCKET_BUFFER_SIZE, &size);
+    }
+}
+
 us_quic_listen_socket_t *us_quic_socket_context_listen(
     us_quic_socket_context_t *ctx, const char *host, int port, int flags,
     unsigned int stream_ext_size)
@@ -865,6 +887,7 @@ us_quic_listen_socket_t *us_quic_socket_context_listen(
         host, (unsigned short) port, flags, &err, ls);
     if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
+    us_quic_set_socket_buffers(ls->udp);
 
     /* Record actual bound address — packet_in needs sa_local. */
     socklen_t sl = sizeof(ls->local);
@@ -1223,6 +1246,7 @@ static us_quic_listen_socket_t *us_quic_client_endpoint(us_quic_socket_context_t
     }
     if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
+    us_quic_set_socket_buffers(ls->udp);
     socklen_t sl = sizeof(ls->local);
     getsockname(us_poll_fd((struct us_poll_t *) ls->udp), (struct sockaddr *) &ls->local, &sl);
     ls->next = ctx->listeners;

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -851,24 +851,42 @@ static void us_quic_set_dontfrag(struct us_udp_socket_t *udp) {
 
 /* Kernel default UDP socket buffers are sized for request/response datagram
  * traffic: Linux net.core.rmem_default (208 KiB) queues fewer than 100
- * full-size QUIC packets once skb overhead is charged, Windows defaults to
- * 64 KiB. lsquic sends up to a cwnd per engine tick and one socket carries
- * every connection, so the tail of any larger burst is dropped by the
- * receiving socket before lsquic sees it, every burst becomes a loss event,
- * and throughput settles at about one socket buffer per RTT. 4 MiB is in line
- * with other QUIC stacks and below macOS's default kern.ipc.maxsockbuf.
- * Linux clamps the request to net.core.{r,w}mem_max (then doubles it), so an
- * untuned host gets 2x the default and a tuned one the full amount. Best
- * effort: a failure, or a default that is already this large, leaves the
- * socket as is. */
+ * full-size QUIC packets once skb overhead is charged; Windows (128 KiB) is
+ * no better. lsquic hands the kernel up to a cwnd per engine tick and one
+ * socket carries every connection, so the tail of any larger burst is
+ * dropped by the receiving socket before lsquic sees it and each such burst
+ * is a loss event. 4 MiB is in line with other QUIC stacks and below macOS's
+ * default kern.ipc.maxsockbuf. Linux clamps the request to
+ * net.core.{r,w}mem_max (then doubles it), so an untuned host gets 2x the
+ * default and a tuned one the full amount. */
 #define US_QUIC_SOCKET_BUFFER_SIZE (4 * 1024 * 1024)
 
+static int us_quic_socket_buffer_request = US_QUIC_SOCKET_BUFFER_SIZE;
+
+void us_quic_set_socket_buffer_size_for_testing(int bytes) {
+    __atomic_store_n(&us_quic_socket_buffer_request, bytes, __ATOMIC_SEQ_CST);
+}
+
+/* Buffers are only ever raised. setsockopt succeeds even when the kernel
+ * clamps the request below a socket's (administratively raised) default and
+ * the old value cannot be restored afterwards, so what the request actually
+ * yields is measured on a throwaway socket first and a socket that already
+ * has at least that much is left alone. Best effort: any failure leaves the
+ * socket at its default. */
 static void us_quic_set_socket_buffers(struct us_udp_socket_t *udp) {
+    int request = __atomic_load_n(&us_quic_socket_buffer_request, __ATOMIC_SEQ_CST);
+    if (request <= 0) return;
+    LIBUS_SOCKET_DESCRIPTOR probe = bsd_create_socket(AF_INET, SOCK_DGRAM, 0, NULL);
+    if (probe == LIBUS_SOCKET_ERROR) return;
     for (int is_recv = 0; is_recv <= 1; is_recv++) {
-        int size = 0;
-        if (us_udp_socket_buffer_size(udp, is_recv, 0, &size) == 0 && size >= US_QUIC_SOCKET_BUFFER_SIZE) continue;
-        us_udp_socket_buffer_size(udp, is_recv, US_QUIC_SOCKET_BUFFER_SIZE, &size);
+        int granted = 0, current = 0;
+        if (bsd_socket_buffer_size(probe, is_recv, request, &granted) != 0 ||
+            bsd_socket_buffer_size(probe, is_recv, 0, &granted) != 0 ||
+            us_udp_socket_buffer_size(udp, is_recv, 0, &current) != 0 ||
+            current >= granted) continue;
+        us_udp_socket_buffer_size(udp, is_recv, request, &current);
     }
+    bsd_close_socket(probe);
 }
 
 us_quic_listen_socket_t *us_quic_socket_context_listen(

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -46,6 +46,11 @@ struct us_quic_header_t {
  * via a thread-safe static local so quic.c stays free of pthread/call_once. */
 void us_quic_global_init(void);
 
+/* bun:internal-for-testing only. Overrides the SO_RCVBUF / SO_SNDBUF size
+ * requested for every QUIC UDP socket created from now on (listeners and the
+ * client endpoint); 0 leaves new sockets at the kernel default. */
+void us_quic_set_socket_buffer_size_for_testing(int bytes);
+
 us_quic_socket_context_t *us_create_quic_socket_context(
     struct us_loop_t *loop, struct us_bun_socket_context_options_t options,
     unsigned int ext_size, unsigned int idle_timeout_s);

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -763,11 +763,9 @@ export const quicInternals = {
    * UDP socket created afterwards (`Bun.serve({ http3 })` listeners and the
    * fetch() HTTP/3 endpoint). 0 leaves new sockets at the kernel default.
    */
-  setSocketBufferSize: $newRustFunction(
-    "runtime/socket/socket.rs",
-    "TestingAPIs.jsSetQuicSocketBufferSize",
-    1,
-  ) as (bytes: number) => void,
+  setSocketBufferSize: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsSetQuicSocketBufferSize", 1) as (
+    bytes: number,
+  ) => void,
 };
 
 export const fileSinkInternals = {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -758,11 +758,7 @@ export const fetchH3Internals = {
 };
 
 export const quicInternals = {
-  /**
-   * Process-wide: the SO_RCVBUF / SO_SNDBUF size quic.c requests for every QUIC
-   * UDP socket created afterwards (`Bun.serve({ http3 })` listeners and the
-   * fetch() HTTP/3 endpoint). 0 leaves new sockets at the kernel default.
-   */
+  /** SO_RCVBUF / SO_SNDBUF quic.c requests for QUIC UDP sockets created afterwards (process-wide); 0 keeps the kernel default. */
   setSocketBufferSize: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsSetQuicSocketBufferSize", 1) as (
     bytes: number,
   ) => void,

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -757,6 +757,19 @@ export const fetchH3Internals = {
   },
 };
 
+export const quicInternals = {
+  /**
+   * Process-wide: the SO_RCVBUF / SO_SNDBUF size quic.c requests for every QUIC
+   * UDP socket created afterwards (`Bun.serve({ http3 })` listeners and the
+   * fetch() HTTP/3 endpoint). 0 leaves new sockets at the kernel default.
+   */
+  setSocketBufferSize: $newRustFunction(
+    "runtime/socket/socket.rs",
+    "TestingAPIs.jsSetQuicSocketBufferSize",
+    1,
+  ) as (bytes: number) => void,
+};
+
 export const fileSinkInternals = {
   liveCount: $newRustFunction("runtime/webcore/FileSink.rs", "TestingAPIs.fileSinkLiveCount", 0) as () => number,
 };

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5254,6 +5254,23 @@ pub mod testing_apis {
         }
     }
 
+    /// `quicInternals.setSocketBufferSize(bytes)`: the SO_RCVBUF / SO_SNDBUF
+    /// size quic.c requests for QUIC UDP sockets created from now on
+    /// (`Bun.serve({ http3 })` listeners and the fetch() HTTP/3 endpoint);
+    /// 0 leaves them at the kernel default.
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_set_quic_socket_buffer_size(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let [bytes] = frame.arguments_as_array::<1>();
+        if !bytes.is_number() {
+            return Err(global.throw_invalid_argument_type_value("bytes", "number", bytes));
+        }
+        bun_uws_sys::quic::set_socket_buffer_size_for_testing(bytes.coerce_to_i32(global)?);
+        Ok(JSValue::UNDEFINED)
+    }
+
     #[cfg(socket_fault_injection)]
     fn parse_errno_name(name: &bun_core::OwnedString) -> Option<c_int> {
         macro_rules! map {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5254,10 +5254,7 @@ pub mod testing_apis {
         }
     }
 
-    /// `quicInternals.setSocketBufferSize(bytes)`: the SO_RCVBUF / SO_SNDBUF
-    /// size quic.c requests for QUIC UDP sockets created from now on
-    /// (`Bun.serve({ http3 })` listeners and the fetch() HTTP/3 endpoint);
-    /// 0 leaves them at the kernel default.
+    /// `quicInternals.setSocketBufferSize(bytes)`, see quic.h.
     #[bun_jsc::host_fn]
     pub(crate) fn js_set_quic_socket_buffer_size(
         global: &JSGlobalObject,

--- a/src/uws_sys/quic.rs
+++ b/src/uws_sys/quic.rs
@@ -30,9 +30,19 @@ pub use self::header::Qpack;
 unsafe extern "C" {
     // safe: no args; idempotent C-side initialization with no preconditions.
     pub(crate) safe fn us_quic_global_init();
+    // safe: atomic store of a plain int; no preconditions.
+    safe fn us_quic_set_socket_buffer_size_for_testing(bytes: core::ffi::c_int);
 }
 
 #[inline]
 pub fn global_init() {
     us_quic_global_init()
+}
+
+/// `bun:internal-for-testing` only: the SO_RCVBUF / SO_SNDBUF size quic.c
+/// requests for every QUIC UDP socket created from now on; 0 leaves new
+/// sockets at the kernel default.
+#[inline]
+pub fn set_socket_buffer_size_for_testing(bytes: core::ffi::c_int) {
+    us_quic_set_socket_buffer_size_for_testing(bytes)
 }

--- a/src/uws_sys/quic.rs
+++ b/src/uws_sys/quic.rs
@@ -39,9 +39,7 @@ pub fn global_init() {
     us_quic_global_init()
 }
 
-/// `bun:internal-for-testing` only: the SO_RCVBUF / SO_SNDBUF size quic.c
-/// requests for every QUIC UDP socket created from now on; 0 leaves new
-/// sockets at the kernel default.
+/// `bun:internal-for-testing` only; documented on the C function in quic.h.
 #[inline]
 pub fn set_socket_buffer_size_for_testing(bytes: core::ffi::c_int) {
     us_quic_set_socket_buffer_size_for_testing(bytes)

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1435,9 +1435,13 @@ describe("Bun.serve HTTP/3 production", () => {
   // The request is applied only when it yields more than the socket already
   // has, so a host whose defaults are larger than what the request yields (a
   // tuned one; simulated here with a request below every platform's default)
-  // keeps its defaults instead of having them lowered.
-  test.concurrent.skipIf(isWindows)("QUIC UDP socket buffers are never lowered below the kernel default", async () => {
-    const { body, defaults, sockets } = await probeQuicSocketBuffers(1024);
+  // keeps its defaults instead of having them lowered. A request of 0 is the
+  // override's documented "leave the sockets alone" value.
+  test.concurrent.skipIf(isWindows).each([
+    ["a request below the kernel default", 1024],
+    ["the request disabled", 0],
+  ])("QUIC UDP socket buffers stay at the kernel default with %s", async (_, requestBytes) => {
+    const { body, defaults, sockets } = await probeQuicSocketBuffers(requestBytes);
     expect({ body, sockets }).toEqual({
       body: "ok",
       sockets: [

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash, randomBytes } from "crypto";
-import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, isASAN, isLinux, isWindows, libcPathForDlopen, tempDir, tls } from "harness";
 import { join } from "path";
 
 // Native HTTP/3 fetch wrapper. Every request in this file forces
@@ -1300,4 +1301,110 @@ describe("Bun.serve HTTP/3 production", () => {
   // Expect: 100-continue is handled at the uWS layer for both transports
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
+
+  // quic.c asks for this much SO_RCVBUF / SO_SNDBUF on every QUIC UDP socket
+  // (US_QUIC_SOCKET_BUFFER_SIZE): the Bun.serve listener and the shared
+  // fetch() client endpoint. The kernel default (Linux net.core.rmem_default,
+  // 208 KiB) queues fewer than 100 full-size packets, so every cwnd-sized
+  // lsquic burst overflowed the receiving socket. The value is only
+  // observable through getsockopt(2) on the live fds, hence bun:ffi.
+  const QUIC_SOCKET_BUFFER = 4 * 1024 * 1024;
+  test.skipIf(isWindows)("QUIC UDP sockets get enlarged kernel buffers", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { dlopen, FFIType, ptr } = require("bun:ffi");
+          const { readdirSync } = require("fs");
+          const isDarwin = process.platform === "darwin";
+          const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, {
+            getsockopt: {
+              args: [FFIType.int, FFIType.int, FFIType.int, FFIType.ptr, FFIType.ptr],
+              returns: FFIType.int,
+            },
+            getsockname: { args: [FFIType.int, FFIType.ptr, FFIType.ptr], returns: FFIType.int },
+          });
+          const SOL_SOCKET = isDarwin ? 0xffff : 1;
+          const SO_SNDBUF = isDarwin ? 0x1001 : 7;
+          const SO_RCVBUF = isDarwin ? 0x1002 : 8;
+          const SO_TYPE = isDarwin ? 0x1008 : 3;
+          const SOCK_DGRAM = 2;
+          const AF_INET = 2;
+          const AF_INET6 = isDarwin ? 30 : 10;
+          function sockopt(fd, opt) {
+            const val = new Int32Array(1);
+            const len = new Uint32Array([4]);
+            return libc.symbols.getsockopt(fd, SOL_SOCKET, opt, ptr(val), ptr(len)) === 0 ? val[0] : -1;
+          }
+          // Every IPv4/IPv6 datagram socket open in this process, with its bound port.
+          function udpSockets() {
+            const out = [];
+            for (const name of readdirSync("/dev/fd")) {
+              const fd = Number(name);
+              if (sockopt(fd, SO_TYPE) !== SOCK_DGRAM) continue;
+              const addr = new Uint8Array(128);
+              const len = new Uint32Array([addr.length]);
+              if (libc.symbols.getsockname(fd, ptr(addr), ptr(len)) !== 0) continue;
+              // Darwin sockaddr starts with a u8 sa_len; Linux with a native-endian u16 sa_family.
+              const family = isDarwin ? addr[1] : (addr[0] | (addr[1] << 8));
+              if (family !== AF_INET && family !== AF_INET6) continue;
+              // sin_port / sin6_port both sit at offset 2, network byte order.
+              out.push({ port: (addr[2] << 8) | addr[3], rcvbuf: sockopt(fd, SO_RCVBUF), sndbuf: sockopt(fd, SO_SNDBUF) });
+            }
+            return out;
+          }
+
+          const server = Bun.serve({
+            port: 0,
+            hostname: "127.0.0.1",
+            tls: ${JSON.stringify(tls)},
+            http3: true,
+            http1: false,
+            fetch: () => new Response("ok"),
+          });
+          const res = await fetch("https://127.0.0.1:" + server.port + "/", {
+            protocol: "http3",
+            tls: { rejectUnauthorized: false },
+          });
+          const body = await res.text();
+          const sockets = udpSockets().map(s => ({ ...s, role: s.port === server.port ? "listener" : "client" }));
+          server.stop(true);
+          console.log(JSON.stringify({ body, sockets }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0 || !stdout.trim()) throw new Error(`probe exited with ${exitCode}:\n${stderr}`);
+    const { body, sockets } = JSON.parse(stdout) as {
+      body: string;
+      sockets: Array<{ role: string; port: number; rcvbuf: number; sndbuf: number }>;
+    };
+
+    // socket(7): Linux clamps the request to net.core.{r,w}mem_max and then
+    // reports double the clamped value, so an untuned host lands at exactly
+    // 2 * 212992. macOS applies the request as-is (it is below the default
+    // kern.ipc.maxsockbuf).
+    const floor = (max: "rmem_max" | "wmem_max") =>
+      isLinux
+        ? Math.min(QUIC_SOCKET_BUFFER, 2 * Number(readFileSync(`/proc/sys/net/core/${max}`, "utf8")))
+        : QUIC_SOCKET_BUFFER;
+    const checked = sockets
+      .sort((a, b) => a.role.localeCompare(b.role))
+      .map(s => ({
+        role: s.role,
+        rcvbuf: s.rcvbuf >= floor("rmem_max") ? "raised" : `not raised (${s.rcvbuf})`,
+        sndbuf: s.sndbuf >= floor("wmem_max") ? "raised" : `not raised (${s.sndbuf})`,
+      }));
+    expect({ body, sockets: checked }).toEqual({
+      body: "ok",
+      sockets: [
+        { role: "client", rcvbuf: "raised", sndbuf: "raised" },
+        { role: "listener", rcvbuf: "raised", sndbuf: "raised" },
+      ],
+    });
+  });
 });

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1306,10 +1306,16 @@ describe("Bun.serve HTTP/3 production", () => {
   // (US_QUIC_SOCKET_BUFFER_SIZE): the Bun.serve listener and the shared
   // fetch() client endpoint. The kernel default (Linux net.core.rmem_default,
   // 208 KiB) queues fewer than 100 full-size packets, so every cwnd-sized
-  // lsquic burst overflowed the receiving socket. The value is only
-  // observable through getsockopt(2) on the live fds, hence bun:ffi.
+  // lsquic burst overflowed the receiving socket.
   const QUIC_SOCKET_BUFFER = 4 * 1024 * 1024;
-  test.skipIf(isWindows)("QUIC UDP sockets get enlarged kernel buffers", async () => {
+
+  // Spawns a bun that starts an h3 server, fetches from it over h3, and reads
+  // SO_RCVBUF / SO_SNDBUF back from every inet datagram socket in the process
+  // (the listener and the client endpoint) via getsockopt(2), the only place
+  // the values are observable. `defaults` is what a plain UDP socket gets on
+  // this host. `requestBytes` overrides quic.c's request through
+  // bun:internal-for-testing; the override is process-wide, hence a child.
+  async function probeQuicSocketBuffers(requestBytes?: number) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -1317,6 +1323,12 @@ describe("Bun.serve HTTP/3 production", () => {
         `
           const { dlopen, FFIType, ptr } = require("bun:ffi");
           const { readdirSync } = require("fs");
+          const dgram = require("dgram");
+          ${
+            requestBytes === undefined
+              ? ""
+              : `require("bun:internal-for-testing").quicInternals.setSocketBufferSize(${requestBytes});`
+          }
           const isDarwin = process.platform === "darwin";
           const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, {
             getsockopt: {
@@ -1355,6 +1367,13 @@ describe("Bun.serve HTTP/3 production", () => {
             return out;
           }
 
+          // Kernel defaults, read off an ordinary UDP socket that is closed
+          // again before the scan below so it does not show up in it.
+          const plain = dgram.createSocket("udp4");
+          await new Promise(resolve => plain.bind(0, "127.0.0.1", resolve));
+          const defaults = { rcvbuf: plain.getRecvBufferSize(), sndbuf: plain.getSendBufferSize() };
+          await new Promise(resolve => plain.close(resolve));
+
           const server = Bun.serve({
             port: 0,
             hostname: "127.0.0.1",
@@ -1368,9 +1387,11 @@ describe("Bun.serve HTTP/3 production", () => {
             tls: { rejectUnauthorized: false },
           });
           const body = await res.text();
-          const sockets = udpSockets().map(s => ({ ...s, role: s.port === server.port ? "listener" : "client" }));
+          const sockets = udpSockets()
+            .map(({ port, ...bufs }) => ({ role: port === server.port ? "listener" : "client", ...bufs }))
+            .sort((a, b) => a.role.localeCompare(b.role));
           server.stop(true);
-          console.log(JSON.stringify({ body, sockets }));
+          console.log(JSON.stringify({ body, defaults, sockets }));
         `,
       ],
       env: bunEnv,
@@ -1379,10 +1400,15 @@ describe("Bun.serve HTTP/3 production", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     if (exitCode !== 0 || !stdout.trim()) throw new Error(`probe exited with ${exitCode}:\n${stderr}`);
-    const { body, sockets } = JSON.parse(stdout) as {
+    return JSON.parse(stdout) as {
       body: string;
-      sockets: Array<{ role: string; port: number; rcvbuf: number; sndbuf: number }>;
+      defaults: { rcvbuf: number; sndbuf: number };
+      sockets: Array<{ role: "client" | "listener"; rcvbuf: number; sndbuf: number }>;
     };
+  }
+
+  test.concurrent.skipIf(isWindows)("QUIC UDP sockets get enlarged kernel buffers", async () => {
+    const { body, sockets } = await probeQuicSocketBuffers();
 
     // socket(7): Linux clamps the request to net.core.{r,w}mem_max and then
     // reports double the clamped value, so an untuned host lands at exactly
@@ -1392,18 +1418,31 @@ describe("Bun.serve HTTP/3 production", () => {
       isLinux
         ? Math.min(QUIC_SOCKET_BUFFER, 2 * Number(readFileSync(`/proc/sys/net/core/${max}`, "utf8")))
         : QUIC_SOCKET_BUFFER;
-    const checked = sockets
-      .sort((a, b) => a.role.localeCompare(b.role))
-      .map(s => ({
-        role: s.role,
-        rcvbuf: s.rcvbuf >= floor("rmem_max") ? "raised" : `not raised (${s.rcvbuf})`,
-        sndbuf: s.sndbuf >= floor("wmem_max") ? "raised" : `not raised (${s.sndbuf})`,
-      }));
+    const checked = sockets.map(s => ({
+      role: s.role,
+      rcvbuf: s.rcvbuf >= floor("rmem_max") ? "raised" : `not raised (${s.rcvbuf})`,
+      sndbuf: s.sndbuf >= floor("wmem_max") ? "raised" : `not raised (${s.sndbuf})`,
+    }));
     expect({ body, sockets: checked }).toEqual({
       body: "ok",
       sockets: [
         { role: "client", rcvbuf: "raised", sndbuf: "raised" },
         { role: "listener", rcvbuf: "raised", sndbuf: "raised" },
+      ],
+    });
+  });
+
+  // The request is applied only when it yields more than the socket already
+  // has, so a host whose defaults are larger than what the request yields (a
+  // tuned one; simulated here with a request below every platform's default)
+  // keeps its defaults instead of having them lowered.
+  test.concurrent.skipIf(isWindows)("QUIC UDP socket buffers are never lowered below the kernel default", async () => {
+    const { body, defaults, sockets } = await probeQuicSocketBuffers(1024);
+    expect({ body, sockets }).toEqual({
+      body: "ok",
+      sockets: [
+        { role: "client", ...defaults },
+        { role: "listener", ...defaults },
       ],
     });
   });


### PR DESCRIPTION
### Problem

Neither the `Bun.serve({ http3: true })` listener nor the UDP endpoint that `fetch(url, { protocol: "http3" })` shares across connections sets a buffer size on its socket, so both run with the kernel default. On Linux that is `net.core.rmem_default` = 212992 bytes, which queues fewer than 100 full-size (1452 byte) QUIC packets once skb overhead is charged; Windows Server 2019 defaults to 131072. lsquic hands the kernel up to a cwnd of packets per engine tick, and one socket carries every connection, so the tail of any burst larger than the buffer is dropped by the receiving socket before lsquic sees it and each such burst is a loss event.

Reading the buffers back with `getsockopt(2)` on current main, after one h3 fetch against an in-process h3 server:

```
{ port: <listener>, rcvbuf: 212992, sndbuf: 212992 }   // Bun.serve({ http3 }) socket
{ port: <client>,   rcvbuf: 212992, sndbuf: 212992 }   // fetch() client endpoint ([::])
```

and `/proc/net/udp6` reports several hundred to ~1800 `drops` on the client socket per 4 MiB loopback download on a debug build (numbers below).

### Fix

`us_quic_set_socket_buffers()` in `quic.c`, called from the two places that create a QUIC UDP socket (`us_quic_socket_context_listen` and `us_quic_client_endpoint`, right after the bound address is recorded), requests 4 MiB of `SO_RCVBUF` and `SO_SNDBUF`.

Buffers are only ever raised. `setsockopt` reports success even when the kernel clamps the request below the socket's current value (Linux: an administratively raised `rmem_default` with a small `rmem_max`), and there is no way back once it has been applied, so the function first applies the request to a throwaway socket of the same address family to see what it actually yields on this host and only touches the real socket when that is more than it already has. Everything is best effort: any failure leaves the socket at its default. `node:dgram` sockets are not affected and keep reporting the OS default from `getRecvBufferSize()` like Node; `node:quic` creates its own socket in `endpoint.rs` and is unchanged too (Node leaves those at the OS default unless `udpReceiveBufferSize` is passed).

Why 4 MiB and why both buffers:

- Linux clamps the request to `net.core.rmem_max` / `wmem_max` and then doubles it (socket(7)), so an untuned host goes from 212992 to 425984 and a host whose `rmem_max` has been raised (the standard step for QUIC deployments) gets the full amount, which Bun previously never asked for. macOS applies the request as-is; 4 MiB is under the per-socket cap derived from the default `kern.ipc.maxsockbuf` (8 MiB), so the request succeeds without a retry loop. Windows applies it as-is.
- Other stacks make the same kind of request: Chromium asks for 1 MiB, quic-go for 7 MiB, msquic for as much as the kernel will give; lsquic's own example server exposes it as the `rcvbuf=` / `sndbuf=` options.
- The size is a cap, not an allocation; memory is only used while packets are queued.
- `SO_SNDBUF` is by argument only, since it cannot be measured on loopback (skbs are orphaned on transmit, which is why `SndbufErrors` never moves there): on a real interface they stay charged to the socket until the driver completes them, so the same ~90 packet limit turns a larger `sendmmsg` burst into an EAGAIN, pause, `on_drain`, resend round trip. The listener's receive buffer is likewise by argument: it only matters for what the listener receives (uploads, and the ACK streams of every connection on the one socket), and the measurements below are downloads, which exercise the client endpoint's receive buffer.

`quicInternals.setSocketBufferSize()` in `bun:internal-for-testing` (a process-wide override of the requested size, `us_quic_set_socket_buffer_size_for_testing` in quic.c) exists so the "do not lower" branch can be exercised on an untuned CI host.

### Measurements

Debug build in this container (`rmem_max` = 212992 and read-only here, so the change only yields the 2x). One binary throughout; "neutralized" is an `LD_PRELOAD` shim that turns `setsockopt(SO_RCVBUF/SO_SNDBUF)` into a no-op, i.e. main's behavior; runs interleaved. In-process h3 server, 4 MiB `fetch()` while the serving loop does 20 ms of synchronous work per iteration:

| 12 runs each | transfer time, sorted | client socket `drops`, sorted |
| --- | --- | --- |
| buffers as in this PR | 497 508 509 513 519 519 581 ms, then 1.1 s, 6.1 s, 7.8 s, 10.5 s, 11.3 s | 0 0 19 69 478 526 804 885 901 908 926 950 |
| neutralized | 650 710 716 732 763 767 769 849 ms, then 2.4 s, 4.7 s, 7.2 s, 11.2 s | 63 243 361 435 814 912 1129 1162 1265 1357 1590 1786 |

Two things follow. The multi-second runs happen in both variants and carry few or no drops, so they are not a socket buffer problem: that is lsquic's adaptive congestion control picking BBR off an inflated first RTT sample, found alongside this and tracked separately. What the buffers buy on an untuned host is the fast mode going from roughly 700 to 850 ms to 500 to 580 ms; enlarging only the listener's buffers reproduces the neutralized numbers and enlarging only the client endpoint's reproduces the fixed ones, as expected for a download. Drops still occur at the 2x size, and the counts are not a clean before/after metric because the faster transfer also sends larger bursts. Idle-loop 16 MiB downloads show no measurable difference here, and neither do uploads into a busy server, which are dominated by the congestion control issue in every variant.

An earlier revision of this description attributed the multi-second runs to the buffers. That was wrong; the table above replaces it.

The same comparison on the Windows Server 2019 box, where the full 4 MiB takes effect (default there is 131072), same patch built as a debug build, the "before" variant being the testing override set to 0 so the binary behaves like main, runs interleaved: busy-loop 4 MiB download, 10 runs each: 365 366 368 369 376 ms then 2.1 s and four runs of 8.3 to 8.5 s with the buffers, against 429 435 457 473 475 ms then five runs of 7.8 to 8.6 s without; idle 16 MiB download, 6 runs each: 302 to 333 ms against 310 to 339 ms. Same picture as Linux: the fast mode gains a bit, the slow mode is the congestion control issue in both variants, idle transfers are unaffected. (Windows' `netstat -s` UDP receive error counter stayed at 0 in every run, so no drop counts from there.)

These runs are debug builds on loopback, where the transfer is CPU-bound; they show the change doing what it says in the regime it targets, not what a release build gains on a real network, where the buffer-versus-burst relationship is the whole story of whether a burst is lost.

### Tests

`test/js/bun/http/serve-http3.test.ts`, "Bun.serve HTTP/3 production":

- `QUIC UDP sockets get enlarged kernel buffers`: a spawned bun starts an h3 server, fetches from it over h3, and reads `SO_RCVBUF` / `SO_SNDBUF` off every inet datagram socket in the process (bun:ffi `getsockopt`), so the listener and the client endpoint are both checked against a floor of `min(4 MiB, 2 * rmem_max|wmem_max)` on Linux and 4 MiB on macOS. Fails on main (all four values 212992), passes with this change (425984 here).
- `QUIC UDP socket buffers stay at the kernel default with a request below the kernel default` / `... with the request disabled`: the same probe with the request overridden to 1024 bytes (which yields less than any platform's default) and to 0 (the override's documented off value); both sockets must then read back exactly what a plain `dgram` socket gets on the host. Deleting the `current >= granted` check in quic.c makes the 1024 case fail with both sockets at 2304 / 4608 (the Linux minimums) while the first test still passes, so the tests are complementary. The case the throwaway socket additionally handles (a raised default that sits above what the request yields but below the request itself) needs sysctl control and rests on the argument above, not on a test.

All three are skipped on Windows (no fd enumeration or libc to dlopen); the call there is the same `bsd_socket_buffer_size()` behind `node:dgram`'s `setRecvBufferSize()`, and on Windows Server 2019 a UDP socket reads back 131072 by default and exactly 4194304 after a 4 MiB request through it (plus the Windows runs above).

`bun bd test` on `serve-http3.test.ts` (51 pass), `fetch-http3-client.test.ts` (53 pass) and `fetch-http3-syscall-fault.test.ts` (3 pass).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-http3.test.ts

<!-- robobun:evidence:end -->