### PR TITLE
install: fail instead of panicking when a local tarball or workspace: path does not fit the path buffer

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1903,18 +1903,25 @@ fn enqueue_local_tarball(
     // other dependencies (e.g. `appendPackage` / `StringBuilder.allocate`
     // in `Package.fromNPM`).
     let mut abs_buf = PathBuffer::uninit();
-    let (tarball_path, normalize): (&[u8], bool) =
-        match local_tarball_base_dir(&this.lockfile, dependency_id, path) {
-            None => (path, true),
-            Some(base_dir) => (
-                Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
-                    &mut abs_buf,
-                    &[base_dir, path],
+    let tarball_path = match local_tarball_base_dir(&this.lockfile, dependency_id, path) {
+        None => Task::TarballPath::Url,
+        Some(base_dir) => {
+            match Path::resolve_path::join_abs_string_buf_checked::<Path::platform::Auto>(
+                FileSystem::instance().top_level_dir(),
+                &mut abs_buf,
+                &[base_dir, path],
+            ) {
+                None => Task::TarballPath::TooLong,
+                Some(joined) => Task::TarballPath::Absolute(
+                    StringOrTinyString::init_append_if_needed(
+                        joined,
+                        &mut crate::network_task::filename_store_appender(),
+                    )
+                    .expect("unreachable"),
                 ),
-                false,
-            ),
-        };
+            }
+        }
+    };
 
     // Build the `Task` value *before* claiming a hive slot — the `.expect()`s
     // below can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
@@ -1949,12 +1956,7 @@ fn enqueue_local_tarball(
                     skip_verify: false,
                     in_trusted_dependencies: false,
                 },
-                tarball_path: StringOrTinyString::init_append_if_needed(
-                    tarball_path,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                normalize,
+                tarball_path,
             }),
         },
         id: task_id,

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -535,23 +535,16 @@ impl<'a> Task<'a> {
                     this.status = Status::Success;
                 }
                 Tag::LocalTarball => {
-                    // `tarball_path` and `normalize` are computed on the main thread when the
-                    // task is enqueued. This callback runs on a ThreadPool worker and must not
-                    // read `manager.lockfile.packages` / `manager.lockfile.buffers.string_bytes`:
+                    // `tarball_path` is computed on the main thread when the task is enqueued.
+                    // This callback runs on a ThreadPool worker and must not read
+                    // `manager.lockfile.packages` / `manager.lockfile.buffers.string_bytes`:
                     // the main thread may reallocate those buffers concurrently while processing
                     // other dependencies.
 
                     // SAFETY: tag == LocalTarball discriminates the union
-                    let req = unsafe { &mut *this.request.local_tarball };
-                    let tarball_path = req.tarball_path.slice();
-                    let normalize = req.normalize;
+                    let req = unsafe { &*this.request.local_tarball };
 
-                    let result = match read_and_extract(
-                        &req.tarball,
-                        tarball_path,
-                        normalize,
-                        &mut this.log,
-                    ) {
+                    let result = match read_and_extract(req, &mut this.log) {
                         Ok(v) => v,
                         Err(err) => {
                             this.err = Some(err);
@@ -602,29 +595,26 @@ impl<'a> Task<'a> {
     }
 }
 
-fn read_and_extract(
-    tarball: &ExtractTarball,
-    tarball_path: &[u8],
-    normalize: bool,
-    log: &mut Log,
-) -> crate::Result<ExtractData> {
-    let bytes = if normalize {
+fn read_and_extract(req: &LocalTarballRequest, log: &mut Log) -> crate::Result<ExtractData> {
+    let bytes = match &req.tarball_path {
         // Resolves
         // a user-provided relative path against `bun.fs.FileSystem.instance.top_level_dir`
         // (the absolute project root cached at startup — NOT the live process cwd).
         // `bun_sys::File::read_from_user_input` takes that base
         // explicitly (T1 `bun_sys` cannot depend on T5 `bun_resolver::fs`), so thread it
         // through here from the install crate's `FileSystem` shim.
-        File::read_from_user_input(
+        TarballPath::Url => File::read_from_user_input(
             Fd::cwd(),
             crate::bun_fs::FileSystem::instance().top_level_dir(),
-            tarball_path,
-        )?
-    } else {
-        File::read_from(Fd::cwd(), tarball_path)?
+            req.tarball.url.slice(),
+        )?,
+        TarballPath::Absolute(path) => File::read_from(Fd::cwd(), path.slice())?,
+        TarballPath::TooLong => {
+            return Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+        }
     };
     // `defer allocator.free(bytes)` → Vec<u8> drops at scope exit
-    tarball.run(log, &bytes)
+    req.tarball.run(log, &bytes)
 }
 
 #[repr(u8)]
@@ -699,9 +689,22 @@ pub struct GitCheckoutRequest {
 
 pub struct LocalTarballRequest {
     pub(crate) tarball: ExtractTarball,
-    /// Resolved by `enqueue_local_tarball` on the main thread; the worker must not read the lockfile.
-    pub(crate) tarball_path: StringOrTinyString,
-    /// When true, `tarball_path` is a user-provided path resolved relative to
-    /// cwd. When false, it is already an absolute path.
-    pub(crate) normalize: bool,
+    /// Computed on the main thread in `enqueue_local_tarball` because
+    /// resolving it requires reading `lockfile.packages` / `string_bytes`,
+    /// which can be reallocated concurrently by the main thread while this
+    /// task runs on a ThreadPool worker.
+    pub(crate) tarball_path: TarballPath,
+}
+
+/// Where a `LocalTarballRequest` reads its tarball from.
+pub(crate) enum TarballPath {
+    /// `tarball.url`, the path as written in the dependency, resolved against
+    /// the project root by `File::read_from_user_input`.
+    Url,
+    /// A tarball declared by a workspace or `file:` folder package, already
+    /// joined with that package's directory.
+    Absolute(StringOrTinyString),
+    /// The joined path does not fit a `PathBuffer`; the task fails
+    /// with `ENAMETOOLONG` like a path the OS rejects.
+    TooLong,
 }

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -535,11 +535,7 @@ impl<'a> Task<'a> {
                     this.status = Status::Success;
                 }
                 Tag::LocalTarball => {
-                    // `tarball_path` is computed on the main thread when the task is enqueued.
-                    // This callback runs on a ThreadPool worker and must not read
-                    // `manager.lockfile.packages` / `manager.lockfile.buffers.string_bytes`:
-                    // the main thread may reallocate those buffers concurrently while processing
-                    // other dependencies.
+                    // Worker thread: the request holds everything needed from the lockfile.
 
                     // SAFETY: tag == LocalTarball discriminates the union
                     let req = unsafe { &*this.request.local_tarball };
@@ -689,22 +685,16 @@ pub struct GitCheckoutRequest {
 
 pub struct LocalTarballRequest {
     pub(crate) tarball: ExtractTarball,
-    /// Computed on the main thread in `enqueue_local_tarball` because
-    /// resolving it requires reading `lockfile.packages` / `string_bytes`,
-    /// which can be reallocated concurrently by the main thread while this
-    /// task runs on a ThreadPool worker.
+    /// Built on the main thread by `enqueue_local_tarball`; the worker must not read the lockfile.
     pub(crate) tarball_path: TarballPath,
 }
 
 /// Where a `LocalTarballRequest` reads its tarball from.
 pub(crate) enum TarballPath {
-    /// `tarball.url`, the path as written in the dependency, resolved against
-    /// the project root by `File::read_from_user_input`.
+    /// `tarball.url` as written in the dependency, resolved against the project root.
     Url,
-    /// A tarball declared by a workspace or `file:` folder package, already
-    /// joined with that package's directory.
+    /// A tarball declared by a workspace or `file:` folder package, already joined with that package's directory.
     Absolute(StringOrTinyString),
-    /// The joined path does not fit a `PathBuffer`; the task fails
-    /// with `ENAMETOOLONG` like a path the OS rejects.
+    /// The joined path does not fit a `PathBuffer`; the task fails with `ENAMETOOLONG`.
     TooLong,
 }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1968,14 +1968,27 @@ impl Package<u64> {
                         } else {
                             'brk: {
                                 let mut buf2 = PathBuffer::uninit();
+                                let Some(joined) = resolve_path::join_abs_string_buf_checked::<
+                                    path::platform::Auto,
+                                >(
+                                    FileSystem::instance().top_level_dir(),
+                                    &mut buf2.0,
+                                    &[source.path.name().dir, workspace],
+                                ) else {
+                                    log.add_error_fmt(
+                                        source,
+                                        value_loc_of(source, key_loc),
+                                        format_args!(
+                                            "Dependency \"{}\" has an unsafe workspace path",
+                                            bstr::BStr::new(external_alias.slice(buf)),
+                                        ),
+                                    );
+                                    return Err(crate::Error::InstallFailed);
+                                };
                                 let rel =
                                     resolve_path::relative_platform::<path::platform::Auto, false>(
                                         FileSystem::instance().top_level_dir(),
-                                        resolve_path::join_abs_string_buf::<path::platform::Auto>(
-                                            FileSystem::instance().top_level_dir(),
-                                            &mut buf2.0,
-                                            &[source.path.name().dir, workspace],
-                                        ),
+                                        joined,
                                     );
                                 #[cfg(windows)]
                                 {

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -361,6 +361,7 @@ impl File {
     /// Normalize a
     /// user-provided relative path against the resolver's cached
     /// `top_level_dir` (NOT a fresh `getcwd()`), then `readFrom`.
+    /// Fails with `ENAMETOOLONG` when the normalized path does not fit a `PathBuffer`.
     ///
     /// The cached `top_level_dir` lives in `bun_resolver::fs` (T5), which
     /// `bun_sys` (T1) must not depend on, so callers pass it explicitly.
@@ -371,12 +372,12 @@ impl File {
     ) -> Maybe<Vec<u8>> {
         let dir = dir.as_fd();
         let mut buf = bun_paths::PathBuffer::default();
-        let normalized = bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Loose>(
-            top_level_dir,
-            &mut buf.0,
-            &[input_path],
-        );
-        Self::read_from(dir, normalized.as_bytes())
+        let Some(normalized) = bun_paths::resolve_path::join_abs_string_buf_checked::<
+            bun_paths::platform::Loose,
+        >(top_level_dir, &mut buf.0, &[input_path]) else {
+            return Err(Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(input_path));
+        };
+        Self::read_from(dir, normalized)
     }
     /// `bun.sys.File.writeFile` — open + write + close.
     pub fn write_file(dir: impl AsFd, path: &ZStr, data: &[u8]) -> Maybe<()> {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6149,7 +6149,7 @@ pub fn openat_a(dir: impl AsFd, path: &[u8], flags: i32, perm: Mode) -> Maybe<Fd
     let dir = dir.as_fd();
     let mut buf = bun_paths::PathBuffer::default();
     if path.len() >= buf.0.len() {
-        return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(path));
+        return Err(Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(path));
     }
     buf.0[..path.len()].copy_from_slice(path);
     buf.0[path.len()] = 0;
@@ -9209,7 +9209,7 @@ pub fn write_file_with_path_buffer(
         PathOrFileDescriptor::Fd(fd) => fd,
         PathOrFileDescriptor::Path(bytes) => {
             if bytes.len() >= path_buf.0.len() {
-                return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(bytes));
+                return Err(Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(bytes));
             }
             path_buf.0[..bytes.len()].copy_from_slice(bytes);
             path_buf.0[bytes.len()] = 0;

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -856,6 +856,88 @@ describe("relative tarballs", async () => {
       }
     }
   });
+
+  // The tarball path is joined with the project root (root dependency) or the
+  // workspace directory (workspace dependency) into a PathBuffer, which holds
+  // 4096 bytes on Linux, 1024 on macOS and 32767 * 3 + 1 on Windows. These
+  // specs exceed it on every platform.
+  const LONG_SPEC_BYTES = 100_000;
+
+  // Writes a root package with one workspace, declaring `spec` as a dependency
+  // of either the root package or the workspace package.
+  async function writeTarballDependency(packageDir: string, owner: "root" | "workspace", name: string, spec: string) {
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          workspaces: ["pkgs/*"],
+          dependencies: owner === "root" ? { [name]: spec } : {},
+        }),
+      ),
+      write(
+        join(packageDir, "pkgs", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: owner === "workspace" ? { [name]: spec } : {},
+        }),
+      ),
+    ]);
+  }
+
+  test.concurrent.each(["root", "workspace"] as const)(
+    "%s dependency on a tarball path longer than the path buffer fails with ENAMETOOLONG",
+    async owner => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
+      const spec = "file:./" + Buffer.alloc(LONG_SPEC_BYTES, "a").toString() + ".tgz";
+      await writeTarballDependency(packageDir, owner, "too-long", spec);
+
+      const { err } = await runBunInstall(env, packageDir, {
+        allowErrors: true,
+        expectedExitCode: 1,
+        savesLockfile: false,
+      });
+
+      expect(err).toContain("error: ENAMETOOLONG extracting tarball from too-long");
+      expect(err).toContain("failed to resolve");
+    },
+  );
+
+  test.concurrent.each(["root", "workspace"] as const)(
+    "%s dependency on a tarball path that only fits the path buffer once normalized resolves",
+    async owner => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
+      // "x/../" repeated: longer than the path buffer as written, but it
+      // normalizes to the tarball next to the root package.json.
+      const detour = Buffer.alloc(LONG_SPEC_BYTES, "x/../").toString();
+      const spec = "./" + detour + (owner === "root" ? "" : "../../") + "qux-0.0.2.tgz";
+      await Promise.all([
+        writeTarballDependency(packageDir, owner, "qux", spec),
+        cp(join(import.meta.dir, "qux-0.0.2.tgz"), join(packageDir, "qux-0.0.2.tgz")),
+      ]);
+
+      // Reading the tarball happens while resolving. Linking it into
+      // node_modules is skipped: the linker formats the resolution into a
+      // 512 byte buffer and cannot install a spec this long yet.
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--lockfile-only"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(err).not.toContain("error:");
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("Saved bun.lock (3 packages)");
+      expect(exitCode).toBe(0);
+      const qux = parseLockfile(packageDir).packages.find((pkg: { name: string }) => pkg.name === "qux");
+      expect(qux.resolution).toMatchObject({ tag: "local_tarball", value: spec });
+    },
+  );
 });
 
 test.concurrent("$npm_package_config_ works in root", async () => {

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -7,6 +7,8 @@ import {
   assertManifestsPopulated,
   bunEnv as baseEnv,
   bunExe,
+  isLinux,
+  isWindows,
   readdirSorted,
   runBunInstall,
   toMatchNodeModulesAt,
@@ -653,6 +655,39 @@ test.concurrent("cwd in workspace script is not the symlink path on windows", as
   expect(await file(join(packageDir, "node_modules", "pkg1", "cwd")).text()).toBe(join(packageDir, "pkg1"));
 });
 
+// Local dependency paths are joined into a PathBuffer of MAX_PATH_BYTES: 4096
+// bytes on Linux, 1024 on the other POSIX platforms, 32767 * 3 + 1 on Windows.
+const PATH_BUFFER_BYTES = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
+// Longer than the buffer on every platform.
+const LONG_SPEC_BYTES = 100_000;
+const WORKSPACE_DIR = "pkgs/pkg1";
+
+// Writes a root package with one workspace at WORKSPACE_DIR, declaring `spec`
+// as a dependency of either the root package or the workspace package.
+async function writeDependency(packageDir: string, owner: "root" | "workspace", name: string, spec: string) {
+  await Promise.all([
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        workspaces: ["pkgs/*"],
+        dependencies: owner === "root" ? { [name]: spec } : {},
+      }),
+    ),
+    write(
+      join(packageDir, WORKSPACE_DIR, "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        dependencies: owner === "workspace" ? { [name]: spec } : {},
+      }),
+    ),
+  ]);
+}
+
+function runFailingInstall(env: Record<string, string>, packageDir: string) {
+  return runBunInstall(env, packageDir, { allowErrors: true, expectedExitCode: 1, savesLockfile: false });
+}
+
 describe("relative tarballs", async () => {
   test.concurrent("from package.json", async () => {
     using ctx = await setupTest();
@@ -857,52 +892,59 @@ describe("relative tarballs", async () => {
     }
   });
 
-  // The tarball path is joined with the project root (root dependency) or the
-  // workspace directory (workspace dependency) into a PathBuffer, which holds
-  // 4096 bytes on Linux, 1024 on macOS and 32767 * 3 + 1 on Windows. These
-  // specs exceed it on every platform.
-  const LONG_SPEC_BYTES = 100_000;
-
-  // Writes a root package with one workspace, declaring `spec` as a dependency
-  // of either the root package or the workspace package.
-  async function writeTarballDependency(packageDir: string, owner: "root" | "workspace", name: string, spec: string) {
-    await Promise.all([
-      write(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "foo",
-          workspaces: ["pkgs/*"],
-          dependencies: owner === "root" ? { [name]: spec } : {},
-        }),
-      ),
-      write(
-        join(packageDir, "pkgs", "pkg1", "package.json"),
-        JSON.stringify({
-          name: "pkg1",
-          dependencies: owner === "workspace" ? { [name]: spec } : {},
-        }),
-      ),
-    ]);
-  }
-
   test.concurrent.each(["root", "workspace"] as const)(
     "%s dependency on a tarball path longer than the path buffer fails with ENAMETOOLONG",
     async owner => {
       using ctx = await setupTest();
       const { packageDir, env } = ctx;
       const spec = "file:./" + Buffer.alloc(LONG_SPEC_BYTES, "a").toString() + ".tgz";
-      await writeTarballDependency(packageDir, owner, "too-long", spec);
+      await writeDependency(packageDir, owner, "too-long", spec);
 
-      const { err } = await runBunInstall(env, packageDir, {
-        allowErrors: true,
-        expectedExitCode: 1,
-        savesLockfile: false,
-      });
+      const { err } = await runFailingInstall(env, packageDir);
 
       expect(err).toContain("error: ENAMETOOLONG extracting tarball from too-long");
       expect(err).toContain("failed to resolve");
     },
   );
+
+  // A relative tarball path of exactly `bytes` bytes made of one letter
+  // directories, so that a path which fits the buffer is looked up by the OS
+  // (ENOENT) instead of tripping its own limit on the length of a single name.
+  function tarballPathOfLength(bytes: number) {
+    const tail = bytes % 2 === 0 ? "dd.tgz" : "d.tgz";
+    return Buffer.alloc(bytes - tail.length, "d/").toString() + tail;
+  }
+
+  // packageDir is a real path and the cwd of the install, so the joined path
+  // is `${packageDir}/${rel}` for the root package and
+  // `${packageDir}/${WORKSPACE_DIR}/${rel}` for the workspace. One byte below
+  // the buffer size the path still reaches the OS; at the buffer size there is
+  // no room for the NUL terminator; above it the join itself overflows. The
+  // workspace rows also tell the workspace join apart from resolving the same
+  // path against the root, which fits the buffer and reports ENOENT instead.
+  test.concurrent.each([
+    ["root", "one byte below", -1],
+    ["root", "exactly", 0],
+    ["root", "one byte above", 1],
+    ["workspace", "one byte below", -1],
+    ["workspace", "exactly", 0],
+    ["workspace", "one byte above", 1],
+  ] as const)("%s dependency whose joined tarball path is %s the path buffer size", async (owner, _, offset) => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    const joinedPrefixBytes =
+      Buffer.byteLength(packageDir) + 1 + (owner === "workspace" ? Buffer.byteLength(WORKSPACE_DIR) + 1 : 0);
+    const spec = "file:" + tarballPathOfLength(PATH_BUFFER_BYTES + offset - joinedPrefixBytes);
+    await writeDependency(packageDir, owner, "edge", spec);
+
+    const { err } = await runFailingInstall(env, packageDir);
+
+    // Windows never looks the fitting path up: it is longer than the 32767
+    // UTF-16 units a Windows path may have.
+    const expected = offset < 0 && !isWindows ? "ENOENT" : "ENAMETOOLONG";
+    expect(err).toContain(`error: ${expected} extracting tarball from edge`);
+    expect(err).toContain("failed to resolve");
+  });
 
   test.concurrent.each(["root", "workspace"] as const)(
     "%s dependency on a tarball path that only fits the path buffer once normalized resolves",
@@ -914,7 +956,7 @@ describe("relative tarballs", async () => {
       const detour = Buffer.alloc(LONG_SPEC_BYTES, "x/../").toString();
       const spec = "./" + detour + (owner === "root" ? "" : "../../") + "qux-0.0.2.tgz";
       await Promise.all([
-        writeTarballDependency(packageDir, owner, "qux", spec),
+        writeDependency(packageDir, owner, "qux", spec),
         cp(join(import.meta.dir, "qux-0.0.2.tgz"), join(packageDir, "qux-0.0.2.tgz")),
       ]);
 
@@ -939,6 +981,20 @@ describe("relative tarballs", async () => {
     },
   );
 });
+
+test.concurrent.each(["root", "workspace"] as const)(
+  "%s dependency on a workspace: path longer than the path buffer fails to install",
+  async owner => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    const spec = "workspace:./" + Buffer.alloc(LONG_SPEC_BYTES, "a").toString();
+    await writeDependency(packageDir, owner, "too-long", spec);
+
+    const { err } = await runFailingInstall(env, packageDir);
+
+    expect(err).toContain('Dependency "too-long" has an unsafe workspace path');
+  },
+);
 
 test.concurrent("$npm_package_config_ works in root", async () => {
   using ctx = await setupTest();


### PR DESCRIPTION
## Repro

```sh
mkdir probe && cd probe
bun -e 'require("fs").writeFileSync("package.json", JSON.stringify({ name: "probe", dependencies: { dep: "file:./" + "a".repeat(5000) + ".tgz" } }))'
bun install
```

```
panic: range end index 5022 out of range for slice of length 4095
```

`bun install` aborts (SIGABRT, exit 134). The same happens when the tarball dependency is declared by a workspace package instead of the root package, and for `"dep": "workspace:./" + "a".repeat(5000)` declared by either. Reproduced with `bun 1.4.0-canary.1` on Linux; the buffer is 4096 bytes on Linux, 1024 on the other POSIX platforms and 32767 * 3 + 1 on Windows.

## Cause

These specs are stored verbatim and nothing bounds their length. Three sites then join them into a stack `PathBuffer` with the unchecked `join_abs_string_buf`, whose normalizer indexes past the buffer when the result does not fit (`resolve_path.rs:1067`; the "length 4095" is the buffer minus the leading separator):

* `File::read_from_user_input` (`src/sys/file.rs`), used by the local tarball task for dependencies of the root package.
* `enqueue_local_tarball` (`PackageManagerEnqueue.rs`), which joins the workspace directory and the spec on the main thread for tarball dependencies of a workspace package.
* The `workspace:` arm of `Package::parse_dependency` (`lockfile/Package.rs`), for `workspace:<path>` specs that do not name a workspace. The `file:` folder arm next to it already uses the checked join.

## Fix

All three use `join_abs_string_buf_checked`, which still succeeds when an over-long spec normalizes down (`x/../x/../...`) and returns `None` only when the normalized path does not fit.

* `read_from_user_input` returns `ENAMETOOLONG`, the same error `openat_a` already returns for a `&[u8]` path that does not fit a `PathBuffer`.
* The workspace join happens before the task exists, so `LocalTarballRequest`'s `(tarball_path, normalize)` pair becomes a `TarballPath` enum: `Url` (resolve `tarball.url` against the project root on the worker; this no longer interns a second copy of the same path), `Absolute` (pre-joined path) and `TooLong`, which the worker reports as `Error::Sys(ENAMETOOLONG)`.
* The `workspace:` arm reports `Dependency "x" has an unsafe workspace path` and fails the install, mirroring the folder arm's `unsafe folder path`.
* `openat_a` (which both tarball sites end up in for a path of exactly `MAX_PATH_BYTES`, where the join fits but there is no room for the NUL) built its error from `libc::ENAMETOOLONG`. On Windows that is the MSVC value 38, and `bun_sys::Error` decodes the stored value against bun's own errno table, where 38 is `ENOSYS`; the boundary tests below reported `ENOSYS extracting tarball` on both Windows lanes. It and the identical guard in `write_file_with_path_buffer` now use the typed `E::ENAMETOOLONG`, like the rest of `bun_sys`. Linux and macOS are unaffected (libc's numbers and bun's table agree there).

Tarballs fail through the task's existing failure path, so both tarball cases print exactly what a too-long path rejected by the OS already prints today:

```
error: ENAMETOOLONG extracting tarball from dep
error: dep@file:./aaaa... failed to resolve
```

and `bun install` exits 1. A path that does not fit `PATH_MAX` can never be opened, so `ENAMETOOLONG` is the accurate error for the buffer case too; the kernel's answer is given one layer earlier instead of indexing out of bounds. Using the checked join rather than a length check on the spec keeps `..`-heavy specs that normalize to a valid path working, which the positive tests pin down.

## Rebase note

#38867 landed on main and generalized the workspace-relative join in `enqueue_local_tarball` into `local_tarball_base_dir`, which also covers tarballs declared by `file:` folder packages and filters out overrides/resolutions/catalogs. The rebase keeps that helper and routes its result through the checked join into `TarballPath`, so `Absolute`/`TooLong` now apply to folder-package tarballs as well as workspace ones. All 87 tests in `bun-workspaces.test.ts` pass after the rebase.

## Not in this PR

* #35863 (open) changes the shared primitive to return an empty path on overflow. That would turn these panics into a misleading `ENOENT`; this PR fixes the call sites so they report the real error either way. The two are independent.
* `folder_resolver::normalize_package_json_path` has overflows of its own, reached by `file:` folder specs whose joined path is within 13 bytes of the buffer size and by any `link:` spec over 1024 bytes (it normalizes through a 1024 byte thread-local buffer). Different mechanism and function; reported separately, still panics after this PR. The `workspace:` change here gives those specs the behaviour folder specs have today, no more.
* The same `from_code_int(libc::...)` mistake exists in a few Windows-compiled stubs in `bun_sys` (`writev`/`readv`/`preadv`, `get_fcntl_flags`, `clonefile`), where `libc::ENOSYS` / `ENOTSUP` decode as `ELOOP` / `EKEYREJECTED`. Reported separately; only the two `ENAMETOOLONG` sites the tests here exercise are changed.
* Linking a package whose resolution string is over 512 bytes panics in `PackageInstaller::install_package_with_name_and_resolution` (reproducible with a valid tarball at a 618 byte relative path, no overflow involved). Also reported separately. The positive tests below use `--lockfile-only`, which stops after the tarball has been read and extracted, and check the lockfile instead of `node_modules`.

## Tests

`test/cli/install/bun-workspaces.test.ts`, each case for a root dependency and for a workspace dependency:

* a 100 kB tarball path (longer than the buffer on every platform) fails with `ENAMETOOLONG extracting tarball from too-long`, exit 1
* a tarball path whose joined length is one byte below, exactly at and one byte above the buffer size (computed from the temp dir, which is the install's cwd): `ENOENT` for the one that fits (`ENAMETOOLONG` on Windows, which rejects anything over 32767 UTF-16 units before looking it up), `ENAMETOOLONG` for the other two. The workspace row above the limit is what pins `TarballPath::TooLong`: with the worker handling it like `Url`, that path fits when joined with the root and comes back `ENOENT` (verified by making exactly that change locally; the 100 kB case cannot tell the two apart because it overflows both joins)
* a 100 kB `x/../x/../...` path that normalizes to an existing tarball resolves (`local_tarball` entry in the lockfile)
* a 100 kB `workspace:` path fails with `unsafe workspace path`

On the unfixed build (`USE_SYSTEM_BUN=1`) 7 of the 12 crash with the panics above (both 100 kB tarball cases, root at and above the limit, workspace above the limit, both `workspace:` cases); the other 5 behave the same before and after. All 75 tests in the file pass with `bun bd test` on Linux, as do the workspace and `tarball path` tests in `bun-install.test.ts` and the local tarball tests in `bun-add.test.ts`. The 12 new tests also pass with a debug build on Windows x64 (before the `openat_a` change the two "exactly" rows failed there with `ENOSYS`, see the Windows lanes of the previous CI run). `cargo check -p bun_install` passes for `x86_64-pc-windows-msvc` and `x86_64-apple-darwin`; clippy is clean for `bun_sys` and `bun_install`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-workspaces.test.ts

<!-- robobun:evidence:end -->
