### PR TITLE
bundler: HTML loader reads chunks via &[Chunk], not *mut [Chunk]

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -282,15 +282,12 @@ impl Chunk {
         }
     }
 
-    pub(crate) fn get_js_chunk_for_html<'a>(
-        &self,
-        chunks: &'a mut [Chunk],
-    ) -> Option<&'a mut Chunk> {
+    pub(crate) fn get_js_chunk_for_html<'a>(&self, chunks: &'a [Chunk]) -> Option<&'a Chunk> {
         // Non-entry chunks created under code splitting carry a default
         // entry_point_id of 0, so the id alone is ambiguous; require
         // is_entry_point to find the actual entry chunk.
         let entry_point_id = self.entry_point.entry_point_id();
-        for other in chunks.iter_mut() {
+        for other in chunks.iter() {
             if matches!(other.content, Content::Javascript(_))
                 && other.entry_point.is_entry_point()
                 && other.entry_point.entry_point_id() == entry_point_id
@@ -301,37 +298,25 @@ impl Chunk {
         None
     }
 
-    pub(crate) fn get_css_chunk_for_html<'a>(
-        &self,
-        chunks: &'a mut [Chunk],
-    ) -> Option<&'a mut Chunk> {
+    pub(crate) fn get_css_chunk_for_html<'a>(&self, chunks: &'a [Chunk]) -> Option<&'a Chunk> {
         // Look up the CSS chunk via the JS chunk's css_chunks indices.
         // This correctly handles deduplicated CSS chunks that are shared
         // across multiple HTML entry points (see issue #23668).
-        // Note: reshaped for borrowck — we scan immutably for the JS chunk, copy the
-        // css-chunk index into a local, drop the borrow, then re-borrow mutably.
         let entry_point_id = self.entry_point.entry_point_id();
-        let css_idx: Option<usize> = 'find: {
-            for other in chunks.iter() {
-                if let Content::Javascript(js) = &other.content {
-                    if other.entry_point.is_entry_point()
-                        && other.entry_point.entry_point_id() == entry_point_id
-                    {
-                        let css_chunk_indices = &js.css_chunks[..];
-                        if !css_chunk_indices.is_empty() {
-                            break 'find Some(css_chunk_indices[0] as usize);
-                        }
-                        break 'find None;
+        for other in chunks.iter() {
+            if let Content::Javascript(js) = &other.content {
+                if other.entry_point.is_entry_point()
+                    && other.entry_point.entry_point_id() == entry_point_id
+                {
+                    if let Some(&css_idx) = js.css_chunks.first() {
+                        return Some(&chunks[css_idx as usize]);
                     }
+                    break;
                 }
             }
-            None
-        };
-        if let Some(idx) = css_idx {
-            return Some(&mut chunks[idx]);
         }
         // Fallback: match by entry_point_id for cases without a JS chunk.
-        for other in chunks.iter_mut() {
+        for other in chunks.iter() {
             if matches!(other.content, Content::Css(_))
                 && other.entry_point.is_entry_point()
                 && other.entry_point.entry_point_id() == entry_point_id

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1583,9 +1583,9 @@ pub struct GenerateChunkCtx<'a> {
     /// `generate_chunks_in_parallel`. The slice outlives every
     /// `GenerateChunkCtx` (joined via `wait_for_all`), so [`bun_ptr::BackRef`]'s
     /// owner-outlives-holder invariant holds and per-task reads go through
-    /// safe `Deref`. Tasks that need write provenance (HTML loader) recover
-    /// the raw `*mut [Chunk]` via [`bun_ptr::BackRef::as_ptr`].
-    pub(crate) chunks: bun_ptr::BackRef<[Chunk], bun_ptr::Mut>,
+    /// safe `Deref`. Read-only: each task writes only through its own
+    /// `*mut Chunk`.
+    pub(crate) chunks: bun_ptr::BackRef<[Chunk]>,
     /// Backref to this task's `Chunk` (an element of `chunks`). Constructed
     /// via [`bun_ptr::BackRef::new_mut`] so the stored `NonNull` carries write
     /// provenance; per-task slot writes recover the raw `*mut Chunk` via

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -64,7 +64,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // SAFETY: `c` is the live `&mut LinkerContext` for the link step;
             // write provenance preserved.
             c: unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) },
-            chunks: bun_ptr::BackRef::new_mut(chunks),
+            chunks: bun_ptr::BackRef::new(&*chunks),
         };
         // SAFETY: `parse_graph` is the `BundleV2.graph` backref (valid for the
         // link step); `pool` is the arena-allocated bundler ThreadPool.
@@ -138,13 +138,12 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         {
             let mut total_count: usize = 0;
             // `GenerateChunkCtx` fields are raw pointers; capture them
-            // before the `iter_mut()` borrow so the same `*mut [Chunk]` can be
+            // before the `iter_mut()` borrow so the same slice backref can be
             // stored in every ctx.
             // SAFETY: `c` is the live `&mut LinkerContext` for the link step.
             let c_ref =
                 unsafe { bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<LinkerContext>(c)) };
-            let chunks_ref: bun_ptr::BackRef<[Chunk], bun_ptr::Mut> =
-                bun_ptr::BackRef::new_mut(chunks);
+            let chunks_ref: bun_ptr::BackRef<[Chunk]> = bun_ptr::BackRef::new(&*chunks);
             for chunk in chunks.iter_mut() {
                 chunk_contexts.push(GenerateChunkCtx {
                     c: c_ref,

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -56,15 +56,12 @@ pub(crate) unsafe fn generate_compile_result_for_html_chunk(task: *mut ThreadPoo
     let i = part_range.i as usize;
     let ctx: &GenerateChunkCtx = part_range.ctx;
 
-    // `ctx.chunks` is a `BackRef<[Chunk]>` constructed via `new_mut` (write
-    // provenance); recover the raw `*mut [Chunk]` for the HTML loader, which
-    // still needs `&mut [Chunk]` for `get_{js,css}_chunk_for_html`.
-    let chunks: *mut [Chunk] = ctx.chunks.as_ptr();
-    // `ctx.c` is `ParentRef<LinkerContext>` and `ctx.chunk` is `BackRef<Chunk>`
-    // — both yield safe shared borrows via `.get()`. `chunk` is this task's
+    // `ctx.c` is a `ParentRef` and `ctx.chunk` / `ctx.chunks` are `BackRef`s;
+    // all yield safe shared borrows via `.get()`. `chunk` is this task's
     // exclusively-owned HTML chunk for the duration of the compile step.
     let c_ref: &LinkerContext = ctx.c.get();
     let chunk_ref: &Chunk = ctx.chunk.get();
+    let chunks: &[Chunk] = ctx.chunks.get();
     let result = generate_compile_result_for_html_chunk_impl(c_ref, chunk_ref, chunks);
     // SAFETY: HTML chunks have exactly one part-range (i == 0); see
     // `Chunk::write_compile_result_slot` for the disjoint-slot contract.
@@ -82,11 +79,9 @@ struct HTMLLoader<'a> {
     linker: &'a LinkerContext<'a>,
     import_records: &'a [ImportRecord],
     current_import_record_index: u32,
-    /// Backref to this task's HTML chunk (an element of `*chunks`). The chunk
-    /// outlives this `HTMLLoader` (link-step duration), so `BackRef`'s
-    /// owner-outlives-holder invariant holds and reads go through safe `Deref`.
-    chunk: bun_ptr::BackRef<Chunk>,
-    chunks: *mut [Chunk],
+    /// This task's HTML chunk, an element of `chunks`.
+    chunk: &'a Chunk,
+    chunks: &'a [Chunk],
     compile_to_standalone_html: bool,
     output: Vec<u8>,
     end_tag_indices: EndTagIndices,
@@ -273,9 +268,7 @@ impl<'a> HTMLLoader<'a> {
     /// The inline `<script type="module">…</script>` holding this HTML
     /// chunk's JavaScript chunk, if it has one.
     fn standalone_body_script(&self) -> Option<String> {
-        // SAFETY: `self.chunks` raw `*mut [Chunk]` valid for the link step; sole live `&mut`.
-        let chunks = unsafe { &mut *self.chunks };
-        let js_chunk = self.chunk.get_js_chunk_for_html(chunks)?;
+        let js_chunk = self.chunk.get_js_chunk_for_html(self.chunks)?;
         Some(format!(
             "<script type=\"module\">{}</script>",
             BStr::new(js_chunk.unique_key)
@@ -284,13 +277,9 @@ impl<'a> HTMLLoader<'a> {
 
     fn get_head_tags(&self) -> Vec<String> {
         let mut array: Vec<String> = Vec::with_capacity(2);
-        // `self.chunk` is a `BackRef` (safe `Deref`).
-        let chunk: &Chunk = &self.chunk;
-        // SAFETY: `chunks` raw pointer valid for the link step; sole live `&mut`.
-        let chunks = unsafe { &mut *self.chunks };
         if self.compile_to_standalone_html {
             // In standalone HTML mode, only put CSS in <head>; JS goes before </body>
-            if let Some(css_chunk) = chunk.get_css_chunk_for_html(chunks) {
+            if let Some(css_chunk) = self.chunk.get_css_chunk_for_html(self.chunks) {
                 array.push(format!(
                     "<style>{}</style>",
                     BStr::new(css_chunk.unique_key)
@@ -298,13 +287,13 @@ impl<'a> HTMLLoader<'a> {
             }
         } else {
             // Put CSS before JS to reduce chances of flash of unstyled content
-            if let Some(css_chunk) = chunk.get_css_chunk_for_html(chunks) {
+            if let Some(css_chunk) = self.chunk.get_css_chunk_for_html(self.chunks) {
                 array.push(format!(
                     "<link rel=\"stylesheet\" crossorigin href=\"{}\">",
                     BStr::new(css_chunk.unique_key)
                 ));
             }
-            if let Some(js_chunk) = chunk.get_js_chunk_for_html(chunks) {
+            if let Some(js_chunk) = self.chunk.get_js_chunk_for_html(self.chunks) {
                 // type="module" scripts do not block rendering, so it is okay to put them in head
                 array.push(format!(
                     "<script type=\"module\" crossorigin src=\"{}\"></script>",
@@ -360,15 +349,10 @@ impl<'a> HTMLLoader<'a> {
     }
 }
 
-/// `chunk` is the HTML chunk being compiled (held read-only via `BackRef`
-/// inside `HTMLLoader`). `chunks` is the raw `*mut [Chunk]` from
-/// `GenerateChunkCtx.chunks` (write provenance, valid for the link step) —
-/// stored as-is and only deref'd at the guarded `&mut *` sites in
-/// `HTMLLoader::{on_tag,get_head_tags}` and the standalone-HTML branch below.
 fn generate_compile_result_for_html_chunk_impl<'a>(
     c: &'a LinkerContext<'a>,
-    chunk: &Chunk,
-    chunks: *mut [Chunk],
+    chunk: &'a Chunk,
+    chunks: &'a [Chunk],
 ) -> CompileResult {
     let parse_graph = c.parse_graph();
     let sources = parse_graph.input_files.items_source();
@@ -397,7 +381,7 @@ fn generate_compile_result_for_html_chunk_impl<'a>(
         import_records: records,
         current_import_record_index: 0,
         compile_to_standalone_html,
-        chunk: bun_ptr::BackRef::new(chunk),
+        chunk,
         chunks,
         output: Vec::new(),
         end_tag_indices: EndTagIndices {


### PR DESCRIPTION
## What

`Chunk::get_js_chunk_for_html` and `Chunk::get_css_chunk_for_html` (`src/bundler/Chunk.rs`) took `&'a mut [Chunk]` and returned `Option<&'a mut Chunk>`, but their only 4 callers (all in `src/bundler/linker_context/generateCompileResultForHtmlChunk.rs`) read just `.unique_key` of the result. To satisfy that signature, the HTML compile task recovered a raw pointer from the shared context (`let chunks: *mut [Chunk] = ctx.chunks.as_ptr();`), stored it in `HTMLLoader.chunks: *mut [Chunk]`, threaded it through `generate_compile_result_for_html_chunk_impl`, and materialised `unsafe { &mut *self.chunks }` in both `standalone_body_script` and `get_head_tags`. The SAFETY comments claimed that was the sole live `&mut`, which is not the case: this callback runs on the worker pool, one task per HTML chunk, concurrently with the JS/CSS part-range tasks holding views into their own elements of the same slice and with any other HTML task doing the same thing.

```rust
// before
pub(crate) fn get_js_chunk_for_html<'a>(&self, chunks: &'a mut [Chunk]) -> Option<&'a mut Chunk>
pub(crate) fn get_css_chunk_for_html<'a>(&self, chunks: &'a mut [Chunk]) -> Option<&'a mut Chunk>

struct HTMLLoader<'a> {
    chunk: bun_ptr::BackRef<Chunk>,
    chunks: *mut [Chunk],
    ..
}

// after
pub(crate) fn get_js_chunk_for_html<'a>(&self, chunks: &'a [Chunk]) -> Option<&'a Chunk>
pub(crate) fn get_css_chunk_for_html<'a>(&self, chunks: &'a [Chunk]) -> Option<&'a Chunk>

struct HTMLLoader<'a> {
    chunk: &'a Chunk,
    chunks: &'a [Chunk],
    ..
}
```

- Both helpers iterate with `iter()` and return shared references. The labelled block in `get_css_chunk_for_html` existed only to copy the CSS index out before re-borrowing mutably; it is now a direct `return Some(&chunks[css_idx as usize])` with the same fallback behaviour (the `break` keeps the old "stop at the first matching JS chunk, then fall back" control flow).
- The task callback takes `ctx.chunks.get()` next to the existing `ctx.c.get()` / `ctx.chunk.get()` and passes plain references to `generate_compile_result_for_html_chunk_impl(c, chunk: &'a Chunk, chunks: &'a [Chunk])`. `HTMLLoader` stores both as `&'a` borrows (the `chunk` field was a lifetime-erased `BackRef` with a comment describing the lifetime that the type now states), and the 4 call sites become `self.chunk.get_..._chunk_for_html(self.chunks)`. Removes 2 unsafe blocks and the `as_ptr()` recovery.
- With no remaining writer through it, `GenerateChunkCtx.chunks` (`src/bundler/LinkerContext.rs`) is narrowed from `BackRef<[Chunk], Mut>` to `BackRef<[Chunk]>`; its two construction sites in `generateChunksInParallel.rs` become `BackRef::new(&*chunks)`. The other readers (`postProcessJSChunk`, `postProcessCSSChunk`, `postProcessHTMLChunk`) already used the safe `Deref`. Per-task writes keep going through `GenerateChunkCtx.chunk` (still `BackRef<Chunk, Mut>`) and the `*mut Chunk` that `each_ptr` hands out.

## Why

The HTML task now holds the same kind of view of the chunk list that the CSS task and the post-process tasks already hold, a shared borrow for the duration of the task, and the context type says that nothing writes through `chunks`; the two unsafe blocks whose justification was false are gone. Only reference mutability and lifetimes change: the lookups compile to the same loops and the same `unique_key` loads (the `first()` check replaces an `is_empty()` plus index), `&[Chunk]`, `*mut [Chunk]` and `BackRef<[Chunk]>` are all one fat pointer, so `HTMLLoader` and `GenerateChunkCtx` keep their layout, and no check, allocation or indirection is added on any path.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/bundler/bundler_html.test.ts: 22 pass, test/bundler/standalone.test.ts: 23 pass, test/bake/dev/html.test.ts: 10 pass, test/js/bun/http/bun-serve-html.test.ts: 17 pass, 2 skip; 0 fail in all four files.
Running bundler_html.test.ts and bun-serve-html.test.ts in the same process aborts on a pre-existing debug assertion in DevServer::relative_path (src/runtime/bake/DevServer.rs:6040, dev server root keeps a trailing slash after an in-process process.chdir); this reproduces identically on main and is unrelated to this change.
