### PR TITLE
paths: make stem() return the basename for dotfiles

### DIFF
--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -293,9 +293,8 @@ pub fn extension(p: &[u8]) -> &[u8] {
 pub fn stem(p: &[u8]) -> &[u8] {
     let filename = basename(p);
     match strings::last_index_of_char(filename, b'.') {
-        Some(0) => p,
-        Some(dot) => &filename[..dot],
-        None => filename,
+        Some(dot) if dot > 0 => &filename[..dot],
+        _ => filename,
     }
 }
 
@@ -987,6 +986,116 @@ pub mod fs {
             self.text = to;
             self.pretty = old_path;
             self.is_symlink = true;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Scalar stand-in: the highway kernels are only linked into the full binary.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_last_index_of_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: the caller (`bun_highway::last_index_of_char`) passes a
+        // live slice's pointer and length.
+        let h = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        h.iter().rposition(|&c| c == needle).unwrap_or(haystack_len)
+    }
+
+    #[track_caller]
+    fn check(path: &str, want_stem: &str, want_extension: &str) {
+        assert_eq!(
+            core::str::from_utf8(stem(path.as_bytes())),
+            Ok(want_stem),
+            "stem({path:?})"
+        );
+        assert_eq!(
+            core::str::from_utf8(extension(path.as_bytes())),
+            Ok(want_extension),
+            "extension({path:?})"
+        );
+    }
+
+    // Unlike `std.fs.path.stem`, which returns the whole path for these.
+    #[test]
+    fn dotfile_is_all_stem() {
+        check(".gitignore", ".gitignore", "");
+        check("/a/b/.gitignore", ".gitignore", "");
+        check("a/.env/", ".env", "");
+        check("/a/.", ".", "");
+        check(
+            "/a/.a-dotfile-longer-than-sixteen-bytes",
+            ".a-dotfile-longer-than-sixteen-bytes",
+            "",
+        );
+    }
+
+    #[test]
+    fn separators_follow_the_host_basename() {
+        if cfg!(windows) {
+            check("C:\\a\\.gitignore", ".gitignore", "");
+            check("C:\\a\\b.tar.gz", "b.tar", ".gz");
+            check("C:.gitignore", ".gitignore", "");
+        } else {
+            check("C:\\a\\.gitignore", "C:\\a\\", ".gitignore");
+            check("C:\\a\\b.tar.gz", "C:\\a\\b.tar", ".gz");
+            check("C:.gitignore", "C:", ".gitignore");
+        }
+        // `/` is a separator on both.
+        check("C:/a/.gitignore", ".gitignore", "");
+    }
+
+    #[test]
+    fn last_dot_splits_stem_and_extension() {
+        check("b.tar.gz", "b.tar", ".gz");
+        check("/a/b.tar.gz", "b.tar", ".gz");
+        check("/a/b.module.css", "b.module", ".css");
+        check("/a/.hidden.css", ".hidden", ".css");
+        check("/a/b.", "b", ".");
+        check("/a.b/c.d/", "c", ".d");
+    }
+
+    #[test]
+    fn no_dot_is_all_stem() {
+        check("b", "b", "");
+        check("/a/b", "b", "");
+        check("/a.b/c", "c", "");
+        check("/", "", "");
+        check("", "", "");
+    }
+
+    #[test]
+    fn stem_and_extension_partition_the_basename() {
+        for path in [
+            "",
+            "/",
+            ".",
+            ".gitignore",
+            "/a/.gitignore",
+            "/a/.",
+            "/a/b",
+            "/a/b.",
+            "/a/b.tar.gz",
+            "/a.b/c",
+            "/a.b/c.d/",
+            "/a/.hidden.css",
+            "/a/.a-dotfile-longer-than-sixteen-bytes",
+            "C:\\a\\.gitignore",
+            "C:\\a\\b.tar.gz",
+            "C:.gitignore",
+        ] {
+            let p = path.as_bytes();
+            let joined = [stem(p), extension(p)].concat();
+            assert_eq!(
+                bstr::BStr::new(&joined),
+                bstr::BStr::new(basename(p)),
+                "stem ++ extension for {path:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
### What

`bun_paths::stem` (src/paths/lib.rs) returned the whole input path instead of the basename when the basename's only dot is the leading one:

```rust
bun_paths::stem(b"/a/b/.gitignore")  // was b"/a/b/.gitignore", now b".gitignore"
bun_paths::stem(b".gitignore")       // b".gitignore" (unchanged)
bun_paths::stem(b"/a/b.tar.gz")      // b"b.tar"      (unchanged)
bun_paths::stem(b"/a/b")             // b"b"          (unchanged)
```

### Why this is the right behavior

The branch comes from Zig's `std.fs.path.stem`, which does `if (index == 0) return path;` (lib/std/fs/path.zig in 0.14.0, still the case on master), so `Some(0) => p` was a faithful port of that line rather than a typo. It is still wrong for this function: Zig's own doc comment ("returns the last component of this path without its extension"), its tests (which only use bare dotfiles, where `path` and the basename are the same string), the doc comment on the Rust `stem`, and `extension()` directly above it (a leading dot is not an extension) all describe the basename. No caller of a function named `stem` can use a directory prefix; in-tree code that needs this value today hand-rolls `basename` minus `extension()` (for example `cli/create/SourceFileProjectGenerator.rs`), which is exactly what the fixed `stem` computes, so anyone adopting the helper as written would have regressed dotfiles. The `[name]` CSS modules segment that calls it is a port of lightningcss, which uses `Path::file_stem()` and also yields `.gitignore` here. The match is now written in the same shape as `extension()`, which makes `stem(p) ++ extension(p) == basename(p)` hold for every input.

Nothing user-visible changes today: the only caller is the CSS modules `[name]` pattern segment (src/css/css_modules.rs), which no code path constructs yet, and CSS module inputs always end in `.module.css` anyway. This was found by another session that was about to use the helper for `bun build --compile` output naming. If keeping `[name]` around is not wanted, the alternative is deleting `stem` together with `Segment::Name`; this PR takes the smaller option of making the helper correct, since it is the natural sibling of `extension()` and the hand-rolled copies above are its prospective callers.

### Tests

`stem` has no JS-visible surface, so it is pinned where it lives: a `#[cfg(test)]` table in src/paths/lib.rs for `stem`/`extension` (dotfiles with and without a directory, trailing slash, `.`, multi-dot names, trailing dot, dots in parent directories, empty and root paths, a 16+ byte dotfile so the non-scalar search path is covered, and `\`/drive-letter rows with the POSIX and Windows answers spelled out in both arms), plus a check that `stem ++ extension` is the basename for every row. The test module supplies a scalar `highway_last_index_of_char` so the test binary links, the same way `string_paths.rs` stubs simdutf.

These run in CI: `bun_paths` is in `MIRI_CRATES` (scripts/rust-miri.ts) and `.github/workflows/miri.yml` triggers on `src/paths/**`, so the "cargo miri test" check on this PR executes the new table (its log lists the five `tests::*` functions). `cargo test -p bun_paths` passes locally as well. On Windows hosts `cargo test -p bun_paths` does not link even at main (84 unresolved bun_core FFI externs pulled in by the pre-existing `string_paths` tests); that is a separate, pre-existing problem and is being tracked on its own.

Verification: with the one-arm fix reverted and the tests in place, three of them fail (`stem("/a/b/.gitignore")` returns `"/a/b/.gitignore"`, and likewise for the `C:/a/.gitignore` row and the partition check); with the fix, all 19 tests in the crate pass.

Earlier revisions of this PR also exposed the helper through `bun:internal-for-testing`, and then wrapped `cargo test` in a test/internal file; both were dropped in review since the Miri workflow already runs the table and neither added coverage CI lacked.
