### PR TITLE
bundler: join in-flight pool tasks before tearing the bundle down

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -297,8 +297,8 @@ impl<C: CompletionStruct> BundleThread<C> {
         // Straight-line teardown: log copy
         // runs on both paths; `completeOnBundleThread` only on success (the error
         // path's `set_result(Err)` + complete happens in `thread_main`). The
-        // `deinitWithoutFreeingArena` + wait-group drain live inside `init_and_run`
-        // (it owns `this`).
+        // `deinit_without_freeing_arena` lives inside `init_and_run` (it owns
+        // `this`).
         let mut out_log = bun_ast::Log::init();
         // SAFETY: `transpiler.log` is the arena-allocated `*mut Log` set up by
         // `configure_bundler`; valid for the lifetime of `heap`. Raw deref so the

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4931,7 +4931,21 @@ pub mod bv2_impl {
             // resolve is dropped here (defer resolve.deinit())
         }
 
+        /// Joins whatever the pass still has on the pool before tearing the
+        /// workers down: a pass that fails between scheduling and the step that
+        /// normally joins (`enqueue_entry_points_*` → `wait_for_parse` on an
+        /// unresolvable entry point, `link` → `generate_chunks_in_parallel` for
+        /// the source-map tasks) gets here with tasks still running
+        /// `Worker::get`. The dev server's asynchronous pass is joined by the JS
+        /// event loop (`on_after_decrement_scan_counter`) and only gets here once
+        /// `is_done()`, so it is never ticked from in here.
         pub fn deinit_without_freeing_arena(&mut self) {
+            if !self.asynchronous && self.graph.pending_items > 0 {
+                self.wait_for_parse();
+            }
+            self.linker.source_maps.line_offset_wait_group.wait();
+            self.linker.source_maps.quoted_contents_wait_group.wait();
+
             {
                 // We do this first to make it harder for any dangling pointers to data to be used in there.
                 let on_parse_finalizers = core::mem::take(&mut self.finalizers);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1253,23 +1253,12 @@ impl CompletionStruct for JSBundleCompletionTask {
             .map(|b| &**b)
             .collect();
 
-        let run = bv2.run_from_js_in_new_thread(&entry_points);
-
-        // The AST-allocator pop lives in `generate_in_new_thread`; the
-        // source-map wait-group waits run only on the error path.
-        match run {
-            Ok(build) => {
-                self.set_result(BundleV2Result::Value(build));
-                bv2.deinit_without_freeing_arena();
-                Ok(())
-            }
-            Err(err) => {
-                bv2.linker.source_maps.line_offset_wait_group.wait();
-                bv2.linker.source_maps.quoted_contents_wait_group.wait();
-                bv2.deinit_without_freeing_arena();
-                Err(err)
-            }
-        }
+        // The AST-allocator pop lives in `generate_in_new_thread`.
+        let run = bv2
+            .run_from_js_in_new_thread(&entry_points)
+            .map(|build| self.set_result(BundleV2Result::Value(build)));
+        bv2.deinit_without_freeing_arena();
+        run
     }
 }
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import fs, { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
 
@@ -575,6 +575,75 @@ describe.concurrent("modules that fail to print", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Failed to generate CSS for this file");
     expect(stderr).toContain("styles.module.css");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});
+
+// Each entry point is handed to the thread pool as soon as it resolves, and
+// linking schedules the source-map tasks before it can fail. A build that fails
+// past either point tears the pool down while those tasks are still running;
+// before teardown joined them, a debug build died in `Worker::deinit_soon`
+// (SEGV on a worker slot claimed by a pool thread but not initialized yet) or
+// on a mimalloc assertion from the exiting pool thread, instead of reporting
+// the error and exiting 1. The entry point order picks which window teardown
+// lands in: a resolvable entry listed last is scheduled right before teardown,
+// a missing directory listed last keeps the main thread busy while the pool
+// thread is setting its worker up.
+describe.concurrent("bun build fails while parse or source-map tasks are in flight", () => {
+  test("entry point that does not resolve, followed by one that does", async () => {
+    using dir = tempDir("build-fail-inflight-parse", { "app.js": "console.log(1);" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./missing.js", "./app.js", "--outdir", "dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: 'error: ModuleNotFound resolving "./missing.js" (entry point)\n',
+      exitCode: 1,
+    });
+  });
+
+  test("entry point that resolves, followed by one in a directory that does not exist", async () => {
+    using dir = tempDir("build-fail-inflight-parse-nodir", { "app.js": "console.log(1);" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./app.js", "./nodir/x.js", "--outdir", "dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: 'error: ModuleNotFound resolving "./nodir/x.js" (entry point)\n',
+      exitCode: 1,
+    });
+  });
+
+  test("--sourcemap build that fails to link", async () => {
+    using dir = tempDir("build-fail-inflight-sourcemap", {
+      "entry.js": `import { nope } from "./lib.js";\nconsole.log(nope);\n`,
+      "lib.js": `export const yes = 1;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./entry.js", "--sourcemap", "--outdir", "dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "1 | import { nope } from "./lib.js";
+                   ^
+      error: No matching export in "lib.js" for import "nope"
+          at <dir>/entry.js:1:10"
+    `);
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });


### PR DESCRIPTION
### Repro

```sh
echo 'console.log(1)' > app.js
bun build ./missing.js ./app.js --outdir dist        # debug build: aborts every run
bun build ./app.js ./nodir/x.js --outdir dist        # debug build: SEGV on most runs
printf 'import { nope } from "./lib.js";\n' > entry.js; echo 'export const yes = 1' > lib.js
bun build ./entry.js --sourcemap --outdir dist       # debug build: SEGV or abort on most runs
```

All three should print the build error and exit 1. On a debug (ASAN) build of main they die during teardown instead, in one of two ways:

```
AddressSanitizer: SEGV on unknown address (READ), rdi = 0xbebebebebebebee6
    #2 <bun_threading::thread_pool::node::Queue>::push            src/threading/ThreadPool.rs:1523
    #3 <bun_threading::thread_pool::Thread>::push_idle_task        src/threading/ThreadPool.rs:1129
    #4 <bun_bundler::thread_pool::Worker>::deinit_soon             src/bundler/ThreadPool.rs:575
    #5 <BundleV2>::deinit_without_freeing_arena                    src/bundler/bundle_v2.rs:5032
    #6 <BundleV2>::generate_from_cli                               src/bundler/bundle_v2.rs:4016
```

```
mimalloc: assertion failed: at "../../vendor/mimalloc/src/threadlocal.c":184, mi_thread_local_get_regular
  assertion: "tls!=NULL"
```

(the second one aborts on a `Bun Pool N` thread while the main thread is already inside `exit`). Release builds have the same race without the diagnostics; the usual visible outcome there is just the error line.

### Cause

Every entry point is handed to the thread pool as soon as it resolves (the runtime's own parse task even earlier), and `link()` schedules the source-map tasks before any of its error returns. A pass that fails after either point (`generate_from_cli`, `generate_from_bake_production_cli`, and the enqueue failure path of `run_from_js_in_new_thread`) went straight to `deinit_without_freeing_arena` with those tasks still running `Worker::get` on the pool:

* `ThreadPool::get_worker_slow` publishes the `Worker` pointer in `workers_assignments` before writing the struct, so teardown walking the map read the `thread` field of an uninitialized allocation (ASAN's `0xbe` fill, hence the address above) and pushed onto it.
* A `Worker` created after teardown walked the map was never torn down; the work its thread has left to do on exit then races the main thread's `exit()` once the error is printed, which is the mimalloc assertion.

The Zig version never freed anything on the CLI error path, so this appeared with the port's teardown-on-every-exit. `run_from_js_in_new_thread` already waited for the parse stage even on error, and `Bun.build`'s caller waited on the two source-map wait groups before deinit; the CLI drivers did neither.

### Fix

`deinit_without_freeing_arena` now joins whatever is still on the pool before it touches the workers: `wait_for_parse()` when `pending_items > 0` (synchronous passes only), then the two source-map wait groups (both are no-ops when nothing was scheduled or the join already happened). Teardown is the one place every driver funnels through and the point where the "no task is still running against this bundle" invariant is actually needed, so enforcing it there covers `bun build`, bake production, `Bun.build`, and the exits no driver handled (the dependency scanner return after `link`, enqueue failures) in one place. The now redundant wait-group waits in `init_and_run` are removed.

The dev server's asynchronous pass is excluded on purpose: it is driven by the JS event loop and only reaches this function once `is_done()`, and ticking that loop from teardown would be wrong. Tearing a dev server or VM down with tasks in flight is a different bug (#31702).

A user-visible consequence for the CLI: when one entry point does not resolve, errors from the entry points that did resolve are now reported as well, which is what `Bun.build()` already did.

### Verification

`test/bundler/cli.test.ts` gains the three repros above, asserting the exact stderr and exit code. On the unfixed debug build the first fails on every run (exit 134 plus the mimalloc lines), the other two on most runs (ASAN report); all pass with the fix. The existing `Bun.build` "sourcemap + build error crash case" covers the JS API side now relying on the join in teardown.

<details>
<summary>Rates on the unfixed and fixed debug build (20 sequential / 24 runs at 8-way concurrency each)</summary>

| layout | unfixed | fixed |
| --- | --- | --- |
| `./missing.js ./app.js` | 20/20 abort, 24/24 | 0/20, 0/24 |
| `./app.js ./nodir/x.js` | 19/20 SEGV, 19/24 | 0/20, 0/24 |
| `./entry.js --sourcemap` (bad named import) | 17/20, 20/24 | 0/20, 0/24 |

Also run with the fix: `bun-build-api.test.ts`, `bundler_html.test.ts`, `bake/dev/production.test.ts`, `bake/dev/bundle.test.ts`, `bake/deinitialization.test.ts`, `cli/test/test-changed.test.ts`.
</details>
