### PR TITLE
Bun.serve: free a gracefully stopped server at VM teardown

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2096,6 +2096,20 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     /// must not be used after this returns.
     pub(super) fn deinit(this: *mut Self) {
         httplog!("deinit");
+        // `NewApp::destroy` below closes nothing itself; close while `this` is
+        // still a raw pointer, since close callbacks re-derive `&Self` from it.
+        // SAFETY: live, uniquely owned server (fn contract); nothing borrows it
+        // across the `close()` call.
+        unsafe {
+            if !(*this).flags.contains(ServerFlags::TERMINATED)
+                && let Some(app) = (*this).app
+            {
+                (*this).flags.insert(ServerFlags::TERMINATED);
+                (*this).deinit_running.set(true);
+                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                bun_opaque::opaque_deref_mut(app).close();
+            }
+        }
         // SAFETY: paired with heap::alloc in `init()`; `this` is uniquely
         // owned here, so reclaim the Box up front and let its `&mut` drive
         // the teardown (dropped — and freed — at scope exit).
@@ -2117,14 +2131,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         }
         if let Some(app) = server.app.take() {
-            // `destroy` closes nothing itself.
-            if !server.flags.contains(ServerFlags::TERMINATED) {
-                server.flags.insert(ServerFlags::TERMINATED);
-                server.deinit_running.set(true);
-                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                bun_opaque::opaque_deref_mut(app).close();
-            }
-            // SAFETY: live, closed uws App handle owned by this server.
+            // SAFETY: live uws App handle owned by this server, closed above or
+            // by whoever set `TERMINATED`.
             unsafe { uws_sys::NewApp::<SSL>::destroy(app) };
         }
     }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2116,21 +2116,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         }
         if let Some(app) = server.app.take() {
-            // `destroy` only deinits the app's socket groups (`us_socket_group_deinit`
-            // asserts they are empty); it closes nothing. Every path that sets
-            // `TERMINATED` closes the app (an abrupt stop synchronously,
-            // `schedule_deinit` in the task queued ahead of the one that gets
-            // here); a gracefully stopped server freed by `finalize()` at VM
-            // teardown, or a `listen()` that failed part-way, gets here without
-            // either.
+            // `destroy` only deinits the socket groups, so whatever no stop
+            // closed (a gracefully stopped server freed at VM teardown, a
+            // `listen()` that failed after binding) is closed here first.
             if !server.flags.contains(ServerFlags::TERMINATED) {
                 server.flags.insert(ServerFlags::TERMINATED);
                 server.deinit_running.set(true);
                 // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                 bun_opaque::opaque_deref_mut(app).close();
             }
-            // SAFETY: live uws App handle owned by this server, closed above or
-            // by the path that set `TERMINATED`.
+            // SAFETY: live, closed uws App handle owned by this server.
             unsafe { uws_sys::NewApp::<SSL>::destroy(app) };
         }
     }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -276,9 +276,10 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// `AnyServer` handles on the JS thread.
     pub(crate) active_websocket_count: core::cell::Cell<u32>,
     /// Set across [`NewServer::deinit_if_we_can`] and the synchronous
-    /// `app.close()` drain in `stop_listening`; lets a nested call (reached
-    /// via a callback the body fires) early-return instead of re-running the
-    /// downgrade/teardown while the outer frame still holds `&mut self`.
+    /// `app.close()` drains in `stop_listening` and `deinit`; lets a nested
+    /// call (reached via a callback the body fires) early-return instead of
+    /// re-running the downgrade/teardown while the outer frame still holds
+    /// `&mut self`.
     deinit_running: core::cell::Cell<bool>,
     pub(crate) request_pool:
         *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
@@ -2116,9 +2117,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         }
         if let Some(app) = server.app.take() {
-            // `destroy` only deinits the socket groups, so whatever no stop
-            // closed (a gracefully stopped server freed at VM teardown, a
-            // `listen()` that failed after binding) is closed here first.
+            // `destroy` closes nothing itself.
             if !server.flags.contains(ServerFlags::TERMINATED) {
                 server.flags.insert(ServerFlags::TERMINATED);
                 server.deinit_running.set(true);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2116,7 +2116,21 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         }
         if let Some(app) = server.app.take() {
-            // SAFETY: live uws App handle owned by this server.
+            // `destroy` only deinits the app's socket groups (`us_socket_group_deinit`
+            // asserts they are empty); it closes nothing. Every path that sets
+            // `TERMINATED` closes the app (an abrupt stop synchronously,
+            // `schedule_deinit` in the task queued ahead of the one that gets
+            // here); a gracefully stopped server freed by `finalize()` at VM
+            // teardown, or a `listen()` that failed part-way, gets here without
+            // either.
+            if !server.flags.contains(ServerFlags::TERMINATED) {
+                server.flags.insert(ServerFlags::TERMINATED);
+                server.deinit_running.set(true);
+                // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                bun_opaque::opaque_deref_mut(app).close();
+            }
+            // SAFETY: live uws App handle owned by this server, closed above or
+            // by the path that set `TERMINATED`.
             unsafe { uws_sys::NewApp::<SSL>::destroy(app) };
         }
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2815,13 +2815,21 @@ where
         // unconditional. `Box::into_raw` (not `heap::release`) keeps raw-owner
         // provenance for the `deinit()` dealloc — a `&mut self`-derived tag
         // there would be Stacked-Borrows UB. JSC-handle Drops are no-ops past
-        // `is_shutting_down()`; `TERMINATED` means `app.close()` already ran,
-        // so `NewApp::destroy` can't orphan a keep-alive socket.
+        // `is_shutting_down()`.
+        //
+        // `DEINIT_SCHEDULED` can only have been set by the `deinit_if_we_can`
+        // call below (it requires the `Finalized` state set just before), so
+        // it means the server is drained; past `is_shutting_down()` it also
+        // means `schedule_deinit` enqueued nothing, since no tick will run.
+        // Nothing else will free the Box then, so free it here — after an
+        // abrupt stop (`TERMINATED`, app closed) and after a graceful one
+        // alike: the app is still open but empty, teardown's stop phase closed
+        // every socket before destroying the heap, and `deinit()` closes it
+        // before destroying it in any case.
         unsafe {
             (*this_ptr).js_value.finalize();
             (*this_ptr).deinit_if_we_can();
             if (*this_ptr).flags.contains(ServerFlags::DEINIT_SCHEDULED)
-                && (*this_ptr).flags.contains(ServerFlags::TERMINATED)
                 && (*this_ptr).vm().is_shutting_down()
             {
                 Self::deinit(this_ptr);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2815,17 +2815,11 @@ where
         // unconditional. `Box::into_raw` (not `heap::release`) keeps raw-owner
         // provenance for the `deinit()` dealloc — a `&mut self`-derived tag
         // there would be Stacked-Borrows UB. JSC-handle Drops are no-ops past
-        // `is_shutting_down()`.
-        //
-        // `DEINIT_SCHEDULED` can only have been set by the `deinit_if_we_can`
-        // call below (it requires the `Finalized` state set just before), so
-        // it means the server is drained; past `is_shutting_down()` it also
-        // means `schedule_deinit` enqueued nothing, since no tick will run.
-        // Nothing else will free the Box then, so free it here — after an
-        // abrupt stop (`TERMINATED`, app closed) and after a graceful one
-        // alike: the app is still open but empty, teardown's stop phase closed
-        // every socket before destroying the heap, and `deinit()` closes it
-        // before destroying it in any case.
+        // `is_shutting_down()`, where `schedule_deinit` (reached below once the
+        // server is drained) enqueues nothing and only sets `DEINIT_SCHEDULED`,
+        // leaving this frame as the Box's last owner; teardown's stop phase
+        // has already closed every socket, so the app is empty even after a
+        // graceful stop.
         unsafe {
             (*this_ptr).js_value.finalize();
             (*this_ptr).deinit_if_we_can();

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2815,11 +2815,8 @@ where
         // unconditional. `Box::into_raw` (not `heap::release`) keeps raw-owner
         // provenance for the `deinit()` dealloc — a `&mut self`-derived tag
         // there would be Stacked-Borrows UB. JSC-handle Drops are no-ops past
-        // `is_shutting_down()`, where `schedule_deinit` (reached below once the
-        // server is drained) enqueues nothing and only sets `DEINIT_SCHEDULED`,
-        // leaving this frame as the Box's last owner; teardown's stop phase
-        // has already closed every socket, so the app is empty even after a
-        // graceful stop.
+        // `is_shutting_down()`, and teardown has closed every socket by then,
+        // so `deinit()` may destroy the app of a gracefully stopped server too.
         unsafe {
             (*this_ptr).js_value.finalize();
             (*this_ptr).deinit_if_we_can();

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -189,7 +189,10 @@ describe.skipIf(!isASAN || isWindows)(
           });
           globalThis.keep = server;
           const ws = new WebSocket("ws://127.0.0.1:" + server.port + "/");
-          await new Promise(resolve => ws.addEventListener("open", resolve));
+          const { promise, resolve, reject } = Promise.withResolvers();
+          ws.onopen = resolve;
+          ws.onclose = reject;
+          await promise;
           server.stop();
           process.exit(0);
         `,

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { join } from "path";
 
@@ -44,6 +44,30 @@ test("dev server html route: non-GET/HEAD requests complete without hanging", as
   }
 });
 
+// The tests below exit a child under LeakSanitizer with BUN_DESTRUCT_VM_ON_EXIT,
+// the way the ASAN CI lane runs every test, and expect a silent, clean exit.
+const leaksanSupp = join(import.meta.dirname, "../../../leaksan.supp");
+
+// LSan symbolizes its report through llvm-symbolizer on failure, which is slow
+// against the debug binary.
+const LEAK_TEST_TIMEOUT = 30_000;
+
+async function exitUnderLeakSanitizer(script: string, { args = [] as string[], suppressions = leaksanSupp } = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script, ...args],
+    env: {
+      ...bunEnv,
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+      LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${suppressions}`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
 // A server whose JS wrapper survives to lastChanceToFinalize used to leak its
 // NewServer Box: finalize() -> schedule_deinit() enqueued a ManagedTask that
 // the now-exiting event loop never ran. The html_bundle::Route.server
@@ -55,33 +79,20 @@ test.skipIf(!isASAN || isWindows)(
     await using dir = tempDir("serve-static-route-teardown-leak", {
       "index.html": `<!DOCTYPE html><html><body>hi</body></html>`,
     });
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const { default: html } = await import(process.argv[1]);
-          const server = Bun.serve({
-            port: 0,
-            development: true,
-            routes: { "/": html },
-            fetch: () => new Response("no"),
-          });
-          await (await fetch(server.url)).text();
-          server.stop(true);
-        `,
-        join(dir, "index.html"),
-      ],
-      env: {
-        ...bunEnv,
-        BUN_DESTRUCT_VM_ON_EXIT: "1",
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const { stdout, stderr, exitCode } = await exitUnderLeakSanitizer(
+      `
+        const { default: html } = await import(process.argv[1]);
+        const server = Bun.serve({
+          port: 0,
+          development: true,
+          routes: { "/": html },
+          fetch: () => new Response("no"),
+        });
+        await (await fetch(server.url)).text();
+        server.stop(true);
+      `,
+      { args: [join(dir, "index.html")] },
+    );
     // The dev-server bundler prints "Bundled page in Nms: <path>" to stderr on
     // first request; strip it so the assertion shows only LSan's report.
     const filtered = stderr
@@ -91,40 +102,112 @@ test.skipIf(!isASAN || isWindows)(
       .trim();
     expect({ stdout, stderr: filtered, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   },
-  // LSan symbolizes through llvm-symbolizer on failure, which is slow against
-  // the debug binary.
-  30_000,
+  LEAK_TEST_TIMEOUT,
 );
 
-// Graceful stop() leaves the keep-alive socket in the uws app's socket group.
-// A NewApp::destroy at lastChanceToFinalize would unlink that group from the
-// loop and orphan the socket, so the synchronous deinit path above is gated
-// on TERMINATED (set only by an abrupt stop or an app.close() that already
-// drained the group).
+// The common shape of the scenarios below (nothing pins the server, stop() is
+// not awaited), run under the CI lane's full suppression list: freeing the
+// gracefully stopped server at teardown has to leave nothing behind there
+// either, in particular the keep-alive socket that stop() closed (a socket
+// still linked into the app would be a direct leak no suppression covers).
 test.skipIf(!isASAN || isWindows)(
   "gracefully-stopped Bun.serve does not orphan a keep-alive socket at VM teardown",
   async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
+    const result = await exitUnderLeakSanitizer(`
+      const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+      await (await fetch(server.url)).text();
+      server.stop();
+    `);
+    expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  },
+  LEAK_TEST_TIMEOUT,
+);
+
+// After a graceful stop() (or node:http server.close()) the drained server is
+// only freed once its JS object is finalized. When that happens during VM
+// teardown, finalize() has to free it inline (no event-loop tick will run the
+// deferred deinit); it used to do so only after an abrupt stop, so every
+// gracefully stopped server still referenced at exit leaked its NewServer Box,
+// uws app and routers.
+//
+// That leak hides behind `leak:uws_create_app` in leaksan.supp: LSan also
+// suppresses everything reachable from a suppressed block, so the whole cycle
+// vanishes and only the llvm-symbolizer pass LSan needs to match the
+// suppression remains (about 15s per such child on the ASAN lane). These
+// children therefore run against the suppression list minus that entry. They
+// create the server only after a timer tick, because a Bun.serve() call made
+// synchronously from the module body has JSModuleLoader::evaluateNonVirtual
+// (suppressed as well) on every allocation's stack, and they keep the server
+// on globalThis so that its wrapper is finalized by the teardown and never by
+// an earlier GC.
+describe.skipIf(!isASAN || isWindows)(
+  "a gracefully stopped server still referenced at exit is freed at VM teardown",
+  () => {
+    const scenarios: [name: string, script: string][] = [
+      [
+        "Bun.serve stop() after serving a request",
         `
+          await Bun.sleep(0);
           const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+          globalThis.keep = server;
           await (await fetch(server.url)).text();
-          server.stop();
+          await server.stop();
         `,
       ],
-      env: {
-        ...bunEnv,
-        BUN_DESTRUCT_VM_ON_EXIT: "1",
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      [
+        "Bun.serve stop() before any connection",
+        `
+          await Bun.sleep(0);
+          const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+          globalThis.keep = server;
+          await server.stop();
+        `,
+      ],
+      [
+        "node:http server.close()",
+        `
+          import { createServer } from "node:http";
+          await Bun.sleep(0);
+          const server = createServer((req, res) => res.end("ok"));
+          globalThis.keep = server;
+          await new Promise(resolve => server.listen(0, resolve));
+          await (await fetch("http://127.0.0.1:" + server.address().port + "/")).text();
+          await new Promise(resolve => server.close(resolve));
+        `,
+      ],
+      [
+        // The websocket keeps the server draining past stop(); the teardown's
+        // stop phase closes it (the stop() promise never settles, script is
+        // forbidden by then) and the finalizer then finds the server drained.
+        "Bun.serve stop() with a websocket still open at process.exit()",
+        `
+          await Bun.sleep(0);
+          const server = Bun.serve({
+            port: 0,
+            fetch: (req, server) => (server.upgrade(req) ? undefined : new Response("no")),
+            websocket: { message() {} },
+          });
+          globalThis.keep = server;
+          const ws = new WebSocket("ws://127.0.0.1:" + server.port + "/");
+          await new Promise(resolve => ws.addEventListener("open", resolve));
+          server.stop();
+          process.exit(0);
+        `,
+      ],
+    ];
+
+    test.concurrent.each(scenarios)(
+      "%s",
+      async (_name, script) => {
+        const suppressions = (await Bun.file(leaksanSupp).text())
+          .split("\n")
+          .filter(line => line.trim() !== "leak:uws_create_app")
+          .join("\n");
+        using dir = tempDir("serve-teardown-leak", { "leaksan.supp": suppressions });
+        const result = await exitUnderLeakSanitizer(script, { suppressions: join(String(dir), "leaksan.supp") });
+        expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
       },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+      LEAK_TEST_TIMEOUT,
+    );
   },
-  30_000,
 );

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -492,6 +492,51 @@ describe("Bun.serve HTTP/3", () => {
     expect(stdout).toContain("listening");
     expect(exitCode).toBe(0);
   });
+
+  // The TCP listener is bound before the UDP one, and a fixed port is not
+  // retried, so a UDP bind failure tears down a server that is already
+  // listening on TCP. That teardown used to destroy the uws app with the
+  // listener still in it: the TCP port stayed bound (and debug builds abort in
+  // us_socket_group_deinit).
+  test("http3 UDP bind failure releases the TCP port the server had bound", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          // Occupy a UDP port whose TCP side is free, then ask for http3 on it.
+          // Retried in case the kernel-chosen port is also busy on TCP.
+          for (let attempt = 0; ; attempt++) {
+            const udp = await Bun.udpSocket({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+            const { port } = udp;
+            let error;
+            try {
+              Bun.serve({ port, hostname: "127.0.0.1", tls: ${JSON.stringify(tls)}, http3: true, fetch: () => new Response("x") });
+            } catch (e) {
+              error = e;
+            }
+            if (error?.code === "EADDRINUSE" && attempt < 5) {
+              udp.close();
+              continue;
+            }
+            using tcp = Bun.serve({ port, hostname: "127.0.0.1", fetch: () => new Response("x") });
+            console.log(String(error?.message).replace(port, "PORT"), "| TCP port rebound:", tcp.port === port);
+            udp.close();
+            break;
+          }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "Failed to listen on UDP port PORT for HTTP/3 | TCP port rebound: true\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });
 
 // Cases ported from h2o t/40http3 and aioquic interop. Each test gets its own


### PR DESCRIPTION
## Repro

```js
// h.js
const server = Bun.serve({ port: 0, fetch: () => new Response("x") });
globalThis.keep = server;
await server.stop(); // graceful
```

```
BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 bun-debug h.js
```

```
Indirect leak of 2104 byte(s) in 1 object(s) allocated from:
    ...
    #12 <bun_runtime::server::NewServer<false, true>>::init src/runtime/server/mod.rs:2143
    #13 bun_runtime::api::bun_object::serve src/runtime/api/BunObject.rs:1568
Indirect leak of 3616 byte(s) in 1 object(s) allocated from:   (uWS::HttpContext, from uws_create_app)
    ...
SUMMARY: AddressSanitizer: 13661 byte(s) leaked in 158 allocation(s).
```

Everything is "indirect" because the app's filter closure points back at the `NewServer` Box: the whole server graph (Box, `TemplatedApp`, `HttpContext`, ~36 router nodes, config strings) is an unreachable cycle. `server.stop(true)` instead: nothing reported. A node:http server after `server.close()`: the same, 173 allocations. Whether a request was served makes no difference; what matters is that the server's JS object is still alive when the VM is torn down (without the `globalThis.keep` line an ordinary GC sometimes collects it first, and that path is clean).

On the ASAN CI lane this never fails a test, because `leak:uws_create_app` in `test/leaksan.supp` matches the app and LSan also suppresses everything reachable from a suppressed block. It does cost time: to match a suppression LSan has to run llvm-symbolizer over the binary, about 7s per child with a local debug build and about 15s with the lane's release binary, and every test child that stops a server gracefully (or closes a node:http server) and still references it at exit pays that. `test/regression/issue/12042.test.ts` took 16s on the asan lane and 0.03s everywhere else for this reason (#37479 works around it in that test); `test/js/node/http/node-http-server-socket-end-drain.test.ts` was another one. A server that is gracefully stopped inside a Worker leaks the same graph for real every time the worker exits, since worker teardown runs the same code.

## Cause

After a graceful `stop()` the server downgrades its wrapper ref and waits for the wrapper's `finalize()` to free the Box. #36750 made `finalize()` free it synchronously when it runs during VM teardown (no event-loop tick will ever run the tasks `schedule_deinit()` would enqueue, so `schedule_deinit()` just sets `DEINIT_SCHEDULED` and returns past `is_shutting_down()`), but gated that on `TERMINATED`. Only an abrupt stop sets `TERMINATED`; the gate was there because, at the time, a graceful stop left keep-alive sockets in the app's socket group and `NewApp::destroy` would have orphaned them. So for a gracefully stopped server finalized by `lastChanceToFinalize`, `schedule_deinit()` sets the flag, `finalize()` declines to free, and nothing else ever will.

## Fix

The fixing line is the removal of the `TERMINATED` condition in `NewServer::finalize()` (`server_body.rs`): the Box is freed whenever `DEINIT_SCHEDULED` was set during shutdown. That flag can only be set by the `deinit_if_we_can()` call inside `finalize()` itself (its only caller requires the `Finalized` state that `finalize()` has just set), so it means precisely "drained, and nothing was enqueued to free it".

`NewServer::deinit()` (`mod.rs`) additionally closes the app before destroying it when nothing has closed it yet. The close happens through the raw `*mut Self`, before the Box is reclaimed, because the close callback of any socket that is still linked re-derives `&Self` from that same pointer (the `deinit_running` guard keeps such a callback from re-entering `deinit_if_we_can`, as in `stop_listening`). `NewApp::destroy` only deinits the socket groups (`us_socket_group_deinit` unlinks and, in debug builds, asserts they are empty); every existing caller reached it with the app closed because every path that sets `TERMINATED` closes it (the abrupt stop synchronously, `schedule_deinit` in the task queued ahead of the deinit task), and that is still the case, so the new branch is only taken by the teardown path above and by a `listen()` that fails after binding its TCP listener (the http3 UDP bind failure), which used to destroy the app with the listener still linked.

Why destroying a gracefully stopped app at teardown is safe now: `VirtualMachine::teardown` runs a stop phase before the JSC heap is destroyed that stops every still-registered server abruptly and closes every connected socket in every linked group (`close_all_socket_groups`), and a graceful `stop()` itself now closes idle keep-alives. By the time `lastChanceToFinalize` reaches a server wrapper its groups are empty, so `deinit()`'s `close()` is a walk over empty lists and `destroy` has its precondition; the websocket scenario below is the case where a connection outlives `stop()` and is closed by the sweep, and the debug build's assertions in `us_socket_group_deinit` run under these tests. The Drop chain that runs is the one the abrupt path has been running at teardown since #36750. The non-shutdown path is unchanged.

I also checked the other ways a server could be drained only at teardown: the wrapper ref stays `Strong` until the server is drained, so a wrapper cannot be finalized by an ordinary GC while connections remain, and a request still in flight at `process.exit()` is released by the stop phase's abrupt close before finalizers run (tried it; clean). So after this every server that reaches teardown is freed by its finalizer.

## Verification

`test/js/bun/http/bun-serve-html-405.test.ts`, next to the teardown tests from #36750. Four new children, each run against `leaksan.supp` minus the `uws_create_app` entry so the cycle is reportable, each creating its server after a timer tick (a `Bun.serve()` made synchronously from the module body has `JSModuleLoader::evaluateNonVirtual`, also suppressed, on every allocation's stack) and keeping it on `globalThis`:

- `Bun.serve` `stop()` after serving a request
- `Bun.serve` `stop()` before any connection
- node:http `server.close()`
- `Bun.serve` `stop()` with a websocket still open at `process.exit()` (drained by the teardown sweep, freed by the finalizer)

All four fail on the unfixed build with the reports above (158 and 173 allocations) and pass with this change; the two existing teardown tests still pass, and the unsuppressed graceful one drops from 7.2s to 0.4s locally since its child no longer needs the symbolizer. The children of `12042.test.ts` and `node-http-server-socket-end-drain.test.ts` no longer use any suppression under the lane's environment; on this PR's asan lane (build 92266) those two files take 0.23s and 0.65s, against 16.0s and 15.0s in builds 91926/91993 on main. `websocket-server.test.ts`, `websocket-server-stop-retained-ws.test.ts`, `websocket-server-reload-leak.test.ts`, `server-url-invalid.test.ts` and `node-http-server-abort-events.test.ts` behave the same with and without the change here (the `websocket-server.test.ts` timeouts I saw under the debug ASAN build reproduce on the unfixed build in the same container; the change cannot run while a test is in progress, it only touches teardown and the listen-failure path).

`test/js/bun/http/serve-http3.test.ts` gets a validation test for the other path that now reaches the close in `deinit()`: a child occupies a UDP port, asks for `http3: true` on that port number (TCP binds, UDP fails, no retry for a fixed port), then binds plain TCP on it. With this change `Bun.serve` throws `Failed to listen on UDP port N for HTTP/3` and the TCP bind succeeds; on the unfixed debug build the child dies with

```
bun-debug: packages/bun-usockets/src/context.c:67: us_socket_group_deinit: Assertion `group->head_listen_sockets == ((void*)0)' failed.
```

(a release build would instead keep the port bound by a listen socket whose group has been freed).

Also run by hand under the same LSan setup with the app suppressions removed, each stopped gracefully and still referenced at exit: a TLS server with `serverName`, an `http3` server with and without `http1`, a node:http server closed while a request was still in flight, a `development` server with an HTML route, and a websocket server inside a Worker (exits with the worker's loop still alive, as in the process case). All of them are freed; the only things left in those reports are two unrelated leaks this turned up, tracked separately: the per-thread RequestContext pool a Worker never frees, and the `HTMLBundle` created by importing an `.html` file.

Not changed: `leak:uws_create_app` stays in `leaksan.supp`; removing it is a separate question once the lane shows nothing else hides behind it.

