### PR TITLE
test(bundler): compile once in compile-process-execargv.test.ts and assert the exact argv

### DIFF
--- a/test/bundler/compile-process-execargv.test.ts
+++ b/test/bundler/compile-process-execargv.test.ts
@@ -1,65 +1,43 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
+import type { BundlerTestRunOptions } from "./expectBundled";
 import { itBundled } from "./expectBundled";
 
+// argv[1] of a standalone executable is the entry point inside the embedded
+// filesystem: "/$bunfs/root/out" on posix, "B:\\~BUN\\root\\out" on Windows.
+const embeddedEntry = /^(\/\$bunfs|B:[\\/]~BUN)[\\/]root[\\/]out$/;
+
+// A standalone executable owns its whole command line: nothing is parsed as a
+// runtime flag, so execArgv is empty and every argument, including ones spelled
+// like bun's own flags, reaches the script in order (#21298).
+function passedThroughToScript(args: string[]): BundlerTestRunOptions {
+  return {
+    args,
+    stderr: "",
+    validate({ stdout }) {
+      expect(JSON.parse(stdout)).toEqual({
+        execArgv: [],
+        argv: ["bun", expect.stringMatching(embeddedEntry), ...args],
+      });
+    },
+  };
+}
+
 describe("bundler", () => {
+  // One compile, run once per argument set. Each `bun build --compile` copies
+  // and rewrites the whole bun binary (~1GB for debug and CI profile builds),
+  // which is what this file's time consists of.
   itBundled("compile/ProcessExecArgvEmpty", {
     compile: true,
+    backend: "cli",
     files: {
       "/entry.ts": /* js */ `
-        // In compiled executables, execArgv should be empty
-        // since arguments like "-a" and "--b" are for the script, not bun
-        if (process.execArgv.length !== 0) {
-          console.error("FAIL: execArgv should be empty but got:", process.execArgv);
-          process.exit(1);
-        }
-        
-        // argv should contain all arguments including script arguments
-        if (!process.argv.includes("-a") || !process.argv.includes("--b")) {
-          console.error("FAIL: argv missing expected arguments:", process.argv);
-          process.exit(1);
-        }
-        
-        console.log("PASS");
+        console.log(JSON.stringify({ execArgv: process.execArgv, argv: process.argv }));
       `,
     },
-    run: {
-      stdout: "PASS",
-      args: ["-a", "--b"],
-    },
-  });
-
-  itBundled("compile/ProcessExecArgvWithComplexArgs", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        // Test with various argument patterns
-        if (process.execArgv.length !== 0) {
-          console.error("FAIL: execArgv should be empty but got:", process.execArgv);
-          process.exit(1);
-        }
-        
-        // Check that all arguments are in argv
-        const expectedArgs = ["--verbose", "-p", "8080", "--config=test.json", "arg1", "arg2"];
-        let missingArgs = [];
-        
-        for (const arg of expectedArgs) {
-          if (!process.argv.includes(arg)) {
-            missingArgs.push(arg);
-          }
-        }
-        
-        if (missingArgs.length > 0) {
-          console.error("FAIL: argv missing arguments:", missingArgs);
-          console.error("Got argv:", process.argv);
-          process.exit(1);
-        }
-        
-        console.log("PASS");
-      `,
-    },
-    run: {
-      stdout: "PASS",
-      args: ["--verbose", "-p", "8080", "--config=test.json", "arg1", "arg2"],
-    },
+    run: [
+      passedThroughToScript(["-a", "--b"]),
+      passedThroughToScript(["--verbose", "-p", "8080", "--config=test.json", "arg1", "arg2"]),
+      passedThroughToScript(["--smol", "--inspect", "--version"]),
+    ],
   });
 });


### PR DESCRIPTION
## What

`test/bundler/compile-process-execargv.test.ts` built two standalone executables to check one property: a compiled executable has an empty `process.execArgv` and every command line argument lands in `process.argv` (#21298). This collapses it to a single `--compile` whose binary is run once per argument set through `expectBundled`'s `run: BundlerTestRunOptions[]` support, and replaces the self-checking program with one that prints `process.execArgv` / `process.argv` as JSON so the test asserts the real values.

Test-only change. `backend: "cli"` is set explicitly, matching `compile-argv.test.ts` and the default in `bundler_compile.test.ts`; with a `run` array the backend would otherwise be picked implicitly.

### Assertions

Before: each program checked itself (`execArgv.length !== 0`, `argv.includes(arg)` per argument) and the test only asserted `stdout === "PASS"`. A wrong order, an extra argument, or anything written to stderr passed.

After, for each of the three argument sets:

- `JSON.parse(stdout)` `toEqual({ execArgv: [], argv: ["bun", <embedded entry>, ...args] })`: `execArgv` is exactly empty, `argv[0]` is the constant `"bun"` a standalone executable reports, `argv[1]` matches the entry inside the embedded filesystem (`/$bunfs/root/out`, or the `B:\~BUN\root\out` form on Windows), and the user arguments follow in the exact order with nothing added or dropped.
- `stderr` is empty.
- exit code 0 (`expectBundled` fails the run before `validate` is called on a non-zero exit, with stdout and stderr in the message).

Argument sets: the two original ones, `["-a", "--b"]` and `["--verbose", "-p", "8080", "--config=test.json", "arg1", "arg2"]` (note `-p` and `--config` are real bun flags), plus `["--smol", "--inspect", "--version"]`, which bun would otherwise act on, to pin down that nothing on the command line is consumed as a runtime flag. A negative check (the same file compiled with `--compile-exec-argv=--smol`) fails with a diff showing `execArgv: ["--smol"]`.

## Why the ubuntu 25.04 x64 lane is slow

This is not ubuntu specific. Pulling the per-file numbers out of the test-bun job logs for build 91993 gives 22.68s on ubuntu 25.04 x64 and 21.65s on debian 13 x64 (same `bun-linux-x64-profile` binary), against 2.9s on x64 asan, 1.3s on alpine x64 and about 1.0s on both aarch64 lanes. The number printed per file is the `time` of the `describe("bundler")` junit suite, i.e. the sum of the two test bodies, so the time is spent inside the two compiles and not in loading or teardown.

It is also recent and growing. Same file, debian 13 x64 lane: 1.5s in build 87550 (Aug 2, which is also what `test/expected-durations.json` records), 7.3s in 87951, 12.4s in 89045, 11.3s in 89811, 21.6s in 90456, 22.9s in 91229, 21.6s in 91993. Artifact sizes were flat over the same builds (x64 profile zip 475MB to 481MB, aarch64 463MB to 469MB), and `compile-sourcemap-internal.test.ts`, a single in-process compile that runs in the same parallel buckets on the same lanes, stayed at 0.8s throughout, so neither the compile code nor this test changed; the environment this file happens to run in did.

The mechanism is the one `bundler_compile.test.ts` already documents: CI runs the tests with `bun-profile`, and on Linux every `--compile` copies the whole running binary, reads the copy back into memory, moves the debug-info tail past the new `.bun` section (`src/exe_format/elf.rs`, `write_bun_section`) and writes it all out again, which is several GB of page cache and anonymous memory traffic per compile. The linux test runners have 7.8GB of RAM, no swap, and `/tmp` on the root volume, and this file runs inside a 3-wide `bun test --parallel` bucket (whose contents shift between builds as files are added), so whether a given compile gets throttled on memory or writeback depends on what else is running at that moment. The identical 57-file bucket from build 91993 run locally at `--parallel=3` with a release x64 build takes 0.37s for this file. I could not pin down what makes the x64 runners hit this consistently while the aarch64 runners (same RAM, same binary size) do not, but the per-compile cost is the only lever on the test side, so this halves it.

Two unrelated things noticed while looking at the logs, both reported separately: `itBundled` registers zero tests on the Windows lanes (this file included), and `standalone.test.ts` leaves a compiled `app` binary in the cwd of the test runner.

## Verification

`bun bd test test/bundler/compile-process-execargv.test.ts` (debug + ASAN, roughly 1GB binary per compile), warm build, two runs each:

|  | before | after |
| --- | --- | --- |
| `--compile` builds | 2 | 1 |
| test bodies | 3.10s + 2.80s, 3.23s + 2.78s | 4.13s, 4.24s |
| `Ran N tests across 1 file` | 9.23s, 9.26s (10.55s right after the build) | 7.59s, 7.57s |
| `expect()` calls | 2 | 6 |

With the release binary (`USE_SYSTEM_BUN=1`, 72MB stripped build, so the copy is cheap): 547ms before, 424ms after.

The remaining body time is one compile plus three executions of the compiled binary; each execution is a fraction of a compile on every build type, which is why the third argument set is cheap to add.
