### PR TITLE
sourcemap: don't abort when a remapped source path exceeds the join buffer

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1370,8 +1370,6 @@ pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'
 
 /// [`join_abs_string`] (thread-local buffer) when the result fits, otherwise
 /// into `spill` (grown as needed). `spill` is untouched in the common case.
-/// Use this when `parts` may contain user-controlled input of arbitrary length
-/// and the result does not need to fit in a path buffer (display strings).
 pub fn join_abs_string_spill<'a, P: PlatformT>(
     cwd: &'a [u8],
     spill: &'a mut Vec<u8>,
@@ -1591,10 +1589,8 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
     normalize_string_node_t::<T, P>(&temp_buf[0..written], buf)
 }
 
-/// Upper bound on the bytes `_join_abs_string_buf` writes for a `cwd` of
-/// `cwd_len` bytes and `parts`, whether the unnormalized concatenation or the
-/// normalized result plus sentinel: normalizing never grows a path by more
-/// than the slack included here.
+/// Buffer size that always holds `_join_abs_string_buf`'s output (and its
+/// unnormalized scratch) for `parts` joined onto a `cwd_len`-byte cwd.
 #[inline]
 fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1368,8 +1368,7 @@ pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'
     PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf_z::<P>(cwd, tl_buf_mut(b), parts))
 }
 
-/// [`join_abs_string`] (thread-local buffer) when the result fits, otherwise
-/// into `spill` (grown as needed). `spill` is untouched in the common case.
+/// [`join_abs_string`], but joins into `spill` when the result may not fit the thread-local buffer.
 pub fn join_abs_string_spill<'a, P: PlatformT>(
     cwd: &'a [u8],
     spill: &'a mut Vec<u8>,
@@ -1589,8 +1588,7 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
     normalize_string_node_t::<T, P>(&temp_buf[0..written], buf)
 }
 
-/// Buffer size that always holds `_join_abs_string_buf`'s output (and its
-/// unnormalized scratch) for `parts` joined onto a `cwd_len`-byte cwd.
+/// Buffer size that always holds `_join_abs_string_buf`'s scratch and output for these inputs.
 #[inline]
 fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -4,6 +4,9 @@ use crate::fs as Fs;
 use crate::{MAX_PATH_BYTES, PathBuffer, SEP, SEP_POSIX, SEP_WINDOWS};
 use bun_core::{ZStr, strings};
 
+/// Output capacity of [`join_abs_string`] / [`join_abs_string_z`].
+const PARSER_JOIN_INPUT_BUFFER_LEN: usize = 4096;
+
 // Thread-local scratch buffers. Stored in `UnsafeCell` (not `RefCell`)
 // because callers must receive a raw `&mut` slice that outlives the `.with` closure
 // — the contract is "valid until next call on this thread". RefCell's
@@ -12,7 +15,8 @@ use bun_core::{ZStr, strings};
 // SAFETY invariant: each buffer has at most one live mutable borrow per thread;
 // callers must not re-enter the accessor while a previous borrow is alive.
 thread_local! {
-    static PARSER_JOIN_INPUT_BUFFER: UnsafeCell<[u8; 4096]> = const { UnsafeCell::new([0u8; 4096]) };
+    static PARSER_JOIN_INPUT_BUFFER: UnsafeCell<[u8; PARSER_JOIN_INPUT_BUFFER_LEN]> =
+        const { UnsafeCell::new([0u8; PARSER_JOIN_INPUT_BUFFER_LEN]) };
     static PARSER_BUFFER: UnsafeCell<[u8; 1024]> = const { UnsafeCell::new([0u8; 1024]) };
 }
 
@@ -1364,6 +1368,26 @@ pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'
     PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf_z::<P>(cwd, tl_buf_mut(b), parts))
 }
 
+/// [`join_abs_string`] (thread-local buffer) when the result fits, otherwise
+/// into `spill` (grown as needed). `spill` is untouched in the common case.
+/// Use this when `parts` may contain user-controlled input of arbitrary length
+/// and the result does not need to fit in a path buffer (display strings).
+pub fn join_abs_string_spill<'a, P: PlatformT>(
+    cwd: &'a [u8],
+    spill: &'a mut Vec<u8>,
+    parts: &[&[u8]],
+) -> &'a [u8] {
+    debug_assert!(!matches!(P::P, Platform::Nt));
+    let needed = join_abs_needed(cwd.len(), parts);
+    if needed < PARSER_JOIN_INPUT_BUFFER_LEN {
+        return join_abs_string::<P>(cwd, parts);
+    }
+    if spill.len() < needed {
+        spill.resize(needed, 0);
+    }
+    join_abs_string_buf::<P>(cwd, &mut spill[..], parts)
+}
+
 const JOIN_BUF_LEN: usize = 4096;
 
 thread_local! {
@@ -1567,6 +1591,15 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
     normalize_string_node_t::<T, P>(&temp_buf[0..written], buf)
 }
 
+/// Upper bound on the bytes `_join_abs_string_buf` writes for a `cwd` of
+/// `cwd_len` bytes and `parts`, whether the unnormalized concatenation or the
+/// normalized result plus sentinel: normalizing never grows a path by more
+/// than the slack included here.
+#[inline]
+fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
+    parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2
+}
+
 /// Scratch buffer for `_join_abs_string_buf`'s unnormalized concatenation.
 /// Draws from the
 /// thread-local `path_buffer_pool` for the common case and only heap-allocates
@@ -1580,10 +1613,7 @@ enum JoinScratch {
 impl JoinScratch {
     #[inline]
     fn init(base: usize, parts: &[&[u8]]) -> Self {
-        let mut total = base + 2;
-        for p in parts {
-            total += p.len() + 1;
-        }
+        let total = join_abs_needed(base, parts);
         if total <= MAX_PATH_BYTES {
             JoinScratch::Pooled(crate::path_buffer_pool::get())
         } else {
@@ -1621,10 +1651,7 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     debug_assert!(!matches!(P::P, Platform::Nt));
     // Fast path: size check only — don't allocate a JoinScratch here since the
     // inner join_abs_string_buf already has its own (avoids doubling stack usage).
-    let mut total: usize = cwd.len() + 2;
-    for p in parts {
-        total += p.len() + 1;
-    }
+    let total = join_abs_needed(cwd.len(), parts);
     if total < buf.len() {
         return Some(join_abs_string_buf::<P>(cwd, buf, parts));
     }

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -412,8 +412,7 @@ impl Lookup {
             // cfg-selected (Posix on unix, Windows on windows).
             let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(base_filename);
             let mut buf = bun_paths::path_buffer_pool::get();
-            // `name` is unbounded source map data; a path that does not fit
-            // cannot be opened anyway.
+            // `name` is unbounded source map data; a path too long to fit is too long to open.
             let path = bun_paths::resolve_path::join_abs_string_buf_checked::<
                 bun_paths::platform::Loose,
             >(dir, &mut buf[..], &[name])?;

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -343,9 +343,7 @@ impl Lookup {
             // `platform::Auto` is a cfg-selected
             // type alias (Posix on unix, Windows on windows).
             let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(base_filename);
-            // `name` comes from the source map's `sources` array, so the joined
-            // path can be longer than any path buffer; it is a display string,
-            // so it is produced at whatever length it has.
+            // `name` is unbounded source map data; the result is only displayed.
             let mut spill = Vec::new();
             return Some(bun_core::String::clone_utf8(
                 bun_paths::resolve_path::join_abs_string_spill::<bun_paths::platform::Auto>(
@@ -414,8 +412,8 @@ impl Lookup {
             // cfg-selected (Posix on unix, Windows on windows).
             let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(base_filename);
             let mut buf = bun_paths::path_buffer_pool::get();
-            // `name` comes from the source map's `sources` array; a joined path
-            // that does not fit in a path buffer cannot be opened either way.
+            // `name` is unbounded source map data; a path that does not fit
+            // cannot be opened anyway.
             let path = bun_paths::resolve_path::join_abs_string_buf_checked::<
                 bun_paths::platform::Loose,
             >(dir, &mut buf[..], &[name])?;

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -343,8 +343,16 @@ impl Lookup {
             // `platform::Auto` is a cfg-selected
             // type alias (Posix on unix, Windows on windows).
             let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(base_filename);
+            // `name` comes from the source map's `sources` array, so the joined
+            // path can be longer than any path buffer; it is a display string,
+            // so it is produced at whatever length it has.
+            let mut spill = Vec::new();
             return Some(bun_core::String::clone_utf8(
-                bun_paths::resolve_path::join_abs::<bun_paths::platform::Auto>(dir, name),
+                bun_paths::resolve_path::join_abs_string_spill::<bun_paths::platform::Auto>(
+                    dir,
+                    &mut spill,
+                    &[name],
+                ),
             ));
         }
 
@@ -402,14 +410,16 @@ impl Lookup {
 
             let name: &[u8] = &source_map.external_source_names[index];
 
-            let mut buf = bun_paths::PathBuffer::uninit();
             // `platform::Auto` is
             // cfg-selected (Posix on unix, Windows on windows).
             let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(base_filename);
-            let normalized = bun_paths::resolve_path::join_abs_string_buf_z::<
+            let mut buf = bun_paths::path_buffer_pool::get();
+            // `name` comes from the source map's `sources` array; a joined path
+            // that does not fit in a path buffer cannot be opened either way.
+            let path = bun_paths::resolve_path::join_abs_string_buf_checked::<
                 bun_paths::platform::Loose,
-            >(dir, &mut buf, &[name]);
-            match bun_sys::File::read_from(bun_sys::Fd::cwd(), normalized) {
+            >(dir, &mut buf[..], &[name])?;
+            match bun_sys::File::read_from(bun_sys::Fd::cwd(), path) {
                 Ok(r) => break 'bytes r,
                 Err(_) => return None,
             }

--- a/test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts
+++ b/test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// A `// @bun`-pragma'd file runs as-is and its sidecar `.map` is consulted
+// when a stack trace is formatted: each frame's display path is the map's
+// `sources` entry joined onto the file's directory, and the source preview of
+// an uncaught error reads that joined path back from disk when the map has no
+// `sourcesContent`. Both joins used to write into fixed-size path buffers with
+// no length check, so a long enough `sources` entry aborted the process:
+//
+//   panic: range end index 4120 out of range for slice of length 4095
+//
+// 4200 overflows the 4096-byte buffer behind the display path on every
+// platform; 1100 only overflows the PATH_MAX-sized buffer the preview reads
+// through on macOS (1024 bytes), where the display path still fits.
+const nameLengths = [1100, 4200];
+
+const body = `// @bun\nfunction t() {\n  return new Error("LONGSRC");\n}\n`;
+
+function fixture(sourceName: string, sourcesContent: string, tail: string) {
+  const code = body + tail + `//# sourceMappingURL=entry.js.map\n`;
+  const lineCount = code.split("\n").length;
+  return {
+    "entry.js": code,
+    "entry.js.map": JSON.stringify({
+      version: 3,
+      sources: [sourceName],
+      sourcesContent: [sourcesContent],
+      names: [],
+      // Line N of entry.js maps to line N of the source.
+      mappings: "AAAA" + ";AACA".repeat(lineCount - 1),
+    }),
+  };
+}
+
+async function run(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("external source map whose `sources` entry is longer than a path buffer", () => {
+  for (const nameLength of nameLengths) {
+    const sourceName = Buffer.alloc(nameLength, "x").toString() + ".ts";
+
+    test(`error.stack is remapped to the joined source path (${nameLength} bytes)`, async () => {
+      using dir = tempDir(
+        "sourcemap-long-source",
+        fixture(sourceName, "", `console.log(t().stack.split("\\n")[1].trim());\n`),
+      );
+      const { stdout, stderr, exitCode } = await run(String(dir));
+      expect(stderr).toBe("");
+      expect(stdout).toMatch(/^at t \(.*:3(:\d+)?\)\n$/s);
+      expect(stdout).toContain(`at t (${join(String(dir), sourceName)}:`);
+      expect(exitCode).toBe(0);
+    });
+
+    for (const [label, sourcesContent] of [
+      ["without sourcesContent, so the preview tries to read the joined path", ""],
+      ["with sourcesContent", "a\nb\nc\nd\ne\nf\n"],
+    ] as const) {
+      test(`uncaught error is printed with the joined source path, ${label} (${nameLength} bytes)`, async () => {
+        using dir = tempDir("sourcemap-long-source-uncaught", fixture(sourceName, sourcesContent, `throw t();\n`));
+        const { stdout, stderr, exitCode } = await run(String(dir));
+        expect(stdout).toBe("");
+        expect(stderr).toContain("LONGSRC");
+        expect(stderr).toContain(`at t (${join(String(dir), sourceName)}:`);
+        expect(exitCode).toBe(1);
+      });
+    }
+  }
+});

--- a/test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts
+++ b/test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts
@@ -77,3 +77,21 @@ describe.concurrent("external source map whose `sources` entry is longer than a 
     }
   }
 });
+
+// Control for the cases above: when the joined path fits and the file exists,
+// the preview is read from it. The source deliberately has an extension bun
+// has no loader for: when the read is skipped, bun falls back to loading the
+// source path as a module, which for a .js/.ts file would print the same file
+// and mask the difference, while for .coffee it prints entry.js instead.
+test.concurrent("uncaught error previews the original source read from the joined path", async () => {
+  using dir = tempDir("sourcemap-source-preview", {
+    ...fixture("original.coffee", "", `throw t();\n`),
+    "original.coffee": "ORIGINAL_LINE_1\nORIGINAL_LINE_2\nORIGINAL_LINE_3\nORIGINAL_LINE_4\n",
+  });
+  const { stdout, stderr, exitCode } = await run(String(dir));
+  expect(stdout).toBe("");
+  expect(stderr).toContain("ORIGINAL_LINE_3");
+  expect(stderr).not.toContain("new Error(");
+  expect(stderr).toContain(`at t (${join(String(dir), "original.coffee")}:3`);
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
### Problem

Reading `error.stack` for a frame in a file that has a sidecar source map aborts the process when the remapped source path is longer than 4095 bytes:

```js
// gen.js: a `// @bun` file plus a sidecar .map whose single `sources` entry is ~4100 chars
import { writeFileSync } from "node:fs";
const name = "x".repeat(4100) + ".ts";
const code = `// @bun\nfunction f() { return new Error("x"); }\nconsole.log(f().stack);\n//# sourceMappingURL=entry.js.map\n`;
writeFileSync("entry.js", code);
writeFileSync("entry.js.map", JSON.stringify({ version: 3, sources: [name], sourcesContent: [""], names: [], mappings: "AAAA" + ";AACA".repeat(code.split("\n").length) }));
```

```
$ bun gen.js && bun entry.js
panic: range end index 4120 out of range for slice of length 4095
```

The same entry at ~4060 chars works. `sources` entries are data from the map file (anything `bun build --target=bun --sourcemap` emits, or any map a user ships), so this is user data crashing the runtime rather than a recoverable condition. Reproduced on 1.4.0-canary.1 (9008ae7ab), Linux x64; the code is the same since the Zig version, so this is not a regression.

### Cause

`Lookup::display_source_url_if_needed` (`src/sourcemap/Mapping.rs`) builds the displayed path with `join_abs`, which normalizes into the fixed 4096-byte thread-local `PARSER_JOIN_INPUT_BUFFER` with no length check (`_join_abs_string_buf` -> `normalize_string_buf`, the slice index panic above).

`Lookup::get_source_code`, a few lines down, joins the same `sources` entry with `join_abs_string_buf_z` into a stack `PathBuffer` to read the original file for an uncaught error's source preview (when the map has no `sourcesContent`). It has the same panic once the first one is out of the way, with a lower threshold on macOS where `PathBuffer` is 1024 bytes.

These two call sites are the only consumers of `external_source_names`.

### Fix

- `src/paths/resolve_path.rs`: add `join_abs_string_spill`, the `join_abs_string` counterpart of the existing `join_spill` / `join_z_spill` (#33145): thread-local buffer when the result fits, caller-provided `Vec` otherwise. The size bound it shares with `join_abs_string_buf_checked` and `JoinScratch` (previously written out inline in both) is now one helper, `join_abs_needed`, and the thread-local's size gets a named constant. No behavior change for any existing caller.
- `display_source_url_if_needed` uses the spill variant: the result is a display string, so it is produced at whatever length it has, and the output is byte-identical to before for every path that used to fit. The `Vec` is only touched on the overflow path, so the common case does not allocate any more than it did.
- `get_source_code` uses `join_abs_string_buf_checked` into a pooled `PathBuffer` and returns `None` when the path does not fit. A path longer than `PathBuffer` cannot be opened (`openat_a` would return `ENAMETOOLONG`), so this is the same outcome as a missing file, minus the crash. `File::read_from` takes a plain slice, so the `_z` variant was not needed.

Why this shape rather than bounds-checking `join_abs_string` itself: that primitive has ~40 callers with different correct fallbacks, #35860 already proposes a change to it for a different entry point, and the source map sites have a clear right answer each (display: any length is fine; preview: too long means unreadable). The fix here is independent of whatever happens to the primitive. #36625 rewrites the same lines of `Mapping.rs` for input-map chaining but keeps the unchecked joins, so the two are complementary.

Unrelated observation while here, not changed: when the original source is neither in `sourcesContent` nor on disk, `remap_zig_exception` returns early after replacing the top frame's path (inherited from the Zig version), so the remaining frames keep their generated positions. Independent of path length.

### Tests

`test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts` runs a `// @bun` file with a sidecar map whose `sources` entry is 1100 and 4200 bytes long and checks that:

- `error.stack` shows `at t (<dir>/<long name>:3)` (display path, `remap_stack_frame_positions`)
- an uncaught error prints the same frame and exits 1, both without `sourcesContent` (exercises the preview read of the too-long path) and with it
- control: with a `sources` entry that fits and exists on disk (no `sourcesContent`), the preview is read from that file. The file is named `.coffee` on purpose: if the read were skipped, bun would fall back to loading the path as a module, which for a `.js`/`.ts` name prints the same file and would hide the difference, while for `.coffee` it prints the generated file instead. Verified this case fails when the read is forced to be skipped.

The 4200-byte cases abort on main (`panic: range end index 4236 out of range for slice of length 4095`) and pass with the fix; the 1100-byte cases cover the macOS `PathBuffer` threshold and, like the control, pass on main too and are there as regression guards. Also ran `test/js/bun/sourcemap/`, `test/js/node/path/`, `test/js/bun/glob/path-length.test.ts`, the source lints, and `cargo check` of the two crates for the windows-msvc and apple-darwin targets.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts
bun test v1.4.0 (df172871c)

test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts:
(pass) external source map whose `sources` entry is longer than a path buffer > error.stack is remapped to the joined source path (1100 bytes) [323.27ms]
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, without sourcesContent, so the preview tries to read the joined path (1100 bytes) [282.15ms]
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, with sourcesContent (1100 bytes) [287.52ms]
(pass) uncaught error previews the original source read from the joined path [285.05ms]
(fail) external source map whose `sources` entry is longer than a path buffer > error.stack is remapped to the joined source path (4200 bytes) [5005.44ms]
  ^ this test timed out after 5000ms.
(fail) external source map whose `sources` entr
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts:
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, without sourcesContent, so the preview tries to read the joined path (1100 bytes) [8.08ms]
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, with sourcesContent (1100 bytes) [7.79ms]
(pass) external source map whose `sources` entry is longer than a path buffer > error.stack is remapped to the joined source path (1100 bytes) [10.36ms]
(pass) uncaught error previews the original source read from the joined path [6.72ms]
54 |       using dir = tempDir(
55 |         "sourcemap-long-source",
56 |         fixture(sourceName, "", `console.log(t().stack.split("\\n")[1].trim());\n`),
57 |       );
58 |       const { stdout, stderr, exitCode } = await run(String(dir));
59 |       expect(stderr).toBe("");
                          ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Canary v1.4.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts
bun test v1.4.0 (df172871c)

test/js/bun/sourcemap/external-sourcemap-long-source-path.test.ts:
(pass) external source map whose `sources` entry is longer than a path buffer > error.stack is remapped to the joined source path (1100 bytes) [314.23ms]
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, without sourcesContent, so the preview tries to read the joined path (1100 bytes) [273.66ms]
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, with sourcesContent (1100 bytes) [277.93ms]
(pass) external source map whose `sources` entry is longer than a path buffer > uncaught error is printed with the joined source path, without sourcesContent, so the preview tries to read the joined path (4200 bytes) [267.98ms]
(pass) external source map whose `sources` entry is longer than a path buffer > error.stack is remap
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1102ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/143] gen JS modules (bundle-modules)
Preprocess modules (9513ms)
Bundle modules (618ms)
Postprocesss modules (962ms)
Bundle Functions (1105ms)
Generate Code (45ms)

[12.28s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[1/143] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_jsc_macros v0.0.0 (/workspace/bun/src/jsc_macros)
[1m[92m   Compiling[0m bun_css_derive v0.0.0 (/workspace/bun/src/css_deri
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/paths/resolve_path.rs                          | 39 +++++++--
 src/sourcemap/Mapping.rs                           | 17 ++--
 .../external-sourcemap-long-source-path.test.ts    | 97 ++++++++++++++++++++++
 3 files changed, 139 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/paths/resolve_path.rs                                    13     15      0
src/sourcemap/Mapping.rs                                      6      9      0
…n/sourcemap/external-sourcemap-long-source-path.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->