### PR TITLE
test_runner: make Snapshots own its buffers and drop its lifetime

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -5,7 +5,7 @@ use crate::cli::test::changed_files_filter as ChangedFilesFilter;
 use crate::cli::test::parallel_runner as ParallelRunner;
 use crate::cli::test::scanner::{self, Scanner};
 use crate::cli::test::timings::Timings;
-use bun_collections::{ArrayHashMap, BoundedArray, StringHashMap};
+use bun_collections::BoundedArray;
 use bun_core::{self as bun, Global, Output, env_var, fmt as bun_fmt};
 use bun_core::{pretty_error, pretty_errorln};
 use bun_dotenv as DotEnv;
@@ -120,8 +120,8 @@ use coverage::{ByteRangeMapping, CodeCoverageReport, Fraction};
 // `crate::test_runner::*`; the façade below adapts the body's nested-path
 // usage (`bun_test::Execution::Result`, `bun_test::BasicResult`, …) without a
 // 2k-line body rewrite.
-use crate::test_runner::jest::{self, FileColumns as _, FileId, Summary, TestRunner};
-use crate::test_runner::snapshot::{InlineSnapshotToWrite, Snapshots};
+use crate::test_runner::jest::{self, FileColumns as _, Summary, TestRunner};
+use crate::test_runner::snapshot::Snapshots;
 
 #[allow(non_snake_case)]
 mod bun_test {
@@ -2151,14 +2151,6 @@ impl TestCommand {
             None
         };
 
-        let mut snapshot_file_buf: Vec<u8> = Vec::new();
-        // `Snapshots::ValuesHashMap` would be an inherent associated type alias
-        // (unstable in Rust); spell out the underlying map instead.
-        let mut snapshot_values: bun_collections::HashMap<u64, Box<[u8]>> =
-            bun_collections::HashMap::new();
-        let mut snapshot_counts: StringHashMap<usize> = StringHashMap::new();
-        let mut inline_snapshots_to_write: ArrayHashMap<FileId, Vec<InlineSnapshotToWrite>> =
-            ArrayHashMap::new();
         jsc::virtual_machine::isBunTest.store(true, core::sync::atomic::Ordering::Relaxed);
 
         // Borrowed-slice views (`&[&[u8]]`) over owned `Vec<Box<[u8]>>` config so the
@@ -2211,28 +2203,7 @@ impl TestCommand {
                     .test_options
                     .test_filter_regex()
                     .map(|p| p.cast::<jsc::RegularExpression>()),
-                snapshots: Snapshots {
-                    update_snapshots: ctx.test_options.update_snapshots,
-                    total: 0,
-                    added: 0,
-                    passed: 0,
-                    failed: 0,
-                    // SAFETY: lifetime-erase to `'static`; the backing locals are
-                    // declared in this never-returning frame (`exec()` only exits
-                    // via process exit).
-                    file_buf: unsafe { bun_ptr::detach_lifetime_mut(&mut snapshot_file_buf) },
-                    // SAFETY: same never-returning-frame invariant as `file_buf` above.
-                    values: unsafe { bun_ptr::detach_lifetime_mut(&mut snapshot_values) },
-                    // SAFETY: same never-returning-frame invariant as `file_buf` above.
-                    counts: unsafe { bun_ptr::detach_lifetime_mut(&mut snapshot_counts) },
-                    _current_file: None,
-                    snapshot_dir_path: None,
-                    // SAFETY: same never-returning-frame invariant as `file_buf` above.
-                    inline_snapshots_to_write: unsafe {
-                        bun_ptr::detach_lifetime_mut(&mut inline_snapshots_to_write)
-                    },
-                    last_error_snapshot_name: None,
-                },
+                snapshots: Snapshots::init(ctx.test_options.update_snapshots),
                 bun_test_root: bun_test::BunTestRoot::init(),
                 // `TestRunner` cannot derive `Default` because of the
                 // `&'a TestOptions` field, so spell the remaining fields out

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -127,7 +127,7 @@ pub struct TestRunner<'a> {
     pub(crate) bail: u32,
     pub(crate) max_concurrency: u32,
 
-    pub(crate) snapshots: Snapshots<'a>,
+    pub(crate) snapshots: Snapshots,
 
     pub(crate) default_timeout_ms: u32,
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -22,38 +22,53 @@ type FileId = super::jest::FileId;
 
 bun_core::declare_scope!(inline_snapshot, visible);
 
-pub struct Snapshots<'a> {
+pub struct Snapshots {
     pub(crate) update_snapshots: bool,
     pub(crate) total: usize,
     pub(crate) added: usize,
     pub(crate) passed: usize,
     pub(crate) failed: usize,
 
-    pub(crate) file_buf: &'a mut Vec<u8>,
+    file_buf: Vec<u8>,
     // LIFETIMES.tsv said `HashMap<usize, String>`; overridden per §Strings (data is bytes) → Box<[u8]>.
     // Key is u64 to match `bun.hash`'s return type (avoids a narrowing cast).
-    pub(crate) values: &'a mut HashMap<u64, Box<[u8]>>,
-    pub(crate) counts: &'a mut StringHashMap<usize>,
-    pub(crate) _current_file: Option<File>,
-    /// Read-only backref into `Jest::RUNNER.files[..].source.path` (not owned
-    /// here, never freed): the runner is process-global and its files are
-    /// never freed mid-run, so the pointee outlives `self`. Only dereferenced
-    /// via `as_ref()` in `get_snapshot_file` (see the SAFETY comments there).
-    pub(crate) snapshot_dir_path: Option<core::ptr::NonNull<[u8]>>,
-    pub(crate) inline_snapshots_to_write: &'a mut IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
+    values: HashMap<u64, Box<[u8]>>,
+    counts: StringHashMap<usize>,
+    _current_file: Option<File>,
+    /// Directory whose `__snapshots__/` was last created (or found existing);
+    /// borrowed from the runner's `File::source.path`, a `Path<'static>`.
+    snapshot_dir_path: Option<&'static [u8]>,
+    inline_snapshots_to_write: IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
     pub(crate) last_error_snapshot_name: Option<Box<[u8]>>,
 }
 
 // Re-export the TSV-mandated container name so the field type matches verbatim.
 pub use bun_collections::ArrayHashMap as IndexMap;
 
-impl<'a> Snapshots<'a> {
+impl Snapshots {
     const FILE_HEADER: &'static [u8] = b"// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n";
 
     #[cfg(windows)]
     const SNAPSHOTS_DIR_NAME: &'static [u8] = b"__snapshots__\\";
     #[cfg(not(windows))]
     const SNAPSHOTS_DIR_NAME: &'static [u8] = b"__snapshots__/";
+
+    pub(crate) fn init(update_snapshots: bool) -> Snapshots {
+        Snapshots {
+            update_snapshots,
+            total: 0,
+            added: 0,
+            passed: 0,
+            failed: 0,
+            file_buf: Vec::new(),
+            values: HashMap::new(),
+            counts: StringHashMap::new(),
+            _current_file: None,
+            snapshot_dir_path: None,
+            inline_snapshots_to_write: IndexMap::new(),
+            last_error_snapshot_name: None,
+        }
+    }
 }
 
 // hoisted out of `impl Snapshots` — inherent associated types are unstable.
@@ -93,7 +108,7 @@ pub struct File {
     pub(crate) file: bun_sys::File,
 }
 
-impl<'a> Snapshots<'a> {
+impl Snapshots {
     /// Reset per-run snapshot counters to 0. Keys stay owned by the map until
     /// `writeSnapshotFile` tears them down on file switch.
     pub(crate) fn reset_counts(&mut self) {
@@ -332,7 +347,7 @@ impl<'a> Snapshots<'a> {
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
         if let Some(file) = self._current_file.take() {
             file.file
-                .write_all(self.file_buf)
+                .write_all(&self.file_buf)
                 .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
             let _ = file.file.close();
             self.file_buf.clear();
@@ -845,25 +860,18 @@ impl<'a> Snapshots<'a> {
                 .copy_from_slice(Self::SNAPSHOTS_DIR_NAME);
             pos += Self::SNAPSHOTS_DIR_NAME.len();
 
-            // SAFETY: snapshot_dir_path is a BACKREF into Jest::runner().files[..].source.path,
-            // which outlives self (runner is process-global; files are never freed mid-run).
-            let cached_dir = self.snapshot_dir_path.map(|p| unsafe { p.as_ref() });
+            let cached_dir = self.snapshot_dir_path;
             if cached_dir.is_none() || !strings::eql_long(dir_path, cached_dir.unwrap(), true) {
                 buf[pos] = 0;
                 // SAFETY: buf[pos] == 0 written above
                 let snapshot_dir_path = ZStr::from_buf(&buf[..], pos);
                 match bun_sys::mkdir(snapshot_dir_path, 0o777) {
                     bun_sys::Result::Ok(()) => {
-                        // SAFETY: read-only backref into Jest::RUNNER.files[..].source.path
-                        // (process-global; outlives self). Never written through — only
-                        // dereferenced via `.as_ref()` above. `NonNull::from(&_)` avoids
-                        // the `*const _ as *mut _` cast while preserving provenance.
-                        self.snapshot_dir_path = Some(core::ptr::NonNull::from(dir_path));
+                        self.snapshot_dir_path = Some(dir_path);
                     }
                     bun_sys::Result::Err(err) => match err.get_errno() {
                         bun_sys::Errno::EEXIST => {
-                            // SAFETY: see above — read-only backref, never written through.
-                            self.snapshot_dir_path = Some(core::ptr::NonNull::from(dir_path));
+                            self.snapshot_dir_path = Some(dir_path);
                         }
                         _ => return Ok(bun_sys::Result::Err(err)),
                     },


### PR DESCRIPTION
## What

`Snapshots<'a>` (`src/runtime/test_runner/snapshot.rs`) held `&'a mut` references to its four working containers. The only constructor, in `TestCommand::exec` (`src/runtime/cli/test_command.rs`), declared the four containers as stack locals whose only use was to be laundered to `'static` with four `bun_ptr::detach_lifetime_mut` calls and stored into the struct literal. The struct also cached the directory of the current snapshot file as an `Option<NonNull<[u8]>>` and read it back through `unsafe { p.as_ref() }`.

```rust
// before
pub struct Snapshots<'a> {
    pub(crate) file_buf: &'a mut Vec<u8>,
    pub(crate) values: &'a mut HashMap<u64, Box<[u8]>>,
    pub(crate) counts: &'a mut StringHashMap<usize>,
    pub(crate) snapshot_dir_path: Option<core::ptr::NonNull<[u8]>>,
    pub(crate) inline_snapshots_to_write: &'a mut IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
    ..
}

// after
pub struct Snapshots {
    file_buf: Vec<u8>,
    values: HashMap<u64, Box<[u8]>>,
    counts: StringHashMap<usize>,
    snapshot_dir_path: Option<&'static [u8]>,
    inline_snapshots_to_write: IndexMap<FileId, Vec<InlineSnapshotToWrite>>,
    ..
}

impl Snapshots {
    pub(crate) fn init(update_snapshots: bool) -> Snapshots { .. }
}
```

`TestCommand::exec` now writes `snapshots: Snapshots::init(ctx.test_options.update_snapshots)` in place of the four locals and the 22 line struct literal, and drops the imports that only served those locals. `TestRunner<'a>` keeps its lifetime for `concurrent_test_glob` and `test_options`; its `snapshots` field is now plain `Snapshots`. Inside `snapshot.rs` every existing access to the four containers compiles unchanged except one, which becomes `write_all(&self.file_buf)`; the `snapshot_dir_path` read becomes a plain copy of the field and its two writes become `Some(dir_path)`. The counters still read from `expect.rs` and the summary printer (`update_snapshots`, `total`, `added`, `passed`, `failed`, `last_error_snapshot_name`) stay `pub(crate)`; the six fields only `snapshot.rs` touches become private. Removes 5 unsafe blocks (4 in `test_command.rs`, 1 in `snapshot.rs`) together with their SAFETY comments; adds none.

## Why

The containers are owned by `Snapshots` and live exactly as long as the `TestRunner` that embeds it, and the type now says so instead of a never-returning-frame argument repeated in four SAFETY comments. `snapshot_dir_path` is assigned from `Source::path.name().dir_with_trailing_slash()`, and `bun_ast::Source::path` is a `Path<'static>`, so `&'static [u8]` is the type the value already had; the `NonNull` only hid it. Zero-cost: the same four containers exist as before, now inline in the process-singleton `TestRunner` instead of one pointer away, and `Option<&'static [u8]>` has the same two-word layout and the same loads and stores as `Option<NonNull<[u8]>>`. No runtime checks are added and nothing here crosses FFI.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test on test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts, bun-snapshots.test.ts, new-snapshot.test.ts and existing-snapshots.test.ts: 68 pass, 1 skip, 1 fail. The one failure ("error snapshots" in snapshot.test.ts, an inline snapshot that expects ANSI color codes in the matcher error message when no color is emitted) fails identically on main (61 pass, 1 skip, 1 fail) and is pre-existing, unrelated to this change.
