### PR TITLE
internal-for-testing: make exposedInternals lazy so loading the module stays cheap

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -453,68 +453,108 @@ function nodeGetValidStdio(stdio, sync?) {
   return { stdio, ipc, ipcFd };
 }
 
+// Entries below that assemble an object rather than return a module are built
+// once, so repeated requires get the same object, as they would in node.
+let cachedInternalUtil;
+let cachedInternalEventTarget;
 let cachedInternalChildProcess;
+let cachedInternalFsUtils;
 
 // Userland access to node-internal modules for vendored node tests that
 // declare `// Flags: --expose-internals` (served via the require interceptor
 // in test/js/node/test/common/index.js). Static requires only — the builtin
 // bundler cannot rewrite variable-path requires. Extend the map as more
 // vendored tests need more internals.
+//
+// Every entry must be a getter (test/internal/internal-for-testing.test.ts
+// enforces it): test/harness.ts loads this module in every test file just to
+// read isASANEnabled, so anything required here is evaluated on every test
+// run. Small-looking entries are not cheap either; internal/assert/myers_diff
+// pulls in internal/util/colors, which materializes process.stderr on load.
 export const exposedInternals = {
-  "internal/streams/add-abort-signal": require("internal/streams/add-abort-signal"),
-  "internal/util/debuglog": require("internal/util/debuglog"),
-  "internal/async_context_frame": require("internal/async_context_frame"),
-  "internal/async_hooks": require("internal/async_hooks"),
-  "internal/webstreams/adapters": require("internal/webstreams_adapters"),
-  "internal/dgram": require("internal/dgram"),
+  get "internal/streams/add-abort-signal"() {
+    return require("internal/streams/add-abort-signal");
+  },
+  get "internal/util/debuglog"() {
+    return require("internal/util/debuglog");
+  },
+  get "internal/async_context_frame"() {
+    return require("internal/async_context_frame");
+  },
+  get "internal/async_hooks"() {
+    return require("internal/async_hooks");
+  },
+  get "internal/webstreams/adapters"() {
+    return require("internal/webstreams_adapters");
+  },
+  get "internal/dgram"() {
+    return require("internal/dgram");
+  },
   // Bun's real implementations, under the names node's tests import them by.
-  "internal/validators": require("internal/validators"),
-  "internal/util/inspect": require("internal/util/inspect"),
-  "internal/freelist": require("internal/freelist"),
+  get "internal/validators"() {
+    return require("internal/validators");
+  },
+  get "internal/util/inspect"() {
+    return require("internal/util/inspect");
+  },
+  get "internal/freelist"() {
+    return require("internal/freelist");
+  },
   // Node's internal/fixed_queue module IS the FixedQueue class.
-  "internal/fixed_queue": require("internal/fixed_queue").FixedQueue,
-  "internal/assert/myers_diff": require("internal/assert/myers_diff"),
+  get "internal/fixed_queue"() {
+    return require("internal/fixed_queue").FixedQueue;
+  },
+  get "internal/assert/myers_diff"() {
+    return require("internal/assert/myers_diff");
+  },
   // Bun's internal/errors only carries aggregateTwoErrors; the ERR_* hierarchy
   // is native, not a JS `codes` table, so nothing else is exposed here.
-  "internal/errors": require("internal/errors"),
+  get "internal/errors"() {
+    return require("internal/errors");
+  },
   // normalizeEncoding wraps the same Rust binding node:crypto and the
   // webstream adapters call; the rest are node's own JS helpers, ported
   // verbatim from lib/internal/util.js where Bun has no native equivalent.
-  "internal/util": {
-    normalizeEncoding: nodeNormalizeEncoding,
-    // Bun always has crypto support compiled in.
-    assertCrypto() {},
-    getCIDR,
-    isError: nodeIsError,
-    assignFunctionName,
-    kEnumerableProperty: Object.freeze({ __proto__: null, enumerable: true }),
-    kEmptyObject: nodeKEmptyObject,
-    WeakReference,
+  get "internal/util"() {
+    return (cachedInternalUtil ??= {
+      normalizeEncoding: nodeNormalizeEncoding,
+      // Bun always has crypto support compiled in.
+      assertCrypto() {},
+      getCIDR,
+      isError: nodeIsError,
+      assignFunctionName,
+      kEnumerableProperty: Object.freeze({ __proto__: null, enumerable: true }),
+      kEmptyObject: nodeKEmptyObject,
+      WeakReference,
+    });
   },
   // Bun's EventTarget/Event/CustomEvent are the native (global) ones; node
   // keeps them in internal/event_target. kWeakHandler is Bun's real weak
   // listener symbol from internal/shared. Bun has no NodeEventTarget.
-  "internal/event_target": {
-    Event: globalThis.Event,
-    CustomEvent: globalThis.CustomEvent,
-    EventTarget: globalThis.EventTarget,
-    kWeakHandler: require("internal/shared").kWeakHandler,
+  get "internal/event_target"() {
+    return (cachedInternalEventTarget ??= {
+      Event: globalThis.Event,
+      CustomEvent: globalThis.CustomEvent,
+      EventTarget: globalThis.EventTarget,
+      kWeakHandler: require("internal/shared").kWeakHandler,
+    });
   },
   // ChildProcess is the real class exec()/spawn() instantiate, so vendored
   // tests can monkeypatch its prototype; getValidStdio is ported from node.
-  // A getter so loading this module does not eagerly pull in child_process.
   get "internal/child_process"() {
     return (cachedInternalChildProcess ??= {
       ChildProcess: require("node:child_process").ChildProcess,
       getValidStdio: nodeGetValidStdio,
     });
   },
-  "internal/fs/utils": {
-    // Both are the REAL parsers the fs entry points use (FileSystemFlags::from_js
-    // and args::Rm::from_js), not JS reimplementations -- vendored tests assert
-    // the production behavior through these.
-    stringToFlags: $newRustFunction("node_fs_binding.rs", "string_to_flags_for_testing", 1),
-    validateRmOptionsSync: $newRustFunction("node_fs_binding.rs", "rm_options_for_testing", 2),
+  get "internal/fs/utils"() {
+    return (cachedInternalFsUtils ??= {
+      // Both are the REAL parsers the fs entry points use (FileSystemFlags::from_js
+      // and args::Rm::from_js), not JS reimplementations -- vendored tests assert
+      // the production behavior through these.
+      stringToFlags: $newRustFunction("node_fs_binding.rs", "string_to_flags_for_testing", 1),
+      validateRmOptionsSync: $newRustFunction("node_fs_binding.rs", "rm_options_for_testing", 2),
+    });
   },
   // internalBinding() is served by the registered "internal/test/binding"
   // module (src/js/internal/test/binding.ts), not from here.
@@ -540,8 +580,6 @@ export function getWebStreamState(stream: ReadableStream | WritableStream): {
       return { state: $inheritsWritableStream(stream) ? "writable" : "readable", storedError: undefined };
   }
 }
-
-export const fs = require("node:fs/promises").$data;
 
 export const fsStreamInternals = {
   writeStreamFastPath(str) {

--- a/test/internal/internal-for-testing.test.ts
+++ b/test/internal/internal-for-testing.test.ts
@@ -1,0 +1,57 @@
+// test/harness.ts requires bun:internal-for-testing from every test file (via
+// test/preload.ts), so loading the module itself has to stay cheap: the node
+// internals it exposes for `--expose-internals` tests must only be evaluated
+// when a test asks for them.
+import { exposedInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const names = Object.keys(exposedInternals);
+
+test("every exposedInternals entry is a getter", () => {
+  expect(names).not.toBeEmpty();
+  const eager = names.filter(
+    name => typeof Object.getOwnPropertyDescriptor(exposedInternals, name)?.get !== "function",
+  );
+  expect(eager).toEqual([]);
+});
+
+test("every exposedInternals entry loads and is the same object on each access", () => {
+  const broken = names.filter(name => {
+    const first = exposedInternals[name];
+    return first === undefined || exposedInternals[name] !== first;
+  });
+  expect(broken).toEqual([]);
+});
+
+// harness.ts loads the module with require(); test files usually import it.
+test.concurrent.each([
+  ["require", `require("bun:internal-for-testing")`],
+  ["import", `await import("bun:internal-for-testing")`],
+])("loading bun:internal-for-testing via %s does not evaluate the exposed internals", async (_, load) => {
+  // internal/util/colors, a dependency of the exposed internal/assert/myers_diff,
+  // reads FORCE_COLOR once, when it is evaluated. Setting the variable after
+  // loading bun:internal-for-testing and only then requiring colors therefore
+  // shows whether loading bun:internal-for-testing had already evaluated it:
+  // hasColors is false if it did, true if colors is first evaluated here.
+  const env = { ...bunEnv };
+  // With either of these set, FORCE_COLOR also prints an "is ignored" warning to stderr.
+  delete env.NO_COLOR;
+  delete env.NODE_DISABLE_COLORS;
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--expose-internals",
+      "-e",
+      `
+        ${load};
+        process.env.FORCE_COLOR = "1";
+        console.log(require("internal/util/colors").hasColors);
+      `,
+    ],
+    env,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "true", stderr: "", exitCode: 0 });
+});


### PR DESCRIPTION
### What does this PR do?

`exposedInternals` in `src/js/internal-for-testing.ts` (the map that serves `require("internal/...")` to vendored `--expose-internals` node tests) was built out of top-level `require()` calls, so loading `bun:internal-for-testing` evaluated all of those internals and everything they pull in. `test/harness.ts` requires the module at import time from every test file in the repo (`test/bunfig.toml` preload -> `preload.ts` -> `harness.ts` -> `detectASAN()`), only to call `isASANEnabled()`.

On a debug build that is a fixed tax on every `bun bd test <file>`. Timing the requires one by one (debug/ASAN build, after the modules harness.ts itself imports are already loaded):

```
internal/util/inspect                  281 ms
internal/webstreams_adapters           231 ms
internal/assert/myers_diff             180 ms   (cold, in a bare process: ~600 ms)
internal/streams/add-abort-signal       35 ms
internal/dgram, fixed_queue, freelist, debuglog, async_hooks, async_context_frame   ~30 ms
bun:internal-for-testing itself         ~50 ms
```

`internal/assert/myers_diff` is the surprising one: it requires `internal/util/colors`, whose load-time `refresh()` reads `process.stderr`, which materializes the stderr stream and the tty/net/stream stack behind it.

Fix: every entry of `exposedInternals` is now a getter, the shape the `internal/child_process` entry already had. Entries that assemble an object rather than return a module (`internal/util`, `internal/event_target`, `internal/child_process`, `internal/fs/utils`) are memoized so repeated requires keep getting one object, as in node; the module-returning entries are already singletons through the internal module registry. The unused `export const fs = require("node:fs/promises").$data` (no consumer in the tree, eagerly loaded `node:fs/promises`) is removed; a named export can not be made lazy because the ESM namespace reads every export on load.

Why this is the right layer: the harness needs the ASAN answer at import time (it feeds `bunEnv.ASAN_OPTIONS` and the exported `isASAN` constant), and `process.config.variables.asan` is deliberately `0` even in ASAN builds (`BunProcess.cpp`), so `isASANEnabled` is the correct probe and the module has to be loaded from the harness. The module therefore has to be cheap to load, which is also what its other exports already are (`$newRustFunction` / `$cpp` bindings, lazy `require()`s inside functions). Nothing observable changes for consumers: the require interceptor in `test/js/node/test/common/index.js`, `common/nodeinternals.js`, `dgram.test.ts` and `node-stream.test.js` all read entries by property access, and the interceptor already caches per id.

Measured on this debug build: `require("bun:internal-for-testing")` in a bare process goes from ~1290 ms to ~150 ms; `import("./harness")` from `test/` goes from ~1.8 s to ~1.35 s (the rest of harness's import time is its own imports, unrelated to this module). On a release build the module loaded in ~14 ms before, so this is a dev-loop change only.

#35567 makes some of the entries getters too, as a side effect of a much larger primordials change that depends on a WebKit bump; this is the standalone fix and covers the entries added since.

### How did you verify your code works?

`test/internal/internal-for-testing.test.ts`:

- every `exposedInternals` entry is an accessor (a data-property entry, i.e. a new eager `require()`, fails the test by name);
- every entry loads and returns the same value on repeated access;
- loading `bun:internal-for-testing`, via `require()` (the harness path) and via `import()` (the test-file path), does not evaluate the exposed internals. `internal/util/colors` decides `hasColors` when it is evaluated, so a child process loads the module, then sets `FORCE_COLOR`, then requires colors: `hasColors` is `true` only if colors had not been evaluated yet.

Without the `src/` change, 3 of the 4 tests fail (the getter check lists the 15 eager entries, and both load variants print `false`); with it, all pass.

Also ran the consumers: the 51 vendored node tests that require one of the mapped ids plus the 15 that go through `nodeinternals.js` (all pass, run the way `scripts/runner.node.mjs` runs them), and `test/js/bun/udp/dgram.test.ts`, `test/js/node/stream/node-stream.test.js`, `test/internal/fifo.test.ts`, `test/internal/internal-module-blob.test.ts` with `bun bd test`.
