### PR TITLE
Report EBADF instead of UV_EBADF for async libuv fs errors on Windows

### DIFF
--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2362,6 +2362,21 @@ pub const fn uv_err_to_e_discriminant(code: c_int) -> Option<u16> {
     })
 }
 
+/// `E::UNKNOWN` discriminant (see the `UV_UNKNOWN` row above).
+const E_UNKNOWN_DISCRIMINANT: u16 = 134;
+
+/// [`uv_err_to_e_discriminant`] for a code that is already known to be a
+/// failure: codes missing from the table fold to `E::UNKNOWN` (the same
+/// fallback as `bun_errno::translate_uv_error_to_e`) instead of disappearing,
+/// so a negative libuv result is always reported as an error.
+#[inline]
+const fn uv_err_to_e_discriminant_lossy(code: c_int) -> u16 {
+    match uv_err_to_e_discriminant(code) {
+        Some(discriminant) => discriminant,
+        None => E_UNKNOWN_DISCRIMINANT,
+    }
+}
+
 /// Reverse of [`uv_err_to_e_discriminant`]: map a `bun.sys.E` / `bun_errno::E`
 /// discriminant to the negative `UV_E*` code node reports in `err.errno` on
 /// Windows (`2` → `UV_ENOENT (-4058)`). Same layering rule (no `bun_errno`
@@ -2516,15 +2531,14 @@ impl ReturnCode {
     }
     /// When negative, map the
     /// `UV_E*` code to the small POSIX `bun.sys.E` discriminant (e.g.
-    /// `UV_ENOENT (-4058)` → `2`). Returns `None` for non-negative *or*
-    /// unmapped negative codes. Downstream callers
+    /// `UV_ENOENT (-4058)` → `2`); `None` when non-negative. Downstream callers
     /// (`node_fs`, `sys::Fd`, `write_file`, …) store this directly into
     /// `bun_sys::Error.errno`, so it MUST be the translated value, not the raw
     /// `|UV_E*|` magnitude — see [`raw_errno`] for the latter.
     #[inline]
     pub const fn errno(self) -> Option<u16> {
         if self.0 < 0 {
-            uv_err_to_e_discriminant(self.0)
+            Some(uv_err_to_e_discriminant_lossy(self.0))
         } else {
             None
         }
@@ -2566,25 +2580,28 @@ impl ReturnCodeI64 {
     pub const fn int(self) -> i64 {
         self.0
     }
+    /// Same contract as [`ReturnCode::errno`]: a negative `req.result` is a
+    /// `UV_E*` code, translated to the `bun.sys.E` discriminant that
+    /// `bun_sys::Error.errno` stores. Storing the raw `|UV_E*|` magnitude there
+    /// instead resolves to the sparse `E::UV_E*` tail variants on Windows, which
+    /// JS then sees as `code: "UV_EBADF"` with an "unknown error" message.
     #[inline]
     pub const fn errno(self) -> Option<u16> {
-        if self.0 < 0 {
-            Some(self.0.unsigned_abs() as u16)
-        } else {
-            None
+        if self.0 >= 0 {
+            return None;
         }
+        Some(if self.0 < c_int::MIN as i64 {
+            E_UNKNOWN_DISCRIMINANT
+        } else {
+            uv_err_to_e_discriminant_lossy(self.0 as c_int)
+        })
     }
-    /// Translated `bun_sys::E`
-    /// discriminant via [`uv_err_to_e_discriminant`] (matching
-    /// [`ReturnCode::err_enum`]). For the typed `bun_sys::E` use
-    /// `bun_sys::ReturnCodeExt::err_enum_e` (layering: `E` lives upstream).
+    /// Same translated value as [`errno`] (matching [`ReturnCode::err_enum`]).
+    /// For the typed `bun_sys::E` use `bun_sys::ReturnCodeExt::err_enum_e`
+    /// (layering: `E` lives upstream).
     #[inline]
     pub const fn err_enum(self) -> Option<u16> {
-        if self.0 < 0 {
-            uv_err_to_e_discriminant(self.0 as c_int)
-        } else {
-            None
-        }
+        self.errno()
     }
     /// `req.result` after a successful `uv_fs_open` is the
     /// CRT fd. Returns the raw `uv_file`; caller wraps with `Fd::from_uv`
@@ -2600,6 +2617,32 @@ impl fmt::Display for ReturnCodeI64 {
         write!(f, "{}", self.0)
     }
 }
+
+// Both return-code types hand out the same translated errno, and a failure
+// never reads as success.
+const _: () = {
+    assert!(matches!(ReturnCode::from_raw(UV_EBADF).errno(), Some(9)));
+    assert!(matches!(
+        ReturnCodeI64::init(UV_EBADF as i64).errno(),
+        Some(9)
+    ));
+    assert!(ReturnCode::from_raw(0).errno().is_none());
+    assert!(ReturnCodeI64::init(0).errno().is_none());
+    assert!(ReturnCodeI64::init(i64::MAX).errno().is_none());
+    // -4000 sits in a gap no UV_E* constant occupies.
+    assert!(matches!(
+        ReturnCode::from_raw(-4000).errno(),
+        Some(E_UNKNOWN_DISCRIMINANT)
+    ));
+    assert!(matches!(
+        ReturnCodeI64::init(-4000).errno(),
+        Some(E_UNKNOWN_DISCRIMINANT)
+    ));
+    assert!(matches!(
+        ReturnCodeI64::init(i64::MIN).errno(),
+        Some(E_UNKNOWN_DISCRIMINANT)
+    ));
+};
 
 // ──────────────────────────────────────────────────────────────────────────
 // `O` — `UV_FS_O_*` flag namespace + `from_bun_o`/`to_bun_o` translation.

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -121,8 +121,9 @@ impl Error {
         })
     }
 
-    /// `Some(err)` when a libuv `ReturnCodeI64` is negative; `None` on success.
-    /// `from_libuv` left at default `false`.
+    /// `Some(err)` when a libuv `ReturnCodeI64` (an async `uv_fs_t.result`) is
+    /// negative; `None` on success. Like [`from_uv_rc`], `ReturnCodeI64::errno()`
+    /// already yields the POSIX `E` discriminant, so `from_libuv` stays `false`.
     #[cfg(windows)]
     #[inline]
     pub(crate) fn from_uv_rc64(

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -137,6 +137,71 @@ const IS_UV_FS_COPYFILE_DISABLED =
     }
   });
 
+  // On Windows the write happens in a libuv completion callback. The error it
+  // reported used to carry the raw libuv code, which JS saw as code "UV_EBADF"
+  // and message "UV_EBADF: unknown error, write"; Node and POSIX say EBADF.
+  describe("Bun.write(Bun.file(read-only fd), data) rejects with EBADF", () => {
+    it.each([
+      ["string", "abc"],
+      ["Uint8Array", new Uint8Array(3)],
+    ])("%s", async (_label, data) => {
+      using dir = tempDir("bun-write-ebadf", { "target.txt": "original" });
+      const target = join(String(dir), "target.txt");
+      const fd = fs.openSync(target, "r");
+      let caught;
+      try {
+        await Bun.write(Bun.file(fd), data);
+      } catch (e) {
+        caught = e;
+      } finally {
+        fs.closeSync(fd);
+      }
+      expect(caught).toBeDefined();
+      const { code, errno, syscall, message } = caught;
+      expect({ code, errno, syscall, message }).toEqual({
+        code: "EBADF",
+        errno: isWindows ? -4083 : -9,
+        syscall: "write",
+        message: "EBADF: bad file descriptor, write",
+      });
+      expect(fs.readFileSync(target, "utf8")).toBe("original");
+    });
+
+    // A pipe source cannot go through uv_fs_copyfile, so this exercises the
+    // uv_fs_read/uv_fs_write loop instead of the single write above. POSIX
+    // rejects a pipe source earlier with a different error, so Windows only.
+    it.skipIf(!isWindows)("Bun.stdin pipe source", async () => {
+      using dir = tempDir("bun-write-ebadf-pipe", { "target.txt": "original" });
+      const target = join(String(dir), "target.txt");
+      const fixture = `
+        const fs = require("fs");
+        const fd = fs.openSync(${JSON.stringify(target)}, "r");
+        try {
+          await Bun.write(Bun.file(fd), Bun.stdin);
+          console.log("resolved");
+        } catch (e) {
+          console.log(JSON.stringify({ code: e.code, errno: e.errno, syscall: e.syscall, message: e.message }));
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdin: new Blob(["hello from the pipe"]),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        code: "EBADF",
+        errno: -4083,
+        syscall: "write",
+        message: "EBADF: bad file descriptor, write",
+      });
+      expect(exitCode).toBe(0);
+      expect(fs.readFileSync(target, "utf8")).toBe("original");
+    });
+  });
+
   describe.each(["plain-ascii-missing.txt", "surro-\ud800-gate.txt"])(
     "Bun.write(dest, Bun.file(missing source)) rejects with ENOENT (%s)",
     basename => {

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -60,6 +60,31 @@ test("Bun.file() read errors include async stack frames", async () => {
   expect(caught.code).toBe("ENOENT");
   expect(caught.stack).toContain("at async level2");
   expect(caught.stack).toContain("at async level1");
+});
+
+// Windows reads the stream through a libuv callback, whose error used to reach
+// JS as code "UV_EBADF" with an "unknown error" message. Bun.file(fd).text()
+// is not affected; only stream() takes this path. On POSIX a failing read does
+// not settle the pull at all yet, so the test is Windows-only.
+test.skipIf(!isWindows)("Bun.file(write-only fd).stream() rejects with EBADF", async () => {
+  await using dir = tempDir("bun-file-stream-ebadf", { "target.txt": "some content" });
+  const handle = await fsPromises.open(join(dir, "target.txt"), "a");
+  let caught: any;
+  try {
+    await Bun.file(handle.fd).stream().getReader().read();
+  } catch (e) {
+    caught = e;
+  } finally {
+    await handle.close();
+  }
+  expect(caught).toBeDefined();
+  const { code, errno, syscall, message } = caught;
+  expect({ code, errno, syscall, message }).toEqual({
+    code: "EBADF",
+    errno: -4083,
+    syscall: "read",
+    message: "EBADF: bad file descriptor, read",
+  });
 });
 
 test("Bun.write() errors include async stack frames", async () => {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -462,6 +462,35 @@ if (isWindows) {
     );
   });
 }
+
+// On Windows the file write completes in a libuv callback, whose error used
+// to reach JS as code "UV_EBADF" with an "unknown error" message.
+it("writing to a read-only fd reports EBADF", async () => {
+  using dir = tempDir("filesink-ebadf", { "target.txt": "original" });
+  const target = join(String(dir), "target.txt");
+  const fd = fs.openSync(target, "r");
+  let caught: any;
+  try {
+    const sink = Bun.file(fd).writer();
+    sink.write("abc");
+    await sink.end();
+  } catch (e) {
+    caught = e;
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {}
+  }
+  expect(caught).toBeDefined();
+  const { code, errno, syscall, message } = caught;
+  expect({ code, errno, syscall, message }).toEqual({
+    code: "EBADF",
+    errno: isWindows ? -4083 : -9,
+    syscall: "write",
+    message: "EBADF: bad file descriptor, write",
+  });
+  expect(fs.readFileSync(target, "utf8")).toBe("original");
+});
 
 // When a write to a pollable fd returns `.pending`, FileSink takes a
 // `must_be_kept_alive_until_eof` ref on itself so it survives until the


### PR DESCRIPTION
### Repro (Windows only)

```js
const fs = require("fs");
const fd = fs.openSync("existing.txt", "r");
Bun.write(Bun.file(fd), "abc").catch(e => console.log(e.code, "|", e.message));
```

```
Windows:  UV_EBADF | UV_EBADF: unknown error, write
POSIX:    EBADF    | EBADF: bad file descriptor, write
Node:     EBADF    | EBADF: bad file descriptor, write   (errno -4083 on Windows, same as Bun)
```

`Bun.write(Bun.file(fd), new Uint8Array(3))`, `Bun.write(Bun.file(fd), Bun.stdin)` with a piped stdin, `Bun.file(fd).writer()` and `Bun.file(fd).stream()` on a write-only fd all report the same `UV_E*` code on Windows. `node:fs` on the same fd, and `Bun.file(fd).text()`, already report `EBADF`. User code checking `err.code === "EBADF"` (or any other errno name) therefore fails on Windows for these Bun APIs only.

### Cause

libuv hands back an error either as the `c_int` return value of a synchronous call (`ReturnCode`) or, for asynchronous requests, in `uv_fs_t.result` (`ReturnCodeI64`). `ReturnCode::errno()` maps the negative `UV_E*` code to the POSIX `E` discriminant that `bun_sys::Error.errno` stores; `ReturnCodeI64::errno()` returned the raw `|UV_E*|` magnitude (4083 for `UV_EBADF`) instead. Every consumer treats the two the same way and stores the value with `from_libuv` unset: `Error::from_uv_rc64` (behind `ReturnCodeI64::to_error`, used by `CopyFileWindows`'s read/write loop and the `PipeWriter`/`PipeReader` file completions that back `FileSink` and `Bun.file().stream()`), and `WriteFileWindows::on_write_complete` directly.

Nothing catches this because on Windows the `E` enum also declares the sparse `UV_E*` tail variants at exactly those magnitudes, so `Error::resolve_system_errno` turns 4083 into `E::UV_EBADF`: strum names it `UV_EBADF`, and the libuv message table only has labels for the `E*` variants, hence "unknown error". Rust-side comparisons such as `err.get_errno() == E::EPIPE` (for example the shell's broken-pipe bookkeeping in `IOWriter::fail_pending_writers`) also never matched errors produced by these paths on Windows. The asymmetry between the two return-code types predates the Rust port.

### Fix

`ReturnCodeI64::errno()` translates the code exactly like `ReturnCode::errno()`; `err_enum()` is now an alias of it, as it already was on `ReturnCode`. The translation is shared through one helper that folds codes missing from the table to `E::UNKNOWN` (the fallback `translate_uv_error_to_e` already uses), so a negative result can never come back as `None` and be mistaken for success. That matters for the async callers, which go on to `try_from(rc.int()).expect(..)` on the "success" path; every code in libuv's `errno.h` is in the table today, so this only changes what would happen on a future libuv addition. A compile-time block pins both types to the same contract.

Fixing the producer rather than teaching `resolve_system_errno` to fold `UV_E*` variants keeps `Error.errno` holding one kind of value for `from_libuv == false`, which is what `get_errno()`/`is_retry()` assume. The `node:fs` completion handlers, which store the raw magnitude with `from_libuv: true`, are a separate convention and are left alone; #32066 is reworking those and independently adds the same unmapped-code fallback to `ReturnCode::errno()`, while explicitly leaving this mislabeling out of scope, so the two overlap only in that hunk.

### Verification

New tests cover each affected producer: `Bun.write(Bun.file(fd), string | Uint8Array)` and `Bun.write(Bun.file(fd), Bun.stdin)` in `test/js/bun/io/bun-write.test.js`, `Bun.file(fd).writer()` in `test/js/bun/util/filesink.test.ts`, `Bun.file(fd).stream()` in `test/js/bun/util/bun-file.test.ts`. The write tests assert the same code/errno/message on every platform (errno is `-4083` on Windows and `-9` elsewhere, matching Node); the pipe-source and stream tests are Windows only because POSIX takes different paths there (a pipe source is rejected earlier, and a failing `stream()` read does not settle yet).

On Windows x64, all five cases fail with bun 1.4.0 (`"code": "UV_EBADF"`, `"message": "UV_EBADF: unknown error, write"`) and pass with this branch; `bun-write.test.js`, `filesink.test.ts`, `bun-file.test.ts`, `spawn.test.ts`, `translate-uv-error-windows.test.ts` and `error-name-from-libuv.test.ts` pass on the debug build. On POSIX the new tests pass before and after, since the changed code is `#[cfg(windows)]`. `cargo check` and clippy are clean for `bun_libuv_sys`/`bun_sys` on `x86_64-pc-windows-msvc`.
