### PR TITLE
websocket: close the proxy connection when a tunneled wss:// client tears down

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -200,12 +200,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
     }
 
-    /// For the paths that drop the connection from this side (`cancel`,
-    /// `finalize`, `drop_connection_without_callback`): in tunnel mode `tcp`
-    /// is detached and closing it is a no-op; the connection is the proxy
-    /// socket behind the tunnel, which has to be closed explicitly once
-    /// `clear_data()` has torn the tunnel down. `clear_data()` also releases
-    /// this struct's tunnel ref, so the tunnel is retained here first.
+    /// In tunnel mode `tcp` is detached: dropping the connection from this side
+    /// means closing the tunnel's socket after `clear_data()`, which releases
+    /// this struct's tunnel ref, so take one that outlives it first.
     fn retain_tunnel(&self) -> Option<RetainedTunnel> {
         self.proxy_tunnel.get().map(|tunnel| RetainedTunnel {
             tunnel,
@@ -234,14 +231,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         match tunnel {
             Some(tunnel) => {
                 tunnel.close_socket();
-                // That closed the upgrade client's socket, not one adopted by
-                // this struct, so handle_close() never fires here. Mirror what
-                // it does for the non-tunnel path: drop the C++ ref (if still
-                // held) via dispatch_abrupt_close. ws.terminate() calls cancel()
-                // and then sets m_connectedWebSocketKind = None, bypassing the
-                // destructor's finalize(), so nothing else would release that
-                // ref. When reached via fail(), outgoing_websocket is already
-                // None and this is a no-op.
+                // That was the upgrade client's socket, so this struct's
+                // handle_close() never runs; release the C++ ref the way it
+                // would (a no-op when reached via fail()).
                 this.dispatch_abrupt_close(ErrorCode::Ended);
             }
             None => {
@@ -1841,19 +1833,17 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 }
 
-/// See [`WebSocket::retain_tunnel`]. Dropping it releases the ref.
+/// See [`WebSocket::retain_tunnel`].
 struct RetainedTunnel {
     tunnel: NonNull<WebSocketProxyTunnel>,
     _ref: bun_ptr::ScopedRef<WebSocketProxyTunnel>,
 }
 
 impl RetainedTunnel {
-    /// Close the proxy connection. Only valid after `clear_data()` has run:
-    /// it clears the tunnel's backref to the WebSocket, which the upgrade
-    /// client's teardown triggered by this close must not find.
+    /// Callers run this after `clear_data()` has detached the tunnel from the
+    /// WebSocket, as [`WebSocketProxyTunnel::close_socket`] requires.
     fn close_socket(&self) {
-        // SAFETY: `_ref` keeps the tunnel live across the re-entrant close;
-        // callers run this after `clear_data()` (see above).
+        // SAFETY: `_ref` keeps the tunnel live across the re-entrant close.
         unsafe { WebSocketProxyTunnel::close_socket(self.tunnel.as_ptr()) };
     }
 }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -200,6 +200,20 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
     }
 
+    /// For the paths that drop the connection from this side (`cancel`,
+    /// `finalize`, `drop_connection_without_callback`): in tunnel mode `tcp`
+    /// is detached and closing it is a no-op; the connection is the proxy
+    /// socket behind the tunnel, which has to be closed explicitly once
+    /// `clear_data()` has torn the tunnel down. `clear_data()` also releases
+    /// this struct's tunnel ref, so the tunnel is retained here first.
+    fn retain_tunnel(&self) -> Option<RetainedTunnel> {
+        self.proxy_tunnel.get().map(|tunnel| RetainedTunnel {
+            tunnel,
+            // SAFETY: `proxy_tunnel` holds a live ref on the tunnel.
+            _ref: unsafe { bun_ptr::ScopedRef::new(tunnel.as_ptr()) },
+        })
+    }
+
     // `extern "C"` entrypoint; `this_ptr` is non-null by C++ contract (see SAFETY comments below).
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) extern "C" fn cancel(this_ptr: *mut Self) {
@@ -214,25 +228,30 @@ impl<const SSL: bool> WebSocket<SSL> {
         // the allocation alive past every re-entrant call below.
         let this = unsafe { &*this_ptr };
 
-        let had_tunnel = this.proxy_tunnel.get().is_some();
+        let tunnel = this.retain_tunnel();
         this.clear_data();
 
-        if SSL {
-            // we still want to send pending SSL buffer + close_notify
-            this.tcp.get().close(uws::CloseKind::Normal);
-        } else {
-            this.tcp.get().close(uws::CloseKind::Failure);
-        }
-
-        // In tunnel mode tcp is .detached so close() above is a no-op and
-        // handle_close() never fires. Mirror what handle_close() does for
-        // the non-tunnel path: drop the C++ ref (if still held) via
-        // dispatch_abrupt_close so e.g. ws.terminate() — which calls
-        // cancel() then sets m_connectedWebSocketKind = None, bypassing
-        // the destructor's finalize() — does not leak. When reached via
-        // fail(), outgoing_websocket is already None and this is a no-op.
-        if had_tunnel {
-            this.dispatch_abrupt_close(ErrorCode::Ended);
+        match tunnel {
+            Some(tunnel) => {
+                tunnel.close_socket();
+                // That closed the upgrade client's socket, not one adopted by
+                // this struct, so handle_close() never fires here. Mirror what
+                // it does for the non-tunnel path: drop the C++ ref (if still
+                // held) via dispatch_abrupt_close. ws.terminate() calls cancel()
+                // and then sets m_connectedWebSocketKind = None, bypassing the
+                // destructor's finalize(), so nothing else would release that
+                // ref. When reached via fail(), outgoing_websocket is already
+                // None and this is a no-op.
+                this.dispatch_abrupt_close(ErrorCode::Ended);
+            }
+            None => {
+                if SSL {
+                    // we still want to send pending SSL buffer + close_notify
+                    this.tcp.get().close(uws::CloseKind::Normal);
+                } else {
+                    this.tcp.get().close(uws::CloseKind::Failure);
+                }
+            }
         }
     }
 
@@ -1732,6 +1751,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // SAFETY: called from C++ with a valid pointer; guarded above.
         let this = unsafe { &*this_ptr };
 
+        let tunnel = this.retain_tunnel();
         this.clear_data();
 
         // This is only called by outgoing_websocket.
@@ -1740,7 +1760,9 @@ impl<const SSL: bool> WebSocket<SSL> {
             unsafe { Self::deref(this_ptr) };
         }
 
-        if !this.tcp.get().is_closed() {
+        if let Some(tunnel) = tunnel {
+            tunnel.close_socket();
+        } else if !this.tcp.get().is_closed() {
             // no need to be .failure we still wanna to send pending SSL buffer + close_notify
             if SSL {
                 this.tcp.get().close(uws::CloseKind::Normal);
@@ -1763,8 +1785,11 @@ impl<const SSL: bool> WebSocket<SSL> {
         let this = unsafe { &*this_ptr };
 
         let had_cpp = this.outgoing_websocket.take().is_some();
+        let tunnel = this.retain_tunnel();
         this.clear_data();
-        if !this.tcp.get().is_closed() {
+        if let Some(tunnel) = tunnel {
+            tunnel.close_socket();
+        } else if !this.tcp.get().is_closed() {
             this.tcp.get().close(uws::CloseKind::Failure);
         }
         if had_cpp {
@@ -1813,6 +1838,23 @@ impl<const SSL: bool> WebSocket<SSL> {
         cost += this.receive_buffer.try_borrow().map_or(0, |b| b.capacity());
         // This is under-estimated a little, as we don't include usockets context.
         cost
+    }
+}
+
+/// See [`WebSocket::retain_tunnel`]. Dropping it releases the ref.
+struct RetainedTunnel {
+    tunnel: NonNull<WebSocketProxyTunnel>,
+    _ref: bun_ptr::ScopedRef<WebSocketProxyTunnel>,
+}
+
+impl RetainedTunnel {
+    /// Close the proxy connection. Only valid after `clear_data()` has run:
+    /// it clears the tunnel's backref to the WebSocket, which the upgrade
+    /// client's teardown triggered by this close must not find.
+    fn close_socket(&self) {
+        // SAFETY: `_ref` keeps the tunnel live across the re-entrant close;
+        // callers run this after `clear_data()` (see above).
+        unsafe { WebSocketProxyTunnel::close_socket(self.tunnel.as_ptr()) };
     }
 }
 

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -119,11 +119,9 @@ pub struct WebSocketProxyTunnel {
     connected_websocket: *mut WebSocketClient,
     /// SSL wrapper for TLS inside tunnel
     wrapper: Option<SslWrapperType>,
-    /// The proxy connection. Owned by the upgrade client, which stays alive
-    /// after the upgrade purely to pump this socket into the tunnel; it takes
-    /// the handle back (`None`) in [`Self::detach_upgrade_client`] when it
-    /// tears down. Until then the connected WebSocket closes the connection
-    /// through [`Self::close_socket`], since its own `tcp` is detached.
+    /// The proxy connection. Owned by the upgrade client, which takes the
+    /// handle back in [`Self::detach_upgrade_client`]; the connected WebSocket
+    /// (whose own `tcp` is detached) closes it through [`Self::close_socket`].
     socket: SocketUnion,
     /// Write buffer for encrypted data (maintains TLS record ordering)
     write_buffer: StreamBuffer,
@@ -312,9 +310,8 @@ impl WebSocketProxyTunnel {
             return;
         }
 
-        // Snapshot backref pointers via short raw-ptr reads; the dispatch below may
-        // re-enter `tunnel.write/shutdown/clear_connected_web_socket/close_socket/
-        // detach_upgrade_client`, so no `&Self`/`&mut Self` may be live across it.
+        // Snapshot the backrefs: the dispatch below may re-enter any of the
+        // `*mut Self` methods, so no `&Self`/`&mut Self` may be live across it.
         // SAFETY: ScopedRef guard holds a ref; `this` is live. Reads of `Copy` fields.
         let (connected_websocket, upgrade_client) =
             unsafe { ((*this).connected_websocket, (*this).upgrade_client) };
@@ -440,10 +437,8 @@ impl WebSocketProxyTunnel {
 
     /// Clear the upgrade client reference. Called before tunnel shutdown during
     /// cleanup so that the SSLWrapper's synchronous onHandshake/onClose callbacks
-    /// do not re-enter the upgrade client's terminate/clearData path. The
-    /// upgrade client owns `socket` and is closing it (or reacting to its
-    /// close), so the handle goes with it: a later [`Self::close_socket`] from
-    /// the connected WebSocket must not touch a socket that is already gone.
+    /// do not re-enter the upgrade client's terminate/clearData path. Its socket
+    /// goes with it, making a later [`Self::close_socket`] a no-op.
     ///
     /// # Safety
     /// Same contract as [`Self::clear_connected_web_socket`].
@@ -455,28 +450,17 @@ impl WebSocketProxyTunnel {
         }
     }
 
-    /// Close the proxy connection: the tunnel-mode counterpart of the connected
-    /// WebSocket closing its `tcp` when it drops the connection itself
-    /// (`terminate()`, a protocol failure, finalization). The upgrade client
-    /// that owns the socket only closes it when the peer does, so without this
-    /// a client-side teardown leaves the connection, and the upgrade client
-    /// whose keep-alive holds the event loop, open until the proxy gives up.
-    ///
-    /// The close dispatches the upgrade client's `handle_close`, which drops
-    /// its ref on this tunnel and frees the upgrade client; the caller must
-    /// hold its own ref on `this` across the call. A TLS hop to the proxy still
-    /// gets a close_notify but is not kept open for the peer's reply the way
-    /// `Normal` would: `handle_close` is the only thing that releases the
-    /// upgrade client. A plain hop is reset, like `tcp.close()` on a plain
-    /// socket. No-op once the upgrade client has detached, i.e. the socket is
-    /// already closed or closing.
+    /// The connected WebSocket's counterpart of closing its (detached) `tcp`:
+    /// the upgrade client that owns this socket otherwise only closes it when
+    /// the peer does, and its keep-alive holds the event loop until then. The
+    /// close runs the upgrade client's `handle_close` synchronously, which
+    /// drops its ref on this tunnel; a TLS hop is therefore not left waiting
+    /// for the peer's close_notify the way `Normal` would.
     ///
     /// # Safety
-    /// `this` must point to a live tunnel that `WebSocket::clear_data` has
-    /// already detached from its WebSocket: the upgrade client's teardown
-    /// shuts the tunnel down again, which must not reach back into a WebSocket
-    /// that is mid-teardown. Takes `*mut Self` because of that re-entry; the
-    /// socket handle is moved out first so no borrow of `*this` spans the close.
+    /// `this` must be live (the caller holds its own ref) and already detached
+    /// from its WebSocket by `WebSocket::clear_data`, since the upgrade
+    /// client's teardown shuts this tunnel down again.
     pub(crate) unsafe fn close_socket(this: *mut Self) {
         bun_core::scoped_log!(WebSocketProxyTunnel, "closeSocket");
         // SAFETY: caller contract: `this` is live; field-scoped raw take.
@@ -612,10 +596,8 @@ impl WebSocketProxyTunnel {
     /// which forms `&mut *ctx`; this function therefore accesses `wrapper` via raw
     /// projection and never holds a `&mut Self` across the call.
     pub(crate) unsafe fn write(this: *mut Self, data: &[u8]) -> crate::Result<usize> {
-        // A write error fires `on_close(ctx)` → `WebSocket::fail` → `cancel`,
-        // which releases the WebSocket's ref and, via `close_socket`, the
-        // upgrade client's: without this ref the allocation `w` lives in
-        // would be freed while `write_data()` is still running.
+        // A write error fires `on_close` → `WebSocket::fail`, which can drop
+        // every other ref on `this` (via `close_socket`) while `w` is in use.
         // SAFETY: caller contract: `this` is live.
         let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
         // SAFETY: `this` is live; projection covers only `wrapper`.

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -37,7 +37,7 @@ use core::ptr::NonNull;
 use bun_boringssl as boringssl;
 use bun_io::StreamBuffer;
 use bun_uws::ssl_wrapper::{Handlers as SslHandlers, SslWrapper};
-use bun_uws::{NewSocketHandler, us_bun_verify_error_t};
+use bun_uws::{CloseCode, NewSocketHandler, us_bun_verify_error_t};
 
 use super::websocket_upgrade_client::{
     HttpUpgradeClient, HttpsUpgradeClient, NewHttpUpgradeClient,
@@ -119,7 +119,11 @@ pub struct WebSocketProxyTunnel {
     connected_websocket: *mut WebSocketClient,
     /// SSL wrapper for TLS inside tunnel
     wrapper: Option<SslWrapperType>,
-    /// Socket reference (the proxy connection)
+    /// The proxy connection. Owned by the upgrade client, which stays alive
+    /// after the upgrade purely to pump this socket into the tunnel; it takes
+    /// the handle back (`None`) in [`Self::detach_upgrade_client`] when it
+    /// tears down. Until then the connected WebSocket closes the connection
+    /// through [`Self::close_socket`], since its own `tcp` is detached.
     socket: SocketUnion,
     /// Write buffer for encrypted data (maintains TLS record ordering)
     write_buffer: StreamBuffer,
@@ -309,8 +313,8 @@ impl WebSocketProxyTunnel {
         }
 
         // Snapshot backref pointers via short raw-ptr reads; the dispatch below may
-        // re-enter `tunnel.write/shutdown/clear_connected_web_socket/detach_upgrade_client`,
-        // so no `&Self`/`&mut Self` may be live across it.
+        // re-enter `tunnel.write/shutdown/clear_connected_web_socket/close_socket/
+        // detach_upgrade_client`, so no `&Self`/`&mut Self` may be live across it.
         // SAFETY: ScopedRef guard holds a ref; `this` is live. Reads of `Copy` fields.
         let (connected_websocket, upgrade_client) =
             unsafe { ((*this).connected_websocket, (*this).upgrade_client) };
@@ -436,13 +440,52 @@ impl WebSocketProxyTunnel {
 
     /// Clear the upgrade client reference. Called before tunnel shutdown during
     /// cleanup so that the SSLWrapper's synchronous onHandshake/onClose callbacks
-    /// do not re-enter the upgrade client's terminate/clearData path.
+    /// do not re-enter the upgrade client's terminate/clearData path. The
+    /// upgrade client owns `socket` and is closing it (or reacting to its
+    /// close), so the handle goes with it: a later [`Self::close_socket`] from
+    /// the connected WebSocket must not touch a socket that is already gone.
     ///
     /// # Safety
     /// Same contract as [`Self::clear_connected_web_socket`].
     pub(crate) unsafe fn detach_upgrade_client(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; raw place write, field-scoped.
-        unsafe { (*this).upgrade_client = UpgradeClientUnion::None };
+        // SAFETY: caller contract: `this` is live; raw place writes, field-scoped.
+        unsafe {
+            (*this).upgrade_client = UpgradeClientUnion::None;
+            (*this).socket = SocketUnion::None;
+        }
+    }
+
+    /// Close the proxy connection: the tunnel-mode counterpart of the connected
+    /// WebSocket closing its `tcp` when it drops the connection itself
+    /// (`terminate()`, a protocol failure, finalization). The upgrade client
+    /// that owns the socket only closes it when the peer does, so without this
+    /// a client-side teardown leaves the connection, and the upgrade client
+    /// whose keep-alive holds the event loop, open until the proxy gives up.
+    ///
+    /// The close dispatches the upgrade client's `handle_close`, which drops
+    /// its ref on this tunnel and frees the upgrade client; the caller must
+    /// hold its own ref on `this` across the call. A TLS hop to the proxy still
+    /// gets a close_notify but is not kept open for the peer's reply the way
+    /// `Normal` would: `handle_close` is the only thing that releases the
+    /// upgrade client. A plain hop is reset, like `tcp.close()` on a plain
+    /// socket. No-op once the upgrade client has detached, i.e. the socket is
+    /// already closed or closing.
+    ///
+    /// # Safety
+    /// `this` must point to a live tunnel that `WebSocket::clear_data` has
+    /// already detached from its WebSocket: the upgrade client's teardown
+    /// shuts the tunnel down again, which must not reach back into a WebSocket
+    /// that is mid-teardown. Takes `*mut Self` because of that re-entry; the
+    /// socket handle is moved out first so no borrow of `*this` spans the close.
+    pub(crate) unsafe fn close_socket(this: *mut Self) {
+        bun_core::scoped_log!(WebSocketProxyTunnel, "closeSocket");
+        // SAFETY: caller contract: `this` is live; field-scoped raw take.
+        let socket = unsafe { ptr::replace(ptr::addr_of_mut!((*this).socket), SocketUnion::None) };
+        match socket {
+            SocketUnion::Ssl(socket) => socket.close(CloseCode::FastShutdown),
+            SocketUnion::Tcp(socket) => socket.close(CloseCode::Failure),
+            SocketUnion::None => {}
+        }
     }
 
     /// SSLWrapper callback: Called with encrypted data to send to network
@@ -569,7 +612,13 @@ impl WebSocketProxyTunnel {
     /// which forms `&mut *ctx`; this function therefore accesses `wrapper` via raw
     /// projection and never holds a `&mut Self` across the call.
     pub(crate) unsafe fn write(this: *mut Self, data: &[u8]) -> crate::Result<usize> {
-        // SAFETY: caller contract — `this` is live; projection covers only `wrapper`.
+        // A write error fires `on_close(ctx)` → `WebSocket::fail` → `cancel`,
+        // which releases the WebSocket's ref and, via `close_socket`, the
+        // upgrade client's: without this ref the allocation `w` lives in
+        // would be freed while `write_data()` is still running.
+        // SAFETY: caller contract: `this` is live.
+        let _guard = unsafe { bun_ptr::ScopedRef::new(this) };
+        // SAFETY: `this` is live; projection covers only `wrapper`.
         let wrapper_ptr = unsafe { ptr::addr_of_mut!((*this).wrapper) };
         // SAFETY: deref of field projection; `this` is live.
         if let Some(w) = unsafe { (*wrapper_ptr).as_ref() } {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -905,12 +905,16 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // For tunnel mode after successful upgrade, forward all data to the tunnel
         // The tunnel will decrypt and pass to the WebSocket client
         if this.state == State::Done {
+            // The WebSocket client may fail the connection while processing
+            // this data (`WebSocketProxyTunnel::close_socket`), which closes
+            // our socket and releases the socket ref that is all that keeps
+            // `this` alive in this state; the tunnel ref below likewise
+            // outlives `proxy` being dropped by that `handle_close`.
+            let _guard = this.ref_guard();
             // SAFETY: short-lived `&mut` for the proxy borrow; ends before return.
             if let Some(p) = unsafe { &mut (*this.as_ptr()).proxy } {
                 if let Some(tunnel) = p.get_tunnel() {
                     let tp = tunnel.as_ptr();
-                    // Ref the tunnel to keep it alive during this call
-                    // (in case the WebSocket client closes during processing)
                     // SAFETY: `p` holds a live ref on `tunnel`.
                     let _g = unsafe { bun_ptr::ScopedRef::new(tp) };
                     // SAFETY: ref guard above keeps the tunnel live.
@@ -1728,40 +1732,40 @@ impl<const SSL: bool> HTTPClient<SSL> {
         debug_assert!(this.is_same_socket(socket));
 
         // Forward to proxy tunnel if active
-        // SAFETY: short-lived `&mut` for the proxy borrow.
-        if let Some(p) = unsafe { &mut (*this.as_ptr()).proxy } {
-            if let Some(tunnel) = p.get_tunnel() {
-                // SAFETY: `p` holds a live ref on `tunnel`.
-                unsafe { WebSocketProxyTunnel::on_writable(tunnel.as_ptr()) };
-                // In .done state (after WebSocket upgrade), just handle tunnel writes
-                if this.state == State::Done {
-                    return;
-                }
+        if let Some(tunnel) = this.proxy.as_ref().and_then(WebSocketProxy::get_tunnel) {
+            // Draining the tunnel can fail the connection: before the upgrade
+            // completes via `terminate`, afterwards via the WebSocket client
+            // closing our socket (`WebSocketProxyTunnel::close_socket`). Either
+            // way `handle_close` runs inside `on_writable`, dropping `proxy`
+            // (our tunnel ref) and the socket ref on `this`, so hold both.
+            let _guard = this.ref_guard();
+            let tunnel = tunnel.as_ptr();
+            // SAFETY: `proxy` holds a live ref on `tunnel`.
+            let _tunnel_guard = unsafe { bun_ptr::ScopedRef::new(tunnel) };
+            // SAFETY: ref guard above keeps the tunnel live.
+            unsafe { WebSocketProxyTunnel::on_writable(tunnel) };
 
-                // Flush any unwritten upgrade request bytes through the tunnel
-                if this.to_send_len == 0 {
-                    return;
-                }
-                // Bumps the intrusive refcount and derefs on Drop at every
-                // return path below.
-                let _guard = this.ref_guard();
-                // SAFETY: `p` holds a live ref on `tunnel`.
-                let wrote =
-                    match unsafe { WebSocketProxyTunnel::write(tunnel.as_ptr(), this.to_send()) } {
-                        Ok(n) => n,
-                        Err(_) => {
-                            // SAFETY: no `&mut Self` is live across this call.
-                            unsafe { Self::terminate(this.as_ptr(), ErrorCode::FailedToWrite) };
-                            return;
-                        }
-                    };
-                // SAFETY: short-lived `&mut` write.
-                unsafe {
-                    let to_send_len = &mut (*this.as_ptr()).to_send_len;
-                    *to_send_len -= wrote.min(*to_send_len);
-                }
+            // In .done state (after WebSocket upgrade), just handle tunnel writes.
+            // Flush any unwritten upgrade request bytes through the tunnel;
+            // a failure above cleared them (`clear_data` → `clear_input`).
+            if this.state == State::Done || this.to_send_len == 0 {
                 return;
             }
+            // SAFETY: ref guard above keeps the tunnel live.
+            let wrote = match unsafe { WebSocketProxyTunnel::write(tunnel, this.to_send()) } {
+                Ok(n) => n,
+                Err(_) => {
+                    // SAFETY: no `&mut Self` is live across this call.
+                    unsafe { Self::terminate(this.as_ptr(), ErrorCode::FailedToWrite) };
+                    return;
+                }
+            };
+            // SAFETY: short-lived `&mut` write.
+            unsafe {
+                let to_send_len = &mut (*this.as_ptr()).to_send_len;
+                *to_send_len -= wrote.min(*to_send_len);
+            }
+            return;
         }
 
         if this.to_send_len == 0 {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -905,16 +905,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // For tunnel mode after successful upgrade, forward all data to the tunnel
         // The tunnel will decrypt and pass to the WebSocket client
         if this.state == State::Done {
-            // The WebSocket client may fail the connection while processing
-            // this data (`WebSocketProxyTunnel::close_socket`), which closes
-            // our socket and releases the socket ref that is all that keeps
-            // `this` alive in this state; the tunnel ref below likewise
-            // outlives `proxy` being dropped by that `handle_close`.
+            // Failing the connection in there closes our socket, and in this
+            // state the socket ref is the only thing keeping `this` alive.
             let _guard = this.ref_guard();
             // SAFETY: short-lived `&mut` for the proxy borrow; ends before return.
             if let Some(p) = unsafe { &mut (*this.as_ptr()).proxy } {
                 if let Some(tunnel) = p.get_tunnel() {
                     let tp = tunnel.as_ptr();
+                    // Ref the tunnel to keep it alive during this call
+                    // (in case the WebSocket client closes during processing)
                     // SAFETY: `p` holds a live ref on `tunnel`.
                     let _g = unsafe { bun_ptr::ScopedRef::new(tp) };
                     // SAFETY: ref guard above keeps the tunnel live.
@@ -1733,11 +1732,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         // Forward to proxy tunnel if active
         if let Some(tunnel) = this.proxy.as_ref().and_then(WebSocketProxy::get_tunnel) {
-            // Draining the tunnel can fail the connection: before the upgrade
-            // completes via `terminate`, afterwards via the WebSocket client
-            // closing our socket (`WebSocketProxyTunnel::close_socket`). Either
-            // way `handle_close` runs inside `on_writable`, dropping `proxy`
-            // (our tunnel ref) and the socket ref on `this`, so hold both.
+            // Draining can fail the connection, which runs `handle_close`
+            // (dropping `proxy`, i.e. our tunnel ref, and the socket ref on
+            // `this`) before `on_writable` returns.
             let _guard = this.ref_guard();
             let tunnel = tunnel.as_ptr();
             // SAFETY: `proxy` holds a live ref on `tunnel`.
@@ -1745,9 +1742,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
             // SAFETY: ref guard above keeps the tunnel live.
             unsafe { WebSocketProxyTunnel::on_writable(tunnel) };
 
-            // In .done state (after WebSocket upgrade), just handle tunnel writes.
-            // Flush any unwritten upgrade request bytes through the tunnel;
-            // a failure above cleared them (`clear_data` → `clear_input`).
+            // Past the upgrade there is nothing of ours to flush; before it,
+            // flush the rest of the request (a failure above zeroed it).
             if this.state == State::Done || this.to_send_len == 0 {
                 return;
             }

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -568,50 +568,57 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     };
   }
 
+  // `opened` rejects on any failure before the open event (the teardown under
+  // test only produces a close event), so a broken setup reports why instead
+  // of hanging on `await opened`.
+  function connect(url: string, options: Bun.WebSocketOptions, onOpen: (ws: WebSocket) => void = () => {}) {
+    const opened = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<number>();
+    const ws = new WebSocket(url, options);
+    ws.onopen = () => {
+      opened.resolve();
+      onOpen(ws);
+    };
+    ws.onerror = event => opened.reject(event);
+    ws.onclose = event => {
+      opened.reject(new Error(`closed before open: ${event.code} ${event.reason}`));
+      closed.resolve(event.code);
+    };
+    return { ws, opened: opened.promise, closed: closed.promise };
+  }
+
   test.each([
     ["synchronously in onopen", true],
     ["after the open event", false],
   ])("ws.terminate() closes the connection to the proxy (%s)", async (_, terminateInOpen) => {
     using proxy = await proxyThatReportsClientClose("http");
-    const opened = Promise.withResolvers<void>();
-    const closed = Promise.withResolvers<number>();
+    const { ws, opened, closed } = connect(
+      `wss://127.0.0.1:${wssPort}`,
+      { proxy: proxy.url, tls: { rejectUnauthorized: false } },
+      ws => {
+        if (terminateInOpen) ws.terminate();
+      },
+    );
 
-    const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
-      proxy: proxy.url,
-      tls: { rejectUnauthorized: false },
-    });
-    ws.onopen = () => {
-      if (terminateInOpen) ws.terminate();
-      opened.resolve();
-    };
-    ws.onclose = event => closed.resolve(event.code);
-    ws.onerror = () => {};
-
-    await opened.promise;
+    await opened;
     if (!terminateInOpen) ws.terminate();
 
-    expect(await closed.promise).toBe(1006);
+    expect(await closed).toBe(1006);
     await proxy.clientClosed;
   });
 
   test("ws.terminate() closes the connection to an HTTPS proxy", async () => {
     using proxy = await proxyThatReportsClientClose("https");
-    const opened = Promise.withResolvers<void>();
-    const closed = Promise.withResolvers<number>();
-
-    const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
+    const { ws, opened, closed } = connect(`wss://127.0.0.1:${wssPort}`, {
       proxy: proxy.url,
       // Both the proxy and the wss:// server use the self-signed test cert.
       tls: { ca: tlsCerts.cert },
     });
-    ws.onopen = () => opened.resolve();
-    ws.onclose = event => closed.resolve(event.code);
-    ws.onerror = () => {};
 
-    await opened.promise;
+    await opened;
     ws.terminate();
 
-    expect(await closed.promise).toBe(1006);
+    expect(await closed).toBe(1006);
     await proxy.clientClosed;
   });
 
@@ -620,17 +627,15 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     async delivery => {
       using server = await wssServerSendingInvalidFrame(delivery);
       using proxy = await proxyThatReportsClientClose("http");
-      const closed = Promise.withResolvers<number>();
-
-      const ws = new WebSocket(`wss://127.0.0.1:${server.port}`, {
+      const { ws, opened, closed } = connect(`wss://127.0.0.1:${server.port}`, {
         proxy: proxy.url,
         tls: { rejectUnauthorized: false },
       });
-      ws.onopen = () => ws.send("hello");
-      ws.onclose = event => closed.resolve(event.code);
-      ws.onerror = () => {};
 
-      expect(await closed.promise).toBe(1002);
+      await opened;
+      if (delivery === "in reply to a message") ws.send("hello");
+
+      expect(await closed).toBe(1002);
       await proxy.clientClosed;
     },
   );
@@ -650,6 +655,7 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
          });
          ws.onclose = event => console.log("closed", event.code);
          await new Promise(resolve => (ws.onopen = resolve));
+         console.log("open");
          ws.terminate();`,
       ],
       env: { ...bunEnv, NO_PROXY: "", no_proxy: "" },
@@ -658,7 +664,8 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout).toBe("closed 1006\n");
+    // A connection that fails before opening also exits, but without "open".
+    expect(stdout).toBe("open\nclosed 1006\n");
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
 import * as harness from "harness";
 import { tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
-import { createHash } from "crypto";
 import net from "net";
 import tls from "tls";
 import { createConnectProxy, createTLSConnectProxy, startProxy } from "./proxy-test-utils";

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as harness from "harness";
 import { tls as tlsCerts } from "harness";
 import type { HttpsProxyAgent as HttpsProxyAgentType } from "https-proxy-agent";
+import { createHash } from "crypto";
 import net from "net";
 import tls from "tls";
 import { createConnectProxy, createTLSConnectProxy, startProxy } from "./proxy-test-utils";
@@ -499,6 +500,167 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
 
     await promise;
     gc();
+  });
+
+  // In tunnel mode the connection to the proxy is owned by the upgrade client,
+  // not by the WebSocket client that JS talks to, so whether a client-side
+  // teardown actually closed it is only observable from the proxy's end.
+  async function proxyThatReportsClientClose(kind: "http" | "https") {
+    const server = kind === "http" ? createConnectProxy() : createTLSConnectProxy();
+    const sockets: net.Socket[] = [];
+    const clientClosed = new Promise<void>(resolve => {
+      server.once(kind === "http" ? "connection" : "secureConnection", (socket: net.Socket) => {
+        sockets.push(socket);
+        socket.once("close", () => resolve());
+      });
+    });
+    const port = await startProxy(server);
+    return {
+      url: `${kind}://127.0.0.1:${port}`,
+      clientClosed,
+      [Symbol.dispose]() {
+        for (const socket of sockets) socket.destroy();
+        server.close();
+      },
+    };
+  }
+
+  // A wss:// endpoint that completes the upgrade and then sends one frame with
+  // the reserved opcode 0x3, which the client has to fail the connection on.
+  // Sent together with the 101, the frame reaches the client as handshake
+  // overflow, which it processes from a microtask; sent in reply to a message
+  // from the client, it arrives as ordinary tunnel data, so the client fails
+  // the connection from inside the upgrade client's own data callback.
+  async function wssServerSendingInvalidFrame(delivery: "with the 101" | "in reply to a message") {
+    const invalidFrame = Buffer.from([0x83, 0x00]);
+    const server = tls.createServer({ key: tlsCerts.key, cert: tlsCerts.cert }, socket => {
+      let head = Buffer.alloc(0);
+      socket.on("data", chunk => {
+        head = Buffer.concat([head, chunk]);
+        if (!head.includes("\r\n\r\n")) return;
+        const key = /Sec-WebSocket-Key:\s*(\S+)/i.exec(head.toString("latin1"))![1];
+        const accept = createHash("sha1")
+          .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        const response = Buffer.from(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+        );
+        socket.removeAllListeners("data");
+        if (delivery === "with the 101") {
+          socket.on("data", () => {});
+          socket.write(Buffer.concat([response, invalidFrame]));
+        } else {
+          socket.once("data", () => socket.write(invalidFrame));
+          socket.write(response);
+        }
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    return {
+      port: (server.address() as net.AddressInfo).port,
+      [Symbol.dispose]() {
+        server.close();
+      },
+    };
+  }
+
+  test.each([
+    ["synchronously in onopen", true],
+    ["after the open event", false],
+  ])("ws.terminate() closes the connection to the proxy (%s)", async (_, terminateInOpen) => {
+    using proxy = await proxyThatReportsClientClose("http");
+    const opened = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<number>();
+
+    const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
+      proxy: proxy.url,
+      tls: { rejectUnauthorized: false },
+    });
+    ws.onopen = () => {
+      if (terminateInOpen) ws.terminate();
+      opened.resolve();
+    };
+    ws.onclose = event => closed.resolve(event.code);
+    ws.onerror = () => {};
+
+    await opened.promise;
+    if (!terminateInOpen) ws.terminate();
+
+    expect(await closed.promise).toBe(1006);
+    await proxy.clientClosed;
+  });
+
+  test("ws.terminate() closes the connection to an HTTPS proxy", async () => {
+    using proxy = await proxyThatReportsClientClose("https");
+    const opened = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<number>();
+
+    const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
+      proxy: proxy.url,
+      // Both the proxy and the wss:// server use the self-signed test cert.
+      tls: { ca: tlsCerts.cert },
+    });
+    ws.onopen = () => opened.resolve();
+    ws.onclose = event => closed.resolve(event.code);
+    ws.onerror = () => {};
+
+    await opened.promise;
+    ws.terminate();
+
+    expect(await closed.promise).toBe(1006);
+    await proxy.clientClosed;
+  });
+
+  test.each(["with the 101", "in reply to a message"] as const)(
+    "failing the connection on a protocol error (invalid frame sent %s) closes the connection to the proxy",
+    async delivery => {
+      using server = await wssServerSendingInvalidFrame(delivery);
+      using proxy = await proxyThatReportsClientClose("http");
+      const closed = Promise.withResolvers<number>();
+
+      const ws = new WebSocket(`wss://127.0.0.1:${server.port}`, {
+        proxy: proxy.url,
+        tls: { rejectUnauthorized: false },
+      });
+      ws.onopen = () => ws.send("hello");
+      ws.onclose = event => closed.resolve(event.code);
+      ws.onerror = () => {};
+
+      expect(await closed.promise).toBe(1002);
+      await proxy.clientClosed;
+    },
+  );
+
+  test("process exits after ws.terminate() on a connection through a proxy", async () => {
+    // The upgrade client keeps the event loop alive for as long as its socket
+    // is open, so leaving the proxy connection open also kept the process up.
+    using proxy = await proxyThatReportsClientClose("http");
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const ws = new WebSocket("wss://127.0.0.1:${wssPort}", {
+           proxy: "${proxy.url}",
+           tls: { rejectUnauthorized: false },
+         });
+         ws.onclose = event => console.log("closed", event.code);
+         await new Promise(resolve => (ws.onopen = resolve));
+         ws.terminate();`,
+      ],
+      env: { ...bunEnv, NO_PROXY: "", no_proxy: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("closed 1006\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### What

For a `wss://` WebSocket connected through an HTTP CONNECT proxy (`new WebSocket(url, { proxy })`, i.e. tunnel mode), a teardown initiated by the client itself never closed the connection to the proxy. `ws.terminate()` and every failure that goes through `WebSocket::cancel()` (for example a protocol error in a received frame) fired `close` (1006 / 1002) in JS, but the TCP connection to the proxy stayed open until the proxy or the server dropped it, and so did the upgrade client behind it, whose keep-alive holds the event loop:

```ts
const ws = new WebSocket(`wss://127.0.0.1:${wssPort}`, {
  proxy: `http://127.0.0.1:${proxyPort}`,
  tls: { rejectUnauthorized: false },
});
ws.onclose = e => console.log("closed", e.code);
await new Promise(r => (ws.onopen = r));
ws.terminate();
// prints "closed 1006", then the process does not exit: the proxy's side of
// the connection is still open, and stays open until the proxy closes it.
```

Direct `wss://` and `ws://` through a proxy close the socket immediately. (Calling `terminate()` synchronously inside `onopen` happened to work, because at that point the tunnel still holds its backref to the upgrade client, which closes the socket when the tunnel is shut down; anything after the open event leaked.)

### Why

In tunnel mode the `WebSocket` struct's `tcp` is detached: the socket to the proxy belongs to the `WebSocketUpgradeClient`, which stays alive in its done state purely to pump socket bytes into the `WebSocketProxyTunnel`, and it only closes that socket when the peer does (`handle_close` / `handle_end`). `WebSocket::cancel()` shut the tunnel's TLS session down (a fast shutdown, which performs no I/O) and then closed `tcp`, which is a no-op on a detached handle. Nothing closed the proxy socket, and `WebSocketProxyTunnel` had no close path at all. `finalize()` and `drop_connection_without_callback()` skipped their close the same way (`is_closed()` is true for a detached handle).

The clean `ws.close()` path is deliberately unchanged: after the close frame is flushed it leaves the connection for the server to close, which is what the direct `wss://` path does too, and the lingering upgrade client is what flushes an encrypted close frame that is still buffered under backpressure.

### How

- `WebSocketProxyTunnel::close_socket()` closes the proxy connection. `WebSocket::cancel()`, `finalize()` and `drop_connection_without_callback()` call it where the direct path closes `tcp`, after `clear_data()` has detached the tunnel from the WebSocket (so the upgrade client's teardown, which shuts the tunnel down again, cannot reach back into the WebSocket), holding their own ref on the tunnel across it since `clear_data()` releases the struct's ref. A plain hop to the proxy is reset like the `!SSL` arm of `tcp.close()`; a TLS hop (https proxy) gets a close_notify but is closed without waiting for the peer's reply, because `handle_close` is the only thing that releases the upgrade client.
- The upgrade client takes its socket handle out of the tunnel when it tears down (`detach_upgrade_client`), so `close_socket()` is a no-op when the connection was closed from the peer side first (the existing `handle_close -> tunnel.shutdown -> ws.fail -> cancel` chain), or in the `terminate()`-inside-`onopen` window described above.
- The close dispatches the upgrade client's `handle_close` synchronously, which releases the socket ref that is all that keeps the upgrade client alive in the done state and drops its ref on the tunnel. The frames this can now happen inside of hold refs across the re-entrant call: the upgrade client's `handle_data` (done state) and `handle_writable`, which previously read `this.state` after draining the tunnel, and `WebSocketProxyTunnel::write`, whose `&SslWrapper` lives in the tunnel allocation.

### Verification

New tests in `test/js/web/websocket/websocket-proxy.test.ts` observe the close from the proxy's end of the connection:

- `ws.terminate()` after the open event (fails before: times out waiting for the proxy socket to close), and synchronously inside `onopen` (the window above, passes before and after).
- `ws.terminate()` through an HTTPS proxy (the TLS hop arm of `close_socket`).
- A protocol error (invalid opcode from the server), delivered both as handshake overflow (processed from a microtask) and as a later tunnel record (processed inside the upgrade client's own data callback, which now frees the upgrade client re-entrantly).
- The process exits on its own after `terminate()` (spawned `bun -e`; hangs before).

Debug (ASAN) build: the four new cases fail on the unpatched build by timing out and pass with the patch; the new tunnel tests pass 10/10 in a loop; `websocket-proxy.test.ts`, `websocket-proxy-tunnel-upgrade-leak`, `websocket-proxy-tunnel-client-leak`, `websocket-proxy-close-reentrancy`, `test-ws-bidir-proxy`, `ws-proxy.test.ts` and the websocket client suites pass (the only failures seen locally are the `websocket.test.js` cases that need `ws.postman-echo.com`, which this environment cannot reach, identically on the unpatched build). `cargo clippy -p bun_http_jsc` is clean.
