### PR TITLE
tls: deliver parked sessions before the data decrypted with them on the duplex path

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -520,33 +520,36 @@ void us_ssl_enable_pending_events(SSL *ssl) {
   SSL_set_ex_data(ssl, us_ssl_is_socket_ex_idx, (void *)1);
 }
 
-static int us_ssl_pop_pending(SSL *ssl, int idx, unsigned char *out, int out_cap) {
-  if (idx < 0) return 0;
+static struct us_ssl_pending_session_t *
+us_ssl_pop_pending(SSL *ssl, int idx, const unsigned char **out_data, size_t *out_len) {
+  if (idx < 0) return NULL;
   struct us_ssl_pending_session_t *pending = SSL_get_ex_data(ssl, idx);
-  if (!pending) return 0;
+  if (!pending) return NULL;
   SSL_set_ex_data(ssl, idx, pending->next);
-  int len = (int)pending->length;
-  if (len > out_cap) {
-    /* The parking sites cap entries (64 KB sessions, 4 KB+1 keylog lines) and
-     * callers pass buffers at least that large, so this is unreachable; drop
-     * the entry rather than overflow. */
-    len = 0;
-  } else {
-    memcpy(out, pending->data, (size_t)len);
-  }
-  us_free(pending);
-  return len;
+  pending->next = NULL;
+  *out_data = pending->data;
+  *out_len = pending->length;
+  return pending;
 }
 
-/* Pop the oldest parked session/keylog entry into `out` (cap `out_cap`).
- * Returns the byte length, or 0 when the queue is empty. Entries arrive in
- * parking order; each pop hands over exactly one entry. */
-int us_ssl_pop_pending_session(SSL *ssl, unsigned char *out, int out_cap) {
-  return us_ssl_pop_pending(ssl, us_ssl_pending_session_idx, out, out_cap);
+/* Detach the oldest parked session/keylog entry from `ssl` (entries come out
+ * in parking order) and point `*out_data`/`*out_len` at its payload. Returns
+ * NULL when the queue is empty. The entry is no longer reachable from the
+ * SSL, so the callback the caller hands it to may close the connection and
+ * SSL_free (which frees whatever is still queued) without invalidating it;
+ * the caller releases it with us_ssl_free_pending() afterwards. */
+struct us_ssl_pending_session_t *
+us_ssl_pop_pending_session(SSL *ssl, const unsigned char **out_data, size_t *out_len) {
+  return us_ssl_pop_pending(ssl, us_ssl_pending_session_idx, out_data, out_len);
 }
 
-int us_ssl_pop_pending_keylog(SSL *ssl, unsigned char *out, int out_cap) {
-  return us_ssl_pop_pending(ssl, us_ssl_pending_keylog_idx, out, out_cap);
+struct us_ssl_pending_session_t *
+us_ssl_pop_pending_keylog(SSL *ssl, const unsigned char **out_data, size_t *out_len) {
+  return us_ssl_pop_pending(ssl, us_ssl_pending_keylog_idx, out_data, out_len);
+}
+
+void us_ssl_free_pending(struct us_ssl_pending_session_t *entry) {
+  us_free(entry);
 }
 
 /* The resumable session most recently delivered via the new-session callback,

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -554,12 +554,17 @@ long us_ssl_ctx_live_count(void);
 int us_ssl_ctx_add_ca_cert(struct ssl_ctx_st *ctx, const char *content);
 /* TLS-over-duplex / named-pipe SSL owners (no us_socket_t): opt an SSL into
  * the parked new-session/keylog queues, then drain them with the pop calls
- * after each SSL_read/SSL_do_handshake stack unwinds. Pop returns the entry
- * length (0 = queue empty); entries are capped at 64 KB (sessions) and
- * 4 KB+1 (keylog lines). */
+ * after each SSL_read/SSL_do_handshake stack unwinds. A pop detaches the
+ * oldest entry (NULL = queue empty) and exposes its payload; the entry stays
+ * valid across whatever the caller dispatches it to, even an SSL_free, until
+ * us_ssl_free_pending(). */
+struct us_ssl_pending_session_t;
 void us_ssl_enable_pending_events(struct ssl_st *ssl);
-int us_ssl_pop_pending_session(struct ssl_st *ssl, unsigned char *out, int out_cap);
-int us_ssl_pop_pending_keylog(struct ssl_st *ssl, unsigned char *out, int out_cap);
+struct us_ssl_pending_session_t *us_ssl_pop_pending_session(
+    struct ssl_st *ssl, const unsigned char **out_data, size_t *out_len);
+struct us_ssl_pending_session_t *us_ssl_pop_pending_keylog(
+    struct ssl_st *ssl, const unsigned char **out_data, size_t *out_len);
+void us_ssl_free_pending(struct us_ssl_pending_session_t *entry);
 /* The resumable session most recently delivered via the new-session callback,
  * or NULL if none. Borrowed; valid until the next NewSessionTicket or SSL_free. */
 struct ssl_session_st *us_ssl_get_new_session(struct ssl_st *ssl);

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1039,10 +1039,8 @@ pub mod ssl_wrapper {
                             self.flags.set_fatal_error(true);
                         }
 
-                        // Deliver what was decrypted (and anything parked ahead
-                        // of it, e.g. a NewSessionTicket that rode in with the
-                        // peer's close_notify) before the close tears the
-                        // wrapper down.
+                        // Also with read == 0: a ticket that arrived with the
+                        // close_notify is still parked.
                         if !self.dispatch_read(&buffer[0..read]) {
                             return false;
                         }
@@ -1074,14 +1072,11 @@ pub mod ssl_wrapper {
             true
         }
 
-        /// Hand a batch of decrypted bytes to the owner. Whatever the
-        /// `SSL_read`s that produced the batch parked (new sessions, keylog
-        /// lines) goes out first, the order `ssl_on_data` in openssl.c uses:
-        /// those records preceded the bytes on the wire, and the data
-        /// callback may close the wrapper, after which nothing would deliver
-        /// them (`deinit` frees the queues with the SSL). Returns false once a
-        /// callback closed or deinitialized the wrapper; the caller must then
-        /// stop touching the SSL.
+        /// Deliver a batch of decrypted bytes, preceded by the sessions/keylog
+        /// lines parked while decrypting it (wire order, and what openssl.c's
+        /// `ssl_on_data` does): a data callback that closes the socket frees
+        /// the queues along with the SSL. Returns false once a callback closed
+        /// the wrapper.
         fn dispatch_read(&self, data: &[u8]) -> bool {
             self.flush_pending_events();
             if self.ssl.get().is_none() || self.flags.closed_notified() {
@@ -1146,20 +1141,15 @@ pub mod ssl_wrapper {
                     self.handle_writing(&mut buffer);
                 }
 
-                // BoringSSL surfaces new-session tickets / keylog lines from
-                // inside SSL_do_handshake/SSL_read, where dispatching JS could
-                // free the SSL out from under the caller, so openssl.c parks
-                // them on the SSL. `dispatch_read` drained everything parked
-                // ahead of decrypted data; this picks up what a handshake
-                // flight or a read that yielded no application data parked.
+                // What the handshake, or a read that produced no application
+                // data, parked; `dispatch_read` covers the rest.
                 self.flush_pending_events();
             }
         }
 
-        /// Drain the parked new-session / keylog queues (sessions first, like
-        /// the C path) into the owner's callbacks. Only SSLs whose handlers
-        /// opted in ever park (see `init_with_ctx`), so this is a no-op FFI
-        /// probe otherwise.
+        /// Deliver the new-session / keylog entries openssl.c parked on the
+        /// SSL during `SSL_read`/`SSL_do_handshake` (only for handlers that
+        /// opted in, see `init_with_ctx`); sessions first, like the C path.
         fn flush_pending_events(&self) {
             let handlers = self.handlers.get();
             if let Some(on_session) = handlers.on_session {
@@ -1170,31 +1160,26 @@ pub mod ssl_wrapper {
             }
         }
 
-        /// Pop one queue dry. Each entry is detached from the SSL before its
-        /// callback runs, so the JS it dispatches may close the wrapper (and
-        /// `deinit` may `SSL_free` the rest of the queue) while the payload
-        /// being delivered stays valid; the liveness check before each pop is
-        /// what stops delivery once that happens, mirroring the closed-socket
-        /// check in openssl.c's `ssl_flush_pending_session`.
+        /// Each entry is detached from the SSL before `deliver` runs, so the
+        /// callback may close the wrapper (`SSL_free` takes the rest of the
+        /// queue with it) without invalidating the payload in flight.
         fn drain_pending(&self, pop: PopPendingFn, ctx: T, deliver: fn(T, &[u8])) {
             while !self.flags.closed_notified() {
                 let Some(ssl) = self.ssl.get() else { return };
                 let mut data: *const u8 = core::ptr::null();
                 let mut len: usize = 0;
-                // SAFETY: `ssl` is live (checked above); `data`/`len` are the
-                // out-params `pop` fills when it returns an entry.
+                // SAFETY: `ssl` is live (checked above); the out-params are locals.
                 let Some(entry) =
                     NonNull::new(unsafe { pop(ssl.as_ptr(), &raw mut data, &raw mut len) })
                 else {
                     return;
                 };
                 let entry = scopeguard::guard(entry, |entry| {
-                    // SAFETY: `pop` handed this frame sole ownership of the
-                    // detached entry; this is its only release.
+                    // SAFETY: `pop` transferred the entry to us; freed exactly once here.
                     unsafe { us_ssl_free_pending(entry.as_ptr()) }
                 });
-                // SAFETY: `pop` pointed `data`/`len` at the payload stored
-                // inside `*entry`, which the guard keeps alive past `deliver`.
+                // SAFETY: `data`/`len` describe the payload inside `*entry`,
+                // which stays allocated until the guard drops below.
                 let payload = unsafe { bun_core::ffi::slice(data, len) };
                 deliver(ctx, payload);
                 drop(entry);
@@ -1218,9 +1203,8 @@ pub mod ssl_wrapper {
     }
 
     bun_opaque::opaque_ffi! {
-        /// One parked new-session / keylog entry (`struct
-        /// us_ssl_pending_session_t` in openssl.c), owned by whoever popped it
-        /// until `us_ssl_free_pending`.
+        /// A parked new-session / keylog entry (openssl.c); owned by whoever
+        /// popped it until `us_ssl_free_pending`.
         struct us_ssl_pending_session_t;
     }
 
@@ -1245,10 +1229,8 @@ pub mod ssl_wrapper {
         /// SSLs without the marker).
         // SAFETY (unsafe fn): `ssl` must be a live `SSL*`.
         fn us_ssl_enable_pending_events(ssl: *mut boring_sys::SSL);
-        /// Detach the oldest parked session/keylog entry from `ssl` and point
-        /// `out_data`/`out_len` at its payload; null when the queue is empty.
-        /// The entry outlives any later `SSL_free` and must be released with
-        /// `us_ssl_free_pending`.
+        /// Detach the oldest parked entry and expose its payload; null when
+        /// the queue is empty.
         // SAFETY (unsafe fn): `ssl` live; `out_data`/`out_len` writable.
         fn us_ssl_pop_pending_session(
             ssl: *mut boring_sys::SSL,

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1039,20 +1039,11 @@ pub mod ssl_wrapper {
                             self.flags.set_fatal_error(true);
                         }
 
-                        // flush the reading
-                        if read > 0 {
-                            log!("triggering data callback (read {})", read);
-                            self.trigger_data_callback(&buffer[0..read]);
-                            // The data callback may have closed the connection
-                            if self.ssl.get().is_none() || self.flags.closed_notified() {
-                                return false;
-                            }
-                        }
-                        // A NewSessionTicket/keylog line that rode in ahead of the
-                        // peer's close_notify is still parked; deliver it before the
-                        // close tears the wrapper down (mirrors the C ZERO_RETURN path).
-                        self.flush_pending_events(buffer);
-                        if self.ssl.get().is_none() || self.flags.closed_notified() {
+                        // Deliver what was decrypted (and anything parked ahead
+                        // of it, e.g. a NewSessionTicket that rode in with the
+                        // peer's close_notify) before the close tears the
+                        // wrapper down.
+                        if !self.dispatch_read(&buffer[0..read]) {
                             return false;
                         }
                         self.trigger_close_callback();
@@ -1068,25 +1059,37 @@ pub mod ssl_wrapper {
 
                 read += usize::try_from(just_read).expect("int cast");
                 if read == buffer.len() {
-                    log!(
-                        "triggering data callback (read {}) and resetting read buffer",
-                        read
-                    );
                     // we filled the buffer
-                    self.trigger_data_callback(&buffer[0..read]);
-                    // The callback may have closed the connection - check before continuing
-                    // Check ssl first as a proxy for whether we were deinited
-                    if self.ssl.get().is_none() || self.flags.closed_notified() {
+                    if !self.dispatch_read(&buffer[0..read]) {
                         return false;
                     }
+                    log!("resetting read buffer");
                     read = 0;
                 }
             }
             // we finished reading
-            if read > 0 {
-                log!("triggering data callback (read {})", read);
-                self.trigger_data_callback(&buffer[0..read]);
-                // The callback may have closed the connection
+            if read > 0 && !self.dispatch_read(&buffer[0..read]) {
+                return false;
+            }
+            true
+        }
+
+        /// Hand a batch of decrypted bytes to the owner. Whatever the
+        /// `SSL_read`s that produced the batch parked (new sessions, keylog
+        /// lines) goes out first, the order `ssl_on_data` in openssl.c uses:
+        /// those records preceded the bytes on the wire, and the data
+        /// callback may close the wrapper, after which nothing would deliver
+        /// them (`deinit` frees the queues with the SSL). Returns false once a
+        /// callback closed or deinitialized the wrapper; the caller must then
+        /// stop touching the SSL.
+        fn dispatch_read(&self, data: &[u8]) -> bool {
+            self.flush_pending_events();
+            if self.ssl.get().is_none() || self.flags.closed_notified() {
+                return false;
+            }
+            if !data.is_empty() {
+                log!("triggering data callback (read {})", data.len());
+                self.trigger_data_callback(data);
                 // Check ssl first as a proxy for whether we were deinited
                 if self.ssl.get().is_none() || self.flags.closed_notified() {
                     return false;
@@ -1143,64 +1146,58 @@ pub mod ssl_wrapper {
                     self.handle_writing(&mut buffer);
                 }
 
-                // The SSL_do_handshake/SSL_read calls above may have parked
-                // new-session tickets / keylog lines (BoringSSL surfaces them
-                // mid-read, where dispatching JS could free the SSL out from
-                // under the caller). The stack has unwound here, so hand them
-                // to the owner - same ordering as the C path's
-                // ssl_flush_pending_session: handshake/data callbacks first,
-                // then sessions.
-                self.flush_pending_events(&mut buffer);
+                // BoringSSL surfaces new-session tickets / keylog lines from
+                // inside SSL_do_handshake/SSL_read, where dispatching JS could
+                // free the SSL out from under the caller, so openssl.c parks
+                // them on the SSL. `dispatch_read` drained everything parked
+                // ahead of decrypted data; this picks up what a handshake
+                // flight or a read that yielded no application data parked.
+                self.flush_pending_events();
             }
         }
 
-        /// Drain the parked new-session / keylog queues into the owner's
-        /// callbacks. Only SSLs whose handlers opted in ever park (see
-        /// `init_with_ctx`), so this is a no-op FFI probe otherwise. The
-        /// callbacks run JS which may close the wrapper; `self.ssl` is
-        /// re-checked between pops.
-        fn flush_pending_events(&self, buffer: &mut [u8; BUFFER_SIZE]) {
-            if self.handlers.get().on_session.is_some() {
-                loop {
-                    let Some(ssl) = self.ssl.get() else { return };
-                    // SAFETY: ssl is live (checked above); buffer is writable
-                    // for BUFFER_SIZE bytes, which covers the 64 KB parking cap.
-                    let len = unsafe {
-                        us_ssl_pop_pending_session(
-                            ssl.as_ptr(),
-                            buffer.as_mut_ptr(),
-                            c_int::try_from(BUFFER_SIZE).expect("int cast"),
-                        )
-                    };
-                    if len <= 0 {
-                        break;
-                    }
-                    let handlers = self.handlers.get();
-                    if let Some(on_session) = handlers.on_session {
-                        on_session(handlers.ctx, &buffer[..len as usize]);
-                    }
-                }
+        /// Drain the parked new-session / keylog queues (sessions first, like
+        /// the C path) into the owner's callbacks. Only SSLs whose handlers
+        /// opted in ever park (see `init_with_ctx`), so this is a no-op FFI
+        /// probe otherwise.
+        fn flush_pending_events(&self) {
+            let handlers = self.handlers.get();
+            if let Some(on_session) = handlers.on_session {
+                self.drain_pending(us_ssl_pop_pending_session, handlers.ctx, on_session);
             }
-            if self.handlers.get().on_keylog.is_some() {
-                loop {
-                    let Some(ssl) = self.ssl.get() else { return };
-                    // SAFETY: same as the session pop above; keylog entries
-                    // are capped at 4 KB+1, well within BUFFER_SIZE.
-                    let len = unsafe {
-                        us_ssl_pop_pending_keylog(
-                            ssl.as_ptr(),
-                            buffer.as_mut_ptr(),
-                            c_int::try_from(BUFFER_SIZE).expect("int cast"),
-                        )
-                    };
-                    if len <= 0 {
-                        break;
-                    }
-                    let handlers = self.handlers.get();
-                    if let Some(on_keylog) = handlers.on_keylog {
-                        on_keylog(handlers.ctx, &buffer[..len as usize]);
-                    }
-                }
+            if let Some(on_keylog) = handlers.on_keylog {
+                self.drain_pending(us_ssl_pop_pending_keylog, handlers.ctx, on_keylog);
+            }
+        }
+
+        /// Pop one queue dry. Each entry is detached from the SSL before its
+        /// callback runs, so the JS it dispatches may close the wrapper (and
+        /// `deinit` may `SSL_free` the rest of the queue) while the payload
+        /// being delivered stays valid; the liveness check before each pop is
+        /// what stops delivery once that happens, mirroring the closed-socket
+        /// check in openssl.c's `ssl_flush_pending_session`.
+        fn drain_pending(&self, pop: PopPendingFn, ctx: T, deliver: fn(T, &[u8])) {
+            while !self.flags.closed_notified() {
+                let Some(ssl) = self.ssl.get() else { return };
+                let mut data: *const u8 = core::ptr::null();
+                let mut len: usize = 0;
+                // SAFETY: `ssl` is live (checked above); `data`/`len` are the
+                // out-params `pop` fills when it returns an entry.
+                let Some(entry) =
+                    NonNull::new(unsafe { pop(ssl.as_ptr(), &raw mut data, &raw mut len) })
+                else {
+                    return;
+                };
+                let entry = scopeguard::guard(entry, |entry| {
+                    // SAFETY: `pop` handed this frame sole ownership of the
+                    // detached entry; this is its only release.
+                    unsafe { us_ssl_free_pending(entry.as_ptr()) }
+                });
+                // SAFETY: `pop` pointed `data`/`len` at the payload stored
+                // inside `*entry`, which the guard keeps alive past `deliver`.
+                let payload = unsafe { bun_core::ffi::slice(data, len) };
+                deliver(ctx, payload);
+                drop(entry);
             }
         }
     }
@@ -1220,6 +1217,20 @@ pub mod ssl_wrapper {
         1
     }
 
+    bun_opaque::opaque_ffi! {
+        /// One parked new-session / keylog entry (`struct
+        /// us_ssl_pending_session_t` in openssl.c), owned by whoever popped it
+        /// until `us_ssl_free_pending`.
+        struct us_ssl_pending_session_t;
+    }
+
+    /// Shape of `us_ssl_pop_pending_session` / `us_ssl_pop_pending_keylog`.
+    type PopPendingFn = unsafe extern "C" fn(
+        ssl: *mut boring_sys::SSL,
+        out_data: *mut *const u8,
+        out_len: *mut usize,
+    ) -> *mut us_ssl_pending_session_t;
+
     unsafe extern "C" {
         /// Process-wide bundled root store from `root_certs.cpp` — built once and
         /// up_ref'd per consumer so the ~150-cert load happens once total, not per
@@ -1234,20 +1245,24 @@ pub mod ssl_wrapper {
         /// SSLs without the marker).
         // SAFETY (unsafe fn): `ssl` must be a live `SSL*`.
         fn us_ssl_enable_pending_events(ssl: *mut boring_sys::SSL);
-        /// Pop the oldest parked session/keylog entry into `out`; returns the
-        /// entry length or 0 when the queue is empty.
-        // SAFETY (unsafe fn): `ssl` live; `out` writable for `out_cap` bytes.
+        /// Detach the oldest parked session/keylog entry from `ssl` and point
+        /// `out_data`/`out_len` at its payload; null when the queue is empty.
+        /// The entry outlives any later `SSL_free` and must be released with
+        /// `us_ssl_free_pending`.
+        // SAFETY (unsafe fn): `ssl` live; `out_data`/`out_len` writable.
         fn us_ssl_pop_pending_session(
             ssl: *mut boring_sys::SSL,
-            out: *mut u8,
-            out_cap: c_int,
-        ) -> c_int;
-        // SAFETY (unsafe fn): `ssl` live; `out` writable for `out_cap` bytes.
+            out_data: *mut *const u8,
+            out_len: *mut usize,
+        ) -> *mut us_ssl_pending_session_t;
+        // SAFETY (unsafe fn): same as `us_ssl_pop_pending_session`.
         fn us_ssl_pop_pending_keylog(
             ssl: *mut boring_sys::SSL,
-            out: *mut u8,
-            out_cap: c_int,
-        ) -> c_int;
+            out_data: *mut *const u8,
+            out_len: *mut usize,
+        ) -> *mut us_ssl_pending_session_t;
+        // SAFETY (unsafe fn): `entry` came from a pop above and is freed once.
+        fn us_ssl_free_pending(entry: *mut us_ssl_pending_session_t);
     }
 }
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -815,22 +815,28 @@ describe("over a duplex, 'session' is emitted before the data that followed it o
     }
   }
 
-  // BoringSSL issues more than one TLS 1.3 ticket per connection, each of
-  // which is its own 'session' event; only the relative order matters here.
-  const distinct = (events: string[]) => [...new Set(events)];
+  // BoringSSL issues more than one TLS 1.3 ticket per connection and each is
+  // its own 'session' event, so the expected sequence is "every session, then
+  // the data" for however many tickets arrived. Nothing may follow the data:
+  // the handler destroyed the socket.
+  function expectSessionsThenData(events: string[]) {
+    const sessions = events.filter(event => event === "session").length;
+    expect(sessions).toBeGreaterThan(0);
+    expect(events).toEqual(["secureConnect", ...Array(sessions).fill("session"), "data"]);
+  }
 
   it("response written after the request", async () => {
     const events = await eventOrder({}, socket => {
       socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"));
     });
-    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+    expectSessionsThenData(events);
   });
 
   it("response and close_notify in the same flight", async () => {
     const events = await eventOrder({}, socket => {
       socket.on("data", () => socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"));
     });
-    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+    expectSessionsThenData(events);
   });
 
   it("response larger than the engine's 64 KiB read buffer, delivered in one pass", async () => {
@@ -843,7 +849,7 @@ describe("over a duplex, 'session' is emitted before the data that followed it o
       },
       { holdResponse: true },
     );
-    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+    expectSessionsThenData(events);
   });
 
   it("TLS 1.2 session established by the same flight as a server banner", async () => {
@@ -857,7 +863,7 @@ describe("over a duplex, 'session' is emitted before the data that followed it o
       },
       { request: false },
     );
-    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+    expectSessionsThenData(events);
   });
 });
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -739,6 +739,128 @@ it("delivers 'session' even when the data handler destroys the socket immediatel
   await once(server, "close");
 });
 
+describe("over a duplex, 'session' is emitted before the data that followed it on the wire", () => {
+  // Same contract as the tls.connect() test above, on the tls.connect({ socket })
+  // path: there the TLS engine is the SSLWrapper rather than usockets, and it
+  // has to hand over the sessions parked during a read pass before the
+  // application data decrypted in that same pass. A 'data' handler that
+  // destroys the socket tears the engine down, together with anything still
+  // parked in it, so delivering the sessions afterwards is too late. Node and
+  // the plain tls.connect() path both emit 'session' first in every variant
+  // below.
+
+  // Transport for the TLSSocket. With `holdUntilEnd` set, everything the raw
+  // socket receives from then on is delivered as one chunk once the peer has
+  // ended, so the engine sees the whole response in a single read pass.
+  class Transport extends Duplex {
+    held: Buffer[] | null = null;
+    constructor(readonly raw: net.Socket) {
+      super();
+      raw.on("data", chunk => {
+        if (this.held) this.held.push(chunk);
+        else this.push(chunk);
+      });
+      raw.on("end", () => {
+        if (this.held) this.push(Buffer.concat(this.held));
+        this.push(null);
+      });
+    }
+    holdUntilEnd() {
+      this.held = [];
+    }
+    _read() {}
+    _write(chunk: Buffer, encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+      this.raw.write(chunk, encoding, callback);
+    }
+    _final(callback: (error?: Error | null) => void) {
+      this.raw.end();
+      callback();
+    }
+  }
+
+  async function eventOrder(
+    serverOptions: tls.TlsOptions,
+    onConnection: (socket: TLSSocket) => void,
+    { holdResponse = false, request = true } = {},
+  ): Promise<string[]> {
+    await using server = tls.createServer({ ...COMMON_CERT_, ...serverOptions }, socket => {
+      // The client tears its side down without a close_notify; whatever the
+      // server side makes of that is not what is being observed here.
+      socket.on("error", () => {});
+      onConnection(socket);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const raw = net.connect(port, "127.0.0.1");
+    try {
+      await once(raw, "connect");
+      const transport = new Transport(raw);
+      const client = tls.connect({ socket: transport, rejectUnauthorized: false });
+      const events: string[] = [];
+      client.on("secureConnect", () => {
+        events.push("secureConnect");
+        if (holdResponse) transport.holdUntilEnd();
+        if (request) client.write("x");
+      });
+      client.on("session", () => events.push("session"));
+      client.on("data", () => {
+        events.push("data");
+        client.destroy();
+      });
+      await once(client, "close");
+      return events;
+    } finally {
+      raw.destroy();
+    }
+  }
+
+  // BoringSSL issues more than one TLS 1.3 ticket per connection, each of
+  // which is its own 'session' event; only the relative order matters here.
+  const distinct = (events: string[]) => [...new Set(events)];
+
+  it("response written after the request", async () => {
+    const events = await eventOrder({}, socket => {
+      socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"));
+    });
+    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+  });
+
+  it("response and close_notify in the same flight", async () => {
+    const events = await eventOrder({}, socket => {
+      socket.on("data", () => socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"));
+    });
+    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+  });
+
+  it("response larger than the engine's 64 KiB read buffer, delivered in one pass", async () => {
+    // The first 64 KiB are dispatched from inside the read loop to make room
+    // for the rest; destroying the socket there must not lose the tickets.
+    const events = await eventOrder(
+      {},
+      socket => {
+        socket.on("data", () => socket.end(Buffer.alloc(160 * 1024, "r")));
+      },
+      { holdResponse: true },
+    );
+    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+  });
+
+  it("TLS 1.2 session established by the same flight as a server banner", async () => {
+    // TLS 1.2 hands the session over while the handshake completes; the
+    // server's Finished and its banner arrive in one read pass.
+    const events = await eventOrder(
+      { maxVersion: "TLSv1.2" },
+      socket => {
+        socket.write("220 ready\r\n");
+        socket.on("data", () => {});
+      },
+      { request: false },
+    );
+    expect(distinct(events)).toEqual(["secureConnect", "session", "data"]);
+  });
+});
+
 describe.each(["TLSv1.2", "TLSv1.3"] as const)("%s: getSession() / getTLSTicket()", version => {
   // BoringSSL never folds a TLS 1.3 NewSessionTicket into the SSL's own
   // established_session; it only hands the ticket-bearing session to the


### PR DESCRIPTION
### Symptom

A TLS client running over a JS stream (`tls.connect({ socket: duplex })`, and the same engine behind `WindowsNamedPipe`) never emits `'session'` when its `'data'` handler destroys the socket and the server's NewSessionTicket records were decrypted in the same read pass as the response. That is the normal TLS 1.3 shape on loopback: the server's tickets go out the moment it sees the client's Finished, its response follows in the same tick, and the client reads both in one chunk. Destroying inside `'data'` is what an `https.Agent` with keep-alive off does as soon as a response completes, so such a client can never cache a resumable session.

```ts
const raw = net.connect(port, "127.0.0.1");
await once(raw, "connect");
const client = tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false });
client.on("secureConnect", () => client.write("x"));   // server answers any data
client.on("session", () => events.push("session"));
client.on("data", () => { events.push("data"); client.destroy(); });
await once(client, "close");
// node v26.3.0 and plain tls.connect():  secureConnect, session, session, data
// tls.connect({ socket }) before:         secureConnect, data
```

Today the event is delivered by accident if the handler happens to `write()` before destroying: the write re-enters the engine and that nested pass flushes the queue from inside the data callback (so it arrives after the data). #37467 stops nested passes from doing that, after which the accidental delivery goes away too.

### Cause

BoringSSL reports new sessions and keylog lines from inside `SSL_read`/`SSL_do_handshake`, so openssl.c parks them on the SSL and the engine delivers them once the read has returned. On the `us_socket_t` path, `ssl_on_data` flushes the parked entries before every `us_dispatch_data` (buffer full, end of the read loop, close_notify) plus once at the tail. `SSLWrapper` (src/uws/lib.rs) only flushed after the whole read loop in `handle_traffic`, and after the data on the close_notify branch. When the data callback destroys the socket, `UpgradedDuplex::on_close -> teardown -> deinit` frees the SSL, and `SSL_free` frees the parked queue with it; the later flush finds nothing.

The flush could not simply be moved in front of the dispatch: `us_ssl_pop_pending_*` copied each entry into a caller buffer, and the only buffer `handle_reading` has is the 64 KiB one holding the decrypted bytes it is about to deliver.

### Fix

* openssl.c / libusockets.h: `us_ssl_pop_pending_session` / `us_ssl_pop_pending_keylog` now detach the oldest entry and return it (payload via out-params) instead of copying; `us_ssl_free_pending` releases it. The entry is unlinked from the SSL before the callback runs, so the callback may close the connection (and `SSL_free` the rest of the queue) without invalidating the bytes being delivered. These two functions have no other callers.
* `SSLWrapper::flush_pending_events` no longer needs a buffer. `handle_reading` routes its three dispatch sites (buffer full, loop exit, close_notify) through `dispatch_read`, which flushes the parked entries and then delivers the data, with the existing closed/deinited re-checks after each step. The tail flush in `handle_traffic` stays for entries parked by a handshake flight or a read that produced no application data. The flush also stops once `closed_notified` is set, like every other callback trigger in the wrapper and like the `us_socket_is_closed` check in the C flush.

This is the order node uses (its NewSessionCallback runs before the data of that read reaches JS) and the order bun's own `us_socket_t` path already uses; it also puts the events in wire order, since the ticket records precede the data they were decrypted with. Explicitly destroying the socket from inside a `'session'` listener drops the rest of that pass, which is what the C path does as well.

Interaction with #37467 (nested `handle_traffic` calls stop decrypting): independent changes, both touch the tail of `handle_traffic` (here the flush just loses its buffer argument), so whichever lands second has a one-line merge. Until #37467 lands, a `'session'`/`'keylog'` listener that synchronously writes to the socket during a burst larger than 64 KiB would have the nested pass deliver the following chunk first, the same nesting #37467 removes for `'data'` handlers; no built-in listener writes from those events.

### Verification

`test/js/node/tls/node-tls-connect.test.ts`, new `describe("over a duplex, 'session' is emitted before the data that followed it on the wire")`, one case per dispatch site plus the handshake-parked case:

* response written after the request (read-loop exit)
* response and close_notify in one flight (close_notify branch)
* 160 KiB response handed to the engine in a single pass (buffer-full branch, destroy on the first 64 KiB)
* TLS 1.2 banner server (session parked while the handshake completes, banner decrypted in the same pass)

All four fail on the released binary (`0 pass 4 fail` in 8 of 8 runs, each receiving `["secureConnect", "data"]`) and pass on the debug build. Client and server share one event loop, so the tickets and the response always land in one read. Also ran on the debug build: the rest of `node-tls-connect.test.ts`, `node-tls-server`, `node-tls-upgrade`, `node-tls-duplex-close-throw-uaf`, `renegotiation`, `node-tls-socket-allow-half-open-option`, `tls-connect-socket-churn`, and the proxy-tunnel consumers of the same engine (`proxy.test.ts`, `proxy-stress-protocol`, `proxy-stress-lifecycle`, `websocket-proxy`, `fetch-proxy-connect-tunnel-split-envelope`; 299 pass). The one failure seen (`SNICallback runs even when the requested servername matches the bind hostname`) fails identically on the unmodified released binary in this sandbox, where `localhost` resolves to `::1` first.
