### PR TITLE
install: reject registry auth tokens containing CR, LF or NUL

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2434,17 +2434,9 @@ fn init_with_runtime_once(
         }
     }
 
-    match manager
+    manager
         .options
-        .load(log, env, Some(cli), bun_install, Subcommand::Install)
-    {
-        Ok(()) => {}
-        Err(e) => {
-            // only error.OutOfMemory possible
-            let _ = e;
-            bun_core::out_of_memory();
-        }
-    }
+        .load(log, env, Some(cli), bun_install, Subcommand::Install)?;
 
     manager.timestamp_for_manifest_cache_control =
         ((u64::try_from(bun_core::time::timestamp().max(0)).expect("int cast")) as u32)

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -360,7 +360,6 @@ static WHY_PARAMS: &[ParamType] = concat_params![
 pub struct CommandLineArguments {
     pub(crate) cache_dir: Option<&'static [u8]>,
     pub lockfile: &'static [u8],
-    pub(crate) token: &'static [u8],
     pub(crate) global: bool,
     pub(crate) config: Option<&'static [u8]>,
     pub(crate) network_concurrency: Option<u16>,
@@ -443,7 +442,6 @@ impl Default for CommandLineArguments {
         Self {
             cache_dir: None,
             lockfile: b"",
-            token: b"",
             global: false,
             config: None,
             network_concurrency: None,

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,7 +1,9 @@
 use crate::bun_schema::api as Api;
+use bstr::BStr;
 use bun_core::ZStr;
-use bun_core::{Output, env_var};
+use bun_core::{Output, env_var, fmt as bun_fmt, strings};
 use bun_paths::PathBuffer;
+use core::fmt;
 
 use super::Subcommand;
 use super::command_line_arguments::{self, CommandLineArguments};
@@ -395,6 +397,42 @@ fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }
 
+/// Registry credentials are copied into the `Authorization` header byte for
+/// byte, so a CR, LF or NUL inside one would end that header line and turn the
+/// rest of the value into extra headers (or a second request) on every
+/// registry request. Every credential `load()` stores passes through here;
+/// `source` says where it was configured.
+fn check_credential(value: &[u8], source: fmt::Arguments<'_>) -> crate::Result<()> {
+    if !strings::contains_any(value, b"\r\n\0") {
+        return Ok(());
+    }
+    Output::err_generic("the auth token {} contains a newline or NUL byte", source);
+    Err(crate::Error::InstallFailed)
+}
+
+/// `Scope::from_api` is where `.npmrc` / bunfig credentials (including
+/// `$ENV_VAR` indirections and `:_authToken=` URL suffixes) take their final
+/// value, so the scope is checked as soon as it is built.
+fn load_scope(
+    name: &[u8],
+    registry: Api::NpmRegistry,
+    env: &mut DotEnvLoader,
+) -> crate::Result<Npm::registry::Scope> {
+    let scope = Npm::registry::Scope::from_api(name, registry, env)?;
+    let registry_url = bun_fmt::redacted_npm_url(scope.url.href());
+    for credential in [&*scope.token, &*scope.auth] {
+        if name.is_empty() {
+            check_credential(credential, format_args!("for registry \"{registry_url}\""))?;
+        } else {
+            check_credential(
+                credential,
+                format_args!("for the @{} registry \"{registry_url}\"", BStr::new(name)),
+            )?;
+        }
+    }
+    Ok(scope)
+}
+
 impl Options {
     pub(crate) fn load(
         &mut self,
@@ -406,7 +444,7 @@ impl Options {
         // resolver storage (`Option<NonNull<api::BunInstall>>`).
         bun_install_: Option<&Api::BunInstall>,
         subcommand: Subcommand,
-    ) -> Result<(), bun_alloc::AllocError> {
+    ) -> crate::Result<()> {
         let mut base = Api::NpmRegistry::default();
         let bun_install_ref = bun_install_;
         if let Some(config) = bun_install_ref {
@@ -423,7 +461,7 @@ impl Options {
         }
         // Clone so the
         // `base.url` fallback below in the scoped-registry loop stays valid.
-        self.scope = Npm::registry::Scope::from_api(b"", base.clone(), env)?;
+        self.scope = load_scope(b"", base.clone(), env)?;
         // `did_override_default_scope` is set at the end of this fn;
         // on the OOM error path the field is irrelevant (process aborts).
 
@@ -441,7 +479,7 @@ impl Options {
                     }
                     self.registries.put(
                         Npm::registry::Scope::hash(name),
-                        Npm::registry::Scope::from_api(name, registry, env)?,
+                        load_scope(name, registry, env)?,
                     )?;
                 }
             }
@@ -620,7 +658,7 @@ impl Options {
                             token,
                             ..Default::default()
                         };
-                        self.scope = Npm::registry::Scope::from_api(b"", api_registry, env)?;
+                        self.scope = load_scope(b"", api_registry, env)?;
                         break;
                     }
                 }
@@ -637,6 +675,7 @@ impl Options {
             for token_key in TOKEN_KEYS {
                 if let Some(token) = env.get(token_key) {
                     if !token.is_empty() {
+                        check_credential(token, format_args!("in ${}", BStr::new(token_key)))?;
                         self.scope.token = token.into();
                         break;
                     }
@@ -708,10 +747,6 @@ impl Options {
 
             if cli.exact {
                 self.enable.set(Enable::EXACT_VERSIONS, true);
-            }
-
-            if !cli.token.is_empty() {
-                self.scope.token = cli.token.into();
             }
 
             if cli.no_save {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -406,7 +406,7 @@ fn check_credential(value: &[u8], source: fmt::Arguments<'_>) -> crate::Result<(
     Err(crate::Error::InstallFailed)
 }
 
-/// Checked after `from_api`, which is where `$VAR` and `:_authToken=` URL-suffix credentials resolve.
+/// Checked after `from_api`, where `$VAR` and `:_authToken=` URL-suffix credentials resolve.
 fn load_scope(
     name: &[u8],
     registry: Api::NpmRegistry,

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -397,8 +397,7 @@ fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }
 
-/// Credentials are sent verbatim in `Authorization`; a CR, LF or NUL in one would
-/// smuggle extra header lines (or a second request) into every registry request.
+/// Sent verbatim in `Authorization`, so CR/LF/NUL would inject header lines into every request.
 fn check_credential(value: &[u8], source: fmt::Arguments<'_>) -> crate::Result<()> {
     if !strings::contains_any(value, b"\r\n\0") {
         return Ok(());
@@ -407,8 +406,7 @@ fn check_credential(value: &[u8], source: fmt::Arguments<'_>) -> crate::Result<(
     Err(crate::Error::InstallFailed)
 }
 
-/// Checked here rather than in the .npmrc / bunfig loaders: `$VAR` indirections
-/// and `:_authToken=` URL suffixes only resolve inside `from_api`.
+/// Checked after `from_api`, which is where `$VAR` and `:_authToken=` URL-suffix credentials resolve.
 fn load_scope(
     name: &[u8],
     registry: Api::NpmRegistry,

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -462,8 +462,6 @@ impl Options {
         // Clone so the
         // `base.url` fallback below in the scoped-registry loop stays valid.
         self.scope = load_scope(b"", base.clone(), env)?;
-        // `did_override_default_scope` is set at the end of this fn;
-        // on the OOM error path the field is irrelevant (process aborts).
 
         if let Some(config) = bun_install_ref {
             if let Some(cache_directory) = config.cache_directory.as_deref() {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -397,11 +397,8 @@ fn leak_static(s: &[u8]) -> &'static [u8] {
     bun_core::heap::release(s.to_vec().into_boxed_slice())
 }
 
-/// Registry credentials are copied into the `Authorization` header byte for
-/// byte, so a CR, LF or NUL inside one would end that header line and turn the
-/// rest of the value into extra headers (or a second request) on every
-/// registry request. Every credential `load()` stores passes through here;
-/// `source` says where it was configured.
+/// Credentials are sent verbatim in `Authorization`; a CR, LF or NUL in one would
+/// smuggle extra header lines (or a second request) into every registry request.
 fn check_credential(value: &[u8], source: fmt::Arguments<'_>) -> crate::Result<()> {
     if !strings::contains_any(value, b"\r\n\0") {
         return Ok(());
@@ -410,9 +407,8 @@ fn check_credential(value: &[u8], source: fmt::Arguments<'_>) -> crate::Result<(
     Err(crate::Error::InstallFailed)
 }
 
-/// `Scope::from_api` is where `.npmrc` / bunfig credentials (including
-/// `$ENV_VAR` indirections and `:_authToken=` URL suffixes) take their final
-/// value, so the scope is checked as soon as it is built.
+/// Checked here rather than in the .npmrc / bunfig loaders: `$VAR` indirections
+/// and `:_authToken=` URL suffixes only resolve inside `from_api`.
 fn load_scope(
     name: &[u8],
     registry: Api::NpmRegistry,

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -698,7 +698,7 @@ describe.concurrent("auth tokens containing CR, LF or NUL", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { registryUrl, seen, stderr, exitCode };
   }
 

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -663,3 +663,103 @@ describe("--registry override", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("auth tokens containing CR, LF or NUL", () => {
+  // The token is written into `Authorization: Bearer <token>` as-is, so a token
+  // holding "\r\n" used to end that header line and send whatever followed it
+  // to the registry as additional header lines (or a second request). Such a
+  // token must be rejected where it is configured, before any request is made.
+  const token = "abc\r\nX-Injected: 1";
+
+  type Seen = { path: string; injected: string | null };
+  type Setup = { files: Record<string, string>; env?: Record<string, string>; dependency?: string };
+
+  async function install(setup: (registryUrl: string) => Setup) {
+    const seen: Seen[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        seen.push({ path: new URL(req.url).pathname, injected: req.headers.get("x-injected") });
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const registryUrl = `http://127.0.0.1:${server.port}/`;
+    const { files, env: extraEnv = {}, dependency = "no-deps" } = setup(registryUrl);
+
+    using dir = tempDir("npmrc-token-crlf", {
+      "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { [dependency]: "1.0.0" } }),
+      ...files,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache"), ...extraEnv },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { registryUrl, seen, stderr, exitCode };
+  }
+
+  test(".npmrc _authToken expanded from an environment variable", async () => {
+    const { registryUrl, seen, stderr, exitCode } = await install(url => ({
+      files: { ".npmrc": `registry=${url}\n//${url.slice("http://".length)}:_authToken=\${NPM_TOKEN}\n` },
+      env: { NPM_TOKEN: token },
+    }));
+    expect(seen).toEqual([]);
+    expect(stderr).toContain(`the auth token for registry "${registryUrl}" contains a newline or NUL byte`);
+    expect(exitCode).toBe(1);
+  });
+
+  test(".npmrc _authToken for a scoped registry", async () => {
+    const { registryUrl, seen, stderr, exitCode } = await install(url => ({
+      files: {
+        ".npmrc":
+          `registry=${url}\n` +
+          `@acme:registry=${url}acme/\n` +
+          `//${url.slice("http://".length)}acme/:_authToken=\${NPM_TOKEN}\n`,
+      },
+      env: { NPM_TOKEN: token },
+      dependency: "@acme/no-deps",
+    }));
+    expect(seen).toEqual([]);
+    expect(stderr).toContain(
+      `the auth token for the @acme registry "${registryUrl}acme/" contains a newline or NUL byte`,
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  test("bunfig.toml token expanded from an environment variable", async () => {
+    const { registryUrl, seen, stderr, exitCode } = await install(url => ({
+      files: { "bunfig.toml": `[install]\nregistry = { url = "${url}", token = "$NPM_TOKEN" }\n` },
+      env: { NPM_TOKEN: token },
+    }));
+    expect(seen).toEqual([]);
+    expect(stderr).toContain(`the auth token for registry "${registryUrl}" contains a newline or NUL byte`);
+    expect(exitCode).toBe(1);
+  });
+
+  test("NPM_CONFIG_TOKEN", async () => {
+    const { seen, stderr, exitCode } = await install(url => ({
+      files: { ".npmrc": `registry=${url}\n` },
+      env: { NPM_CONFIG_TOKEN: token },
+    }));
+    expect(seen).toEqual([]);
+    expect(stderr).toContain("the auth token in $NPM_CONFIG_TOKEN contains a newline or NUL byte");
+    expect(exitCode).toBe(1);
+  });
+
+  test.each([
+    ["a trailing newline", '"abc\\n"'],
+    ["a carriage return", '"abc\\rdef"'],
+    ["a NUL byte", '"abc\\u0000def"'],
+  ])("bunfig.toml token with %s", async (_, tomlToken) => {
+    const { registryUrl, seen, stderr, exitCode } = await install(url => ({
+      files: { "bunfig.toml": `[install]\nregistry = { url = "${url}", token = ${tomlToken} }\n` },
+    }));
+    expect(seen).toEqual([]);
+    expect(stderr).toContain(`the auth token for registry "${registryUrl}" contains a newline or NUL byte`);
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
### What

`bun install` (and every other command that talks to a registry: `add`, `update`, `publish`, `audit`, `pm view`, runtime auto-install) writes the configured registry token into the `Authorization` header byte for byte. A token containing `\r\n` therefore ended the header line, and whatever followed it reached the registry as additional header lines, or as a second request on the same connection.

```sh
# fake registry that answers 404 and records what it received
printf 'registry=http://127.0.0.1:4873/\n//127.0.0.1:4873/:_authToken=${NPM_TOKEN}\n' > .npmrc
echo '{"name":"p","dependencies":{"foo":"1.0.0"}}' > package.json
NPM_TOKEN=$'abc\r\nX-Injected: 1' bun install
```

Request as received by the registry on 1.4.0 (the same happens with a bunfig.toml `token`, a `:_authToken=` registry URL suffix, and `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` / `npm_config_token`):

```
GET /foo HTTP/1.1
Authorization: Bearer abc
X-Injected: 1
npm-auth-type: legacy
...
```

With `NPM_TOKEN=$'abc\r\nHost: x\r\n\r\nGET /evil HTTP/1.1\r\nX: 1'` the registry sees two requests. npm rejects the same token with `ERR_INVALID_CHAR`; `fetch()` rejects these bytes too, but the install client builds its headers itself.

### Fix

The value is validated where it enters `Options::load` (`src/install/PackageManager/PackageManagerOptions.rs`), which is the only place registry credentials are stored:

- `load_scope()` wraps `Scope::from_api()` and checks `token` and `auth` of every scope right after it is built. `from_api` is where `.npmrc` / bunfig values, `$VAR` indirections, and `:_authToken=` / `:_auth=` URL suffixes take their final value, so this covers the default registry, `[install.scopes]`, and `BUN_CONFIG_REGISTRY`.
- The `BUN_CONFIG_TOKEN` / `NPM_CONFIG_TOKEN` / `npm_config_token` value is checked before it is applied.

A credential containing CR, LF or NUL fails the command before any request is made:

```
error: the auth token for registry "http://127.0.0.1:4873/" contains a newline or NUL byte
error: the auth token for the @acme registry "http://127.0.0.1:4873/acme/" contains a newline or NUL byte
error: the auth token in $NPM_CONFIG_TOKEN contains a newline or NUL byte
```

The registry URL is printed through `redacted_npm_url`; the token itself is never echoed. `Options::load` now returns `crate::Result` so the error propagates through `PackageManager::init` / `init_with_runtime` (the runtime path previously assumed the only possible error was OOM).

Removed: `CommandLineArguments.token` and the `Options::load` branch copying it. No flag ever set the field, and it would otherwise have been the one unchecked write to `scope.token`.

### Verification

`test/cli/install/npmrc.test.ts`, "auth tokens containing CR, LF or NUL": each entrance (`.npmrc` default and scoped `_authToken` via `${NPM_TOKEN}`, bunfig `token = "$NPM_TOKEN"`, `NPM_CONFIG_TOKEN`) plus bare LF, bare CR and NUL payloads. Each test runs `bun install` against a local `Bun.serve` registry and asserts the registry received no request, the error names the source, and the exit code is 1. On the released 1.4.0 all seven fail (the four CRLF cases record the request arriving with `x-injected: 1`); with this change they pass, as does the rest of `npmrc.test.ts`, `redacted-config-logs.test.ts`, and the token env var tests in `bun-install-registry.test.ts`.

Other callers of `Options::load`, checked by hand with the same bad token: `bun publish`, `bun audit` and `bun pm view` print the error and exit 1 (`publish` additionally prints its usual "failed to initialize bun install" line). Runtime auto-install (`bun --install=force` on a file importing a missing package, token in bunfig.toml) prints the error, and the resolver then reports the module as unresolvable through the existing init-failure mapping in `auto_installer.rs`; no abort.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/npmrc.test.ts
bun test v1.4.0 (bc9194632)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_QD4Uq9/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [240.27ms]
package dir /tmp/verdaccio-test-_l5zt5y
bun install v1.4.0 (bc9194632)
No packages! Deleted empty lockfile

[96.00ms] done
(pass) npmrc > works with empty file [202.59ms]
package dir /tmp/verdaccio-test-_oAj9bn
bun install v1.4.0 (bc9194632)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [224.00ms]
(pass) npmrc > sets default registry [294.82ms]
bun install v1.4.0 (bc9194632)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [136.00ms]
(pass) npmrc > sets scoped registry [207.30ms]
package dir /tmp/verdaccio-test-_lHC8lJ
home dir /tmp/verdaccio-test-_lHC8lJ/home_dir
bun install v1.4.0 (bc9194632)

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [98.00m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9d4df187c)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_WaHGOL/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [6.16ms]
package dir /tmp/verdaccio-test-_PVHF4k
bun install v1.4.0-canary.1 (9d4df187c)
No packages! Deleted empty lockfile

[0.00ms] done
(pass) npmrc > works with empty file [5.95ms]
package dir /tmp/verdaccio-test-_ynurio
bun install v1.4.0-canary.1 (9d4df187c)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [23.00ms]
(pass) npmrc > sets default registry [27.82ms]
bun install v1.4.0-canary.1 (9d4df187c)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [6.00ms]
(pass) npmrc > sets scoped registry [10.55ms]
package dir /tmp/verdaccio-test-_ypFnhE
home dir /tmp/verdaccio-test-_ypFnhE/home_dir
bun install v1.4.0-canary.1 (9d4df187c)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [1.00ms]
(pass) npmrc > works with home config [7.90ms]
package dir /tmp/verdaccio-test-_1s7KX8
home dir /tmp/verdaccio-t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/npmrc.test.ts
bun test v1.4.0 (bc9194632)

test/cli/install/npmrc.test.ts:
{
  out: "/tmp/verdaccio-test-_QPqWCr/hi!",
  err: "",
}
(pass) npmrc > should convert to utf8 if BOM [189.03ms]
package dir /tmp/verdaccio-test-_3PU3ot
bun install v1.4.0 (bc9194632)
No packages! Deleted empty lockfile

[104.00ms] done
(pass) npmrc > works with empty file [205.98ms]
package dir /tmp/verdaccio-test-_PILPKp
bun install v1.4.0 (bc9194632)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package installed [143.00ms]
(pass) npmrc > sets default registry [215.84ms]
bun install v1.4.0 (bc9194632)
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile

+ @types/no-deps@1.0.0 (v2.0.0 available)

1 package installed [127.00ms]
(pass) npmrc > sets scoped registry [197.64ms]
package dir /tmp/verdaccio-test-_7XfIzi
home dir /tmp/verdaccio-test-_7XfIzi/home_dir
bun install v1.4.0 (bc9194632)
Saved lockfile

+ no-deps@1.0.0 (v2.0.0 available)

1 package i
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 802ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
^[[1m^[[92m   Compiling^[[0m bun_output v0.0.0 (/workspace/bun/src/output)
^[[1m^[[92m   Compiling^[[0m bun_clap 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |  12 +--
 src/install/PackageManager/CommandLineArguments.rs |   2 -
 .../PackageManager/PackageManagerOptions.rs        |  49 +++++++---
 test/cli/install/npmrc.test.ts                     | 100 +++++++++++++++++++++
 4 files changed, 140 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager.rs                            5      1      0
src/install/PackageManager/CommandLineArguments.rs       1      2      0
src/install/PackageManager/PackageManagerOptions.rs     11     16      0
test/cli/install/npmrc.test.ts                           5      6      0
```

</details>

<!-- robobun:evidence:end -->
