### PR TITLE
dotenv: bound how much text a file's variable references can expand to

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -137,6 +137,8 @@ BAR=hello\$FOO
 process.env.BAR; // => "hello$FOO"
 ```
 
+Expansion is limited to 4 MiB of substituted text per file. If a file goes past that, Bun prints a warning naming the variable it stopped at and leaves that variable, and the ones after it in the same file, unexpanded.
+
 ### `dotenv`
 
 Bun reads `.env` files automatically, so `dotenv` and `dotenv-expand` are unnecessary.

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -615,7 +615,8 @@ impl Loader {
         // `Source.contents: &'static [u8]` lifetime constraint (callers like
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
-        Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)
+        Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)?;
+        Ok(())
     }
 
     pub fn load<D: DirEntryProbe + ?Sized>(
@@ -871,7 +872,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                if let Some(key) =
+                    Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?
+                {
+                    warn_expansion_limit(base, key);
+                }
             }
         }
 
@@ -918,7 +923,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                if let Some(key) =
+                    Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?
+                {
+                    warn_expansion_limit(file_path, key);
+                }
             }
         }
 
@@ -945,6 +954,17 @@ enum ReadEnvFile {
     Bytes(Vec<u8>),
 }
 
+#[cold]
+fn warn_expansion_limit(file_path: &[u8], key: &[u8]) {
+    bun_core::warn!(
+        "{} expands to more than {} of variable references, so {} and the values after it were left unexpanded",
+        bun_core::fmt::quote(file_path),
+        bun_core::fmt::bytes(Parser::MAX_EXPANSION_BYTES),
+        bun_core::fmt::quote(key),
+    );
+    Output::flush();
+}
+
 fn read_env_file_contents(file: &bun_sys::File) -> crate::Result<ReadEnvFile> {
     match file.read_to_end() {
         Ok(buf) if buf.is_empty() => Ok(ReadEnvFile::Empty),
@@ -963,13 +983,28 @@ struct Parser<'a> {
     pos: usize,
     src: &'a [u8],
     value_buffer: &'a mut Vec<u8>,
+    /// Bytes of referenced values this file may still substitute in; starts at
+    /// [`Self::MAX_EXPANSION_BYTES`].
+    expansion_budget: usize,
 }
+
+/// A value's `$NAME` / `${NAME}` references would substitute in more bytes
+/// than the file's remaining [`Parser::expansion_budget`].
+struct ExpansionLimitExceeded;
 
 // Input is UTF-8, so this set must be ASCII-only: 0xA0 is a continuation byte
 // there (NBSP is C2 A0), and trimming it byte-wise corrupts multi-byte sequences.
 const WHITESPACE_CHARS: &[u8] = b"\t\x0B\x0C \n\r";
 
 impl<'a> Parser<'a> {
+    /// Total bytes one file's `${...}` references may substitute in. Every
+    /// value is expanded against the already-expanded values above it, so
+    /// without a bound a few hundred bytes of `A1=${A0}${A0}...` grow by 10x
+    /// per line. Only substituted bytes count: a value's own text is bounded
+    /// by the file size. Anything past a few MB could not be passed to a child
+    /// process anyway (Linux caps the environment at ARG_MAX, 2 MiB by default).
+    const MAX_EXPANSION_BYTES: usize = 4 * 1024 * 1024;
+
     fn skip_line(&mut self) {
         if let Some(i) = strings::index_of_any(&self.src[self.pos..], b"\n\r") {
             self.pos += i + 1;
@@ -1134,12 +1169,17 @@ impl<'a> Parser<'a> {
         Ok(strings::trim(&self.src[start..end], WHITESPACE_CHARS))
     }
 
-    fn expand_value(&mut self, map: &Map, value: &[u8]) -> Result<Option<&[u8]>, AllocError> {
+    /// `Ok(None)` when `value` contains nothing to expand.
+    fn expand_value(
+        &mut self,
+        map: &Map,
+        value: &[u8],
+    ) -> Result<Option<&[u8]>, ExpansionLimitExceeded> {
         if value.len() < 2 {
             return Ok(None);
         }
         self.value_buffer.clear();
-        if !Self::expand_into(map, value, self.value_buffer, 0) {
+        if !Self::expand_into(map, value, self.value_buffer, &mut self.expansion_budget, 0)? {
             return Ok(None);
         }
         Ok(Some(self.value_buffer.as_slice()))
@@ -1148,11 +1188,30 @@ impl<'a> Parser<'a> {
     /// Left-to-right expansion of `$NAME` / `${NAME}` / `${NAME:-default}`.
     /// `${...}` locates its matching `}` by depth (`${` opens, `}` closes,
     /// `\x` skipped); malformed forms fall through as literal text. The `:-`
-    /// default clause is expanded recursively.
-    fn expand_into(map: &Map, value: &[u8], out: &mut Vec<u8>, depth: u8) -> bool {
+    /// default clause is expanded recursively. Every referenced value that is
+    /// substituted in is charged to `budget`.
+    fn expand_into(
+        map: &Map,
+        value: &[u8],
+        out: &mut Vec<u8>,
+        budget: &mut usize,
+        depth: u8,
+    ) -> Result<bool, ExpansionLimitExceeded> {
         #[inline]
         fn is_ident(b: u8) -> bool {
             matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+        }
+
+        fn substitute(
+            out: &mut Vec<u8>,
+            budget: &mut usize,
+            referenced: &[u8],
+        ) -> Result<(), ExpansionLimitExceeded> {
+            *budget = budget
+                .checked_sub(referenced.len())
+                .ok_or(ExpansionLimitExceeded)?;
+            out.extend_from_slice(referenced);
+            Ok(())
         }
 
         let mut pos = 0;
@@ -1212,13 +1271,13 @@ impl<'a> Parser<'a> {
                 let rest = &inner[key_end..];
                 if rest.is_empty() {
                     if let Some(v) = map.get(key) {
-                        out.extend_from_slice(v);
+                        substitute(out, budget, v)?;
                     }
                 } else if let Some(default) = rest.strip_prefix(b":-") {
                     if let Some(v) = map.get(key) {
-                        out.extend_from_slice(v);
+                        substitute(out, budget, v)?;
                     } else if depth < 200 {
-                        Self::expand_into(map, default, out, depth + 1);
+                        Self::expand_into(map, default, out, budget, depth + 1)?;
                     } else {
                         out.extend_from_slice(default);
                     }
@@ -1236,7 +1295,7 @@ impl<'a> Parser<'a> {
                     k += 1;
                 }
                 if let Some(v) = map.get(&value[key_start..k]) {
-                    out.extend_from_slice(v);
+                    substitute(out, budget, v)?;
                 }
                 pos = k;
                 continue;
@@ -1244,13 +1303,15 @@ impl<'a> Parser<'a> {
             out.push(b'$');
             pos += 1;
         }
-        changed
+        Ok(changed)
     }
 
-    fn parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    /// Returns the key at which expansion ran out of [`Self::expansion_budget`],
+    /// if any; that value and every value after it are left as written.
+    fn parse<'m, const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         &mut self,
-        map: &mut Map,
-    ) -> Result<(), AllocError> {
+        map: &'m mut Map,
+    ) -> Result<Option<&'m [u8]>, AllocError> {
         let mut count = map.map.count();
         while self.pos < self.src.len() {
             let Some(key) = self.parse_key::<true>() else {
@@ -1282,27 +1343,31 @@ impl<'a> Parser<'a> {
             let mut idx = count;
             while idx < total {
                 let current: Box<[u8]> = Box::from(&*map.map.values()[idx].value);
-                if let Some(expanded) = self.expand_value(map, &current)? {
-                    map.map.values_mut()[idx] = HashTableValue {
-                        value: Box::from(expanded),
-                    };
+                match self.expand_value(map, &current) {
+                    Ok(Some(expanded)) => {
+                        map.map.values_mut()[idx] = HashTableValue {
+                            value: Box::from(expanded),
+                        };
+                    }
+                    Ok(None) => {}
+                    Err(ExpansionLimitExceeded) => return Ok(Some(&map.map.keys()[idx])),
                 }
                 idx += 1;
             }
             count = 0;
         }
         let _ = count;
-        Ok(())
+        Ok(None)
     }
 
     /// Same as [`parse`] but takes the source bytes directly. Exists so
     /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
     /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
-    fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    fn parse_bytes<'m, const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         src: &[u8],
-        map: &mut Map,
+        map: &'m mut Map,
         value_buffer: &mut Vec<u8>,
-    ) -> Result<(), AllocError> {
+    ) -> Result<Option<&'m [u8]>, AllocError> {
         // Clear the buffer before each parse to ensure no leftover data
         value_buffer.clear();
         let mut parser = Parser {
@@ -1311,6 +1376,7 @@ impl<'a> Parser<'a> {
             // first key fails `parse_key` and `skip_line` silently drops line 1.
             src: strings::without_utf8_bom(src),
             value_buffer,
+            expansion_budget: Self::MAX_EXPANSION_BYTES,
         };
         parser.parse::<OVERRIDE, IS_PROCESS, EXPAND>(map)
     }

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -331,6 +331,45 @@ test(".env ${VAR:-default} with nested references (issue #32411)", async () => {
   expect(result.exitCode).toBe(0);
 });
 
+test.concurrent(".env expansion stops once a file substitutes in more than 4 MiB", async () => {
+  // Each line substitutes the previous value ten times (alternating between
+  // the two reference syntaxes), so A(n) is 10^(n+1) bytes: A5 is 1 MB, A6
+  // would be 10 MB and two more lines would reach 1 GB. The loader gives up at
+  // A6 and leaves it, and everything after it, as written. Other files are
+  // expanded with a budget of their own.
+  const lines = ["A0=xxxxxxxxxx"];
+  for (let i = 1; i <= 6; i++) lines.push(`A${i}=` + (i % 2 ? `\${A${i - 1}}` : `$A${i - 1}`).repeat(10));
+  lines.push("AFTER=${A0}/after");
+  using dir = tempDir("dotenv-expand-limit", {
+    ".env.local": lines.join("\n"),
+    ".env": "BASE=base\nOTHER_FILE=${BASE}/other",
+    "index.ts": `console.log(JSON.stringify({
+      A5: process.env.A5.length,
+      A6: process.env.A6,
+      AFTER: process.env.AFTER,
+      OTHER_FILE: process.env.OTHER_FILE,
+    }));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, NODE_ENV: undefined },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(
+    'warn: ".env.local" expands to more than 4.19 MB of variable references, so "A6" and the values after it were left unexpanded',
+  );
+  expect(JSON.parse(stdout)).toEqual({
+    A5: 1_000_000,
+    A6: "$A5".repeat(10),
+    AFTER: "${A0}/after",
+    OTHER_FILE: "base/other",
+  });
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent(".env comments", async () => {
   using dir = tempDir("dotenv-comments", {
     ".env": "#FOZ\nFOO = foo#FAIL\nBAR='bar' #BAZ",


### PR DESCRIPTION
## Repro

A `.env` in the current directory (loaded implicitly by `bun <file>`, `bun run`, `bun test` and `bunx`) where each line references the previous one ten times:

```sh
D=8; { echo 'A0=xxxxxxxxxx'; for i in $(seq 1 $D); do printf 'A%d=' $i; for j in $(seq 10); do printf '${A%d}' $((i-1)); done; echo; done; } > .env
echo 'console.log(process.env.A'$D'.length, (process.memoryUsage().rss/1e6)|0, "MB")' > p.js
bun p.js
```

On 1.4.0 the 446 byte file produces `A8` = 1,000,000,000 bytes: 2.1 GB RSS and about 2.5 s (release build) before the first line of `p.js` runs. Depth 9 (500 bytes) is OOM killed inside a 6 GB cgroup; uncapped it needs around 20 GB. Every intermediate value also stays in `process.env` and is copied into every child's environment.

## Cause

`Parser::expand_into` in `src/dotenv/env_loader.rs` copies the referenced value into the output for every `$NAME` / `${NAME}` with no bound. Values are expanded in file order against the already expanded values above them, so the output grows by the fan-out factor on every line. There is a nesting depth guard for `${A:-${B:-...}}` defaults, but nothing bounds the amount of output or work.

## Fix

Give each file a budget of 4 MiB of substituted bytes (`Parser::MAX_EXPANSION_BYTES`). `expand_into` charges every substituted reference against it with `checked_sub`, the same shape as the YAML parser's alias expansion budget. Only referenced bytes are charged; the literal text of a value is already bounded by the file size, so large plain values are unaffected. When a value runs the file out of budget, `parse` stops expanding: that value and the values after it in that file are left exactly as written (the same fallback the expander already uses for malformed and too deeply nested references), and the loader prints, once per file:

```
warn: ".env" expands to more than 4.19 MB of variable references, so "A6" and the values after it were left unexpanded
```

The warning is not gated on `Loader.quiet`, since that flag is set whenever the log level is below info, i.e. in every default release invocation. Each file gets its own budget, so a pathological file cannot prevent the other `.env*` files from expanding; at most 4 files are loaded implicitly.

With the fix, the depth 9 file from the repro loads in a few ms with about 10 MB of extra memory, and `A5` (1 MB) is the largest value left in the environment.

Supersedes #34005, which capped individual values on the previous version of the expander and no longer applies.

## Verification

`test/cli/run/env.test.ts`, `.env expansion stops once a file substitutes in more than 4 MiB`: a 7 line `.env.local` whose values grow tenfold per line, alternating `${A}` and `$A` syntax. Asserts `A5` expanded to 1,000,000 bytes, `A6` and the following `AFTER` line were left as written, a sibling `.env` still expands, and the warning above (naming `.env.local` and `A6`) is printed. On 1.4.0 the test fails: no warning, and `A6` is a 10 MB string. The rest of `env.test.ts`, `no-envfile.test.ts`, `bundler_env.test.ts` and the `util.parseEnv` tests pass with the change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->