### PR TITLE
tls: stop SSLWrapper from decrypting re-entrantly inside its own callbacks (wss proxy tunnel misparses >64KiB bursts)

### DIFF
--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -214,6 +214,18 @@ pub mod ssl_wrapper {
         pub flags: Flags,
         pub(crate) renegotiation_count: Cell<u8>,
         pub(crate) renegotiation_window_start: Cell<Option<std::time::Instant>>,
+        traffic: Cell<Traffic>,
+    }
+
+    /// Re-entrancy state of [`SSLWrapper::handle_traffic`].
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Traffic {
+        Idle,
+        /// `handle_traffic` is on the stack, running a pass.
+        Running,
+        /// `handle_traffic` was called again from inside one of the running
+        /// pass's callbacks; the outermost call owes another pass.
+        RerunRequested,
     }
 
     /// CamelCase alias for callers that use the alternate spelling
@@ -480,6 +492,7 @@ pub mod ssl_wrapper {
                 ssl: Cell::new(Some(ssl)),
                 renegotiation_count: Cell::new(0),
                 renegotiation_window_start: Cell::new(None),
+                traffic: Cell::new(Traffic::Idle),
             })
         }
 
@@ -1128,30 +1141,84 @@ pub mod ssl_wrapper {
             }
         }
 
+        /// Pump the engine: handshake, flush ciphertext, decrypt and dispatch,
+        /// then the parked session/keylog events.
+        ///
+        /// Not re-entrant. The callbacks a pass fires call straight back in:
+        /// owners write from `on_data`/`on_handshake`, a peer that answers
+        /// synchronously feeds `receive_data` from inside the write callback.
+        /// A nested pass must not decrypt, since that hands the owner the next
+        /// chunk while it is still inside its callback for the previous one
+        /// (the WebSocket client keeps its parse cursor on the stack across a
+        /// dispatch, so a burst longer than [`BUFFER_SIZE`] whose first chunk
+        /// provoked a pong was misparsed; node's `TLSWrap::Cycle` has the same
+        /// guard). A nested call therefore only flushes the ciphertext its
+        /// caller queued and leaves the rest to the outermost call, which
+        /// keeps running passes until none of them was re-entered.
+        ///
+        /// The nested flush keeps wire order because `handle_writing` delivers
+        /// everything it has read before it fires a callback, and it has to
+        /// happen right away: owners tear the wrapper down straight after a
+        /// final write (the WebSocket close frame is written and the tunnel is
+        /// fast-shutdown from the same callback).
+        ///
+        /// Callbacks may `deinit` the wrapper but never free it while a call
+        /// is on the stack (see `UpgradedDuplex::teardown`), so `self.traffic`
+        /// stays writable after every callback.
         fn handle_traffic(&self) {
-            // always handle the handshake first
-            if self.update_handshake_state() {
-                // shared stack buffer for reading and writing
-                // PERF: 64KiB on-stack array — verify stack-size headroom.
-                let mut buffer = [0u8; BUFFER_SIZE];
-                // drain the input BIO first
+            // Shared scratch buffer for reading and writing. A nested call
+            // needs its own: the outer pass's buffer holds the chunk the owner
+            // is still consuming.
+            // PERF: 64KiB on-stack array, verify stack-size headroom.
+            let mut buffer = [0u8; BUFFER_SIZE];
+            if self.traffic.get() != Traffic::Idle {
                 self.handle_writing(&mut buffer);
-
-                // drain the output BIO in loop, because read can trigger writing and vice versa
-                while self.has_pending_read() && self.handle_reading(&mut buffer) {
-                    // read data can trigger writing so we need to handle it
-                    self.handle_writing(&mut buffer);
-                }
-
-                // The SSL_do_handshake/SSL_read calls above may have parked
-                // new-session tickets / keylog lines (BoringSSL surfaces them
-                // mid-read, where dispatching JS could free the SSL out from
-                // under the caller). The stack has unwound here, so hand them
-                // to the owner - same ordering as the C path's
-                // ssl_flush_pending_session: handshake/data callbacks first,
-                // then sessions.
-                self.flush_pending_events(&mut buffer);
+                self.traffic.set(Traffic::RerunRequested);
+                return;
             }
+            loop {
+                self.traffic.set(Traffic::Running);
+                self.traffic_pass(&mut buffer);
+                if self.traffic.get() != Traffic::RerunRequested {
+                    break;
+                }
+            }
+            self.traffic.set(Traffic::Idle);
+        }
+
+        fn traffic_pass(&self, buffer: &mut [u8; BUFFER_SIZE]) {
+            // always handle the handshake first
+            if !self.update_handshake_state() {
+                return;
+            }
+            // flush what the handshake queued before reading
+            self.handle_writing(buffer);
+
+            // reading can queue writes and vice versa, so alternate until the
+            // input BIO is drained. Once a callback has re-entered, stop after
+            // the current step and let the next pass start over from
+            // update_handshake_state: bytes a peer fed in from inside the write
+            // callback may still belong to the handshake, and only the
+            // SSL_do_handshake there reports its completion (SSL_read would
+            // complete it silently).
+            while self.traffic.get() == Traffic::Running
+                && self.has_pending_read()
+                && self.handle_reading(buffer)
+            {
+                self.handle_writing(buffer);
+            }
+            if self.traffic.get() != Traffic::Running {
+                return;
+            }
+
+            // The SSL_do_handshake/SSL_read calls above may have parked
+            // new-session tickets / keylog lines (BoringSSL surfaces them
+            // mid-read, where dispatching JS could free the SSL out from
+            // under the caller). The stack has unwound here, so hand them
+            // to the owner - same ordering as the C path's
+            // ssl_flush_pending_session: handshake/data callbacks first,
+            // then sessions.
+            self.flush_pending_events(buffer);
         }
 
         /// Drain the parked new-session / keylog queues into the owner's

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -221,10 +221,9 @@ pub mod ssl_wrapper {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum Traffic {
         Idle,
-        /// `handle_traffic` is on the stack, running a pass.
+        /// A pass is on the stack.
         Running,
-        /// `handle_traffic` was called again from inside one of the running
-        /// pass's callbacks; the outermost call owes another pass.
+        /// A callback of the running pass called `handle_traffic` again.
         RerunRequested,
     }
 
@@ -1141,45 +1140,26 @@ pub mod ssl_wrapper {
             }
         }
 
-        /// Pump the engine: handshake, flush ciphertext, decrypt and dispatch,
-        /// then the parked session/keylog events.
-        ///
-        /// Not re-entrant. The callbacks a pass fires call straight back in:
-        /// owners write from `on_data`/`on_handshake`, a peer that answers
-        /// synchronously feeds `receive_data` from inside the write callback.
-        /// A nested pass must not decrypt, since that hands the owner the next
-        /// chunk while it is still inside its callback for the previous one
-        /// (the WebSocket client keeps its parse cursor on the stack across a
-        /// dispatch, so a burst longer than [`BUFFER_SIZE`] whose first chunk
-        /// provoked a pong was misparsed; node's `TLSWrap::Cycle` has the same
-        /// guard). A nested call therefore only flushes the ciphertext its
-        /// caller queued and leaves the rest to the outermost call, which
-        /// keeps running passes until none of them was re-entered.
-        ///
-        /// The nested flush keeps wire order because `handle_writing` delivers
-        /// everything it has read before it fires a callback, and it has to
-        /// happen right away: owners tear the wrapper down straight after a
-        /// final write (the WebSocket close frame is written and the tunnel is
-        /// fast-shutdown from the same callback).
-        ///
-        /// Callbacks may `deinit` the wrapper but never free it while a call
-        /// is on the stack (see `UpgradedDuplex::teardown`), so `self.traffic`
-        /// stays writable after every callback.
+        /// Pumps the engine. Not re-entrant: callbacks call back in (owners
+        /// write from `on_data`/`on_handshake`, a synchronous peer feeds
+        /// `receive_data` from the write callback), and a nested pass would hand
+        /// the owner the next decrypted chunk while it is still inside its
+        /// callback for the previous one (the WebSocket client parses with its
+        /// cursor on the stack). A nested call only flushes the ciphertext its
+        /// caller queued (owners may tear the wrapper down right after a final
+        /// write) and the outermost call runs another pass, like node's
+        /// `TLSWrap::Cycle`.
         fn handle_traffic(&self) {
-            // Shared scratch buffer for reading and writing. A nested call
-            // needs its own: the outer pass's buffer holds the chunk the owner
-            // is still consuming.
-            // PERF: 64KiB on-stack array, verify stack-size headroom.
-            let mut buffer = [0u8; BUFFER_SIZE];
             if self.traffic.get() != Traffic::Idle {
                 log!("handleTraffic re-entered, flushing and deferring to the outer pass");
+                let mut buffer = [0u8; BUFFER_SIZE];
                 self.handle_writing(&mut buffer);
                 self.traffic.set(Traffic::RerunRequested);
                 return;
             }
             loop {
                 self.traffic.set(Traffic::Running);
-                self.traffic_pass(&mut buffer);
+                self.traffic_pass();
                 if self.traffic.get() != Traffic::RerunRequested {
                     break;
                 }
@@ -1187,39 +1167,39 @@ pub mod ssl_wrapper {
             self.traffic.set(Traffic::Idle);
         }
 
-        fn traffic_pass(&self, buffer: &mut [u8; BUFFER_SIZE]) {
+        fn traffic_pass(&self) {
             // always handle the handshake first
-            if !self.update_handshake_state() {
-                return;
-            }
-            // flush what the handshake queued before reading
-            self.handle_writing(buffer);
+            if self.update_handshake_state() {
+                // shared stack buffer for reading and writing
+                // PERF: 64KiB on-stack array — verify stack-size headroom.
+                let mut buffer = [0u8; BUFFER_SIZE];
+                // drain the input BIO first
+                self.handle_writing(&mut buffer);
 
-            // reading can queue writes and vice versa, so alternate until the
-            // input BIO is drained. Once a callback has re-entered, stop after
-            // the current step and let the next pass start over from
-            // update_handshake_state: bytes a peer fed in from inside the write
-            // callback may still belong to the handshake, and only the
-            // SSL_do_handshake there reports its completion (SSL_read would
-            // complete it silently).
-            while self.traffic.get() == Traffic::Running
-                && self.has_pending_read()
-                && self.handle_reading(buffer)
-            {
-                self.handle_writing(buffer);
-            }
-            if self.traffic.get() != Traffic::Running {
-                return;
-            }
+                // drain the output BIO in loop, because read can trigger writing and vice versa.
+                // Stop once a callback re-entered: bytes a synchronous peer fed in may be
+                // handshake bytes, which only update_handshake_state reports, so the next
+                // pass has to start from there.
+                while self.traffic.get() == Traffic::Running
+                    && self.has_pending_read()
+                    && self.handle_reading(&mut buffer)
+                {
+                    // read data can trigger writing so we need to handle it
+                    self.handle_writing(&mut buffer);
+                }
+                if self.traffic.get() != Traffic::Running {
+                    return;
+                }
 
-            // The SSL_do_handshake/SSL_read calls above may have parked
-            // new-session tickets / keylog lines (BoringSSL surfaces them
-            // mid-read, where dispatching JS could free the SSL out from
-            // under the caller). The stack has unwound here, so hand them
-            // to the owner - same ordering as the C path's
-            // ssl_flush_pending_session: handshake/data callbacks first,
-            // then sessions.
-            self.flush_pending_events(buffer);
+                // The SSL_do_handshake/SSL_read calls above may have parked
+                // new-session tickets / keylog lines (BoringSSL surfaces them
+                // mid-read, where dispatching JS could free the SSL out from
+                // under the caller). The stack has unwound here, so hand them
+                // to the owner - same ordering as the C path's
+                // ssl_flush_pending_session: handshake/data callbacks first,
+                // then sessions.
+                self.flush_pending_events(&mut buffer);
+            }
         }
 
         /// Drain the parked new-session / keylog queues into the owner's

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1140,15 +1140,11 @@ pub mod ssl_wrapper {
             }
         }
 
-        /// Pumps the engine. Not re-entrant: callbacks call back in (owners
-        /// write from `on_data`/`on_handshake`, a synchronous peer feeds
-        /// `receive_data` from the write callback), and a nested pass would hand
-        /// the owner the next decrypted chunk while it is still inside its
-        /// callback for the previous one (the WebSocket client parses with its
-        /// cursor on the stack). A nested call only flushes the ciphertext its
-        /// caller queued (owners may tear the wrapper down right after a final
-        /// write) and the outermost call runs another pass, like node's
-        /// `TLSWrap::Cycle`.
+        /// Not re-entrant. A call made from inside a pass's callback (a write
+        /// from `on_data`, a synchronous peer feeding `receive_data`) flushes the
+        /// ciphertext queued so far and schedules another pass; decrypting there
+        /// would hand the owner the next chunk while it is still inside its
+        /// callback for the previous one.
         fn handle_traffic(&self) {
             if self.traffic.get() != Traffic::Idle {
                 log!("handleTraffic re-entered, flushing and deferring to the outer pass");
@@ -1176,10 +1172,9 @@ pub mod ssl_wrapper {
                 // drain the input BIO first
                 self.handle_writing(&mut buffer);
 
-                // drain the output BIO in loop, because read can trigger writing and vice versa.
-                // Stop once a callback re-entered: bytes a synchronous peer fed in may be
-                // handshake bytes, which only update_handshake_state reports, so the next
-                // pass has to start from there.
+                // drain the output BIO in loop, because read can trigger writing and vice versa
+                // Once a callback re-entered, the next pass takes over: the bytes it fed in
+                // may belong to the handshake, which only update_handshake_state reports.
                 while self.traffic.get() == Traffic::Running
                     && self.has_pending_read()
                     && self.handle_reading(&mut buffer)

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1172,6 +1172,7 @@ pub mod ssl_wrapper {
             // PERF: 64KiB on-stack array, verify stack-size headroom.
             let mut buffer = [0u8; BUFFER_SIZE];
             if self.traffic.get() != Traffic::Idle {
+                log!("handleTraffic re-entered, flushing and deferring to the outer pass");
                 self.handle_writing(&mut buffer);
                 self.traffic.set(Traffic::RerunRequested);
                 return;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -709,6 +709,93 @@ it("'session' and 'keylog' are emitted for a TLSSocket over a duplex stream (tls
   await once(server, "close");
 });
 
+it("a write from inside 'data' does not re-enter 'data' on a TLSSocket over a duplex (tls.connect({ socket }))", async () => {
+  // The TLS engine behind a duplex decrypts into a 64 KiB buffer and emits one
+  // buffer at a time. A write() from inside the 'data' handler used to pump the
+  // engine again from within that dispatch, so the next 64 KiB arrived as a
+  // 'data' event nested inside the handler for the previous one; node never
+  // does that. The transport below hands the engine the whole burst in one
+  // push, so there is always more to decrypt at the moment the handler writes.
+  const payload = Buffer.alloc(128 * 1024, Buffer.from(Array.from({ length: 256 }, (_, i) => i)));
+  // 64 KiB of plaintext plus a whole 16 KiB TLS record of slack.
+  const releaseAt = 96 * 1024;
+
+  // "got reply" is only sent once the ack written from inside 'data' actually
+  // arrived; the client writes nothing after the ack, so the ack has to reach
+  // the wire on its own.
+  await using server = tls.createServer({ ...COMMON_CERT_ }, socket => {
+    socket.on("data", data => {
+      if (data.toString() === "go") socket.write(payload);
+      else if (data.toString() === "ack") socket.end("got reply");
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  // Like SocketProxy, except that while `held` is set the ciphertext is
+  // accumulated and pushed as one chunk once `releaseAt` bytes are queued.
+  class HoldingTransport extends Duplex {
+    held: Buffer[] | null = null;
+    constructor(readonly raw: net.Socket) {
+      super();
+      raw.on("data", chunk => {
+        if (this.held === null) {
+          this.push(chunk);
+          return;
+        }
+        this.held.push(chunk);
+        if (this.held.reduce((total, part) => total + part.length, 0) >= releaseAt) {
+          const burst = Buffer.concat(this.held);
+          this.held = null;
+          this.push(burst);
+        }
+      });
+      raw.on("end", () => this.push(null));
+    }
+    _read() {}
+    _write(chunk: Buffer, _encoding: string, callback: (error?: Error | null) => void) {
+      this.raw.write(chunk, callback);
+    }
+    _final(callback: () => void) {
+      this.raw.end();
+      callback();
+    }
+  }
+
+  const raw = net.connect(port, "127.0.0.1");
+  await once(raw, "connect");
+  const transport = new HoldingTransport(raw);
+  const client = tls.connect({ socket: transport, rejectUnauthorized: false });
+  await once(client, "secureConnect");
+
+  const chunks: Buffer[] = [];
+  let depth = 0;
+  let nestedDataEvents = 0;
+  let acked = false;
+  client.on("data", (chunk: Buffer) => {
+    depth++;
+    if (depth > 1) nestedDataEvents++;
+    chunks.push(chunk);
+    if (!acked) {
+      acked = true;
+      client.write("ack");
+    }
+    depth--;
+  });
+  transport.held = [];
+  client.write("go");
+  await once(client, "end");
+  client.end();
+  await once(client, "close");
+
+  const received = Buffer.concat(chunks);
+  expect({
+    nestedDataEvents,
+    payloadIntact: received.subarray(0, payload.length).equals(payload),
+    tail: received.subarray(payload.length).toString(),
+  }).toEqual({ nestedDataEvents: 0, payloadIntact: true, tail: "got reply" });
+});
+
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {
   // The TLS1.3 NewSessionTickets ride in the same read pass as the response
   // bytes. If the parked session were only flushed after the data dispatch,

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -796,6 +796,53 @@ it("a write from inside 'data' does not re-enter 'data' on a TLSSocket over a du
   }).toEqual({ nestedDataEvents: 0, payloadIntact: true, tail: "got reply" });
 });
 
+it("a client and a server TLSSocket connected through a synchronous in-memory duplex pair talk to each other", async () => {
+  // Each side's _write pushes straight into the other side, so every reply,
+  // including the server's handshake flight, is fed to the engine from inside
+  // its own write callback. The engine has to pick those bytes up after the
+  // write that provoked them instead of decrypting them in place.
+  const makeSide = (peer: () => Duplex) =>
+    new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        peer().push(chunk);
+        callback();
+      },
+      final(callback) {
+        peer().push(null);
+        callback();
+      },
+    });
+  const clientSide: Duplex = makeSide(() => serverSide);
+  const serverSide: Duplex = makeSide(() => clientSide);
+
+  const secure = { client: false, server: false };
+  const exchange: string[] = [];
+  const server = new TLSSocket(serverSide, { isServer: true, secureContext: tls.createSecureContext(COMMON_CERT_) });
+  server.on("secure", () => (secure.server = true));
+  server.on("data", (data: Buffer) => {
+    exchange.push(`server got ${data}`);
+    server.write(`pong ${data}`);
+  });
+  server.on("end", () => server.end());
+
+  const client = tls.connect({ socket: clientSide, rejectUnauthorized: false }, () => {
+    secure.client = true;
+    client.write("one");
+  });
+  client.on("data", (data: Buffer) => {
+    exchange.push(`client got ${data}`);
+    if (String(data) === "pong one") client.write("two");
+    else client.end();
+  });
+  await once(client, "close");
+
+  expect({ secure, exchange }).toEqual({
+    secure: { client: true, server: true },
+    exchange: ["server got one", "client got pong one", "server got two", "client got pong two"],
+  });
+});
+
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {
   // The TLS1.3 NewSessionTickets ride in the same read pass as the response
   // bytes. If the parked session were only flushed after the data dispatch,

--- a/test/js/web/websocket/proxy-test-utils.ts
+++ b/test/js/web/websocket/proxy-test-utils.ts
@@ -9,6 +9,12 @@ import tls from "tls";
 
 export interface ConnectProxyOptions {
   requireAuth?: boolean;
+  /**
+   * Intercepts the bytes flowing target -> client once the tunnel is up. Call
+   * `forward` to deliver bytes to the client. Defaults to forwarding every
+   * chunk as it arrives.
+   */
+  onTargetData?: (chunk: Buffer, forward: (bytes: Buffer) => void) => void;
 }
 
 /**
@@ -90,8 +96,15 @@ export function createConnectProxy(options: ConnectProxyOptions = {}): net.Serve
         }
 
         // Set up bidirectional piping
+        const forward = (bytes: Buffer) => {
+          clientSocket.write(bytes);
+        };
         targetSocket!.on("data", chunk => {
-          clientSocket.write(chunk);
+          if (options.onTargetData) {
+            options.onTargetData(chunk, forward);
+          } else {
+            forward(chunk);
+          }
         });
       });
 

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -500,6 +500,128 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     await promise;
     gc();
   });
+
+  // The tunnel's TLS engine decrypts into a 64 KiB buffer and hands the frame
+  // parser one buffer at a time. A write issued while the parser is still inside
+  // the first buffer (the automatic pong for a ping, or send() from a message
+  // handler) used to pump the engine again from inside that callback, so the rest
+  // of the burst reached the parser re-entrantly and mid-frame: payload bytes
+  // were read as frame headers and the connection failed.
+  //
+  // Getting more than one engine buffer into a single read takes two steps: the
+  // server first streams a warm-up message so the client's TCP receive window
+  // grows past 64 KiB, then the proxy holds the burst and releases it in one
+  // write.
+  describe.each([
+    { reply: "automatic pong for a server ping", lead: "ping" },
+    { reply: "send() from the message handler", lead: "message" },
+  ])("burst larger than the TLS read buffer while the client replies with $reply", ({ lead }) => {
+    test("every frame is delivered intact and the reply reaches the server", async () => {
+      const payload = Buffer.alloc(128 * 1024, Buffer.from(Array.from({ length: 256 }, (_, i) => i)));
+      // 64 KiB of plaintext plus a whole 16 KiB TLS record of slack, so the
+      // released write always decrypts to more than one engine buffer.
+      const releaseAt = 96 * 1024;
+
+      // "got reply" is only sent once the client's pong/ack arrived, and the
+      // client writes nothing else after replying, so receiving it proves the
+      // reply reached the wire on its own instead of riding along with a later
+      // write. The server-side close code checks the other write made from
+      // inside a message handler: ws.close() writes the close frame and shuts
+      // the tunnel down in the same callback, so the frame has to be flushed
+      // immediately or the server only ever sees the TCP connection drop (1006).
+      const serverClosed = Promise.withResolvers<number>();
+      using server = Bun.serve({
+        port: 0,
+        tls: { key: tlsCerts.key, cert: tlsCerts.cert },
+        fetch(req, server) {
+          if (server.upgrade(req)) return;
+          return new Response("Expected WebSocket", { status: 400 });
+        },
+        websocket: {
+          open(ws) {
+            ws.send(payload); // warm-up
+          },
+          message(ws, message) {
+            if (message === "go") {
+              if (lead === "ping") ws.ping();
+              else ws.send("first");
+              ws.send(payload);
+              ws.send("marker");
+            } else if (message === "ack") {
+              ws.send("got reply");
+            }
+          },
+          pong(ws) {
+            ws.send("got reply");
+          },
+          close(_ws, code) {
+            serverClosed.resolve(code);
+          },
+        },
+      });
+
+      let held: Buffer[] | null = null;
+      const burstProxy = createConnectProxy({
+        onTargetData(chunk, forward) {
+          if (held === null) {
+            forward(chunk);
+            return;
+          }
+          held.push(chunk);
+          if (held.reduce((total, part) => total + part.length, 0) >= releaseAt) {
+            const burst = Buffer.concat(held);
+            held = null;
+            forward(burst);
+          }
+        },
+      });
+      const burstProxyPort = await startProxy(burstProxy);
+
+      const received: string[] = [];
+      const clientClosed = Promise.withResolvers<number>();
+      const ws = new WebSocket(`wss://127.0.0.1:${server.port}`, {
+        proxy: `http://127.0.0.1:${burstProxyPort}`,
+        tls: { rejectUnauthorized: false },
+        // Keep the payload at its full size on the wire.
+        perMessageDeflate: false,
+      });
+      ws.binaryType = "arraybuffer";
+      try {
+        ws.onmessage = event => {
+          if (typeof event.data === "string") {
+            received.push(event.data);
+            if (event.data === "first") ws.send("ack");
+            if (event.data === "got reply") ws.close(1000);
+            return;
+          }
+          const data = Buffer.from(event.data as ArrayBuffer);
+          received.push(data.equals(payload) ? "payload" : `corrupt payload (${data.length} bytes)`);
+          if (received.length === 1) {
+            // Warm-up consumed; hold the burst that "go" provokes.
+            held = [];
+            ws.send("go");
+          }
+        };
+        ws.onclose = event => clientClosed.resolve(event.code);
+
+        const closeCode = await clientClosed.promise;
+        // A client that failed the connection itself never tells the server
+        // anything, so the server's close is only awaited after a clean close.
+        const serverCloseCode = closeCode === 1000 ? await serverClosed.promise : "client did not close cleanly";
+        expect({ received, closeCode, serverCloseCode }).toEqual({
+          received:
+            lead === "ping"
+              ? ["payload", "payload", "marker", "got reply"]
+              : ["payload", "first", "payload", "marker", "got reply"],
+          closeCode: 1000,
+          serverCloseCode: 1000,
+        });
+      } finally {
+        ws.close();
+        burstProxy.close();
+      }
+    });
+  });
 });
 
 describe("WebSocket through HTTPS proxy (TLS proxy)", () => {


### PR DESCRIPTION
### Symptom

A `wss://` WebSocket going through an HTTP `CONNECT` proxy closes with code 1002 (or delivers garbage) when more than 64 KiB of frames arrive in one read and something in the first 64 KiB makes the client write: a server ping (automatic pong) or a message whose `onmessage` handler calls `send()`. This needs the connection's receive window to have grown past 64 KiB first, so it shows up on long-lived, chatty connections rather than on the first message.

`tls.connect({ socket: duplex })` has the same underlying problem in a milder form: when a `'data'` handler calls `write()` while more ciphertext is queued, the next `'data'` event is emitted nested inside the running handler. Node never does that.

```ts
// wss server: on "go" -> ws.ping(); ws.send(Buffer.alloc(128 * 1024)); ws.send("marker");
const ws = new WebSocket(`wss://127.0.0.1:${port}`, { proxy: `http://127.0.0.1:${proxyPort}`, tls: { rejectUnauthorized: false } });
// (proxy releases the burst in a single write)
// before: onclose code 1002 after the ping, the 128 KiB message and "marker" never arrive
// after:  message, "marker" and the pong all delivered
```

### Cause

`SSLWrapper::handle_traffic` (`src/uws/lib.rs`, the in-memory BIO engine used by the WebSocket proxy tunnel, the fetch proxy tunnel, `UpgradedDuplex` and `WindowsNamedPipe`) ran a complete pass every time it was called, and it is called from inside its own callbacks: `write_data()` from `on_data`/`on_handshake`, `receive_data()` from a peer that answers synchronously, `flush()`. `handle_reading` decrypts into a 64 KiB buffer and dispatches it when full; if that dispatch writes, the nested `handle_traffic` ran `handle_reading` again and delivered the rest of the input BIO to the owner while the owner was still inside `on_data` for the first chunk.

The WebSocket client parses a chunk with a `RecvCursor` on the stack and only writes the parser state back afterwards (`handle_data_loop`), so the nested chunk was parsed from the state as it was before the first chunk (payload bytes read as a frame header, `1002`), and when the outer call resumed it overwrote whatever the nested call had stored.

### Fix

`handle_traffic` now records whether it is already on the stack (`Traffic::{Idle, Running, RerunRequested}`):

* A nested call only flushes the ciphertext its caller just queued (`handle_writing`) and marks a rerun; it never decrypts.
* The outermost call runs passes until one completes without being re-entered. A pass that was re-entered stops before reading, so the next pass starts from `update_handshake_state` again (bytes a synchronous peer fed in during the write callback may still be handshake bytes, and only the `SSL_do_handshake` there reports completion).

This is the same shape as node's `TLSWrap::Cycle()` recursion guard. Keeping the nested flush synchronous is deliberate: owners write and tear the wrapper down from the same callback (`ws.close()` inside `onmessage` writes the close frame and then fast-shutdowns the tunnel, `WebSocket::send_close_with_body` -> `clear_data`). I tried a pure "defer everything" variant: frames are delivered correctly but the server never receives the close frame written from a message handler, which the new test's server-side close code (`1000`) would catch. Flushing from a nested frame is order preserving because `handle_writing` hands out everything it has read before it invokes a callback.

Wire output is unchanged for every existing flow (writes still hit the socket at the same points); what changes is that `on_data` / `on_handshake` / `on_session` are no longer delivered while the owner is inside another callback of the same wrapper. Nesting also no longer stacks 64 KiB buffers per level.

Out of scope, seen while writing the tests (both pre-existing, being tracked separately): the wrapper flushes parked session/keylog events only after the data dispatch (the C path flushes before), and `ws.terminate()` on a wss-over-proxy connection does not close the proxy TCP connection.

### Verification

* `test/js/web/websocket/websocket-proxy.test.ts`: burst through a CONNECT proxy, one variant per write trigger (automatic pong, `send()` from `onmessage`). The server streams a warm-up message so the client's receive window grows, then the proxy holds the burst and releases it in one write. Asserts every frame arrives intact, the reply reaches the server on its own, and the server observes the clean close. Fails on the unfixed engine with `closeCode: 1002` in 10/10 runs (release and ASAN debug builds); `createConnectProxy` gained an `onTargetData` hook for the hold.
* `test/js/node/tls/node-tls-connect.test.ts`: TLSSocket over a duplex whose `'data'` handler writes back during a 128 KiB burst; asserts no nested `'data'` event, intact payload, and that the ack written from inside the handler was flushed. Fails unfixed with `nestedDataEvents: 1`.
* Also in `node-tls-connect.test.ts`: a client and a server TLSSocket over a synchronous in-memory duplex pair, where every reply (including the handshake flight) is fed back into the engine from inside its own write callback. Passes before and after; it pins the restart-from-the-handshake-check behaviour (with `BUN_DEBUG_SSLWrapper=1` the re-entered branch fires during the handshake and again for each reply).
* Ran the consumer suites locally on the debug build: all `websocket-proxy*` / `test-ws-bidir-proxy` tests, `fetch` proxy tests, the eight `proxy-stress-*` suites (841 tests), `test/js/node/tls/`, `node-http2.test.js`, and the node parallel TLS-over-duplex tests. The only failures are ones that also fail on the unmodified binary in this sandbox (`localhost` resolution / ambient `NO_PROXY` / debug-build timeouts unrelated to TLS).
