### PR TITLE
runner: read each bucket file's result from its file suite in the junit report

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -62,6 +62,7 @@ import {
   isWindows,
   isX64,
   markBuildkiteStepReported,
+  parseJunitFileSuites,
   printEnvironment,
   reportAnnotationToBuildKite,
   startGroup,
@@ -1014,32 +1015,9 @@ async function runTests() {
       );
       if (crashes) process.stderr.write(crashes);
 
-      const suites = new Map(); // repo-relative path -> { failures, seconds, cases: [{name, message}] }
-      const unescapeXml = str =>
-        str
-          .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
-          .replace(/&quot;/g, '"')
-          .replace(/&apos;/g, "'")
-          .replace(/&lt;/g, "<")
-          .replace(/&gt;/g, ">")
-          .replace(/&amp;/g, "&");
+      let suites = new Map(); // repo-relative path -> { failures, seconds, cases: [{name, message}] }
       try {
-        const xml = readFileSync(junitPath, "utf-8");
-        for (const [, attrs] of xml.matchAll(/<testsuite\b([^>]*)>/g)) {
-          const file = /\bfile="([^"]+)"/.exec(attrs)?.[1];
-          const failures = Number(/\bfailures="(\d+)"/.exec(attrs)?.[1] ?? 0);
-          const seconds = Number(/\btime="([\d.]+)"/.exec(attrs)?.[1] ?? 0);
-          if (file) suites.set(unescapeXml(file).replaceAll("\\", "/"), { failures, seconds, cases: [] });
-        }
-        for (const [, caseAttrs, failureAttrs] of xml.matchAll(/<testcase\b([^>]*)>\s*<failure\b([^>]*)>/g)) {
-          const file = /\bfile="([^"]+)"/.exec(caseAttrs)?.[1];
-          const entry = file && suites.get(unescapeXml(file).replaceAll("\\", "/"));
-          if (!entry) continue;
-          entry.cases.push({
-            name: unescapeXml(/\bname="([^"]*)"/.exec(caseAttrs)?.[1] ?? "(unnamed)"),
-            message: unescapeXml(/\bmessage="([^"]*)"/.exec(failureAttrs)?.[1] ?? ""),
-          });
-        }
+        suites = parseJunitFileSuites(readFileSync(junitPath, "utf-8"));
       } catch {}
       if (suites.size && isBuildkite) uploadArtifactsToBuildKite(junitPath);
       else rmSync(junitPath, { force: true });

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1449,6 +1449,68 @@ export function escapePowershell(string) {
 }
 
 /**
+ * @param {string} string
+ * @returns {string}
+ */
+function unescapeXml(string) {
+  return string
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * @typedef {object} JunitFileSuite
+ * @property {number} failures failed tests in the whole file, describe blocks included
+ * @property {number} seconds wall clock of the whole file, loading it included
+ * @property {{ name: string, message: string }[]} cases the failed tests, in report order
+ */
+
+/**
+ * Reads the report written by `bun test --reporter=junit` into one entry per test file,
+ * keyed by the path the reporter printed (relative to the directory `bun test` ran in)
+ * with `/` separators.
+ *
+ * The reporter writes one `<testsuite>` named after each file and, nested inside it, one
+ * more `<testsuite>` per describe block. All of them carry the same `file` attribute, but
+ * only the file's own suite counts the failures of the whole file (the describe blocks'
+ * counts roll up into it) and times the file as a whole (a describe block's `time` is the
+ * sum of its tests, which over-counts `describe.concurrent`), so the nested suites are
+ * skipped.
+ *
+ * @param {string} xml
+ * @returns {Map<string, JunitFileSuite>}
+ */
+export function parseJunitFileSuites(xml) {
+  const attribute = (attributes, name) => new RegExp(`\\s${name}="([^"]*)"`).exec(attributes)?.[1];
+  const keyOf = file => unescapeXml(file).replaceAll("\\", "/");
+  /** @type {Map<string, JunitFileSuite>} */
+  const files = new Map();
+  for (const [, attributes] of xml.matchAll(/<testsuite\b([^>]*)>/g)) {
+    const file = attribute(attributes, "file");
+    if (!file || attribute(attributes, "name") !== file) continue;
+    files.set(keyOf(file), {
+      failures: Number(attribute(attributes, "failures") ?? 0),
+      seconds: Number(attribute(attributes, "time") ?? 0),
+      cases: [],
+    });
+  }
+  for (const [, caseAttributes, failureAttributes] of xml.matchAll(/<testcase\b([^>]*)>\s*<failure\b([^>]*)>/g)) {
+    const file = attribute(caseAttributes, "file");
+    const entry = file && files.get(keyOf(file));
+    if (!entry) continue;
+    entry.cases.push({
+      name: unescapeXml(attribute(caseAttributes, "name") ?? "(unnamed)"),
+      message: unescapeXml(attribute(failureAttributes, "message") ?? ""),
+    });
+  }
+  return files;
+}
+
+/**
  * @returns {string}
  */
 export function homedir() {

--- a/test/internal/runner-junit.test.ts
+++ b/test/internal/runner-junit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * scripts/runner.node.mjs runs the bucket of parallel-safe test files as a single
+ * `bun test --parallel` and reads the junit report it writes to decide which files
+ * failed (to re-run them alone), what to print per file and what to put in the flaky
+ * annotation. parseJunitFileSuites() in scripts/utils.mjs is that parsing step.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+import { parseJunitFileSuites } from "../../scripts/utils.mjs";
+
+const parse = (xml: string) => Object.fromEntries(parseJunitFileSuites(xml));
+
+describe("parseJunitFileSuites", () => {
+  test("reports each file from its own suite, not from the describe suites nested in it", () => {
+    // Shape of bun's reporter: a suite per file, and inside it a suite per describe
+    // block, every one of them carrying the file attribute. The file suite's counts
+    // include the describe blocks; its time is the file's wall clock, theirs is the
+    // sum of their tests.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="5" assertions="5" failures="2" skipped="0" time="2.5">
+  <testsuite name="test/a.test.ts" file="test/a.test.ts" tests="4" assertions="4" failures="2" skipped="0" time="1.5" hostname="ci">
+    <testcase name="top level" classname="" time="0.1" file="test/a.test.ts" assertions="1">
+      <failure type="AssertionError" message="expect(received).toBe(expected)&#10;&#10;Expected: 2&#10;Received: 1">AssertionError: expect(received).toBe(expected)</failure>
+    </testcase>
+    <testsuite name="first" file="test/a.test.ts" line="3" tests="1" assertions="1" failures="1" skipped="0" time="0.2" hostname="ci">
+      <testcase name="in &quot;first&quot;" classname="first" time="0.2" file="test/a.test.ts" assertions="1">
+        <failure type="Error" message="a &lt; b &amp;&amp; c &gt; d" />
+      </testcase>
+    </testsuite>
+    <testsuite name="second" file="test/a.test.ts" line="6" tests="2" assertions="2" failures="0" skipped="0" time="9" hostname="ci">
+      <testsuite name="inner" file="test/a.test.ts" line="7" tests="2" assertions="2" failures="0" skipped="0" time="9" hostname="ci">
+        <testcase name="fast" classname="second &gt; inner" time="0.3" file="test/a.test.ts" assertions="1" />
+        <testcase name="skipped" classname="second &gt; inner" time="0" file="test/a.test.ts" assertions="0">
+          <skipped />
+        </testcase>
+        <testcase name="slow" classname="second &gt; inner" time="8.7" file="test/a.test.ts" assertions="1" />
+      </testsuite>
+    </testsuite>
+  </testsuite>
+  <testsuite name="test/b.test.ts" file="test/b.test.ts" tests="1" assertions="1" failures="0" skipped="0" time="0.25" hostname="ci">
+    <testcase name="plain" classname="" time="0.01" file="test/b.test.ts" assertions="1" />
+  </testsuite>
+</testsuites>
+`;
+    expect(parse(xml)).toEqual({
+      "test/a.test.ts": {
+        failures: 2,
+        seconds: 1.5,
+        cases: [
+          { name: "top level", message: "expect(received).toBe(expected)\n\nExpected: 2\nReceived: 1" },
+          { name: 'in "first"', message: "a < b && c > d" },
+        ],
+      },
+      "test/b.test.ts": { failures: 0, seconds: 0.25, cases: [] },
+    });
+  });
+
+  test("keys files by their unescaped path with forward slashes", () => {
+    // On Windows the reporter writes the path with backslashes; the runner looks files
+    // up by their forward-slash path.
+    const xml = `<testsuites name="bun test" tests="1" failures="1" time="0.5">
+  <testsuite name="test\\js\\a &amp; b.test.ts" file="test\\js\\a &amp; b.test.ts" tests="1" failures="1" time="0.5">
+    <testcase name="t" classname="" time="0.1" file="test\\js\\a &amp; b.test.ts" assertions="1">
+      <failure type="Error" message="boom" />
+    </testcase>
+  </testsuite>
+</testsuites>
+`;
+    expect(parse(xml)).toEqual({
+      "test/js/a & b.test.ts": { failures: 1, seconds: 0.5, cases: [{ name: "t", message: "boom" }] },
+    });
+  });
+
+  test("reports the suite bun test --parallel writes for a file whose worker crashed", () => {
+    // Written by the coordinator instead of the worker's reporter; its testcase has no
+    // file attribute, so the file counts as failed without a case to show.
+    const xml = `<testsuites name="bun test" tests="1" assertions="0" failures="1" skipped="0" time="0.3">
+  <testsuite name="test/crash.test.ts" file="test/crash.test.ts" tests="1" assertions="0" failures="1" skipped="0" time="0">
+    <testcase name="(worker crashed)" classname="test/crash.test.ts">
+      <failure message="worker process crashed before reporting results"></failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+`;
+    expect(parse(xml)).toEqual({ "test/crash.test.ts": { failures: 1, seconds: 0, cases: [] } });
+  });
+
+  test("reports nothing for a report without file suites", () => {
+    expect(parse("")).toEqual({});
+    expect(parse(`<testsuites name="bun test" tests="0" failures="0" time="0">\n</testsuites>\n`)).toEqual({});
+  });
+});
+
+test("parseJunitFileSuites reads the report bun test --parallel --reporter=junit writes", async () => {
+  using dir = tempDir("runner-junit", {
+    "test/describes.test.ts": `
+      import { describe, expect, test } from "bun:test";
+      test("top level fails", () => expect(1).toBe(2));
+      describe("first", () => {
+        test('fails in "first"', () => expect("a").toBe("b"));
+      });
+      describe("second", () => {
+        describe("inner", () => {
+          test("passes", () => expect(1).toBe(1));
+        });
+        test("passes too", () => expect(2).toBe(2));
+      });
+    `,
+    "test/plain.test.ts": `
+      import { expect, test } from "bun:test";
+      test("passes", () => expect(1).toBe(1));
+    `,
+    "test/crash.test.ts": `
+      import { test } from "bun:test";
+      test("exits the worker", () => process.exit(7));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--reporter=junit", "--reporter-outfile=report.xml"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("worker crashed");
+  const xml = await Bun.file(join(String(dir), "report.xml")).text();
+
+  // The suites describes.test.ts gets: the file's own, "first", "second" and "inner",
+  // the last three nested in the first. All of them name the file.
+  expect(xml.match(/<testsuite [^>]*\sfile="test[\\/]describes\.test\.ts"/g)).toHaveLength(4);
+  const fileSuiteSeconds = Number(/<testsuite name="test[\\/]describes\.test\.ts"[^>]*\stime="([^"]+)"/.exec(xml)![1]);
+
+  expect(parse(xml)).toEqual({
+    "test/describes.test.ts": {
+      failures: 2,
+      seconds: fileSuiteSeconds,
+      cases: [
+        { name: "top level fails", message: expect.stringContaining("Expected: 2") },
+        { name: 'fails in "first"', message: expect.stringContaining('Expected: "b"') },
+      ],
+    },
+    "test/plain.test.ts": { failures: 0, seconds: expect.any(Number), cases: [] },
+    "test/crash.test.ts": { failures: 1, seconds: 0, cases: [] },
+  });
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
### Problem

`scripts/runner.node.mjs` runs the parallel-safe bucket as one `bun test --parallel --reporter=junit` (#36175) and reads the report to decide which files failed, what to re-run alone, and the `(X.XXs)` it prints per file. It collected the suites like this:

```js
for (const [, attrs] of xml.matchAll(/<testsuite\b([^>]*)>/g)) {
  const file = /\bfile="([^"]+)"/.exec(attrs)?.[1];
  ...
  if (file) suites.set(file, { failures, seconds, cases: [] });
}
```

bun's reporter writes one `<testsuite name="<path>" file="<path>">` per file and, nested inside it, one `<testsuite name="<describe>" file="<path>">` per describe block (`begin_test_suite_with_line` in `src/runtime/cli/test_command.rs` puts `file=` on both kinds). Every suite of a file therefore overwrote the previous one, and a file with describe blocks ended up represented by whichever describe suite came last in the report.

Report written by the released bun for a file with a failing top-level test, a failing `describe("first")` and a passing `describe("second")`, plus a file with a `describe.concurrent` of three 100ms tests:

```xml
<testsuite name="test/a.test.ts" file="test/a.test.ts" tests="4" failures="2" time="0.002066623" ...>
  ...
  <testsuite name="first"  file="test/a.test.ts" tests="1" failures="1" time="0" ...>
  <testsuite name="second" file="test/a.test.ts" tests="2" failures="0" time="0" ...>
</testsuite>
<testsuite name="test/b.test.ts" file="test/b.test.ts" tests="3" failures="0" time="0.100953121" ...>
  <testsuite name="conc" file="test/b.test.ts" tests="3" failures="0" time="0.3" ...>
</testsuite>
```

The runner's loop turned that into `a.test.ts: { failures: 0, seconds: 0 }` and `b.test.ts: { seconds: 0.3 }`:

* `a.test.ts` is not added to `failed`, and because the report exists (`evidence` is true) nothing is re-run: the file is printed as passed and pushed to `okResults`, so the bucket's non-zero exit is swallowed and the job goes green. Any bucket file whose failures are at top level or in a describe block other than the last one is affected.
* The per-file time is a describe block's sum of test durations instead of the file suite's wall clock (`end_test_suite` times file suites from `file_start_ns` to `file_end_ns` and describe suites by summing their tests), so `describe.concurrent` files over-report and files with several describes under-report. These lines feed `scripts/ci-slowest-tests.ts` and `scripts/update-test-durations.mjs`.
* The failing cases are attached to that same entry, and since the file is not classified as failed they are never printed in the "failing in the parallel batch" group or the flaky annotation.

### Fix

The parsing moves to `parseJunitFileSuites()` in `scripts/utils.mjs` (the runner's existing helper module; `runner.node.mjs` itself runs on import, so it cannot be unit tested) and only keeps suites whose `name` is their `file`, which is how the reporter writes file suites. That is the right suite to read on its own terms: `end_test_suite` adds each closed suite's metrics to its parent, so the file suite's `failures` includes every nested describe block, and its `time` is the only wall clock measurement in the report. The synthetic suite the `--parallel` coordinator writes for a file whose worker crashed or was interrupted (`merge_junit_fragments` in `src/runtime/cli/test/parallel/aggregate.rs`) has the same `name == file` shape, so crashed and hung files are still classified as failed. The `<testcase>` loop is unchanged: it keys on each case's own `file` attribute. The runner's classification, printing and annotation code is unchanged apart from calling the helper. #36218 (in flight) keeps the same file-suite shape, so it is unaffected.

The earlier draft of the batch runner, #29654, applied this same `name === file` rule in its `parsePassedFilesFromJunit()`; the rule did not make it into the version that landed in #36175. #29654 is a rewrite of the whole batch mechanism and conflicts with main, so this PR only restores the rule in the code that shipped.

### Tests

`test/internal/runner-junit.test.ts`:

* a hand-written report in the reporter's shape (top-level failure, a failing describe, a passing describe with a nested describe last, a second plain file): the file is reported with `failures: 2`, the file suite's `time`, and both failing cases with their names and messages unescaped;
* Windows-style backslash paths and escaped characters are keyed the way the runner looks files up;
* the coordinator's crashed-file suite is reported as one failure with no cases;
* a real `bun test --parallel=2 --reporter=junit` run over a file with describe blocks, a plain file and a file that calls `process.exit()`: the report contains four suites carrying the describe file's path, and the parsed result has the file suite's counts, its `time`, the two failing cases, and the crash marker.

With the previous behaviour (every suite with a `file` attribute) the first and last of these fail (`failures: 0` and the last describe block's time for the file with describe blocks); with this change all five pass under `bun bd test` and with the released bun. `node scripts/runner.node.mjs --exec-path ./build/debug/bun-debug js/web/encoding` still forms the 8-file bucket, prints the file suites' times, and re-ran the one file the interrupted batch marked as failed.

