### PR TITLE
test: run the writeEarlyHints CRLF scenarios in-process instead of spawning four children

### DIFF
--- a/test/js/node/http/early-hints-crlf-injection.test.ts
+++ b/test/js/node/http/early-hints-crlf-injection.test.ts
@@ -9,7 +9,7 @@ describe("writeEarlyHints", () => {
   // handler passes to res.writeEarlyHints(), and the handler records what the
   // call threw instead of asserting in place, so a mismatch shows up as a
   // failed expect() in the test rather than as a response that never arrives.
-  type Scenario = { hints: Record<string, string>; thrown: unknown };
+  type Scenario = { hints: Record<string, string>; thrown: unknown; cpuMs: number };
   const scenarios = new Map<string, Scenario>();
   let server: Server;
   let port: number;
@@ -17,11 +17,14 @@ describe("writeEarlyHints", () => {
   beforeAll(async () => {
     server = createServer((req, res) => {
       const scenario = scenarios.get(req.url!)!;
+      const cpuBefore = process.cpuUsage();
       try {
         res.writeEarlyHints(scenario.hints);
       } catch (error) {
         scenario.thrown = error;
       }
+      const { user, system } = process.cpuUsage(cpuBefore);
+      scenario.cpuMs = (user + system) / 1000;
       res.end("ok");
     });
     server.listen(0, "127.0.0.1");
@@ -37,7 +40,7 @@ describe("writeEarlyHints", () => {
 
   async function writeEarlyHintsFor(hints: Record<string, string>) {
     const path = `/${scenarios.size}`;
-    const scenario: Scenario = { hints, thrown: undefined };
+    const scenario: Scenario = { hints, thrown: undefined, cpuMs: NaN };
     scenarios.set(path, scenario);
 
     const earlyHints: InformationEvent[] = [];
@@ -48,9 +51,13 @@ describe("writeEarlyHints", () => {
     });
 
     return {
-      thrown: scenario.thrown,
-      earlyHints,
-      response: { statusCode: response.statusCode, body: await text(response) },
+      outcome: {
+        thrown: scenario.thrown,
+        earlyHints,
+        response: { statusCode: response.statusCode, body: await text(response) },
+      },
+      /** CPU time the res.writeEarlyHints() call itself took, in milliseconds. */
+      cpuMs: scenario.cpuMs,
     };
   }
 
@@ -58,7 +65,7 @@ describe("writeEarlyHints", () => {
 
   test("rejects CRLF injection in header name", async () => {
     const name = "x-custom\r\nSet-Cookie: session=evil\r\nX-Injected";
-    const outcome = await writeEarlyHintsFor({ link: "</style.css>; rel=preload", [name]: "val" });
+    const { outcome } = await writeEarlyHintsFor({ link: "</style.css>; rel=preload", [name]: "val" });
 
     expect(outcome.thrown).toBeInstanceOf(TypeError);
     expect(outcome).toEqual({
@@ -72,7 +79,7 @@ describe("writeEarlyHints", () => {
   });
 
   test("rejects CRLF injection in header value", async () => {
-    const outcome = await writeEarlyHintsFor({
+    const { outcome } = await writeEarlyHintsFor({
       link: "</style.css>; rel=preload",
       "x-custom": "legitimate\r\nSet-Cookie: session=evil",
     });
@@ -91,7 +98,7 @@ describe("writeEarlyHints", () => {
   test("rejects CRLF injection in the link value", async () => {
     // The Link format check accepts anything between "<" and ">", so this one
     // is caught by the separate CR/LF check on the link value.
-    const outcome = await writeEarlyHintsFor({ link: "</style.css\r\nSet-Cookie: session=evil>; rel=preload" });
+    const { outcome } = await writeEarlyHintsFor({ link: "</style.css\r\nSet-Cookie: session=evil>; rel=preload" });
 
     expect(outcome.thrown).toBeInstanceOf(TypeError);
     expect(outcome).toEqual({
@@ -107,7 +114,7 @@ describe("writeEarlyHints", () => {
   });
 
   test("allows valid non-link headers in early hints", async () => {
-    const outcome = await writeEarlyHintsFor({
+    const { outcome } = await writeEarlyHintsFor({
       link: "</style.css>; rel=preload",
       "x-custom": "valid-value",
       "x-another": "also-valid",
@@ -131,13 +138,17 @@ describe("writeEarlyHints", () => {
   });
 
   test("rejects pathological link value without catastrophic backtracking", async () => {
-    // If the link-param name pattern admits "=", each ";a=b" matches two ways
-    // and the trailing space forces 2^32 retries before the match fails (node
-    // v26.3.0 hangs on this input). A regression here trips the per-test
-    // timeout; the assertion below pins the instant rejection.
+    // If the link-param name class admits "=", every ";a=b" matches two ways
+    // and the trailing space makes the regex backtrack through all 2^32
+    // combinations. JSC stops such a match at Yarr::matchLimit (~2s of CPU) and
+    // reports no match, so a regressed regex still throws the error asserted
+    // below; only the CPU time of the call tells it apart from the ~1ms a
+    // linear check takes. CPU time rather than wall-clock so a preempted CI
+    // machine cannot fail this.
     const link = "</x>" + ";a=b".repeat(32) + " ";
-    const outcome = await writeEarlyHintsFor({ link });
+    const { outcome, cpuMs } = await writeEarlyHintsFor({ link });
 
+    expect(cpuMs).toBeLessThan(250);
     expect(outcome.thrown).toBeInstanceOf(TypeError);
     expect(outcome).toEqual({
       thrown: expect.objectContaining({

--- a/test/js/node/http/early-hints-crlf-injection.test.ts
+++ b/test/js/node/http/early-hints-crlf-injection.test.ts
@@ -1,180 +1,151 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import { createServer, get, type IncomingMessage, type InformationEvent, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { text } from "node:stream/consumers";
 
-describe.concurrent("writeEarlyHints", () => {
-  test("rejects CRLF injection in header name", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const http = require("node:http");
-        const server = http.createServer((req, res) => {
-          try {
-            res.writeEarlyHints({
-              link: "</style.css>; rel=preload",
-              "x-custom\\r\\nSet-Cookie: session=evil\\r\\nX-Injected": "val",
-            });
-            console.log("FAIL: no error thrown");
-            process.exit(1);
-          } catch (e) {
-            console.log("error_code:" + e.code);
-            res.writeHead(200);
-            res.end("ok");
-          }
-        });
-        server.listen(0, () => {
-          http.get({ port: server.address().port }, (res) => {
-            let data = "";
-            res.on("data", (c) => data += c);
-            res.on("end", () => {
-              console.log("body:" + data);
-              server.close();
-            });
-          });
-        });
-        `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
+describe("writeEarlyHints", () => {
+  // All scenarios share one server. The request path selects the hints the
+  // handler passes to res.writeEarlyHints(), and the handler records what the
+  // call threw instead of asserting in place, so a mismatch shows up as a
+  // failed expect() in the test rather than as a response that never arrives.
+  type Scenario = { hints: Record<string, string>; thrown: unknown };
+  const scenarios = new Map<string, Scenario>();
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const scenario = scenarios.get(req.url!)!;
+      try {
+        res.writeEarlyHints(scenario.hints);
+      } catch (error) {
+        scenario.thrown = error;
+      }
+      res.end("ok");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  async function writeEarlyHintsFor(hints: Record<string, string>) {
+    const path = `/${scenarios.size}`;
+    const scenario: Scenario = { hints, thrown: undefined };
+    scenarios.set(path, scenario);
+
+    const earlyHints: InformationEvent[] = [];
+    const response = await new Promise<IncomingMessage>((resolve, reject) => {
+      get({ host: "127.0.0.1", port, path, agent: false }, resolve)
+        .on("information", info => earlyHints.push(info))
+        .on("error", reject);
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      thrown: scenario.thrown,
+      earlyHints,
+      response: { statusCode: response.statusCode, body: await text(response) },
+    };
+  }
 
-    expect(stdout).toContain("error_code:ERR_INVALID_HTTP_TOKEN");
-    expect(stdout).toContain("body:ok");
-    expect(exitCode).toBe(0);
+  const okResponse = { statusCode: 200, body: "ok" };
+
+  test("rejects CRLF injection in header name", async () => {
+    const name = "x-custom\r\nSet-Cookie: session=evil\r\nX-Injected";
+    const outcome = await writeEarlyHintsFor({ link: "</style.css>; rel=preload", [name]: "val" });
+
+    expect(outcome.thrown).toBeInstanceOf(TypeError);
+    expect(outcome).toEqual({
+      thrown: expect.objectContaining({
+        code: "ERR_INVALID_HTTP_TOKEN",
+        message: `Header name must be a valid HTTP token ["${name}"]`,
+      }),
+      earlyHints: [],
+      response: okResponse,
+    });
   });
 
   test("rejects CRLF injection in header value", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const http = require("node:http");
-        const server = http.createServer((req, res) => {
-          try {
-            res.writeEarlyHints({
-              link: "</style.css>; rel=preload",
-              "x-custom": "legitimate\\r\\nSet-Cookie: session=evil",
-            });
-            console.log("FAIL: no error thrown");
-            process.exit(1);
-          } catch (e) {
-            console.log("error_code:" + e.code);
-            res.writeHead(200);
-            res.end("ok");
-          }
-        });
-        server.listen(0, () => {
-          http.get({ port: server.address().port }, (res) => {
-            let data = "";
-            res.on("data", (c) => data += c);
-            res.on("end", () => {
-              console.log("body:" + data);
-              server.close();
-            });
-          });
-        });
-        `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
+    const outcome = await writeEarlyHintsFor({
+      link: "</style.css>; rel=preload",
+      "x-custom": "legitimate\r\nSet-Cookie: session=evil",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(outcome.thrown).toBeInstanceOf(TypeError);
+    expect(outcome).toEqual({
+      thrown: expect.objectContaining({
+        code: "ERR_INVALID_CHAR",
+        message: 'Invalid character in header content ["x-custom"]',
+      }),
+      earlyHints: [],
+      response: okResponse,
+    });
+  });
 
-    expect(stdout).toContain("error_code:ERR_INVALID_CHAR");
-    expect(stdout).toContain("body:ok");
-    expect(exitCode).toBe(0);
+  test("rejects CRLF injection in the link value", async () => {
+    // The Link format check accepts anything between "<" and ">", so this one
+    // is caught by the separate CR/LF check on the link value.
+    const outcome = await writeEarlyHintsFor({ link: "</style.css\r\nSet-Cookie: session=evil>; rel=preload" });
+
+    expect(outcome.thrown).toBeInstanceOf(TypeError);
+    expect(outcome).toEqual({
+      thrown: expect.objectContaining({
+        code: "ERR_INVALID_ARG_VALUE",
+        message:
+          `The argument 'hints' must be an array or string of format "</styles.css>; rel=preload; as=style". ` +
+          `Received '</style.css\\r\\nSet-Cookie: session=evil>; rel=preload'`,
+      }),
+      earlyHints: [],
+      response: okResponse,
+    });
   });
 
   test("allows valid non-link headers in early hints", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const http = require("node:http");
-        const server = http.createServer((req, res) => {
-          try {
-            res.writeEarlyHints({
-              link: "</style.css>; rel=preload",
-              "x-custom": "valid-value",
-              "x-another": "also-valid",
-            });
-            console.log("OK: no error");
-            res.writeHead(200);
-            res.end("ok");
-          } catch (e) {
-            console.log("FAIL: " + e.message);
-            process.exit(1);
-          }
-        });
-        server.listen(0, () => {
-          http.get({ port: server.address().port }, (res) => {
-            let data = "";
-            res.on("data", (c) => data += c);
-            res.on("end", () => {
-              console.log("body:" + data);
-              server.close();
-            });
-          });
-        });
-        `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
+    const outcome = await writeEarlyHintsFor({
+      link: "</style.css>; rel=preload",
+      "x-custom": "valid-value",
+      "x-another": "also-valid",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stdout).toContain("OK: no error");
-    expect(stdout).toContain("body:ok");
-    expect(exitCode).toBe(0);
+    expect(outcome).toEqual({
+      thrown: undefined,
+      earlyHints: [
+        {
+          httpVersion: "1.1",
+          httpVersionMajor: 1,
+          httpVersionMinor: 1,
+          statusCode: 103,
+          statusMessage: "Early Hints",
+          headers: { "link": "</style.css>; rel=preload", "x-custom": "valid-value", "x-another": "also-valid" },
+          rawHeaders: ["Link", "</style.css>; rel=preload", "x-custom", "valid-value", "x-another", "also-valid"],
+        },
+      ],
+      response: okResponse,
+    });
   });
 
   test("rejects pathological link value without catastrophic backtracking", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const http = require("node:http");
-        const server = http.createServer((req, res) => {
-          try {
-            res.writeEarlyHints({
-              link: "</x>" + ";a=b".repeat(32) + " ",
-            });
-            console.log("FAIL: no error thrown");
-            process.exit(1);
-          } catch (e) {
-            console.log("error_code:" + e.code);
-            res.writeHead(200);
-            res.end("ok");
-          }
-        });
-        server.listen(0, () => {
-          http.get({ port: server.address().port }, (res) => {
-            let data = "";
-            res.on("data", (c) => data += c);
-            res.on("end", () => {
-              console.log("body:" + data);
-              server.close();
-            });
-          });
-        });
-        `,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
+    // If the link-param name pattern admits "=", each ";a=b" matches two ways
+    // and the trailing space forces 2^32 retries before the match fails (node
+    // v26.3.0 hangs on this input). A regression here trips the per-test
+    // timeout; the assertion below pins the instant rejection.
+    const link = "</x>" + ";a=b".repeat(32) + " ";
+    const outcome = await writeEarlyHintsFor({ link });
+
+    expect(outcome.thrown).toBeInstanceOf(TypeError);
+    expect(outcome).toEqual({
+      thrown: expect.objectContaining({
+        code: "ERR_INVALID_ARG_VALUE",
+        message:
+          `The argument 'hints' must be an array or string of format "</styles.css>; rel=preload; as=style". ` +
+          `Received '${link}'`,
+      }),
+      earlyHints: [],
+      response: okResponse,
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stdout).toContain("error_code:ERR_INVALID_ARG_VALUE");
-    expect(stdout).toContain("body:ok");
-    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/http/early-hints-crlf-injection.test.ts
+++ b/test/js/node/http/early-hints-crlf-injection.test.ts
@@ -29,8 +29,10 @@ describe("writeEarlyHints", () => {
     port = (server.address() as AddressInfo).port;
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    const closed = once(server, "close");
     server.close();
+    await closed;
   });
 
   async function writeEarlyHintsFor(hints: Record<string, string>) {


### PR DESCRIPTION
Test-only change. `test/js/node/http/early-hints-crlf-injection.test.ts` showed up in the slow-test sweep at ~31s on the debian 13 x64-asan lane (31.21s for the file in the parallel batch of build #91993, similar in #91926) versus ~0.3s on the non-ASAN lanes.

### Where the time went

Each of the four tests spawned its own `bun -e` child that created a `node:http` server, made one request to itself and closed. Timing one child under the debug/ASAN build (`build/debug/bun-debug`):

| step | time |
| --- | --- |
| process startup (`bun -e 'console.log(1)'`) | ~0.4s |
| `require("node:http")` | ~2.2s |
| listen, serve one request, `server.close()` | ~1.2s (mostly first-use loading of the client side) |
| `server.close()` callback to process exit | ~80ms |

So each child burns ~4s of CPU loading `node:http` and the client side under ASAN, and the four children run concurrently: the whole file costs ~16-17s of CPU locally (`time` over the run, children included), which the contended parallel batch on the ASAN lane stretched to 31s of wall time. Nothing lingers after `server.close()`: the client sockets are released and the process exits ~80ms later, so there is no runtime bug to report here.

### Change

The scenarios now share one `http` server created in `beforeAll` (port 0, closed and awaited in `afterAll`) and each makes a single in-process request with `agent: false`. The request path selects the hints the handler passes to `res.writeEarlyHints()`; the handler records what the call threw and how much CPU it used and always answers `200 ok`, and the test asserts on the recorded outcome plus what the client actually received. No child processes, no sleeps, no fixed ports.

All four original scenarios are kept under their original names. One scenario is added: CRLF inside the link value itself (`</style.css\r\nSet-Cookie: ...>`), which the Link format check alone would accept and which is rejected by the separate CR/LF check, so it exercises a code path the other two injection cases do not. Node v26.3.0 rejects it the same way.

### Assertions

Before, each test checked `stdout` with `toContain("error_code:...")` plus the exit code. Now every scenario asserts, with one `toEqual` on the whole outcome:

- the thrown error is a `TypeError` with the exact `code` and the exact `message` (all messages match Node v26.3.0 byte for byte; for the pathological case the message is built from the same 32x `;a=b` input)
- `earlyHints: []` for every rejected call, i.e. no `103` reached the client, checked through the client's `information` events
- the final response is still `200` with body `ok` after a rejected call
- for the valid case, the `103 Early Hints` the client received: status, HTTP version, `headers` and the exact `rawHeaders` order (`Link` first, then the extra headers as given)

There is no stderr check because there is no child process any more.

### The backtracking case

The old test relied on the 5s test timeout to notice a regressed regex. That never actually worked: JSC stops a backtracking match at `Yarr::matchLimit` after roughly 2-4s of CPU and reports no match, so `writeEarlyHints()` throws the same `ERR_INVALID_ARG_VALUE` as the linear check and finishes inside the timeout (and bun test cannot interrupt a synchronously busy test anyway; a `for (;;) {}` test with a 1s timeout runs until something external kills it). The handler therefore measures `process.cpuUsage()` around the `writeEarlyHints()` call and the pathological test asserts it used less than 250ms of CPU, on top of the exact error. Measured: ~1ms under the debug/ASAN build (~30ms when the same call runs cold as the first scenario), 0.04ms in release. With `linkValueRegExp` in `src/js/internal/validators.ts` temporarily changed back to Node's shape and bun rebuilt, that assertion fails with `Received: 4012.739` while the other four tests keep passing; the change was reverted and is not part of this PR. CPU time rather than wall-clock so a preempted CI machine cannot fail it.

### Timing (`bun bd test test/js/node/http/early-hints-crlf-injection.test.ts`, debug + ASAN, same machine, back to back)

| | summed per-test | file total | CPU for the whole run (children included) |
| --- | --- | --- | --- |
| before (4 tests) | 16.3s / 19.3s (two runs, ~4-4.9s per test) | 7.4s / 8.9s | 16.2s / 17.8s |
| after (5 tests) | 1.14s / 1.18s | 4.3s / 4.6s | 5.9s / 6.2s |

The local debug build reproduces the slowness the sweep saw (each test ~4s of mostly CPU-bound work here). Of the remaining file total, ~3.2s of wall time (and most of the ~6s of CPU) is the floor for any file in `test/` under this build: an empty test file costs ~2.5-3s through `test/preload.ts` and importing `node:http` adds ~0.7s. The first test carries the remaining ~0.8s of first-use loading of the client side, the other four take 55-150ms each. Under the release build the file runs in ~0.18s (was ~0.33s).

On CI, build #92211 for this branch ran the file on the debian 13 x64-asan lane in 0.41s (`Ran 5 tests across 1 file. [406.00ms]`; it ran serially there as a changed file, whereas the 31.21s before was measured inside the parallel batch, so the wall-clock figures are not exactly like for like; the CPU column above is the contention-independent comparison).

Since this only touches the test, there is no fail-before to show; the file passes on main before and after.
