### PR TITLE
uws: only flag the parsed socket as upgraded in HttpResponse::upgrade()

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -331,7 +331,6 @@ private:
         /* Mark that we are inside the parser now. Save/restore the parsed
          * socket: node:http's read replay can nest a parse inside another
          * socket's dispatch. */
-        httpContextData->flags.isParsingHttp = true;
         struct us_socket_t *prevParsingSocket = httpContextData->parsingSocket;
         httpContextData->parsingSocket = s;
         httpResponseData->isIdle = false;
@@ -584,7 +583,6 @@ private:
         auto httpErrorStatusCode = result.httpErrorStatusCode();
 
         /* Mark that we are no longer parsing Http */
-        httpContextData->flags.isParsingHttp = false;
         httpContextData->parsingSocket = prevParsingSocket;
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -28,7 +28,6 @@ template<bool> struct HttpResponse;
 struct HttpRequest;
 
 struct HttpFlags {
-    bool isParsingHttp: 1 = false;
     bool rejectUnauthorized: 1 = false;
     bool usingCustomExpectHandler: 1 = false;
     bool requireHostHeader: 1 = true;
@@ -69,11 +68,14 @@ private:
     HttpRouter<RouterData> *currentRouter = &router;
 
     /* The socket onData is currently parsing, nullptr outside a parse. The
-     * close gates in internalEnd need the per-socket identity: a DIFFERENT
-     * socket's response can complete inside this window (a microtask drained
-     * during a request dispatch), and the context-wide isParsingHttp bit
-     * alone would wrongly defer its close to a post-parse gate that only
-     * checks the parsed socket. */
+     * close gates in internalEnd and the upgradedWebSocket hand-over in
+     * upgrade() need the per-socket identity: a DIFFERENT socket's response
+     * can complete, or be upgraded, inside this window (a microtask drained
+     * during a request dispatch, a handler upgrading a request it parked
+     * earlier), and a context-wide "parsing" bit would attribute that to the
+     * parsed socket: deferring its close to a post-parse gate that only checks
+     * the parsed socket, or making onData hand the parsed socket's read over
+     * to the other connection's WebSocket. */
     struct us_socket_t *parsingSocket = nullptr;
 
     /* This is the default router for default SNI or non-SSL */

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -416,6 +416,14 @@ public:
         LoopData *loopData = Super::getLoopData();
         int corkedSlot = loopData->findCorkSlot(this);
 
+        /* Only the socket onData is parsing right now may redirect the parser.
+         * Any other socket's request can be upgraded inside that window too (a
+         * handler upgrading a request it parked earlier, or a drained microtask
+         * finishing an async upgrade); to the parser that is an "async"
+         * upgrade and must leave the parsed socket alone. Decided before the
+         * adoption below, which may move this socket. */
+        const bool upgradingParsedSocket = httpContextData->parsingSocket == (us_socket_t *) this;
+
         /* Adopting a socket invalidates it, do not rely on it directly to carry any data */
         /* The old ext size is only used as an upper bound to keep the block in
          * place (and as the copy length when it cannot be). The base size is
@@ -439,9 +447,8 @@ public:
             httpContextData->onSocketUpgraded(socketData, SSL, usSocket);
         }
 
-        /* We should only mark this if inside the parser; if upgrading "async" we cannot set this */
-        if (httpContextData->flags.isParsingHttp) {
-            /* We need to tell the Http parser that we changed socket */
+        /* We need to tell the Http parser that we changed socket */
+        if (upgradingParsedSocket) {
             httpContextData->upgradedWebSocket = webSocket;
         }
 

--- a/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
+++ b/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
@@ -214,6 +214,13 @@ test("server.upgrade() of a request parked by another connection leaves the conn
   });
 
   const ws = new WebSocket(new URL("/ws", server.url).href.replace("http", "ws"));
+  const websocketFailed = (event: Event) => {
+    const error = new Error(`client WebSocket ${event.type}`);
+    requestParked.reject(error);
+    websocketOpened.reject(error);
+  };
+  ws.addEventListener("error", websocketFailed);
+  ws.addEventListener("close", websocketFailed);
   await requestParked.promise;
 
   // Both requests in one write so the parser sees the second one in the same
@@ -244,12 +251,12 @@ test("server.upgrade() of a request parked by another connection leaves the conn
     },
   });
 
-  await connectionClosed.promise;
+  await Promise.all([connectionClosed.promise, websocketOpened.promise]);
   const responses = Buffer.concat(received).toString();
   expect(responses.match(/HTTP\/1\.1 200 OK\r\n/g)).toHaveLength(2);
   expect(responses).toEndWith("\r\n\r\n/second");
   expect(responses).toContain("\r\n\r\napproved");
 
-  await websocketOpened.promise;
+  ws.removeEventListener("close", websocketFailed);
   ws.close();
 });

--- a/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
+++ b/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
@@ -171,3 +171,85 @@ for (const via of ["data", "headers"] as const) {
     expect(exitCode).toBe(0);
   });
 }
+
+// uws marks the connection its parser is currently working on as "upgraded"
+// when server.upgrade() runs inside a request dispatch. That mark used to be
+// set for ANY upgrade performed during the dispatch, including one for a
+// request that arrived on a different connection (parked by fetch() and
+// upgraded later from another request's handler, or from a microtask drained
+// during it). The connection actually being parsed was then treated as gone:
+// the rest of its read buffer (pipelined requests) was dropped and its
+// post-parse bookkeeping skipped.
+test("server.upgrade() of a request parked by another connection leaves the connection being parsed intact", async () => {
+  let parked: { request: Request; resolve: (response: Response | undefined) => void } | undefined;
+  const requestParked = Promise.withResolvers<void>();
+  const websocketOpened = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request, server) {
+      const { pathname } = new URL(request.url);
+      switch (pathname) {
+        case "/ws":
+          return new Promise<Response | undefined>(resolve => {
+            parked = { request, resolve };
+            requestParked.resolve();
+          });
+        case "/approve": {
+          const upgraded = server.upgrade(parked!.request);
+          parked!.resolve(undefined);
+          return new Response(upgraded ? "approved" : "upgrade failed");
+        }
+        default:
+          return new Response(pathname);
+      }
+    },
+    websocket: {
+      open() {
+        websocketOpened.resolve();
+      },
+      message() {},
+    },
+  });
+
+  const ws = new WebSocket(new URL("/ws", server.url).href.replace("http", "ws"));
+  await requestParked.promise;
+
+  // Both requests in one write so the parser sees the second one in the same
+  // read as the one whose handler performs the upgrade. `Connection: close`
+  // on the second makes the server close the connection once it has been
+  // answered; a dropped second request leaves the connection open instead.
+  const received: Buffer[] = [];
+  const connectionClosed = Promise.withResolvers<void>();
+  await Bun.connect({
+    hostname: server.hostname,
+    port: server.port,
+    socket: {
+      open(socket) {
+        socket.write(
+          "GET /approve HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n" +
+            "GET /second HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        );
+      },
+      data(_socket, data) {
+        received.push(Buffer.from(data));
+      },
+      close() {
+        connectionClosed.resolve();
+      },
+      error(_socket, error) {
+        connectionClosed.reject(error);
+      },
+    },
+  });
+
+  await connectionClosed.promise;
+  const responses = Buffer.concat(received).toString();
+  expect(responses.match(/HTTP\/1\.1 200 OK\r\n/g)).toHaveLength(2);
+  expect(responses).toEndWith("\r\n\r\n/second");
+  expect(responses).toContain("\r\n\r\napproved");
+
+  await websocketOpened.promise;
+  ws.close();
+});


### PR DESCRIPTION
Follow-up to #37074 in the same spirit: `HttpResponse::upgrade()` still decided whether to hand the parser over to the new WebSocket using the context-wide `isParsingHttp` bit, so an upgrade performed for a request that belongs to a *different* connection, while some connection of the same server is being parsed, was attributed to the connection being parsed.

## Repro

A handler parks an upgrade request and a request on another connection performs it later (a drained microtask finishing an async upgrade inside another request's dispatch takes the same path). The performing connection has a second request pipelined behind the first:

```ts
let parked: Request;
Bun.serve({
  fetch(req, server) {
    switch (new URL(req.url).pathname) {
      case "/ws":      parked = req; return new Promise(() => {});
      case "/approve": server.upgrade(parked); return new Response("approved");
      default:         return new Response("second");
    }
  },
  websocket: { message() {} },
});
// raw client, one write:
// "GET /approve HTTP/1.1\r\n\r\nGET /second HTTP/1.1\r\nConnection: close\r\n\r\n"
```

Before: the client receives `approved` (flushed by the end-of-tick cork drain) and nothing else; `/second` is never answered and the connection stays open. After: both responses, then the server closes the connection.

## Cause

`upgrade()` ran while `/approve` was being parsed, so it set `httpContextData->upgradedWebSocket` to the `/ws` connection's WebSocket. The request-handler arm in `HttpContext::onData` reads that as "the socket I am parsing was upgraded" and returns early: the rest of the read buffer is dropped, the post-parse path for the parsed socket (unref, uncork, `Connection: close` gate) is skipped, and `onData` uncorks the other connection's WebSocket and returns it to the event loop as the socket that had just been read (`loop.c` then continues the readable dispatch on it; with kqueue's EV_EOF riding on the same event that is the socket that gets closed).

## Fix

Compare against `parsingSocket` (added by #37074 for the close gates, which had the same problem) instead of the context-wide bit: only an upgrade of the socket `onData` is currently parsing redirects the parser; anything else is an async upgrade as far as the parser is concerned. The comparison is taken before `us_socket_adopt`, which may move the socket. `isParsingHttp` had no other readers and is removed.

The synchronous case is unchanged: the response being upgraded inside its own dispatch is `parsingSocket`. An upgrade can only happen inside a body dispatch for a request that has an upgrade context, and those are created without a body (`on_web_socket_upgrade`), so the data-handler arm does not need the same check.

## Verification

New case in `test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts`: times out waiting for the second response on the current build (also on the released 1.4.0), passes with the fix. `test/js/bun/websocket/`, `test/js/first_party/ws/ws.test.ts`, `ws-upgrade-events.test.ts`, `test/js/node/http/node-http-with-ws.test.ts` and `test/js/bun/http/bun-server.test.ts` otherwise unchanged (the failures I see locally in the last two, `localhost` connection refusals and the 30s send benchmark, reproduce without this change).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts

<!-- robobun:evidence:end -->