### PR TITLE
server: replace upgrade_context pointer sentinel with UpgradeState enum

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -92,6 +92,17 @@ pub type RequestContextStackAllocator<
     REQUEST_CONTEXT_POOL_CAPACITY,
 >;
 
+#[derive(Clone, Copy)]
+pub(crate) enum UpgradeState {
+    /// Plain HTTP request.
+    None,
+    /// WebSocket handshake waiting for `server.upgrade()`. uWS owns the
+    /// context (one per `.ws()` route) and it outlives the request.
+    Pending(NonNull<WebSocketUpgradeContext>),
+    /// `server.upgrade()` handed the socket over to a `ServerWebSocket`.
+    Upgraded,
+}
+
 ///
 pub struct RequestContext<
     ThisServer,
@@ -120,7 +131,7 @@ pub struct RequestContext<
 
     pub(crate) flags: Flags<DEBUG_MODE>,
 
-    pub(crate) upgrade_context: Cell<Option<*mut WebSocketUpgradeContext>>,
+    pub(crate) upgrade_context: Cell<UpgradeState>,
 
     /// We can only safely free once the request body promise is finalized
     /// and the response is rejected
@@ -1323,7 +1334,7 @@ where
                 signal: Cell::new(None),
                 cookies: JsCell::new(None),
                 flags: Flags::<DEBUG_MODE>::default(),
-                upgrade_context: Cell::new(None),
+                upgrade_context: Cell::new(UpgradeState::None),
                 response_jsvalue: Cell::new(JSValue::ZERO),
                 ref_count: Cell::new(1),
                 pin_count: Cell::new(0),
@@ -2258,10 +2269,7 @@ where
     }
 
     pub(crate) fn did_upgrade_web_socket(&self) -> bool {
-        self.upgrade_context
-            .get()
-            .map(|p| p as usize == usize::MAX)
-            .unwrap_or(false)
+        matches!(self.upgrade_context.get(), UpgradeState::Upgraded)
     }
 
     fn to_async_without_abort_handler(

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -56,7 +56,9 @@ pub(super) use super::html_bundle::{self as html_bundle, HTMLBundle};
 pub(super) use super::any_request_context::AnyRequestContext;
 pub(super) use super::file_route::FileRoute;
 pub(super) use super::node_http_response::NodeHTTPResponse;
-pub(super) use super::request_context::{DeferDeinitFlag, RequestContext as NewRequestContext};
+pub(super) use super::request_context::{
+    DeferDeinitFlag, RequestContext as NewRequestContext, UpgradeState,
+};
 pub(super) use super::server_config::{self as server_config, ServerConfig};
 pub(super) use super::server_web_socket::ServerWebSocket;
 pub(super) use super::static_route::StaticRoute;
@@ -1938,15 +1940,13 @@ where
             return Ok(JSValue::FALSE);
         }
 
-        let upgrade_context = upgrader.upgrade_context.get();
-        if upgrade_context.is_none() || upgrade_context.map(|p| p as usize) == Some(usize::MAX) {
+        let UpgradeState::Pending(upgrade_ctx) = upgrader.upgrade_context.get() else {
             return Ok(JSValue::FALSE);
-        }
+        };
 
         let Some(resp) = upgrader.resp.get() else {
             return Ok(JSValue::FALSE);
         };
-        let upgrade_ctx = upgrade_context.unwrap();
 
         // Keep the upgrader alive across option getters below, which run
         // arbitrary user JS. A re-entrant server.upgrade(req) from a getter
@@ -2182,9 +2182,7 @@ where
 
         // --- After this point, do not throw an exception
         // See https://github.com/oven-sh/bun/issues/1339
-        upgrader
-            .upgrade_context
-            .set(Some(usize::MAX as *mut WebSocketUpgradeContext));
+        upgrader.upgrade_context.set(UpgradeState::Upgraded);
         let signal = upgrader.signal.take();
         upgrader.resp.set(None);
 
@@ -2230,11 +2228,9 @@ where
             sec_websocket_key_str.slice(),
             proto_str.slice(),
             ext_str.slice(),
-            // S008: `WebSocketUpgradeContext` is an `opaque_ffi!` ZST — safe
-            // deref (`upgrade_ctx` checked non-null / non-sentinel above;
-            // the uWS HttpContext owns it for the request's
-            // duration).
-            Some(bun_opaque::opaque_deref_mut(upgrade_ctx)),
+            // S008: `WebSocketUpgradeContext` is an `opaque_ffi!` ZST, safe
+            // deref; `UpgradeState::Pending` documents who keeps it alive.
+            Some(bun_opaque::opaque_deref_mut(upgrade_ctx.as_ptr())),
         );
 
         Ok(JSValue::TRUE)
@@ -3391,7 +3387,11 @@ where
             return;
         };
         // SAFETY: `prepared.ctx` is the freshly-allocated RequestContext slot.
-        unsafe { (*prepared.ctx).upgrade_context.set(Some(upgrade_ctx)) };
+        unsafe {
+            (*prepared.ctx)
+                .upgrade_context
+                .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)))
+        };
         let server_request_list = Self::js_route_list_get_cached(server_js).unwrap();
         // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe deref.
         let global = bun_opaque::opaque_deref(server_ref.global_this);
@@ -3515,7 +3515,8 @@ where
             Some(signal_for_req),
             body_hive,
         ));
-        ctx.upgrade_context.set(Some(upgrade_ctx));
+        ctx.upgrade_context
+            .set(UpgradeState::Pending(NonNull::from(upgrade_ctx)));
         // Leaked so the ctx (which outlives this stack frame) can hold the
         // pointer; freed via ctx.deinit's request_weakref. Everything below
         // goes through this raw pointer rather than a `&mut Request` reborrow:


### PR DESCRIPTION
## What

`RequestContext.upgrade_context` (`src/runtime/server/RequestContext.rs`) was a `Cell<Option<*mut WebSocketUpgradeContext>>` that actually encoded three states: `None` for a plain HTTP request, a live pointer while a WebSocket handshake is waiting for `server.upgrade()`, and `usize::MAX as *mut _` once the upgrade had happened. `server.upgrade()` tested for `None` or the sentinel and then `.unwrap()`ed the pointer, and `did_upgrade_web_socket()` compared the pointer against `usize::MAX`.

```rust
// before
pub(crate) upgrade_context: Cell<Option<*mut WebSocketUpgradeContext>>,

// after
#[derive(Clone, Copy)]
pub(crate) enum UpgradeState {
    None,
    Pending(NonNull<WebSocketUpgradeContext>),
    Upgraded,
}

pub(crate) upgrade_context: Cell<UpgradeState>,
```

Every use of the field is migrated (3 sites in `RequestContext.rs`, 5 in `server_body.rs`):

- `create()` initialises `UpgradeState::None`.
- `did_upgrade_web_socket()` becomes `matches!(.., UpgradeState::Upgraded)`; its 6 callers are unchanged.
- `server.upgrade()` reads the field with `let UpgradeState::Pending(upgrade_ctx) = .. else { return Ok(JSValue::FALSE) };`, which deletes the sentinel compare and the `.unwrap()`, writes `UpgradeState::Upgraded` at the point of no return, and passes `upgrade_ctx.as_ptr()` to the existing `opaque_deref_mut` call.
- The two places that arm a request for upgrade (`upgrade_web_socket_user_route` and `on_web_socket_upgrade`) store `UpgradeState::Pending(NonNull::from(upgrade_ctx))`, built from the `&mut WebSocketUpgradeContext` uWS passed to the handler.

The variant docs record who owns the pending context (uWS, one per `.ws()` route, outliving the request), which previously lived in a comment at the deref site. The `usize::MAX` sentinel no longer appears in the server module.

## Why

The magic pointer value and the state "upgraded but still carrying a handshake pointer" are now unrepresentable, and the ownership of the pending pointer is stated on the type that holds it instead of at one use site. This is zero-cost: `Option<*mut T>` has no niche and is a tag plus a pointer, and the new enum (two dataless variants plus one `NonNull` payload) has the same 16 byte, align 8 layout, so the pooled `RequestContext` size is unchanged; each discriminant test replaces one pointer compare, and the `.unwrap()` branch disappears. No FFI signature changes; `WebSocketUpgradeContext` stays the same opaque handle on both sides of the `resp.upgrade()` call.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/websocket/websocket-server.test.ts: 114 pass, 3 todo, 1 fail; websocket-server-upgrade-reentrant.test.ts, websocket-upgrade-signal-gc.test.ts and test/regression/issue/23474.test.ts: 6 pass, 0 fail.
The one failure, ServerWebSocket > send() > (benchmark) (30s timeout in the debug build), fails identically on main (114 pass, 1 fail), so it is pre-existing.
