### PR TITLE
compile: remove the temp executable on Windows when the move to the outfile fails

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1260,6 +1260,7 @@ pub(crate) fn inject(
                         "<r><red>error<r><d>:<r> failed to open temporary file to copy bun into\n{}",
                         e
                     );
+                    let _ = Syscall::unlink(zname);
                     return Fd::invalid();
                 }
             };
@@ -1920,7 +1921,7 @@ pub fn to_executable(
     {
         // Get the current path of the temp file
         let mut temp_buf = PathBuffer::uninit();
-        let temp_path = match bun_sys::get_fd_path(fd, &mut temp_buf) {
+        let temp_path = match bun_sys::get_fd_path_z(fd, &mut temp_buf) {
             Ok(p) => p,
             Err(e) => {
                 if fd != Fd::INVALID {
@@ -1933,6 +1934,11 @@ pub fn to_executable(
             }
         };
 
+        // Windows cannot move or delete the file while this handle is open, and
+        // nothing below needs it. Every failure from here on unlinks `temp_path`,
+        // otherwise a full copy of the bun executable is left behind in cwd.
+        fd.close();
+
         // Build the absolute destination path
         // On Windows, we need an absolute path for MoveFileExW
         // Get the current working directory and join with outfile
@@ -1940,9 +1946,7 @@ pub fn to_executable(
         let cwd_path: &[u8] = match bun_sys::getcwd(&mut cwd_buf) {
             Ok(len) => &cwd_buf[..len],
             Err(e) => {
-                if fd != Fd::INVALID {
-                    fd.close();
-                }
+                let _ = Syscall::unlink(temp_path);
                 return Ok(CompileResult::fail_fmt(format_args!(
                     "Failed to get current directory: {}",
                     bstr::BStr::new(e.name())
@@ -1958,7 +1962,8 @@ pub fn to_executable(
         // Convert paths to Windows UTF-16
         let mut temp_buf_w = OSPathBuffer::uninit();
         let mut dest_buf_w = OSPathBuffer::uninit();
-        let temp_w_len = strings::paths::to_w_path_normalized(&mut temp_buf_w, temp_path).len();
+        let temp_w_len =
+            strings::paths::to_w_path_normalized(&mut temp_buf_w, temp_path.as_bytes()).len();
         let dest_w_len = strings::paths::to_w_path_normalized(&mut dest_buf_w, dest_path).len();
 
         // `to_w_path_normalized` already NUL-terminates (`buf[len] = 0`); the
@@ -1967,9 +1972,6 @@ pub fn to_executable(
         let dest_buf_u16: &mut [u16] = &mut dest_buf_w;
         temp_buf_u16[temp_w_len] = 0;
         dest_buf_u16[dest_w_len] = 0;
-
-        // Close the file handle before moving (Windows requires this)
-        fd.close();
 
         use bun_sys::windows::{self, Win32ErrorExt as _};
         // Move the file using MoveFileExW
@@ -1987,7 +1989,9 @@ pub fn to_executable(
             )
         } == windows::FALSE
         {
+            // Read the error before the unlink below overwrites GetLastError.
             let werr = windows::Win32Error::get();
+            let _ = Syscall::unlink(temp_path);
             if let Some(sys_err) = werr.to_system_errno() {
                 if sys_err == bun_sys::SystemErrno::EISDIR {
                     return Ok(CompileResult::fail_fmt(format_args!(

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync, closeSync, cpSync, existsSync, openSync, readSync } from "node:fs";
+import { chmodSync, closeSync, cpSync, existsSync, openSync, readdirSync, readSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -766,6 +766,63 @@ describe("compiled binary in a deleted cwd", () => {
     },
     60_000,
   );
+});
+
+// The executable is assembled as a `.<hex>.bun-build` copy of bun in cwd and
+// then renamed onto the outfile. A non-empty directory at the outfile path makes
+// that rename fail (an empty one gets replaced on POSIX); the failed build must
+// not leave the copy behind.
+describe.concurrent("compile whose rename onto the outfile fails", () => {
+  // On Windows the compiler appends .exe to the outfile, so that is the name to block.
+  const blocker = isWindows ? "isdir.exe" : "isdir";
+  const blockerDir = { "occupied.txt": "" };
+  const failure = /is a directory|failed to move executable/;
+
+  test("bun build --compile removes the temp copy", async () => {
+    using dir = tempDir("build-compile-outfile-is-dir", {
+      "app.js": `console.log("never built");`,
+      [blocker]: blockerDir,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./app.js", "--outfile", "isdir"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toMatch(failure);
+    expect(readdirSync(String(dir)).sort()).toEqual(["app.js", blocker]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("Bun.build({ compile }) removes the temp copy", async () => {
+    using dir = tempDir("build-compile-api-outfile-is-dir", {
+      "app.js": `console.log("never built");`,
+      [blocker]: blockerDir,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const result = await Bun.build({ entrypoints: ["./app.js"], throw: false, compile: { outfile: "isdir" } });
+         console.log(JSON.stringify({ success: result.success, logs: result.logs.map(String) }));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(JSON.parse(stdout)).toEqual({ success: false, logs: [expect.stringMatching(failure)] });
+    expect(readdirSync(String(dir)).sort()).toEqual(["app.js", blocker]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });
 
 // file command test works well


### PR DESCRIPTION
### What does this PR do?

On Windows, every `bun build --compile` / `Bun.build({ compile })` whose final move onto the outfile fails leaves the temporary copy of bun it was assembling (`.<hex>-00000000.bun-build` in the cwd, ~85 MB for a release build) behind on disk:

```pwsh
PS> echo 'console.log(1)' > app.js; mkdir isdir.exe
PS> bun build --compile ./app.js --outfile isdir
failed to move executable to C:\tmp\repro\isdir.exe: EPERM
PS> ls -Force
isdir.exe
.0a136e1c3197f48e-00000000.bun-build    84805632
app.js
```

`Bun.build({ entrypoints: ["./app.js"], throw: false, compile: { outfile: "isdir" } })` returns `success: false` with the same message and leaves the same file. Reproduced with bun 1.4.0-canary (da3851e57a) on Windows Server 2019; any failing destination does it (a directory at the outfile path, a name the filesystem rejects, etc.). On Linux and macOS the same commands leave nothing behind.

### Cause

`to_executable` in `src/standalone_graph/StandaloneModuleGraph.rs` gets the finished executable back from `inject()` as a temp file in cwd and then moves it onto the outfile. The POSIX branch unlinks the temp file when `move_file_z_with_handle` fails; the `#[cfg(windows)]` branch returned the `MoveFileExW` error (and the earlier `getcwd` error) without deleting it. `inject()` itself has the same gap one step earlier on Windows: if opening the copy it just made with `CopyFileW` fails, it returns without removing the copy.

### Fix

The Windows branch now reads the temp path with `get_fd_path_z`, closes the handle as soon as it has the path (the file cannot be moved or deleted while the handle is open, and nothing after that point uses it), and unlinks the temp file before returning on both remaining failure paths; the `MoveFileExW` error is captured before the unlink so the unlink cannot clobber `GetLastError`. `inject()`'s open failure unlinks the copy too. Both use `bun_sys::unlink`, the helper the POSIX branch and `inject()`'s own cleanup already use; on Windows it goes through libuv, which clears a read-only attribute first, so a copy of a read-only `bun.exe` (CopyFileW preserves attributes) is removed as well, where `DeleteFileW` would fail.

This is the same behavior the POSIX branch has had all along: the temp file is an implementation detail of the build, and a failed build should leave the cwd as it found it. The `get_fd_path_z` failure right after `inject()` still only closes the handle, since at that point there is no path to delete; it would mean Windows could not name a regular file we just created. Success paths are unchanged.

The error message for a directory at the outfile path on Windows is still the `EPERM` one above (the `EISDIR` arm does not match what `MoveFileExW` reports); that is a separate message-quality issue and is left alone here. #37478 touches the same block to bound the outfile length and explicitly leaves this cleanup out; the two changes are independent.

### How did you verify your code works?

Two tests in `test/bundler/bun-build-compile.test.ts` ("compile whose rename onto the outfile fails"): one through `bun build --compile`, one through `Bun.build({ compile })` in a child process, each with cwd set to a temp dir containing a non-empty directory at the outfile path (an empty one gets replaced on POSIX). They assert the build reports the failure and that the directory listing afterwards is exactly `["app.js", <blocker>]`, so a leftover `.bun-build` shows up in the diff by name.

On a Windows x64 machine, against an unfixed debug build of main (da3851e57a) both fail with

```
  [
+   ".c065633f426cdbb2-00000000.bun-build",
    "app.js",
    "isdir.exe",
  ]
```

and after rebuilding with this change the whole file passes (10 pass, 1 skip). On Linux the file passes with `bun bd test` (16 pass, 1 skip); the new tests also pass there without the fix because the POSIX branch never had the bug, so they act as coverage for that branch and the fail-before proof is Windows-only. `cargo check` and `cargo clippy` of `bun_standalone_graph` for `x86_64-pc-windows-msvc` report nothing new (the two pre-existing `large_stack_frames` hits in this file are unchanged).

Not covered by the tests: the `getcwd` failure and the `inject()` open failure, which cannot be triggered from a test; they now run the same unlink as the tested path.
