### PR TITLE
Bun.sleepSync: sleep to an absolute deadline so caught signals do not extend the sleep

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1074,9 +1074,13 @@ fn sleep_sync(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult
         )));
     }
 
-    std::thread::sleep(core::time::Duration::from_millis(
-        u64::try_from(milliseconds).expect("int cast"),
-    ));
+    // Not `thread::sleep`: that re-arms a relative nanosleep with the remaining
+    // time after every EINTR, so with a signal handler installed (process.on)
+    // each delivery adds its round trip to the sleep and a fast enough signal
+    // stream keeps it from ever returning. An absolute deadline is immune.
+    let duration =
+        core::time::Duration::from_millis(u64::try_from(milliseconds).expect("int cast"));
+    std::thread::sleep_until(std::time::Instant::now() + duration);
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/lib.rs
+++ b/src/runtime/lib.rs
@@ -5,6 +5,7 @@
 #![deny(improper_ctypes, improper_ctypes_definitions)]
 #![feature(thread_local)]
 #![feature(adt_const_params)]
+#![feature(thread_sleep_until)]
 
 pub mod error;
 pub use error::{Error, Result};

--- a/test/js/bun/util/sleepSync.test.ts
+++ b/test/js/bun/util/sleepSync.test.ts
@@ -1,5 +1,6 @@
 import { sleepSync } from "bun";
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
 
 it("sleepSync uses milliseconds", async () => {
   const start = performance.now();
@@ -27,4 +28,42 @@ it("sleepSync with negative number throws", async () => {
 
 it("can map with sleepSync", async () => {
   [1, 2, 3].map(sleepSync);
+});
+
+// sleepSync used to re-arm a relative nanosleep with the remaining time after
+// every EINTR, so once a signal handler was installed each delivery added its
+// round trip to the sleep, and a fast enough stream of signals kept sleepSync
+// from returning until the stream stopped. The child floods itself with SIGUSR2
+// from a `sh` loop and times a 100 ms sleepSync while the flood is running.
+it.skipIf(isWindows)("sleepSync returns on time while signals are being delivered", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { promise: firstSignal, resolve } = Promise.withResolvers();
+      process.on("SIGUSR2", resolve);
+      const flood = Bun.spawn({
+        cmd: ["sh", "-c", "i=0; while [ $i -lt 1000000 ] && kill -s USR2 " + process.pid + "; do i=$((i+1)); done"],
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      await firstSignal;
+      const start = performance.now();
+      Bun.sleepSync(100);
+      const elapsed = performance.now() - start;
+      flood.kill();
+      console.log(JSON.stringify({ elapsed }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { elapsed } = JSON.parse(stdout);
+  // Without the fix this is however long the flood lasts (seconds).
+  expect(elapsed).toBeGreaterThanOrEqual(100);
+  expect(elapsed).toBeLessThan(1000);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem

`Bun.sleepSync(ms)` overshoots in proportion to the rate at which caught signals are delivered to the process, and under a sustained signal stream it does not return until the stream stops.

```js
// bun repro.mjs
import { spawn } from "node:child_process";
process.on("SIGUSR2", () => {});
const sh = spawn("sh", ["-c", `i=0; while [ $i -lt 300000 ] && kill -s USR2 ${process.pid}; do i=$((i+1)); done`], { stdio: "ignore" });
await new Promise(r => setTimeout(r, 200));
for (const [name, fn] of [
  ["sleepSync(300)", () => Bun.sleepSync(300)],
  ["Atomics.wait(300)", () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 300)],
]) {
  const t = performance.now();
  fn();
  console.log(name, (performance.now() - t).toFixed(1) + "ms");
}
sh.kill();
```

bun 1.4.0 (same process, same flood):

```
sleepSync(300) 6256.0ms      <- returns when the flood runs dry
Atomics.wait(300) 300.2ms
```

A 1 kHz `SIGPROF`/`SIGALRM` sampler or a `SIGCHLD`-heavy supervisor with a `process.on` handler installed gets the proportional version of this (a few percent per kHz).

### Cause

`sleep_sync` (src/runtime/api/BunObject.rs) called `std::thread::sleep`, which loops a relative `nanosleep`/`clock_nanosleep` and re-arms it with the `rem` the kernel hands back on `EINTR`. Only time spent inside the syscall is credited: the return to user space, the signal handler (Bun's handler does a wakeup syscall per delivery) and the re-entry are lost on every delivery, and if another signal is already pending the call returns immediately with `rem ~= req`. Progress per delivery goes to zero as the delivery rate goes up. `nanosleep` is never restarted by `SA_RESTART`, so the handler flags do not help. The event loop's own poll was fixed the same way in #34780; this is the `sleepSync` counterpart.

### Fix

Compute the deadline once and call `std::thread::sleep_until`, which re-issues an absolute-deadline wait after each interruption (`clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME)` on Linux/BSD/Android, `mach_wait_until` on macOS, a deadline loop over `Sleep` on Windows). The function is still unstable, so `bun_runtime` gains `#![feature(thread_sleep_until)]` next to the features it already enables.

With the fix (debug build), the same script: `sleepSync(300)` 301.6 to 306.5 ms across 3 runs (`Atomics.wait` in the same runs: 304.1 to 309.2 ms). A standalone Rust probe with the same handler shape goes from 10.4 s (`thread::sleep`) to 300.1 ms (`thread::sleep_until`) for a 300 ms sleep.

### Test

`test/js/bun/util/sleepSync.test.ts`: the child installs a `SIGUSR2` listener, floods itself from a `sh` loop, waits for the first delivery and then times `sleepSync(100)`; the parent asserts 100 ms <= elapsed < 1000 ms. Skipped on Windows.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/sleepSync.test.ts`: the new test times out at 5 s (sleepSync does not return while the flood is running).
- `bun bd test test/js/bun/util/sleepSync.test.ts`: 6 pass; the child measures 100.4 to 101.7 ms across 10 runs.

### Related

#35103 (worker.terminate() vs. a worker parked in sleepSync) is a different bug in the same function; its worker branch slices the sleep with `thread::sleep`, so each slice would still be subject to this, and it would want `sleep_until` per slice if it lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/sleepSync.test.ts

<!-- robobun:evidence:end -->