### PR TITLE
node:quic: default the congestion controller to Cubic

### DIFF
--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -112,8 +112,7 @@ const PREFERRED_ADDRESS_USE: u64 = 1;
 /// seconds unit `transportParams.maxIdleTimeout` uses.
 const DEFAULT_MAX_IDLE_TIMEOUT_SECS: u64 = 10;
 pub(super) const MS_PER_SEC: u64 = 1_000;
-/// lsquic.h `es_cc_algo`. Adaptive (3, lsquic's default) is never used: on a
-/// loop-ticked engine it picks BBRv1, which then pins cwnd at its floor.
+/// lsquic.h `es_cc_algo` values.
 const CC_ALGO_CUBIC: c_uint = 1;
 const CC_ALGO_BBR: c_uint = 2;
 
@@ -935,7 +934,7 @@ fn apply_transport_params(
     // Node's default max_idle_timeout is 10 seconds
     // (node/src/quic/transportparams.h DEFAULT_MAX_IDLE_TIMEOUT); lsquic's is 30.
     s.idle_timeout(10);
-    // Node's default `cc` is cubic; see CC_ALGO_CUBIC.
+    // Node's default `cc` is cubic; lsquic's own default is adaptive.
     s.cc_algo(CC_ALGO_CUBIC);
     if !options.is_object() {
         local_tp.max_idle_timeout = match s.get_idle_timeout_ms() {

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -112,12 +112,9 @@ const PREFERRED_ADDRESS_USE: u64 = 1;
 /// seconds unit `transportParams.maxIdleTimeout` uses.
 const DEFAULT_MAX_IDLE_TIMEOUT_SECS: u64 = 10;
 pub(super) const MS_PER_SEC: u64 = 1_000;
-/// lsquic.h `es_cc_algo`. Never left at lsquic's own default (3, "adaptive"):
-/// adaptive commits each connection to Cubic or BBRv1 on its first RTT
-/// sample, and since these engines only run when the event loop ticks them,
-/// that sample (and every later bandwidth sample BBRv1 would act on) measures
-/// the JS that ran between two ticks rather than the path. On a busy loop
-/// BBRv1 shrinks cwnd to its 4-packet floor and stays there.
+/// lsquic.h `es_cc_algo`. Never lsquic's own default, adaptive (3): it picks
+/// BBRv1 off a handshake RTT that here measures event-loop ticks, and BBRv1
+/// then pins cwnd at its 4-packet floor whenever the loop is busy.
 const CC_ALGO_CUBIC: c_uint = 1;
 const CC_ALGO_BBR: c_uint = 2;
 
@@ -939,8 +936,7 @@ fn apply_transport_params(
     // Node's default max_idle_timeout is 10 seconds
     // (node/src/quic/transportparams.h DEFAULT_MAX_IDLE_TIMEOUT); lsquic's is 30.
     s.idle_timeout(10);
-    // Node's default `cc` is cubic (ngtcp2's default); see CC_ALGO_CUBIC for
-    // why lsquic's adaptive default is not usable here.
+    // Node's default `cc` is cubic; see CC_ALGO_CUBIC.
     s.cc_algo(CC_ALGO_CUBIC);
     if !options.is_object() {
         local_tp.max_idle_timeout = match s.get_idle_timeout_ms() {
@@ -1075,9 +1071,7 @@ fn apply_transport_params(
         let name = bun_core::String::from_js(cc, global)?.to_utf8_bytes();
         let algo = match name.as_slice() {
             b"bbr" => CC_ALGO_BBR,
-            // 'cubic', and 'reno': lsquic ships no Reno (NGTCP2_CC_ALGO_RENO
-            // in node's backend), so it gets Cubic, the closest loss-based
-            // option.
+            // Also 'reno': lsquic has no Reno, Cubic is the closest loss-based option.
             _ => CC_ALGO_CUBIC,
         };
         s.cc_algo(algo);

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -112,6 +112,14 @@ const PREFERRED_ADDRESS_USE: u64 = 1;
 /// seconds unit `transportParams.maxIdleTimeout` uses.
 const DEFAULT_MAX_IDLE_TIMEOUT_SECS: u64 = 10;
 pub(super) const MS_PER_SEC: u64 = 1_000;
+/// lsquic.h `es_cc_algo`. Never left at lsquic's own default (3, "adaptive"):
+/// adaptive commits each connection to Cubic or BBRv1 on its first RTT
+/// sample, and since these engines only run when the event loop ticks them,
+/// that sample (and every later bandwidth sample BBRv1 would act on) measures
+/// the JS that ran between two ticks rather than the path. On a busy loop
+/// BBRv1 shrinks cwnd to its 4-packet floor and stays there.
+const CC_ALGO_CUBIC: c_uint = 1;
+const CC_ALGO_BBR: c_uint = 2;
 
 /// Copy a sockaddr sized by its family (sockaddr_in = 16, sockaddr_in6 = 28)
 /// so an AF_INET address never over-reads past its allocation.
@@ -931,6 +939,9 @@ fn apply_transport_params(
     // Node's default max_idle_timeout is 10 seconds
     // (node/src/quic/transportparams.h DEFAULT_MAX_IDLE_TIMEOUT); lsquic's is 30.
     s.idle_timeout(10);
+    // Node's default `cc` is cubic (ngtcp2's default); see CC_ALGO_CUBIC for
+    // why lsquic's adaptive default is not usable here.
+    s.cc_algo(CC_ALGO_CUBIC);
     if !options.is_object() {
         local_tp.max_idle_timeout = match s.get_idle_timeout_ms() {
             0 => s.get_idle_timeout().saturating_mul(1000),
@@ -1062,14 +1073,12 @@ fn apply_transport_params(
     };
     if let Some(cc) = options.get(global, "cc")?.filter(|v| v.is_string()) {
         let name = bun_core::String::from_js(cc, global)?.to_utf8_bytes();
-        // lsquic.h es_cc_algo: 0=default(→3 Adaptive), 1=Cubic, 2=BBRv1,
-        // 3=Adaptive. lsquic ships no Reno (NGTCP2_CC_ALGO_RENO in node's
-        // backend), so map 'reno' to Cubic, the closest loss-based option,
-        // rather than silently falling through to Adaptive which may pick BBR.
         let algo = match name.as_slice() {
-            b"cubic" | b"reno" => 1,
-            b"bbr" => 2,
-            _ => 0,
+            b"bbr" => CC_ALGO_BBR,
+            // 'cubic', and 'reno': lsquic ships no Reno (NGTCP2_CC_ALGO_RENO
+            // in node's backend), so it gets Cubic, the closest loss-based
+            // option.
+            _ => CC_ALGO_CUBIC,
         };
         s.cc_algo(algo);
     }

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -112,9 +112,8 @@ const PREFERRED_ADDRESS_USE: u64 = 1;
 /// seconds unit `transportParams.maxIdleTimeout` uses.
 const DEFAULT_MAX_IDLE_TIMEOUT_SECS: u64 = 10;
 pub(super) const MS_PER_SEC: u64 = 1_000;
-/// lsquic.h `es_cc_algo`. Never lsquic's own default, adaptive (3): it picks
-/// BBRv1 off a handshake RTT that here measures event-loop ticks, and BBRv1
-/// then pins cwnd at its 4-packet floor whenever the loop is busy.
+/// lsquic.h `es_cc_algo`. Adaptive (3, lsquic's default) is never used: on a
+/// loop-ticked engine it picks BBRv1, which then pins cwnd at its floor.
 const CC_ALGO_CUBIC: c_uint = 1;
 const CC_ALGO_BBR: c_uint = 2;
 

--- a/test/js/node/quic/busy-loop-sender-fixture.ts
+++ b/test/js/node/quic/busy-loop-sender-fixture.ts
@@ -8,6 +8,9 @@
 //   busy-loop-sender-fixture.ts connect <port> [cc]  open a stream to the
 //                                                    test's server and send
 //
+// The tests leave `cc` unset, since the default is what they are about; pass
+// "bbr" to see the collapse they rule out on a build that has the fix.
+//
 // Both modes block the thread for SETUP_BLOCK_MS while the session's first
 // round trip is in flight (a server doing work in its session callback, a
 // client doing work right after connect()), so the first RTT sample lsquic
@@ -16,14 +19,16 @@
 // this makes it pick BBRv1 every time; with plain loopback samples the pick
 // would depend on what else the loop happened to be doing.
 //
-// Once the transfer starts the loop is left idle for a moment, so the
-// controller sees the real loopback RTT at least once, then paced with
-// Bun.sleepSync for ITERATIONS iterations of BUSY_MS. BBRv1 is down to its
-// 4-packet floor (5840 bytes) within 20 to 30 iterations of that and returns
-// to it within a few rounds after every bump ACK bunching gives it, so the
-// minimum over the second half is the floor; Cubic, which only reacts to
-// loss, stays at 100 KiB or more throughout (bounded by the receiver's UDP
-// buffer).
+// The transfer then runs with the loop free until FREE_RUN_BYTES have gone
+// out, which takes a few rounds of ACKs and so gives the controller the real
+// loopback RTT (BBR's min RTT is taken from raw ACK timing, so it has to come
+// from a moment when the loop was actually free; a fixed idle delay was not
+// enough on a loaded machine). After that the loop is paced with Bun.sleepSync
+// for ITERATIONS iterations of BUSY_MS. BBRv1 is down to its 4-packet floor
+// (5840 bytes) within 20 to 30 iterations of that and returns to it within a
+// few rounds after every bump ACK bunching gives it, so the minimum over the
+// second half is the floor; Cubic, which only reacts to loss, stays just under
+// what the receiver's UDP buffer holds throughout.
 import { createPrivateKey } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -34,7 +39,9 @@ const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
 const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
 
 const SETUP_BLOCK_MS = 30;
-const IDLE_BEFORE_WINDOW_MS = 20;
+// Several times the initial window (32 packets), so reaching it means ACKs
+// were processed while the loop was free.
+const FREE_RUN_BYTES = 256 * 1024;
 const ITERATIONS = 60;
 const BUSY_MS = 12;
 // Larger than any window either controller reaches here, so every tick is
@@ -49,6 +56,14 @@ const cc = rest.shift() as "reno" | "cubic" | "bbr" | undefined;
 let session: Awaited<ReturnType<typeof connect>>;
 let iterations = 0;
 let minCwnd = Infinity;
+
+function freeRun() {
+  if (Number(session.stats.bytesSent) < FREE_RUN_BYTES) {
+    setImmediate(freeRun);
+    return;
+  }
+  spin();
+}
 
 function spin() {
   iterations++;
@@ -67,7 +82,7 @@ function spin() {
 }
 
 async function* chunks() {
-  setTimeout(spin, IDLE_BEFORE_WINDOW_MS);
+  setImmediate(freeRun);
   while (iterations < ITERATIONS) yield CHUNK;
 }
 

--- a/test/js/node/quic/busy-loop-sender-fixture.ts
+++ b/test/js/node/quic/busy-loop-sender-fixture.ts
@@ -1,0 +1,98 @@
+// Sends a stream of large chunks from a process whose event loop is busy and
+// reports, over IPC, the smallest congestion window the sending session used
+// during the second half of that. Spawned by quic-endpoint.test.ts, which is
+// the receiving end.
+//
+//   busy-loop-sender-fixture.ts listen [cc]          send on the first stream
+//                                                    the peer opens
+//   busy-loop-sender-fixture.ts connect <port> [cc]  open a stream to the
+//                                                    test's server and send
+//
+// Both modes block the thread for SETUP_BLOCK_MS while the session's first
+// round trip is in flight (a server doing work in its session callback, a
+// client doing work right after connect()), so the first RTT sample lsquic
+// takes on the connection is that long. An engine left in lsquic's "adaptive"
+// mode makes its Cubic-or-BBRv1 choice from that sample (threshold 1.5 ms), so
+// this makes it pick BBRv1 every time; with plain loopback samples the pick
+// would depend on what else the loop happened to be doing.
+//
+// Once the transfer starts the loop is left idle for a moment, so the
+// controller sees the real loopback RTT at least once, then paced with
+// Bun.sleepSync for ITERATIONS iterations of BUSY_MS. BBRv1 is down to its
+// 4-packet floor (5840 bytes) within 20 to 30 iterations of that and returns
+// to it within a few rounds after every bump ACK bunching gives it, so the
+// minimum over the second half is the floor; Cubic, which only reacts to
+// loss, stays at 100 KiB or more throughout (bounded by the receiver's UDP
+// buffer).
+import { createPrivateKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { connect, listen } from "node:quic";
+
+const keysDir = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
+const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
+
+const SETUP_BLOCK_MS = 30;
+const IDLE_BEFORE_WINDOW_MS = 20;
+const ITERATIONS = 60;
+const BUSY_MS = 12;
+// Larger than any window either controller reaches here, so every tick is
+// limited by the congestion window rather than by what the application had
+// queued (application-limited rounds never let BBRv1 leave startup).
+const CHUNK = Buffer.alloc(512 * 1024, "cwnd");
+
+const [mode, ...rest] = process.argv.slice(2);
+const port = mode === "connect" ? Number(rest.shift()) : undefined;
+const cc = rest.shift() as "reno" | "cubic" | "bbr" | undefined;
+
+let session: Awaited<ReturnType<typeof connect>>;
+let iterations = 0;
+let minCwnd = Infinity;
+
+function spin() {
+  iterations++;
+  if (iterations > ITERATIONS / 2) {
+    minCwnd = Math.min(minCwnd, Number(session.stats.cwnd));
+  }
+  if (iterations === ITERATIONS) {
+    process.send!({ minCwnd });
+    // Graceful: chunks() stops on its next pull, the stream ends with a FIN
+    // and the CONNECTION_CLOSE that follows lets the test's side close too.
+    session.close();
+    return;
+  }
+  Bun.sleepSync(BUSY_MS);
+  setImmediate(spin);
+}
+
+async function* chunks() {
+  setTimeout(spin, IDLE_BEFORE_WINDOW_MS);
+  while (iterations < ITERATIONS) yield CHUNK;
+}
+
+if (mode === "listen") {
+  const endpoint = await listen(
+    s => {
+      session = s;
+      s.closed.catch(() => {});
+      Bun.sleepSync(SETUP_BLOCK_MS);
+      s.onstream = stream => {
+        stream.closed.catch(() => {});
+        stream.setBody(chunks());
+      };
+    },
+    { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"], cc },
+  );
+  process.send!({ port: endpoint.address.port });
+} else {
+  // connect() has put the Initial on the wire by the time it returns.
+  const connecting = connect(`127.0.0.1:${port}`, { alpn: "quic-test", verifyPeer: "manual", cc });
+  Bun.sleepSync(SETUP_BLOCK_MS);
+  session = await connecting;
+  session.closed.catch(() => {});
+  await session.opened;
+  const stream = await session.createBidirectionalStream();
+  stream.closed.catch(() => {});
+  stream.setBody(chunks());
+}

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -260,8 +260,9 @@ describe("transportParams.maxIdleTimeout", () => {
 // window per loop iteration while its min RTT is the real loopback RTT, so on
 // a busy loop its window shrinks to the 4-packet floor (5840 bytes) and the
 // connection moves one such window per iteration. Cubic only reacts to loss,
-// which a slow loop does not produce; its window stays at 100 KiB or more here
-// (bounded by the receiver's UDP buffer).
+// which a slow loop does not produce; its window settles just under what the
+// receiver's UDP buffer holds (100 KiB and up with Linux's 208 KiB default,
+// about 50 to 64 KiB with Windows' 64 KiB default) and stays there.
 //
 // The sender runs in busy-loop-sender-fixture.ts (see the notes there, in
 // particular on how it keeps the adaptive pick from being a coin flip) and
@@ -269,7 +270,11 @@ describe("transportParams.maxIdleTimeout", () => {
 // iterations; BBRv1 is on its floor well before that half starts. Both engines
 // are covered: listen() builds one, connect() the other.
 describe.concurrent("congestion control default", () => {
-  const HEALTHY_MIN_CWND = 32 * 1024;
+  // About 3x below the smallest window Cubic settles at on any platform. The
+  // unfixed default reports exactly the 5840-byte floor here; an explicit
+  // cc: 'bbr' reports the same (that run is not asserted on: on a starved
+  // single core BBR does not always get all the way down within the window).
+  const HEALTHY_MIN_CWND = 16 * 1024;
   const fixture = join(import.meta.dir, "busy-loop-sender-fixture.ts");
   type Report = { minCwnd: number };
 
@@ -303,79 +308,56 @@ describe.concurrent("congestion control default", () => {
     };
   }
 
-  // The server engine (listen) sends.
-  async function serverSends(cc?: string): Promise<Report> {
-    const sender = spawnSender(["listen", ...(cc ? [cc] : [])]);
-    await using _proc = sender.proc;
-    const client = await connect(`127.0.0.1:${await sender.port()}`, { alpn: "quic-test", verifyPeer: "manual" });
-    const closed = client.closed.then(
-      () => {},
-      () => {},
-    );
-    await client.opened;
-    // A stream only reaches the peer once something is sent on it.
-    const stream = await client.createBidirectionalStream({ body: "go" });
-    stream.closed.catch(() => {});
-    const draining = drain(stream);
-    const report = await sender.report();
-    await draining;
-    await closed;
-    return report;
-  }
-
-  // The client engine (connect) sends.
-  async function clientSends(): Promise<Report> {
-    const closed = Promise.withResolvers<void>();
-    const draining = Promise.withResolvers<void>();
-    await using server = await listen(
-      (s: any) => {
-        s.closed.then(closed.resolve, closed.resolve);
-        s.onstream = (stream: any) => {
-          stream.closed.catch(() => {});
-          // Nothing to send back. Ending this side is what lets the fixture's
-          // stream, and so its graceful session close, finish.
-          stream.setBody(null);
-          draining.resolve(drain(stream));
-        };
-      },
-      { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"] },
-    );
-    const sender = spawnSender(["connect", String(server.address.port)]);
-    await using _proc = sender.proc;
-    const report = await sender.report();
-    await draining.promise;
-    await closed.promise;
-    return report;
-  }
-
   // Debug builds spend about two seconds just loading node:quic in the fixture.
   const TIMEOUT = 30_000;
 
   test(
-    "a server session keeps its window on a busy loop",
+    "a server session (listen engine) keeps its window on a busy loop",
     async () => {
-      const { minCwnd } = await serverSends();
+      const sender = spawnSender(["listen"]);
+      await using _proc = sender.proc;
+      const client = await connect(`127.0.0.1:${await sender.port()}`, { alpn: "quic-test", verifyPeer: "manual" });
+      const closed = client.closed.then(
+        () => {},
+        () => {},
+      );
+      await client.opened;
+      // A stream only reaches the peer once something is sent on it.
+      const stream = await client.createBidirectionalStream({ body: "go" });
+      stream.closed.catch(() => {});
+      const draining = drain(stream);
+      const { minCwnd } = await sender.report();
+      await draining;
+      await closed;
       expect(minCwnd).toBeGreaterThanOrEqual(HEALTHY_MIN_CWND);
     },
     TIMEOUT,
   );
 
   test(
-    "a client session keeps its window on a busy loop",
+    "a client session (connect engine) keeps its window on a busy loop",
     async () => {
-      const { minCwnd } = await clientSends();
+      const closed = Promise.withResolvers<void>();
+      const draining = Promise.withResolvers<void>();
+      await using server = await listen(
+        (s: any) => {
+          s.closed.then(closed.resolve, closed.resolve);
+          s.onstream = (stream: any) => {
+            stream.closed.catch(() => {});
+            // Nothing to send back. Ending this side is what lets the fixture's
+            // stream, and so its graceful session close, finish.
+            stream.setBody(null);
+            draining.resolve(drain(stream));
+          };
+        },
+        { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"] },
+      );
+      const sender = spawnSender(["connect", String(server.address.port)]);
+      await using _proc = sender.proc;
+      const { minCwnd } = await sender.report();
+      await draining.promise;
+      await closed.promise;
       expect(minCwnd).toBeGreaterThanOrEqual(HEALTHY_MIN_CWND);
-    },
-    TIMEOUT,
-  );
-
-  // Asking for BBR still gets BBR. This is also the collapse the two tests
-  // above rule out, measured by the same fixture.
-  test(
-    "cc: 'bbr' is still honored",
-    async () => {
-      const { minCwnd } = await serverSends("bbr");
-      expect(minCwnd).toBeLessThan(HEALTHY_MIN_CWND);
     },
     TIMEOUT,
   );

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -252,6 +252,135 @@ describe("transportParams.maxIdleTimeout", () => {
   });
 });
 
+// Node's default `cc` is cubic. Left unset, lsquic would fall back to its own
+// "adaptive" default, which commits each connection to Cubic or BBRv1 based on
+// its first RTT sample. These engines only run when the event loop ticks them,
+// so that sample measures whatever JS ran in between, and BBRv1 then keeps
+// measuring the loop instead of the path: the bandwidth it can observe is one
+// window per loop iteration while its min RTT is the real loopback RTT, so on
+// a busy loop its window shrinks to the 4-packet floor (5840 bytes) and the
+// connection moves one such window per iteration. Cubic only reacts to loss,
+// which a slow loop does not produce; its window stays at 100 KiB or more here
+// (bounded by the receiver's UDP buffer).
+//
+// The sender runs in busy-loop-sender-fixture.ts (see the notes there, in
+// particular on how it keeps the adaptive pick from being a coin flip) and
+// reports the smallest stats.cwnd it saw during the second half of 60 busy
+// iterations; BBRv1 is on its floor well before that half starts. Both engines
+// are covered: listen() builds one, connect() the other.
+describe.concurrent("congestion control default", () => {
+  const HEALTHY_MIN_CWND = 32 * 1024;
+  const fixture = join(import.meta.dir, "busy-loop-sender-fixture.ts");
+  type Report = { minCwnd: number };
+
+  // The receiving side has to keep reading, or flow control rather than the
+  // congestion controller would be what limits the sender.
+  async function drain(stream: any) {
+    for await (const _ of stream);
+  }
+
+  function spawnSender(args: string[]) {
+    const port = Promise.withResolvers<number>();
+    const report = Promise.withResolvers<Report>();
+    const proc = Bun.spawn({
+      cmd: [bunExe(), fixture, ...args],
+      env: bunEnv,
+      stderr: "pipe",
+      ipc(message: { port: number } | Report) {
+        if ("port" in message) port.resolve(message.port);
+        else report.resolve(message);
+      },
+    });
+    // A fixture that dies early fails the test instead of hanging it.
+    const died = proc.exited.then(async code => {
+      throw new Error(`fixture exited with code ${code} before reporting:\n${await proc.stderr.text()}`);
+    });
+    died.catch(() => {});
+    return {
+      proc,
+      port: () => Promise.race([port.promise, died]),
+      report: () => Promise.race([report.promise, died]),
+    };
+  }
+
+  // The server engine (listen) sends.
+  async function serverSends(cc?: string): Promise<Report> {
+    const sender = spawnSender(["listen", ...(cc ? [cc] : [])]);
+    await using _proc = sender.proc;
+    const client = await connect(`127.0.0.1:${await sender.port()}`, { alpn: "quic-test", verifyPeer: "manual" });
+    const closed = client.closed.then(
+      () => {},
+      () => {},
+    );
+    await client.opened;
+    // A stream only reaches the peer once something is sent on it.
+    const stream = await client.createBidirectionalStream({ body: "go" });
+    stream.closed.catch(() => {});
+    const draining = drain(stream);
+    const report = await sender.report();
+    await draining;
+    await closed;
+    return report;
+  }
+
+  // The client engine (connect) sends.
+  async function clientSends(): Promise<Report> {
+    const closed = Promise.withResolvers<void>();
+    const draining = Promise.withResolvers<void>();
+    await using server = await listen(
+      (s: any) => {
+        s.closed.then(closed.resolve, closed.resolve);
+        s.onstream = (stream: any) => {
+          stream.closed.catch(() => {});
+          // Nothing to send back. Ending this side is what lets the fixture's
+          // stream, and so its graceful session close, finish.
+          stream.setBody(null);
+          draining.resolve(drain(stream));
+        };
+      },
+      { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"] },
+    );
+    const sender = spawnSender(["connect", String(server.address.port)]);
+    await using _proc = sender.proc;
+    const report = await sender.report();
+    await draining.promise;
+    await closed.promise;
+    return report;
+  }
+
+  // Debug builds spend about two seconds just loading node:quic in the fixture.
+  const TIMEOUT = 30_000;
+
+  test(
+    "a server session keeps its window on a busy loop",
+    async () => {
+      const { minCwnd } = await serverSends();
+      expect(minCwnd).toBeGreaterThanOrEqual(HEALTHY_MIN_CWND);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a client session keeps its window on a busy loop",
+    async () => {
+      const { minCwnd } = await clientSends();
+      expect(minCwnd).toBeGreaterThanOrEqual(HEALTHY_MIN_CWND);
+    },
+    TIMEOUT,
+  );
+
+  // Asking for BBR still gets BBR. This is also the collapse the two tests
+  // above rule out, measured by the same fixture.
+  test(
+    "cc: 'bbr' is still honored",
+    async () => {
+      const { minCwnd } = await serverSends("bbr");
+      expect(minCwnd).toBeLessThan(HEALTHY_MIN_CWND);
+    },
+    TIMEOUT,
+  );
+});
+
 // A graceful close() waits for live sessions to drain, but the listener kept
 // accepting: each new session re-filled `sessions`, so the
 // `closing && sessions.is_empty()` finish gate never tripped and `closed`


### PR DESCRIPTION
### Problem

A `node:quic` session created without the `cc` option gets lsquic's default congestion controller, which is `es_cc_algo` 3, "adaptive". Node's default is `cubic` (ngtcp2's default; `src/js/internal/quic/quic.ts` only validates `cc` and passes `undefined` through, and `apply_transport_params` in `src/runtime/node/quic/endpoint.rs` only called `cc_algo()` when the option was given).

Adaptive mode is also the wrong default for these engines on its own merits. It commits each connection to Cubic or BBRv1 on the connection's first RTT sample (`send_ctl_select_cc`, threshold 1.5 ms), and both `node:quic` engines are only ticked from the event loop, so that sample measures whatever JS ran between two ticks. A server that does any work in its session callback, or a client that does any work right after `connect()`, gets BBRv1 (`BUN_DEBUG_lsquic=1`: `select BBRv1 congestion controller`), and BBRv1 then keeps modelling the loop as the path: the only bandwidth it can observe is one window per loop iteration while its min RTT is the real loopback RTT, so on a busy loop the window shrinks to BBR's 4-packet floor and stays there. With the released binary, a session sending 512 KiB chunks from a loop paced at 12 ms per iteration reports `session.stats.cwnd === 5840n` within 20 iterations (20/20 runs) and moves about 5.9 KB per iteration from then on; the same transfer on Cubic keeps a window of 100 to 240 KiB (bounded by the receiver's UDP buffer) and moves 4 to 170 times as much. Which of the two a given session got depended on what the loop happened to be doing during its handshake. #37455 makes the same change for the `Bun.serve({http3})` and `fetch` engines in `quic.c` and deliberately left `node:quic` out; this is the `node:quic` half.

### Fix

`apply_transport_params` sets Cubic before looking at the options, so the default and the `options` is-not-an-object path both get it, and the `cc` mapping is now `bbr` to BBRv1 and everything else (`cubic`, and `reno`, which lsquic does not ship) to Cubic. The previous catch-all arm mapped to 0, which is adaptive again; nothing reaches it through the public API (the JS layer validates `cc`), but it is gone too. Both engines go through this function (`build_engine`, from `listen()` and `connect()`).

### Verification

`test/js/node/quic/quic-endpoint.test.ts`, "congestion control default": one test per engine (the `listen()` one sends to the test's client, the `connect()` one sends to the test's server), with the busy sender in `test/js/node/quic/busy-loop-sender-fixture.ts`. Two things about the fixture are worth calling out:

- Getting adaptive mode to pick BBRv1 reliably on loopback: lsquic subtracts the peer's reported ACK delay from its RTT samples, and the first full-connection sample is usually taken while the loop is still inside the handshake burst, so merely pacing the loop with 5 ms sleeps still produced first samples of 150 to 1300 us and Cubic 8 times out of 8. The fixture instead blocks the thread for 30 ms while the first round trip is in flight (in the `listen()` session callback, and right after `connect()`, which has already put the Initial on the wire), which makes that sample about 30 ms and the pick BBRv1 every time; with the fix there is no pick to make.
- Getting BBRv1 to actually collapse: its min RTT comes from raw ACK timing, so the connection has to have been ACKed while the loop was genuinely free. The fixture free-runs until 256 KiB have been sent (a few rounds of ACKs) rather than idling for a fixed delay, which was not enough on a loaded machine, then paces 60 iterations of 12 ms and reports the smallest `stats.cwnd` it saw over the last 30 of them. The tests require 16 KiB: Cubic settles just under what the receiver's UDP buffer holds (100 KiB and up with Linux's 208 KiB default, about 50 to 64 KiB behind Windows' 64 KiB default), and the unfixed default reports exactly 5840.

Results:

- Unfixed (`USE_SYSTEM_BUN=1`, 1.4.0): both tests fail with `Received: 5840` in 10/10 runs of the file, and in 3/3 runs with the whole thing pinned to one CPU.
- Fixed debug build: 10/10 runs pass, plus 6/6 with three copies of the file running at once and 6/6 pinned to one or two CPUs; each test takes 3.5 to 4 s, almost all of it the fixture loading `node:quic` in a debug build (hence the explicit timeout). `test/js/node/quic/` passes, and the upstream `test-quic-cc-algorithm`, `-session-stats-detailed`, `-stream-bidi-varchunklen`, `-flow-control-uni`, `-datagram` and `-connection-concurrent` tests pass with their flags.
- An explicit `cc: 'bbr'` run of the fixture on the fixed build reports the same 5840, which is how the fixture was checked against the thing it rules out; it is not asserted on in the suite because, starved to a single core, BBR did not always get all the way down within the window (one run out of three reported 20 KiB).
