### PR TITLE
node:quic: write the outbound queue to lsquic in place instead of copying it every on_write

### DIFF
--- a/src/lsquic_sys/lib.rs
+++ b/src/lsquic_sys/lib.rs
@@ -190,7 +190,7 @@ unsafe extern "C" {
     fn lsquic_stream_id(s: *const lsquic_stream) -> u64;
     pub fn lsquic_stream_conn(s: *const lsquic_stream) -> *mut lsquic_conn;
     pub fn lsquic_stream_read(s: *mut lsquic_stream, buf: *mut c_void, len: usize) -> isize;
-    pub fn lsquic_stream_write(s: *mut lsquic_stream, buf: *const c_void, len: usize) -> isize;
+    fn lsquic_stream_writev(s: *mut lsquic_stream, vec: *const iovec, iovcnt: c_int) -> isize;
     pub fn lsquic_stream_flush(s: *mut lsquic_stream) -> c_int;
     pub fn lsquic_stream_shutdown(s: *mut lsquic_stream, how: c_int) -> c_int;
     pub fn lsquic_stream_close(s: *mut lsquic_stream) -> c_int;
@@ -667,9 +667,19 @@ impl Stream {
         // SAFETY: as above; `buf` is a live slice.
         unsafe { lsquic_stream_read(self.0, buf.as_mut_ptr().cast(), buf.len()) }
     }
-    pub fn write(&self, buf: &[u8]) -> isize {
-        // SAFETY: as above.
-        unsafe { lsquic_stream_write(self.0, buf.as_ptr().cast(), buf.len()) }
+    /// Offers `bufs` back to back; returns how many bytes lsquic took (it
+    /// copies them into packets or its own buffer before returning), 0 when
+    /// it can take none, -1 on error.
+    pub fn writev<const N: usize>(&self, bufs: [&[u8]; N]) -> isize {
+        let iov = bufs.map(|buf| iovec {
+            // lsquic only reads through `iov_base`; the struct is `*mut` for
+            // layout parity with the POSIX one.
+            iov_base: buf.as_ptr().cast_mut().cast::<c_void>(),
+            iov_len: buf.len(),
+        });
+        // SAFETY: as above; `iov` and the slices it points into are live for
+        // the call, and `N` is a small compile-time constant.
+        unsafe { lsquic_stream_writev(self.0, iov.as_ptr(), N as c_int) }
     }
     pub fn flush(&self) -> c_int {
         // SAFETY: as above.

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -2032,7 +2032,7 @@ impl QuicSession {
             unsafe {
                 (*qs).outbound.with_mut(|o| {
                     o.started = true;
-                    o.data.extend(buf.byte_slice().iter().copied());
+                    o.data.extend(buf.byte_slice());
                     o.fin_pending = true;
                 });
                 // As attach_source/init_streaming_source/send_headers do: this

--- a/src/runtime/node/quic/stream.rs
+++ b/src/runtime/node/quic/stream.rs
@@ -465,30 +465,28 @@ impl QuicStream {
 
     fn drain_outbound(&self) {
         let Some(s) = self.ls() else { return };
-        loop {
-            let (slice, contig): (Vec<u8>, usize) = {
-                let out = self.outbound.get();
-                if out.data.is_empty() {
-                    break;
-                }
-                let (a, _) = out.data.as_slices();
-                (a.to_vec(), a.len())
+        let queued = self.outbound.get().data.len();
+        if queued > 0 {
+            // Written straight out of the deque: this runs on every on_write,
+            // so copying it first would cost the whole buffered body per
+            // engine tick. Holding the borrow across the call is fine because
+            // lsquic_stream_writev copies what it takes before returning and
+            // never re-enters this stream's callbacks.
+            let taken = {
+                let (head, tail) = self.outbound.get().data.as_slices();
+                s.writev([head, tail])
             };
-            let n = s.write(&slice);
-            if n <= 0 {
-                self.note_write_blocked();
-                break;
+            let taken = usize::try_from(taken).unwrap_or(0).min(queued);
+            if taken > 0 {
+                self.blocked_reported.set(false);
+                self.wrote_to_lsquic.set(true);
+                self.outbound.with_mut(|out| {
+                    out.data.drain(..taken);
+                });
+                self.add_stat(IDX_STATS_BYTES_SENT, taken as u64);
             }
-            self.blocked_reported.set(false);
-            self.wrote_to_lsquic.set(true);
-            let n = n as usize;
-            self.outbound.with_mut(|out| {
-                out.data.drain(..n.min(contig));
-            });
-            self.add_stat(IDX_STATS_BYTES_SENT, n as u64);
-            if n < slice.len() {
+            if taken < queued {
                 self.note_write_blocked();
-                break;
             }
         }
         let (empty, fin) = {
@@ -659,10 +657,10 @@ impl QuicStream {
             return Ok(JSValue::UNDEFINED);
         }
         let source = frame.arguments_as_array::<1>()[0];
-        let bytes = if source.is_empty_or_undefined_or_null() {
-            Vec::new()
+        let body = if source.is_empty_or_undefined_or_null() {
+            None
         } else if let Some(buf) = source.as_array_buffer(global) {
-            buf.byte_slice().to_vec()
+            Some(buf)
         } else {
             return Err(global.throw(format_args!(
                 "Unsupported QUIC stream body source (Blob and FileHandle sources are not implemented yet)"
@@ -670,7 +668,11 @@ impl QuicStream {
         };
         self.outbound.with_mut(|o| {
             o.started = true;
-            o.data.extend(bytes.iter().copied());
+            if let Some(body) = &body {
+                // `extend` from a slice is one memcpy; from `.iter().copied()`
+                // it is a per-byte loop (no VecDeque specialization for it).
+                o.data.extend(body.byte_slice());
+            }
             o.fin_pending = true;
         });
         self.with_state(|s| s.has_outbound = 1);
@@ -702,8 +704,7 @@ impl QuicStream {
         let mut queued: u64 = 0;
         let mut append = |bytes: &[u8]| {
             queued += bytes.len() as u64;
-            self.outbound
-                .with_mut(|o| o.data.extend(bytes.iter().copied()));
+            self.outbound.with_mut(|o| o.data.extend(bytes));
         };
         if batch.is_array() {
             let len = batch.get_length(global)?;

--- a/test/js/node/quic/outbound-body-rss-fixture.ts
+++ b/test/js/node/quic/outbound-body-rss-fixture.ts
@@ -1,0 +1,89 @@
+// Queues one large body on a QUIC stream, waits until the first bytes of it
+// have reached the peer (so the native side has gone through at least one
+// on_write with the whole body still queued), and reports how much this
+// process's resident set grew. Spawned by quic-stream.test.ts, once per way
+// of handing the native side a body:
+//
+//   open     createBidirectionalStream({ body })
+//   setBody  stream.setBody(body)
+//   writer   stream.writer.writeSync(body)
+//
+// The body itself is allocated and filled before the baseline, so the growth
+// is what the native side allocated: the one queue it keeps the body in, plus
+// anything it copied the body into on the way there or on the way out. Freed
+// copies still count: both ASAN's quarantine (debug builds) and mimalloc's
+// page cache (release) keep a just-freed block of this size resident, which
+// is what lets a single rss() reading after the fact see them.
+//
+// Prints one JSON line: { bodyBytes, rssBefore, rssAfter, bytesSent }
+import { createPrivateKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { connect, listen } from "node:quic";
+
+const keysDir = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
+const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
+
+const BODY_BYTES = 64 * 1024 * 1024;
+const mode = process.argv[2];
+
+// A client-initiated stream only materializes on the server once data for it
+// arrives, so onstream firing means the client drained into lsquic.
+const peerGotData = Promise.withResolvers<void>();
+const server = await listen(
+  (session: any) => {
+    session.closed.catch(() => {});
+    session.onstream = (stream: any) => {
+      stream.closed.catch(() => {});
+      peerGotData.resolve();
+    };
+  },
+  { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["rss-fixture"] },
+);
+
+const client = await connect(`127.0.0.1:${server.address.port}`, { alpn: "rss-fixture", verifyPeer: "manual" });
+client.closed.catch(() => {});
+await client.opened;
+
+const body = Buffer.alloc(BODY_BYTES, "body");
+let stream: any;
+if (mode !== "open") {
+  stream = await client.createBidirectionalStream();
+  stream.closed.catch(() => {});
+}
+
+Bun.gc(true);
+const rssBefore = process.memoryUsage.rss();
+
+switch (mode) {
+  case "open":
+    stream = await client.createBidirectionalStream({ body });
+    stream.closed.catch(() => {});
+    break;
+  case "setBody":
+    stream.setBody(body);
+    break;
+  case "writer":
+    if (!stream.writer.writeSync(body)) throw new Error("writeSync refused the body");
+    break;
+  default:
+    throw new Error(`unknown mode ${JSON.stringify(mode)}`);
+}
+
+await peerGotData.promise;
+const rssAfter = process.memoryUsage.rss();
+
+// Still referenced here, so the caller's copy is part of both readings.
+if (body.byteLength !== BODY_BYTES) throw new Error("unreachable");
+
+console.log(
+  JSON.stringify({
+    bodyBytes: BODY_BYTES,
+    rssBefore,
+    rssAfter,
+    bytesSent: Number(stream.stats.bytesSent),
+  }),
+);
+client.destroy();
+server.destroy();

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -2,6 +2,7 @@
 // `onwanttrailers`, records `trailers_pending` rather than `fin_pending`)
 // must deliver it with a FIN, never retract it with a RESET_STREAM.
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { createPrivateKey } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -177,5 +178,93 @@ describe("HTTP/3 header encoding", () => {
 
     expect(seen.length).toBe(1);
     expect(Object.keys(seen[0])).not.toContain("authorization");
+  });
+});
+
+// The native side keeps a stream's unsent body in one queue and, on every
+// on_write, used to copy all of it into a fresh Vec to offer lsquic the few
+// KiB it would take, so sending a body cost (body size x engine ticks) in
+// memcpy and briefly doubled its memory on every tick; setBody() also copied
+// the body twice on the way in. The body must now be resident once beyond
+// the caller's own buffer, whichever way it is handed over. The fixture
+// explains what it measures and why freed copies still show up in it.
+describe.concurrent("a queued body is buffered natively exactly once", () => {
+  const fixture = join(import.meta.dir, "outbound-body-rss-fixture.ts");
+
+  test.each(["open", "setBody", "writer"])(
+    "%s",
+    async mode => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture, mode],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) throw new Error(`fixture exited with ${exitCode}:\n${stderr}`);
+      const { bodyBytes, rssBefore, rssAfter, bytesSent } = JSON.parse(stdout);
+      expect(bytesSent).toBeGreaterThan(0);
+      // Fixed: 1.00x to 1.05x measured on debug+ASAN and on release.
+      // Unfixed: at least 2x (the queue plus one on_write copy); 2.0x on
+      // release, 4.4x on debug+ASAN, where every tick before the peer saw
+      // the data left another quarantined copy behind.
+      expect((rssAfter - rssBefore) / bodyBytes).toBeLessThan(1.5);
+    },
+    // Debug builds spend a few seconds just loading node:quic in the fixture.
+    60_000,
+  );
+});
+
+// The queue is a ring buffer that is handed to lsquic in place as its (up to)
+// two halves, so feed lsquic across the seam and check what comes out. The
+// receiver's stream window is smaller than a chunk, so every chunk is only
+// partly taken, and highWaterMark equals the chunk size, so each next chunk
+// is appended while the previous one still has a tail queued (a drain takes
+// at most one window, which is less than the high water mark). Chunk 1 sizes
+// the buffer, chunk 2 grows it and ends exactly at its physical end, and
+// from then on every other chunk wraps around to the front.
+describe("outbound queue wrap-around", () => {
+  test("a body fed through a wrapped queue arrives intact", async () => {
+    const CHUNK = 48 * 1024;
+    const chunks = Array.from({ length: 8 }, (_, i) => Buffer.alloc(CHUNK, `chunk ${i} `));
+
+    const received = Promise.withResolvers<Buffer>();
+    await using server = await listen(
+      (session: any) => {
+        session.closed.catch(() => {});
+        session.onstream = async (stream: any) => {
+          stream.closed.catch(() => {});
+          try {
+            const parts: Uint8Array[] = [];
+            for await (const batch of stream) parts.push(...batch);
+            received.resolve(Buffer.concat(parts));
+          } catch (e) {
+            received.reject(e);
+          }
+        };
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        alpn: ["wrap-test"],
+        transportParams: { initialMaxStreamDataBidiRemote: 16 * 1024 },
+      },
+    );
+
+    const client = await connect(`127.0.0.1:${server.address.port}`, { alpn: "wrap-test", verifyPeer: "manual" });
+    client.closed.catch(() => {});
+    await client.opened;
+    const stream = await client.createBidirectionalStream({ highWaterMark: CHUNK });
+    stream.closed.catch(() => {});
+    stream.setBody(
+      (async function* () {
+        yield* chunks;
+      })(),
+    );
+
+    const expected = Buffer.concat(chunks);
+    const got = await received.promise;
+    client.close();
+    const firstMismatch = got.findIndex((byte, i) => byte !== expected[i]);
+    expect({ length: got.length, firstMismatch }).toEqual({ length: expected.length, firstMismatch: -1 });
   });
 });


### PR DESCRIPTION
### Symptom

Sending a body on a `node:quic` stream gets slower the bigger the body is, much faster than linearly. One bidirectional stream over loopback, `createBidirectionalStream({ body })`, receiver draining, release builds of main and of this branch (two runs each, one-file script):

| body | main | this PR |
|---|---|---|
| 4 MiB | 39 ms | 22 to 26 ms |
| 8 MiB | 85 to 99 ms | 42 ms |
| 16 MiB | 490 to 630 ms | ~80 ms |
| 32 MiB | 3.6 to 4.1 s | ~160 ms |
| 64 MiB | 12.5 to 16.5 s | 350 to 470 ms |

Same script on debug+ASAN builds (only the shape matters): 4 MiB 1.1 s -> 0.5 s, 16 MiB 9.5 s -> 1.7 s, 64 MiB 102.7 s -> 8.4 s. Throughput is now flat at about 180 to 200 MiB/s in release instead of falling from 100 MiB/s to 4 MiB/s as the body grows.

### Cause

`QuicStream::drain_outbound` (`src/runtime/node/quic/stream.rs`) did, on every iteration of its write loop,

```rust
let (a, _) = out.data.as_slices();
(a.to_vec(), a.len())
```

and then `lsquic_stream_write` on the copy. lsquic takes at most a flow-control/congestion window per call (about 14 KiB per tick in the tests here), while the copy is the whole queued body. `drain_outbound` runs from `on_write` on every engine tick for every stream with data queued, and again after each JS write, so a body costs (bytes queued x ticks) in memcpy, plus a body-sized allocation and free per tick (most of the unfixed debug time above is `sys`: mmap and page faults for those). When the deque had wrapped, the loop also only offered the first half and went around again, copying again, for the second.

`attach_source` (`stream.setBody(buffer)`) additionally copied the body into a `Vec` and then into the deque, and all three ingest paths extended the deque with `.iter().copied()`, which is `VecDeque`'s per-element `TrustedLen` path rather than its slice memcpy specialization (about 4 s for 64 MiB in a debug build).

### Fix

* `drain_outbound` hands both `as_slices()` halves of the deque to `lsquic_stream_writev` in one call and drains the accepted prefix afterwards. Nothing is copied. Holding the borrow across the call is sound because `lsquic_stream_writev` copies what it accepts into packets or its own buffer before returning and does not re-enter the stream's callbacks. Checked against the vendored lsquic (`vendor/lsquic/src/liblsquic`): every `stream_if->on_*` call in `lsquic_stream.c` sits in `lsquic_stream_call_on_new` (:558), `lsquic_stream_destroy` (:634), `lsquic_stream_call_on_close` (:772), `lsquic_stream_rst_in` (:1207), `lsquic_stream_stop_sending_in` (:1311), the read/write dispatch loops (:2202 to :2465) or `lsquic_stream_set_stream_if` (:4883), and on the IETF connection those are only reached from `process_rst_stream_frame`, `process_stop_sending_frame`, `process_stream_frame`, `process_streams_{read,write}_events` and `service_streams` in `lsquic_full_conn_ietf.c`, i.e. from packet processing and the tick inside `lsquic_engine_process_conns`. `lsquic_stream_writev` (:3815) goes `stream_write` (:3707) -> `save_to_buffer` / `stream_write_to_packets` (:3432), and (via `maybe_flush_stream`, :3567) `stream_flush`, which is `stream_write_to_packets` again; the only things that function does besides filling packets are `maybe_conn_to_tickable_if_writeable` (puts the conn on the engine's tickable heap), `abort_connection` (:3368, sets `SMQF_ABORT_CONN` for the next tick) and `ci_internal_error` (`lsquic_full_conn_ietf.c:9235`, sets flags). Nothing in that path calls `on_write`, `on_close` or `on_reset`, so nothing touches `outbound` while the borrow is live. The blocked/`wrote_to_lsquic`/`BYTES_SENT` bookkeeping is unchanged: same outcome for a full, partial, zero or failed write as the old loop had.
* `bun_lsquic_sys::Stream::write` had this one caller; it becomes `writev`, built on the `iovec` the crate already declares for packets out (its layout matches lsquic's Windows compat struct as well as the POSIX one).
* `attach_source`, `QuicStream::write` and `QuicSession::open_stream` extend the deque straight from the `ArrayBuffer` slice, so a body is copied exactly once on the way in.

No wire or API behaviour changes; this only changes how many times the bytes are copied.

### Tests

`test/js/node/quic/quic-stream.test.ts`:

* `a queued body is buffered natively exactly once` spawns `outbound-body-rss-fixture.ts` once per ingest path (`createBidirectionalStream({ body })`, `setBody()`, `writer.writeSync()`). The fixture fills a 64 MiB body, takes an RSS baseline, queues it, waits for the peer to see the first bytes (so at least one `on_write` has run with the whole body queued) and reports the RSS growth. The test asserts growth < 1.5x the body. Measured: fixed 1.00x on a release build of this branch and 1.00x to 1.05x on debug+ASAN; unfixed 2.0x on release and 4.4x on debug+ASAN (the freed copies stay resident in mimalloc's page cache and in ASAN's quarantine, which is what makes them visible to a reading taken afterwards; `fetch-buffer-peak-fixture.ts` relies on the same thing).
* `outbound queue wrap-around` makes the deque actually wrap (receiver stream window 16 KiB, 48 KiB chunks, `highWaterMark` equal to the chunk size, so every other chunk from the third on lands in front of the previous one's tail) and checks the 384 KiB arrive intact. Verified with a temporary log that the test produces three wraps per run and that lsquic's takes cross the seam between the two halves each time. This one passes before and after; it guards the new two-slice path.

Also ran the 235 vendored `test-quic-*` node tests against the debug build: all pass except `test-quic-session-initial-rtt.mjs`, which asserts a loopback RTT bound that debug builds already miss on main (noted in #32602).
