### PR TITLE
Release the stack frame strings leaked by the C++ source map remap callers

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -184,8 +184,8 @@ WTF::String formatStackTrace(
                 // "".test(/[a-0]/);
                 auto originalLine = WTF::OrdinalNumber::fromOneBasedInt(err->line());
 
-                ZigStackFrame remappedFrame = {};
-                memset(&remappedFrame, 0, sizeof(ZigStackFrame));
+                OwnedZigStackFrames remappedFrames(1);
+                ZigStackFrame& remappedFrame = remappedFrames[0];
 
                 remappedFrame.position.line_zero_based = originalLine.zeroBasedInt();
                 remappedFrame.position.column_zero_based = 0;
@@ -197,8 +197,7 @@ WTF::String formatStackTrace(
                     // https://github.com/oven-sh/bun/issues/3595
                     if (!sourceURLForFrame.isEmpty()) {
                         remappedFrame.source_url = Bun::toStringRef(sourceURLForFrame);
-                        // This ensures the lifetime of the sourceURL is accounted for correctly
-                        Bun__remapStackFramePositions(getBunVM(), &remappedFrame, 1);
+                        remappedFrames.remap(getBunVM());
 
                         sourceURLForFrame = remappedFrame.source_url.toWTFString();
                     }
@@ -241,11 +240,9 @@ WTF::String formatStackTrace(
     // Pass 1: collect (line, col, source_url) for frames that should be
     // source-mapped, then batch the remap so the Rust side can resolve each
     // file's map once instead of per frame.
-    WTF::Vector<ZigStackFrame, 8> remappedFrames;
+    OwnedZigStackFrames remappedFrames(framesCount);
     WTF::Vector<WTF::String, 8> sourceURLs;
     WTF::Vector<LineColumn, 8> originalLineColumns;
-    remappedFrames.grow(framesCount);
-    memset(remappedFrames.begin(), 0, sizeof(ZigStackFrame) * framesCount);
     sourceURLs.grow(framesCount);
     originalLineColumns.grow(framesCount);
     bool anyRemap = false;
@@ -255,7 +252,7 @@ WTF::String formatStackTrace(
         ZigStackFrame& remappedFrame = remappedFrames[i];
         // Match `ZigStackFramePosition::INVALID` exactly so the Rust batch loop's
         // `position.isInvalid()` skips frames we never populate (vm-context
-        // frames, frames without line/col info). memset alone leaves
+        // frames, frames without line/col info). A zero-initialized frame has
         // `line_start_byte = 0` which fails that byte-compare.
         remappedFrame.position.line_zero_based = -1;
         remappedFrame.position.column_zero_based = -1;
@@ -289,7 +286,7 @@ WTF::String formatStackTrace(
     }
 
     if (anyRemap) {
-        Bun__remapStackFramePositions(getBunVM(), remappedFrames.begin(), framesCount);
+        remappedFrames.remap(getBunVM());
     }
 
     // Pass 2: format. Everything except (display line/col, source_url) is
@@ -443,11 +440,9 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     // We need to sourcemap it if it's a GlobalObject.
 
     const int n = stackTrace.size();
-    WTF::Vector<ZigStackFrame, 8> remappedFrames;
+    OwnedZigStackFrames remappedFrames(n);
     WTF::Vector<WTF::String, 8> sourceURLs;
     WTF::Vector<bool, 8> didRemap;
-    remappedFrames.grow(n);
-    memset(remappedFrames.begin(), 0, sizeof(ZigStackFrame) * n);
     sourceURLs.grow(n);
     didRemap.grow(n);
     bool anyRemap = false;
@@ -492,7 +487,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     }
 
     if (anyRemap) {
-        Bun__remapStackFramePositions(globalObject->bunVM(), remappedFrames.begin(), n);
+        remappedFrames.remap(globalObject->bunVM());
     }
 
     for (int i = 0; i < n; i++) {
@@ -623,12 +618,13 @@ void computeLineColumnWithSourcemap(JSC::VM& vm, JSC::SourceProvider* _Nonnull s
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(lineColumn.line);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(lineColumn.column);
 
-    ZigStackFrame frame = {};
+    OwnedZigStackFrames frames(1);
+    ZigStackFrame& frame = frames[0];
     frame.position.line_zero_based = line.zeroBasedInt();
     frame.position.column_zero_based = column.zeroBasedInt();
     frame.source_url = Bun::toStringRef(sourceURL);
 
-    Bun__remapStackFramePositions(Bun::vm(vm), &frame, 1);
+    frames.remap(Bun::vm(vm));
 
     if (frame.remapped) {
         lineColumn.line = frame.position.line().oneBasedInt();

--- a/src/jsc/bindings/InspectorTestReporterAgent.cpp
+++ b/src/jsc/bindings/InspectorTestReporterAgent.cpp
@@ -168,8 +168,6 @@ void InspectorTestReporterAgent::reportTestFound(JSC::CallFrame* callFrame, int 
     JSC::SourceID sourceID = 0;
     String sourceURL;
 
-    ZigStackFrame remappedFrame = {};
-
     auto* globalObject = &m_globalObject;
     auto& vm = JSC::getVM(globalObject);
 
@@ -210,11 +208,13 @@ void InspectorTestReporterAgent::reportTestFound(JSC::CallFrame* callFrame, int 
         OrdinalNumber originalLine = OrdinalNumber::fromOneBasedInt(lineColumn.line);
         OrdinalNumber originalColumn = OrdinalNumber::fromOneBasedInt(lineColumn.column);
 
+        Bun::OwnedZigStackFrames remappedFrames(1);
+        ZigStackFrame& remappedFrame = remappedFrames[0];
         remappedFrame.position.line_zero_based = originalLine.zeroBasedInt();
         remappedFrame.position.column_zero_based = originalColumn.zeroBasedInt();
         remappedFrame.source_url = Bun::toStringRef(sourceURL);
 
-        Bun__remapStackFramePositions(Bun::vm(globalObject), &remappedFrame, 1);
+        remappedFrames.remap(Bun::vm(globalObject));
 
         sourceURL = remappedFrame.source_url.toWTFString();
         lineColumn.line = OrdinalNumber::fromZeroBasedInt(remappedFrame.position.line_zero_based).oneBasedInt();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6507,8 +6507,6 @@ CPP_DECL void Bun__CallFrame__getCallerSrcLoc(JSC::CallFrame* callFrame, JSC::JS
     JSC::LineColumn lineColumn;
     String sourceURL;
 
-    ZigStackFrame remappedFrame = {};
-
     JSC::StackVisitor::visit(callFrame, vm, [&](JSC::StackVisitor& visitor) -> WTF::IterationStatus {
         if (Zig::isImplementationVisibilityPrivate(visitor))
             return WTF::IterationStatus::Continue;
@@ -6529,11 +6527,13 @@ CPP_DECL void Bun__CallFrame__getCallerSrcLoc(JSC::CallFrame* callFrame, JSC::JS
         OrdinalNumber originalLine = OrdinalNumber::fromOneBasedInt(lineColumn.line);
         OrdinalNumber originalColumn = OrdinalNumber::fromOneBasedInt(lineColumn.column);
 
+        Bun::OwnedZigStackFrames remappedFrames(1);
+        ZigStackFrame& remappedFrame = remappedFrames[0];
         remappedFrame.position.line_zero_based = originalLine.zeroBasedInt();
         remappedFrame.position.column_zero_based = originalColumn.zeroBasedInt();
         remappedFrame.source_url = Bun::toStringRef(sourceURL);
 
-        Bun__remapStackFramePositions(Bun::vm(globalObject), &remappedFrame, 1);
+        remappedFrames.remap(Bun::vm(globalObject));
 
         sourceURL = remappedFrame.source_url.toWTFString();
         lineColumn.line = OrdinalNumber::fromZeroBasedInt(remappedFrame.position.line_zero_based).oneBasedInt();
@@ -6675,12 +6675,13 @@ CPP_DECL [[ZIG_EXPORT(nothrow)]] unsigned int Bun__CallFrame__getLineNumber(JSC:
     });
 
     if (!sourceURL.isEmpty() && lineColumn.line > 0) {
-        ZigStackFrame remappedFrame = {};
+        Bun::OwnedZigStackFrames remappedFrames(1);
+        ZigStackFrame& remappedFrame = remappedFrames[0];
         remappedFrame.position.line_zero_based = lineColumn.line - 1;
         remappedFrame.position.column_zero_based = lineColumn.column;
         remappedFrame.source_url = Bun::toStringRef(sourceURL);
 
-        Bun__remapStackFramePositions(Bun::vm(globalObject), &remappedFrame, 1);
+        remappedFrames.remap(Bun::vm(globalObject));
 
         return remappedFrame.position.line_zero_based + 1;
     }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -477,12 +477,7 @@ ALWAYS_INLINE void BunString::deref()
 
 namespace Bun {
 
-// Frames built on the C++ side for Bun__remapStackFramePositions. Each frame
-// owns a ref on its strings; the remap derefs the source_url it was given and
-// stores a freshly allocated one when a source map renames the file, so the
-// strings left in the frames are released here once the caller is done reading
-// them. Frames behind ZigStackTrace::frames_ptr are released by the Rust side,
-// which is why this is not a destructor on ZigStackFrame itself.
+// Frames built here for Bun__remapStackFramePositions, which may swap in a freshly allocated source_url; frames behind ZigStackTrace::frames_ptr are released by Rust instead.
 class OwnedZigStackFrames {
     WTF_MAKE_NONCOPYABLE(OwnedZigStackFrames);
 

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -3,6 +3,8 @@
 #include "wtf/text/OrdinalNumber.h"
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/ArgList.h"
+#include <wtf/Noncopyable.h>
+#include <wtf/Vector.h>
 #include <set>
 
 #ifndef HEADERS_HANDWRITTEN
@@ -472,6 +474,44 @@ ALWAYS_INLINE void BunString::deref()
         this->impl.wtf->deref();
     }
 }
+
+namespace Bun {
+
+// Frames built on the C++ side for Bun__remapStackFramePositions. Each frame
+// owns a ref on its strings; the remap derefs the source_url it was given and
+// stores a freshly allocated one when a source map renames the file, so the
+// strings left in the frames are released here once the caller is done reading
+// them. Frames behind ZigStackTrace::frames_ptr are released by the Rust side,
+// which is why this is not a destructor on ZigStackFrame itself.
+class OwnedZigStackFrames {
+    WTF_MAKE_NONCOPYABLE(OwnedZigStackFrames);
+
+public:
+    explicit OwnedZigStackFrames(size_t count)
+        : m_frames(count)
+    {
+    }
+
+    ~OwnedZigStackFrames()
+    {
+        for (ZigStackFrame& frame : m_frames) {
+            frame.function_name.deref();
+            frame.source_url.deref();
+        }
+    }
+
+    ZigStackFrame& operator[](size_t index) { return m_frames[index]; }
+
+    void remap(void* bunVM)
+    {
+        Bun__remapStackFramePositions(bunVM, m_frames.begin(), m_frames.size());
+    }
+
+private:
+    WTF::Vector<ZigStackFrame, 8> m_frames;
+};
+
+} // namespace Bun
 
 #define CLEAR_IF_EXCEPTION(scope__) (void)scope__.tryClearException();
 

--- a/test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts
+++ b/test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+
+// Formatting a stack trace hands one ZigStackFrame per frame to
+// Bun__remapStackFramePositions. When the frame's file has an external source
+// map (here a `// @bun` file with a sidecar .map, the shape `bun build
+// --target=bun --sourcemap` produces), the remap replaces each frame's
+// source_url with a freshly allocated string naming the original file. The C++
+// callers used to drop their frames without releasing it, so every read of
+// `.stack` leaked one string per remapped frame. With a long `sources` entry the
+// unfixed leak grows RSS by about FRAMES * SOURCE_NAME_LENGTH bytes per read:
+// 45 MB (release) to 50 MB (debug ASAN) over ITERATIONS reads, while a fixed
+// build moved by -6 to +2 MB over the same loop in both.
+
+const FRAMES = 10;
+// Stays well under the 4096-byte path buffer the remap joins the name into,
+// even with the temp dir prefixed.
+const SOURCE_NAME_LENGTH = 3000;
+const WARMUP = 200;
+const ITERATIONS = 1500;
+const MAX_GROWTH_MB = isASAN ? 24 : 16;
+// Formatting WARMUP + ITERATIONS ten-frame stacks takes the child a few seconds
+// on debug and ASAN builds.
+const CHILD_TIMEOUT_MS = 30_000;
+
+const sourceName = Buffer.alloc(SOURCE_NAME_LENGTH - 3, "s").toString() + ".ts";
+// Only present in stack output once the remap swapped the original file name in.
+const remappedMarker = Buffer.alloc(64, "s").toString() + ".ts";
+
+// `const error = ...; return error;` keeps every fN on the stack: module code is
+// strict, so `return fN()` would be a proper tail call and JSC would drop the frame.
+const framesSource =
+  [
+    "// @bun",
+    ...Array.from({ length: FRAMES }, (_, i) => {
+      const callee = i === FRAMES - 1 ? 'new Error("boom")' : `f${i + 1}()`;
+      return `function f${i}() { const error = ${callee}; return error; }`;
+    }),
+    "export function makeError() { const error = f0(); return error; }",
+    "//# sourceMappingURL=frames.js.map",
+  ].join("\n") + "\n";
+
+// One segment per generated line, each advancing one line into sources[0], so
+// every frame in frames.js has a mapping and gets remapped.
+const framesSourceMap = JSON.stringify({
+  version: 3,
+  sources: [sourceName],
+  sourcesContent: [""],
+  names: [],
+  mappings: "AAAA" + ";AACA".repeat(framesSource.split("\n").length),
+});
+
+// "stack" reads through the default error.stack formatter; "prepareStackTrace"
+// reads through the Error.prepareStackTrace path, which remaps into CallSites.
+// Both modes count how many frames of each read came back remapped, so a map
+// that silently failed to load cannot make the growth check pass vacuously.
+const mainSource = /* js */ `
+  import { makeError } from "./frames.js";
+
+  const mode = process.argv[2];
+  const marker = ${JSON.stringify(remappedMarker)};
+  Error.stackTraceLimit = ${FRAMES};
+  const rss =
+    process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+      ? Bun.unsafe.memoryFootprint
+      : process.memoryUsage.rss;
+
+  let remappedFrames = 0;
+  if (mode === "prepareStackTrace") {
+    Error.prepareStackTrace = (error, callSites) => {
+      for (const callSite of callSites) {
+        if (callSite.getFileName().includes(marker)) remappedFrames++;
+      }
+      return "";
+    };
+  }
+
+  function run(count) {
+    for (let i = 0; i < count; i++) {
+      const stack = makeError().stack;
+      if (mode === "stack") {
+        // One marker per remapped frame line; indexOf keeps the count free of
+        // per-read garbage that would add noise to the RSS delta.
+        for (let at = stack.indexOf(marker); at !== -1; at = stack.indexOf(marker, at + 1)) remappedFrames++;
+      }
+    }
+  }
+
+  run(${WARMUP});
+  Bun.gc(true);
+  const before = rss();
+  run(${ITERATIONS});
+  Bun.gc(true);
+  const after = rss();
+
+  console.log(JSON.stringify({ remappedFrames, growthMB: Math.round((after - before) / 1024 / 1024) }));
+`;
+
+describe.concurrent("error.stack with an external source map does not leak the remapped file names", () => {
+  test.each(["stack", "prepareStackTrace"])(
+    "%s",
+    async mode => {
+      using dir = tempDir("external-sourcemap-stack-leak", {
+        "frames.js": framesSource,
+        "frames.js.map": framesSourceMap,
+        "main.js": mainSource,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.js", mode],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      const { remappedFrames, growthMB } = JSON.parse(stdout);
+      expect(remappedFrames).toBe((WARMUP + ITERATIONS) * FRAMES);
+      expect(growthMB, `RSS grew by ${growthMB} MB over ${ITERATIONS} .stack reads`).toBeLessThan(MAX_GROWTH_MB);
+    },
+    CHILD_TIMEOUT_MS,
+  );
+});

--- a/test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts
+++ b/test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Formatting a stack trace hands one ZigStackFrame per frame to
 // Bun__remapStackFramePositions. When the frame's file has an external source
@@ -9,8 +9,8 @@ import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 // callers used to drop their frames without releasing it, so every read of
 // `.stack` leaked one string per remapped frame. With a long `sources` entry the
 // unfixed leak grows RSS by about FRAMES * SOURCE_NAME_LENGTH bytes per read:
-// 45 MB (release) to 50 MB (debug ASAN) over ITERATIONS reads, while a fixed
-// build moved by -6 to +2 MB over the same loop in both.
+// 44 to 50 MB over ITERATIONS reads on release and debug ASAN builds alike,
+// while a fixed build moved by -5 to +3 MB over the same loop on both.
 
 const FRAMES = 10;
 // Stays well under the 4096-byte path buffer the remap joins the name into,
@@ -18,7 +18,7 @@ const FRAMES = 10;
 const SOURCE_NAME_LENGTH = 3000;
 const WARMUP = 200;
 const ITERATIONS = 1500;
-const MAX_GROWTH_MB = isASAN ? 24 : 16;
+const MAX_GROWTH_MB = 24;
 // Formatting WARMUP + ITERATIONS ten-frame stacks takes the child a few seconds
 // on debug and ASAN builds.
 const CHILD_TIMEOUT_MS = 30_000;
@@ -106,8 +106,13 @@ describe.concurrent("error.stack with an external source map does not leak the r
         "main.js": mainSource,
       });
 
+      // --smol: each read also makes ~FRAMES * SOURCE_NAME_LENGTH bytes of
+      // garbage, the default heap sizes how much of it piles up between
+      // collections by machine RAM, and what the final Bun.gc(true) just freed
+      // is still resident when RSS is sampled. The small heap keeps that residue
+      // to a few MB on any machine; the leaked strings are never freed at all.
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "main.js", mode],
+        cmd: [bunExe(), "--smol", "main.js", mode],
         cwd: String(dir),
         env: bunEnv,
         stdout: "pipe",


### PR DESCRIPTION
### What

Every read of `error.stack` leaked one `WTF::StringImpl` per stack frame whose file has an external source map (`bun build --sourcemap` output run directly, or a `bun build --compile --sourcemap` binary). RSS grows linearly with the number of `.stack` materializations.

Repro: a `// @bun` file with a sidecar `.map` whose `sources[0]` is a ~3000 byte name (same shape as the new test), reading the stack of a 10 frame error in a loop:

```
reads     RSS growth (bun 1.4.0 release)
 2000     +8 MB
10000     +39 MB
20000     +75 MB
```

Same program without the `.map` next to it: flat. Plain `bun run file.ts` (internal maps, the file name is not rewritten): flat.

### Cause

`Bun__remapStackFramePositions` works on `ZigStackFrame`s whose strings are owned refs: the C++ callers fill in `source_url = Bun::toStringRef(url)` (+1), and the Rust side (`VirtualMachine::remap_stack_frame_positions`) derefs that and stores the `bun_core::String::clone_utf8(...)` it gets from `Lookup::display_source_url_if_needed` whenever the source map renames the file. Rust-owned frames (`ZigStackTrace::frames_ptr`, used for printing uncaught errors) are released by `ZigStackFrame::deinit()` on the Rust side, but all seven C++ callers build their frames on their own stack, read `remappedFrame.source_url.toWTFString()` (a copy) and then drop the frames without a `deref()`. With a renamed file that leaks the fresh string on every call; without one it leaves an extra ref on the source provider's URL string per frame per read instead.

Sites: `formatStackTrace` (the default `.stack` formatter, plus its SyntaxError `<parse>` line), `computeErrorInfoWithPrepareStackTrace` (`Error.prepareStackTrace`), `computeLineColumnWithSourcemap` (cpu profiles), `Bun__CallFrame__getCallerSrcLoc`, `Bun__CallFrame__getLineNumber`, and `InspectorTestReporterAgent::reportTestFound`.

### Fix

`Bun::OwnedZigStackFrames` (next to the `Bun__remapStackFramePositions` declaration in `headers-handwritten.h`) holds the frames the C++ side builds for a remap and derefs `function_name`/`source_url` of each one in its destructor; all seven sites now go through it, and the `memset`s that duplicated the `ZigStackFrame` constructor go away with the raw vectors. The remaining direct use of the extern is inside the holder, so a new caller gets the release for free.

Why a holder rather than a destructor on `ZigStackFrame`: the same struct is also the element type of the Rust-owned frame buffers, which C++ fills in through references and Rust releases (and `ZigException.cpp` assigns and copies it as a plain value), so the type itself has to stay a plain value type. The thing that owns strings on the C++ side is specifically "the frames built for a remap", which is what the holder models, the same way `ResolvedSourceCodeHolder` does for `ResolvedSource`.

### Test

`test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts` builds the `// @bun` + sidecar map fixture with a 3000 byte source name and 10 frames, reads `.stack` 1500 times after a warmup, and checks RSS growth, once through the default formatter and once through `Error.prepareStackTrace`. It also counts the remapped frames it saw (`(warmup + iterations) * 10`) so a map that fails to load cannot make it pass vacuously.

The child runs with `--smol`: every read also produces ~30 KB of garbage (the formatted stack), the default heap sizes how much of that accumulates between collections by machine RAM, and whatever the final `Bun.gc(true)` freed is still resident when RSS is sampled; without `--smol` a fixed build read +19 MB on one CI machine. With it, measured growth over the 1500 reads is 44 to 50 MB unfixed (release and debug ASAN) and -5 to +3 MB fixed, against a 24 MB bound. The child takes ~0.1 s in release and ~4 to 5 s on the debug ASAN build, so the test carries an explicit 30 s timeout.

The other four sites (cpu profiler, caller location for inline snapshots, junit line numbers, inspector test reporter) remap once per event, which is not measurable through RSS; they are fixed by the same holder and covered for regressions by the existing `cpu-prof`, snapshot, junit and `test-reporter` tests, which pass on this branch. The SyntaxError `<parse>` remap is likewise only structurally covered: a user constructed `SyntaxError` has an empty `sourceURL()`, so that line never remaps a renamed file in a loop.

While looking at this I found two unrelated issues that are tracked separately: a source map `sources` entry long enough to overflow the 4096 byte path join buffer panics on the first `.stack` read, and `Bun.cron`'s `resolve_path` never releases the string returned by `getCallerSrcLoc`.