### PR TITLE
spawn: add a `cgroup` option (Linux)

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -168,6 +168,27 @@ console.log(`CPU time (user): ${usage.cpuTime.user} µs`);
 console.log(`CPU time (system): ${usage.cpuTime.system} µs`);
 ```
 
+## Resource limits with cgroups (Linux)
+
+On Linux, pass `cgroup` to start the subprocess inside a [control group](https://docs.kernel.org/admin-guide/cgroup-v2.html). The child joins the cgroup before it begins executing, so limits configured on it — memory, pids, CPU — apply from the first instruction and to every process the child spawns in turn. When a memory limit is exceeded the kernel OOM-kills a process _inside_ the cgroup instead of reclaiming memory from the parent.
+
+A cgroup is a directory under `/sys/fs/cgroup`; create and configure it with ordinary file operations, then pass its path (or an open directory file descriptor):
+
+```ts index.ts icon="/icons/typescript.svg"
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const dir = "/sys/fs/cgroup/build-jobs";
+mkdirSync(dir, { recursive: true });
+writeFileSync(`${dir}/memory.max`, String(2 * 1024 ** 3)); // cgroup v1: memory.limit_in_bytes
+
+const proc = Bun.spawn({
+  cmd: ["make", "-j8"],
+  cgroup: dir,
+});
+```
+
+The same directory can be passed to any number of spawns; the limit applies to their combined usage. Both cgroup v1 and v2 hierarchies are supported. Creating cgroups typically requires root or a delegated subtree. On other platforms the option is ignored; on Linux, the spawn fails if the cgroup cannot be joined.
+
 ## Using AbortSignal
 
 You can abort a subprocess using an `AbortSignal`:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6962,6 +6962,33 @@ declare module "bun" {
       gid?: number;
 
       /**
+       * Start the child process inside this control group.
+       *
+       * Pass the path of an existing cgroup directory (e.g.
+       * `"/sys/fs/cgroup/my-jobs"`), or an open file descriptor for one. The
+       * child joins it before it begins executing, so resource limits
+       * configured on the cgroup (`memory.max`, `pids.max`, …) apply from its
+       * first instruction and to everything it spawns in turn. Works with both
+       * cgroup v1 and v2 hierarchies.
+       *
+       * Bun does not create or configure the cgroup; do that with `node:fs`
+       * beforehand.
+       *
+       * Linux only; ignored on other platforms. On Linux, the spawn fails if
+       * the cgroup cannot be joined (e.g. the directory does not exist).
+       *
+       * @example
+       * ```ts
+       * import { mkdirSync, writeFileSync } from "node:fs";
+       * const dir = "/sys/fs/cgroup/build-jobs";
+       * mkdirSync(dir, { recursive: true });
+       * writeFileSync(dir + "/memory.max", String(2 * 1024 ** 3));
+       * Bun.spawn({ cmd: ["make"], cgroup: dir });
+       * ```
+       */
+      cgroup?: string | number;
+
+      /**
        * The environment variables of the process
        *
        * Defaults to `process.env` as it was when the current Bun process launched.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4602,6 +4602,8 @@ pub mod spawn_ffi {
         pub gid: u32,
         pub set_uid: bool,
         pub set_gid: bool,
+        /// Linux: directory fd of the cgroup the child starts in. -1 = unset.
+        pub cgroup_fd: c_int,
     }
 
     impl Default for BunSpawnRequest {
@@ -4617,6 +4619,7 @@ pub mod spawn_ffi {
                 gid: 0,
                 set_uid: false,
                 set_gid: false,
+                cgroup_fd: -1,
             }
         }
     }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -238,6 +238,7 @@ function execFile(file, args, options, callback) {
     killSignal: options.killSignal,
     uid: options.uid,
     gid: options.gid,
+    cgroup: options.cgroup,
     windowsHide: options.windowsHide,
     windowsVerbatimArguments: options.windowsVerbatimArguments,
     shell: options.shell,
@@ -569,6 +570,7 @@ function spawnSync(file, args, options) {
       detached: options.detached,
       uid: options.uid,
       gid: options.gid,
+      cgroup: options.cgroup,
       windowsVerbatimArguments: options.windowsVerbatimArguments,
       windowsHide: options.windowsHide,
       argv0: options.args[0],
@@ -1410,6 +1412,7 @@ class ChildProcess extends EventEmitter {
         detached: typeof detachedOption !== "undefined" ? !!detachedOption : false,
         uid: options.uid,
         gid: options.gid,
+        cgroup: options.cgroup,
         onExit: (handle, exitCode, signalCode, err) => {
           this.#handle = handle;
           this.pid = this.#handle.pid;

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -3,6 +3,7 @@
 #if OS(LINUX) || OS(DARWIN) || OS(FREEBSD)
 
 #include <fcntl.h>
+#include <atomic>
 #include <cstring>
 #include <signal.h>
 #include <unistd.h>
@@ -208,8 +209,11 @@ template<typename Fn>
 static void cloneTrampoline(void* ctx)
 {
     (*static_cast<Fn*>(ctx))();
-    rawExit(127);
 }
+
+// Kernels < 5.3 and common container seccomp profiles return ENOSYS for
+// clone3; don't keep asking.
+static std::atomic<bool> clone3Unavailable { false };
 
 #if __has_feature(address_sanitizer)
 // What compiler-rt's vfork interceptor calls in the parent: the child ran
@@ -257,10 +261,8 @@ extern "C" ssize_t posix_spawn_bun(
     int saved_dumpable = (request->set_uid || request->set_gid) ? prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) : -1;
     volatile bool cgroup_failed = false;
     bool join_cgroup_in_child = false;
-    pid_t child = -1;
-#else
-    pid_t child = -1;
 #endif
+    pid_t child = -1;
 
 #if OS(DARWIN) || OS(FREEBSD)
     const auto childFailed = [&]() -> ssize_t {
@@ -302,7 +304,7 @@ extern "C" ssize_t posix_spawn_bun(
         // touches is charged to the cgroup. Writing "0" moves the writer.
         if (join_cgroup_in_child) {
             int procs = openat(request->cgroup_fd, "cgroup.procs", O_WRONLY | O_CLOEXEC);
-            if (procs < 0 || write(procs, "0", 1) < 0) {
+            if (procs < 0 || write(procs, "0", 1) != 1) {
                 cgroup_failed = true;
                 return childFailed();
             }
@@ -459,13 +461,9 @@ extern "C" ssize_t posix_spawn_bun(
     };
 
 #if OS(LINUX)
-    // On Linux, use vfork() for performance. The parent is suspended until
-    // the child calls exec or _exit, so we can detect exec failure via the
-    // child's exit status without needing the self-pipe trick.
-    // While POSIX restricts vfork children to only calling _exit() or exec*(),
-    // Linux's vfork() is more permissive and allows the setup we need
-    // (setsid, ioctl, dup2, etc.) before exec.
-    if (request->cgroup_fd >= 0) {
+    if (request->cgroup_fd >= 0 && clone3Unavailable.load(std::memory_order_relaxed)) {
+        join_cgroup_in_child = true;
+    } else if (request->cgroup_fd >= 0) {
         // cgroup v2: the child is created inside the cgroup. Migrating it after
         // the fact (writing cgroup.procs) takes cgroup_threadgroup_rwsem for
         // write — an RCU grace period on >= 6.0 kernels — with this thread
@@ -475,15 +473,24 @@ extern "C" ssize_t posix_spawn_bun(
         args.exit_signal = SIGCHLD;
         args.cgroup = static_cast<uint64_t>(request->cgroup_fd);
         long rc = bun_clone3_vfork(&args, sizeof(args), cloneTrampoline<decltype(startChild)>, (void*)&startChild);
-#if __has_feature(address_sanitizer)
-        if (__asan_handle_vfork) {
-            __asan_handle_vfork(__builtin_frame_address(0));
-        }
-#endif
         if (rc >= 0) {
+#if __has_feature(address_sanitizer)
+            if (__asan_handle_vfork) {
+                void* sp;
+#if CPU(X86_64)
+                asm volatile("movq %%rsp, %0" : "=r"(sp));
+#else
+                asm volatile("mov %0, sp" : "=r"(sp));
+#endif
+                __asan_handle_vfork(sp);
+            }
+#endif
             child = static_cast<pid_t>(rc);
         } else if (rc == -ENOSYS || rc == -EBADF || rc == -EINVAL || rc == -E2BIG || rc == -EOPNOTSUPP || rc == -EPERM) {
             // No clone3 (old kernel / seccomp), or not a cgroup2 directory.
+            if (rc == -ENOSYS) {
+                clone3Unavailable.store(true, std::memory_order_relaxed);
+            }
             join_cgroup_in_child = true;
         } else {
             // EBUSY (subtree_control set), EACCES (delegation), ENOENT
@@ -492,7 +499,11 @@ extern "C" ssize_t posix_spawn_bun(
             cgroup_failed = true;
         }
     }
-    if (child == -1 && (request->cgroup_fd < 0 || join_cgroup_in_child)) {
+    // Otherwise vfork(): the parent is suspended until the child calls exec
+    // or _exit, so exec failure is visible via child_errno without the
+    // self-pipe trick. POSIX restricts vfork children to _exit()/exec*(), but
+    // Linux permits the setup we need (setsid, ioctl, dup2, ...) before exec.
+    if (child == -1 && !cgroup_failed) {
         child = vfork();
         if (child == 0) {
             return startChild();

--- a/src/jsc/bindings/bun-spawn.cpp
+++ b/src/jsc/bindings/bun-spawn.cpp
@@ -17,6 +17,7 @@
 #if OS(LINUX)
 #include <sys/syscall.h>
 #include <sys/prctl.h>
+#include <sched.h>
 #endif
 
 extern char** environ;
@@ -107,6 +108,7 @@ typedef struct bun_spawn_request_t {
     uint32_t gid; // setgid(gid) in the child before exec when set_gid is true
     bool set_uid;
     bool set_gid;
+    int cgroup_fd; // -1 = unset; Linux: directory fd of the cgroup the child starts in
 } bun_spawn_request_t;
 
 // Raw exit syscall that doesn't go through libc.
@@ -120,6 +122,102 @@ static inline void rawExit(int status)
     _exit(status);
 #endif
 }
+
+#if OS(LINUX)
+
+#ifndef __NR_clone3
+#define __NR_clone3 435
+#endif
+#ifndef CLONE_INTO_CGROUP
+#define CLONE_INTO_CGROUP 0x200000000ULL
+#endif
+
+struct bun_clone_args {
+    uint64_t flags;
+    uint64_t pidfd;
+    uint64_t child_tid;
+    uint64_t parent_tid;
+    uint64_t exit_signal;
+    uint64_t stack;
+    uint64_t stack_size;
+    uint64_t tls;
+    uint64_t set_tid;
+    uint64_t set_tid_size;
+    uint64_t cgroup;
+};
+
+// clone3() with vfork semantics: the child runs fn(arg) on the *parent's*
+// stack (args->stack == 0, CLONE_VM|CLONE_VFORK) and must not return. This
+// cannot go through syscall(2) — the child would pop the wrapper's frame and
+// then scribble over the return address the suspended parent still needs — so,
+// like every libc's vfork.S, the return path touches no stack.
+// Returns the child pid, or -errno.
+extern "C" long bun_clone3_vfork(bun_clone_args* args, size_t size, void (*fn)(void*), void* arg);
+
+#if CPU(X86_64)
+asm(".pushsection .text\n"
+    ".globl bun_clone3_vfork\n"
+    ".type bun_clone3_vfork,@function\n"
+    "bun_clone3_vfork:\n"
+    "    movq %rdx, %r8\n" // fn  (rdx/rcx are not preserved across syscall)
+    "    movq %rcx, %r9\n" // arg
+    "    movl $435, %eax\n"
+    "    syscall\n"
+    "    testq %rax, %rax\n"
+    "    jz 1f\n"
+    "    ret\n"
+    "1:  xorl %ebp, %ebp\n"
+    "    andq $-16, %rsp\n"
+    "    movq %r9, %rdi\n"
+    "    callq *%r8\n"
+    "    movl $127, %edi\n"
+    "    movl $231, %eax\n" // exit_group
+    "    syscall\n"
+    "    hlt\n"
+    ".size bun_clone3_vfork, .-bun_clone3_vfork\n"
+    ".popsection\n");
+#elif CPU(ARM64)
+asm(".pushsection .text\n"
+    ".globl bun_clone3_vfork\n"
+    ".type bun_clone3_vfork,%function\n"
+    "bun_clone3_vfork:\n"
+    "    mov x5, x2\n" // fn
+    "    mov x6, x3\n" // arg
+    "    mov x8, #435\n"
+    "    svc #0\n"
+    "    cbz x0, 1f\n"
+    "    ret\n"
+    "1:  mov x29, #0\n"
+    "    mov x30, #0\n"
+    "    mov x0, x6\n"
+    "    blr x5\n"
+    "    mov x0, #127\n"
+    "    mov x8, #94\n" // exit_group
+    "    svc #0\n"
+    "    brk #0\n"
+    ".size bun_clone3_vfork, .-bun_clone3_vfork\n"
+    ".popsection\n");
+#else
+extern "C" long bun_clone3_vfork(bun_clone_args*, size_t, void (*)(void*), void*)
+{
+    return -ENOSYS;
+}
+#endif
+
+template<typename Fn>
+static void cloneTrampoline(void* ctx)
+{
+    (*static_cast<Fn*>(ctx))();
+    rawExit(127);
+}
+
+#if __has_feature(address_sanitizer)
+// What compiler-rt's vfork interceptor calls in the parent: the child ran
+// instrumented code on our stack, so its frame poison is still in the shadow.
+extern "C" __attribute__((weak)) void __asan_handle_vfork(void* sp);
+#endif
+
+#endif
 
 extern "C" ssize_t posix_spawn_bun(
     int* pid,
@@ -151,23 +249,17 @@ extern "C" ssize_t posix_spawn_bun(
 #endif
 
 #if OS(LINUX)
-    // On Linux, use vfork() for performance. The parent is suspended until
-    // the child calls exec or _exit, so we can detect exec failure via the
-    // child's exit status without needing the self-pipe trick.
-    // While POSIX restricts vfork children to only calling _exit() or exec*(),
-    // Linux's vfork() is more permissive and allows the setup we need
-    // (setsid, ioctl, dup2, etc.) before exec.
     volatile int child_errno = 0;
     // The vfork child shares this mm, and set*id in the child resets the
     // mm-wide "dumpable" flag to /proc/sys/fs/suid_dumpable (commit_creds).
     // Save it so the parent can restore it once vfork returns, like Go's
     // forkAndExecInChild1 and systemd's safe_fork_full do.
     int saved_dumpable = (request->set_uid || request->set_gid) ? prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) : -1;
-    pid_t child = vfork();
+    volatile bool cgroup_failed = false;
+    bool join_cgroup_in_child = false;
+    pid_t child = -1;
 #else
-    // On macOS, we must use fork() because vfork() is more strictly enforced.
-    // This code path should only be used for PTY spawns on macOS.
-    pid_t child = fork();
+    pid_t child = -1;
 #endif
 
 #if OS(DARWIN) || OS(FREEBSD)
@@ -204,6 +296,19 @@ extern "C" ssize_t posix_spawn_bun(
         for (int i = 0; i < NSIG; i++) {
             sigaction(i, &sa, 0);
         }
+
+#if OS(LINUX)
+        // cgroup v1 / pre-5.7 fallback. First, so every page the exec'd image
+        // touches is charged to the cgroup. Writing "0" moves the writer.
+        if (join_cgroup_in_child) {
+            int procs = openat(request->cgroup_fd, "cgroup.procs", O_WRONLY | O_CLOEXEC);
+            if (procs < 0 || write(procs, "0", 1) < 0) {
+                cgroup_failed = true;
+                return childFailed();
+            }
+            close(procs);
+        }
+#endif
 
         // Make "detached" work, or set up PTY as controlling terminal
         if (request->detached || request->pty_slave_fd >= 0) {
@@ -353,13 +458,56 @@ extern "C" ssize_t posix_spawn_bun(
         return -1;
     };
 
+#if OS(LINUX)
+    // On Linux, use vfork() for performance. The parent is suspended until
+    // the child calls exec or _exit, so we can detect exec failure via the
+    // child's exit status without needing the self-pipe trick.
+    // While POSIX restricts vfork children to only calling _exit() or exec*(),
+    // Linux's vfork() is more permissive and allows the setup we need
+    // (setsid, ioctl, dup2, etc.) before exec.
+    if (request->cgroup_fd >= 0) {
+        // cgroup v2: the child is created inside the cgroup. Migrating it after
+        // the fact (writing cgroup.procs) takes cgroup_threadgroup_rwsem for
+        // write — an RCU grace period on >= 6.0 kernels — with this thread
+        // parked in vfork for the duration.
+        bun_clone_args args = {};
+        args.flags = CLONE_VM | CLONE_VFORK | CLONE_INTO_CGROUP;
+        args.exit_signal = SIGCHLD;
+        args.cgroup = static_cast<uint64_t>(request->cgroup_fd);
+        long rc = bun_clone3_vfork(&args, sizeof(args), cloneTrampoline<decltype(startChild)>, (void*)&startChild);
+#if __has_feature(address_sanitizer)
+        if (__asan_handle_vfork) {
+            __asan_handle_vfork(__builtin_frame_address(0));
+        }
+#endif
+        if (rc >= 0) {
+            child = static_cast<pid_t>(rc);
+        } else if (rc == -ENOSYS || rc == -EBADF || rc == -EINVAL || rc == -E2BIG || rc == -EOPNOTSUPP || rc == -EPERM) {
+            // No clone3 (old kernel / seccomp), or not a cgroup2 directory.
+            join_cgroup_in_child = true;
+        } else {
+            // EBUSY (subtree_control set), EACCES (delegation), ENOENT
+            // (rmdir'd), EAGAIN (pids.max) ... — all about the destination.
+            errno = static_cast<int>(-rc);
+            cgroup_failed = true;
+        }
+    }
+    if (child == -1 && (request->cgroup_fd < 0 || join_cgroup_in_child)) {
+        child = vfork();
+        if (child == 0) {
+            return startChild();
+        }
+    }
+#else
+    // On macOS, we must use fork() because vfork() is more strictly enforced.
+    // This code path should only be used for PTY spawns on macOS.
+    child = fork();
     if (child == 0) {
-#if OS(DARWIN) || OS(FREEBSD)
         // Close read end in child
         close(errpipe[0]);
-#endif
         return startChild();
     }
+#endif
 
 #if OS(DARWIN) || OS(FREEBSD)
     // macOS fork() path: use self-pipe trick to detect exec failure
@@ -422,6 +570,10 @@ extern "C" ssize_t posix_spawn_bun(
     } else {
         // vfork() failed
         res = errno;
+    }
+    // Negative: joining the cgroup failed, not the spawn proper.
+    if (cgroup_failed) {
+        res = -res;
     }
 
     // PR_SET_DUMPABLE only accepts SUID_DUMP_DISABLE (0) / SUID_DUMP_USER (1);

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -360,6 +360,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut gid: Option<u32> = None;
     let mut kill_signal: SignalCode = SignalCode::DEFAULT;
     let mut max_buffer: Option<i64> = None;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let mut cgroup: Option<CgroupTarget> = None;
 
     #[cfg(windows)]
     let mut windows_hide: bool = false;
@@ -688,6 +690,14 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                         },
                     )?;
                     gid = Some(gid_int as u32);
+                }
+            }
+
+            // Ignored where cgroups don't exist, like `windowsHide` on POSIX.
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if let Some(value) = args.get(global_this, "cgroup")? {
+                if !value.is_undefined_or_null() {
+                    cgroup = Some(CgroupTarget::from_js(global_this, value)?);
                 }
             }
 
@@ -1096,6 +1106,12 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     let loop_handle = EventLoopHandle::init(event_loop.cast::<()>());
 
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let cgroup_dir = match &cgroup {
+        Some(target) => Some(target.open(global_this)?),
+        None => None,
+    };
+
     let mut spawn_options = SpawnOptions {
         // Empty means "inherit the parent's working directory". Only chdir
         // when the user asked for it: the stored cwd path string can be stale
@@ -1156,6 +1172,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             verbatim_arguments: windows_verbatim_arguments,
             loop_: loop_handle,
         },
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        cgroup_fd: cgroup_dir.as_ref().map(|c| c.dir),
         ..Default::default()
     };
 
@@ -1209,6 +1227,14 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             sys::Result::Err(err) => {
                 // See EMFILE arm above.
                 spawn_options.deinit();
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                if err.syscall == sys::Tag::clone3 {
+                    let err = match cgroup_dir.as_ref() {
+                        Some(c) => err.with_path(&c.display_path),
+                        None => err,
+                    };
+                    return Err(global_this.throw_value(err.to_js(global_this)));
+                }
                 match err.get_errno() {
                     errno @ (sys::Errno::EACCES
                     | sys::Errno::ENOENT
@@ -2166,4 +2192,95 @@ fn append_envp_from_js(
         storage.push(line);
     }
     Ok(())
+}
+
+/// `cgroup` option: a cgroup directory the child starts inside.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+enum CgroupTarget {
+    Path(ZBox),
+    DirFd(Fd),
+}
+
+/// The directory fd handed to `posix_spawn_bun`, plus what to blame on error.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+struct OpenCgroup {
+    dir: Fd,
+    /// Keeps a directory we opened ourselves alive (and closes it on drop);
+    /// `None` when the caller passed their own fd.
+    _owned: Option<sys::File>,
+    display_path: Box<[u8]>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl CgroupTarget {
+    fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Self> {
+        use bun_sys_jsc::FdJsc as _;
+        if let Some(fd) = Fd::from_js_validated(value, global)? {
+            return Ok(Self::DirFd(fd));
+        }
+        if value.is_string() {
+            let path = value.to_slice(global)?;
+            if strings::contains_char(path.slice(), 0) {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "The \"cgroup\" option must be a string without null bytes"
+                )));
+            }
+            return Ok(Self::Path(ZBox::from_bytes(path.slice())));
+        }
+        Err(global.throw_invalid_argument_type_value(b"cgroup", b"string or number", value))
+    }
+
+    /// Resolve to a directory fd in the parent so a bad path fails the spawn
+    /// with errno + path rather than an opaque exit 127 from the child.
+    fn open(&self, global: &JSGlobalObject) -> JsResult<OpenCgroup> {
+        let opened = match self {
+            Self::DirFd(dir) => OpenCgroup {
+                dir: *dir,
+                _owned: None,
+                display_path: b"cgroup.procs"[..].into(),
+            },
+            Self::Path(path) => {
+                let flags = sys::O::RDONLY | sys::O::DIRECTORY | sys::O::CLOEXEC;
+                match sys::File::open(path.as_zstr(), flags, 0) {
+                    Ok(file) => OpenCgroup {
+                        dir: file.handle(),
+                        _owned: Some(file),
+                        display_path: path.as_bytes().into(),
+                    },
+                    Err(err) => {
+                        return Err(
+                            global.throw_value(err.with_path(path.as_bytes()).to_js(global))
+                        );
+                    }
+                }
+            }
+        };
+
+        // A frozen destination would park the child before exec and, through
+        // vfork, this thread with it.
+        if Self::is_frozen(opened.dir) {
+            let err = sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::open)
+                .with_path(&opened.display_path);
+            return Err(global.throw_value(err.to_js(global)));
+        }
+
+        Ok(opened)
+    }
+
+    fn is_frozen(dir: Fd) -> bool {
+        for (file, needle) in [
+            (&b"cgroup.events"[..], &b"frozen 1"[..]),
+            (b"freezer.state", b"FROZEN"),
+        ] {
+            let Ok(file) = sys::File::openat(dir, file, sys::O::RDONLY | sys::O::CLOEXEC, 0) else {
+                continue;
+            };
+            let mut buf = [0u8; 256];
+            let n = file.read_all(&mut buf).unwrap_or(0);
+            if strings::contains(&buf[..n], needle) {
+                return true;
+            }
+        }
+        false
+    }
 }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2219,9 +2219,18 @@ impl CgroupTarget {
     }
 
     fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Self> {
-        use bun_sys_jsc::FdJsc as _;
-        if let Some(fd) = Fd::from_js_validated(value, global)? {
-            return Ok(Self::DirFd(fd));
+        if value.is_number() {
+            let fd = global.validate_integer_range::<i32>(
+                value,
+                0,
+                bun_sql_jsc::jsc::IntegerRange {
+                    min: 0,
+                    max: i128::from(i32::MAX),
+                    field_name: b"cgroup",
+                    ..Default::default()
+                },
+            )?;
+            return Ok(Self::DirFd(Fd::from_native(fd)));
         }
         if value.is_string() {
             let path = value.to_slice(global)?;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2276,14 +2276,16 @@ impl CgroupTarget {
     }
 
     fn is_frozen(dir: Fd) -> bool {
-        // `cgroup.freeze` is the requested state, set before `cgroup.events`
-        // reports `frozen 1`; new children are trapped as soon as it is 1.
-        match sys::File::read_from(dir, b"cgroup.freeze") {
-            Ok(freeze) => freeze.starts_with(b"1"),
-            // Not cgroup2; v1 only freezes where the freezer controller is
-            // co-mounted, and reports THAWED / FREEZING / FROZEN.
-            Err(_) => sys::File::read_from(dir, b"freezer.state")
-                .is_ok_and(|state| !state.starts_with(b"THAWED")),
+        // v2: `cgroup.freeze` is this cgroup's own request (set before freezing
+        // completes); `cgroup.events` `frozen 1` is the effective state,
+        // including a freeze inherited from an ancestor.
+        if let Ok(freeze) = sys::File::read_from(dir, b"cgroup.freeze") {
+            return freeze.starts_with(b"1")
+                || sys::File::read_from(dir, b"cgroup.events")
+                    .is_ok_and(|events| strings::contains(&events, b"frozen 1"));
         }
+        // v1 only freezes where the freezer controller is co-mounted, and
+        // reports THAWED / FREEZING / FROZEN (effective state).
+        sys::File::read_from(dir, b"freezer.state").is_ok_and(|state| !state.starts_with(b"THAWED"))
     }
 }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1231,7 +1231,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 if let Some(c) = &cgroup_dir
                     && err.syscall == sys::Tag::clone3
                 {
-                    return Err(global_this.throw_value(c.blame(err).to_js(global_this)));
+                    return Err(global_this.throw_value(c.blame(&err).to_js(global_this)));
                 }
                 match err.get_errno() {
                     errno @ (sys::Errno::EACCES
@@ -2211,7 +2211,7 @@ struct OpenCgroup<'a> {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 impl OpenCgroup<'_> {
     /// Attach whichever of path / fd the caller gave us.
-    fn blame(&self, err: sys::Error) -> sys::Error {
+    fn blame(&self, err: &sys::Error) -> sys::Error {
         match self.target {
             CgroupTarget::Path(path) => err.with_path(path.as_bytes()),
             CgroupTarget::DirFd(fd) => err.with_fd(*fd),
@@ -2262,7 +2262,7 @@ impl CgroupTarget {
         // Best-effort: a frozen destination would park the child before exec
         // and, through vfork, this thread with it. The kernel reports no error.
         if Self::is_frozen(opened.dir) {
-            let err = opened.blame(sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::clone3));
+            let err = opened.blame(&sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::clone3));
             return Err(global.throw_value(err.to_js(global)));
         }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1231,8 +1231,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 if let Some(c) = &cgroup_dir
                     && err.syscall == sys::Tag::clone3
                 {
-                    let err = err.with_path(c.display_path());
-                    return Err(global_this.throw_value(err.to_js(global_this)));
+                    return Err(global_this.throw_value(c.blame(err).to_js(global_this)));
                 }
                 match err.get_errno() {
                     errno @ (sys::Errno::EACCES
@@ -2211,10 +2210,11 @@ struct OpenCgroup<'a> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 impl OpenCgroup<'_> {
-    fn display_path(&self) -> &[u8] {
+    /// Attach whichever of path / fd the caller gave us.
+    fn blame(&self, err: sys::Error) -> sys::Error {
         match self.target {
-            CgroupTarget::Path(path) => path.as_bytes(),
-            CgroupTarget::DirFd(_) => b"cgroup.procs",
+            CgroupTarget::Path(path) => err.with_path(path.as_bytes()),
+            CgroupTarget::DirFd(fd) => err.with_fd(*fd),
         }
     }
 }
@@ -2262,8 +2262,7 @@ impl CgroupTarget {
         // Best-effort: a frozen destination would park the child before exec
         // and, through vfork, this thread with it. The kernel reports no error.
         if Self::is_frozen(opened.dir) {
-            let err = sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::open)
-                .with_path(opened.display_path());
+            let err = opened.blame(sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::clone3));
             return Err(global.throw_value(err.to_js(global)));
         }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1173,7 +1173,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             loop_: loop_handle,
         },
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        cgroup_fd: cgroup_dir.as_ref().map(|c| c.dir),
+        cgroup_fd: cgroup_dir.as_ref().map(|c| c.dir.handle()),
         ..Default::default()
     };
 
@@ -1231,7 +1231,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 if let Some(c) = &cgroup_dir
                     && err.syscall == sys::Tag::clone3
                 {
-                    return Err(global_this.throw_value(c.blame(&err).to_js(global_this)));
+                    return Err(global_this.throw_value(c.target.blame(&err).to_js(global_this)));
                 }
                 match err.get_errno() {
                     errno @ (sys::Errno::EACCES
@@ -2202,25 +2202,22 @@ enum CgroupTarget {
 /// The directory fd handed to `posix_spawn_bun`, plus what to blame on error.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 struct OpenCgroup<'a> {
-    dir: Fd,
-    /// Closes a directory we opened ourselves on drop; `None` for a caller's fd.
-    _owned: Option<sys::File>,
+    /// Always ours and `O_CLOEXEC` (a caller's fd is dup'd), so it can neither
+    /// leak into the child nor be closed under us mid-spawn.
+    dir: sys::File,
     target: &'a CgroupTarget,
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-impl OpenCgroup<'_> {
+impl CgroupTarget {
     /// Attach whichever of path / fd the caller gave us.
     fn blame(&self, err: &sys::Error) -> sys::Error {
-        match self.target {
-            CgroupTarget::Path(path) => err.with_path(path.as_bytes()),
-            CgroupTarget::DirFd(fd) => err.with_fd(*fd),
+        match self {
+            Self::Path(path) => err.with_path(path.as_bytes()),
+            Self::DirFd(fd) => err.with_fd(*fd),
         }
     }
-}
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-impl CgroupTarget {
     fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Self> {
         use bun_sys_jsc::FdJsc as _;
         if let Some(fd) = Fd::from_js_validated(value, global)? {
@@ -2229,9 +2226,15 @@ impl CgroupTarget {
         if value.is_string() {
             let path = value.to_slice(global)?;
             if strings::contains_char(path.slice(), 0) {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "The \"cgroup\" option must be a string without null bytes"
-                )));
+                return Err(global
+                    .err(
+                        jsc::ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "The property 'options.cgroup' must be a string without null bytes. Received {}",
+                            bun_fmt::quote(path.slice())
+                        ),
+                    )
+                    .throw());
             }
             return Ok(Self::Path(ZBox::from_bytes(path.slice())));
         }
@@ -2241,28 +2244,22 @@ impl CgroupTarget {
     /// Resolve to a directory fd in the parent so a bad path fails the spawn
     /// with errno + path rather than an opaque exit 127 from the child.
     fn open(&self, global: &JSGlobalObject) -> JsResult<OpenCgroup<'_>> {
-        let opened = match self {
-            Self::DirFd(dir) => OpenCgroup {
-                dir: *dir,
-                _owned: None,
+        let dir = match self {
+            Self::DirFd(fd) => sys::dup(*fd),
+            Self::Path(path) => sys::open_dir_absolute(path.as_bytes()),
+        };
+        let opened = match dir {
+            Ok(dir) => OpenCgroup {
+                dir: sys::File::from_fd(dir),
                 target: self,
             },
-            Self::Path(path) => match sys::open_dir_absolute(path.as_bytes()) {
-                Ok(dir) => OpenCgroup {
-                    dir,
-                    _owned: Some(sys::File::from_fd(dir)),
-                    target: self,
-                },
-                Err(err) => {
-                    return Err(global.throw_value(err.with_path(path.as_bytes()).to_js(global)));
-                }
-            },
+            Err(err) => return Err(global.throw_value(self.blame(&err).to_js(global))),
         };
 
         // Best-effort: a frozen destination would park the child before exec
         // and, through vfork, this thread with it. The kernel reports no error.
-        if Self::is_frozen(opened.dir) {
-            let err = opened.blame(&sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::clone3));
+        if Self::is_frozen(opened.dir.handle()) {
+            let err = self.blame(&sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::clone3));
             return Err(global.throw_value(err.to_js(global)));
         }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1228,11 +1228,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 // See EMFILE arm above.
                 spawn_options.deinit();
                 #[cfg(any(target_os = "linux", target_os = "android"))]
-                if err.syscall == sys::Tag::clone3 {
-                    let err = match cgroup_dir.as_ref() {
-                        Some(c) => err.with_path(&c.display_path),
-                        None => err,
-                    };
+                if let Some(c) = &cgroup_dir
+                    && err.syscall == sys::Tag::clone3
+                {
+                    let err = err.with_path(c.display_path());
                     return Err(global_this.throw_value(err.to_js(global_this)));
                 }
                 match err.get_errno() {
@@ -2203,12 +2202,21 @@ enum CgroupTarget {
 
 /// The directory fd handed to `posix_spawn_bun`, plus what to blame on error.
 #[cfg(any(target_os = "linux", target_os = "android"))]
-struct OpenCgroup {
+struct OpenCgroup<'a> {
     dir: Fd,
-    /// Keeps a directory we opened ourselves alive (and closes it on drop);
-    /// `None` when the caller passed their own fd.
+    /// Closes a directory we opened ourselves on drop; `None` for a caller's fd.
     _owned: Option<sys::File>,
-    display_path: Box<[u8]>,
+    target: &'a CgroupTarget,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl OpenCgroup<'_> {
+    fn display_path(&self) -> &[u8] {
+        match self.target {
+            CgroupTarget::Path(path) => path.as_bytes(),
+            CgroupTarget::DirFd(_) => b"cgroup.procs",
+        }
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -2232,35 +2240,30 @@ impl CgroupTarget {
 
     /// Resolve to a directory fd in the parent so a bad path fails the spawn
     /// with errno + path rather than an opaque exit 127 from the child.
-    fn open(&self, global: &JSGlobalObject) -> JsResult<OpenCgroup> {
+    fn open(&self, global: &JSGlobalObject) -> JsResult<OpenCgroup<'_>> {
         let opened = match self {
             Self::DirFd(dir) => OpenCgroup {
                 dir: *dir,
                 _owned: None,
-                display_path: b"cgroup.procs"[..].into(),
+                target: self,
             },
-            Self::Path(path) => {
-                let flags = sys::O::RDONLY | sys::O::DIRECTORY | sys::O::CLOEXEC;
-                match sys::File::open(path.as_zstr(), flags, 0) {
-                    Ok(file) => OpenCgroup {
-                        dir: file.handle(),
-                        _owned: Some(file),
-                        display_path: path.as_bytes().into(),
-                    },
-                    Err(err) => {
-                        return Err(
-                            global.throw_value(err.with_path(path.as_bytes()).to_js(global))
-                        );
-                    }
+            Self::Path(path) => match sys::open_dir_absolute(path.as_bytes()) {
+                Ok(dir) => OpenCgroup {
+                    dir,
+                    _owned: Some(sys::File::from_fd(dir)),
+                    target: self,
+                },
+                Err(err) => {
+                    return Err(global.throw_value(err.with_path(path.as_bytes()).to_js(global)));
                 }
-            }
+            },
         };
 
-        // A frozen destination would park the child before exec and, through
-        // vfork, this thread with it.
+        // Best-effort: a frozen destination would park the child before exec
+        // and, through vfork, this thread with it. The kernel reports no error.
         if Self::is_frozen(opened.dir) {
             let err = sys::Error::from_code(sys::Errno::EBUSY, sys::Tag::open)
-                .with_path(&opened.display_path);
+                .with_path(opened.display_path());
             return Err(global.throw_value(err.to_js(global)));
         }
 
@@ -2268,19 +2271,11 @@ impl CgroupTarget {
     }
 
     fn is_frozen(dir: Fd) -> bool {
-        for (file, needle) in [
-            (&b"cgroup.events"[..], &b"frozen 1"[..]),
-            (b"freezer.state", b"FROZEN"),
-        ] {
-            let Ok(file) = sys::File::openat(dir, file, sys::O::RDONLY | sys::O::CLOEXEC, 0) else {
-                continue;
-            };
-            let mut buf = [0u8; 256];
-            let n = file.read_all(&mut buf).unwrap_or(0);
-            if strings::contains(&buf[..n], needle) {
-                return true;
-            }
+        match sys::File::read_from(dir, b"cgroup.events") {
+            Ok(events) => strings::contains(&events, b"frozen 1"),
+            // Not cgroup2; v1 only freezes where the freezer controller is co-mounted.
+            Err(_) => sys::File::read_from(dir, b"freezer.state")
+                .is_ok_and(|state| state.starts_with(b"FROZEN")),
         }
-        false
     }
 }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2270,11 +2270,14 @@ impl CgroupTarget {
     }
 
     fn is_frozen(dir: Fd) -> bool {
-        match sys::File::read_from(dir, b"cgroup.events") {
-            Ok(events) => strings::contains(&events, b"frozen 1"),
-            // Not cgroup2; v1 only freezes where the freezer controller is co-mounted.
+        // `cgroup.freeze` is the requested state, set before `cgroup.events`
+        // reports `frozen 1`; new children are trapped as soon as it is 1.
+        match sys::File::read_from(dir, b"cgroup.freeze") {
+            Ok(freeze) => freeze.starts_with(b"1"),
+            // Not cgroup2; v1 only freezes where the freezer controller is
+            // co-mounted, and reports THAWED / FREEZING / FROZEN.
             Err(_) => sys::File::read_from(dir, b"freezer.state")
-                .is_ok_and(|state| state.starts_with(b"FROZEN")),
+                .is_ok_and(|state| !state.starts_with(b"THAWED")),
         }
     }
 }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2220,9 +2220,10 @@ impl CgroupTarget {
 
     fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Self> {
         if value.is_number() {
+            // `validate_integer_range` maps NaN to the default; there is no default fd.
             let fd = global.validate_integer_range::<i32>(
                 value,
-                0,
+                -1,
                 bun_sql_jsc::jsc::IntegerRange {
                     min: 0,
                     max: i128::from(i32::MAX),
@@ -2230,6 +2231,16 @@ impl CgroupTarget {
                     ..Default::default()
                 },
             )?;
+            if fd < 0 {
+                return Err(global.throw_range_error(
+                    value.as_number(),
+                    bun_fmt::OutOfRangeOptions {
+                        field_name: b"cgroup",
+                        msg: b"an integer",
+                        ..Default::default()
+                    },
+                ));
+            }
             return Ok(Self::DirFd(Fd::from_native(fd)));
         }
         if value.is_string() {

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -237,6 +237,7 @@ pub mod bun_spawn {
         pub linux_pdeathsig: i32,
         pub uid: Option<u32>,
         pub gid: Option<u32>,
+        pub cgroup_fd: i32,
     }
 
     impl Default for Attr {
@@ -253,6 +254,7 @@ pub mod bun_spawn {
                 linux_pdeathsig: 0,
                 uid: None,
                 gid: None,
+                cgroup_fd: -1,
             }
         }
     }
@@ -517,6 +519,12 @@ pub mod posix_spawn {
             return sys::Result::Ok(pid_t::try_from(pid).expect("int cast"));
         }
 
+        // Negative: the child could not be placed in `cgroup_fd`. The caller
+        // knows the cgroup's path; don't blame argv[0].
+        if rc < 0 {
+            return sys::Result::Err(sys::Error::from_code_int((-rc) as _, sys::Tag::clone3));
+        }
+
         // SAFETY: argv has at least one element (the NULL terminator)
         let arg0 = unsafe {
             let p = *argv;
@@ -653,6 +661,7 @@ pub mod posix_spawn {
                     gid: gid.unwrap_or(0),
                     set_uid: uid.is_some(),
                     set_gid: gid.is_some(),
+                    cgroup_fd: attr.map_or(-1, |a| a.cgroup_fd),
                 },
                 argv,
                 envp,

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -349,6 +349,9 @@ pub struct PosixSpawnOptions {
     /// no-orphans mode is enabled (see `ParentDeathWatchdog`), else 0 (no
     /// PDEATHSIG). Not exposed to JS yet.
     pub linux_pdeathsig: Option<u8>,
+    /// Linux only. Directory fd of a cgroup the child starts inside
+    /// (`CLONE_INTO_CGROUP`, else a pre-exec `cgroup.procs` write). Caller owns the fd.
+    pub cgroup_fd: Option<Fd>,
 }
 
 impl Default for PosixSpawnOptions {
@@ -374,6 +377,7 @@ impl Default for PosixSpawnOptions {
             pty_slave_fd: -1,
             pseudoconsole: (),
             linux_pdeathsig: None,
+            cgroup_fd: None,
         }
     }
 }
@@ -706,6 +710,7 @@ pub unsafe fn spawn_process_posix(
     attr.new_process_group = options.new_process_group;
     attr.uid = options.uid;
     attr.gid = options.gid;
+    attr.cgroup_fd = options.cgroup_fd.map_or(-1, |fd| fd.native());
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1410,6 +1410,7 @@ impl Tag {
     pub(crate) const getrlimit: Tag = Tag(105);
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
+    pub const clone3: Tag = Tag(107);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1417,7 +1418,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 107] = [
+        const NAMES: [&str; 108] = [
             "TODO",
             "dup",
             "access",
@@ -1526,6 +1527,7 @@ impl Tag {
             "ioctl",
             "getrlimit",
             "setrlimit",
+            "clone3",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmdirSync, writeFileSync, constants } from "node:fs";
-import { execFile, fork, spawn as cpSpawn, spawnSync as cpSpawnSync } from "node:child_process";
-import { dirname, join } from "node:path";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { spawn as cpSpawn, spawnSync as cpSpawnSync, execFile, fork } from "node:child_process";
+import { closeSync, constants, existsSync, mkdirSync, openSync, readFileSync, rmdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 // Find somewhere we are allowed to create a cgroup with a memory limit, or
 // null if this host doesn't let us (not root, read-only cgroupfs, no memory

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -1,0 +1,296 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmdirSync, writeFileSync, constants } from "node:fs";
+import { execFile, fork, spawn as cpSpawn, spawnSync as cpSpawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+// Find somewhere we are allowed to create a cgroup with a memory limit, or
+// null if this host doesn't let us (not root, read-only cgroupfs, no memory
+// controller). v2: a sibling of our own cgroup (children of a populated cgroup
+// can't get controllers). v1: directly under the memory hierarchy root.
+function setupCgroup(): { dir: string; version: 1 | 2; relative: string; canOOM: boolean } | null {
+  if (!isLinux || process.getuid?.() !== 0) return null;
+  const name = `bun-spawn-test-${process.pid}`;
+  const candidates: { dir: string; version: 1 | 2; relative: string }[] = [];
+
+  if (existsSync("/sys/fs/cgroup/memory/memory.limit_in_bytes")) {
+    candidates.push({ dir: `/sys/fs/cgroup/memory/${name}`, version: 1, relative: `/${name}` });
+  }
+  if (existsSync("/sys/fs/cgroup/cgroup.controllers")) {
+    const self = readFileSync("/proc/self/cgroup", "utf8")
+      .split("\n")
+      .find(l => l.startsWith("0::"))
+      ?.slice(3);
+    if (self && self !== "/") {
+      const parent = dirname(self);
+      candidates.push({
+        dir: join("/sys/fs/cgroup", parent, name),
+        version: 2,
+        relative: join(parent, name),
+      });
+    }
+    candidates.push({ dir: `/sys/fs/cgroup/${name}`, version: 2, relative: `/${name}` });
+  }
+
+  for (const c of candidates) {
+    try {
+      mkdirSync(c.dir);
+    } catch {
+      continue;
+    }
+    try {
+      let swapCapped = true;
+      if (c.version === 2) {
+        if (!readFileSync(join(c.dir, "cgroup.controllers"), "utf8").includes("memory")) throw 0;
+        writeFileSync(join(c.dir, "memory.max"), String(64 * 1024 * 1024));
+        try {
+          writeFileSync(join(c.dir, "memory.swap.max"), "0");
+        } catch {
+          swapCapped = false;
+        }
+      } else {
+        writeFileSync(join(c.dir, "memory.limit_in_bytes"), String(64 * 1024 * 1024));
+        try {
+          writeFileSync(join(c.dir, "memory.memsw.limit_in_bytes"), String(64 * 1024 * 1024));
+        } catch {
+          swapCapped = false;
+        }
+      }
+      // Without a swap cap the over-limit child gets swapped instead of OOM-killed.
+      const hasSwap = readFileSync("/proc/swaps", "utf8").trim().split("\n").length > 1;
+      return { ...c, canOOM: swapCapped || !hasSwap };
+    } catch {
+      try {
+        rmdirSync(c.dir);
+      } catch {}
+    }
+  }
+  return null;
+}
+
+const cg = setupCgroup();
+
+afterAll(() => {
+  if (!cg) return;
+  for (let i = 0; i < 100 && existsSync(cg.dir); i++) {
+    for (const pid of readFileSync(join(cg.dir, "cgroup.procs"), "utf8").split("\n").filter(Boolean)) {
+      try {
+        process.kill(Number(pid), "SIGKILL");
+      } catch {}
+    }
+    try {
+      rmdirSync(cg.dir);
+    } catch {
+      Bun.sleepSync(5);
+    }
+  }
+});
+
+function memoryCgroupOf(text: string): string | undefined {
+  // v2: "0::/path"; v1: "N:...memory...:/path"
+  for (const line of text.trim().split("\n")) {
+    const [id, controllers, path] = line.split(":");
+    if ((id === "0" && controllers === "") || controllers?.split(",").includes("memory")) return path;
+  }
+}
+
+describe.skipIf(!cg)("spawn({ cgroup })", () => {
+  test("child starts inside the cgroup; parent does not move", async () => {
+    const before = readFileSync("/proc/self/cgroup", "utf8");
+    await using proc = Bun.spawn({
+      cmd: ["cat", "/proc/self/cgroup"],
+      cgroup: cg!.dir,
+      stdout: "pipe",
+      stderr: "inherit",
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(memoryCgroupOf(stdout)).toBe(cg!.relative);
+    expect(readFileSync("/proc/self/cgroup", "utf8")).toBe(before);
+    expect(memoryCgroupOf(before)).not.toBe(cg!.relative);
+    expect(exitCode).toBe(0);
+  });
+
+  test("accepts a directory fd, and works with spawnSync", () => {
+    const fd = openSync(cg!.dir, constants.O_RDONLY | constants.O_DIRECTORY);
+    try {
+      const result = Bun.spawnSync({
+        cmd: ["cat", "/proc/self/cgroup"],
+        cgroup: fd,
+        env: bunEnv,
+      });
+      expect(memoryCgroupOf(result.stdout.toString())).toBe(cg!.relative);
+      expect(result.exitCode).toBe(0);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  test.skipIf(!cg?.canOOM)("a child that exceeds the cgroup memory limit is OOM-killed, not the parent", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        // Touch well past the 64 MiB limit in 8 MiB steps so RSS actually grows.
+        `const keep = []; for (let i = 0; i < 64; i++) { const b = Buffer.allocUnsafe(8 << 20); b.fill(i); keep.push(b); } console.log("survived", keep.length);`,
+      ],
+      cgroup: cg!.dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).not.toContain("survived");
+    expect(proc.signalCode).toBe("SIGKILL");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("descendants of the child are in the cgroup too", async () => {
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", "cat /proc/self/cgroup; exec sh -c 'cat /proc/self/cgroup'"],
+      cgroup: cg!.dir,
+      stdout: "pipe",
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const halves = stdout.trim().split("\n");
+    expect(halves.length).toBeGreaterThanOrEqual(2);
+    for (const chunk of [halves.slice(0, halves.length / 2), halves.slice(halves.length / 2)]) {
+      expect(memoryCgroupOf(chunk.join("\n"))).toBe(cg!.relative);
+    }
+    expect(exitCode).toBe(0);
+  });
+});
+
+// These exercise the option's plumbing without root or a writable cgroupfs: a
+// plain directory is not a cgroup2 dir, so CLONE_INTO_CGROUP is refused and the
+// child falls back to writing "0" into <dir>/cgroup.procs before exec.
+describe.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () => {
+  test("child writes itself into <dir>/cgroup.procs before exec", async () => {
+    using dir = tempDir("spawn-cgroup", { "cgroup.procs": "" });
+    await using proc = Bun.spawn({
+      cmd: ["cat", join(String(dir), "cgroup.procs")],
+      cgroup: String(dir),
+      stdout: "pipe",
+      env: bunEnv,
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    // The write happened before exec, so the exec'd `cat` already sees it.
+    expect(stdout).toBe("0");
+    expect(readFileSync(join(String(dir), "cgroup.procs"), "utf8")).toBe("0");
+    expect(exitCode).toBe(0);
+  });
+
+  test("directory fd form, spawnSync", () => {
+    using dir = tempDir("spawn-cgroup", { "cgroup.procs": "" });
+    const fd = openSync(String(dir), constants.O_RDONLY | constants.O_DIRECTORY);
+    try {
+      const result = Bun.spawnSync({ cmd: ["true"], cgroup: fd, env: bunEnv });
+      expect(readFileSync(join(String(dir), "cgroup.procs"), "utf8")).toBe("0");
+      expect(result.exitCode).toBe(0);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  test("a directory that does not exist fails with ENOENT and its path", () => {
+    using dir = tempDir("spawn-cgroup", {});
+    const missing = join(String(dir), "does-not-exist");
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: missing })).toThrow(
+      expect.objectContaining({ code: "ENOENT", path: missing }),
+    );
+    expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: missing })).toThrow(
+      expect.objectContaining({ code: "ENOENT", path: missing }),
+    );
+  });
+
+  test("a directory without cgroup.procs fails the spawn and names the cgroup, not argv[0]", () => {
+    using dir = tempDir("spawn-cgroup", {});
+    let error: any;
+    try {
+      Bun.spawnSync({ cmd: ["true"], cgroup: String(dir) });
+    } catch (e) {
+      error = e;
+    }
+    expect(error?.code).toBe("ENOENT");
+    expect(error?.path).toBe(String(dir));
+    expect(error?.syscall).not.toBe("posix_spawn");
+  });
+
+  test("a frozen cgroup is refused up front instead of hanging the parent", () => {
+    using v2 = tempDir("spawn-cgroup", { "cgroup.procs": "", "cgroup.events": "populated 0\nfrozen 1\n" });
+    expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v2) })).toThrow(
+      expect.objectContaining({ code: "EBUSY", path: String(v2) }),
+    );
+    using v1 = tempDir("spawn-cgroup", { "cgroup.procs": "", "freezer.state": "FROZEN\n" });
+    expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v1) })).toThrow(
+      expect.objectContaining({ code: "EBUSY" }),
+    );
+    expect(readFileSync(join(String(v1), "cgroup.procs"), "utf8")).toBe("");
+  });
+
+  test("rejects invalid values", () => {
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: {} as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: -1 })).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: 1.5 })).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: "/sys/fs/cgroup/x\0y" })).toThrow("without null bytes");
+  });
+
+  test("node:child_process passes cgroup through (spawn, spawnSync, execFile, fork)", async () => {
+    using dir = tempDir("spawn-cgroup", {
+      "cgroup.procs": "",
+      "child.js": "process.send('hi'); process.disconnect();",
+    });
+    const procs = join(String(dir), "cgroup.procs");
+    const reset = () => writeFileSync(procs, "");
+
+    expect(cpSpawnSync("true", [], { cgroup: String(dir) } as any).status).toBe(0);
+    expect(readFileSync(procs, "utf8")).toBe("0");
+
+    reset();
+    {
+      const { promise, resolve } = Promise.withResolvers<number | null>();
+      cpSpawn("true", [], { cgroup: String(dir) } as any).on("close", resolve);
+      expect(await promise).toBe(0);
+      expect(readFileSync(procs, "utf8")).toBe("0");
+    }
+
+    reset();
+    {
+      const { promise, resolve } = Promise.withResolvers<unknown>();
+      execFile("true", [], { cgroup: String(dir) } as any, err => resolve(err));
+      expect(await promise).toBeNull();
+      expect(readFileSync(procs, "utf8")).toBe("0");
+    }
+
+    reset();
+    {
+      const { promise, resolve } = Promise.withResolvers<unknown>();
+      const child = fork(join(String(dir), "child.js"), [], {
+        cgroup: String(dir),
+        execPath: bunExe(),
+        env: bunEnv,
+      } as any);
+      child.on("message", resolve);
+      expect(await promise).toBe("hi");
+      await new Promise(r => child.on("close", r));
+      expect(readFileSync(procs, "utf8")).toBe("0");
+    }
+  });
+
+  test("null and undefined mean no cgroup", () => {
+    expect(Bun.spawnSync({ cmd: ["true"], cgroup: undefined }).exitCode).toBe(0);
+    expect(Bun.spawnSync({ cmd: ["true"], cgroup: null as any }).exitCode).toBe(0);
+  });
+});
+
+test.skipIf(isLinux)("cgroup is ignored on platforms without cgroups", () => {
+  const result = Bun.spawnSync({ cmd: [bunExe(), "--version"], cgroup: "/definitely/not/a/cgroup", env: bunEnv });
+  expect(result.exitCode).toBe(0);
+});

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -165,9 +165,11 @@ describe.skipIf(!cg)("spawn({ cgroup })", () => {
       env: bunEnv,
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    const halves = stdout.trim().split("\n");
-    expect(halves.length).toBeGreaterThanOrEqual(2);
-    for (const chunk of [halves.slice(0, halves.length / 2), halves.slice(halves.length / 2)]) {
+    // /proc/self/cgroup has one line per hierarchy; both cats print the same count.
+    const perProcess = readFileSync("/proc/self/cgroup", "utf8").trim().split("\n").length;
+    const lines = stdout.trim().split("\n");
+    expect(lines.length).toBe(perProcess * 2);
+    for (const chunk of [lines.slice(0, perProcess), lines.slice(perProcess)]) {
       expect(memoryCgroupOf(chunk.join("\n"))).toBe(cg!.relative);
     }
     expect(exitCode).toBe(0);
@@ -283,17 +285,21 @@ describe.concurrent.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () =>
 
     reset();
     {
-      const { promise, resolve } = Promise.withResolvers<unknown>();
+      const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+      const closed = Promise.withResolvers<unknown>();
       const child = fork(join(String(dir), "child.js"), [], {
         cgroup: String(dir),
         execPath: bunExe(),
         env: bunEnv,
       } as any);
       child.on("message", resolve);
+      child.on("error", reject);
+      child.on("close", (code, signal) => {
+        reject(new Error(`child exited before sending a message: ${code ?? signal}`));
+        closed.resolve(code);
+      });
       expect(await promise).toBe("hi");
-      const closed = Promise.withResolvers<unknown>();
-      child.on("close", closed.resolve);
-      await closed.promise;
+      expect(await closed.promise).toBe(0);
       expect(readFileSync(procs, "utf8")).toBe("0");
     }
   });

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -251,8 +251,9 @@ describe.concurrent.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () =>
       expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
     );
     expect(() => Bun.spawn({ cmd: ["true"], cgroup: 1.5 })).toThrow(
-      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: -1 })).toThrow('The value of "cgroup" is out of range');
     expect(() => Bun.spawn({ cmd: ["true"], cgroup: "/sys/fs/cgroup/x\0y" })).toThrow("without null bytes");
   });
 

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -145,7 +145,7 @@ describe.skipIf(!cg)("spawn({ cgroup })", () => {
     await using proc = Bun.spawn({
       cmd: ["tail", "/dev/zero"],
       cgroup: cg!.dir,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       env: bunEnv,
     });
@@ -232,11 +232,11 @@ describe.concurrent.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () =>
   });
 
   test("a frozen cgroup is refused up front instead of hanging the parent", () => {
-    using v2 = tempDir("spawn-cgroup", { "cgroup.procs": "", "cgroup.events": "populated 0\nfrozen 1\n" });
+    using v2 = tempDir("spawn-cgroup", { "cgroup.procs": "", "cgroup.freeze": "1\n" });
     expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v2) })).toThrow(
       expect.objectContaining({ code: "EBUSY", path: String(v2) }),
     );
-    using v1 = tempDir("spawn-cgroup", { "cgroup.procs": "", "freezer.state": "FROZEN\n" });
+    using v1 = tempDir("spawn-cgroup", { "cgroup.procs": "", "freezer.state": "FREEZING\n" });
     expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v1) })).toThrow(
       expect.objectContaining({ code: "EBUSY" }),
     );

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -236,6 +236,15 @@ describe.concurrent.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () =>
     expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v2) })).toThrow(
       expect.objectContaining({ code: "EBUSY", path: String(v2) }),
     );
+    // Frozen through an ancestor: own cgroup.freeze is 0, cgroup.events says frozen.
+    using v2ancestor = tempDir("spawn-cgroup", {
+      "cgroup.procs": "",
+      "cgroup.freeze": "0\n",
+      "cgroup.events": "populated 1\nfrozen 1\n",
+    });
+    expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v2ancestor) })).toThrow(
+      expect.objectContaining({ code: "EBUSY" }),
+    );
     using v1 = tempDir("spawn-cgroup", { "cgroup.procs": "", "freezer.state": "FREEZING\n" });
     expect(() => Bun.spawnSync({ cmd: ["true"], cgroup: String(v1) })).toThrow(
       expect.objectContaining({ code: "EBUSY" }),

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -263,6 +263,9 @@ describe.concurrent.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () =>
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
     expect(() => Bun.spawn({ cmd: ["true"], cgroup: -1 })).toThrow('The value of "cgroup" is out of range');
+    expect(() => Bun.spawn({ cmd: ["true"], cgroup: NaN })).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
     expect(() => Bun.spawn({ cmd: ["true"], cgroup: "/sys/fs/cgroup/x\0y" })).toThrow("without null bytes");
   });
 

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -126,22 +126,34 @@ describe.skipIf(!cg)("spawn({ cgroup })", () => {
     }
   });
 
+  function oomKills(): number {
+    const file = cg!.version === 2 ? "memory.events" : "memory.oom_control";
+    return Number(/^oom_kill (\d+)$/m.exec(readFileSync(join(cg!.dir, file), "utf8"))?.[1] ?? 0);
+  }
+
   test.skipIf(!cg?.canOOM)("a child that exceeds the cgroup memory limit is OOM-killed, not the parent", async () => {
+    // A small process fits: the limit is not what kills things by itself.
+    // (Not bunExe(): a debug build's startup footprint alone can exceed 64 MiB.)
+    {
+      await using ok = Bun.spawn({ cmd: ["sh", "-c", "echo fits"], cgroup: cg!.dir, stdout: "pipe", env: bunEnv });
+      const [stdout, exitCode] = await Promise.all([ok.stdout.text(), ok.exited]);
+      expect(stdout).toBe("fits\n");
+      expect(exitCode).toBe(0);
+    }
+    // `tail /dev/zero` buffers an endless "line": a portable unbounded allocator.
+    const before = oomKills();
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        // Touch well past the 64 MiB limit in 8 MiB steps so RSS actually grows.
-        `const keep = []; for (let i = 0; i < 64; i++) { const b = Buffer.allocUnsafe(8 << 20); b.fill(i); keep.push(b); } console.log("survived", keep.length);`,
-      ],
+      cmd: ["tail", "/dev/zero"],
       cgroup: cg!.dir,
       stdout: "pipe",
       stderr: "pipe",
       env: bunEnv,
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout).not.toContain("survived");
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // Killed by the cgroup OOM killer, not by malloc failing (that would print "memory exhausted").
+    expect(stderr).toBe("");
     expect(proc.signalCode).toBe("SIGKILL");
+    expect(oomKills()).toBe(before + 1);
     expect(exitCode).not.toBe(0);
   });
 
@@ -165,7 +177,7 @@ describe.skipIf(!cg)("spawn({ cgroup })", () => {
 // These exercise the option's plumbing without root or a writable cgroupfs: a
 // plain directory is not a cgroup2 dir, so CLONE_INTO_CGROUP is refused and the
 // child falls back to writing "0" into <dir>/cgroup.procs before exec.
-describe.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () => {
+describe.concurrent.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () => {
   test("child writes itself into <dir>/cgroup.procs before exec", async () => {
     using dir = tempDir("spawn-cgroup", { "cgroup.procs": "" });
     await using proc = Bun.spawn({
@@ -279,7 +291,9 @@ describe.skipIf(!isLinux)("spawn({ cgroup }) without cgroupfs", () => {
       } as any);
       child.on("message", resolve);
       expect(await promise).toBe("hi");
-      await new Promise(r => child.on("close", r));
+      const closed = Promise.withResolvers<unknown>();
+      child.on("close", closed.resolve);
+      await closed.promise;
       expect(readFileSync(procs, "utf8")).toBe("0");
     }
   });


### PR DESCRIPTION
### What does this PR do?

Adds `cgroup?: string | number` to `Bun.spawn` / `Bun.spawnSync`: pass an existing cgroup directory (path or dir fd) and the child is placed in it **before it starts executing**, so limits set on that cgroup (`memory.max`, `pids.max`, …) apply from the first instruction and to everything the child forks. The motivating case is running untrusted/heavy tools next to a long-lived parent: with a memory cap on the tools' cgroup the kernel OOM-kills the tool, instead of reclaiming the parent's file-backed pages until it stalls.

Bun deliberately does not create, configure or remove cgroups — that's `mkdirSync` + `writeFileSync` and depends on the host's hierarchy. It only does the one step userland can't do racelessly: joining before exec.

- **cgroup v2:** `clone3(CLONE_VM|CLONE_VFORK|CLONE_INTO_CGROUP)` through a small vfork-style asm shim (x64/arm64). No migration, so the parent isn't parked across the `cgroup_threadgroup_rwsem` write that a `cgroup.procs` write costs on ≥6.0 kernels (measured ~100 ms per sporadic spawn vs ~1 ms this way).
- **cgroup v1 / no clone3 (old kernel, seccomp):** the vfork child writes `"0"` to `<dir>/cgroup.procs` before exec. Same semantics; pays the rwsem cost unless the hierarchy is mounted `favordynmods`.
- Directory is opened in the parent → bad path fails with errno + path. Join failures surface as `clone3 '<dir>'`, not `posix_spawn argv[0]`. Frozen cgroups are refused (`EBUSY`) since they'd park the vfork child and the calling thread with it.
- Ignored on non-Linux (like `windowsHide` on POSIX). `node:child_process` forwards the option, undocumented.

### How did you verify your code works?

`test/js/bun/spawn/spawn-cgroup.test.ts`: root+cgroupfs tests (membership, fd form, descendants, over-limit child is OOM-killed while parent is untouched) plus rootless tests that exercise the plumbing against a plain directory (pre-exec write observed by the exec'd `cat`, ENOENT/EBUSY attribution, validation, child_process pass-through). Fails 11/12 under `USE_SYSTEM_BUN=1`. `spawn.test.ts`, `spawnSync.test.ts`, `child_process.test.ts` unchanged vs main; `rust:check-all` 10/10; ASAN debug build clean on a stack-poison repro that aborts without the `__asan_handle_vfork` call.