### PR TITLE
bundler: bundle a file once per requested loader instead of once per path

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -630,7 +630,7 @@ impl<'a> LinkerContext<'a> {
                 let source_index: u32 = unsafe {
                     (*parse_graph).path_to_source_index_map(Target::Browser)
                 }
-                .get(path_text)
+                .get_with_loader(path_text, Loader::Html)
                 .unwrap_or_else(|| {
                     panic!("Assertion failed: HTML import file not found in pathToSourceIndexMap");
                 });

--- a/src/bundler/PathToSourceIndexMap.rs
+++ b/src/bundler/PathToSourceIndexMap.rs
@@ -1,6 +1,8 @@
 use bun_collections::StringHashMap;
+use enum_map::EnumMap;
 
 use crate::IndexStringMap::IndexInt;
+use crate::options::Loader;
 
 /// Abstracts over the two structurally-identical `Path` ports (`bun_paths::fs::Path`
 /// and `bun_resolver::fs::Path`) so the bundler can key the map with either while
@@ -18,50 +20,120 @@ impl PathLike for bun_paths::fs::Path<'_> {
     }
 }
 
-/// The lifetime of the keys are not owned by this map.
+pub(crate) type GetOrPutResult<'a, V> = bun_collections::hash_map::GetOrPutResult<'a, V>;
+
+/// A module is identified by its resolved path plus the loader the import asked
+/// for: `import a from "./x.json" with { type: "text" }` and `import b from
+/// "./x.json"` are two different modules. Nearly every path is only ever
+/// requested with one loader, so that first registration lives in `by_path`;
+/// further loaders for the same path go in `by_loader`, allocated the first time
+/// a build needs it.
 ///
-/// We assume it's arena allocated.
+/// `V` is a source index in the module graph (`PathToSourceIndexMap`), or the
+/// pending `ParseTask` while one file's imports are being resolved
+/// (`bundle_v2::ResolveQueue`).
 #[derive(Default)]
-pub struct PathToSourceIndexMap {
-    pub(crate) map: Map,
+pub struct ModuleMap<V> {
+    by_path: StringHashMap<FirstRegistered<V>>,
+    by_loader: Option<Box<EnumMap<Loader, StringHashMap<V>>>>,
+    /// The dev server's IncrementalGraph identifies files by path alone, so it
+    /// keeps one module per path no matter which loader each import asked for.
+    pub(crate) one_module_per_path: bool,
 }
 
-pub type Map = StringHashMap<IndexInt>;
+#[derive(Default)]
+struct FirstRegistered<V> {
+    loader: Loader,
+    value: V,
+}
 
-/// std `HashMap::entry` doesn't expose
-/// `found_existing` + value-ptr together, so we hand-roll a thin shim.
-pub(crate) type GetOrPutResult<'a> = bun_collections::string_hash_map::GetOrPutResult<'a, IndexInt>;
+pub type PathToSourceIndexMap = ModuleMap<IndexInt>;
 
-impl PathToSourceIndexMap {
-    pub(crate) fn get_path(&self, path: &impl PathLike) -> Option<IndexInt> {
+impl<V: Copy + Default> ModuleMap<V> {
+    /// The first module registered for `text`, whatever loader requested it.
+    /// For callers that identify a module by path alone (entry points, the dev
+    /// server, dual-package `secondary_path` lookups).
+    pub(crate) fn get(&self, text: &[u8]) -> Option<V> {
+        self.by_path.get(text).map(|first| first.value)
+    }
+
+    pub(crate) fn get_path(&self, path: &impl PathLike) -> Option<V> {
         self.get(path.path_text())
     }
 
-    pub(crate) fn get(&self, text: impl AsRef<[u8]>) -> Option<IndexInt> {
-        self.map.get(text.as_ref()).copied()
-    }
-
-    // Takes `&[u8]` (not `impl AsRef<[u8]>`)
-    // to avoid E0283 inference ambiguity at `.into()` call sites in bundle_v2.
-    pub(crate) fn put(
-        &mut self,
-        text: &[u8],
-        value: IndexInt,
-    ) -> Result<(), bun_alloc::AllocError> {
-        // PERF: bun_collections::StringHashMap is keyed by `Box<[u8]>`, so we dupe here.
-        // Revisit once StringHashMap gains a borrowed-key variant.
-        self.map.put(text, value)
+    pub(crate) fn get_with_loader(&self, text: &[u8], loader: Loader) -> Option<V> {
+        let first = self.by_path.get(text)?;
+        if self.one_module_per_path || first.loader == loader {
+            return Some(first.value);
+        }
+        self.by_loader.as_ref()?[loader].get(text).copied()
     }
 
     pub(crate) fn get_or_put(
         &mut self,
-        text: impl AsRef<[u8]>,
-    ) -> Result<GetOrPutResult<'_>, bun_alloc::AllocError> {
-        // PERF: see note in `put` re: key duplication.
-        self.map.get_or_put(text.as_ref())
+        text: &[u8],
+        loader: Loader,
+    ) -> Result<GetOrPutResult<'_, V>, bun_alloc::AllocError> {
+        let one_module_per_path = self.one_module_per_path;
+        // PERF: bun_collections::StringHashMap is keyed by `Box<[u8]>`, so the key is
+        // duped on insert. Revisit once StringHashMap gains a borrowed-key variant.
+        let first = self.by_path.get_or_put(text)?;
+        if !first.found_existing {
+            first.value_ptr.loader = loader;
+        }
+        if !first.found_existing || one_module_per_path || first.value_ptr.loader == loader {
+            return Ok(GetOrPutResult {
+                found_existing: first.found_existing,
+                value_ptr: &mut first.value_ptr.value,
+            });
+        }
+        self.by_loader.get_or_insert_default()[loader].get_or_put(text)
     }
 
-    pub fn remove(&mut self, text: impl AsRef<[u8]>) -> bool {
-        self.map.remove(text.as_ref()).is_some()
+    pub(crate) fn put(
+        &mut self,
+        text: &[u8],
+        loader: Loader,
+        value: V,
+    ) -> Result<(), bun_alloc::AllocError> {
+        *self.get_or_put(text, loader)?.value_ptr = value;
+        Ok(())
+    }
+
+    /// Forgets every module registered for `text`. `by_loader` entries are only
+    /// reachable through the path's `by_path` entry, so they go too.
+    pub fn remove(&mut self, text: &[u8]) -> bool {
+        let mut removed = self.by_path.remove(text).is_some();
+        if let Some(by_loader) = &mut self.by_loader {
+            for map in by_loader.values_mut() {
+                removed |= map.remove(text).is_some();
+            }
+        }
+        removed
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.by_path.reserve(additional);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.by_path.clear();
+        self.by_loader = None;
+    }
+
+    /// `(path, value)` for every registered module. The first module registered
+    /// for each path comes before any registered for the same path under another
+    /// loader.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&[u8], V)> {
+        let first = self
+            .by_path
+            .iter()
+            .map(|(text, first)| (&**text, first.value));
+        let others = self
+            .by_loader
+            .iter()
+            .flat_map(|by_loader| by_loader.values())
+            .flat_map(|map| map.iter().map(|(text, value)| (&**text, *value)));
+        first.chain(others)
     }
 }

--- a/src/bundler/PathToSourceIndexMap.rs
+++ b/src/bundler/PathToSourceIndexMap.rs
@@ -22,22 +22,15 @@ impl PathLike for bun_paths::fs::Path<'_> {
 
 pub(crate) type GetOrPutResult<'a, V> = bun_collections::hash_map::GetOrPutResult<'a, V>;
 
-/// A module is identified by its resolved path plus the loader the import asked
-/// for: `import a from "./x.json" with { type: "text" }` and `import b from
-/// "./x.json"` are two different modules. Nearly every path is only ever
-/// requested with one loader, so that first registration lives in `by_path`;
-/// further loaders for the same path go in `by_loader`, allocated the first time
-/// a build needs it.
-///
-/// `V` is a source index in the module graph (`PathToSourceIndexMap`), or the
-/// pending `ParseTask` while one file's imports are being resolved
-/// (`bundle_v2::ResolveQueue`).
+/// Keyed by resolved path plus the loader the import asked for, so `./x.json`
+/// imported `with { type: "text" }` and imported plainly are two modules.
 #[derive(Default)]
 pub struct ModuleMap<V> {
+    /// The first loader registered for each path. Nearly every path only ever has one.
     by_path: StringHashMap<FirstRegistered<V>>,
+    /// Further loaders for paths already in `by_path`.
     by_loader: Option<Box<EnumMap<Loader, StringHashMap<V>>>>,
-    /// The dev server's IncrementalGraph identifies files by path alone, so it
-    /// keeps one module per path no matter which loader each import asked for.
+    /// The dev server's IncrementalGraph is keyed by path alone.
     pub(crate) one_module_per_path: bool,
 }
 
@@ -50,9 +43,7 @@ struct FirstRegistered<V> {
 pub type PathToSourceIndexMap = ModuleMap<IndexInt>;
 
 impl<V: Copy + Default> ModuleMap<V> {
-    /// The first module registered for `text`, whatever loader requested it.
-    /// For callers that identify a module by path alone (entry points, the dev
-    /// server, dual-package `secondary_path` lookups).
+    /// The first module registered for `text`, whatever loader it was registered with.
     pub(crate) fn get(&self, text: &[u8]) -> Option<V> {
         self.by_path.get(text).map(|first| first.value)
     }
@@ -75,8 +66,6 @@ impl<V: Copy + Default> ModuleMap<V> {
         loader: Loader,
     ) -> Result<GetOrPutResult<'_, V>, bun_alloc::AllocError> {
         let one_module_per_path = self.one_module_per_path;
-        // PERF: bun_collections::StringHashMap is keyed by `Box<[u8]>`, so the key is
-        // duped on insert. Revisit once StringHashMap gains a borrowed-key variant.
         let first = self.by_path.get_or_put(text)?;
         if !first.found_existing {
             first.value_ptr.loader = loader;
@@ -100,8 +89,7 @@ impl<V: Copy + Default> ModuleMap<V> {
         Ok(())
     }
 
-    /// Forgets every module registered for `text`. `by_loader` entries are only
-    /// reachable through the path's `by_path` entry, so they go too.
+    /// Forgets every module registered for `text`, under any loader.
     pub fn remove(&mut self, text: &[u8]) -> bool {
         let mut removed = self.by_path.remove(text).is_some();
         if let Some(by_loader) = &mut self.by_loader {
@@ -121,9 +109,7 @@ impl<V: Copy + Default> ModuleMap<V> {
         self.by_loader = None;
     }
 
-    /// `(path, value)` for every registered module. The first module registered
-    /// for each path comes before any registered for the same path under another
-    /// loader.
+    /// `(path, value)` for every registered module, `by_path` entries first.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&[u8], V)> {
         let first = self
             .by_path

--- a/src/bundler/PathToSourceIndexMap.rs
+++ b/src/bundler/PathToSourceIndexMap.rs
@@ -89,6 +89,30 @@ impl<V: Copy + Default> ModuleMap<V> {
         Ok(())
     }
 
+    /// Lookups of `text` that would have found `from` find `to` instead, whichever
+    /// loader `from` was registered under.
+    pub(crate) fn redirect(&mut self, text: &[u8], from: V, to: V)
+    where
+        V: PartialEq,
+    {
+        if let Some(first) = self.by_path.get_mut(text) {
+            if first.value == from {
+                first.value = to;
+                return;
+            }
+        }
+        if let Some(by_loader) = &mut self.by_loader {
+            for map in by_loader.values_mut() {
+                if let Some(value) = map.get_mut(text) {
+                    if *value == from {
+                        *value = to;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
     /// Forgets every module registered for `text`, under any loader.
     pub fn remove(&mut self, text: &[u8]) -> bool {
         let mut removed = self.by_path.remove(text).is_some();

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1068,7 +1068,9 @@ pub mod bv2_impl {
                 pub(crate) import_record_index: u32,
                 pub(crate) range: bun_ast::Range,
                 pub(crate) original_target: Target,
-                /// Set for the html file of a dev server route, see `BundleV2::requested_file_loader`.
+                /// The loader the request asks for: an import's `with { type }` attribute, or
+                /// `Loader::Html` for the html file of a dev server route. See
+                /// `BundleV2::requested_file_loader`.
                 pub(crate) loader: Option<Loader>,
             }
 
@@ -2224,18 +2226,12 @@ pub mod bv2_impl {
                 ) {
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
-                    let loader: Loader = 'brk: {
-                        let record: &ImportRecord = &self.graph.ast.items_import_records()
-                            [import_record.importer_source_index as usize]
-                            .as_slice()[import_record.import_record_index as usize];
-                        if let Some(out_loader) = record.loader {
-                            break 'brk out_loader;
-                        }
+                    let loader: Loader = import_record.loader.unwrap_or_else(|| {
                         // SAFETY: see `transpiler` note above.
-                        break 'brk Fs::Path::init(path_primary.text)
+                        Fs::Path::init(path_primary.text)
                             .loader(unsafe { &(*transpiler).options.loaders })
-                            .unwrap_or(Loader::File);
-                    };
+                            .unwrap_or(Loader::File)
+                    });
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
                     // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
@@ -2470,19 +2466,11 @@ pub mod bv2_impl {
             path.assert_pretty_is_valid();
             path.assert_file_path_is_absolute();
 
-            let loader: Loader = 'brk: {
-                let record: &ImportRecord = &self.graph.ast.items_import_records()
-                    [import_record.importer_source_index as usize]
-                    .as_slice()[import_record.import_record_index as usize];
-                if let Some(out_loader) = record.loader {
-                    break 'brk out_loader;
-                }
+            let loader: Loader = import_record.loader.unwrap_or_else(|| {
                 // SAFETY: see `transpiler` note above.
-                break 'brk path
-                    .loader(unsafe { &(*transpiler).options.loaders })
-                    .unwrap_or(Loader::File);
-                // HTML is only allowed at the entry point.
-            };
+                path.loader(unsafe { &(*transpiler).options.loaders })
+                    .unwrap_or(Loader::File)
+            });
 
             // borrowck: get-then-put (instead of a single get-or-put) so the map
             // borrow doesn't span `enqueue_parse_task` (which needs `&mut self`).
@@ -4727,14 +4715,14 @@ pub mod bv2_impl {
                         } else {
                             path.namespace = result_ns_static;
                         }
-                        // A file that a plugin resolved the record to instead keeps its own loader.
-                        let loader = this.requested_file_loader(
-                            &path,
-                            resolve
-                                .import_record
-                                .loader
-                                .filter(|_| path.text == &*resolve.import_record.specifier),
-                        );
+                        // An import attribute applies to whatever the import resolves to. The
+                        // dev server's loader is for the route file itself, not for a file a
+                        // plugin resolves the entry point to instead.
+                        let requested = resolve.import_record.loader.filter(|_| {
+                            resolve.import_record.kind != ImportKind::EntryPointBuild
+                                || path.text == &*resolve.import_record.specifier
+                        });
+                        let loader = this.requested_file_loader(&path, requested);
 
                         // SAFETY: `GetOrPutResult` borrows `&mut this` for its whole
                         // lifetime, blocking the `free_list`/`graph` accesses below.
@@ -5647,7 +5635,7 @@ pub mod bv2_impl {
                             import_record_index,
                             range: import_record.range,
                             original_target,
-                            loader: None,
+                            loader: import_record.loader,
                         },
                     );
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6853,11 +6853,11 @@ pub mod bv2_impl {
 
                     if let Some(compare) = get_redirect_id(ctx.redirect_import_record_index) {
                         if compare == i as u32 {
-                            let _ = path_to_source_index_map.put(
+                            path_to_source_index_map.redirect(
                                 ctx.source_path,
-                                ctx.loader,
+                                ctx.source_index.get(),
                                 source_index,
-                            ); // OOM-only Result
+                            );
                         }
                     }
                 }
@@ -7322,8 +7322,11 @@ pub mod bv2_impl {
 
                         this.graph
                             .path_to_source_index_map(result_ast_target)
-                            .put(source_path_text, source_loader, reference_source_index)
-                            .expect("oom");
+                            .redirect(
+                                source_path_text,
+                                result_source_index as IndexInt,
+                                reference_source_index,
+                            );
 
                         this.graph
                             .server_component_boundaries

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6838,9 +6838,7 @@ pub mod bv2_impl {
                 if !only_selected_record(ctx.only_records, i) {
                     continue;
                 }
-                // Only records `resolve_import_records` queued a module for carry a
-                // loader; the rest (internal, external, unresolved, plugin-resolved)
-                // get their source index elsewhere.
+                // Set by `resolve_import_records` on every record it queued a module for.
                 let Some(loader) = record.loader else {
                     continue;
                 };

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1068,9 +1068,8 @@ pub mod bv2_impl {
                 pub(crate) import_record_index: u32,
                 pub(crate) range: bun_ast::Range,
                 pub(crate) original_target: Target,
-                /// The loader the request asks for: an import's `with { type }` attribute, or
-                /// `Loader::Html` for the html file of a dev server route. See
-                /// `BundleV2::requested_file_loader`.
+                /// An import's `with { type }` loader, or `Loader::Html` for a dev server
+                /// route's html file. See `BundleV2::requested_file_loader`.
                 pub(crate) loader: Option<Loader>,
             }
 
@@ -4715,9 +4714,8 @@ pub mod bv2_impl {
                         } else {
                             path.namespace = result_ns_static;
                         }
-                        // An import attribute applies to whatever the import resolves to. The
-                        // dev server's loader is for the route file itself, not for a file a
-                        // plugin resolves the entry point to instead.
+                        // A route's html loader is for the route file itself, not for a file a
+                        // plugin swaps in for it.
                         let requested = resolve.import_record.loader.filter(|_| {
                             resolve.import_record.kind != ImportKind::EntryPointBuild
                                 || path.text == &*resolve.import_record.specifier

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6,7 +6,7 @@
 
 use core::ptr::NonNull;
 
-use bun_collections::{ArrayHashMap, StringHashMap};
+use bun_collections::ArrayHashMap;
 use bun_core::ThreadLock;
 
 // `bake_types` / `dispatch` are canonically defined in `bv2_impl` below
@@ -32,7 +32,7 @@ pub use bv2_impl::{
 
 pub use crate::DeferredBatchTask::DeferredBatchTask;
 use crate::Graph::Graph;
-use crate::PathToSourceIndexMap::PathToSourceIndexMap;
+use crate::PathToSourceIndexMap::{ModuleMap, PathToSourceIndexMap};
 use crate::barrel_imports::RequestedExports;
 use crate::cache::ExternalFreeFunction;
 use crate::options::{self, Target};
@@ -146,8 +146,8 @@ bun_core::declare_scope!(Bundle, visible);
 bun_core::declare_scope!(scan_counter, visible);
 
 /// Values are raw `*mut ParseTask` (arena-owned by `graph.heap`); the map only
-/// dedups by path during a single `on_parse_task_complete` pass.
-pub(crate) type ResolveQueue = StringHashMap<*mut ParseTask>;
+/// dedups by path + loader during a single `on_parse_task_complete` pass.
+pub(crate) type ResolveQueue = ModuleMap<*mut ParseTask>;
 
 pub struct BakeOptions<'a> {
     pub framework: bake::Framework,
@@ -2224,6 +2224,18 @@ pub mod bv2_impl {
                 ) {
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
+                    let loader: Loader = 'brk: {
+                        let record: &ImportRecord = &self.graph.ast.items_import_records()
+                            [import_record.importer_source_index as usize]
+                            .as_slice()[import_record.import_record_index as usize];
+                        if let Some(out_loader) = record.loader {
+                            break 'brk out_loader;
+                        }
+                        // SAFETY: see `transpiler` note above.
+                        break 'brk Fs::Path::init(path_primary.text)
+                            .loader(unsafe { &(*transpiler).options.loaders })
+                            .unwrap_or(Loader::File);
+                    };
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
                     // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
@@ -2231,7 +2243,7 @@ pub mod bv2_impl {
                     let (found_existing, value_ptr): (bool, *mut u32) = {
                         let entry = self
                             .path_to_source_index_map(target)
-                            .get_or_put(path_primary.text)
+                            .get_or_put(path_primary.text, loader)
                             .expect("oom");
                         (
                             entry.found_existing,
@@ -2239,20 +2251,6 @@ pub mod bv2_impl {
                         )
                     };
                     if !found_existing {
-                        let loader: Loader = 'brk: {
-                            let record: &mut ImportRecord =
-                                &mut self.graph.ast.items_import_records_mut()
-                                    [import_record.importer_source_index as usize]
-                                    .as_mut_slice()
-                                    [import_record.import_record_index as usize];
-                            if let Some(out_loader) = record.loader {
-                                break 'brk out_loader;
-                            }
-                            // SAFETY: see `transpiler` note above.
-                            break 'brk Fs::Path::init(path_primary.text)
-                                .loader(unsafe { &(*transpiler).options.loaders })
-                                .unwrap_or(Loader::File);
-                        };
                         // For virtual files, use the path text as-is (no relative path computation needed).
                         path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
                         let mut tmp_source = bun_ast::Source {
@@ -2472,9 +2470,26 @@ pub mod bv2_impl {
             path.assert_pretty_is_valid();
             path.assert_file_path_is_absolute();
 
+            let loader: Loader = 'brk: {
+                let record: &ImportRecord = &self.graph.ast.items_import_records()
+                    [import_record.importer_source_index as usize]
+                    .as_slice()[import_record.import_record_index as usize];
+                if let Some(out_loader) = record.loader {
+                    break 'brk out_loader;
+                }
+                // SAFETY: see `transpiler` note above.
+                break 'brk path
+                    .loader(unsafe { &(*transpiler).options.loaders })
+                    .unwrap_or(Loader::File);
+                // HTML is only allowed at the entry point.
+            };
+
             // borrowck: get-then-put (instead of a single get-or-put) so the map
             // borrow doesn't span `enqueue_parse_task` (which needs `&mut self`).
-            if let Some(existing) = self.path_to_source_index_map(target).get(path.text) {
+            if let Some(existing) = self
+                .path_to_source_index_map(target)
+                .get_with_loader(path.text, loader)
+            {
                 out_source_index = Some(Index::init(existing));
             } else {
                 path = self
@@ -2487,19 +2502,6 @@ pub mod bv2_impl {
                 if let Some(p) = resolve_result.path() {
                     *p = path;
                 }
-                let loader: Loader = 'brk: {
-                    let record: &ImportRecord = &self.graph.ast.items_import_records()
-                        [import_record.importer_source_index as usize]
-                        .as_slice()[import_record.import_record_index as usize];
-                    if let Some(out_loader) = record.loader {
-                        break 'brk out_loader;
-                    }
-                    // SAFETY: see `transpiler` note above.
-                    break 'brk path
-                        .loader(unsafe { &(*transpiler).options.loaders })
-                        .unwrap_or(Loader::File);
-                    // HTML is only allowed at the entry point.
-                };
                 let mut tmp_source = bun_ast::Source {
                     path: path_as_static(&path.dupe_alloc(self.arena()).expect("oom")),
                     contents: std::borrow::Cow::Borrowed(&b""[..]),
@@ -2514,7 +2516,7 @@ pub mod bv2_impl {
                     )
                     .expect("oom");
                 self.path_to_source_index_map(target)
-                    .put(path.text, idx)
+                    .put(path.text, loader, idx)
                     .expect("oom");
                 out_source_index = Some(Index::init(idx));
 
@@ -2550,11 +2552,11 @@ pub mod bv2_impl {
                         _ => (Target::Browser, Target::ServerComponentsSsr),
                     };
                     self.path_to_source_index_map(ta)
-                        .put(&key_text, idx)
+                        .put(&key_text, loader, idx)
                         .expect("oom");
                     if separate_ssr {
                         self.path_to_source_index_map(tb)
-                            .put(&key_text, idx)
+                            .put(&key_text, loader, idx)
                             .expect("oom");
                     }
                 }
@@ -2604,7 +2606,7 @@ pub mod bv2_impl {
             // `pretty`.
             result.path_pair.primary = path;
             self.path_to_source_index_map(target)
-                .put(path_slice, source_index.get())
+                .put(path_slice, loader, source_index.get())
                 .expect("oom");
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
 
@@ -2674,18 +2676,17 @@ pub mod bv2_impl {
             );
 
             path.assert_file_path_is_absolute();
+            let loader = self.requested_file_loader(&path, loader);
             // borrowck: get-then-put instead of a single get-or-put.
             if self
                 .path_to_source_index_map(target)
-                .get(path.text)
+                .get_with_loader(path.text, loader)
                 .is_some()
             {
                 return Ok(None);
             }
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
-
-            let loader = self.requested_file_loader(&path, loader);
 
             // SAFETY: `path_with_pretty_initialized` allocates into `self.graph.heap`, which
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
@@ -2715,7 +2716,7 @@ pub mod bv2_impl {
                 *p = path;
             }
             self.path_to_source_index_map(target)
-                .put(path.text, source_index.get())
+                .put(path.text, loader, source_index.get())
                 .expect("oom");
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
 
@@ -3258,7 +3259,7 @@ pub mod bv2_impl {
             // try this.graph.entry_points.append(arena, Index.runtime);
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
             self.path_to_source_index_map(self.transpiler.options.target)
-                .put(&b"bun:wrap"[..], Index::RUNTIME.get())
+                .put(b"bun:wrap", Loader::Js, Index::RUNTIME.get())
                 .expect("oom");
             // SAFETY: arena (`self.graph.heap`) outlives the bundle pass; coerce the
             // `&mut ParseTask` to `*mut` immediately so the `&self` borrow from
@@ -4726,6 +4727,14 @@ pub mod bv2_impl {
                         } else {
                             path.namespace = result_ns_static;
                         }
+                        // A file that a plugin resolved the record to instead keeps its own loader.
+                        let loader = this.requested_file_loader(
+                            &path,
+                            resolve
+                                .import_record
+                                .loader
+                                .filter(|_| path.text == &*resolve.import_record.specifier),
+                        );
 
                         // SAFETY: `GetOrPutResult` borrows `&mut this` for its whole
                         // lifetime, blocking the `free_list`/`graph` accesses below.
@@ -4735,7 +4744,7 @@ pub mod bv2_impl {
                         let (value_ptr, found_existing) = {
                             let existing = this
                                 .path_to_source_index_map(resolve.import_record.original_target)
-                                .get_or_put(path.text)
+                                .get_or_put(path.text, loader)
                                 .expect("oom");
                             (
                                 std::ptr::from_mut(existing.value_ptr),
@@ -4764,14 +4773,6 @@ pub mod bv2_impl {
                             unsafe { *value_ptr = source_index.get() };
                             out_source_index = Some(source_index);
                             let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
-                            // A file that a plugin resolved the record to instead keeps its own loader.
-                            let loader = this.requested_file_loader(
-                                &path,
-                                resolve
-                                    .import_record
-                                    .loader
-                                    .filter(|_| path.text == &*resolve.import_record.specifier),
-                            );
 
                             this.graph
                                 .input_files
@@ -5244,6 +5245,9 @@ pub mod bv2_impl {
             bake_entry_points: &bake_types::EntryPointList,
         ) -> Result<DevServerInput, Error> {
             self.unique_key = generate_unique_key();
+            for map in self.graph.build_graphs.values_mut() {
+                map.one_module_per_path = true;
+            }
 
             /* arena: help_catch_memory_issues — no-op (mimalloc TLH check) */
 
@@ -6198,15 +6202,17 @@ pub mod bv2_impl {
                         });
                         import_record.loader = Some(import_record_loader);
 
-                        if let Some(id) =
-                            self.path_to_source_index_map(target).get(path_primary.text)
+                        if let Some(id) = self
+                            .path_to_source_index_map(target)
+                            .get_with_loader(path_primary.text, import_record_loader)
                         {
                             import_record.source_index = Index::init(id);
                             continue;
                         }
 
-                        let resolve_entry =
-                            resolve_queue.get_or_put(path_primary.text).expect("oom");
+                        let resolve_entry = resolve_queue
+                            .get_or_put(path_primary.text, import_record_loader)
+                            .expect("oom");
                         if resolve_entry.found_existing {
                             // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                             import_record.path =
@@ -6565,7 +6571,10 @@ pub mod bv2_impl {
                     && target.is_server_side()
                     && self.dev_server.is_none();
 
-                if let Some(id) = self.path_to_source_index_map(target).get(path.text) {
+                if let Some(id) = self
+                    .path_to_source_index_map(target)
+                    .get_with_loader(path.text, import_record_loader)
+                {
                     if self.dev_server.is_some() && loader != Loader::Html {
                         import_record.path =
                             self.graph.input_files.items_source()[id as usize].path;
@@ -6579,7 +6588,9 @@ pub mod bv2_impl {
                     import_record.kind = ImportKind::HtmlManifest;
                 }
 
-                let resolve_entry = resolve_queue.get_or_put(path.text).expect("oom");
+                let resolve_entry = resolve_queue
+                    .get_or_put(path.text, import_record_loader)
+                    .expect("oom");
                 if resolve_entry.found_existing {
                     // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                     import_record.path =
@@ -6655,7 +6666,6 @@ pub mod bv2_impl {
                 });
             let dev_server_is_none = self.dev_server.is_none();
             for (key, value) in resolve_queue.iter() {
-                let value: *mut ParseTask = *value;
                 // SAFETY: ParseTask was arena-allocated in `resolve_import_records`;
                 // the arena outlives this loop.
                 let value = unsafe { &mut *value };
@@ -6675,7 +6685,7 @@ pub mod bv2_impl {
                     } else {
                         self.graph.path_to_source_index_map(target)
                     };
-                    let existing = map.get_or_put(key).expect("oom");
+                    let existing = map.get_or_put(key, loader).expect("oom");
                     (
                         existing.found_existing,
                         std::ptr::from_mut::<IndexInt>(existing.value_ptr),
@@ -6840,7 +6850,15 @@ pub mod bv2_impl {
                 if !only_selected_record(ctx.only_records, i) {
                     continue;
                 }
-                if let Some(source_index) = path_to_source_index_map.get_path(&record.path) {
+                // Only records `resolve_import_records` queued a module for carry a
+                // loader; the rest (internal, external, unresolved, plugin-resolved)
+                // get their source index elsewhere.
+                let Some(loader) = record.loader else {
+                    continue;
+                };
+                if let Some(source_index) =
+                    path_to_source_index_map.get_with_loader(record.path.text, loader)
+                {
                     if save_import_record_source_index
                         || input_file_loaders[source_index as usize].is_css()
                     {
@@ -6849,7 +6867,11 @@ pub mod bv2_impl {
 
                     if let Some(compare) = get_redirect_id(ctx.redirect_import_record_index) {
                         if compare == i as u32 {
-                            let _ = path_to_source_index_map.put(ctx.source_path, source_index); // OOM-only Result
+                            let _ = path_to_source_index_map.put(
+                                ctx.source_path,
+                                ctx.loader,
+                                source_index,
+                            ); // OOM-only Result
                         }
                     }
                 }
@@ -6941,9 +6963,11 @@ pub mod bv2_impl {
             let _ = self.graph.ast.append(ast_for_html_entrypoint); // OOM/capacity: fire-and-forget
 
             import_record.source_index = Index::init(fake_source_index.0);
-            let _ = self
-                .path_to_source_index_map(target)
-                .put(path_text, fake_source_index.0); // OOM-only Result
+            let _ = self.path_to_source_index_map(target).put(
+                path_text,
+                Loader::Html,
+                fake_source_index.0,
+            ); // OOM-only Result
             self.graph
                 .html_imports
                 .server_source_indices
@@ -7312,7 +7336,7 @@ pub mod bv2_impl {
 
                         this.graph
                             .path_to_source_index_map(result_ast_target)
-                            .put(source_path_text, reference_source_index)
+                            .put(source_path_text, source_loader, reference_source_index)
                             .expect("oom");
 
                         this.graph

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -983,6 +983,44 @@ body {
     },
   });
 
+  // The HTML references manifest.json as an asset (file loader) while the script
+  // imports it as JSON. These are two modules; the script must not end up with
+  // the asset's output path in place of the parsed object.
+  itBundled("html/manifest-json-also-imported-as-json", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="manifest" href="./manifest.json" />
+  </head>
+  <body>
+    <script src="./app.js"></script>
+  </body>
+</html>`,
+      "/manifest.json": JSON.stringify({ name: "My App" }),
+      "/app.js": /* js */ `
+        import manifest from "./manifest.json";
+        console.log(manifest.name);
+      `,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const htmlContent = api.readFile("out/index.html");
+
+      const manifestMatch = htmlContent.match(/href="(?:\.\/|\/)?(manifest-[a-zA-Z0-9]+\.json)"/);
+      expect(manifestMatch).not.toBeNull();
+      expect(api.readFile("out/" + manifestMatch![1])).toBe(JSON.stringify({ name: "My App" }));
+
+      const scriptMatch = htmlContent.match(/src="(?:\.\/|\/)?([^"]+\.js)"/);
+      expect(scriptMatch).not.toBeNull();
+      const js = api.readFile("out/" + scriptMatch![1]);
+      expect(js).toContain('"My App"');
+      expect(js).not.toContain(manifestMatch![1]);
+    },
+  });
+
   // Test that other non-JS/CSS file types referenced via URL imports are copied as assets
   itBundled("html/xml-asset", {
     outdir: "out/",

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -170,6 +170,93 @@ describe("bundler", async () => {
     },
   });
 
+  // A module is identified by its path and the loader the import asked for. One
+  // file imported with two different `type` attributes is two modules; the
+  // bundler used to merge them into whichever loader happened to get queued
+  // first.
+  describe("same file imported with different loaders", () => {
+    itBundled("bun/loader-same-file-different-loaders-across-modules", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import { asText } from "./as-text";
+          import { asJson } from "./as-json";
+          console.log(JSON.stringify({ text: asText.trim(), json: asJson }));
+        `,
+        "/as-text.ts": /* js */ `
+          import data from "./data.json" with { type: "text" };
+          export const asText = data;
+        `,
+        "/as-json.ts": /* js */ `
+          import data from "./data.json";
+          export const asJson = data;
+        `,
+        "/data.json": `{"a":1}`,
+      },
+      run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
+    });
+
+    itBundled("bun/loader-same-file-different-loaders-in-one-module", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import asText from "./data.json" with { type: "text" };
+          import asJson from "./data.json";
+          console.log(JSON.stringify({ text: asText.trim(), json: asJson }));
+        `,
+        "/data.json": `{"a":1}`,
+      },
+      run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
+    });
+
+    itBundled("bun/loader-same-file-different-loaders-dynamic-import", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import asJson from "./data.json";
+          const { default: asText } = await import("./data.json", { with: { type: "text" } });
+          console.log(JSON.stringify({ text: asText.trim(), json: asJson }));
+        `,
+        "/data.json": `{"a":1}`,
+      },
+      run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
+    });
+
+    itBundled("bun/loader-entry-point-imports-itself-as-text", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import source from "./entry.ts" with { type: "text" };
+          console.log(typeof source, source.includes('with { type: "text" }'));
+        `,
+      },
+      run: { stdout: "string true" },
+    });
+
+    // An explicit `type` that matches the loader the extension already selects
+    // is still the same module.
+    itBundled("bun/loader-same-file-same-loader-is-one-module", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import { a } from "./a";
+          import { b } from "./b";
+          console.log(a === b);
+        `,
+        "/a.ts": /* js */ `
+          import data from "./data.json" with { type: "json" };
+          export const a = data;
+        `,
+        "/b.ts": /* js */ `
+          import data from "./data.json";
+          export const b = data;
+        `,
+        "/data.json": `{"a":1}`,
+      },
+      run: { stdout: "true" },
+    });
+  });
+
   itBundled("bun/loader-json-proto-key-is-own-property", {
     target: "bun",
     files: {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -544,6 +544,32 @@ describe("bundler", () => {
       },
     };
   });
+  // An onResolve callback that declines every import sends resolution through
+  // the plugin fallback path. The loader from the import attribute is still part
+  // of the module's identity there: the same file imported as text and as JSON
+  // is two modules.
+  itBundled("plugin/ResolveFallthroughSameFileDifferentLoaders", {
+    files: {
+      "index.ts": /* ts */ `
+        import { asText } from "./as-text";
+        import { asJson } from "./as-json";
+        console.log(JSON.stringify({ text: asText.trim(), json: asJson }));
+      `,
+      "as-text.ts": /* ts */ `
+        import data from "./data.json" with { type: "text" };
+        export const asText = data;
+      `,
+      "as-json.ts": /* ts */ `
+        import data from "./data.json";
+        export const asJson = data;
+      `,
+      "data.json": `{"a":1}`,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
+  });
   itBundled("plugin/ManyFiles", ({ root }) => {
     const FILES = process.platform === "win32" ? 50 : 200; // windows is slower at this
     const create = (fn: (i: number) => string) => new Array(FILES).fill(0).map((_, i) => fn(i));

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -570,6 +570,32 @@ describe("bundler", () => {
     },
     run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
   });
+  // Same thing when onResolve itself resolves the specifier to a file on disk:
+  // each importer's attribute still picks that importer's loader.
+  itBundled("plugin/ResolveSuccessSameFileDifferentLoaders", ({ root }) => {
+    return {
+      files: {
+        "index.ts": /* ts */ `
+          import { asText } from "./as-text";
+          import { asJson } from "./as-json";
+          console.log(JSON.stringify({ text: asText.trim(), json: asJson }));
+        `,
+        "as-text.ts": /* ts */ `
+          import data from "virtual:data" with { type: "text" };
+          export const asText = data;
+        `,
+        "as-json.ts": /* ts */ `
+          import data from "virtual:data";
+          export const asJson = data;
+        `,
+        "data.json": `{"a":1}`,
+      },
+      plugins(builder) {
+        builder.onResolve({ filter: /^virtual:data$/ }, () => ({ path: join(root, "data.json") }));
+      },
+      run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
+    };
+  });
   itBundled("plugin/ManyFiles", ({ root }) => {
     const FILES = process.platform === "win32" ? 50 : 200; // windows is slower at this
     const create = (fn: (i: number) => string) => new Array(FILES).fill(0).map((_, i) => fn(i));

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -596,6 +596,30 @@ describe("bundler", () => {
       run: { stdout: '{"text":"{\\"a\\":1}","json":{"a":1}}' },
     };
   });
+  // A `module.exports = require(...)` module is a redirect: importers are linked
+  // straight to its target. That must also hold when onResolve resolved the
+  // require, since such records get their module later than the rest.
+  itBundled("plugin/ResolveSuccessCommonJSReExportRedirect", ({ root }) => {
+    return {
+      files: {
+        "index.ts": /* ts */ `
+          import viaShim from "./shim.js";
+          import viaShimAgain from "./shim.js";
+          import direct from "./target.js";
+          console.log(viaShim.value, viaShim === viaShimAgain, viaShim === direct);
+        `,
+        "shim.js": `module.exports = require("./target.js");`,
+        "target.js": `module.exports = { value: "from target" };`,
+      },
+      plugins(builder) {
+        builder.onResolve({ filter: /\.js$/ }, args => ({ path: join(root, args.path.replace(/^\.\//, "")) }));
+      },
+      run: { stdout: "from target true true" },
+      onAfterBundle(api) {
+        expect(api.readFile("/out.js")).not.toContain("shim.js");
+      },
+    };
+  });
   itBundled("plugin/ManyFiles", ({ root }) => {
     const FILES = process.platform === "win32" ? 50 : 200; // windows is slower at this
     const create = (fn: (i: number) => string) => new Array(FILES).fill(0).map((_, i) => fn(i));


### PR DESCRIPTION
`bun build` merged two imports of the same file that used different import attributes into one module. Which loader that module got depended on which importer happened to be parsed first, so the build silently produced different (and wrong) output from run to run. This is the bundler counterpart of #32999, which fixes the same collapse in the runtime module registry and deliberately left the bundler for a separate PR.

### Reproduction

```js
// j.json
{"a":1}
// a.mjs
import j from "./j.json" with { type: "text" }; export const ta = typeof j;
// b.mjs
import j from "./j.json"; export const tb = typeof j; export const val = j.a;
// cross.mjs
import { ta } from "./a.mjs"; import { tb, val } from "./b.mjs";
console.log(ta, tb, val);
```

```
$ bun cross.mjs
string object 1
$ for i in 1 2 3 4 5 6; do bun build cross.mjs --outdir=o >/dev/null; bun o/cross.js; done
string string undefined
object object 1
string string undefined
...
```

The bundle contains a single `// j.json` module, and 12 builds of the same input produce two different output hashes. The same collapse makes `import self from "./entry.mjs" with { type: "text" }` fail to bundle with `No matching export in "entry.mjs" for import "default"` (the text request is folded into the JS module), and makes a script that imports `manifest.json` as JSON receive the asset's output path when the HTML entry also references that file via `<link rel="manifest">` (the HTML reference is forced to the file loader). That last one is deterministic, since the HTML entry is always parsed first.

### Cause

`PathToSourceIndexMap` (per target) and the per-file `ResolveQueue` in `bundle_v2.rs` are keyed on the resolved path text only. `resolve_import_records` computes the loader each import asked for, but the lookup right after it ignores that loader: the second import of a path reuses whatever task was queued first, and the loader of that first task decides how the file is parsed for everybody.

### Fix

Both maps now identify a module by (path, loader the import asked for). `PathToSourceIndexMap.rs` gets a small generic `ModuleMap<V>` used for both:

- The first registration for a path is stored in the path map as before, tagged with its loader. Additional loaders for the same path go into a per-loader side table that is only allocated the first time a build needs one, so the common case costs one byte per entry and no extra lookups.
- `get`/`get_path` keep returning the first registration for callers that identify a module by path alone (entry point dedup, dual-package `secondary_path` rewrites, dev server invalidation, the dev-only barrel fallbacks). `get_with_loader`/`get_or_put`/`put` take the loader. The compiler found every registration site; they all already had the loader at hand (`import_record_loader`, the task loader in `process_resolve_queue`, the extension loader in `enqueue_entry_item`, the import's attribute loader (captured on `MiniImportRecord` when the plugin request is dispatched) or else the extension loader in `run_resolver`/`on_resolve`, `Loader::Html` for the HTML import manifest on both the insert side and the `LinkerContext` read side). The two sites that used to overwrite an entry so later importers land elsewhere (the CJS re-export shortcut and the "use client" proxy) now call `redirect(path, from, to)`, which swaps out whichever entry holds the module being replaced, so they need no loader at all.
- `patch_import_record_source_indices` looks records up with the loader `resolve_import_records` stored on them; records that were never queued (internal, external, unresolved, plugin-resolved) get their source index elsewhere and are skipped.
- The dev server keeps one module per path (`one_module_per_path`, set in `start_from_bake_dev_server`): its incremental graph and HMR runtime are keyed by path, so a second module for the same path has nothing to map onto. Its behaviour is unchanged.
- `remove` (used by `IncrementalGraph::on_file_deleted`) also drops side-table entries for the path.
- Plugin `onResolve` results used to take the loader from the returned path's extension and drop the import attribute. The attribute now wins there too, as it already did when the plugin declined, so the same file resolved through a plugin is also one module per requested loader.

An explicit attribute that names the loader the extension already selects (`import x from "./a.json" with { type: "json" }`) still shares the module with a plain import, since the requested loaders are equal.

### Tests

`test/bundler/bundler_loader.test.ts` (new `describe`): the cross-module case above, the same two imports inside one module, a static import plus `import(..., { with: { type: "text" } })` of the same file, an entry point importing itself as text, and a control that `type: "json"` on a `.json` file is still one module. `test/bundler/bundler_html.test.ts`: manifest referenced by HTML and imported as JSON by the script. `test/bundler/bundler_plugin.test.ts`: the cross-module case with a catch-all `onResolve` that declines (resolution goes through `run_resolver`), and again with an `onResolve` that resolves a virtual specifier to the file on disk (the `on_resolve` success path). Also a guard that a plugin-resolved `module.exports = require(...)` shim still links importers straight to its target (the redirect shortcut in `patch_import_record_source_indices` never applied to plugin-resolved records, before or after this change; the linker follows redirects itself).

With `USE_SYSTEM_BUN=1` the new tests fail (4 in the loader file plus the passing control, the html one, both plugin ones); with `bun bd` they pass. The repro above gives `string object 1` on every run and one output hash across 12 builds. Also run with the debug build: `bundler_html_server`, `html-import-manifest`, `bundler_plugin`, `bundler_barrel`, `bundler_splitting`, `bundler_edgecase`, `esbuild/loader`, `metafile`, `esbuild/metafile`, `bundler_bun`, `bun-build-api`, `bundler_files`, `bundler_plugin_chain`, `native-plugin`, and `test/bake/dev/{bundle,esm,incremental-graph-edge-deletion,production,hot,html,plugins,css}` (production needs a longer timeout than the 5s default on a debug build regardless of this change).

### Notes

- When a path really is bundled twice, the metafile now lists it twice under the same `inputs` key (the `imports[].with` entries already distinguish the two). esbuild disambiguates such keys with a `with { type: ... }` suffix; that is a small follow-up in `MetafileBuilder` and not needed for the fix itself.
- Rebased over #39814, which added `MiniImportRecord.loader` and `requested_file_loader` for the dev server's html routes. The field now carries both the route's html loader and an import's attribute loader. In the `onResolve` success path the "only when the plugin returned the requested file itself" rule from #39814 still applies to entry points, while an import's attribute applies to whatever the plugin resolved it to, like the non-plugin paths. `test/js/bun/http/bun-serve-html.test.ts` and the bake dev server suites pass on the rebased branch.
- #36549 adds the plugin namespace to the same map's key. The two changes are independent but touch the same call sites, so whichever lands second needs a small rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->



