### PR TITLE
install: PatchTask::new_* return Box; enqueue_patch_task takes the Box

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1740,25 +1740,20 @@ impl<'a> PackageInstaller<'a> {
             // into cache, then install into node_modules
             if let Some(patch_contents_hash) = installer.patch.as_ref().map(|p| p.contents_hash) {
                 if installer.patched_package_missing_from_cache(self.manager_mut(), package_id) {
-                    let task: *mut PatchTask = PatchTask::new_apply_patch_hash(
+                    let mut task = PatchTask::new_apply_patch_hash(
                         self.manager_mut(),
                         package_id,
                         patch_contents_hash,
                         patch_name_and_version_hash.unwrap(),
                     );
-                    // SAFETY: `task` was just `heap::alloc`'d in `new_apply_patch_hash`;
-                    // we hold the only pointer until `enqueue_patch_task` takes ownership.
-                    if let patch_install::Callback::Apply(apply) = unsafe { &mut (*task).callback }
-                    {
+                    if let patch_install::Callback::Apply(apply) = &mut task.callback {
                         apply.install_context = Some(patch_install::InstallContext {
                             dependency_id,
                             tree_id: self.current_tree_id,
                             path: self.node_modules.path.clone(),
                         });
                     }
-                    // SAFETY: `task` was just `heap::alloc`'d in `new_apply_patch_hash`;
-                    // ownership transfers to the patch-task fifo here.
-                    unsafe { package_manager::enqueue_patch_task(self.manager_mut(), task) };
+                    package_manager::enqueue_patch_task(self.manager_mut(), task);
                     return;
                 }
             }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -579,43 +579,38 @@ pub fn enqueue_network_task(this: &mut PackageManager, task: *mut NetworkTask) {
     this.network_task_fifo.write_item_assume_capacity(task);
 }
 
-/// # Safety
-/// `task` must be a non-null `heap::alloc`'d `PatchTask` whose ownership is
-/// being transferred to the patch-task fifo.
-pub unsafe fn enqueue_patch_task(this: &mut PackageManager, task: *mut PatchTask) {
+/// Hands the task to the patch-task fifo as a raw pointer; it is reclaimed once
+/// in `run_tasks` after the thread pool pushes it onto `patch_task_queue`.
+pub fn enqueue_patch_task(this: &mut PackageManager, task: Box<PatchTask>) {
     bun_output::scoped_log!(
         PackageManager,
-        "Enqueue patch task: 0x{:x} {}",
-        task as usize,
-        // SAFETY: `task` is non-null (fresh `heap::alloc` from `new_*`).
-        unsafe { (*task).callback.tag_name() }
+        "Enqueue patch task: {:p} {}",
+        task,
+        task.callback.tag_name()
     );
     if this.patch_task_fifo.writable_length() == 0 {
         this.flush_patch_task_queue();
     }
 
-    this.patch_task_fifo.write_item_assume_capacity(task);
+    this.patch_task_fifo
+        .write_item_assume_capacity(bun_core::heap::into_raw(task));
 }
 
 /// We need to calculate all the patchfile hashes at the beginning so we don't run into problems with stale hashes
-/// # Safety
-/// `task` must be a non-null `heap::alloc`'d `PatchTask` whose ownership is
-/// being transferred to the patch-task fifo.
-pub unsafe fn enqueue_patch_task_pre(this: &mut PackageManager, task: *mut PatchTask) {
+pub fn enqueue_patch_task_pre(this: &mut PackageManager, mut task: Box<PatchTask>) {
     bun_output::scoped_log!(
         PackageManager,
-        "Enqueue patch task pre: 0x{:x} {}",
-        task as usize,
-        // SAFETY: `task` is non-null (fresh `heap::alloc` from `new_*`).
-        unsafe { (*task).callback.tag_name() }
+        "Enqueue patch task pre: {:p} {}",
+        task,
+        task.callback.tag_name()
     );
-    // SAFETY: `task` is non-null (fresh `heap::alloc` from `new_*`).
-    unsafe { (*task).pre = true };
+    task.pre = true;
     if this.patch_task_fifo.writable_length() == 0 {
         this.flush_patch_task_queue();
     }
 
-    this.patch_task_fifo.write_item_assume_capacity(task);
+    this.patch_task_fifo
+        .write_item_assume_capacity(bun_core::heap::into_raw(task));
     let _ = this.pending_pre_calc_hashes.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -925,9 +920,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     }
                                 }
                                 ResolvedPackageTask::PatchTask(patch_task) => {
-                                    // SAFETY: `patch_task` is a non-null `heap::alloc`.
-                                    let cb = unsafe { &(*patch_task).callback };
-                                    if cb.is_calc_hash()
+                                    if patch_task.callback.is_calc_hash()
                                         && get_preinstall_state(this, result.package.meta.id)
                                             == install::PreinstallState::CalcPatchHash
                                     {
@@ -936,9 +929,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                             result.package.meta.id,
                                             install::PreinstallState::CalcingPatchHash,
                                         );
-                                        // SAFETY: `patch_task` is a non-null `heap::alloc`.
-                                        unsafe { enqueue_patch_task(this, patch_task) };
-                                    } else if cb.is_apply()
+                                        enqueue_patch_task(this, patch_task);
+                                    } else if patch_task.callback.is_apply()
                                         && get_preinstall_state(this, result.package.meta.id)
                                             == install::PreinstallState::ApplyPatch
                                     {
@@ -947,8 +939,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                             result.package.meta.id,
                                             install::PreinstallState::ApplyingPatch,
                                         );
-                                        // SAFETY: `patch_task` is a non-null `heap::alloc`.
-                                        unsafe { enqueue_patch_task(this, patch_task) };
+                                        enqueue_patch_task(this, patch_task);
                                     }
                                 }
                             }
@@ -1716,9 +1707,7 @@ fn enqueue_git_clone(
                 PackageIndexEntry::Id(p) => *p,
                 PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
             };
-            let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-            // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
-            let mut pt = unsafe { bun_core::heap::take(pt) };
+            let mut pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
             pt.callback.apply_mut().task_id = Some(task_id);
             Some(pt)
         } else {
@@ -1800,9 +1789,7 @@ pub fn enqueue_git_checkout(
                     PackageIndexEntry::Id(p) => *p,
                     PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
                 };
-                let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-                // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
-                let mut pt = bun_core::heap::take(pt);
+                let mut pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
                 pt.callback.apply_mut().task_id = Some(task_id);
                 Some(pt)
             } else {
@@ -1938,7 +1925,7 @@ pub(crate) enum ResolvedPackageTask {
     NetworkTask(*mut NetworkTask),
 
     /// Apply patch task or calc patch hash task
-    PatchTask(*mut PatchTask),
+    PatchTask(Box<PatchTask>),
 }
 
 #[derive(Default)]

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -578,8 +578,7 @@ pub fn install_with_manager(
             let keys: Vec<u64> = manager.lockfile.patched_dependencies.keys().to_vec();
             for key in keys {
                 let task = PatchTask::new_calc_patch_hash(manager, key, None);
-                // SAFETY: `task` is a fresh `heap::alloc` from `new_calc_patch_hash`.
-                unsafe { enqueue_patch_task_pre(manager, task) };
+                enqueue_patch_task_pre(manager, task);
             }
         }
         // Anything that needs to be downloaded from an update needs to be scheduled here
@@ -1582,8 +1581,7 @@ fn create_new_lockfile_and_enqueue(
         let keys: Vec<u64> = manager.lockfile.patched_dependencies.keys().to_vec();
         for key in keys {
             let task = PatchTask::new_calc_patch_hash(manager, key, None);
-            // SAFETY: `task` is a fresh `heap::alloc` from `new_calc_patch_hash`.
-            unsafe { enqueue_patch_task_pre(manager, task) };
+            enqueue_patch_task_pre(manager, task);
         }
     }
     enqueue_dependency_list(manager, root.dependencies);

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -199,8 +199,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
             break;
         }
         // SAFETY: `next()` returned non-null; node is exclusively owned by this
-        // batch. `ptask_ptr` was produced by `heap::alloc` in `PatchTask::new_*`
-        // — reclaim ownership exactly once here so the `Box` drops at end of
+        // batch. `ptask_ptr` is the `Box` that `enqueue_patch_task` /
+        // `enqueue_patch_task_pre` handed to the fifo via `heap::into_raw`;
+        // reclaim ownership exactly once here so the `Box` drops at end of
         // iteration on every path.
         let mut ptask = unsafe { bun_core::heap::take(ptask_ptr) };
         debug_assert!(manager.pending_task_count() > 0);
@@ -1788,15 +1789,11 @@ pub fn generate_network_task_for_tarball<'a>(
         ))
     });
     let apply_patch_task = if let Some((h, patch_hash)) = patch {
-        let task: *mut PatchTask =
-            PatchTask::new_apply_patch_hash(this, package.meta.id, patch_hash, h);
-        // SAFETY: `task` is a fresh non-null `heap::alloc` from
-        // `new_apply_patch_hash`; we hold the only reference.
-        if let PatchTaskCallback::Apply(apply) = unsafe { &mut (*task).callback } {
+        let mut task = PatchTask::new_apply_patch_hash(this, package.meta.id, patch_hash, h);
+        if let PatchTaskCallback::Apply(apply) = &mut task.callback {
             apply.task_id = Some(task_id);
         }
-        // SAFETY: reclaiming the `Box` produced by `new_apply_patch_hash`.
-        Some(unsafe { bun_core::heap::take(task) })
+        Some(task)
     } else {
         None
     };

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -279,24 +279,12 @@ impl<'a> Installer<'a> {
         let node_id = entry_node_ids[entry_id.get() as usize];
         let node_pkg_ids = store.nodes.items_pkg_id();
         let pkg_id = node_pkg_ids[node_id.get() as usize];
-        let patch_task_ptr = install::PatchTask::new_apply_patch_hash(
+        let mut patch_task = install::PatchTask::new_apply_patch_hash(
             self.manager_mut(),
             pkg_id,
             patch.contents_hash,
             patch.name_and_version_hash,
         );
-        // SAFETY: `new_apply_patch_hash` returns a freshly Box-allocated PatchTask;
-        // sole ownership lives in this scope.
-        struct PatchTaskGuard(*mut install::PatchTask);
-        impl Drop for PatchTaskGuard {
-            fn drop(&mut self) {
-                // SAFETY: exclusive owner; created by `heap::alloc` in `new_*`.
-                unsafe { install::PatchTask::destroy(self.0) };
-            }
-        }
-        let _guard = PatchTaskGuard(patch_task_ptr);
-        // SAFETY: exclusive owner — see above.
-        let patch_task = unsafe { &mut *patch_task_ptr };
         // Every peer variant shares one patched cache dir (named by the patch
         // contents hash, not the peer set). Once it exists, reuse it: rebuilding
         // it replaces the directory under earlier entries' running hardlink tasks.

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -138,23 +138,6 @@ pub struct InstallContext {
 }
 
 impl PatchTask {
-    /// Destroy a heap-allocated `PatchTask` previously created by
-    /// `new_calc_patch_hash` / `new_apply_patch_hash`.
-    ///
-    /// The owned fields (`Box<[u8]>`, `Vec<u8>`, `Log`, `Option<...>`) drop automatically, so no
-    /// `impl Drop` body is needed. Because `PatchTask` is held via raw pointer through the
-    /// intrusive `next`/thread-pool queue, the named reclaim point is `unsafe fn destroy`.
-    ///
-    /// # Safety
-    /// `this` must have been produced by `heap::alloc` in the `new_*` constructors below and
-    /// ownership must be returned here exactly once.
-    pub(crate) unsafe fn destroy(this: *mut Self) {
-        // TODO: how to deinit `this.callback.calc_hash.network_task`
-        // SAFETY: caller contract — `this` was produced by `heap::into_raw` in
-        // `new_calc_patch_hash`/`new_apply_patch_hash` and is reclaimed exactly once.
-        drop(unsafe { bun_core::heap::take(this) });
-    }
-
     /// # Safety
     /// Only invoked by `ThreadPool` via the `callback` fn-pointer registered in
     /// `new_calc_patch_hash` / `new_apply_patch_hash`. `task` must be live and
@@ -385,9 +368,7 @@ impl PatchTask {
                     );
                     if manager.get_preinstall_state(pkg_meta_id) == PreinstallState::ApplyPatch {
                         manager.set_preinstall_state(pkg_meta_id, PreinstallState::ApplyingPatch);
-                        // SAFETY: `patch_task` is a fresh `heap::alloc` from
-                        // `new_apply_patch_hash`; ownership transfers to the fifo.
-                        unsafe { package_manager::enqueue_patch_task(manager, patch_task) };
+                        package_manager::enqueue_patch_task(manager, patch_task);
                     }
                 }
                 _ => {}
@@ -735,7 +716,7 @@ impl PatchTask {
         manager: &mut PackageManager,
         name_and_version_hash: u64,
         state: Option<EnqueueAfterState>,
-    ) -> *mut PatchTask {
+    ) -> Box<PatchTask> {
         let patchdep = manager
             .lockfile
             .patched_dependencies
@@ -747,7 +728,7 @@ impl PatchTask {
         // log formatting), so no trailing NUL is needed.
 
         let tempdir = manager.get_temporary_directory().handle.fd();
-        let pt = Box::new(PatchTask {
+        Box::new(PatchTask {
             tempdir,
             callback: Callback::CalcHash(CalcPatchHash {
                 state,
@@ -764,9 +745,7 @@ impl PatchTask {
             },
             pre: false,
             next: bun_threading::Link::new(),
-        });
-
-        bun_core::heap::into_raw(pt)
+        })
     }
 
     pub(crate) fn new_apply_patch_hash(
@@ -774,7 +753,7 @@ impl PatchTask {
         pkg_id: PackageID,
         patch_hash: u64,
         name_and_version_hash: u64,
-    ) -> *mut PatchTask {
+    ) -> Box<PatchTask> {
         let pkg_name = pkg_manager.lockfile.packages.items_name()[pkg_id as usize];
 
         // Borrowck — `compute_cache_dir_and_subpath` borrows `&mut PackageManager`
@@ -819,7 +798,7 @@ impl PatchTask {
         let cache_dir = stuff.cache_dir;
 
         let tempdir = pkg_manager.get_temporary_directory().handle.fd();
-        let pt = Box::new(PatchTask {
+        Box::new(PatchTask {
             tempdir,
             callback: Callback::Apply(ApplyPatch {
                 pkg_id,
@@ -841,9 +820,7 @@ impl PatchTask {
             },
             pre: false,
             next: bun_threading::Link::new(),
-        });
-
-        bun_core::heap::into_raw(pt)
+        })
     }
 }
 


### PR DESCRIPTION
## What

`PatchTask::new_calc_patch_hash` and `PatchTask::new_apply_patch_hash` (`src/install/patch_install.rs`) built a `Box<PatchTask>` and immediately returned it as `*mut PatchTask`. Every consumer then re-established ownership by hand: `enqueue_git_clone`, `enqueue_git_checkout` and `generate_network_task_for_tarball` did `unsafe { heap::take(pt) }` straight back into the `Option<Box<PatchTask>>` fields that `Task` and `NetworkTask` already have; `PackageInstaller` and `generate_network_task_for_tarball` dereferenced the pointer to set `install_context` / `task_id`; the isolated installer's `apply_package_patch` defined a local `PatchTaskGuard` Drop type around `PatchTask::destroy` just to use the task synchronously; `ResolvedPackageTask::PatchTask(*mut PatchTask)` was read through `unsafe { &(*patch_task).callback }`; and `enqueue_patch_task` / `enqueue_patch_task_pre` were `unsafe fn`s whose only unsafe operations were reading `.callback` and writing `.pre` through the pointer before pushing it into `patch_task_fifo`.

```rust
// before
pub(crate) fn new_apply_patch_hash(..) -> *mut PatchTask
pub unsafe fn enqueue_patch_task(this: &mut PackageManager, task: *mut PatchTask)
pub unsafe fn enqueue_patch_task_pre(this: &mut PackageManager, task: *mut PatchTask)
PatchTask(*mut PatchTask),            // ResolvedPackageTask

// after
pub(crate) fn new_apply_patch_hash(..) -> Box<PatchTask>
pub fn enqueue_patch_task(this: &mut PackageManager, task: Box<PatchTask>)
pub fn enqueue_patch_task_pre(this: &mut PackageManager, mut task: Box<PatchTask>)
PatchTask(Box<PatchTask>),            // ResolvedPackageTask
```

Both constructors now return the `Box`. The two enqueue functions log `task.callback.tag_name()`, set `task.pre` through the `Box`, and call `heap::into_raw` only at the point where the pointer is written into `patch_task_fifo`; the fifo itself stays `*mut PatchTask` and the `heap::take` in `run_tasks` remains the single reclaim point (its SAFETY comment now names the `into_raw` site). The three `apply_patch_task` producers become `let mut pt = PatchTask::new_apply_patch_hash(..); ...; Some(pt)`, `PackageInstaller` sets `install_context` through the `Box` and passes it to `enqueue_patch_task`, `apply_package_patch` holds the `Box` in a local and `PatchTaskGuard` is deleted, and the `ResolvedPackageTask::PatchTask` arm reads `patch_task.callback` directly. The 6 `enqueue_patch_task*` call sites lose their `unsafe` wrappers. In total this removes 17 unsafe blocks, 3 `unsafe fn` signatures and `PatchTask::destroy`, which had no remaining caller. 6 files, net 58 lines removed.

## Why

Ownership of a freshly built `PatchTask` is now carried by `Box<PatchTask>` from the constructor to whichever of the three owners it ends up in (a `Task` / `NetworkTask` field, a synchronous local, or the fifo), so the only remaining raw-pointer span is the fifo / thread-pool / `patch_task_queue` hand-off, bracketed by `heap::into_raw` in the two enqueue functions and `heap::take` in `run_tasks`. `Box<PatchTask>` and `*mut PatchTask` are the same single non-null pointer, `heap::into_raw` and the removed `heap::take` calls compile to nothing, and the `ResolvedPackageTask` variant keeps its size, so the allocation count and the value pushed into the fifo are byte-for-byte unchanged. The one behavioural difference is that a task built for a package whose preinstall state moved on before it could be enqueued (the fall-through in `enqueue_dependency_with_main_and_success_fn` and in `run_from_main_thread_calc_hash`) is now dropped instead of leaked.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/cli/install/bun-install-patch.test.ts test/cli/install/bun-patch.test.ts test/cli/install/isolated-install.test.ts: 111 pass, 0 fail across 3 files.
