### PR TITLE
install: stop panicking on package labels longer than the stack buffers

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -427,6 +427,22 @@ pub(crate) fn alias_is_safe_install_target(alias: &[u8]) -> bool {
     component_count == 1 || (component_count == 2 && alias[0] == b'@')
 }
 
+/// Formats the version label `PackageInstall` verifies and hashes patches
+/// against. npm versions fit `buf`; tarball, folder and git resolutions (and
+/// prerelease tags) repeat a user-supplied path, URL or tag of unbounded
+/// length, so a label that does not fit is formatted into `spill` instead.
+fn print_package_version<'a>(
+    buf: &'a mut [u8],
+    spill: &'a mut Vec<u8>,
+    args: core::fmt::Arguments<'_>,
+) -> &'a [u8] {
+    if let Ok(label) = bun_core::fmt::buf_print(buf, args) {
+        return label;
+    }
+    std::io::Write::write_fmt(spill, args).expect("formatting into a Vec is infallible");
+    spill
+}
+
 impl<'a> PackageInstaller<'a> {
     // ──────────────────────────────────────────────────────────────────────
     // BACKREF accessors
@@ -1314,6 +1330,7 @@ impl<'a> PackageInstaller<'a> {
         let pkg_name_hash = self.pkg_name_hashes[package_id as usize];
 
         let mut resolution_buf = [0u8; 512];
+        let mut resolution_spill = Vec::new();
         let package_version: &[u8] = if resolution.tag == resolution::Tag::Workspace {
             'brk: {
                 if let Some(workspace_version) = self
@@ -1322,22 +1339,22 @@ impl<'a> PackageInstaller<'a> {
                     .workspace_versions
                     .get(&pkg_name_hash)
                 {
-                    break 'brk bun_core::fmt::buf_print(
+                    break 'brk print_package_version(
                         &mut resolution_buf,
+                        &mut resolution_spill,
                         format_args!("{}", workspace_version.fmt(string_buf!())),
-                    )
-                    .expect("unreachable");
+                    );
                 }
 
                 // no version
                 break 'brk b"";
             }
         } else {
-            bun_core::fmt::buf_print(
+            print_package_version(
                 &mut resolution_buf,
+                &mut resolution_spill,
                 format_args!("{}", resolution.fmt(string_buf!(), PathSep::Posix)),
             )
-            .expect("unreachable")
         };
 
         let (patch_patch, patch_contents_hash, patch_name_and_version_hash, remove_patch) = 'brk: {

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -22,13 +22,28 @@ use crate::package_manager_real::package_manager_directories::{
     compute_cache_dir_and_subpath, get_temporary_directory,
 };
 use crate::{
-    BuntagHashBuf, DependencyID, Features, PackageID, buntaghashbuf_make, initialize_store,
-    invalid_package_id,
+    BuntagHashBuf, DependencyID, Features, PackageID, Resolution, buntaghashbuf_make,
+    initialize_store, invalid_package_id,
 };
 
 #[inline]
 fn string_hash(s: &[u8]) -> u64 {
     bun_semver::semver_string::Builder::string_hash(s)
+}
+
+/// Formats `resolution` as the version half of a `name@version` patch key into
+/// `label` (cleared first, so one allocation serves a whole candidate loop).
+/// Tarball, folder and git resolutions repeat a user-supplied path or URL, so
+/// the label has no length bound.
+fn print_resolution_label<'a>(
+    label: &'a mut Vec<u8>,
+    resolution: &Resolution,
+    string_buf: &[u8],
+) -> &'a [u8] {
+    label.clear();
+    write!(label, "{}", resolution.fmt(string_buf, PathSep::Posix))
+        .expect("formatting into a Vec is infallible");
+    label
 }
 
 #[derive(Default)]
@@ -144,7 +159,6 @@ pub fn do_patch_commit(
     };
 
     let mut iterator = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(&lockfile);
-    let mut resolution_buf = [0u8; 1024];
     // reshaped for borrowck — `compute_cache_dir_and_subpath` borrows
     // `manager` mutably while the package name/resolution borrow `lockfile`
     // (which itself sometimes aliases `manager.lockfile`). Clone the slice/
@@ -219,20 +233,15 @@ pub fn do_patch_commit(
                     }
                     Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
                     Some(PackageIndexEntry::Ids(ids)) => 'brk: {
+                        let mut resolution_label = Vec::new();
                         for &id in ids.as_slice() {
                             let pkg = *lockfile.packages.get(id as usize);
-                            let total = resolution_buf.len();
-                            let mut cursor: &mut [u8] = &mut resolution_buf[..];
-                            write!(
-                                &mut cursor,
-                                "{}",
-                                pkg.resolution
-                                    .fmt(lockfile.buffers.string_bytes.as_slice(), PathSep::Posix)
-                            )
-                            .expect("unreachable");
-                            let written = total - cursor.len();
-                            let resolution_label = &resolution_buf[..written];
-                            if resolution_label == version {
+                            if print_resolution_label(
+                                &mut resolution_label,
+                                &pkg.resolution,
+                                lockfile.buffers.string_bytes.as_slice(),
+                            ) == version
+                            {
                                 break 'brk pkg;
                             }
                         }
@@ -305,20 +314,15 @@ pub fn do_patch_commit(
     let pkg: Package = pkg;
 
     let name = pkg.name.slice(lockfile.buffers.string_bytes.as_slice());
-    let resolution_label_len = {
-        let total = resolution_buf.len();
-        let mut cursor: &mut [u8] = &mut resolution_buf[..];
-        write!(
-            &mut cursor,
-            "{}@{}",
-            bstr::BStr::new(name),
-            pkg.resolution
-                .fmt(lockfile.buffers.string_bytes.as_slice(), PathSep::Posix)
-        )
-        .expect("unreachable");
-        total - cursor.len()
-    };
-    let resolution_label = &resolution_buf[..resolution_label_len];
+    let mut patch_key = Vec::new();
+    write!(
+        &mut patch_key,
+        "{}@{}",
+        bstr::BStr::new(name),
+        pkg.resolution
+            .fmt(lockfile.buffers.string_bytes.as_slice(), PathSep::Posix)
+    )
+    .expect("formatting into a Vec is infallible");
 
     let patchfile_contents: Vec<u8> = 'brk: {
         let new_folder = changes_dir;
@@ -402,7 +406,7 @@ pub fn do_patch_commit(
         // If the package was already patched then it might have a ".bun-tag-XXXXXXXX"
         // we need to rename this out and back too.
         let bun_patch_tag: Option<&[u8]> = 'has_bun_patch_tag: {
-            let name_and_version_hash = string_hash(resolution_label);
+            let name_and_version_hash = string_hash(&patch_key);
             let patch_tag: &[u8] = 'patch_tag: {
                 if let Some(patchdep) = lockfile.patched_dependencies.get(&name_and_version_hash) {
                     if let Some(hash) = patchdep.patchfile_hash() {
@@ -585,17 +589,11 @@ pub fn do_patch_commit(
         Global::crash();
     }
 
-    resolution_buf[resolution_label_len..resolution_label_len + b".patch".len()]
-        .copy_from_slice(b".patch");
-    let mut patch_filename: &[u8] = &resolution_buf[0..resolution_label_len + b".patch".len()];
-    let escaped_owned: Option<Box<[u8]>>;
-    if let Some(escaped) = escape_patch_filename(patch_filename) {
-        escaped_owned = Some(escaped);
-        patch_filename = escaped_owned.as_deref().unwrap();
-    } else {
-        escaped_owned = None;
-    }
-    let _ = &escaped_owned;
+    let unescaped_patch_filename = [patch_key.as_slice(), b".patch"].concat();
+    let escaped_patch_filename = escape_patch_filename(&unescaped_patch_filename);
+    let patch_filename: &[u8] = escaped_patch_filename
+        .as_deref()
+        .unwrap_or(&unescaped_patch_filename);
 
     let patches_dir: &[u8] = match &manager.options.patch_features {
         PatchFeatures::Commit { patches_dir } => patches_dir,
@@ -632,16 +630,6 @@ pub fn do_patch_commit(
         Global::crash();
     }
 
-    let mut patch_key = Vec::new();
-    // re-slice instead of reusing `resolution_label` so its borrow ends
-    // before the `.patch` suffix write above; the prefix bytes are unchanged.
-    write!(
-        &mut patch_key,
-        "{}",
-        bstr::BStr::new(&resolution_buf[..resolution_label_len])
-    )
-    .expect("infallible: in-memory write");
-    let patch_key: Box<[u8]> = patch_key.into_boxed_slice();
     let patchfile_path: Box<[u8]> = Box::<[u8]>::from(path_in_patches_dir.as_bytes());
     let _ = sys::unlink(resolve_path::join_z::<platform::Auto>(&[
         changes_dir,
@@ -649,7 +637,7 @@ pub fn do_patch_commit(
     ]));
 
     Ok(Some(PatchCommitResult {
-        patch_key,
+        patch_key: patch_key.into_boxed_slice(),
         patchfile_path,
         not_in_workspace_root,
     }))
@@ -729,7 +717,6 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let arg_kind: PatchArgKind = PatchArgKind::from_arg(argument);
 
     let mut folder_path_buf = PathBuffer::uninit();
-    let mut resolution_buf = [0u8; 1024];
 
     #[cfg(windows)]
     let mut win_normalizer = PathBuffer::uninit();
@@ -840,19 +827,15 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     }
                     Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
                     Some(PackageIndexEntry::Ids(ids)) => 'id: {
+                        let mut resolution_label = Vec::new();
                         for &id in ids.as_slice() {
                             let pkg = *lockfile.packages.get(id as usize);
-                            let total = resolution_buf.len();
-                            let mut cursor: &mut [u8] = &mut resolution_buf[..];
-                            write!(
-                                &mut cursor,
-                                "{}",
-                                pkg.resolution.fmt(strbuf, PathSep::Posix)
-                            )
-                            .expect("unreachable");
-                            let written = total - cursor.len();
-                            let resolution_label = &resolution_buf[..written];
-                            if resolution_label == version {
+                            if print_resolution_label(
+                                &mut resolution_label,
+                                &pkg.resolution,
+                                strbuf,
+                            ) == version
+                            {
                                 break 'id pkg;
                             }
                         }
@@ -1295,7 +1278,7 @@ fn pkg_info_for_name_and_version(
 
     let strbuf = lockfile.buffers.string_bytes.as_slice();
 
-    let mut buf = [0u8; 1024];
+    let mut resolution_label = Vec::new();
     let dependencies = lockfile.buffers.dependencies.as_slice();
 
     for (dep_id, dep) in dependencies.iter().enumerate() {
@@ -1308,19 +1291,7 @@ fn pkg_info_for_name_and_version(
         }
         let pkg = *lockfile.packages.get(pkg_id as usize);
         if let Some(v) = version {
-            let written = {
-                let total = buf.len();
-                let mut cursor: &mut [u8] = &mut buf[..];
-                write!(
-                    &mut cursor,
-                    "{}",
-                    pkg.resolution.fmt(strbuf, PathSep::Posix)
-                )
-                .expect("Resolution name too long");
-                total - cursor.len()
-            };
-            let label = &buf[..written];
-            if label == v {
+            if print_resolution_label(&mut resolution_label, &pkg.resolution, strbuf) == v {
                 pairs.push((dep_id as DependencyID, pkg_id));
             }
         } else {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,7 +1,7 @@
 import { $, ShellOutput } from "bun";
-import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { lstatSync } from "fs";
-import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { lstatSync, readFileSync } from "fs";
+import { bunEnv, bunExe, isASAN, tempDir, VerdaccioRegistry } from "harness";
 import { isAbsolute, join, sep } from "path";
 
 const expectNoError = (o: ShellOutput) => expect(o.stderr.toString()).not.toContain("error");
@@ -63,6 +63,115 @@ describe("error messages", () => {
     expect(stderr).toContain("bun patch-commit node_modules/<package>");
     expect(stderr).toContain("bun patch-commit --help");
     expect(exitCode).toBe(1);
+  });
+});
+
+// `bun patch` identifies packages by `name@label`, where a tarball package's label is
+// the spec it was installed from. These labels used to be formatted into 1024 byte
+// stack buffers (512 bytes in the installer itself), so a long enough spec crashed
+// every command that formatted it.
+describe("packages whose label is longer than 1024 bytes", () => {
+  const registry = new VerdaccioRegistry();
+
+  beforeAll(async () => {
+    await registry.start();
+  });
+
+  afterAll(() => {
+    registry.stop();
+  });
+
+  // `x/../` normalizes away, so the tarball still lives at a short path that is valid
+  // on every platform while the recorded spec stays long.
+  const longSpec = (tarball: string) => `./${Buffer.alloc(1050, "x/../").toString()}${tarball}`;
+
+  async function createProject(tarball: string, packageJson: Record<string, unknown>) {
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: {
+        "package.json": JSON.stringify(packageJson),
+        [tarball]: readFileSync(join(import.meta.dir, tarball)),
+      },
+    });
+    return packageDir;
+  }
+
+  async function runBun(cwd: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  async function install(cwd: string) {
+    const { stderr, exitCode } = await runBun(cwd, "install");
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  test.concurrent("bun patch <name>@<label>", async () => {
+    const spec = longSpec("bar-0.0.2.tgz");
+    const packageDir = await createProject("bar-0.0.2.tgz", { name: "foo", dependencies: { bar: spec } });
+    await install(packageDir);
+
+    const { stdout, stderr, exitCode } = await runBun(packageDir, "patch", `bar@${spec}`);
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain("To patch bar, edit the following folder:\n\n  node_modules/bar\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // `bun patch <path>` and `bun patch --commit <path>` find the package by comparing the
+  // label of every package with that name against the version in <path>/package.json.
+  // The lockfile lists the long-labeled `bar` before `bar-from-npm`, so both commands
+  // format the long label before reaching the package that matches.
+  test.concurrent("bun patch <path> when another package with the same name has a long label", async () => {
+    const packageDir = await createProject("bar-0.0.2.tgz", {
+      name: "foo",
+      dependencies: { "bar": longSpec("bar-0.0.2.tgz"), "bar-from-npm": "npm:bar@0.0.7" },
+    });
+    await install(packageDir);
+
+    const prepare = await runBun(packageDir, "patch", "node_modules/bar-from-npm");
+    expect(prepare.stderr).not.toContain("error:");
+    expect(prepare.stdout).toContain("To patch bar, edit the following folder:\n\n  node_modules/bar-from-npm\n");
+    expect(prepare.exitCode).toBe(0);
+
+    await Bun.write(join(packageDir, "node_modules", "bar-from-npm", "index.js"), "module.exports = 'patched';\n");
+
+    const commit = await runBun(packageDir, "patch", "--commit", "node_modules/bar-from-npm");
+    expect(commit.stderr).not.toContain("error:");
+    expect(commit.exitCode).toBe(0);
+    expect((await Bun.file(join(packageDir, "package.json")).json()).patchedDependencies).toEqual({
+      "bar@0.0.7": "patches/bar@0.0.7.patch",
+    });
+    expect(await Bun.file(join(packageDir, "patches", "bar@0.0.7.patch")).text()).toContain(
+      "+module.exports = 'patched';",
+    );
+  });
+
+  // Committing formats `name@label` before doing anything else. The commit itself cannot
+  // succeed for such a package (the patch file is named after the label, which no file
+  // system accepts at this length), so what is pinned here is that it fails as an error.
+  test.concurrent("bun patch --commit of a long-labeled package exits 1 without recording a patch", async () => {
+    const packageJson = { name: "foo", dependencies: { baz: longSpec("baz-0.0.3.tgz") } };
+    const packageDir = await createProject("baz-0.0.3.tgz", packageJson);
+    await install(packageDir);
+
+    const prepare = await runBun(packageDir, "patch", "node_modules/baz");
+    expect(prepare.stderr).not.toContain("error:");
+    expect(prepare.exitCode).toBe(0);
+
+    await Bun.write(join(packageDir, "node_modules", "baz", "index.js"), "console.log('patched baz');\n");
+
+    const commit = await runBun(packageDir, "patch", "--commit", "node_modules/baz");
+    expect(commit.stderr).toContain("error:");
+    expect(commit.exitCode).toBe(1);
+    expect(await Bun.file(join(packageDir, "package.json")).json()).toEqual(packageJson);
   });
 });
 

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2140,3 +2140,121 @@ test("matching workspace devDependency and npm peerDependency", async () => {
   expect(err).not.toContain("updated");
   expect(out).toContain("no changes");
 });
+
+// While linking, the hoisted installer formats each package's version label (its
+// version, or for tarball/folder/git packages the spec it was resolved from) into a
+// 512 byte stack buffer. Labels longer than that used to abort the whole install.
+describe("packages whose version label is longer than 512 bytes", () => {
+  // Long enough to overflow the buffer, but `x/../` normalizes away, so the tarball
+  // still lives at a short path that is valid on every platform. The resolution
+  // recorded in the lockfile (and formatted by the installer) is the spec verbatim.
+  const longTarballSpec = (tarball: string) => `./${Buffer.alloc(650, "x/../").toString()}${tarball}`;
+
+  async function installHoisted(ctx: TestCtx) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", "--linker", "hoisted"],
+      cwd: ctx.packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: ctx.env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+  }
+
+  test.concurrent("local tarball", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const spec = longTarballSpec("bar-0.0.2.tgz");
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", dependencies: { bar: spec } })),
+      cp(join(import.meta.dir, "bar-0.0.2.tgz"), join(packageDir, "bar-0.0.2.tgz")),
+    ]);
+
+    await installHoisted(ctx);
+
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain(`"bar@${spec}"`);
+    expect(await file(join(packageDir, "node_modules", "bar", "package.json")).json()).toEqual({
+      name: "bar",
+      version: "0.0.2",
+    });
+  });
+
+  test.concurrent("remote tarball", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const tarball = file(join(import.meta.dir, "bar-0.0.2.tgz"));
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response(tarball),
+    });
+    const url = `${server.url}${Buffer.alloc(600, "a").toString()}/bar-0.0.2.tgz`;
+    await write(packageJson, JSON.stringify({ name: "foo", dependencies: { bar: url } }));
+
+    await installHoisted(ctx);
+
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain(`"bar@${url}"`);
+    expect(await file(join(packageDir, "node_modules", "bar", "package.json")).json()).toEqual({
+      name: "bar",
+      version: "0.0.2",
+    });
+  });
+
+  // Workspace packages are labeled with their own version rather than a resolution.
+  test.concurrent("workspace package with a long prerelease version", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const version = `1.0.0-${Buffer.alloc(600, "a").toString()}`;
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", workspaces: ["pkgs/*"] })),
+      write(join(packageDir, "pkgs", "pkg1", "package.json"), JSON.stringify({ name: "pkg1", version })),
+    ]);
+
+    await installHoisted(ctx);
+
+    expect(await file(join(packageDir, "node_modules", "pkg1", "package.json")).json()).toEqual({
+      name: "pkg1",
+      version,
+    });
+  });
+
+  // The same label is the version half of the `name@version` patchedDependencies key,
+  // so a patch keyed by a long spec has to be found and applied, not just not crash.
+  test.concurrent("patchedDependencies keyed by the long label is applied", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const spec = longTarballSpec("baz-0.0.3.tgz");
+    const patch = [
+      "diff --git a/index.js b/index.js",
+      "--- a/index.js",
+      "+++ b/index.js",
+      "@@ -1,3 +1,3 @@",
+      " #! /usr/bin/env node",
+      " ",
+      '-console.log("run baz");',
+      '+console.log("patched baz");',
+      "",
+    ].join("\n");
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: { baz: spec },
+          patchedDependencies: { [`baz@${spec}`]: "patches/baz.patch" },
+        }),
+      ),
+      write(join(packageDir, "patches", "baz.patch"), patch),
+      cp(join(import.meta.dir, "baz-0.0.3.tgz"), join(packageDir, "baz-0.0.3.tgz")),
+    ]);
+
+    await installHoisted(ctx);
+
+    expect(await file(join(packageDir, "node_modules", "baz", "index.js")).text()).toBe(
+      '#! /usr/bin/env node\n\nconsole.log("patched baz");\n',
+    );
+  });
+});


### PR DESCRIPTION
## Repro

```sh
mkdir probe && cd probe
cp <bun repo>/test/cli/install/bar-0.0.2.tgz .
bun -e 'require("fs").writeFileSync("package.json", JSON.stringify({ name: "foo", dependencies: { bar: "./" + "x/../".repeat(130) + "bar-0.0.2.tgz" } }))'
bun install
```

```
Resolved, downloaded and extracted [1]
panic: unreachable: Error
```

`bun install` aborts (SIGABRT, exit 134) after the tarball has been resolved and extracted. The spec normalizes to `./bar-0.0.2.tgz`, which exists; a real 618 byte relative path behaves the same (that is how this was found, see #37462). The same abort happens for a remote tarball whose URL is longer than 512 bytes, a `file:` folder at a long path, and a workspace package whose version has a ~500 byte prerelease tag. `--lockfile-only` succeeds, so it is the link step. Reproduced with `bun 1.4.0-canary.1` and main.

Top frame: `Result::expect` in `PackageInstaller::install_package_with_name_and_resolution` (`src/install/PackageInstaller.rs:1340`), called from `install_package` / `hoisted_install::install_hoisted_packages`.

## Cause

While linking each package, the hoisted installer formats the package's version label into `let mut resolution_buf = [0u8; 512]` with `buf_print(..).expect("unreachable")`. For npm packages the label is the version; for tarball, folder and git packages it is the spec they were resolved from (stored verbatim), and for workspace packages it is the workspace's own version. Those are user supplied and have no length bound, so the overflow `buf_print` reports is reachable and the `expect` turns it into the panic. Both branches (workspace version and resolution) have it.

The isolated linker already builds this label in a `Vec` (`Installer::package_patch_info`) and is not affected by this panic. It fails such installs with `ENAMETOOLONG` instead, because the store directory name embeds the spec; that is a separate problem and not touched here.

## Fix

`print_package_version` keeps the 512 byte stack buffer as the allocation-free path and, only when the label does not fit, formats it into a `Vec` that lives next to the buffer (the same shape as `resolve_path::join_z_buf_spill`). The linking loop runs once per installed package, so the common case still does not allocate.

Spilling is the only correct behavior for this label: it is compared against the installed `package.json` version and hashed as the version half of the `name@version` `patchedDependencies` key, so a truncated label would silently fail verification or miss a patch, and rejecting the package would refuse a valid install (nothing on disk is named after the label; the tarball cache folder is a hash of it). The new patchedDependencies test below checks the spilled label byte for byte by keying a patch with it.

`bun patch` formats the same labels into 1024 byte buffers with the same `expect` at four sites in `src/install/PackageManager/patchPackage.rs`, all reproducible the same way once the install succeeds (verified with a build that only had the installer change):

* `pkg_info_for_name_and_version` (`bun patch <name>@<version>` compares the label of every package with that name; panicked with `Resolution name too long`),
* the multiple-packages-with-this-name loops in `prepare_patch` and `do_patch_commit` (`bun patch <path>` when another package with the same name has a long label),
* the `name@label` key in `do_patch_commit`, which is also the patch file name.

These format into a `Vec` (`print_resolution_label`, reused across a candidate loop). In `do_patch_commit` the key `Vec` is returned as the `patch_key` directly and the file name is built from it, replacing the re-slicing of the shared buffer; the bytes are unchanged (the key was already valid UTF-8, so the former `BStr` round trip was a copy). Committing a package whose label is this long still cannot succeed, since the patch file would be named after the label, but it now exits 1 with an error instead of aborting; today it fails before that at the diff step for tarball packages (#37124), which this does not change either way.

## Tests

`test/cli/install/bun-workspaces.test.ts`, "packages whose version label is longer than 512 bytes" (hoisted linker): local tarball, remote tarball served from a local `Bun.serve`, workspace package with a long prerelease version (the other branch), and a `patchedDependencies` entry keyed by the long spec that must actually be applied. `test/cli/install/bun-patch.test.ts`, "packages whose label is longer than 1024 bytes": `bun patch <name>@<label>`, `bun patch <path>` plus `--commit` when a same-named package has a long label (the long one is listed first, so the loops format it), and `--commit` of a long-labeled package exiting 1 without touching `package.json`. The long specs use `x/../` repeated so nothing long is ever created on disk.

All seven fail on the unfixed build (`panic: unreachable: Error` during the install) and pass with the fix; with only the installer change applied, the three `bun patch` tests fail at the `bun patch` step instead, so each patch site is covered on its own. Both files pass in full, as does `bun-install-patch.test.ts`; `cargo clippy -p bun_install` is clean and `cargo check -p bun_install` passes for `x86_64-pc-windows-msvc` and `x86_64-apple-darwin`.
