### PR TITLE
dotenv: replace placeholder Source slots with EnumSet<DefaultEnvFile>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,6 @@ dependencies = [
  "bitflags",
  "bstr",
  "bun_alloc",
- "bun_ast",
  "bun_collections",
  "bun_core",
  "bun_dispatch",

--- a/src/dotenv/Cargo.toml
+++ b/src/dotenv/Cargo.toml
@@ -24,7 +24,6 @@ bun_core.workspace = true
 bun_errno.workspace = true
 bun_dispatch.workspace = true
 bun_collections.workspace = true
-bun_ast.workspace = true
 bun_paths.workspace = true
 bun_sys.workspace = true
 bun_url.workspace = true

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -4,13 +4,14 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
 use bun_alloc::AllocError;
-use bun_collections::{ArrayHashMapExt, GetOrPutResult, StringArrayHashMap};
+use bun_collections::{ArrayHashMapExt, GetOrPutResult, StringSet};
 use bun_core::{self, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::{self, MAX_PATH_BYTES, PathBuffer};
 use bun_sys;
 use bun_url::URL;
 use bun_which::which;
+use enumset::EnumSet;
 
 use bun_core::analytics;
 
@@ -19,6 +20,35 @@ pub enum DotEnvFileSuffix {
     Development,
     Production,
     Test,
+}
+
+/// The `.env*` files `Loader::load_default_files` probes for, declared in the
+/// order `print_loaded` lists them.
+#[derive(enumset::EnumSetType)]
+pub(crate) enum DefaultEnvFile {
+    DevelopmentLocal,
+    ProductionLocal,
+    TestLocal,
+    Local,
+    Development,
+    Production,
+    Test,
+    Env,
+}
+
+impl DefaultEnvFile {
+    fn name(self) -> &'static [u8] {
+        match self {
+            Self::DevelopmentLocal => b".env.development.local",
+            Self::ProductionLocal => b".env.production.local",
+            Self::TestLocal => b".env.test.local",
+            Self::Local => b".env.local",
+            Self::Development => b".env.development",
+            Self::Production => b".env.production",
+            Self::Test => b".env.test",
+            Self::Env => b".env",
+        }
+    }
 }
 
 /// Directory-entry probe used by `Loader::load`. `bun_dotenv` sits below
@@ -111,17 +141,10 @@ pub struct S3Credentials {
 pub struct Loader {
     pub map: Map,
     // allocator dropped — global mimalloc (see PORTING.md §Allocators)
-    pub(crate) env_local: Option<bun_ast::Source>,
-    pub(crate) env_development: Option<bun_ast::Source>,
-    pub(crate) env_production: Option<bun_ast::Source>,
-    pub(crate) env_test: Option<bun_ast::Source>,
-    pub(crate) env_development_local: Option<bun_ast::Source>,
-    pub(crate) env_production_local: Option<bun_ast::Source>,
-    pub(crate) env_test_local: Option<bun_ast::Source>,
-    pub(crate) env: Option<bun_ast::Source>,
+    pub(crate) default_files_loaded: EnumSet<DefaultEnvFile>,
 
     /// only populated with files specified explicitly (e.g. --env-file arg)
-    pub(crate) custom_files_loaded: StringArrayHashMap<bun_ast::Source>,
+    pub(crate) custom_files_loaded: StringSet,
 
     pub quiet: bool,
 
@@ -564,15 +587,8 @@ impl Loader {
     pub fn init_with_map(map: Map) -> Loader {
         Loader {
             map,
-            env_local: None,
-            env_development: None,
-            env_production: None,
-            env_test: None,
-            env_development_local: None,
-            env_production_local: None,
-            env_test_local: None,
-            env: None,
-            custom_files_loaded: StringArrayHashMap::default(),
+            default_files_loaded: EnumSet::empty(),
+            custom_files_loaded: StringSet::new(),
             quiet: false,
             did_load_process: false,
             reject_unauthorized: Cell::new(None),
@@ -688,107 +704,81 @@ impl Loader {
         let dir_handle = bun_sys::Fd::cwd();
 
         match suffix {
-            DotEnvFileSuffix::Development => {
-                self.try_load_default(dir, dir_handle, b".env.development.local", value_buffer)?
-            }
-            DotEnvFileSuffix::Production => {
-                self.try_load_default(dir, dir_handle, b".env.production.local", value_buffer)?
-            }
+            DotEnvFileSuffix::Development => self.try_load_default(
+                dir,
+                dir_handle,
+                DefaultEnvFile::DevelopmentLocal,
+                value_buffer,
+            )?,
+            DotEnvFileSuffix::Production => self.try_load_default(
+                dir,
+                dir_handle,
+                DefaultEnvFile::ProductionLocal,
+                value_buffer,
+            )?,
             DotEnvFileSuffix::Test => {
-                self.try_load_default(dir, dir_handle, b".env.test.local", value_buffer)?
+                self.try_load_default(dir, dir_handle, DefaultEnvFile::TestLocal, value_buffer)?
             }
         }
 
         if suffix != DotEnvFileSuffix::Test {
-            self.try_load_default(dir, dir_handle, b".env.local", value_buffer)?;
+            self.try_load_default(dir, dir_handle, DefaultEnvFile::Local, value_buffer)?;
         }
 
         match suffix {
             DotEnvFileSuffix::Development => {
-                self.try_load_default(dir, dir_handle, b".env.development", value_buffer)?
+                self.try_load_default(dir, dir_handle, DefaultEnvFile::Development, value_buffer)?
             }
             DotEnvFileSuffix::Production => {
-                self.try_load_default(dir, dir_handle, b".env.production", value_buffer)?
+                self.try_load_default(dir, dir_handle, DefaultEnvFile::Production, value_buffer)?
             }
             DotEnvFileSuffix::Test => {
-                self.try_load_default(dir, dir_handle, b".env.test", value_buffer)?
+                self.try_load_default(dir, dir_handle, DefaultEnvFile::Test, value_buffer)?
             }
         }
 
-        self.try_load_default(dir, dir_handle, b".env", value_buffer)
+        self.try_load_default(dir, dir_handle, DefaultEnvFile::Env, value_buffer)
     }
 
-    /// Probe `dir` for a known `.env*` filename and, if present, load it into
-    /// its dedicated slot and bump the analytics counter. Shared body for the
-    /// eight call sites in `load_default_files`.
+    /// Probe `dir` for a known `.env*` filename and, if present, load it and
+    /// bump the analytics counter. Shared body for the eight call sites in
+    /// `load_default_files`.
     #[inline]
     fn try_load_default<D: DirEntryProbe + ?Sized>(
         &mut self,
         dir: &D,
         dir_handle: bun_sys::Fd,
-        name: &'static [u8],
+        env_file: DefaultEnvFile,
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
-        if dir.has_comptime_query(name) {
-            self.load_env_file::<false>(dir_handle, name, value_buffer)?;
+        if dir.has_comptime_query(env_file.name()) {
+            self.load_env_file::<false>(dir_handle, env_file, value_buffer)?;
             analytics::Features::dotenv_inc();
         }
         Ok(())
     }
 
     pub(crate) fn print_loaded(&self, start: i128) {
-        let count: usize = (self.env_development_local.is_some() as usize)
-            + (self.env_production_local.is_some() as usize)
-            + (self.env_test_local.is_some() as usize)
-            + (self.env_local.is_some() as usize)
-            + (self.env_development.is_some() as usize)
-            + (self.env_production.is_some() as usize)
-            + (self.env_test.is_some() as usize)
-            + (self.env.is_some() as usize)
-            + self.custom_files_loaded.count();
+        let count: usize = self.default_files_loaded.len() + self.custom_files_loaded.count();
 
         if count == 0 {
             return;
         }
         let elapsed = (bun_core::time::nano_timestamp() - start) as f64 / 1_000_000.0;
 
-        const ALL: [&[u8]; 8] = [
-            b".env.development.local",
-            b".env.production.local",
-            b".env.test.local",
-            b".env.local",
-            b".env.development",
-            b".env.production",
-            b".env.test",
-            b".env",
-        ];
-        let loaded: [bool; 8] = [
-            self.env_development_local.is_some(),
-            self.env_production_local.is_some(),
-            self.env_test_local.is_some(),
-            self.env_local.is_some(),
-            self.env_development.is_some(),
-            self.env_production.is_some(),
-            self.env_test.is_some(),
-            self.env.is_some(),
-        ];
-
         let mut loaded_i: usize = 0;
         Output::print_elapsed(elapsed);
         bun_core::pretty_error!(" <d>");
 
-        for (i, &yes) in loaded.iter().enumerate() {
-            if yes {
-                loaded_i += 1;
-                if count == 1 || (loaded_i >= count && count > 1) {
-                    bun_core::pretty_error!("\"{}\"", bstr::BStr::new(ALL[i]));
-                } else {
-                    bun_core::pretty_error!("\"{}\", ", bstr::BStr::new(ALL[i]));
-                }
+        for env_file in self.default_files_loaded.iter() {
+            loaded_i += 1;
+            if count == 1 || (loaded_i >= count && count > 1) {
+                bun_core::pretty_error!("\"{}\"", bstr::BStr::new(env_file.name()));
+            } else {
+                bun_core::pretty_error!("\"{}\", ", bstr::BStr::new(env_file.name()));
             }
         }
 
-        // `iterator()` requires `&mut self`; iterate `keys()` slice instead.
         for k in self.custom_files_loaded.keys() {
             loaded_i += 1;
             if count == 1 || (loaded_i >= count && count > 1) {
@@ -802,30 +792,16 @@ impl Loader {
         Output::flush();
     }
 
-    /// Helper: maps a known `.env*` filename to its `Option<Source>` field.
-    fn default_file_slot(&mut self, base: &'static [u8]) -> &mut Option<bun_ast::Source> {
-        match base {
-            b".env.local" => &mut self.env_local,
-            b".env.development" => &mut self.env_development,
-            b".env.production" => &mut self.env_production,
-            b".env.test" => &mut self.env_test,
-            b".env.development.local" => &mut self.env_development_local,
-            b".env.production.local" => &mut self.env_production_local,
-            b".env.test.local" => &mut self.env_test_local,
-            b".env" => &mut self.env,
-            _ => unreachable!(),
-        }
-    }
-
     pub(crate) fn load_env_file<const OVERRIDE: bool>(
         &mut self,
         dir: bun_sys::Fd,
-        base: &'static [u8],
+        env_file: DefaultEnvFile,
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
-        if self.default_file_slot(base).is_some() {
+        if self.default_files_loaded.contains(env_file) {
             return Ok(());
         }
+        let base = env_file.name();
 
         // `bun_sys` is errno-based; the match arms below group the recoverable
         // errnos. Any errno not listed propagates.
@@ -837,8 +813,7 @@ impl Loader {
                     match err.get_errno() {
                         E::EISDIR | E::ENOENT => {
                             // prevent retrying
-                            *self.default_file_slot(base) =
-                                Some(bun_ast::Source::init_path_string(base, b""));
+                            self.default_files_loaded.insert(env_file);
                             return Ok(());
                         }
                         E::EBUSY | E::EACCES => {
@@ -850,8 +825,7 @@ impl Loader {
                                 );
                             }
                             // prevent retrying
-                            *self.default_file_slot(base) =
-                                Some(bun_ast::Source::init_path_string(base, b""));
+                            self.default_files_loaded.insert(env_file);
                             return Ok(());
                         }
                         _ => return Err(err.into()),
@@ -875,11 +849,7 @@ impl Loader {
             }
         }
 
-        // The file buffer is dropped after parsing because
-        // `bun_ast::Source.contents` is `&'static [u8]` and §Forbidden bans
-        // `Box::leak`. The stored `Source` is only ever checked for
-        // `.is_some()` / its path printed, so dropping the bytes is fine.
-        *self.default_file_slot(base) = Some(bun_ast::Source::init_path_string(base, b""));
+        self.default_files_loaded.insert(env_file);
         Ok(())
     }
 
@@ -896,12 +866,7 @@ impl Loader {
             Ok(f) => f,
             Err(_) => {
                 // prevent retrying
-                // `Source::init_path_string` requires a `'static` path; the
-                // map key already carries `file_path` (boxed), and the value is never
-                // read for its path/contents — only `.contains()` and key iteration —
-                // so an empty placeholder is observationally identical.
-                self.custom_files_loaded
-                    .put(file_path, bun_ast::Source::default())?;
+                self.custom_files_loaded.insert(file_path)?;
                 return Ok(());
             }
         };
@@ -922,10 +887,7 @@ impl Loader {
             }
         }
 
-        // See `load_env_file` — `Source.contents` is not retained; only
-        // `.contains()` / key iteration are ever observed.
-        self.custom_files_loaded
-            .put(file_path, bun_ast::Source::default())?;
+        self.custom_files_loaded.insert(file_path)?;
         Ok(())
     }
 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -22,8 +22,7 @@ pub enum DotEnvFileSuffix {
     Test,
 }
 
-/// The `.env*` files `Loader::load_default_files` probes for, declared in the
-/// order `print_loaded` lists them.
+/// Declaration order is the order `print_loaded` lists the files in.
 #[derive(enumset::EnumSetType)]
 pub(crate) enum DefaultEnvFile {
     DevelopmentLocal,
@@ -737,9 +736,6 @@ impl Loader {
         self.try_load_default(dir, dir_handle, DefaultEnvFile::Env, value_buffer)
     }
 
-    /// Probe `dir` for a known `.env*` filename and, if present, load it and
-    /// bump the analytics counter. Shared body for the eight call sites in
-    /// `load_default_files`.
     #[inline]
     fn try_load_default<D: DirEntryProbe + ?Sized>(
         &mut self,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -627,9 +627,6 @@ impl Loader {
         &mut self,
         str: &[u8],
     ) -> Result<(), AllocError> {
-        // Go straight to `parse_bytes` to avoid the
-        // `Source.contents: &'static [u8]` lifetime constraint (callers like
-        // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
         Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)
     }
@@ -1257,9 +1254,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    /// Same as [`parse`] but takes the source bytes directly. Exists so
-    /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
-    /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
+    /// Builds a [`Parser`] over `src` (minus any UTF-8 BOM) and runs [`Parser::parse`] into `map`.
     fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
         src: &[u8],
         map: &mut Map,


### PR DESCRIPTION
## What

`bun_dotenv::Loader` (`src/dotenv/env_loader.rs`) recorded which default `.env*` files it had already handled in eight separate fields, `env_development_local`, `env_production_local`, `env_test_local`, `env_local`, `env_development`, `env_production`, `env_test` and `env`, each an `Option<bun_ast::Source>`, plus a `StringArrayHashMap<bun_ast::Source>` for `--env-file` paths. No `Source` was ever read: the three write sites in `load_env_file` stored `Some(Source::init_path_string(base, b""))`, the two in `load_env_file_dynamic` stored `Source::default()`, and the only reads were `is_some()` / `contains()`. `default_file_slot` mapped the `&'static [u8]` filename back to its field with a byte-string `match` ending in `unreachable!()`, and `print_loaded` re-listed the eight filenames in a parallel `ALL` table next to a `[bool; 8]`.

```rust
// before
pub(crate) env_local: Option<bun_ast::Source>,
/* ... seven more identical fields ... */
pub(crate) custom_files_loaded: StringArrayHashMap<bun_ast::Source>,

fn default_file_slot(&mut self, base: &'static [u8]) -> &mut Option<bun_ast::Source> {
    match base { b".env.local" => &mut self.env_local, /* ... */ _ => unreachable!() }
}

// after
#[derive(enumset::EnumSetType)]
pub(crate) enum DefaultEnvFile {
    DevelopmentLocal, ProductionLocal, TestLocal, Local, Development, Production, Test, Env,
}
impl DefaultEnvFile { fn name(self) -> &'static [u8] { /* the eight literals */ } }

pub(crate) default_files_loaded: EnumSet<DefaultEnvFile>,
pub(crate) custom_files_loaded: StringSet,
```

`try_load_default` and `load_env_file` now take a `DefaultEnvFile` and use `name()` for the directory probe, `openat` and the two error messages; the eight call sites in `load_default_files` pass variants instead of byte literals. The already-handled check becomes `default_files_loaded.contains(env_file)` and the three "prevent retrying" / done writes become `insert(env_file)`. `print_loaded` iterates the set (the enum is declared in the order the old `ALL` table had, and `EnumSet` iterates in declaration order) and uses `len()` for the count, so its output is unchanged; the `ALL` table, the `[bool; 8]`, `default_file_slot` and its `unreachable!()` are deleted. The two `custom_files_loaded.put(path, Source::default())` calls become `StringSet::insert(path)` (the existing `bun.StringSet` type in `bun_collections`, a `StringArrayHashMap<()>`). `bun_ast` is removed from `src/dotenv/Cargo.toml` (and the matching line from `Cargo.lock`); these placeholders were the crate's only use of it.

## Why

The set of files the loader can track is now closed at the type level: `load_env_file` can only be asked about one of the eight known files, so the filename-to-field mapping and its unreachable arm no longer exist, and the print order is the enum declaration order rather than a second copy of the filename list. It is zero-cost in the strict sense: `EnumSet<DefaultEnvFile>` is a `repr(transparent)` `u8` replacing eight `Option<bun_ast::Source>` fields of 112 bytes each; marking a file done is a bit-or instead of filling in a 112-byte placeholder struct; `StringSet` keeps the same key boxing and lookup as before and simply has no values column to fill. `name()` is a `match` returning the same static slices the callers used to pass in. Nothing outside `env_loader.rs` referenced any of the removed items (all were `pub(crate)` with no other users), and `bun_dotenv` drops `bun_ast` from its dependency graph.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/cli/run/env.test.ts test/cli/run/no-envfile.test.ts: 105 pass, 1 skip (Windows-only), 2 todo, 0 fail.
