### PR TITLE
compile: report a directory at the outfile as a directory on Windows

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1988,25 +1988,31 @@ pub fn to_executable(
         } == windows::FALSE
         {
             let werr = windows::Win32Error::get();
-            if let Some(sys_err) = werr.to_system_errno() {
-                if sys_err == bun_sys::SystemErrno::EISDIR {
-                    return Ok(CompileResult::fail_fmt(format_args!(
-                        "{} is a directory. Please choose a different --outfile or delete the directory",
-                        bstr::BStr::new(outfile)
-                    )));
-                } else {
-                    return Ok(CompileResult::fail_fmt(format_args!(
-                        "failed to move executable to {}: {}",
-                        bstr::BStr::new(dest_path),
-                        <&'static str>::from(sys_err)
-                    )));
-                }
-            } else {
+            // MoveFileExW fails with ERROR_ACCESS_DENIED (EPERM) when the
+            // destination is a directory, so the error code alone cannot tell
+            // that case apart from a real permission problem. The wide path is
+            // empty when `dest_path` did not fit (`to_w_path_normalized` fails
+            // safe to ""), and an empty name would resolve to cwd itself.
+            let dest_w = &dest_buf_u16[..dest_w_len];
+            if !dest_w.is_empty()
+                && bun_sys::directory_exists_at_w(Fd::cwd(), dest_w).unwrap_or(false)
+            {
                 return Ok(CompileResult::fail_fmt(format_args!(
-                    "failed to move executable to {}",
-                    bstr::BStr::new(dest_path)
+                    "{} is a directory. Please choose a different --outfile or delete the directory",
+                    bstr::BStr::new(outfile)
                 )));
             }
+            if let Some(sys_err) = werr.to_system_errno() {
+                return Ok(CompileResult::fail_fmt(format_args!(
+                    "failed to move executable to {}: {}",
+                    bstr::BStr::new(dest_path),
+                    <&'static str>::from(sys_err)
+                )));
+            }
+            return Ok(CompileResult::fail_fmt(format_args!(
+                "failed to move executable to {}",
+                bstr::BStr::new(dest_path)
+            )));
         }
 
         // Set Windows icon and/or metadata using unified function

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -108,6 +108,79 @@ describe("Bun.build compile", () => {
   });
 });
 
+// `app.exe` is the outfile on every platform, so Windows has nothing to append to it. The
+// directory is non-empty on purpose: POSIX replaces an empty directory at the outfile, while a
+// non-empty one fails the rename with EISDIR. Every case runs in a child process with cwd set to
+// the temp dir because the executable is assembled as a temp file in cwd before it is moved.
+describe.concurrent("compile with an outfile the executable cannot be moved onto", () => {
+  const hint = "app.exe is a directory. Please choose a different --outfile or delete the directory";
+  const files = {
+    "app.js": `console.log("unreachable");`,
+    "app.exe/keep": "",
+  };
+
+  async function buildInChild(dir: string, compile: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const result = await Bun.build({ entrypoints: ["./app.js"], throw: false, compile: ${compile} });
+         console.log(JSON.stringify({
+           success: result.success,
+           logs: result.logs.map(log => log.message.length > 1000 ? log.message.slice(0, 60) + "..." + log.message.slice(-200) : log.message),
+         }));`,
+      ],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test("bun build --compile reports the directory", async () => {
+    using dir = tempDir("build-compile-outfile-is-dir-cli", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./app.js", "--outfile", "app.exe"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
+
+    expect(stderr).toContain(hint);
+    expect(exitCode).toBe(1);
+    expect(existsSync(join(String(dir), "app.exe", "keep"))).toBe(true);
+  });
+
+  test("Bun.build() reports the directory", async () => {
+    using dir = tempDir("build-compile-outfile-is-dir-api", files);
+
+    expect(await buildInChild(String(dir), `{ outfile: "app.exe" }`)).toEqual({
+      success: false,
+      logs: [expect.stringContaining(hint)],
+    });
+    expect(existsSync(join(String(dir), "app.exe", "keep"))).toBe(true);
+  });
+
+  // The destination is converted to UTF-16 before the move, and that conversion yields an empty
+  // path when the name does not fit the 32767-unit wide path buffer. The directory check has to
+  // leave that case alone: an empty name would resolve to cwd, which is a directory.
+  test.skipIf(!isWindows)("Bun.build() keeps the move error for an outfile longer than a wide path", async () => {
+    using dir = tempDir("build-compile-outfile-too-long", { "app.js": files["app.js"] });
+
+    expect(await buildInChild(String(dir), `{ outfile: Buffer.alloc(33_000, "a").toString() }`)).toEqual({
+      success: false,
+      logs: [expect.stringMatching(/^failed to move executable to .*\.exe: E[A-Z]+$/)],
+    });
+  });
+});
+
 describe("compiled binary validity", () => {
   test("output binary has valid executable header", async () => {
     using dir = tempDir("build-compile-valid-header", {


### PR DESCRIPTION
### What does this PR do?

On Windows, compiling onto an outfile that is an existing directory reports a permission error instead of saying what is actually wrong:

```pwsh
PS> echo 'console.log(1)' > app.js; mkdir isdir.exe
PS> bun build --compile ./app.js --outfile isdir
failed to move executable to C:\tmp\repro\isdir.exe: EPERM
```

`Bun.build({ compile: { outfile } })` fails with the same message. Linux and macOS print `isdir is a directory. Please choose a different --outfile or delete the directory` for the same situation. Reproduced with bun 1.4.0-canary (da3851e57a) on Windows Server 2019.

### Cause

The `#[cfg(windows)]` branch of `to_executable` in `src/standalone_graph/StandaloneModuleGraph.rs` moves the finished executable onto the outfile with `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` and, when that fails, prints the directory hint only if the Win32 error maps to `EISDIR`. `MoveFileExW` refuses to replace a directory with `ERROR_ACCESS_DENIED`, which the errno table maps to `EPERM` (the only Win32 code mapped to `EISDIR` is `ERROR_INVALID_FUNCTION`, which this call never returns), so that arm never matched. The POSIX branch gets `EISDIR` from `rename(2)` directly, which is why it works there.

### Fix

When the move fails, check whether the destination is a directory (`bun_sys::directory_exists_at_w` on the wide destination path that was just handed to `MoveFileExW`) and print the same hint the POSIX branch prints; otherwise the existing errno message is kept. The error code alone cannot distinguish the two cases: a running executable at the outfile also fails with `ERROR_ACCESS_DENIED`, and that one still reports `failed to move executable to ...: EPERM` (checked by hand with the compiled program still running). The check only runs on the failure path, so successful builds are unchanged.

The check is skipped when the wide destination path is empty. `to_w_path_normalized` fails safe to `""` for a destination that does not fit the 32767-unit wide buffer, and an empty relative name passed to `NtQueryAttributesFile` resolves to the current directory, so without the guard an over-long outfile would have been reported as "is a directory" (observed with a 33000-character `compile.outfile` during development). With the guard it keeps reporting `failed to move executable to ...: ENOENT`, as it does today.

Only the message changes. POSIX additionally replaces an empty directory at the outfile (`move_file_z_with_handle` removes it and retries); this PR does not start deleting directories on Windows, the hint tells the user what to do either way. The unrelated leftover temp file on this failure path is handled by #37485, and over-long outfiles by #37478; this change is independent of both apart from touching neighbouring lines.

### How did you verify your code works?

Three tests added to `test/bundler/bun-build-compile.test.ts`, all running the build in a child process whose cwd is a temp dir:

* `bun build --compile` onto a non-empty directory named `app.exe` prints the hint, exits 1, and leaves the directory alone;
* `Bun.build({ compile })` onto the same directory returns the hint in `logs`;
* (Windows only) `Bun.build({ compile })` with a 33000-character outfile still reports `failed to move executable to ...: E...`, covering the empty-wide-path guard and the unchanged errno path.

`app.exe` is the outfile on every platform so nothing gets appended on Windows, and the directory is non-empty because POSIX replaces an empty one.

Windows x64, system bun 1.4.0-canary (da3851e57a), i.e. without the fix:

```
(fail) ... > Bun.build() reports the directory
(fail) ... > bun build --compile reports the directory
(pass) ... > Bun.build() keeps the move error for an outfile longer than a wide path
```

with the two failures showing `failed to move executable to C:\...\app.exe: EPERM`. Windows x64 debug build of this branch: the whole file passes (11 pass, 1 skip). Linux x64 `bun bd test`: the whole file passes (16 pass, 1 skip).

The change is inside `#[cfg(windows)]`, so on Linux the two directory tests also pass without the fix (the POSIX branch already printed the hint); the fail-before proof is the Windows run above. `cargo check -p bun_standalone_graph --target x86_64-pc-windows-msvc` is clean; clippy for that target reports only the two `large_stack_frames` hits in this file that are already present on main.
