### PR TITLE
fetch: reject an unreadable Bun.file() request body with a TypeError

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -368,11 +368,8 @@ fn reject_on_exception(
     Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
 }
 
-/// Rejection for a `Bun.file()` request body that cannot be opened or read.
-/// The fetch spec turns a request body that fails to be read into a network
-/// error, so this has the same shape as the network errors from
-/// `FetchTasklet::on_reject` (`ValueError::SystemTypeError`): a `TypeError`
-/// that keeps the system error's `code`/`errno`/`syscall`/`path`.
+/// A request body that cannot be read is a network error in fetch terms, so it
+/// rejects with the same `TypeError` shape as `FetchTasklet::on_reject`.
 fn request_body_file_error(err: &bun_sys::Error, global_this: &JSGlobalObject) -> JSValue {
     jsc::SystemError::from(err.to_system_error()).to_type_error_instance(global_this)
 }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -368,8 +368,7 @@ fn reject_on_exception(
     Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
 }
 
-/// A request body that cannot be read is a network error in fetch terms, so it
-/// rejects with the same `TypeError` shape as `FetchTasklet::on_reject`.
+/// Same `TypeError` shape as the network errors from `FetchTasklet::on_reject`.
 fn request_body_file_error(err: &bun_sys::Error, global_this: &JSGlobalObject) -> JSValue {
     jsc::SystemError::from(err.to_system_error()).to_type_error_instance(global_this)
 }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -55,7 +55,7 @@ use bun_core::{String as BunString, Tag as BunStringTag, ZigStringSlice};
 use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
-use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
+use bun_jsc::{HTTPHeaderName, StringJsc as _};
 use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
@@ -366,6 +366,15 @@ fn reject_on_exception(
         },
     };
     Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
+}
+
+/// Rejection for a `Bun.file()` request body that cannot be opened or read.
+/// The fetch spec turns a request body that fails to be read into a network
+/// error, so this has the same shape as the network errors from
+/// `FetchTasklet::on_reject` (`ValueError::SystemTypeError`): a `TypeError`
+/// that keeps the system error's `code`/`errno`/`syscall`/`path`.
+fn request_body_file_error(err: &bun_sys::Error, global_this: &JSGlobalObject) -> JSValue {
+    jsc::SystemError::from(err.to_system_error()).to_type_error_instance(global_this)
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1709,7 +1718,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
             let opened_fd = match opened_fd_res {
                 Err(err) => {
-                    let err_js = err.to_js(global_this);
+                    let err_js = request_body_file_error(&err, global_this);
                     let rejected_value =
                         JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
@@ -1808,7 +1817,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     let rejected_value =
                         JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
-                            err.to_js(global_this),
+                            request_body_file_error(&err, global_this),
                         );
                     body.detach();
                     return Ok(rejected_value);

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -265,6 +265,7 @@ describe.concurrent("Bun.file() body that cannot be read rejects with a TypeErro
     expect(err).toBeInstanceOf(TypeError);
     expect(err).toMatchObject({
       code: "ENOENT",
+      errno: expect.any(Number),
       syscall: "open",
       path: expect.stringContaining("missing.txt"),
     });
@@ -277,7 +278,12 @@ describe.concurrent("Bun.file() body that cannot be read rejects with a TypeErro
     const request = new Request("http://127.0.0.1:1/", { method: "POST", body: Bun.file(path) });
     const err = await earlyRejection(fetch(request));
     expect(err).toBeInstanceOf(TypeError);
-    expect(err).toMatchObject({ code: "ENOENT", syscall: "open" });
+    expect(err).toMatchObject({
+      code: "ENOENT",
+      errno: expect.any(Number),
+      syscall: "open",
+      path: expect.stringContaining("missing.txt"),
+    });
   });
 
   test("directory (open succeeds, read fails)", async () => {
@@ -285,14 +291,16 @@ describe.concurrent("Bun.file() body that cannot be read rejects with a TypeErro
 
     const err = await earlyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(String(dir)) }));
     expect(err).toBeInstanceOf(TypeError);
-    expect(err).toMatchObject({ code: "EISDIR", syscall: "read" });
+    expect(err).toMatchObject({ code: "EISDIR", errno: expect.any(Number), syscall: "read" });
   });
 
   test("file descriptor that is not open (dup fails)", async () => {
-    const err = await earlyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(1 << 30) }));
+    const fd = 1 << 30;
+
+    const err = await earlyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(fd) }));
     expect(err).toBeInstanceOf(TypeError);
-    // Windows reports a different errno for a descriptor number that was never
-    // opened; posix dup() fails with EBADF.
-    if (!isWindows) expect(err).toMatchObject({ code: "EBADF" });
+    expect(err).toMatchObject({ code: expect.any(String), errno: expect.any(Number) });
+    // Windows does not report EBADF for a descriptor number that was never opened.
+    if (!isWindows) expect(err).toMatchObject({ code: "EBADF", fd });
   });
 });

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -239,3 +239,60 @@ test("missing file throws the expected error", async () => {
   });
   Bun.gc(true);
 });
+
+// Like the network errors fetch() rejects with, a Bun.file() body that cannot
+// be read rejects with a TypeError that still carries the system error fields.
+describe.concurrent("Bun.file() body that cannot be read rejects with a TypeError", () => {
+  // The body is read before anything is connected, so the promise comes back
+  // already rejected. Checking that (and the system error fields) pins the
+  // rejection to the body, not to the connection the URL would refuse.
+  function earlyRejection(promise: Promise<Response>): Promise<unknown> {
+    const error = promise.then(
+      () => {
+        throw new Error("fetch() resolved");
+      },
+      err => err,
+    );
+    expect(Bun.peek.status(promise)).toBe("rejected");
+    return error;
+  }
+
+  test("file that does not exist (open fails)", async () => {
+    using dir = tempDir("fetch-unreadable-body", {});
+    const path = join(String(dir), "missing.txt");
+
+    const err = await earlyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(path) }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err).toMatchObject({
+      code: "ENOENT",
+      syscall: "open",
+      path: expect.stringContaining("missing.txt"),
+    });
+  });
+
+  test("file that does not exist, as the body of a Request", async () => {
+    using dir = tempDir("fetch-unreadable-body", {});
+    const path = join(String(dir), "missing.txt");
+
+    const request = new Request("http://127.0.0.1:1/", { method: "POST", body: Bun.file(path) });
+    const err = await earlyRejection(fetch(request));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err).toMatchObject({ code: "ENOENT", syscall: "open" });
+  });
+
+  test("directory (open succeeds, read fails)", async () => {
+    using dir = tempDir("fetch-unreadable-body", {});
+
+    const err = await earlyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(String(dir)) }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err).toMatchObject({ code: "EISDIR", syscall: "read" });
+  });
+
+  test("file descriptor that is not open (dup fails)", async () => {
+    const err = await earlyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(1 << 30) }));
+    expect(err).toBeInstanceOf(TypeError);
+    // Windows reports a different errno for a descriptor number that was never
+    // opened; posix dup() fails with EBADF.
+    if (!isWindows) expect(err).toMatchObject({ code: "EBADF" });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

`fetch()` with a `Bun.file()` request body that cannot be read rejects with a plain `Error`. Since #35855 the network errors `fetch()` produces are `TypeError`s that carry the system error fields, and this rejection is the one remaining system error on the request side that was left out:

```js
try {
  await fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file("/definitely/missing/upload") });
} catch (e) {
  console.log(e.constructor.name, e instanceof TypeError, e.code);
}
// before: Error false ENOENT
// after:  TypeError true ENOENT
// for comparison, fetch("http://127.0.0.1:1/") rejects with TypeError { code: "ConnectionRefused" }
```

The same applies to a directory as the body (`EISDIR` from the read), a descriptor that is not open (`EBADF` from the dup), and a `Request` whose body is the `Bun.file()`.

**Cause:** in the `needs_to_read_file()` block of `src/runtime/webcore/fetch.rs`, both the open/dup failure and the `read_file` failure converted the `bun_sys::Error` with `to_js()`, which is `SystemError::to_error_instance`, i.e. a plain `Error`.

**Fix:** both sites now go through a small helper that builds the same `SystemError` with `to_type_error_instance` (the binding #35855 added, and what `ValueError::SystemTypeError` uses for the network errors from `FetchTasklet::on_reject`). `code`, `errno`, `syscall`, `path`/`fd` and the message are unchanged; only the prototype differs. The `SysErrorJsc` import goes away because these were its only uses in the file.

### Why a TypeError

The fetch spec turns a request body that fails to be read into a network error (HTTP-network fetch, `processBodyError`), and `fetch()` rejects every network error with a `TypeError`. Node does the same for the equivalent input: a body stream over a missing file rejects with `TypeError: fetch failed` (cause `ENOENT`). Bun's convention since #35855 is to put the system error fields directly on the `TypeError` rather than under `cause`, and that is the shape this change produces, so `err instanceof TypeError` now identifies all of `fetch()`'s own failures regardless of whether the body or the connection failed.

Out of scope and unchanged here: a `FormData` body holding an unreadable `Bun.file()` (a body extraction error shared with the `Request`/`Response` constructors) and `data:` URL failures still reject with a plain `Error`; those are separate code paths. The rejected promise is still created the same way as before, so this composes with #37434, which changes how these early rejections are reported but not their class.

### How did you verify your code works?

New `describe` block in `test/js/bun/http/fetch-file-upload.test.ts` covering the open failure (missing file, also via a `Request`), the read failure (directory) and the dup failure (descriptor that is not open). Each test checks that the promise comes back already rejected (`Bun.peek.status`), that the error is `instanceof TypeError`, and that the system error fields are still there. All four fail on the current release (`Expected constructor: TypeError`, received the plain `Error` with the same fields) and pass with this change; the rest of the file passes as well. `cargo clippy -p bun_runtime` is clean.
