### PR TITLE
test/bundler: stop compile-asset-bunfs.test.ts stalling on its own Bun.build compile

### DIFF
--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -1,339 +1,320 @@
 // https://github.com/oven-sh/bun/issues/15734
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { join, sep } from "path";
+import { readdirSync } from "fs";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
+import { tmpdir } from "os";
+import { basename, join } from "path";
 
 // `bun build --compile` copies + rewrites the whole bun binary (~1GB under
 // debug+ASAN), which blows the 5s default.
 const TIMEOUT = 60_000;
-const exe = process.platform === "win32" ? ".exe" : "";
+const exe = isWindows ? ".exe" : "";
 
-async function compile(dir: string, extraArgs: string[] = []) {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "app", ...extraArgs],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  if (code !== 0) throw new Error(`compile failed (exit ${code})\n${stdout}\n${stderr}`);
+// Inside a compiled executable, import.meta.dir/path use the platform form of
+// the virtual root while file-loader asset paths use its forward-slash form.
+const root = isWindows ? "B:\\~BUN\\root" : "/$bunfs/root";
+const publicRoot = isWindows ? "B:/~BUN/root" : "/$bunfs/root";
+
+// One program + asset layout is compiled once through the CLI and once through
+// Bun.build(); both executables must print exactly expectedOutput(). It covers
+// a file-loader asset and its parent directory, an asset directory tree walked
+// the way svelte-adapter-bun does (readdir, stat, Bun.file()), a single-file
+// asset, an asset named like the entry point's source file (the entry is keyed
+// at basename(outfile), so it must not collide), and the ENOENT / ENOTDIR /
+// EISDIR / EACCES error paths of the virtual filesystem.
+const assetArgs = ["./client", "./config.json", "./cfg/index.js"];
+const files = {
+  "index.ts": /* ts */ `
+    import asset from "./data.txt" with { type: "file" };
+    import fs from "node:fs";
+    import path from "node:path";
+
+    const code = (fn: () => unknown) => {
+      try {
+        fn();
+        return null;
+      } catch (e: any) {
+        return e.code;
+      }
+    };
+    const dir = import.meta.dir;
+    const assetDir = path.dirname(asset);
+    const client = path.join(dir, "client");
+    const config = path.join(dir, "config.json");
+    const missing = path.join(dir, "does-not-exist");
+
+    console.log(
+      JSON.stringify({
+        dir,
+        entry: import.meta.path,
+        rootEntries: fs.readdirSync(dir).sort(),
+        embeddedFiles: Bun.embeddedFiles.map(f => f.name).sort(),
+        asset,
+        assetContent: fs.readFileSync(asset, "utf8"),
+        assetWritable: code(() => fs.accessSync(asset, fs.constants.W_OK)),
+        assetDir: {
+          path: assetDir,
+          exists: fs.existsSync(assetDir),
+          existsWithTrailingSlash: fs.existsSync(assetDir + "/"),
+          statIsDirectory: fs.statSync(assetDir).isDirectory(),
+          lstatIsDirectory: fs.lstatSync(assetDir).isDirectory(),
+          access: code(() => fs.accessSync(assetDir)),
+          entries: fs.readdirSync(assetDir).sort(),
+        },
+        client: {
+          entries: fs
+            .readdirSync(client, { withFileTypes: true })
+            .map(e => ({ name: e.name, isDirectory: e.isDirectory(), isFile: e.isFile() }))
+            .sort((a, b) => (a.name < b.name ? -1 : 1)),
+          indexHtmlSize: fs.statSync(path.join(client, "index.html")).size,
+          indexHtml: await Bun.file(path.join(client, "index.html")).text(),
+          nestedCss: await Bun.file(path.join(client, "_app", "immutable", "app.css")).text(),
+          nestedCssViaReadFile: fs.readFileSync(path.join(client, "_app", "immutable", "app.css"), "utf8"),
+          nestedDirIsDirectory: fs.statSync(path.join(client, "_app", "immutable")).isDirectory(),
+          readFileOnDirectory: code(() => fs.readFileSync(client)),
+          recursive: fs.readdirSync(client, { recursive: true }).map(String).sort(),
+          recursiveAsync: (await fs.promises.readdir(client, { recursive: true })).map(String).sort(),
+        },
+        singleFile: {
+          exists: fs.existsSync(config),
+          content: fs.readFileSync(config, "utf8"),
+          readdir: code(() => fs.readdirSync(config)),
+        },
+        entryNamedAsset: fs.readFileSync(path.join(dir, "index.js"), "utf8"),
+        missing: {
+          exists: fs.existsSync(missing),
+          stat: code(() => fs.statSync(missing)),
+          readdir: code(() => fs.readdirSync(missing)),
+        },
+      }),
+    );
+  `,
+  "data.txt": "hello",
+  "client/index.html": "<!doctype html><h1>hi</h1>",
+  "client/favicon.svg": "<svg/>",
+  "client/_app/immutable/app.css": "body{margin:0}",
+  "client/_app/immutable/chunks/entry.js": "export default 1;",
+  "config.json": `{"ok":true}`,
+  "cfg/index.js": "ASSET_CONTENT",
+};
+
+function expectedOutput(assetName: string) {
+  const rootEntries = ["app", "client", "config.json", assetName, "index.js"].sort();
+  // recursive readdir joins with the platform separator, like it does on a real directory
+  const clientTree = [
+    "_app",
+    join("_app", "immutable"),
+    join("_app", "immutable", "app.css"),
+    join("_app", "immutable", "chunks"),
+    join("_app", "immutable", "chunks", "entry.js"),
+    "favicon.svg",
+    "index.html",
+  ].sort();
+  return {
+    dir: root,
+    entry: join(root, "app"),
+    rootEntries,
+    embeddedFiles: [
+      "client/_app/immutable/app.css",
+      "client/_app/immutable/chunks/entry.js",
+      "client/favicon.svg",
+      "client/index.html",
+      "config.json",
+      assetName,
+      "index.js",
+    ].sort(),
+    asset: `${publicRoot}/${assetName}`,
+    assetContent: "hello",
+    assetWritable: "EACCES",
+    assetDir: {
+      path: publicRoot,
+      exists: true,
+      existsWithTrailingSlash: true,
+      statIsDirectory: true,
+      lstatIsDirectory: true,
+      access: null,
+      entries: rootEntries,
+    },
+    client: {
+      entries: [
+        { name: "_app", isDirectory: true, isFile: false },
+        { name: "favicon.svg", isDirectory: false, isFile: true },
+        { name: "index.html", isDirectory: false, isFile: true },
+      ],
+      indexHtmlSize: files["client/index.html"].length,
+      indexHtml: files["client/index.html"],
+      nestedCss: files["client/_app/immutable/app.css"],
+      nestedCssViaReadFile: files["client/_app/immutable/app.css"],
+      nestedDirIsDirectory: true,
+      readFileOnDirectory: "EISDIR",
+      recursive: clientTree,
+      recursiveAsync: clientTree,
+    },
+    singleFile: { exists: true, content: files["config.json"], readdir: "ENOTDIR" },
+    entryNamedAsset: files["cfg/index.js"],
+    missing: { exists: false, stat: "ENOENT", readdir: "ENOENT" },
+  };
 }
 
-async function run(dir: string) {
-  // cwd outside the build dir so the binary cannot accidentally find real files on disk.
-  await using proc = Bun.spawn({
-    cmd: [join(dir, "app" + exe)],
-    cwd: process.platform === "win32" ? process.env.TEMP || "C:\\Windows\\Temp" : "/tmp",
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, code };
+async function run(cmd: string[], cwd: string) {
+  await using proc = Bun.spawn({ cmd, cwd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function expectAppOutput({ stdout, stderr, exitCode }: Awaited<ReturnType<typeof run>>) {
+  expect(stderr).toBe("");
+  const output = JSON.parse(stdout);
+  // The file loader hashes the asset's name; everything else is exact.
+  const assetName = basename(output.asset);
+  expect(assetName).toMatch(/^data-[a-z0-9]+\.txt$/);
+  expect(output).toEqual(expectedOutput(assetName));
+  expect(exitCode).toBe(0);
 }
 
 describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
-  // One compiled binary exercises every CLI-side /$bunfs/ path we care about:
-  // a file-loader asset's parent directory, an --asset directory tree, an
-  // --asset single file, and the ENOENT/ENOTDIR/EISDIR/EACCES error paths.
-  // These used to be four separate `bun build --compile` invocations.
   test(
-    "CLI: file-loader asset, --asset dir + file, and /$bunfs/ fs semantics",
+    "bun build --compile --asset",
     async () => {
-      using dir = tempDir("bunfs-cli", {
-        "index.ts": /* ts */ `
-        import asset from "./data.txt" with { type: "file" };
-        import fs from "node:fs";
-        import path from "node:path";
+      using dir = tempDir("bunfs-cli", files);
+      const assetFlags = assetArgs.flatMap(asset => ["--asset", asset]);
+      const build = await run(
+        [bunExe(), "build", "--compile", "./index.ts", "--outfile", "app", ...assetFlags],
+        String(dir),
+      );
+      expect(build.stderr).toBe("");
+      expect(build.exitCode).toBe(0);
 
-        function errcode(fn: () => unknown): string {
-          try { fn(); return ""; } catch (e: any) { return e.code; }
-        }
-
-        // file-loader asset: parent-directory semantics
-        const assetDir = path.dirname(asset);
-        const fileLoader = {
-          assetExists: fs.existsSync(asset),
-          dirExists: fs.existsSync(assetDir),
-          dirExistsTrailingSlash: fs.existsSync(assetDir + "/"),
-          dirStatIsDir: fs.statSync(assetDir).isDirectory(),
-          dirLstatIsDir: fs.lstatSync(assetDir).isDirectory(),
-          accessOk: errcode(() => fs.accessSync(assetDir)) === "",
-          accessWriteErr: errcode(() => fs.accessSync(asset, fs.constants.W_OK)),
-          readdir: fs.readdirSync(assetDir).sort(),
-          readdirHasAsset: fs.readdirSync(assetDir).includes(path.basename(asset)),
-        };
-
-        // --asset directory tree (mirrors svelte-adapter-bun: walk a directory
-        // relative to the bundled entry, stat each entry, serve via Bun.file())
-        const root = path.join(import.meta.dir, "client");
-        if (!fs.existsSync(root)) throw new Error("client dir missing: " + root);
-        const entries = fs.readdirSync(root, { withFileTypes: true });
-        const byName: Record<string, { isDir: boolean; isFile: boolean }> = {};
-        for (const e of entries) byName[e.name] = { isDir: e.isDirectory(), isFile: e.isFile() };
-        const indexHtml = path.join(root, "index.html");
-        const nestedCss = path.join(root, "_app", "immutable", "app.css");
-        const client = {
-          root,
-          entries: Object.keys(byName).sort(),
-          byName,
-          indexHtmlExists: fs.existsSync(indexHtml),
-          indexHtmlSize: fs.statSync(indexHtml).size,
-          indexHtmlContent: await Bun.file(indexHtml).text(),
-          nestedCssExists: fs.existsSync(nestedCss),
-          nestedCssContent: await Bun.file(nestedCss).text(),
-          nestedCssViaReadFile: fs.readFileSync(nestedCss, "utf8"),
-          nestedDirIsDir: fs.statSync(path.join(root, "_app", "immutable")).isDirectory(),
-          readFileDirErr: errcode(() => fs.readFileSync(root)),
-          recursive: fs.readdirSync(root, { recursive: true }).map(String).sort(),
-          recursiveAsync: (await fs.promises.readdir(root, { recursive: true })).map(String).sort(),
-          embeddedFileCount: Bun.embeddedFiles.length,
-        };
-
-        // readdir on a non-existent /$bunfs/ path
-        const missing = path.join(import.meta.dir, "does-not-exist");
-        const enoent = {
-          code: errcode(() => fs.readdirSync(missing)),
-          exists: fs.existsSync(missing),
-        };
-
-        // --asset single file
-        const cfg = path.join(import.meta.dir, "config.json");
-        const singleFile = {
-          exists: fs.existsSync(cfg),
-          content: fs.readFileSync(cfg, "utf8"),
-          readdirCode: errcode(() => fs.readdirSync(cfg)),
-        };
-
-        console.log(JSON.stringify({ fileLoader, client, enoent, singleFile }));
-      `,
-        "data.txt": "hello",
-        "client/index.html": "<!doctype html><h1>hi</h1>",
-        "client/favicon.svg": "<svg/>",
-        "client/_app/immutable/app.css": "body{margin:0}",
-        "client/_app/immutable/chunks/entry.js": "export default 1;",
-        "config.json": `{"ok":true}`,
-      });
-
-      await compile(String(dir), ["--asset", "./client", "--asset", "./config.json"]);
-      const { stdout, stderr, code } = await run(String(dir));
-      expect(stderr.trim()).toBe("");
-      const r = JSON.parse(stdout.trim());
-
-      const expectedRecursive = [
-        "_app",
-        join("_app", "immutable"),
-        join("_app", "immutable", "app.css"),
-        join("_app", "immutable", "chunks"),
-        join("_app", "immutable", "chunks", "entry.js"),
-        "favicon.svg",
-        "index.html",
-      ].sort();
-
-      expect(r).toEqual({
-        fileLoader: {
-          assetExists: true,
-          dirExists: true,
-          dirExistsTrailingSlash: true,
-          dirStatIsDir: true,
-          dirLstatIsDir: true,
-          accessOk: true,
-          accessWriteErr: "EACCES",
-          // the hashed file-loader name is covered by readdirHasAsset
-          readdir: expect.arrayContaining(["client", "config.json"]),
-          readdirHasAsset: true,
-        },
-        client: {
-          root: expect.stringMatching(/[/\\]root[/\\]client$/),
-          entries: ["_app", "favicon.svg", "index.html"],
-          byName: {
-            _app: { isDir: true, isFile: false },
-            "favicon.svg": { isDir: false, isFile: true },
-            "index.html": { isDir: false, isFile: true },
-          },
-          indexHtmlExists: true,
-          indexHtmlSize: "<!doctype html><h1>hi</h1>".length,
-          indexHtmlContent: "<!doctype html><h1>hi</h1>",
-          nestedCssExists: true,
-          nestedCssContent: "body{margin:0}",
-          nestedCssViaReadFile: "body{margin:0}",
-          nestedDirIsDir: true,
-          readFileDirErr: "EISDIR",
-          recursive: expectedRecursive,
-          recursiveAsync: expectedRecursive,
-          embeddedFileCount: expect.any(Number),
-        },
-        enoent: { code: "ENOENT", exists: false },
-        singleFile: { exists: true, content: `{"ok":true}`, readdirCode: "ENOTDIR" },
-      });
-      // recursive uses the platform path separator (same as Node's real-fs recursive readdir)
-      expect(r.client.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");
-      // data.txt + config.json + 4 under client/
-      expect(r.client.embeddedFileCount).toBeGreaterThanOrEqual(6);
-      expect(code).toBe(0);
+      // Run from a cwd outside the build directory so the executable cannot find the real files on disk.
+      expectAppOutput(await run([join(String(dir), "app" + exe)], tmpdir()));
     },
     TIMEOUT,
   );
 
-  // One Bun.build() covers both the directory-asset and the single-file-asset
-  // JS-API paths, including the index.js-does-not-collide-with-entry case.
-  // These used to be two separate Bun.build() calls (each writes a ~1GB binary).
+  // Bun.build() writes the executable on the calling thread, and on Windows
+  // spawning a freshly written executable blocks the caller until the antivirus
+  // has scanned it. Doing both in a child process keeps this test from stalling
+  // the rest of the file and lets its scan overlap with the CLI test's.
   test(
-    "Bun.build({compile: {assets}}): directory + file assets, entry keyed at basename(outfile)",
+    "Bun.build({ compile: { assets } })",
     async () => {
       using dir = tempDir("bunfs-jsapi", {
-        "index.ts": /* ts */ `
-          import fs from "node:fs";
-          import path from "node:path";
-          const root = path.join(import.meta.dir, "public");
-          console.log(JSON.stringify({
-            entries: fs.readdirSync(root).sort(),
-            content: fs.readFileSync(path.join(root, "index.html"), "utf8"),
-            subCss: fs.readFileSync(path.join(root, "sub", "a.css"), "utf8"),
-            // entry is keyed at basename(outfile), so an index.js asset is readable as itself
-            indexJs: fs.readFileSync(path.join(import.meta.dir, "index.js"), "utf8"),
-          }));
+        ...files,
+        "build.ts": /* ts */ `
+          import { tmpdir } from "node:os";
+          import { join } from "node:path";
+
+          await Bun.build({
+            entrypoints: ["./index.ts"],
+            compile: { outfile: "app", assets: ${JSON.stringify(assetArgs)} },
+          });
+          // Run from a cwd outside the build directory so the executable cannot find the real files on disk.
+          const app = Bun.spawnSync({
+            cmd: [join(import.meta.dir, "app${exe}")],
+            cwd: tmpdir(),
+            stdout: "inherit",
+            stderr: "inherit",
+          });
+          process.exit(app.exitCode);
         `,
-        "public/index.html": "<h1>js-api</h1>",
-        "public/sub/a.css": "body{}",
-        "cfg/index.js": `ASSET_CONTENT`,
       });
 
-      const result = await Bun.build({
-        entrypoints: [join(String(dir), "index.ts")],
-        compile: {
-          outfile: join(String(dir), "app"),
-          assets: [join(String(dir), "public"), join(String(dir), "cfg", "index.js")],
-        },
-      });
-      expect(result.success).toBe(true);
-
-      const { stdout, stderr, code } = await run(String(dir));
-      expect(stderr.trim()).toBe("");
-      expect(JSON.parse(stdout.trim())).toEqual({
-        entries: ["index.html", "sub"],
-        content: "<h1>js-api</h1>",
-        subCss: "body{}",
-        indexJs: "ASSET_CONTENT",
-      });
-      expect(code).toBe(0);
+      expectAppOutput(await run([bunExe(), "build.ts"], String(dir)));
     },
     TIMEOUT,
   );
 
-  test(
-    "Bun.build({compile: {assets}}) rejects colliding paths",
-    async () => {
-      using dir = tempDir("bunfs-asset-jsapi-err", {
-        "index.ts": `console.log("x");`,
-        "a/data.json": `1`,
-        "b/data.json": `2`,
-      });
+  // Both front ends reject bad asset sets before the executable is written,
+  // so none of the cases below copies the bun binary.
+  const rejectFiles = {
+    "index.ts": `console.log("unreachable");`,
+    "index.html": `<!doctype html>`,
+    "a/config.json": `1`,
+    "b/config.json": `2`,
+    "client/index.html": `x`,
+    "public/a.txt": `a`,
+  };
+  const rejectEntries = ["a", "b", "client", "index.html", "index.ts", "public"];
+
+  test.each([
+    {
+      name: "two assets embedding at the same path",
+      outfile: "app",
+      assets: ["a/config.json", "b/config.json"],
+      error: `asset "<dir>/b/config.json" collides with another embedded file at "config.json"`,
+    },
+    {
+      name: "an asset named like the outfile",
+      outfile: "dist/client",
+      assets: ["client"],
+      error: `asset "<dir>/client" would embed at the same path as the entry point; use a different outfile`,
+    },
+  ])(
+    "Bun.build({ compile: { assets } }) rejects $name",
+    async ({ outfile, assets, error }) => {
+      using dir = tempDir("bunfs-jsapi-reject", rejectFiles);
       const result = await Bun.build({
         entrypoints: [join(String(dir), "index.ts")],
         throw: false,
         compile: {
-          outfile: join(String(dir), "app"),
-          assets: [join(String(dir), "a", "data.json"), join(String(dir), "b", "data.json")],
+          outfile: join(String(dir), outfile),
+          assets: assets.map(asset => join(String(dir), asset)),
         },
       });
+      expect(result.logs.map(log => `${log.level}: ${normalizeBunSnapshot(log.message, String(dir))}`)).toEqual([
+        `error: ${error}`,
+      ]);
+      expect(result.outputs).toEqual([]);
       expect(result.success).toBe(false);
-      const logs = result.logs.map(String).join("\n");
-      expect(logs).toContain("collides");
-      expect(logs).toContain("data.json");
-    },
-    TIMEOUT,
-  );
-
-  test(
-    "--asset errors on colliding embedded paths",
-    async () => {
-      using dir = tempDir("bunfs-asset-collide", {
-        "index.ts": `console.log("unreachable");`,
-        "a/config.json": `1`,
-        "b/config.json": `2`,
-      });
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "build",
-          "--compile",
-          "./index.ts",
-          "--outfile",
-          "app",
-          "--asset",
-          "./a/config.json",
-          "--asset",
-          "./b/config.json",
-        ],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "ignore",
-        stderr: "pipe",
-      });
-      const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain("collides");
-      expect(stderr).toContain("config.json");
-      expect(code).not.toBe(0);
-    },
-    TIMEOUT,
-  );
-
-  test(
-    "--asset errors when its basename matches --outfile",
-    async () => {
-      using dir = tempDir("bunfs-asset-entry", {
-        "index.ts": `console.log("unreachable");`,
-        "client/index.html": `x`,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "build", "--compile", "./index.ts", "--outfile", "./dist/client", "--asset", "./client"],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "ignore",
-        stderr: "pipe",
-      });
-      const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain("same path as the entry point");
-      expect(code).not.toBe(0);
+      expect(readdirSync(String(dir)).sort()).toEqual(rejectEntries);
     },
     TIMEOUT,
   );
 
   test.each([
-    [["build", "./index.ts", "--asset", "./public"], "--asset requires --compile"],
-    [
-      ["build", "--compile", "--target=browser", "./index.html", "--asset", "./public"],
-      "--target browser with --asset",
-    ],
-    [["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"], "failed to read asset"],
-    ...(process.platform === "win32"
+    {
+      name: "two assets embedding at the same path",
+      args: ["--compile", "./index.ts", "--outfile", "app", "--asset", "./a/config.json", "--asset", "./b/config.json"],
+      error: `asset "./b/config.json" collides with another embedded file at "config.json"`,
+    },
+    {
+      name: "an asset named like the outfile",
+      args: ["--compile", "./index.ts", "--outfile", "./dist/client", "--asset", "./client"],
+      error: `asset "./client" would embed at the same path as the entry point; use a different outfile`,
+    },
+    {
+      name: "--asset without --compile",
+      args: ["./index.ts", "--asset", "./public"],
+      error: "--asset requires --compile",
+    },
+    {
+      name: "--asset with --target=browser",
+      args: ["--compile", "--target=browser", "./index.html", "--asset", "./public"],
+      error: "cannot use --compile --target browser with --asset",
+    },
+    {
+      name: "an asset that does not exist",
+      args: ["--compile", "./index.ts", "--outfile", "app", "--asset", "./does-not-exist"],
+      error: `failed to read asset "./does-not-exist": ENOENT: ./does-not-exist: No such file or directory (stat())`,
+    },
+    ...(isWindows
       ? []
       : [
-          [
-            ["build", "--compile", "./index.ts", "--outfile", "app", "--asset", "/dev/null"],
-            "is not a regular file or directory",
-          ] as const,
+          {
+            name: "an asset that is neither a file nor a directory",
+            args: ["--compile", "./index.ts", "--outfile", "app", "--asset", "/dev/null"],
+            error: `asset "/dev/null" is not a regular file or directory`,
+          },
         ]),
   ])(
-    "rejects %j",
-    async (args, expected) => {
-      using dir = tempDir("bunfs-asset-reject", {
-        "index.ts": `console.log("x");`,
-        "index.html": `<!doctype html>`,
-        "public/a.txt": `a`,
-      });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), ...args],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "ignore",
-        stderr: "pipe",
-      });
-      const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain(expected);
-      expect(code).not.toBe(0);
+    "bun build rejects $name",
+    async ({ args, error }) => {
+      using dir = tempDir("bunfs-cli-reject", rejectFiles);
+      const { stdout, stderr, exitCode } = await run([bunExe(), "build", ...args], String(dir));
+      expect(stdout).toBe("");
+      expect(stderr).toBe(`error: ${error}\n`);
+      expect(exitCode).toBe(1);
+      expect(readdirSync(String(dir)).sort()).toEqual(rejectEntries);
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## What

`test/bundler/compile-asset-bunfs.test.ts` shows up as the slowest file on the Windows 11 aarch64 lane (39.90s in builds 91993 and 91926; the other lanes report ~7s). Test-only change, `src/` is untouched.

## Why it was slow

The number the runner prints for a file in the parallel bucket is the describe block's sum of per-case durations, and every one of the 8 cases in this file was reporting roughly the duration of a compile. #36820 had already cut the file down to two real compiles (one `bun build --compile`, one `Bun.build({ compile })`); the other six cases fail while collecting assets, before the bun binary is copied, and take 0.1-0.5s each in isolation under a debug build. They were reporting 2.6s (linux debug) to 4.8s (Windows) because the test process itself was stalled:

- `Bun.build({ compile })` writes the executable on the thread that called it (`do_compilation` runs inside the bundle completion task), so while the in-process build in this file was copying the binary, no other test could observe its subprocess exiting. Under a debug build that is a 2.5s+ stall; a 1ms interval shows a single `132ms -> 2701ms` gap.
- On Windows, spawning a freshly written executable blocks inside `Bun.spawn()` until the antivirus has scanned it (~2.2s for a 75MB exe on the arm64 runner; the same exe starts in 35ms the second time). With both compiled executables spawned from the test process, those two scans ran back to back on the test thread, so the whole file took ~4.9s of wall clock and every case was charged ~4.8s.

## Change

- One program and one asset layout are compiled twice, once through `bun build --compile --asset ...` and once through `Bun.build({ compile: { assets } })`, and both executables have to print exactly the same JSON. The `Bun.build()` build and the run of its executable happen in a small `build.ts` child so the copy and the scan happen off the test thread and overlap with the CLI test's.
- The rejection cases become two `test.each` tables (CLI and JS API) over a shared layout.

Compiles: 2 before, 2 after. The two front ends reach the shared backend through different code (`collect_compile_assets` is called with the raw `--outfile` by the CLI and with the computed entry key by `do_compilation`), so one executable per front end is the minimum that keeps both success paths covered; the rejection cases never copy the binary.

## Assertions

- The `Bun.build()` executable is checked against the same full expected object as the CLI one (it previously checked four fields).
- `import.meta.dir` and `import.meta.path` are asserted exactly (`/$bunfs/root/app`, `B:\~BUN\root\app` on Windows), which checks the entry-keyed-at-`basename(outfile)` rule directly for both front ends.
- `readdir` of the virtual root is an exact list (was `arrayContaining` plus an `includes` check); the file-loader asset's path is asserted as `<root>/data-<hash>.txt` and its content is read back.
- `Bun.embeddedFiles` is asserted as the exact list of names (was `expect.any(Number)` plus `>= 6`).
- `accessSync` results are reported as the raw code (`null` / `"EACCES"`) instead of a boolean; `statSync` on a missing path is asserted to give `ENOENT`.
- New scenarios at no extra compile cost: an `--asset` whose basename matches the entry's source file name on the CLI path (was JS API only), and `Bun.build()` rejecting an asset named like the outfile (was CLI only).
- Rejections assert the exact stderr line and exit code 1 (was two `toContain` and `not.toBe(0)`), that stdout is empty, and that the directory listing is unchanged afterwards. The JS API cases assert `result.logs` as the exact `level: message`, `outputs` empty, and the same unchanged listing.
- The CLI build step asserts empty stderr and exit 0; both executables assert `stderr` is exactly `""` (was `.trim()`), with the exit code checked last.

## Timing

Interleaved runs of the file before and after, three rounds each, same machine and binary.

`bun bd test test/bundler/compile-asset-bunfs.test.ts` (linux-x64, debug + ASAN; the 1GB binary copy dominates either way):

| | before | after |
| --- | --- | --- |
| file time reported by `bun test` | 8.11s / 6.83s / 6.47s | 7.04s / 6.82s / 7.03s |
| sum of case durations | 20.5s / 16.9s / 16.4s | 10.5s / 10.1s / 10.5s |
| cases | 9 | 10 |
| expect() calls | 25 | 42 |

`bun test test/bundler/compile-asset-bunfs.test.ts` with a release build of the same commit on Windows 11 aarch64 (the lane from the report):

| | before | after |
| --- | --- | --- |
| wall clock | 4.90s / 4.88s / 4.85s | 2.77s / 2.74s / 2.73s |
| sum of case durations (the number CI reports) | 35.7s / 35.6s / 35.4s | 5.6s / 5.5s / 5.5s |
| cases | 8 | 9 |

On this PR's own CI run (build 92237) the Windows 11 aarch64 lane ran the file in 3.29s wall clock; every lane passed.

The error messages asserted exactly are produced from bun's own errno table and were byte-identical on linux and Windows.

The `Bun.build()` stall and the runner reporting a describe suite's summed time as the file's time are separate problems; this PR only restructures the test.

