### PR TITLE
test(worker_threads): keep worker_destruction.test.ts under the default timeout on debug builds

### DIFF
--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -3,13 +3,14 @@ import { bunEnv, bunExe, bunRun, isDebug } from "harness";
 import { join } from "path";
 
 // worker_thread_check.ts runs RUN_COUNT rounds of CONCURRENCY Workers, terminating each as it comes
-// online. On a debug build a worker_threads Worker takes ~1.7s just to come online (~30ms on release),
-// so every round costs ~2s regardless of its size and the full 5 x 10 takes ~30s per case, well past
-// the 5s default timeout. Debug builds run one round of a few workers (~3s), which still takes each
-// teardown path with several workers terminating at once; release builds, which is all CI runs (ASAN
-// lanes included), keep the full count.
+// online. On a debug+ASAN build one worker_threads spawn + terminate costs ~2.4s of CPU (~30ms on
+// release), and the three cases run concurrently with each other and with the test below them, so the
+// file needs roughly 3 x CONCURRENCY x 2.4s + ~8s of CPU, spread over the available cores, to fit the
+// 5s default timeout: 5 x 10 takes ~30s per case, and even one round of 3 per case (~29s of CPU) times
+// out on 4 to 6 cores. Debug builds therefore take each teardown path once (~15s of CPU, 3 to 4s per
+// test on 4 cores); release builds, which is all CI runs (ASAN lanes included), keep the full count.
 const RUN_COUNT = isDebug ? 1 : 5;
-const CONCURRENCY = isDebug ? 3 : 10;
+const CONCURRENCY = isDebug ? 1 : 10;
 
 describe("Worker destruction", () => {
   const method = ["Bun.connect", "Bun.listen", "fetch"];

--- a/test/js/node/worker_threads/worker_destruction.test.ts
+++ b/test/js/node/worker_threads/worker_destruction.test.ts
@@ -1,12 +1,29 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun } from "harness";
+import { bunEnv, bunExe, bunRun, isDebug } from "harness";
 import { join } from "path";
+
+// worker_thread_check.ts runs RUN_COUNT rounds of CONCURRENCY Workers, terminating each as it comes
+// online. On a debug build a worker_threads Worker takes ~1.7s just to come online (~30ms on release),
+// so every round costs ~2s regardless of its size and the full 5 x 10 takes ~30s per case, well past
+// the 5s default timeout. Debug builds run one round of a few workers (~3s), which still takes each
+// teardown path with several workers terminating at once; release builds, which is all CI runs (ASAN
+// lanes included), keep the full count.
+const RUN_COUNT = isDebug ? 1 : 5;
+const CONCURRENCY = isDebug ? 3 : 10;
 
 describe("Worker destruction", () => {
   const method = ["Bun.connect", "Bun.listen", "fetch"];
   describe.each(method)("bun when %s is used in a Worker that is terminating", method => {
     test.concurrent("exits cleanly", async () => {
-      expect(await bunRun([join(import.meta.dir, "worker_thread_check.ts"), method])).toSpawn();
+      const result = await bunRun([join(import.meta.dir, "worker_thread_check.ts"), method], {
+        RUN_COUNT: String(RUN_COUNT),
+        CONCURRENCY: String(CONCURRENCY),
+      });
+      expect(result).toSpawn();
+      // One line per completed round, so a misread count cannot turn this into a no-op run.
+      expect(result.stdout.split("\n").map(line => line.replace(/ RSS \d+ MB$/, ""))).toEqual(
+        Array(RUN_COUNT).fill(`Spawned ${CONCURRENCY} workers`),
+      );
     });
   });
 

--- a/test/js/node/worker_threads/worker_thread_check.ts
+++ b/test/js/node/worker_threads/worker_thread_check.ts
@@ -1,5 +1,6 @@
-const CONCURRENCY = 10;
-const RUN_COUNT = 5;
+// worker_destruction.test.ts lowers these on debug builds; see the note there.
+const CONCURRENCY = Number(process.env.CONCURRENCY ?? 10);
+const RUN_COUNT = Number(process.env.RUN_COUNT ?? 5);
 
 import { Worker, isMainThread, workerData } from "worker_threads";
 


### PR DESCRIPTION
### What

`bun bd test test/js/node/worker_threads/worker_destruction.test.ts` fails three of its four tests on a debug build purely on time:

```
(pass) Worker destruction > terminate() a Worker with a child process and a pending stdin write [4540.64ms]
(fail) Worker destruction > bun when Bun.connect is used in a Worker that is terminating > exits cleanly [5016.59ms]
  ^ this test timed out after 5000ms.
(fail) Worker destruction > bun when Bun.listen is used in a Worker that is terminating > exits cleanly [5000.16ms]
  ^ this test timed out after 5000ms.
(fail) Worker destruction > bun when fetch is used in a Worker that is terminating > exits cleanly [5000.15ms]
  ^ this test timed out after 5000ms.
```

With `--timeout 180000` they pass in ~29.5s each (19s for one case run on its own), so they are slow rather than hung. CI does not see this: it runs release and release+ASAN binaries, where the whole file takes 1.1s / 2.5s (`test/expected-durations.json`), under a 90s per-test timeout. It only affects running the file against `bun bd`.

### Why

Each case runs `worker_thread_check.ts`, which does 5 rounds of 10 `node:worker_threads` Workers, each terminated shortly after it comes online, and the three cases are `test.concurrent` with each other and with the fourth test, so the file starts 150 workers at once. On a debug+ASAN build one worker_threads spawn + terminate costs ~2.4s of CPU and ~1.7s of latency (both under 30ms on release; a plain Web Worker comes up in ~130ms on the same build, the rest is the node:worker_threads bootstrap running in the worker at debug speed, the same ~65x factor `require("worker_threads")` shows on the main thread: 7ms release, ~460ms debug). The file is CPU bound: it needs roughly `3 x CONCURRENCY x 2.4s + ~8s` of CPU (three fixture processes, the fourth test and the runner itself), spread over however many cores the machine has, inside the 5s default timeout.

Measured with the real test file on this debug+ASAN build, pinned with `taskset` to vary the core count (per-test times, two or three runs each):

| debug workload per case | CPU per file | 4 cores | 6 cores | 8 cores | 12 cores |
| --- | --- | --- | --- | --- | --- |
| 5 x 10 (before) | ~340s | | | | ~29.5s per case, 3 of 4 time out |
| 1 x 3 | ~29s | 4 of 4 time out | 4.7 to 5.0s, 1 to 3 time out per run | 3.2 to 4.2s | ~3.0s |
| 1 x 2 | ~22s | 3 to 4 time out per run | 3.3 to 3.9s | 2.9 to 3.5s | |
| 1 x 1 (this PR) | ~15s | 3.2 to 4.0s | 2.8 to 3.3s | 2.8 to 2.9s | 2.7 to 3.1s |

The fourth test (one worker plus a child process) is ~2.9s on its own on this build, all of it worker boot; at HEAD it reaches 4.2 to 4.5s (7.2s was seen on a busier box) only because it shares the CPU with the other 150 workers, and it is unchanged. With one worker per case it sets the floor for the file: the four tests finish within ~0.3s of each other at every core count above.

### Change

Test-only. `worker_thread_check.ts` reads `RUN_COUNT` and `CONCURRENCY` from the environment, defaulting to the previous 5 x 10, and `worker_destruction.test.ts` passes `1 x 1` when `isDebug` and `5 x 10` otherwise, following the existing `isDebug` convention for repetition counts (`worker_heap_snapshot_gc.test.ts` in the same directory, `fs.test.ts`, #37374). Release builds, and therefore every CI lane including ASAN, run exactly what they ran before. A debug build takes each of the three teardown paths (Bun.connect, Bun.listen, fetch in a terminating worker) once, in three concurrent processes, which is the functional check; the repetition that makes it a stress test stays on release. The fix this fixture shipped with (#11494) is per-VM shutdown guards in the socket and server code, so nothing it guards needs more than one worker per process; a first version of this PR used 3 per case on the strength of "a few at once", and the table above is why it was dropped to 1: 3 is ~29s of CPU and still times out on 4 and 6 core machines, while 1 passes on 4 cores with over a second to spare. Per REVIEW.md the workload is shrunk rather than the timeout raised; with one worker per case no debug-only timeout is needed. More rounds are not an option either: each round is ~2s of latency on top of ~0.75s of fixture startup, so 2 rounds is at the limit even with one worker.

The test now also asserts that stdout is exactly one `Spawned N workers` line per round (the RSS suffix stripped), so the counts are checked against what the fixture actually ran. Previously only the exit code and empty stderr were checked, so a fixture that ran zero rounds would have passed. Checked by running the new test file against the unmodified fixture: it fails with 5 x `Spawned 10 workers` received where a single line was expected.

### Verification

- `bun bd test test/js/node/worker_threads/worker_destruction.test.ts`: 3 of 4 fail on time before (above); after, 4/4 on every run at the 12 core quota (2.7 to 3.1s per test, file ~5.3s, was ~33s with a raised timeout), and 4/4 in five runs pinned to 4 cores and four pinned to 6 (table above).
- `USE_SYSTEM_BUN=1 bun test ...` (release, runs the unchanged 5 x 10 through the new assertion): 4/4, ~0.5s per case, 8 expect() calls.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/worker_threads/worker_destruction.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/worker_threads/worker_destruction.test.ts
bun test v1.4.0 (910faac42)

test/js/node/worker_threads/worker_destruction.test.ts:
(pass) Worker destruction > bun when fetch is used in a Worker that is terminating > exits cleanly [2696.90ms]
(pass) Worker destruction > bun when Bun.listen is used in a Worker that is terminating > exits cleanly [2709.70ms]
(pass) Worker destruction > bun when Bun.connect is used in a Worker that is terminating > exits cleanly [2781.85ms]
(pass) Worker destruction > terminate() a Worker with a child process and a pending stdin write [2843.05ms]

 4 pass
 0 fail
 8 expect() calls
Ran 4 tests across 1 file. [5.28s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../node/worker_threads/worker_destruction.test.ts | 22 ++++++++++++++++++++--
 test/js/node/worker_threads/worker_thread_check.ts |  5 +++--
 2 files changed, 23 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
test/js/node/worker_threads/worker_destruction.test.ts      3      7      0
test/js/node/worker_threads/worker_thread_check.ts          1      1      0
```

</details>

<!-- robobun:evidence:end -->