### PR TITLE
sql/mysql: replace ExecuteParams c_void hooks with ExecuteParam trait

### DIFF
--- a/src/sql/mysql/protocol/PreparedStatement.rs
+++ b/src/sql/mysql/protocol/PreparedStatement.rs
@@ -4,10 +4,18 @@ use super::command_type::CommandType;
 use super::new_writer::{NewWriter, WriterContext};
 use crate::mysql::mysql_param::Param;
 use crate::mysql::mysql_types::FieldType;
+use crate::shared::Data;
 
 bun_core::declare_scope!(PreparedStatement, hidden);
 
-pub struct Execute<'a> {
+/// A bound parameter value. The concrete type (`bun_sql_jsc`'s `Value`) lives
+/// in a higher-tier crate this crate cannot depend on.
+pub trait ExecuteParam {
+    fn is_null(&self) -> bool;
+    fn to_data(&self, field_type: FieldType) -> Result<Data, any_mysql_error::Error>;
+}
+
+pub struct Execute<'a, P: ExecuteParam> {
     /// ID of the prepared statement to execute, returned from COM_STMT_PREPARE
     pub statement_id: u32,
     /// Execution flags. Currently only CURSOR_TYPE_READ_ONLY (0x01) is supported
@@ -18,32 +26,11 @@ pub struct Execute<'a> {
     pub param_types: &'a [Param],
     /// Whether to send parameter types. Set to true for first execution, false for subsequent executions
     pub new_params_bind_flag: bool,
-    // `params: []Value` — see gated `ExecuteParams` below.
-    pub params: ExecuteParams<'a>,
+    /// One value per entry of `param_types`
+    pub params: &'a [P],
 }
 
-/// `Value` (`bun_sql_jsc::mysql::mysql_value::Value`) lives in the
-/// higher-tier `bun_sql_jsc` crate, which this crate cannot depend on. The
-/// borrowed slice is carried behind a context pointer so `len` is real;
-/// encoding goes through the `is_null` / `to_data` hooks the jsc-side caller
-/// fills in.
-pub struct ExecuteParams<'a> {
-    pub len: usize,
-    pub ctx: *mut core::ffi::c_void,
-    /// `param == .null`
-    pub is_null: fn(*mut core::ffi::c_void, usize) -> bool,
-    /// `param.toData(field_type)`
-    pub to_data: fn(
-        *mut core::ffi::c_void,
-        usize,
-        FieldType,
-    ) -> Result<crate::shared::Data, any_mysql_error::Error>,
-    pub _marker: core::marker::PhantomData<&'a ()>,
-}
-
-// Ownership of params stays with the caller (borrowed slice) — no Drop here.
-
-impl<'a> Execute<'a> {
+impl<P: ExecuteParam> Execute<'_, P> {
     fn write_null_bitmap<C: WriterContext>(
         &self,
         writer: NewWriter<C>,
@@ -51,11 +38,11 @@ impl<'a> Execute<'a> {
         const MYSQL_MAX_PARAMS: usize = (u16::MAX as usize / 8) + 1;
 
         let mut null_bitmap_buf = [0u8; MYSQL_MAX_PARAMS];
-        let bitmap_bytes = self.params.len.div_ceil(8);
+        let bitmap_bytes = self.params.len().div_ceil(8);
         let null_bitmap = &mut null_bitmap_buf[0..bitmap_bytes];
 
-        for i in 0..self.params.len {
-            if (self.params.is_null)(self.params.ctx, i) {
+        for (i, param) in self.params.iter().enumerate() {
+            if param.is_null() {
                 null_bitmap[i >> 3] |= 1u8 << ((i & 7) as u8);
             }
         }
@@ -73,7 +60,7 @@ impl<'a> Execute<'a> {
         writer.int1(self.flags)?;
         writer.int4(self.iteration_count)?;
 
-        if self.params.len > 0 {
+        if !self.params.is_empty() {
             self.write_null_bitmap(writer)?;
 
             // Write new params bind flag
@@ -95,15 +82,13 @@ impl<'a> Execute<'a> {
             }
 
             // Write parameter values
-            debug_assert_eq!(self.params.len, self.param_types.len());
-            for (i, param_type) in self.param_types.iter().enumerate() {
-                if (self.params.is_null)(self.params.ctx, i)
-                    || param_type.r#type == FieldType::MYSQL_TYPE_NULL
-                {
+            debug_assert_eq!(self.params.len(), self.param_types.len());
+            for (param, param_type) in self.params.iter().zip(self.param_types) {
+                if param.is_null() || param_type.r#type == FieldType::MYSQL_TYPE_NULL {
                     continue;
                 }
 
-                let value = (self.params.to_data)(self.params.ctx, i, param_type.r#type)?;
+                let value = param.to_data(param_type.r#type)?;
                 if param_type.r#type.is_binary_format_supported() {
                     writer.write(value.slice())?;
                 } else {

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -1,6 +1,3 @@
-use core::ffi::c_void;
-use core::marker::PhantomData;
-
 use crate::error::ThrowSqlError;
 use crate::jsc::{JSGlobalObject, JSValue, MarkedArgumentBuffer};
 use bun_core::String as BunString;
@@ -8,11 +5,10 @@ use bun_core::String as BunString;
 use super::my_sql_value::Value;
 use bun_sql::mysql::mysql_param::Param;
 use bun_sql::mysql::mysql_request;
-use bun_sql::mysql::mysql_types::FieldType;
-use bun_sql::mysql::protocol::any_mysql_error::{self as any_mysql_error, AnyMySQLError};
+use bun_sql::mysql::protocol::any_mysql_error::AnyMySQLError;
 use bun_sql::mysql::protocol::column_definition41::ColumnFlags;
 use bun_sql::mysql::protocol::new_writer::{NewWriter, WriterContext};
-use bun_sql::mysql::protocol::prepared_statement::{self as prepared_statement, ExecuteParams};
+use bun_sql::mysql::protocol::prepared_statement;
 use bun_sql::mysql::query_status::Status;
 use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode;
 
@@ -230,22 +226,6 @@ impl MySQLQuery {
         )?;
         // `defer execute.deinit()` — `params: Vec<Value>` drops at end of scope.
 
-        // Thunks bridging the higher-tier `Value` into the lower-tier `ExecuteParams`
-        // hooks (which can't name `Value` directly across crates).
-        fn is_null_thunk(ctx: *mut c_void, i: usize) -> bool {
-            // SAFETY: `ctx` is `params.as_ptr()` and `i < params.len()` (asserted by
-            // the `len` field passed alongside, checked in `Execute::write_internal`).
-            unsafe { matches!(*ctx.cast::<Value>().add(i), Value::Null) }
-        }
-        fn to_data_thunk(
-            ctx: *mut c_void,
-            i: usize,
-            ft: FieldType,
-        ) -> Result<bun_sql::shared::Data, any_mysql_error::Error> {
-            // SAFETY: same as `is_null_thunk`.
-            unsafe { (*ctx.cast::<Value>().add(i)).to_data(ft) }
-        }
-
         let execute = prepared_statement::Execute {
             statement_id: statement.statement_id,
             flags: 0,
@@ -254,13 +234,7 @@ impl MySQLQuery {
             new_params_bind_flag: statement
                 .execution_flags
                 .contains(ExecutionFlags::NEED_TO_SEND_PARAMS),
-            params: ExecuteParams {
-                len: params.len(),
-                ctx: params.as_ptr().cast_mut().cast::<c_void>(),
-                is_null: is_null_thunk,
-                to_data: to_data_thunk,
-                _marker: PhantomData,
-            },
+            params: &params,
         };
 
         let mut packet = writer.start(0)?;

--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -11,6 +11,7 @@ use bun_core::{OwnedString, String as BunString};
 
 use bun_sql::mysql::mysql_types::FieldType;
 use bun_sql::mysql::protocol::any_mysql_error;
+use bun_sql::mysql::protocol::prepared_statement::ExecuteParam;
 use bun_sql::shared::Data;
 
 use crate::jsc::webcore::Blob;
@@ -212,8 +213,12 @@ fn validate_bigint<T: bun_core::Integer>(
         .map_err(js_error_to_mysql)
 }
 
-impl Value {
-    pub(crate) fn to_data(&self, field_type: FieldType) -> Result<Data, any_mysql_error::Error> {
+impl ExecuteParam for Value {
+    fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    fn to_data(&self, field_type: FieldType) -> Result<Data, any_mysql_error::Error> {
         let mut buffer = [0u8; 15]; // Large enough for all fixed-size types
 
         let pos: usize = match self {
@@ -276,7 +281,9 @@ impl Value {
 
         Data::create(&buffer[0..pos]).map_err(|_| any_mysql_error::Error::OutOfMemory)
     }
+}
 
+impl Value {
     pub(crate) fn from_js(
         value: JSValue,
         global_object: &JSGlobalObject,


### PR DESCRIPTION
## What

`bun_sql::mysql::protocol::prepared_statement::Execute` carried its bound parameters as `ExecuteParams`, a hand-rolled borrowed slice plus vtable: a `len`, a `*mut c_void` pointing at the `Vec<Value>` buffer owned by `bun_sql_jsc`, two `fn` pointers, and a `PhantomData` lifetime. Its only producer (`MySQLQuery::bind_and_execute_impl`) filled the two `fn` pointers with thunks that each did `unsafe { *ctx.cast::<Value>().add(i) }`, relying on the `len` passed alongside the pointer to keep `i` in bounds.

```rust
// before
pub struct ExecuteParams<'a> {
    pub len: usize,
    pub ctx: *mut c_void,
    pub is_null: fn(*mut c_void, usize) -> bool,
    pub to_data: fn(*mut c_void, usize, FieldType) -> Result<Data, Error>,
    pub _marker: PhantomData<&'a ()>,
}

// after
pub trait ExecuteParam {
    fn is_null(&self) -> bool;
    fn to_data(&self, field_type: FieldType) -> Result<Data, Error>;
}

pub struct Execute<'a, P: ExecuteParam> {
    /* unchanged fields */
    pub params: &'a [P],
}
```

`Execute::write` now iterates `params` directly: `enumerate()` for the null bitmap and `zip(param_types)` for the values (the `debug_assert_eq!` on the two lengths stays). The 3 hook invocations in `PreparedStatement.rs` become plain method calls. `Value` implements `ExecuteParam` next to its definition in `MySQLValue.rs`: `is_null` is `matches!(self, Value::Null)` and the existing inherent `to_data`, which had no other caller, becomes the trait method with its body unchanged. The single construction site in `MySQLQuery.rs` passes `params: &params`. `ExecuteParams`, both thunks and their 2 unsafe blocks, and the now unused `c_void`, `PhantomData`, `FieldType` and `any_mysql_error` imports are deleted.

## Why

The protocol crate still cannot name `Value` (it lives in the higher-tier `bun_sql_jsc`), but the element type and the bound of the parameter array are now carried by `&[P]` instead of a raw pointer, a separate `len` field and a SAFETY comment, so no `unsafe` is left on the parameter encoding path. This is zero-cost: `Execute::write` is monomorphised exactly once (`P = Value`), so the two indirect calls per parameter become direct calls; `&[P]` is the same pointer and length pair `ExecuteParams` carried (the stack-local `Execute` shrinks by the two function pointers); nothing is allocated or copied, and the loops gain no per-element checks (`zip` is bounded by the two lengths that `MySQLQuery::bind` already guarantees equal).

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/sql/sql-mysql.test.ts test/js/sql/sql-mysql-bind-blob-borrow.test.ts test/js/sql/sql-mysql-bind-oob.test.ts: 3 pass, 0 fail (3 tests across 3 files). No MySQL server was reachable locally, so the server-backed cases in those files were skipped; CI runs them against the containerized servers.

