### PR TITLE
test: make 12042.test.ts exit cleanly under LeakSanitizer and tighten its assertions

### DIFF
--- a/test/regression/issue/12042.test.ts
+++ b/test/regression/issue/12042.test.ts
@@ -1,47 +1,69 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 
+// https://github.com/oven-sh/bun/issues/12042: BUN_CONFIG_VERBOSE_FETCH=curl
+// omitted --data-raw for application/x-www-form-urlencoded request bodies.
 test("#12042 curl verbose fetch logs form-urlencoded body", async () => {
-  using dir = tempDir("issue-12042", {
-    "form.ts": `
-const server = Bun.serve({
-  port: 0,
-  fetch() {
-    return new Response(JSON.stringify({ ok: true }), {
-      headers: { "Content-Type": "application/json" },
-    });
-  },
-});
-
-const params = new URLSearchParams();
-params.set("grant_type", "client_credentials");
-params.set("client_id", "abc");
-params.set("client_secret", "xyz");
-
-await fetch(String(server.url), {
-  method: "POST",
-  headers: { "Content-Type": "application/x-www-form-urlencoded" },
-  body: params,
-});
-
-await server.stop();
-    `,
-  });
-
-  const dirPath = String(dir);
+  const body = "grant_type=client_credentials&client_id=abc&client_secret=xyz";
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "form.ts"],
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            return Response.json({ contentType: req.headers.get("content-type"), body: await req.text() });
+          },
+        });
+
+        const params = new URLSearchParams(${JSON.stringify(body)});
+        const explicitHeader = await fetch(server.url, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: params,
+        });
+        // No Content-Type header: fetch derives one from the URLSearchParams body.
+        const derivedHeader = await fetch(server.url, { method: "POST", body: params });
+
+        console.log(
+          JSON.stringify({
+            port: server.port,
+            explicitHeader: await explicitHeader.json(),
+            derivedHeader: await derivedHeader.json(),
+          }),
+        );
+
+        // stop(true) also closes the uWS app, so the server is freed at exit.
+        // After a graceful stop() it stays allocated and LeakSanitizer (ASAN
+        // lane) spends ~15s symbolizing it just to match the suppressions.
+        await server.stop(true);
+      `,
+    ],
     env: { ...bunEnv, BUN_CONFIG_VERBOSE_FETCH: "curl" },
-    cwd: dirPath,
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const output = stdout + stderr;
-  const normalized = normalizeBunSnapshot(output, dirPath);
+  const { port, ...received } = JSON.parse(stdout);
+  expect(received).toEqual({
+    explicitHeader: { contentType: "application/x-www-form-urlencoded", body },
+    derivedHeader: { contentType: "application/x-www-form-urlencoded;charset=UTF-8", body },
+  });
 
-  expect(normalized).toContain('--data-raw "grant_type=client_credentials&client_id=abc&client_secret=xyz');
+  const curlLines = normalizeBunSnapshot(stderr)
+    .replaceAll(`:${port}`, ":<port>")
+    .split("\n")
+    .filter(line => line.startsWith("curl "));
+  expect(curlLines).toMatchInlineSnapshot(`
+    [
+      "curl --http1.1 "http://localhost:<port>/" -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Connection: keep-alive" -H "User-Agent: Bun/<bun-version>" -H "Accept: */*" -H "Host: localhost:<port>" -H "Accept-Encoding: gzip, deflate, br, zstd" --compressed -H "Content-Length: 61" --data-raw "grant_type=client_credentials&client_id=abc&client_secret=xyz"",
+      "curl --http1.1 "http://localhost:<port>/" -X POST -H "Content-Type: application/x-www-form-urlencoded;charset=UTF-8" -H "Connection: keep-alive" -H "User-Agent: Bun/<bun-version>" -H "Accept: */*" -H "Host: localhost:<port>" -H "Accept-Encoding: gzip, deflate, br, zstd" --compressed -H "Content-Length: 61" --data-raw "grant_type=client_credentials&client_id=abc&client_secret=xyz"",
+    ]
+  `);
+
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Test-only change. `test/regression/issue/12042.test.ts` took 16.0s on the debian 13 x64-asan lane (builds 91926 and 91993) and 0.03s on every other lane. One test, one child process, one loopback request.

### What the 15 seconds were

Not the child lingering: under the release build the whole test takes ~14ms, and the child exits as soon as `await server.stop()` resolves (graceful `stop()` already closes idle keep-alive connections).

The ASAN lane runs tests and their children with `ASAN_OPTIONS=detect_leaks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1` and `LSAN_OPTIONS=suppressions=test/leaksan.supp` (`scripts/runner.node.mjs`). After a graceful `stop()` of a server that served a request, VM teardown leaves the server and its uWS app allocated: `Server::finalize()` only frees inline at shutdown when the server is `TERMINATED`, which a graceful stop never sets. LeakSanitizer finds that graph (158 allocations, 13.6KB, all indirect) and ends up suppressing all of it (`leak:uws_create_app` matches the app and context, and LSAN ignores whatever is reachable from a suppressed block), so the child still exits 0. Matching the suppressions needs symbolized stacks though, so LSAN launches `llvm-symbolizer` against the bun binary and the child sits in a pipe read until it has loaded the debug info: ~5.5s with a local debug build, ~15s with CI's release ASAN binary. The unfixed test never noticed because it only awaited the stdio pipes and did a single `toContain`.

Minimal form, under the same environment the runner uses (`BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=$PWD/test/leaksan.supp`, debug build):

```js
const server = Bun.serve({ port: 0, fetch: () => new Response("x") });
await fetch(server.url);
await server.stop();       // 5.8s, LSAN reports "Suppressions used: uws_create_app"
// await server.stop(true) // 0.37s, nothing for LSAN to symbolize
```

The teardown side of this (a drained, gracefully stopped server not being freed at exit) is reported separately; this PR only fixes the test.

### Changes to the test

- The child calls `server.stop(true)`, so the server is freed at exit and LSAN has nothing to symbolize. The verbose fetch output this test exists for is produced before that point, so coverage is unchanged.
- The script is passed with `-e` instead of a temp dir.
- The server echoes back the `Content-Type` it received and the request body; the test asserts both, so the body is known to have arrived intact for each request.
- Two requests: one with an explicit `Content-Type: application/x-www-form-urlencoded` (the case from #12042) and one with no header, where fetch derives `application/x-www-form-urlencoded;charset=UTF-8` from the `URLSearchParams` body. The fix in #22849 is a prefix match, and the second request covers the `;charset=` form of it.
- Both `curl` lines from stderr are pinned with an inline snapshot (port and Bun version normalized), including the `Content-Length` and the full `--data-raw "..."` argument, instead of one `toContain`.
- `proc.exited` is awaited and the exit code is asserted (last). The old test would have passed even if the child had aborted after printing the line, which is exactly what it would do under LSAN if any of those allocations were not suppressed.

### Timing

Local, `bun bd` (debug + ASAN) build. `bun bd test` alone does not set the LSAN environment, so the slowdown only shows up with the runner's variables set:

| | before | after |
|---|---|---|
| `bun bd test test/regression/issue/12042.test.ts` (test / file) | 373-385ms / 2.8s | 374-408ms / 3.0s |
| same, with the ASAN lane's env vars (`BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1`, suppressions) | 6372ms / 9.18s | 498ms / 3.22s |
| CI, debian 13 x64-asan, build 91993 | 16.04s | |

The ~2.7s of file time that remains locally is debug-build test runner startup and is paid by every file. The remaining ~0.4s of test time is the debug child's own startup. Also passes with the release binary (`USE_SYSTEM_BUN=1`, 10ms), which checks that the snapshot is stable across version strings.
