### PR TITLE
compile: report ENAMETOOLONG for an over-long outfile instead of aborting

### DIFF
--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -27,7 +27,7 @@ use bun_jsc::WorkPool;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue};
 use bun_options_types::WindowsOptions;
 use bun_options_types::schema::api;
-use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf, platform};
+use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf_checked, platform};
 use bun_paths::{self as paths, PathBuffer, SEP};
 use bun_ptr::BackRef;
 use bun_ptr::RefCount;
@@ -315,23 +315,25 @@ impl JSBundleCompletionTask {
         // correctly with PE metadata operations.
         // Add .exe extension for Windows targets if not already present.
         let full_outfile_path: Box<[u8]> = {
-            let outdir_slice = &self.config.outdir.list;
-            let outfile_slice = &compile_options.outfile.list;
-            let joined: &[u8] = if !outdir_slice.is_empty() {
-                join_abs_string_buf::<platform::Auto>(
-                    top_level_dir,
-                    &mut outbuf[..],
-                    &[outdir_slice, outfile_slice],
-                )
-            } else if paths::is_absolute(outfile_slice) {
-                outfile_slice
+            let outdir_slice: &[u8] = &self.config.outdir.list;
+            let outfile_slice: &[u8] = &compile_options.outfile.list;
+            let parts: &[&[u8]] = if outdir_slice.is_empty() {
+                &[outfile_slice]
             } else {
-                // For relative paths, ensure we make them absolute relative to the current working directory
-                join_abs_string_buf::<platform::Auto>(
-                    top_level_dir,
-                    &mut outbuf[..],
-                    &[outfile_slice],
-                )
+                &[outdir_slice, outfile_slice]
+            };
+            // An absolute outfile goes through the join too: everything downstream
+            // (`to_bytes`, `to_executable`) copies pieces of this path into fixed
+            // path buffers, so the bound has to hold for every branch.
+            let Some(joined) = join_abs_string_buf_checked::<platform::Auto>(
+                top_level_dir,
+                &mut outbuf[..],
+                parts,
+            ) else {
+                return CompileResult::fail_fmt(format_args!(
+                    "Failed to resolve compile.outfile {}: ENAMETOOLONG",
+                    bun_core::fmt::quote(&parts.join(&SEP))
+                ));
             };
             if compile_options.compile_target.os == OperatingSystem::Windows
                 && !joined.ends_with(b".exe")

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1949,10 +1949,28 @@ pub fn to_executable(
                 )));
             }
         };
-        let dest_path = if bun_paths::is_absolute(outfile) {
+        let mut dest_buf = bun_paths::path_buffer_pool::get();
+        let dest_path: &[u8] = if bun_paths::is_absolute(outfile) {
             outfile
         } else {
-            path::resolve_path::join_abs_string::<path::platform::Auto>(cwd_path, &[outfile])
+            // `outfile` is `--outfile` verbatim, and the thread-local buffer behind
+            // `join_abs_string` is 4 KiB, far less than a `PathBuffer` on Windows.
+            match path::resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
+                cwd_path,
+                &mut dest_buf[..],
+                &[outfile],
+            ) {
+                Some(p) => p,
+                None => {
+                    if fd != Fd::INVALID {
+                        fd.close();
+                    }
+                    return Ok(CompileResult::fail_fmt(format_args!(
+                        "failed to move executable to {}: ENAMETOOLONG",
+                        bstr::BStr::new(outfile)
+                    )));
+                }
+            }
         };
 
         // Convert paths to Windows UTF-16
@@ -2058,12 +2076,13 @@ pub fn to_executable(
         };
         let mut temp_posix_buf = PathBuffer::uninit();
         let temp_posix = path::resolve_path::z(&temp_location, &mut temp_posix_buf);
-        let outfile_basename = bun_paths::basename(outfile);
-        let mut outfile_posix_buf = PathBuffer::uninit();
-        let outfile_posix = path::resolve_path::z(outfile_basename, &mut outfile_posix_buf);
+        // Not `resolve_path::z` into a `PathBuffer`: `--outfile` is unbounded user
+        // input, and `z` turns a name that does not fit into "" (so the rename
+        // reports ENOENT, or panics in debug builds) instead of ENAMETOOLONG.
+        let outfile_posix = bun_core::ZBox::from_bytes(bun_paths::basename(outfile));
 
         if let Err(e) =
-            bun_sys::move_file_z_with_handle(fd, Fd::cwd(), temp_posix, root_dir, outfile_posix)
+            bun_sys::move_file_z_with_handle(fd, Fd::cwd(), temp_posix, root_dir, &outfile_posix)
         {
             fd.close();
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
-import { join } from "path";
+import { chmodSync, closeSync, cpSync, existsSync, openSync, readdirSync, readSync } from "node:fs";
+import { join, sep } from "path";
 
 describe("Bun.build compile", () => {
   test("compile with current platform target string", async () => {
@@ -766,6 +766,147 @@ describe("compiled binary in a deleted cwd", () => {
     },
     60_000,
   );
+});
+
+describe.concurrent("compile with an outfile longer than a path buffer", () => {
+  // The executable's path (`outdir` + `compile.outfile`) is resolved into a fixed-size
+  // path buffer. That used to be unchecked, so an over-long value took the whole
+  // process down instead of failing the build:
+  //   panic: range end index 5022 out of range for slice of length 4095
+  // Hence every case here runs in a child process. 100_000 bytes is longer than the
+  // buffer on every platform (about 96 KiB on Windows); 5000, the length from the
+  // report, is longer than it on POSIX only (4 KiB on Linux, 1 KiB on macOS). On
+  // Windows a 5000-byte name fits the buffer and fails later, when the file is moved.
+  const lengths = isWindows ? [100_000] : [5000, 100_000];
+
+  // `options` is evaluated in the child with `long` (the over-long string), `dir`
+  // (the temp directory) and `sep` in scope; `shown` is the path the error quotes.
+  const variants: Record<string, { options: string; shown: (long: string, dir: string) => string }> = {
+    "relative compile.outfile": {
+      options: `{ compile: { outfile: long } }`,
+      shown: long => long,
+    },
+    "compile.outfile inside outdir": {
+      options: `{ outdir: "dist", compile: { outfile: long } }`,
+      shown: long => `dist${sep}${long}`,
+    },
+    "short compile.outfile inside an over-long outdir": {
+      options: `{ outdir: long, compile: { outfile: "app" } }`,
+      shown: long => `${long}${sep}app`,
+    },
+    "absolute compile.outfile": {
+      options: `{ compile: { outfile: dir + sep + long } }`,
+      shown: (long, dir) => `${dir}${sep}${long}`,
+    },
+  };
+
+  const matrix = Object.keys(variants).flatMap(name => lengths.map(length => [name, length] as const));
+
+  test.each(matrix)("Bun.build: %s of %d bytes fails the build", async (name, length) => {
+    const { options, shown } = variants[name];
+    using dir = tempDir("build-compile-long-outfile", {
+      "app.js": `console.log("never compiled");`,
+    });
+    const long = Buffer.alloc(length, "a").toString();
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const long = Buffer.alloc(${length}, "a").toString();
+         const dir = ${JSON.stringify(String(dir))};
+         const sep = ${JSON.stringify(sep)};
+         const result = await Bun.build({ entrypoints: ["./app.js"], throw: false, ...${options} });
+         console.log(JSON.stringify({
+           success: result.success,
+           outputs: result.outputs.length,
+           logs: result.logs.map(log => log.message),
+         }));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      success: false,
+      outputs: 0,
+      logs: [`Failed to resolve compile.outfile "${shown(long, String(dir))}": ENAMETOOLONG`],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.build: the default throw rejects with the same error", async () => {
+    using dir = tempDir("build-compile-long-outfile-throw", {
+      "app.js": `console.log("never compiled");`,
+    });
+    const long = Buffer.alloc(100_000, "a").toString();
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const long = Buffer.alloc(100_000, "a").toString();
+         try {
+           await Bun.build({ entrypoints: ["./app.js"], compile: { outfile: long } });
+           console.log("resolved");
+         } catch (error) {
+           console.log(JSON.stringify({
+             name: error.constructor.name,
+             message: error.message,
+             errors: error.errors.map(e => e.message),
+           }));
+         }`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      name: "AggregateError",
+      message: "Bundle failed",
+      errors: [`Failed to resolve compile.outfile "${long}": ENAMETOOLONG`],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // The CLI hands --outfile to the same executable writer without resolving it first,
+  // so this exercises the writer's own handling of an over-long name. 5000 bytes still
+  // fits in a command line on every platform (100_000 would not on Windows) and exceeds
+  // the buffers involved: a 4 KiB join buffer on Windows, PATH_MAX-sized ones on POSIX.
+  test("bun build --compile --outfile of 5000 bytes fails instead of crashing", async () => {
+    using dir = tempDir("build-compile-long-outfile-cli", {
+      "app.js": `console.log("never compiled");`,
+    });
+    const long = Buffer.alloc(5000, "a").toString();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./app.js", "--outfile", long],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    if (isWindows) {
+      // Resolved against the cwd and given the .exe suffix, then rejected by the OS.
+      expect(stderr).toContain("failed to move executable to ");
+      expect(stderr).toContain(`${sep}${long}.exe: `);
+    } else {
+      expect(stderr).toContain(` to ${long}: ENAMETOOLONG`);
+      // The temporary copy of the executable is removed again on failure.
+      expect(readdirSync(String(dir))).toEqual(["app.js"]);
+    }
+    expect(exitCode).toBe(1);
+  }, 60_000);
 });
 
 // file command test works well


### PR DESCRIPTION
### What does this PR do?

`Bun.build` with a `compile.outfile` (or an `outdir`) longer than a path buffer aborts the process instead of failing the build. `throw: false` does not help because no error is ever produced:

```sh
$ echo 'console.log(1)' > app.js
$ bun -e 'await Bun.build({ entrypoints: ["./app.js"], compile: { outfile: Buffer.alloc(5000, "a").toString() }, throw: false })'
panic: range end index 5022 out of range for slice of length 4095
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
$ echo $?
134
```

Reproduces on bun 1.4.0 and on main (54d6d16cc9); the code is a straight port of the Zig version, so this is not a regression. Same crash with `outdir` set, with a long `outdir` and a short outfile, and on Windows (there the buffer is ~96 KiB, so it takes a longer value). An absolute outfile of the same length takes a different route and is not much better: on Linux/macOS the release build reports `failed to rename ...: ENOENT` for what is really ENAMETOOLONG and a debug build panics with `path too long`; on Windows a long enough one panics in the module graph serialization instead. The CLI has the same class of problem one layer down: `bun build --compile --outfile <5000 chars>` reports ENOENT on POSIX (panics in debug builds), and on Windows panics with `range end index 5012 out of range for slice of length 4096`.

### Cause

`do_compilation` (`src/runtime/api/js_bundle_completion_task.rs`) resolves `outdir` + `compile.outfile` with the unchecked `join_abs_string_buf` into a pooled `PathBuffer`; the normalize step indexes past the buffer when the result does not fit. An absolute outfile skipped the join and was passed through unbounded, and everything downstream copies pieces of that path into fixed-size buffers: `to_executable` puts the basename through `resolve_path::z` (which returns `""` for a name that does not fit, and panics in debug builds), and on Windows `to_bytes` normalizes the entry key into a `PathBuffer`.

In `to_executable` (`src/standalone_graph/StandaloneModuleGraph.rs`, shared with the CLI), the POSIX branch has that same `resolve_path::z` on a name the CLI passes through verbatim, and the Windows branch joins a relative `--outfile` through `join_abs_string`, whose thread-local buffer is 4 KiB on every platform, i.e. much smaller than a Windows `PathBuffer`.

### Fix

- `do_compilation` resolves all three cases (with `outdir`, relative, absolute) through one `join_abs_string_buf_checked` call and turns `None` into a `CompileResult` error, which surfaces like any other compile failure (a `logs` entry with `throw: false`, an `AggregateError` otherwise):

  ```
  Failed to resolve compile.outfile "aaaa...": ENAMETOOLONG
  Failed to resolve compile.outfile "dist/aaaa...": ENAMETOOLONG
  ```

  Routing the absolute case through the join is what bounds the downstream buffers too; `join_abs_string_buf_checked` is the variant the rest of the tree already uses for user-controlled path input (`BunObject.rs`, `Package.rs`, `AutoAbsPathChecked`). The only observable difference for a valid absolute outfile is that it is now lexically normalized, which is what already happened to it whenever an `outdir` was set; the existing exact `BuildArtifact.path` assertions for absolute outfiles in `bun-build-compile.test.ts` still pass.
- `to_executable`, POSIX: build the NUL-terminated basename on the heap instead of copying it into a `PathBuffer`, so an over-long name reaches `renameat` and fails with the kernel's ENAMETOOLONG through the existing error message.
- `to_executable`, Windows: join the relative outfile into a pooled `PathBuffer` with the checked variant. The conversion to a wide path right after it already fails safe, so this is the one unbounded step on that path.

Not changed here: output paths from `naming` templates overflow a different buffer in the bundler proper (independent of compile), and the Windows branch of `to_executable` leaving its temp file behind whenever the move fails is pre-existing; both are separate problems.

### How did you verify your code works?

New `describe` block at the end of `test/bundler/bun-build-compile.test.ts`, every case in a child process since the unfixed behavior is a crash:

- `Bun.build` with a relative outfile, an outfile inside `outdir`, a short outfile inside an over-long `outdir`, and an absolute outfile, at 100,000 bytes everywhere plus 5000 bytes on POSIX (the reported size; on Windows that still fits the buffer). Each asserts the exact `{ success, outputs, logs }` including the full message.
- The default `throw: true` form rejects with an `AggregateError` carrying the same message.
- `bun build --compile --outfile <5000 bytes>` exits 1 with `... to aaaa...: ENAMETOOLONG` and no temp file left in the cwd on POSIX, and with `failed to move executable to <cwd>\aaaa....exe: ...` on Windows.

On Linux all 10 fail with `USE_SYSTEM_BUN=1` (the six join cases and the throw case crash the child, the two absolute cases and the CLI case get ENOENT instead of ENAMETOOLONG) and pass with `bun bd test`; the rest of the file and `cli.test.ts`, `bun-build-compile-sourcemap.test.ts`, `compile-outfile-subdirs.test.ts` pass too. On a Windows x64 machine the 6 cases that run there fail with the released canary (the CLI one with the `5012 out of range` panic above) and pass with a debug build of this branch. `cargo check` of `bun_standalone_graph` and `bun_runtime` for `x86_64-pc-windows-msvc` and of `bun_standalone_graph` for `aarch64-apple-darwin` is clean.
