### PR TITLE
compile: derive the default outfile the same way in Bun.build and the CLI

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -1271,6 +1271,8 @@ compile: {
 }
 ```
 
+Without an `outfile`, the executable is named after the entrypoint and written to the current working directory, or to `outdir` when one is set, just like `bun build --compile` without `--outfile`: `./src/cli.ts` produces `./cli` (`./cli.exe` for Windows targets). An `index.*` entrypoint is named after its directory instead (`./packages/cli/index.ts` produces `./cli`); when that name is taken by the directory itself, as with `./src/index.ts` built from the project root, the executable is named `index`. A relative `outfile` is resolved the same way, against `outdir` or the current working directory.
+
 ### Supported targets
 
 ```ts title="Bun.Build.CompileTarget" icon="/icons/typescript.svg"

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3228,6 +3228,19 @@ declare module "bun" {
     target?: Bun.Build.CompileTarget;
     execArgv?: string[];
     executablePath?: string;
+    /**
+     * Path of the executable to write. A relative path is resolved against
+     * `outdir`, or against the working directory when there is no `outdir`.
+     * Windows targets get a `.exe` suffix if the path has none.
+     *
+     * Defaults to the entrypoint's file name without its extension, written
+     * to the same place (`./src/cli.ts` produces `cli`), like
+     * `bun build --compile` without `--outfile`. An `index.*` entrypoint is
+     * named after its directory instead, or `index` when that name is taken
+     * by the directory itself (`./src/index.ts` built from the project root).
+     *
+     * Equivalent CLI flag: `--outfile`
+     */
     outfile?: string;
     /**
      * Files or directories to embed into the executable under their original

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -232,7 +232,13 @@ pub mod js_bundler {
         pub(crate) windows_version: OwnedString,
         pub(crate) windows_description: OwnedString,
         pub(crate) windows_copyright: OwnedString,
+        /// `compile.outfile`, or the default name `Config::from_js` fills in.
+        /// Either way it is resolved by `JSBundleCompletionTask::do_compilation`:
+        /// against `outdir`, or the working directory when there is none.
         pub(crate) outfile: OwnedString,
+        /// `DefaultOutfile::is_dir_name` of a filled-in default; false for an
+        /// explicit `compile.outfile`.
+        pub(crate) outfile_is_entry_dir_name: bool,
         pub(crate) assets: Vec<Box<[u8]>>,
         pub(crate) autoload_dotenv: bool,
         pub(crate) autoload_bunfig: bool,
@@ -254,6 +260,7 @@ pub mod js_bundler {
                 windows_description: OwnedString::default(),
                 windows_copyright: OwnedString::default(),
                 outfile: OwnedString::default(),
+                outfile_is_entry_dir_name: false,
                 assets: Vec::new(),
                 autoload_dotenv: true,
                 autoload_bunfig: true,
@@ -1218,57 +1225,16 @@ pub mod js_bundler {
                     }
 
                     if compile.outfile.is_empty() {
-                        let entry_point: &[u8] = &this.entry_points.keys()[0];
-                        let mut outfile = bun_paths::basename(entry_point);
-                        let ext = bun_paths::extension(outfile);
-                        if !ext.is_empty() {
-                            outfile = &outfile[0..outfile.len() - ext.len()];
-                        }
-
-                        if outfile == b"index" {
-                            let d = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
-                                entry_point,
-                            );
-                            outfile = bun_paths::basename(if d.is_empty() { b"index" } else { d });
-                        }
-
-                        if outfile == b"bun" {
-                            let d = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
-                                entry_point,
-                            );
-                            outfile = bun_paths::basename(if d.is_empty() { b"bun" } else { d });
-                        }
+                        let outfile =
+                            StandaloneModuleGraph::default_outfile(&this.entry_points.keys()[0]);
 
                         // If argv[0] is "bun" or "bunx", we don't check if the binary is standalone
-                        if outfile == b"bun" || outfile == b"bunx" {
+                        if outfile.name == b"bun" || outfile.name == b"bunx" {
                             return Err(global_this.throw_invalid_arguments(format_args!("cannot use compile with an output file named 'bun' because bun won't realize it's a standalone executable. Please choose a different name for compile.outfile")));
                         }
 
-                        // NOTE: when no `outdir`/`outfile` was given, place the
-                        // auto-derived executable next to its entry point — the
-                        // only path the caller actually supplied. Resolving the
-                        // basename against the process-wide cwd instead would
-                        // make every `Bun.build({compile: true, entrypoints:
-                        // [tmp + "/app.js"]})` from any test process write the
-                        // *same* `<cwd>/app`, so concurrently-running test files
-                        // would race on the executable (observed flake in
-                        // bun-build-compile-sourcemap.test.ts). This keeps each
-                        // build's output inside its own (temp) directory and is
-                        // also the more intuitive default for a programmatic API.
-                        // Explicit `outfile`/`outdir` are unaffected.
-                        let entry_dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
-                            entry_point,
-                        );
-                        if this.outdir.is_empty()
-                            && !entry_dir.is_empty()
-                            && bun_paths::is_absolute(entry_dir)
-                        {
-                            compile.outfile.append_slice_exact(entry_dir)?;
-                            compile
-                                .outfile
-                                .append_slice_exact(core::slice::from_ref(&bun_paths::SEP))?;
-                        }
-                        compile.outfile.append_slice_exact(outfile)?;
+                        compile.outfile.append_slice_exact(outfile.name)?;
+                        compile.outfile_is_entry_dir_name = outfile.is_dir_name;
                     }
                 }
             }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -232,12 +232,9 @@ pub mod js_bundler {
         pub(crate) windows_version: OwnedString,
         pub(crate) windows_description: OwnedString,
         pub(crate) windows_copyright: OwnedString,
-        /// `compile.outfile`, or the default name `Config::from_js` fills in.
-        /// Either way it is resolved by `JSBundleCompletionTask::do_compilation`:
-        /// against `outdir`, or the working directory when there is none.
+        /// Resolved against `outdir`, else the working directory, in `do_compilation`.
         pub(crate) outfile: OwnedString,
-        /// `DefaultOutfile::is_dir_name` of a filled-in default; false for an
-        /// explicit `compile.outfile`.
+        /// `DefaultOutfile::is_dir_name`; false for an explicit `compile.outfile`.
         pub(crate) outfile_is_entry_dir_name: bool,
         pub(crate) assets: Vec<Box<[u8]>>,
         pub(crate) autoload_dotenv: bool,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -191,8 +191,7 @@ pub(crate) fn create_and_schedule_completion_task(
     Ok(completion)
 }
 
-/// Absolute path of the executable: `outfile` is relative to `outdir`, or to
-/// the working directory when there is no `outdir`.
+/// `outfile` is relative to `outdir`, or to the working directory without one.
 fn resolve_outfile<'a>(
     top_level_dir: &'a [u8],
     outdir: &'a [u8],
@@ -330,9 +329,7 @@ impl JSBundleCompletionTask {
         let outdir: &[u8] = &self.config.outdir.list;
         let mut outfile: &[u8] = &compile_options.outfile.list;
 
-        // A default name taken from the entry point's directory (`src/index.ts`
-        // -> `src`) resolves to that directory itself whenever the build runs
-        // from its parent; fall back to `index` like `bun build --compile` does.
+        // Same fallback as the CLI when the name is the directory it would overwrite;
         // Windows targets get `.exe` appended, so they cannot collide.
         if compile_options.outfile_is_entry_dir_name
             && compile_options.compile_target.os != OperatingSystem::Windows

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -329,8 +329,7 @@ impl JSBundleCompletionTask {
         let outdir: &[u8] = &self.config.outdir.list;
         let mut outfile: &[u8] = &compile_options.outfile.list;
 
-        // Same fallback as the CLI when the name is the directory it would overwrite;
-        // Windows targets get `.exe` appended, so they cannot collide.
+        // Windows targets get `.exe` appended, so the directory name cannot collide there.
         if compile_options.outfile_is_entry_dir_name
             && compile_options.compile_target.os != OperatingSystem::Windows
         {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -191,6 +191,23 @@ pub(crate) fn create_and_schedule_completion_task(
     Ok(completion)
 }
 
+/// Absolute path of the executable: `outfile` is relative to `outdir`, or to
+/// the working directory when there is no `outdir`.
+fn resolve_outfile<'a>(
+    top_level_dir: &'a [u8],
+    outdir: &'a [u8],
+    outfile: &'a [u8],
+    buf: &'a mut [u8],
+) -> &'a [u8] {
+    if !outdir.is_empty() {
+        join_abs_string_buf::<platform::Auto>(top_level_dir, buf, &[outdir, outfile])
+    } else if paths::is_absolute(outfile) {
+        outfile
+    } else {
+        join_abs_string_buf::<platform::Auto>(top_level_dir, buf, &[outfile])
+    }
+}
+
 /// `if (s.slice().len > 0) s.slice() else null` for the windows-options block.
 #[inline]
 fn opt_box(s: &[u8]) -> Option<Box<[u8]>> {
@@ -310,29 +327,32 @@ impl JSBundleCompletionTask {
         // SAFETY: `FileSystem::instance()` is the process-lifetime singleton
         // initialized during VM startup before any `Bun.build` is reachable.
         let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let outdir: &[u8] = &self.config.outdir.list;
+        let mut outfile: &[u8] = &compile_options.outfile.list;
+
+        // A default name taken from the entry point's directory (`src/index.ts`
+        // -> `src`) resolves to that directory itself whenever the build runs
+        // from its parent; fall back to `index` like `bun build --compile` does.
+        // Windows targets get `.exe` appended, so they cannot collide.
+        if compile_options.outfile_is_entry_dir_name
+            && compile_options.compile_target.os != OperatingSystem::Windows
+        {
+            let resolved = bun_core::ZBox::from_bytes(resolve_outfile(
+                top_level_dir,
+                outdir,
+                outfile,
+                &mut outbuf[..],
+            ));
+            if bun_sys::directory_exists_at(bun_sys::Fd::cwd(), &resolved).unwrap_or(false) {
+                outfile = b"index";
+            }
+        }
 
         // Always get an absolute path for the outfile to ensure it works
         // correctly with PE metadata operations.
         // Add .exe extension for Windows targets if not already present.
         let full_outfile_path: Box<[u8]> = {
-            let outdir_slice = &self.config.outdir.list;
-            let outfile_slice = &compile_options.outfile.list;
-            let joined: &[u8] = if !outdir_slice.is_empty() {
-                join_abs_string_buf::<platform::Auto>(
-                    top_level_dir,
-                    &mut outbuf[..],
-                    &[outdir_slice, outfile_slice],
-                )
-            } else if paths::is_absolute(outfile_slice) {
-                outfile_slice
-            } else {
-                // For relative paths, ensure we make them absolute relative to the current working directory
-                join_abs_string_buf::<platform::Auto>(
-                    top_level_dir,
-                    &mut outbuf[..],
-                    &[outfile_slice],
-                )
-            };
+            let joined = resolve_outfile(top_level_dir, outdir, outfile, &mut outbuf[..]);
             if compile_options.compile_target.os == OperatingSystem::Windows
                 && !joined.ends_with(b".exe")
             {

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -249,7 +249,7 @@ impl BuildCommand {
         }
 
         this_transpiler.options.bytecode = ctx.bundler_options.bytecode;
-        let mut was_renamed_from_index = false;
+        let mut outfile_is_entry_dir_name = false;
 
         if ctx.bundler_options.compile {
             if ctx.bundler_options.transform_only {
@@ -325,24 +325,12 @@ impl BuildCommand {
                 this_transpiler.options.public_path = base_public_path.into();
 
                 if outfile.is_empty() {
-                    outfile = bun_paths::basename(&first_entry_point);
-                    let ext = bun_paths::extension(outfile);
-                    if !ext.is_empty() {
-                        outfile = &outfile[0..outfile.len() - ext.len()];
-                    }
-
-                    if outfile == b"index" {
-                        outfile = bun_paths::basename(
-                            bun_core::dirname(&first_entry_point).unwrap_or(b"index"),
+                    let default_outfile =
+                        bun_standalone_module_graph::StandaloneModuleGraph::default_outfile(
+                            &first_entry_point,
                         );
-                        was_renamed_from_index = outfile != b"index";
-                    }
-
-                    if outfile == b"bun" {
-                        outfile = bun_paths::basename(
-                            bun_core::dirname(&first_entry_point).unwrap_or(b"bun"),
-                        );
-                    }
+                    outfile = default_outfile.name;
+                    outfile_is_entry_dir_name = default_outfile.is_dir_name;
                 }
 
                 // If argv[0] is "bun" or "bunx", we don't check if the binary is standalone
@@ -869,7 +857,7 @@ impl BuildCommand {
                     write!(&mut outfile_owned, "{}.exe", bstr::BStr::new(outfile))
                         .expect("unreachable");
                     outfile = &outfile_owned;
-                } else if was_renamed_from_index && outfile != b"index" {
+                } else if outfile_is_entry_dir_name {
                     // If we're going to fail due to EISDIR, we should instead pick a different name.
                     let mut zbuf = PathBuffer::uninit();
                     let n = outfile.len().min(zbuf.0.len() - 1);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -135,17 +135,13 @@ pub fn target_base_public_path(
 /// See [`default_outfile`].
 pub struct DefaultOutfile<'a> {
     pub name: &'a [u8],
-    /// `name` is the entry point's directory name. The executable is usually
-    /// written to that directory's parent (`bun build --compile ./src/index.ts`
-    /// from the project root), where the name is taken by the directory itself;
-    /// callers write `index` instead when it is.
+    /// `name` is the entry point's directory name, so the output path is usually that
+    /// directory itself; callers fall back to `index` when it is.
     pub is_dir_name: bool,
 }
 
-/// Name of the executable when compiling without an outfile: the first entry
-/// point's file name without its extension, except that `index` and `bun`
-/// entry points are named after their directory (`packages/cli/index.ts` ->
-/// `cli`), or `index` when there is no directory name to use (`./index.ts`).
+/// Executable name when compiling without an outfile: the entry point's file name
+/// without extension; for `index.*` and `bun.*` its directory name, else `index`.
 pub fn default_outfile(entry_point: &[u8]) -> DefaultOutfile<'_> {
     let file_name = path::basename(entry_point);
     let name = &file_name[..file_name.len() - path::extension(file_name).len()];

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -132,6 +132,46 @@ pub fn target_base_public_path(
     }
 }
 
+/// See [`default_outfile`].
+pub struct DefaultOutfile<'a> {
+    pub name: &'a [u8],
+    /// `name` is the entry point's directory name. The executable is usually
+    /// written to that directory's parent (`bun build --compile ./src/index.ts`
+    /// from the project root), where the name is taken by the directory itself;
+    /// callers write `index` instead when it is.
+    pub is_dir_name: bool,
+}
+
+/// Name of the executable when compiling without an outfile: the first entry
+/// point's file name without its extension, except that `index` and `bun`
+/// entry points are named after their directory (`packages/cli/index.ts` ->
+/// `cli`), or `index` when there is no directory name to use (`./index.ts`).
+pub fn default_outfile(entry_point: &[u8]) -> DefaultOutfile<'_> {
+    let file_name = path::basename(entry_point);
+    let name = &file_name[..file_name.len() - path::extension(file_name).len()];
+    if !name.is_empty() && name != b"index" && name != b"bun" {
+        return DefaultOutfile {
+            name,
+            is_dir_name: false,
+        };
+    }
+
+    let dir_name: &[u8] = match path::dirname(entry_point) {
+        Some(dir) => path::basename(dir),
+        None => b"",
+    };
+    match dir_name {
+        b"" | b"." | b".." => DefaultOutfile {
+            name: b"index",
+            is_dir_name: false,
+        },
+        _ => DefaultOutfile {
+            name: dir_name,
+            is_dir_name: true,
+        },
+    }
+}
+
 pub(crate) fn is_bun_standalone_file_path_canonicalized(str_: &[u8]) -> bool {
     str_.starts_with(BASE_PATH.as_bytes())
         || (cfg!(windows) && str_.starts_with(BASE_PUBLIC_PATH.as_bytes()))

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -135,13 +135,11 @@ pub fn target_base_public_path(
 /// See [`default_outfile`].
 pub struct DefaultOutfile<'a> {
     pub name: &'a [u8],
-    /// `name` is the entry point's directory name, so the output path is usually that
-    /// directory itself; callers fall back to `index` when it is.
+    /// Callers use `index` instead when the output path turns out to be that directory itself.
     pub is_dir_name: bool,
 }
 
-/// Executable name when compiling without an outfile: the entry point's file name
-/// without extension; for `index.*` and `bun.*` its directory name, else `index`.
+/// Entry file name minus extension; `index.*`/`bun.*` use the directory name (or `index` if none).
 pub fn default_outfile(entry_point: &[u8]) -> DefaultOutfile<'_> {
     let file_name = path::basename(entry_point);
     let name = &file_name[..file_name.len() - path::extension(file_name).len()];

--- a/test/bundler/bun-build-compile-sourcemap.test.ts
+++ b/test/bundler/bun-build-compile-sourcemap.test.ts
@@ -21,7 +21,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       sourcemap: sourcemapValue,
     });
 
@@ -66,7 +66,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       // No sourcemap option
     });
 
@@ -99,7 +99,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       sourcemap: "external",
     });
 
@@ -134,7 +134,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "nosourcemap_entry.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "nosourcemap_entry") },
     });
 
     expect(result.success).toBe(true);
@@ -163,7 +163,7 @@ export function greet() {
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "entry.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "entry") },
       splitting: true,
       sourcemap: "external",
     });
@@ -275,7 +275,7 @@ main();`,
 
     const result = await Bun.build({
       entrypoints: [join(String(dir), "app.js")],
-      compile: true,
+      compile: { outfile: join(String(dir), "app") },
       sourcemap: "inline",
     });
 

--- a/test/bundler/compile-default-outfile.test.ts
+++ b/test/bundler/compile-default-outfile.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
+
+// Without an outfile, the executable is named after the entrypoint and written to the working
+// directory (or outdir), wherever the entrypoint lives; `Bun.build` and `bun build --compile`
+// share the rule. An index.* (or bun.*) entrypoint is named after its directory, unless that name
+// is taken by the directory itself, in which case the executable is named `index`. Windows
+// executables get a `.exe` suffix, so there the directory name never collides.
+
+// Every case compiles once, which copies the whole bun binary (~1 GB under debug+ASAN).
+const TIMEOUT = 60_000;
+const exe = isWindows ? ".exe" : "";
+
+const files = {
+  // Builds with the temp dir as the working directory; prints the output paths relative to it.
+  "build-fixture.ts": `
+    import { relative, sep } from "node:path";
+    const [entrypoint, outdir] = process.argv.slice(2);
+    const result = await Bun.build({ entrypoints: [entrypoint], compile: true, ...(outdir ? { outdir } : {}) });
+    console.log(JSON.stringify(result.outputs.map(output => relative(process.cwd(), output.path).replaceAll(sep, "/"))));
+  `,
+  "index.ts": `console.log("index");`,
+  "src/index.ts": `console.log("src/index");`,
+  "src/bun.ts": `console.log("src/bun");`,
+  "src/app.js": `console.log("src/app");`,
+  "tools/mycli/index.ts": `console.log("mycli");`,
+  "out/src/placeholder.txt": "",
+};
+
+function filesWritten(dir: string): string[] {
+  return Array.from(new Bun.Glob("**/*").scanSync(dir))
+    .map(file => file.replaceAll("\\", "/"))
+    .filter(file => !(file in files));
+}
+
+describe("Bun.build({ compile: true })", () => {
+  test.each([
+    {
+      description: "an absolute entrypoint in a subdirectory is written to the working directory",
+      entrypoint: ["src", "app.js"],
+      expected: `app${exe}`,
+    },
+    {
+      description: "index.ts is named after its directory",
+      entrypoint: ["tools", "mycli", "index.ts"],
+      expected: `mycli${exe}`,
+    },
+    {
+      description: "./src/index.ts, whose directory name is taken by ./src itself",
+      entrypoint: "./src/index.ts",
+      expected: isWindows ? "src.exe" : "index",
+    },
+    {
+      description: "./index.ts has no directory name to use",
+      entrypoint: "./index.ts",
+      expected: `index${exe}`,
+    },
+    {
+      description: "./src/index.ts with an outdir that already contains a src directory",
+      entrypoint: "./src/index.ts",
+      outdir: "out",
+      expected: isWindows ? "out/src.exe" : "out/index",
+    },
+  ])(
+    "$description",
+    async ({ entrypoint, outdir, expected }) => {
+      using dir = tempDir("compile-default-outfile", files);
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "run",
+          "build-fixture.ts",
+          Array.isArray(entrypoint) ? join(String(dir), ...entrypoint) : entrypoint,
+          ...(outdir ? [outdir] : []),
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode, written: filesWritten(String(dir)) }).toEqual({
+        stdout: JSON.stringify([expected]) + "\n",
+        stderr: "",
+        exitCode: 0,
+        written: [expected],
+      });
+    },
+    TIMEOUT,
+  );
+});
+
+describe("bun build --compile", () => {
+  test.each([
+    { entrypoint: "./src/index.ts", expected: isWindows ? "src.exe" : "index" },
+    { entrypoint: "./src/bun.ts", expected: isWindows ? "src.exe" : "index" },
+  ])(
+    "$entrypoint compiles to $expected",
+    async ({ entrypoint, expected }) => {
+      using dir = tempDir("compile-default-outfile-cli", files);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", entrypoint],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stderr, exitCode, written: filesWritten(String(dir)) }).toEqual({
+        stderr: "",
+        exitCode: 0,
+        written: [expected],
+      });
+    },
+    TIMEOUT,
+  );
+});

--- a/test/bundler/compile-default-outfile.test.ts
+++ b/test/bundler/compile-default-outfile.test.ts
@@ -8,7 +8,9 @@ import { join } from "node:path";
 // is taken by the directory itself, in which case the executable is named `index`. Windows
 // executables get a `.exe` suffix, so there the directory name never collides.
 
-// Every case compiles once, which copies the whole bun binary (~1 GB under debug+ASAN).
+// Every case compiles once, which reads and rewrites the whole bun binary (~1 GB under
+// debug+ASAN): hence the timeout, and hence plain `describe` rather than `describe.concurrent`,
+// since concurrent compiles exhaust CI memory/IO (see the note in bundler_compile.test.ts).
 const TIMEOUT = 60_000;
 const exe = isWindows ? ".exe" : "";
 

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -385,6 +385,7 @@ body { color: blue; }`,
     // fall back to normal bun executable compile (not standalone HTML)
     const result = await Bun.build({
       entrypoints: [`${dir}/app.js`],
+      outdir: String(dir),
       compile: true,
       target: "browser",
     });


### PR DESCRIPTION
### What does this PR do?

`Bun.build({ compile })` without a `compile.outfile` puts the executable in a different place depending on how the entrypoint was spelled, and fails outright for the common `src/index.ts` layout. With `src/index.ts` and `src/app.js` in the working directory (bun 1.4.0 canary, same on main):

```ts
await Bun.build({ entrypoints: ["./src/index.ts"], compile: true });
// AggregateError: Bundle failed
//   - src is a directory. Please choose a different --outfile or delete the directory

await Bun.build({ entrypoints: [process.cwd() + "/src/index.ts"], compile: true });
// writes src/src

await Bun.build({ entrypoints: ["./src/app.js"], compile: true });           // writes ./app
await Bun.build({ entrypoints: [process.cwd() + "/src/app.js"], compile: true }); // writes src/app

await Bun.build({ entrypoints: ["./index.ts"], compile: true });
// error: failed to rename <cwd>/.xxxx.bun-build to <cwd basename>: ENOTEMPTY
// (the derived name is ".", so it tries to replace the working directory itself)
```

`bun build --compile` with the same entrypoints writes `./index`, `./index`, `./app`, `./app` and `./index`: always the bare name in the working directory, falling back to `index` when the name taken from the directory is the directory itself (added in #20511).

### Cause

The name derivation in `Config::from_js` (`src/runtime/api/JSBundler.rs`) was a copy of the CLI's that never got the CLI's two follow-ups: the `index` fallback for a name that collides with the directory it came from, and the `.`/`..` guard. The Rust port (#30412) then added the entry-directory prefix for absolute entrypoints on top of it; the comment there says it was done to stop concurrently running test files from racing on the same `<cwd>/app`, which is a property of tests that compile without an outfile, not something the API should encode. Before the port the API used the bare name, like the CLI, and every other path `Bun.build` writes (`outdir`, an explicit `compile.outfile`, and the metafile paths in #37423) is resolved against `outdir` or the working directory, never against the entrypoint.

### Fix

* `StandaloneModuleGraph::default_outfile` (new, `src/standalone_graph/StandaloneModuleGraph.rs`) is the one derivation used by both `build_command.rs` and `JSBundler.rs`: file name minus extension; `index`/`bun` entrypoints take their directory's name; a missing, `.` or `..` directory yields `index`. It also reports whether the name is the directory's name.
* `JSBundler.rs` now stores just that name, so `compile: true` behaves exactly like `compile: { outfile: "<name>" }`: resolved against `outdir`, otherwise the working directory, for relative and absolute entrypoints alike. This is the line that fixes the placement split.
* `do_compilation` (`js_bundle_completion_task.rs`) applies the CLI's fallback: when the name is the directory's name and the resolved path is an existing directory, it uses `index` instead. The existing resolution is factored into `resolve_outfile` so the check and the final path resolve the same way. Windows targets are excluded like in the CLI, since `.exe` is appended and cannot collide.
* `build_command.rs` calls the shared helper; its EISDIR fallback is otherwise unchanged.

Observable changes, all of them either restoring the pre-port behaviour or turning a failure into an executable:

| entrypoint (cwd is the project root) | before | after |
|---|---|---|
| `Bun.build`, absolute `<root>/src/app.js` | `src/app` | `./app` (CLI parity, pre-port behaviour) |
| `Bun.build`, absolute `<root>/src/index.ts` | `src/src` | `./index` |
| `Bun.build`, `./src/index.ts` | "src is a directory" | `./index` |
| `Bun.build`, `./index.ts` | ENOTEMPTY error | `./index` |
| `Bun.build`, `./src/index.ts` with `outdir: "out"` and an existing `out/src/` | "src is a directory" | `out/index` |
| `Bun.build` and CLI, `./src/bun.ts` | "src is a directory" | `./index` (same fallback as `index.ts`) |
| CLI, `bun.ts` with no directory component | error "named 'bun'" | `./index`, which is what `./bun.ts` already produced |

Relative entrypoints with ordinary names, explicit `compile.outfile`, `outdir`, and the `bun`/`bunx` name error are unchanged. The docs paragraph and the new JSDoc on `CompileBuildOptions.outfile` state the rule; the `compile` JSDoc block itself is being rewritten in #37421, so this PR stays out of it.

Two existing tests compiled without an outfile and relied on the entry-directory placement to keep their output in the temp dir (`bun-build-compile-sourcemap.test.ts`, `standalone.test.ts` "falls back to normal compile"); they now pass an outfile / outdir, which also removes the race the removed comment was worried about. #36083 restructures the sourcemap file and #37478 rewrites the resolution block this PR factors into `resolve_outfile`; whichever lands second needs a small rebase.

### How did you verify your code works?

`test/bundler/compile-default-outfile.test.ts` (new file rather than an addition to `bun-build-compile.test.ts`, because it covers the CLI and the API together and, like the other `compile-*.test.ts` files, each case is a full 1 GB debug compile). It runs each build from a temp working directory and asserts the reported output paths and the exact set of files written. On the unfixed build 6 of the 7 cases fail with the outputs from the table above (`["src/app"]`, `["tools/mycli/mycli"]`, "src is a directory" x3, ENOTEMPTY); the CLI `./src/index.ts` case passes before and after and pins the behaviour the refactor has to keep. With the fix all 7 pass, as do `bun-build-compile-sourcemap.test.ts`, `standalone.test.ts`, `bun-build-compile.test.ts` (with `--timeout=60000`; several of its pre-existing compiles exceed the 5 s default under debug+ASAN here, with or without this change) and the bun-types integration test; `cargo check` for the Windows target and clippy on the two touched crates are clean.
