### PR TITLE
install: keep isolated store entry names within NAME_MAX

### DIFF
--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -344,6 +344,66 @@ pub mod entry {
         }
     }
 
+    /// Longest file name every supported filesystem accepts: 255 bytes on
+    /// Linux and macOS, 255 UTF-16 units on NTFS (never more than the UTF-8
+    /// byte count).
+    const NAME_MAX: usize = 255;
+    /// `+<16 hex>` appended by `StorePathFormatter` when the entry has peers.
+    const PEER_SUFFIX_LEN: usize = 1 + 16;
+    /// `-<16 hex>` appended by `GlobalStorePathFormatter`, plus the
+    /// `.tmp-<u64 hex>` / `.old-<u64 hex>` the installer appends to that
+    /// while publishing a global store entry.
+    const GLOBAL_STORE_SUFFIX_LEN: usize = (1 + 16) + (".tmp-".len() + 16);
+    /// A `<name>@<resolution>` longer than this is cut to `CUT_NAME_LEN` bytes
+    /// followed by `+<16 hex wyhash of the full text>`, so that a tarball URL,
+    /// folder path or git URL of any length yields an entry whose directory
+    /// name fits in NAME_MAX together with every suffix above.
+    const MAX_VERBATIM_NAME_LEN: usize = NAME_MAX - PEER_SUFFIX_LEN - GLOBAL_STORE_SUFFIX_LEN;
+    const CUT_NAME_LEN: usize = MAX_VERBATIM_NAME_LEN - (1 + 16);
+
+    /// `fmt::Write` sink for the `<name>@<resolution>` text: keeps the first
+    /// `MAX_VERBATIM_NAME_LEN` bytes, and the length and hash of all of it.
+    struct NameSink {
+        buf: [u8; MAX_VERBATIM_NAME_LEN],
+        len: usize,
+        hasher: bun_wyhash::Wyhash,
+    }
+
+    impl NameSink {
+        fn new() -> Self {
+            Self {
+                buf: [0; MAX_VERBATIM_NAME_LEN],
+                len: 0,
+                hasher: bun_wyhash::Wyhash::init(0),
+            }
+        }
+
+        fn write_to(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if self.len <= MAX_VERBATIM_NAME_LEN {
+                return f.write_str(bun_core::str_utf8(&self.buf[..self.len]).ok_or(fmt::Error)?);
+            }
+            let mut cut = CUT_NAME_LEN;
+            while !bun_core::strings::is_on_char_boundary(&self.buf, cut) {
+                cut -= 1;
+            }
+            f.write_str(bun_core::str_utf8(&self.buf[..cut]).ok_or(fmt::Error)?)?;
+            write!(f, "+{:016x}", self.hasher.final_())
+        }
+    }
+
+    impl fmt::Write for NameSink {
+        fn write_str(&mut self, s: &str) -> fmt::Result {
+            let bytes = s.as_bytes();
+            if let Some(room) = self.buf.get_mut(self.len..) {
+                let n = bytes.len().min(room.len());
+                room[..n].copy_from_slice(&bytes[..n]);
+            }
+            self.len += bytes.len();
+            self.hasher.update(bytes);
+            Ok(())
+        }
+    }
+
     pub struct StorePathFormatter<'a> {
         pub(crate) entry_id: Id,
         pub(crate) store: &'a Store,
@@ -352,15 +412,25 @@ pub mod entry {
 
     impl<'a> fmt::Display for StorePathFormatter<'a> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            let mut name = NameSink::new();
+            self.write_name(&mut name)?;
+            name.write_to(f)?;
+
+            let peer_hash = self.store.entries.items_peer_hash()[self.entry_id.get() as usize];
+            if peer_hash != PeerHash::NONE {
+                write!(f, "+{:016x}", peer_hash.cast())?;
+            }
+
+            Ok(())
+        }
+    }
+
+    impl<'a> StorePathFormatter<'a> {
+        /// Writes the untruncated `<name>@<resolution>` text.
+        fn write_name(&self, f: &mut impl fmt::Write) -> fmt::Result {
             use super::node::NodeColumns as _;
             let store = self.store;
-            let entries = store.entries.slice();
-            // derive(MultiArrayElement)-generated SliceExt accessors: `.items_peer_hash()`, `.items_node_id()`.
-            let entry_peer_hashes = entries.items_peer_hash();
-            let entry_node_ids = entries.items_node_id();
-
-            let peer_hash = entry_peer_hashes[self.entry_id.get() as usize];
-            let node_id = entry_node_ids[self.entry_id.get() as usize];
+            let node_id = store.entries.items_node_id()[self.entry_id.get() as usize];
             let pkg_id = store.nodes.items_pkg_id()[node_id.get() as usize];
 
             let string_buf = self.lockfile.buffers.string_bytes.as_slice();
@@ -405,10 +475,6 @@ pub mod entry {
                         pkg_res.fmt_store_path(string_buf),
                     )?;
                 }
-            }
-
-            if peer_hash != PeerHash::NONE {
-                write!(f, "+{:016x}", peer_hash.cast())?;
             }
 
             Ok(())

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,10 +1,10 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, readlinkSync, statSync } from "fs";
+import { existsSync, lstatSync, readFileSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -1754,6 +1754,253 @@ test("tarball URL with query string resolves at runtime", async () => {
   expect(stderr).toBe("");
   expect(stdout).toBe("1.0.0\n");
   expect(exitCode).toBe(0);
+});
+
+describe("long store entry names", () => {
+  // A store entry is named `<name>@<resolution>`. For tarball, folder and git
+  // packages the resolution is the user's path or URL, so the name can grow
+  // past NAME_MAX (255 bytes) and creating the entry fails with ENAMETOOLONG.
+  // Names longer than 200 bytes are therefore cut to 183 bytes and suffixed
+  // with `+` and the 16 hex digit wyhash (seed 0, `Bun.hash`) of the full
+  // name. The remaining 55 bytes are reserved for the peer-set suffix and the
+  // global store's `-<hash>` and `.tmp-<hash>` suffixes.
+  const maxVerbatimLength = 200;
+
+  function cutEntryName(fullName: string): string {
+    expect(Buffer.byteLength(fullName)).toBeGreaterThan(maxVerbatimLength);
+    return `${fullName.slice(0, 183)}+${Bun.hash(fullName).toString(16).padStart(16, "0")}`;
+  }
+
+  function entryPattern(entry: string, suffix: string): RegExp {
+    return new RegExp(`^${entry.replaceAll(/[.+]/g, "\\$&")}${suffix}$`);
+  }
+
+  test("local tarball and folder dependencies in a deep directory", async () => {
+    // Every path component is short; only the entry name, which embeds the
+    // whole relative path (257 bytes here), would exceed NAME_MAX.
+    const segment = Buffer.alloc(85, "d").toString();
+    const deep = `${segment}/${segment}/${segment}`;
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        [`${deep}/bar-0.0.2.tgz`]: readFileSync(join(import.meta.dir, "bar-0.0.2.tgz")),
+        [`${deep}/pkg/package.json`]: JSON.stringify({ name: "folder-pkg", version: "1.0.0" }),
+      },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "long-specs",
+        dependencies: {
+          "bar": `file:./${deep}/bar-0.0.2.tgz`,
+          "folder-pkg": `file:./${deep}/pkg`,
+        },
+      }),
+    );
+
+    const tarballEntry = cutEntryName(`bar@.+${deep.replaceAll("/", "+")}+bar-0.0.2.tgz`);
+    const folderEntry = cutEntryName(`folder-pkg@file+${deep.replaceAll("/", "+")}+pkg`);
+    const expectedEntries = [tarballEntry, folderEntry, "node_modules"].sort();
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const bunDir = join(packageDir, "node_modules", ".bun");
+    expect(await readdirSorted(bunDir)).toEqual(expectedEntries);
+    expect(
+      await Promise.all([
+        readlink(join(packageDir, "node_modules", "bar")),
+        readlink(join(packageDir, "node_modules", "folder-pkg")),
+        readlink(join(bunDir, "node_modules", "bar")),
+        file(join(packageDir, "node_modules", "bar", "package.json")).json(),
+        file(join(packageDir, "node_modules", "folder-pkg", "package.json")).json(),
+      ]),
+    ).toEqual([
+      join(".bun", tarballEntry, "node_modules", "bar"),
+      join(".bun", folderEntry, "node_modules", "folder-pkg"),
+      join("..", tarballEntry, "node_modules", "bar"),
+      { name: "bar", version: "0.0.2" },
+      { name: "folder-pkg", version: "1.0.0" },
+    ]);
+
+    // The name is derived from the `<name>@<resolution>` text alone, so a
+    // second install finds the same entries instead of creating new ones.
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(await readdirSorted(bunDir)).toEqual(expectedEntries);
+  });
+
+  test("remote tarball with a long URL in the global store", async () => {
+    const tarball = file(join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz"));
+    const urlPath = `/${Buffer.alloc(220, "u").toString()}/no-deps.tgz`;
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname !== urlPath) {
+          return new Response("Not found", { status: 404 });
+        }
+        return new Response(tarball, { headers: { "Content-Type": "application/octet-stream" } });
+      },
+    });
+    const url = `http://localhost:${server.port}${urlPath}`;
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated", globalStore: true },
+      files: { "index.mjs": `import pkg from "no-deps";\nconsole.log(pkg.version);` },
+    });
+    await write(packageJson, JSON.stringify({ name: "long-tarball-url", dependencies: { "no-deps": url } }));
+
+    const entry = cutEntryName(`no-deps@${url.replaceAll(/[:/]/g, "+")}`);
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const bunDir = join(packageDir, "node_modules", ".bun");
+    expect(await readdirSorted(bunDir)).toEqual([entry, "node_modules"]);
+    // The project entry links into `<cache>/links/`, where the directory is
+    // the same cut name plus the entry hash (plus the staging suffix while it
+    // was being built).
+    expect(lstatSync(join(bunDir, entry)).isSymbolicLink()).toBe(true);
+    expect(basename(readlinkSync(join(bunDir, entry)))).toMatch(entryPattern(entry, "-[0-9a-f]{16}"));
+    expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+      join(".bun", entry, "node_modules", "no-deps"),
+    );
+
+    await using proc = spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1.0.0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("names up to the limit are kept verbatim", async () => {
+    const name = Buffer.alloc(189, "n").toString();
+    // `<name>@file+pkg-a` is exactly 200 bytes, `<name>@file+pkg-bb` is 201.
+    const verbatimEntry = `${name}@file+pkg-a`;
+    expect(Buffer.byteLength(verbatimEntry)).toBe(maxVerbatimLength);
+    const cutEntry = cutEntryName(`${name}@file+pkg-bb`);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        "pkg-a/package.json": JSON.stringify({ name, version: "1.0.0" }),
+        "pkg-bb/package.json": JSON.stringify({ name, version: "2.0.0" }),
+      },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "entry-name-limit",
+        dependencies: { "dep-a": "file:./pkg-a", "dep-b": "file:./pkg-bb" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // (Folder packages are not linked into the `.bun/node_modules` fallback
+    // directory, so the store holds just the two entries.)
+    expect(await readdirSorted(join(packageDir, "node_modules", ".bun"))).toEqual([verbatimEntry, cutEntry].sort());
+    expect(
+      await Promise.all([
+        readlink(join(packageDir, "node_modules", "dep-a")),
+        readlink(join(packageDir, "node_modules", "dep-b")),
+        file(join(packageDir, "node_modules", "dep-a", "package.json")).json(),
+        file(join(packageDir, "node_modules", "dep-b", "package.json")).json(),
+      ]),
+    ).toEqual([
+      join(".bun", verbatimEntry, "node_modules", name),
+      join(".bun", cutEntry, "node_modules", name),
+      { name, version: "1.0.0" },
+      { name, version: "2.0.0" },
+    ]);
+  });
+
+  test("names that only differ after the cut get separate entries", async () => {
+    const name = Buffer.alloc(200, "s").toString();
+    const entryOne = cutEntryName(`${name}@file+one`);
+    const entryTwo = cutEntryName(`${name}@file+two`);
+    expect(entryOne.slice(0, 183)).toBe(entryTwo.slice(0, 183));
+    expect(entryOne).not.toBe(entryTwo);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        "one/package.json": JSON.stringify({ name, version: "1.0.0" }),
+        "two/package.json": JSON.stringify({ name, version: "2.0.0" }),
+      },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "same-cut-prefix",
+        dependencies: { "dep-one": "file:./one", "dep-two": "file:./two" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    expect(await readdirSorted(join(packageDir, "node_modules", ".bun"))).toEqual([entryOne, entryTwo].sort());
+    expect(
+      await Promise.all([
+        readlink(join(packageDir, "node_modules", "dep-one")),
+        readlink(join(packageDir, "node_modules", "dep-two")),
+        file(join(packageDir, "node_modules", "dep-one", "package.json")).json(),
+        file(join(packageDir, "node_modules", "dep-two", "package.json")).json(),
+      ]),
+    ).toEqual([
+      join(".bun", entryOne, "node_modules", name),
+      join(".bun", entryTwo, "node_modules", name),
+      { name, version: "1.0.0" },
+      { name, version: "2.0.0" },
+    ]);
+  });
+
+  test("the peer-set suffix follows the cut name", async () => {
+    const name = Buffer.alloc(200, "p").toString();
+    const entry = cutEntryName(`${name}@file+with-peer`);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        "with-peer/package.json": JSON.stringify({
+          name,
+          version: "1.0.0",
+          peerDependencies: { "no-deps": "1.0.0" },
+        }),
+      },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "cut-name-with-peer",
+        dependencies: { "with-peer": "file:./with-peer", "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const bunDir = join(packageDir, "node_modules", ".bun");
+    const entries = await readdirSorted(bunDir);
+    expect(entries).toEqual([
+      "no-deps@1.0.0",
+      "node_modules",
+      expect.stringMatching(entryPattern(entry, "\\+[0-9a-f]{16}")),
+    ]);
+    const entryWithPeer = entries[2];
+    expect(
+      await Promise.all([
+        readlink(join(bunDir, entryWithPeer, "node_modules", "no-deps")),
+        readlink(join(packageDir, "node_modules", "with-peer")),
+      ]),
+    ).toEqual([
+      join("..", "..", "no-deps@1.0.0", "node_modules", "no-deps"),
+      join(".bun", entryWithPeer, "node_modules", name),
+    ]);
+  });
 });
 
 describe("global virtual store", () => {


### PR DESCRIPTION
### Repro

```sh
mkdir probe && cd probe
cp <bun repo>/test/cli/install/bar-0.0.2.tgz .
bun -e 'require("fs").writeFileSync("package.json", JSON.stringify({ name: "probe", dependencies: { bar: "./" + "x/../".repeat(130) + "bar-0.0.2.tgz" } }))'
bun install --linker isolated
```

```
ENAMETOOLONG: File name too long: failed to link package: bar@./x/../x/../x/../...bar-0.0.2.tgz (link)
Failed to install 1 package
```

Exit code 1, on `bun 1.4.0` and main. The tarball itself is at a valid path (the spec normalizes to `./bar-0.0.2.tgz`); a tarball or folder at a really deep relative path, or a remote tarball whose URL is long, fails the same way. The hoisted linker installs all of these (its cache folder for a tarball is a hash of the URL); with the isolated linker there is no workaround other than shortening the spec.

### Cause

The isolated linker creates one directory per store entry, `node_modules/.bun/<name>@<resolution>` (`entry::StorePathFormatter` in `src/install/isolated_install/Store.rs`). For npm packages the resolution is the version, but for local and remote tarballs, folders and git dependencies it is the user's path or URL, so the directory name is as long as the spec and `mkdir` fails once it passes NAME_MAX (255 bytes on Linux and macOS, 255 UTF-16 units on NTFS). The peer-set suffix (`+<16 hex>`) and, with `install.globalStore`, the `-<entry hash>` and `.tmp-<suffix>` suffixes that the installer appends to the same text make the effective limit lower still.

### Fix

`StorePathFormatter` now formats `<name>@<resolution>` through a small sink that keeps the first 200 bytes and hashes all of it. A name of at most 200 bytes is emitted unchanged. A longer one is emitted as its first 183 bytes (backed up to a UTF-8 character boundary) followed by `+` and the 16 hex digit wyhash (seed 0, so `Bun.hash(fullName)` reproduces it) of the full text; the peer-set suffix is appended after that as before. 200 is `255 - 17 - 17 - 21`: NAME_MAX minus the peer suffix, the global store's `-<hash>`, and the `.tmp-<u64 hex>` / `.old-<u64 hex>` staging suffixes, so the worst-case directory name in either store is exactly 255 bytes. The constants in `Store.rs` spell out that arithmetic.

Why this shape:

* Every consumer (the project-local directory, the `<cache>/links/` directory name, the dependency symlink targets, and the entry hash seeded from this text) goes through this one `Display` impl, so cutting the name there keeps all of them consistent, and the global store needs no separate treatment.
* Names up to 200 bytes are byte-for-byte what they were, so existing installs are not re-linked on upgrade. The only names that change are ones in the 201 to 255 byte range that happened to fit before without peers or the global store; those are re-created once under the new name on the next install. Names over 255 bytes never existed on disk.
* Keeping a readable prefix plus a hash of the whole text, rather than replacing the name with a hash the way the tarball cache does, leaves `ls node_modules/.bun` readable and keeps the cut name a pure function of the same text, so two specs that share the first 183 bytes still get separate entries. This is also what pnpm does for its virtual store (`virtual-store-dir-max-length`).

#36973 (open) documents the store layout; if it lands, its entry-name table should get a sentence about this rule. #37469 fixes the hoisted linker's panic on the same inputs and #37462 the path-buffer overflow when reading such a tarball; all three are independent.

### Verification

New `long store entry names` block in `test/cli/install/isolated-install.test.ts`:

* a local tarball and a folder dependency three 85-byte directories deep (entry names of 277 bytes) install, resolve through `node_modules`, and a second install reuses the same entries
* a remote tarball with a 230 byte URL served by a local `Bun.serve`, with `install.globalStore` enabled: the `node_modules/.bun` entry has the cut name and links to `<cache>/links/<cut name>-<hash>`, and the package imports at runtime
* a 200 byte name is kept verbatim while a 201 byte one is cut (pins the threshold)
* two packages whose names only differ after the cut point get two entries, each alias resolving to its own package
* a cut entry with a resolved peer gets `+<peer hash>` appended after the cut name and links its peer

The expected names are computed in the test with `Bun.hash`, so they pin the exact derivation. The first two fail with exit code 1 (`ENAMETOOLONG`) on the unfixed build and the other three fail on the entry name; all five pass with `bun bd test`, as does the rest of `isolated-install.test.ts` (67 tests), `public-hoist-pattern.test.ts`, `bun-install-native-binlink.test.ts`, `config-version.test.ts`, `bun-install-hardlink-fallback.test.ts`, `regression/issue/31652.test.ts` and the two `--linker=isolated` tests in `bun-add.test.ts`.
