### PR TITLE
bundler: fail the build instead of aborting when a naming template renders an output path that does not fit a path buffer

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -666,7 +666,7 @@ impl IntermediateOutput {
         let additional_files = graph.input_files.items_additional_files();
         let unique_key_for_additional_files =
             graph.input_files.items_unique_key_for_additional_file();
-        let mut relative_platform_buf = bun_paths::path_buffer_pool::get();
+        let mut relative_spill = Vec::new();
         let mut file_path_buf = bun_paths::path_buffer_pool::get();
         match self {
             IntermediateOutput::Pieces(pieces) => {
@@ -784,11 +784,10 @@ impl IntermediateOutput {
                                 if use_outdir_relative_path {
                                     file_path
                                 } else {
-                                    bun_paths::resolve_path::relative_platform_buf::<
+                                    bun_paths::resolve_path::relative_platform_spill::<
                                         bun_paths::platform::Posix,
-                                        false,
                                     >(
-                                        &mut relative_platform_buf[..], from_chunk_dir, file_path
+                                        &mut relative_spill, from_chunk_dir, file_path
                                     )
                                 },
                             );
@@ -965,11 +964,10 @@ impl IntermediateOutput {
                                 if use_outdir_relative_path {
                                     file_path
                                 } else {
-                                    bun_paths::resolve_path::relative_platform_buf::<
+                                    bun_paths::resolve_path::relative_platform_spill::<
                                         bun_paths::platform::Posix,
-                                        false,
                                     >(
-                                        &mut relative_platform_buf[..], from_chunk_dir, file_path
+                                        &mut relative_spill, from_chunk_dir, file_path
                                     )
                                 },
                             );

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2461,10 +2461,12 @@ impl<'a> LinkerContext<'a> {
                             let path = &parse_graph.additional_output_files
                                 [*output_file_id as usize]
                                 .dest_path;
-                            hash.write(bun_paths::resolve_path::relative_platform::<
+                            let mut relative_spill = Vec::new();
+                            hash.write(bun_paths::resolve_path::relative_platform_spill::<
                                 bun_paths::resolve_path::platform::Posix,
-                                false,
-                            >(from_chunk_dir, path));
+                            >(
+                                &mut relative_spill, from_chunk_dir, path
+                            ));
                         }
                         AdditionalFile::SourceIndex(_) => {}
                     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4207,6 +4207,7 @@ pub mod bv2_impl {
                     )
                 };
                 let mut additional_output_files: Vec<options::OutputFile> = Vec::new();
+                let mut has_unusable_output_path = false;
 
                 for reachable_source in reachable_files {
                     let index = reachable_source.get() as usize;
@@ -4277,6 +4278,15 @@ pub mod bv2_impl {
                             v.into_boxed_slice()
                         };
 
+                        if !template.check_output_path(
+                            self.transpiler.log_mut(),
+                            source.path.pretty,
+                            &output_path,
+                        ) {
+                            has_unusable_output_path = true;
+                            continue;
+                        }
+
                         let loader = loaders[index];
 
                         // Hand the existing `source.contents` buffer to the
@@ -4314,6 +4324,9 @@ pub mod bv2_impl {
                 }
 
                 self.graph.additional_output_files = additional_output_files;
+                if has_unusable_output_path {
+                    return Err(crate::Error::BuildFailed);
+                }
             }
             Ok(())
         }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -371,6 +371,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         let mut duplicates_map: StringArrayHashMap<DuplicateEntry> = StringArrayHashMap::default();
 
         let mut chunk_visit_map = AutoBitSet::init_empty(chunks.len())?;
+        let mut has_unusable_output_path = false;
 
         // Compute the final hashes of each chunk, then use those to create the final
         // paths of each chunk. This can technically be done in parallel but it
@@ -401,6 +402,18 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 .print(&mut rel_path, !c.options.compile_mode.is_executable())
                 .expect("write to Vec<u8>");
             path::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
+
+            let input: &[u8] = c.parse_graph().input_files.items_source()
+                [chunk.entry_point.source_index() as usize]
+                .path
+                .pretty;
+            if !chunk
+                .template
+                .check_output_path(c.log_disjoint(), input, &rel_path)
+            {
+                has_unusable_output_path = true;
+                continue;
+            }
 
             if path_names_map.get_or_put(&rel_path)?.found_existing {
                 // collect all duplicates in a list
@@ -496,6 +509,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             }
 
             return Err(crate::Error::DuplicateOutputPath);
+        }
+
+        if has_unusable_output_path {
+            return Err(crate::Error::BuildFailed);
         }
     }
 
@@ -702,7 +719,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // so the sourceMappingURL resolves relative to the HTML
                         // file rather than a JS file next to the .map. Point at
                         // the .map path relative to the HTML chunk's directory.
-                        let mut relative_platform_buf = path::path_buffer_pool::get();
+                        let mut relative_spill = Vec::new();
                         let [a, b]: [&[u8]; 2] = if !c.options.public_path.is_empty() {
                             cheap_prefix_normalizer(
                                 c.options.public_path,
@@ -730,13 +747,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 if html_dir.is_empty() {
                                     &source_map_final_rel_path
                                 } else {
-                                    path::resolve_path::relative_platform_buf::<
+                                    path::resolve_path::relative_platform_spill::<
                                         path::platform::Posix,
-                                        false,
                                     >(
-                                        &mut relative_platform_buf[..],
-                                        html_dir,
-                                        &source_map_final_rel_path,
+                                        &mut relative_spill, html_dir, &source_map_final_rel_path
                                     )
                                 },
                             )

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2336,6 +2336,38 @@ impl PathTemplate {
             sanitize_parent_dirs,
         )
     }
+
+    /// Longest output path the rest of the build can hold. Rendered paths are
+    /// copied into `PathBuffer`s (the import paths printed into chunks,
+    /// `resolve_path::z` before writing), chunk paths also with a `.map` or
+    /// `.jsc` sidecar extension appended, and `PATH_MAX` counts the NUL.
+    pub(crate) const MAX_OUTPUT_PATH_LEN: usize = bun_paths::MAX_PATH_BYTES - 1 - ".map".len();
+
+    /// Whether `output_path`, rendered from this template for `input`, is usable;
+    /// logs an error against the template when it is not.
+    pub(crate) fn check_output_path(
+        &self,
+        log: &mut bun_ast::Log,
+        input: &[u8],
+        output_path: &[u8],
+    ) -> bool {
+        if output_path.len() <= Self::MAX_OUTPUT_PATH_LEN {
+            return true;
+        }
+        log.add_range_error_fmt_with_note(
+            None,
+            bun_ast::Range::NONE,
+            format_args!(
+                "Output path for {} is too long ({} bytes, the limit on this platform is {})",
+                bun_core::fmt::quote(input),
+                output_path.len(),
+                Self::MAX_OUTPUT_PATH_LEN,
+            ),
+            format_args!("naming template is {}", bun_core::fmt::quote(&self.data)),
+            bun_ast::Range::NONE,
+        );
+        false
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -651,9 +651,59 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
 ) -> &'a [u8] {
     // RELATIVE_FROM_BUF and RELATIVE_TO_BUF are independent allocations so the
     // two `&mut` borrows below are disjoint.
-    let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
-    let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
+    relative_platform_scratch::<P, ALWAYS_COPY>(
+        buf,
+        &mut RELATIVE_FROM_BUF.with(lazy_path_buf)[..],
+        &mut RELATIVE_TO_BUF.with(lazy_path_buf)[..],
+        from,
+        to,
+    )
+}
 
+/// Upper bound on what [`relative_platform_scratch`] writes into any one of its
+/// three buffers. Either input grows by a few bytes at most when it is resolved
+/// against the top-level dir and normalized; the result spends at most `/..`
+/// per segment of the normalized `from` (segments are at least two bytes apart,
+/// so under 1.5x its length) plus a separator and the tail of `to`. Rounded up.
+fn relative_scratch_len(from: &[u8], to: &[u8]) -> usize {
+    let top_level_dir_len = Fs::FileSystem::instance().top_level_dir().len();
+    let normalized_from = top_level_dir_len + from.len() + 4;
+    let normalized_to = top_level_dir_len + to.len() + 4;
+    2 * normalized_from + normalized_to + 8
+}
+
+/// [`relative_platform`] for inputs of any length. Uses the thread-local path
+/// buffers when they provably fit, otherwise computes in `spill` (grown as
+/// needed), so neither a long input nor a long `../` chain in the result can
+/// overflow a `PathBuffer`. Like [`relative_platform`], the result is valid
+/// until the next relative-path call on this thread or the next use of `spill`.
+pub fn relative_platform_spill<'a, P: PlatformT>(
+    spill: &'a mut Vec<u8>,
+    from: &[u8],
+    to: &[u8],
+) -> &'a [u8] {
+    let needed = relative_scratch_len(from, to);
+    if needed <= MAX_PATH_BYTES {
+        return relative_platform::<P, false>(from, to);
+    }
+    if spill.len() < needed * 3 {
+        spill.resize(needed * 3, 0);
+    }
+    let (buf, rest) = spill.split_at_mut(needed);
+    let (relative_from_buf, relative_to_buf) = rest.split_at_mut(needed);
+    relative_platform_scratch::<P, false>(buf, relative_from_buf, relative_to_buf, from, to)
+}
+
+/// `relative_from_buf` and `relative_to_buf` must each hold the absolute,
+/// normalized form of their input and `buf` the result; see
+/// [`relative_scratch_len`].
+fn relative_platform_scratch<'a, P: PlatformT, const ALWAYS_COPY: bool>(
+    buf: &'a mut [u8],
+    relative_from_buf: &'a mut [u8],
+    relative_to_buf: &'a mut [u8],
+    from: &[u8],
+    to: &[u8],
+) -> &'a [u8] {
     let normalized_from: &[u8] = if P::P.is_absolute(from) {
         'brk: {
             if P::P == Platform::Loose && cfg!(windows) {
@@ -2428,3 +2478,59 @@ pub fn posix_to_platform_in_place<T: PathChar>(path_buffer: &mut [T]) {
 // `PathChar` is now canonical at `crate::path_char`; re-export for callers
 // that still path through `resolve_path::PathChar`.
 pub use crate::PathChar;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The top-level dir is process-wide, so every test here resolves relative
+    // inputs against the same seed.
+    fn relative_spill<'a>(spill: &'a mut Vec<u8>, from: &[u8], to: &[u8]) -> &'a [u8] {
+        Fs::FileSystem::init(b"/cwd");
+        relative_platform_spill::<platform::Posix>(spill, from, to)
+    }
+
+    #[test]
+    fn relative_platform_spill_uses_thread_locals_when_inputs_fit() {
+        let mut spill = Vec::new();
+        assert_eq!(
+            relative_spill(&mut spill, b"./chunks", b"./assets/x.txt"),
+            b"../assets/x.txt"
+        );
+        assert_eq!(relative_spill(&mut spill, b"", b"./x.txt"), b"x.txt");
+        assert_eq!(
+            relative_spill(&mut spill, b"/cwd/a/b", b"/cwd/c"),
+            b"../../c"
+        );
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn relative_platform_spill_to_longer_than_a_path_buffer_once_resolved() {
+        // Fits a PathBuffer on its own; does not once joined onto the top-level dir.
+        let name = vec![b'a'; MAX_PATH_BYTES - 8];
+        let to: Vec<u8> = [b"./".as_slice(), &name].concat();
+        let mut spill = Vec::new();
+        assert_eq!(relative_spill(&mut spill, b"", &to), name);
+        assert!(!spill.is_empty());
+
+        let name = vec![b'a'; MAX_PATH_BYTES * 2];
+        let to: Vec<u8> = [b"./".as_slice(), &name].concat();
+        assert_eq!(
+            relative_spill(&mut spill, b"./chunks", &to),
+            [b"../".as_slice(), &name].concat()
+        );
+    }
+
+    #[test]
+    fn relative_platform_spill_result_longer_than_either_input() {
+        // `from` fits a PathBuffer, but climbing out of it takes 3 bytes per segment.
+        let segments = MAX_PATH_BYTES / 2;
+        let mut from = b"a/".repeat(segments);
+        from.pop();
+        let expected: Vec<u8> = [b"../".repeat(segments).as_slice(), b"x.txt"].concat();
+        let mut spill = Vec::new();
+        assert_eq!(relative_spill(&mut spill, &from, b"x.txt"), expected);
+        assert!(expected.len() > MAX_PATH_BYTES);
+    }
+}

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
 import { ESBUILD, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -407,4 +407,177 @@ describe("bundler", () => {
       expect(exitCode).toBe(0);
     });
   }
+});
+
+// Output paths rendered from a naming template used to be copied into fixed-size
+// path buffers unchecked, so a template that rendered too long aborted the
+// process instead of failing the build. Every case spawns bun because the old
+// behavior was a crash.
+describe("bundler naming templates that render long output paths", () => {
+  // bun's PathBuffer size (MAX_PATH_BYTES): PATH_MAX on POSIX, 32767 UTF-16 units as UTF-8 on Windows.
+  const maxPathBytes = isWindows ? 32767 * 3 + 1 : isMacOS ? 1024 : 4096;
+  // Output paths also have to fit with a ".map" / ".jsc" sidecar extension appended.
+  const maxOutputPathLen = maxPathBytes - 1 - ".map".length;
+  // Templates start with "./" so they render to exactly their own length.
+  const templateOfLength = (length: number) => "./" + Buffer.alloc(length - 2, "a").toString();
+
+  interface BuildReport {
+    success: boolean;
+    logs: { message: string; notes: string[] }[];
+    outputs: { kind: string; path: string; text: string }[];
+  }
+
+  async function build(configSource: string): Promise<BuildReport> {
+    using dir = tempDir("naming-long-output-path", {
+      "asset.txt": "hello",
+      "app.js": `import f from "./asset.txt" with { type: "file" }; console.log(f);`,
+      "plain.js": `console.log(1);`,
+      "dynamic.js": `import("./shared.js").then(m => console.log(m.x));`,
+      "shared.js": `export const x = 1;`,
+      "build.ts": `
+        const result = await Bun.build({ throw: false, ...(${configSource}) });
+        const outputs = [];
+        for (const output of result.outputs) {
+          outputs.push({ kind: output.kind, path: output.path, text: await output.text() });
+        }
+        console.log(JSON.stringify({
+          success: result.success,
+          logs: result.logs.map(log => ({ message: log.message, notes: log.notes.map(note => note.message) })),
+          outputs,
+        }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  /** The asset reference printed into the entry point: its only string literal. */
+  function assetReference(report: BuildReport): string {
+    const entry = report.outputs.find(output => output.kind === "entry-point")!;
+    return entry.text.match(/"([^"]*)"/)![1];
+  }
+
+  test.concurrent("asset naming rendering past the limit fails the build", async () => {
+    const template = templateOfLength(maxPathBytes + 100) + "-[name].[ext]";
+    const report = await build(`{ entrypoints: ["./app.js"], naming: { asset: ${JSON.stringify(template)} } }`);
+    expect(report.success).toBe(false);
+    expect(report.outputs).toEqual([]);
+    expect(report.logs).toEqual([
+      {
+        message: `Output path for "asset.txt" is too long (${template.length + "asset.txt".length - "[name].[ext]".length} bytes, the limit on this platform is ${maxOutputPathLen})`,
+        notes: [`naming template is ${JSON.stringify(template)}`],
+      },
+    ]);
+  });
+
+  test.concurrent("chunk naming rendering past the limit fails the build", async () => {
+    const template = templateOfLength(maxPathBytes + 100) + "-[name]-[hash].[ext]";
+    const report = await build(
+      `{ entrypoints: ["./dynamic.js"], splitting: true, naming: { chunk: ${JSON.stringify(template)} } }`,
+    );
+    expect(report.success).toBe(false);
+    expect(report.outputs).toEqual([]);
+    expect(report.logs.length).toBeGreaterThan(0);
+    for (const log of report.logs) {
+      expect(log.message).toMatch(
+        /^Output path for ".+" is too long \(\d+ bytes, the limit on this platform is \d+\)$/,
+      );
+      expect(log.notes).toEqual([`naming template is ${JSON.stringify(template)}`]);
+    }
+  });
+
+  test.concurrent("entry naming rendering past the limit fails the build", async () => {
+    const template = templateOfLength(maxPathBytes + 100) + "-[name].[ext]";
+    const report = await build(`{ entrypoints: ["./plain.js"], naming: { entry: ${JSON.stringify(template)} } }`);
+    expect(report.success).toBe(false);
+    expect(report.outputs).toEqual([]);
+    expect(report.logs).toEqual([
+      {
+        message: `Output path for "plain.js" is too long (${template.length + "plain.js".length - "[name].[ext]".length} bytes, the limit on this platform is ${maxOutputPathLen})`,
+        notes: [`naming template is ${JSON.stringify(template)}`],
+      },
+    ]);
+  });
+
+  test.concurrent("one byte past the limit is rejected", async () => {
+    const template = templateOfLength(maxOutputPathLen + 1);
+    const report = await build(`{ entrypoints: ["./app.js"], naming: { asset: ${JSON.stringify(template)} } }`);
+    expect(report.success).toBe(false);
+    expect(report.logs).toEqual([
+      {
+        message: `Output path for "asset.txt" is too long (${maxOutputPathLen + 1} bytes, the limit on this platform is ${maxOutputPathLen})`,
+        notes: [`naming template is ${JSON.stringify(template)}`],
+      },
+    ]);
+  });
+
+  // These paths fit, but resolving them against the cwd while computing the import
+  // specifier did not fit in a path buffer.
+  test.concurrent("an output path exactly at the limit builds", async () => {
+    const template = templateOfLength(maxOutputPathLen);
+    const report = await build(`{ entrypoints: ["./app.js"], naming: { asset: ${JSON.stringify(template)} } }`);
+    expect(report.logs).toEqual([]);
+    expect(report.success).toBe(true);
+    expect(report.outputs.map(output => [output.kind, output.path])).toEqual([
+      ["entry-point", "./app.js"],
+      ["asset", isWindows ? template.replaceAll("/", "\\") : template],
+    ]);
+    expect(assetReference(report)).toBe(template);
+  });
+
+  test.concurrent("a chunk in a subdirectory can reference an output path at the limit", async () => {
+    const template = templateOfLength(maxOutputPathLen);
+    const report = await build(
+      `{ entrypoints: ["./app.js"], naming: { entry: "./deep/[name].[ext]", asset: ${JSON.stringify(template)} } }`,
+    );
+    expect(report.logs).toEqual([]);
+    expect(report.success).toBe(true);
+    expect(assetReference(report)).toBe("../" + template.slice("./".length));
+  });
+
+  test.concurrent("an import specifier longer than a path buffer is printed in full", async () => {
+    // The chunk path fits; the "../" per directory needed to get back out of it does not.
+    const depth = Math.floor(maxPathBytes * 0.4);
+    const entry = "./" + Buffer.alloc(depth * 2, "a/").toString() + "[name].[ext]";
+    const report = await build(
+      `{ entrypoints: ["./app.js"], naming: { entry: ${JSON.stringify(entry)}, asset: "./[name].[ext]" } }`,
+    );
+    expect(report.logs).toEqual([]);
+    expect(report.success).toBe(true);
+    const reference = assetReference(report);
+    expect(reference).toBe(Buffer.alloc(depth * 3, "../").toString() + "asset.txt");
+    expect(reference.length).toBeGreaterThan(maxPathBytes);
+  });
+
+  test.concurrent("bun build reports a template whose placeholders expand past the limit", async () => {
+    const name = Buffer.alloc(100, "b").toString();
+    const template =
+      Buffer.alloc("[name]".length * Math.ceil((maxPathBytes + 100) / name.length), "[name]").toString() + ".[ext]";
+    using dir = tempDir("naming-long-output-path-cli", {
+      [`${name}.txt`]: "hello",
+      "app.js": `import f from "./${name}.txt" with { type: "file" }; console.log(f);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./app.js", "--outdir", "./out", "--asset-naming", template],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`Output path for "${name}.txt" is too long (`);
+    expect(stderr).toContain(`naming template is "`);
+    expect(stderr).toContain(template);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### Reproduction

```js
import { writeFileSync } from "node:fs";
writeFileSync("asset.txt", "hello");
writeFileSync("app.js", 'import f from "./asset.txt" with { type: "file" }; console.log(f);');
const r = await Bun.build({
  entrypoints: ["./app.js"],
  throw: false,
  naming: { asset: Buffer.alloc(5000, "a").toString() + "-[name].[ext]" },
});
console.log(r.success);
```

On bun 1.4.0 this aborts the process (exit 134), `throw: false` notwithstanding:

```
panic: range end index 5010 out of range for slice of length 4096
```

`naming.chunk` with `splitting: true` crashes the same way (in `IntermediateOutput::code_with_source_map_shifts`), and the template does not have to be absurd: with the cwd `/tmp/repro-naming`, an asset template of 4080 bytes (a rendered path of 4086 bytes, which fits in a path buffer) still crashes with `range end index 4101 out of range for slice of length 4095`. A chunk naming template with ~1400 nested directories and a short asset crashes too (`range end index 4097 out of range for slice of length 4096`). An `outdir` is not needed; in-memory builds crash as well.

### Cause

Output paths rendered from the entry, chunk and asset naming templates flow into several fixed-size `PathBuffer`s without a length check: `resolve_path::relative_platform` while hashing chunks (`LinkerContext::append_isolated_hashes_for_imported_chunks`) and while printing import specifiers into chunks (`Chunk.rs`), the `file_path_buf` scratch copy in `Chunk.rs`, and `resolve_path::z` before the files are written. The first one to be reached panics on the slice copy.

`relative_platform` has two more ways to overflow even when both paths fit on their own: it resolves relative inputs against the cwd inside thread-local `PathBuffer`s (so the limit effectively shrinks by the cwd length), and it writes the result into a `PathBuffer` although a `../` chain climbing out of a deep chunk directory can be longer than either input.

### Fix

* `PathTemplate::check_output_path` validates each rendered path where it is rendered: `process_files_to_copy` for assets and `generate_chunks_in_parallel` for entry points and chunks. A path that does not fit fails the build with an error naming the input and a note naming the template:

  ```
  error: Output path for "asset.txt" is too long (5012 bytes, the limit on this platform is 4091)
  note: naming template is "./aaaa...-[name].[ext]"
  ```

  The limit is `MAX_PATH_BYTES - 1` minus room for the `.map` / `.jsc` sidecar extension that is appended to chunk paths downstream, so every later consumer of the path is covered by the one check.

* `resolve_path::relative_platform_spill` computes the same result as `relative_platform`, but sizes its scratch from the inputs and computes in a caller-provided `Vec` when the thread-local buffers are not provably large enough. The existing `relative_platform_buf` body becomes `relative_platform_scratch` with the buffers as parameters, so both variants share one implementation and the common case still runs on the thread-local buffers with no allocation. The three bundler sites that relativize one output path against another (chunk hashing, chunk printing, the standalone HTML sourcemap link) use it.

Why reject at render time rather than make every consumer tolerant: an output path longer than a path buffer cannot be opened by any syscall on the platform, so there is nothing useful a build can do with it, and the naming template is the thing the user has to change. Checking at the two render sites covers every consumer (including the sidecar names and `resolve_path::z`) with one error message instead of a different failure mode per site. The relative-path primitive is fixed separately because its overflow condition depends on the cwd and on the chunk directory depth, which no per-path bound can express without rejecting legitimate paths.

Behavior change: an in-memory build whose only output had an over-long entry path used to report `success: true`; it now fails like every other variant (the same build with an `outdir`, a second output or a subdirectory already failed or crashed).

### Verification

`test/bundler/bundler_naming.test.ts` gains eight spawned cases: asset, chunk and entry templates past the limit fail with the message above; one byte past the limit is rejected; a path exactly at the limit builds from a root chunk and from a chunk in a subdirectory (both previously hit the cwd-join overflow); a chunk ~0.4 * `MAX_PATH_BYTES` directories deep prints an import specifier longer than a path buffer; and `bun build --asset-naming` with a short template whose `[name]` placeholders expand past the limit reports the error on stderr. All eight crash or pass wrongly on 1.4.0 and pass with this change. `relative_platform_spill` also has unit tests in `bun_paths` (run under `bun run rust:miri -p bun_paths`) for the cwd-join and `../`-chain cases. `bundler_naming`, `bundler_splitting`, `bundler_loader`, `bundler_files`, `bundler_html`, `standalone`, `html-import-manifest` and `bun-build-api` pass locally (one unrelated 400-build stress test times out on the local debug build regardless of this change).
