### PR TITLE
s3: S3Credentials::dupe() returns Box; drop the unshared refcount

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -94,7 +94,7 @@ impl DotEnvBehavior {
 
 /// Mirrors the value fields of `bun_s3_signing::S3Credentials` (T5). Defined locally so
 /// this T2 crate names no `bun_s3_signing` types — see PORTING.md §Dispatch (cold-path,
-/// upward dep). The high-tier caller constructs the real refcounted `S3Credentials` from
+/// upward dep). The high-tier caller constructs the real `S3Credentials` from
 /// this POD at the call site.
 #[derive(Clone, Default)]
 pub struct S3Credentials {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1891,7 +1891,7 @@ fn get_s3_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JSValue 
         return v;
     }
     // NOTE (layering): `bun_dotenv::Loader::get_s3_credentials` returns the
-    // T2 POD mirror; lift it into the refcounted `bun_s3_signing::S3Credentials`
+    // T2 POD mirror; lift it into `bun_s3_signing::S3Credentials`
     // here at the high-tier call site (dotenv ≤T2 may not name s3_signing T5).
     // SAFETY: `transpiler.env` is the process-lifetime dotenv loader; disjoint
     // from `rare_data` storage.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1407,9 +1407,7 @@ impl BlobExt for Blob {
             let proxy_url = proxy.map(|p| p.href);
 
             // When no JS overrides were supplied, hand the store's *base*
-            // credentials to the upload (`upload_stream` consumes an
-            // `IntrusiveRc` by value, so the else-arm heap-dupes from the
-            // store's `Arc` instead of from the `aws_options` clone).
+            // credentials to the upload.
             return crate::webcore::__s3_client::upload_stream(
                 if extra_options.is_some() {
                     aws_options.credentials.dupe()
@@ -1733,8 +1731,6 @@ impl BlobExt for Blob {
                 let credentials_with_options =
                     s3.get_credentials_with_options(Some(options), global_this)?;
                 // `defer credentialsWithOptions.deinit()` → Drop handles slices.
-                // `writable_stream` adopts the dup'd ref by value; the
-                // MultiPartUpload derefs on done.
                 return crate::webcore::s3::client::writable_stream(
                     credentials_with_options.credentials.dupe(),
                     path,

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -37,10 +37,6 @@ pub(crate) trait S3CredentialsExt {
     fn guess_bucket(endpoint: &[u8]) -> Option<&[u8]>;
     #[allow(clippy::too_many_arguments)]
     fn get_credentials_with_options(
-        // Takes `&S3Credentials` (not by-value) — `bun_s3_signing::S3Credentials`
-        // has a private `ref_count` field and no `Clone`, so callers holding a borrow
-        // (e.g. `&IntrusiveRc<S3Credentials>` deref) cannot produce an owned copy. The
-        // real impl in `s3/credentials_jsc.rs` deep-copies internally.
         this: &S3Credentials,
         default_options: MultiPartUploadOptions,
         options: Option<JSValue>,
@@ -248,21 +244,11 @@ where
 
 #[bun_jsc::JsClass]
 pub struct S3Client {
-    pub(crate) credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    pub(crate) credentials: Box<S3Credentials>,
     pub(crate) options: MultiPartUploadOptions,
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
     pub(crate) request_payer: bool,
-}
-
-impl Drop for S3Client {
-    fn drop(&mut self) {
-        // `IntrusiveRc<T>` is `bun_ptr::RefPtr<T>`, which has no `Drop` impl
-        // of its own (only `ScopedRef<T>` does), so the +1 taken by
-        // `aws_options.credentials.dupe()` in `constructor` must be released
-        // explicitly.
-        self.credentials.deref();
-    }
 }
 
 impl S3Client {

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -252,7 +252,6 @@ fn construct_s3_file_internal_store(
     construct_s3_file_with_s3_credentials(global, path, options, &existing_credentials)
 }
 
-/// if the credentials have changed, we need to clone it, if not we can just ref/deref it
 pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
     global: &JSGlobalObject,
     path: PathLike,
@@ -276,11 +275,6 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
     let credentials = if aws_options.changed_credentials {
         std::mem::take(&mut aws_options.credentials)
     } else {
-        // The `Store::S3` field is `Rc<S3Credentials>` (separate rc
-        // layer), so we can't share the existing intrusive allocation —
-        // deep-clone the value instead and let `init_s3` `Rc::new` it.
-        // PERF: profile if hot once Store.rs migrates
-        // `Rc<S3Credentials>` → `IntrusiveRc`.
         default_credentials.clone()
     };
     let store = blob::Store::init_s3(path, None, credentials).expect("oom");

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -263,10 +263,6 @@ impl S3Ext for S3 {
         options: Option<JSValue>,
         global_object: &JSGlobalObject,
     ) -> JsResult<S3CredentialsWithOptions> {
-        // The associated fn (surfaced via `S3CredentialsExt` in `webcore/S3Client.rs`)
-        // takes `&S3Credentials` instead of by-value because `S3Credentials` carries a
-        // private intrusive ref-count and cannot be struct-copied; the impl deep-copies
-        // internally.
         use crate::webcore::s3_client::S3CredentialsExt as _;
         S3Credentials::get_credentials_with_options(
             self.get_credentials(),

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -98,7 +98,7 @@ fn ssl_config_intern_for_http(config: SSLConfig) -> http::ssl_config::SharedPtr 
     http::ssl_config::global_registry::intern(config)
 }
 
-/// Build the refcounted `bun_s3_signing::S3Credentials` from the lower-tier
+/// Build the `bun_s3_signing::S3Credentials` from the lower-tier
 /// `bun_dotenv::S3Credentials` POD mirror. The dotenv crate (T2) cannot name
 /// `bun_s3_signing` types (would be an upward dep), so the conversion lives at
 /// the call site here in T6.
@@ -1943,9 +1943,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 // lifetime is managed by the resolve callback itself).
                 let _ = S3StreamWrapper::resolve(result, ctx.cast::<S3StreamWrapper<'static>>());
             }
-            // `dupe()` heap-allocates a fresh intrusive-refcounted copy.
-            // `upload_stream` adopts the ref by value (no extra bump) and the
-            // MultiPartUpload derefs on completion.
             let _ = s3::upload_stream(
                 credentials_with_options.credentials.dupe(),
                 s3_path,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -415,11 +415,8 @@ pub(crate) fn upload(
 }
 
 /// returns a writable stream that writes to the s3 path
-///
-/// Takes ownership of one `credentials` ref (adopted directly into the
-/// `MultiPartUpload`; not bumped). Callers pass `creds.dupe()`.
 pub(crate) fn writable_stream(
-    credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    credentials: Box<S3Credentials>,
     path: &[u8],
     global_this: &JSGlobalObject,
     options: MultiPartUploadOptions,
@@ -483,7 +480,6 @@ pub(crate) fn writable_stream(
     }
 
     let proxy_url = proxy.unwrap_or(b"");
-    // `credentials` ref adopted by value — moved into the MultiPartUpload below.
     // JSC_BORROW: `global_this` outlives the task (it owns the VM/heap that owns the JS
     // objects which keep the task alive); stored via `GlobalRef` in the heap-allocated
     // MultiPartUpload.
@@ -817,12 +813,8 @@ impl Drop for S3UploadStreamWrapper {
 }
 
 /// consumes the readable stream and upload to s3
-///
-/// Takes ownership of one `credentials` ref (adopted directly into the
-/// `MultiPartUpload`; not bumped). Callers pass `creds.dupe()`. On every
-/// early-return path the ref is explicitly released.
 pub(crate) fn upload_stream(
-    credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    credentials: Box<S3Credentials>,
     path: &[u8],
     readable_stream: ReadableStream,
     global_this: &JSGlobalObject,
@@ -839,7 +831,6 @@ pub(crate) fn upload_stream(
 ) -> JsResult<JSValue> {
     let proxy_url = proxy.unwrap_or(b"");
     if readable_stream.is_disturbed(global_this) {
-        credentials.deref();
         return Ok(bun_jsc::JSPromise::rejected_promise(
             global_this,
             bun_core::String::static_("ReadableStream is already disturbed")
@@ -850,7 +841,6 @@ pub(crate) fn upload_stream(
 
     match readable_stream.ptr {
         ReadableStreamPtr::Invalid => {
-            credentials.deref();
             return Ok(bun_jsc::JSPromise::rejected_promise(
                 global_this,
                 bun_core::String::static_("ReadableStream is invalid")
@@ -882,7 +872,6 @@ pub(crate) fn upload_stream(
                 });
                 let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
-                credentials.deref();
                 return Ok(bun_jsc::JSPromise::rejected_promise(global_this, js_err).to_js());
             }
         }
@@ -907,7 +896,6 @@ pub(crate) fn upload_stream(
                 });
                 let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
-                credentials.deref();
                 return Ok(bun_jsc::JSPromise::rejected_promise(global_this, js_err).to_js());
             }
         }
@@ -931,8 +919,6 @@ pub(crate) fn upload_stream(
         );
     }
 
-    // `credentials` is owned-by-value and explicitly `.deref()`ed on each early
-    // return above; the ref is adopted by value — moved into the MultiPartUpload below.
     // SAFETY (JSC_BORROW): see `writable_stream` for rationale.
     let global_static = GlobalRef::from(global_this);
     let part_size = options.part_size;

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -77,9 +77,6 @@ pub(crate) fn get_credentials_with_options(
 ) -> JsResult<S3CredentialsWithOptions> {
     bun_analytics::features::s3.fetch_add(1, Ordering::Relaxed);
     // get ENV config
-    // `S3Credentials`
-    // carries an intrusive ref-count and is not `Copy`; `Clone` performs a
-    // deep field copy with a fresh ref-count.
     let mut new_credentials = S3CredentialsWithOptions {
         credentials: this.clone(),
         options: default_options,

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -135,7 +135,7 @@ pub struct MultiPartUpload {
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
     pub(crate) request_payer: bool,
-    pub(crate) credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    pub(crate) credentials: Box<S3Credentials>,
     pub poll_ref: JsCell<KeepAlive>,
     pub(crate) vm: &'static VirtualMachine,
     // JSC_BORROW per LIFETIMES.tsv row 1886 — rust_type `&JSGlobalObject` used verbatim
@@ -382,9 +382,6 @@ impl Drop for MultiPartUpload {
             ))
         });
         // path, proxy, content_type, content_disposition, content_encoding — Box dropped automatically
-        // `IntrusiveRc<T>` (= `RefPtr<T>`) has no `Drop` — release the +1 the
-        // constructing `writable_stream`/`upload_stream` adopted.
-        self.credentials.deref();
         // multipart_etags: Vec<UploadPartResult> — Drop (each etag Box<[u8]> freed)
         // multipart_upload_list: Vec<u8> — Drop
         // bun.destroy(this) — handled by deref_() via heap::take

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -6,7 +6,7 @@ use bstr::BStr;
 use bun_core::strings;
 use bun_http_types::Method::Method;
 use bun_picohttp::Header as PicoHeader;
-use bun_ptr::{IntrusiveRc, RawSlice, RefCount};
+use bun_ptr::RawSlice;
 
 use super::acl::ACL;
 use super::storage_class::StorageClass;
@@ -163,69 +163,24 @@ fn boring_engine() -> *mut bun_sha_hmac::sha::ffi::ENGINE {
 // S3Credentials
 // ──────────────────────────────────────────────────────────────────────────
 
-// `bun.ptr.RefCount(...)` mixin → IntrusiveRc handles ref/deref; when count hits
-// zero the boxed allocation is dropped, which drops the Box<[u8]> fields, so no
-// explicit Drop body is needed here.
-#[derive(bun_ptr::RefCounted)]
+#[derive(Clone, Default)]
 pub struct S3Credentials {
-    // Intrusive refcount; managed by bun_ptr::IntrusiveRc<S3Credentials>.
-    ref_count: RefCount<S3Credentials>,
     pub access_key_id: Box<[u8]>,
     pub secret_access_key: Box<[u8]>,
     pub region: Box<[u8]>,
     pub endpoint: Box<[u8]>,
     pub bucket: Box<[u8]>,
     pub session_token: Box<[u8]>,
-    pub(crate) storage_class: Option<StorageClass>,
     /// Important for MinIO support.
     pub insecure_http: bool,
     /// indicates if the endpoint is a virtual hosted style bucket
     pub virtual_hosted_style: bool,
 }
 
-// `S3Credentials` owns its bytes via
-// `Box<[u8]>`, so a manual `Clone` deep-copies them and resets `ref_count` — the
-// intrusive count only applies to heap (`IntrusiveRc`) instances; a fresh value
-// must start at 1.
-impl Clone for S3Credentials {
-    fn clone(&self) -> Self {
-        Self {
-            ref_count: RefCount::init(),
-            access_key_id: self.access_key_id.clone(),
-            secret_access_key: self.secret_access_key.clone(),
-            region: self.region.clone(),
-            endpoint: self.endpoint.clone(),
-            bucket: self.bucket.clone(),
-            session_token: self.session_token.clone(),
-            storage_class: self.storage_class,
-            insecure_http: self.insecure_http,
-            virtual_hosted_style: self.virtual_hosted_style,
-        }
-    }
-}
-
-impl Default for S3Credentials {
-    fn default() -> Self {
-        Self {
-            ref_count: RefCount::init(),
-            access_key_id: Box::default(),
-            secret_access_key: Box::default(),
-            region: Box::default(),
-            endpoint: Box::default(),
-            bucket: Box::default(),
-            session_token: Box::default(),
-            storage_class: None,
-            insecure_http: false,
-            virtual_hosted_style: false,
-        }
-    }
-}
-
 impl S3Credentials {
-    /// Construct a value (refcount = 1) from owned field data. Exists so
-    /// higher-tier callers (e.g. `bun_runtime`) can build the refcounted
-    /// signing credentials from the lower-tier `bun_dotenv::S3Credentials`
-    /// POD mirror without naming the private `ref_count` field.
+    /// Construct from owned field data; used by higher-tier callers (e.g.
+    /// `bun_runtime`) to build the signing credentials from the lower-tier
+    /// `bun_dotenv::S3Credentials` POD mirror.
     #[allow(clippy::too_many_arguments)]
     pub fn new_value(
         access_key_id: Box<[u8]>,
@@ -237,14 +192,12 @@ impl S3Credentials {
         insecure_http: bool,
     ) -> Self {
         Self {
-            ref_count: RefCount::init(),
             access_key_id,
             secret_access_key,
             region,
             endpoint,
             bucket,
             session_token,
-            storage_class: None,
             insecure_http,
             virtual_hosted_style: false,
         }
@@ -259,19 +212,8 @@ impl S3Credentials {
             + self.bucket.len()
     }
 
-    pub fn dupe(&self) -> IntrusiveRc<S3Credentials> {
-        IntrusiveRc::new(S3Credentials {
-            ref_count: RefCount::init(),
-            access_key_id: self.access_key_id.clone(),
-            secret_access_key: self.secret_access_key.clone(),
-            region: self.region.clone(),
-            endpoint: self.endpoint.clone(),
-            bucket: self.bucket.clone(),
-            session_token: self.session_token.clone(),
-            storage_class: None,
-            insecure_http: self.insecure_http,
-            virtual_hosted_style: self.virtual_hosted_style,
-        })
+    pub fn dupe(&self) -> Box<S3Credentials> {
+        Box::new(self.clone())
     }
 
     pub fn sign_request<const ALLOW_EMPTY_PATH: bool>(


### PR DESCRIPTION
## What

`bun_s3_signing::S3Credentials` (`src/s3_signing/credentials.rs`) carried an intrusive `ref_count: RefCount<S3Credentials>` and `dupe()` returned a `bun_ptr::IntrusiveRc<S3Credentials>`, but nothing ever shared that count: there is no `ref_()`, `dupe_ref()`, `clone()` or `from_raw` on any credentials handle anywhere in `src/`, and the blob store keeps its own `Rc<S3Credentials>`. The only four holders (`S3Client.credentials`, `MultiPartUpload.credentials`, and the by-value `credentials` parameters of `writable_stream` and `upload_stream`) each owned exactly one handle and released it by hand, because `IntrusiveRc` has no `Drop`: the whole body of `impl Drop for S3Client`, one line of `MultiPartUpload::drop`, and a `credentials.deref()` on each of the four early returns of `upload_stream`, with doc comments on both stream constructors telling callers how to keep the count balanced.

```rust
// before
#[derive(bun_ptr::RefCounted)]
pub struct S3Credentials { ref_count: RefCount<S3Credentials>, pub access_key_id: Box<[u8]>, .. }
pub fn dupe(&self) -> IntrusiveRc<S3Credentials> { IntrusiveRc::new(S3Credentials { ref_count: RefCount::init(), .. }) }
pub(crate) credentials: bun_ptr::IntrusiveRc<S3Credentials>,   // + self.credentials.deref() in Drop

// after
#[derive(Clone, Default)]
pub struct S3Credentials { pub access_key_id: Box<[u8]>, .. }
pub fn dupe(&self) -> Box<S3Credentials> { Box::new(self.clone()) }
pub(crate) credentials: Box<S3Credentials>,
```

The two fields and the two parameters become `Box<S3Credentials>`, and the six manual `deref()` calls, the `impl Drop for S3Client`, and the balancing comments are deleted. In `credentials.rs` the `ref_count` field, the `RefCounted` derive and the four `RefCount::init()` initialisers go away, which makes the hand-written `Clone` and `Default` impls identical to the derives, so they are derived. Deriving `Clone` exposed that the crate-private `S3Credentials.storage_class` field was only ever written as `None` (three constructors) and was read by nothing but that manual `Clone` (the signing code reads `SignOptions::storage_class` instead), so the field is removed as well; with it gone `dupe()` is exactly a boxed `clone()`. All 13 `dupe()` call expressions (`S3Client.rs`, `api/BunObject.rs`, `fetch.rs`, ten in `Blob.rs`) and every read of the fields (`&self.credentials` / `&ctx.credentials` coercing to `&S3Credentials`) are unchanged. The remaining seven files (`Blob.rs`, `fetch.rs`, `S3File.rs`, `blob/Store.rs`, `s3/credentials_jsc.rs`, `api/BunObject.rs`, `dotenv/env_loader.rs`) only lose comments that described the refcount or the adopt-and-deref protocol. No unsafe blocks are touched.

## Why

Ownership of the credentials copy is now stated by the type: a `Box<S3Credentials>` has one owner and is freed exactly when that owner drops, so the "handle dropped without `deref()`" leak that the deleted comments warned about is no longer expressible, and the signing type itself is plain owned data (six `Box<[u8]>` and two bools, which also makes it `Send + Sync` by auto trait; nothing relied on the opposite). It is zero-cost: `Box<T>` and `RefPtr<T>` are both a single non-null pointer (`RefPtr` only adds a debug-build tracking id), `dupe()` still performs one heap allocation plus the same six `Box<[u8]>` clones, dropping the `Box` is the same single free that `deref()` did when the count went from one to zero minus the decrement, and `S3Credentials` only loses fields (the counter and a one-byte `Option`), so it does not grow. The credentials are freed at the same point for `S3Client` (drop glue instead of the `Drop` body), at the end of `MultiPartUpload`'s drop instead of in the middle of it, and on `upload_stream`'s early returns at function exit instead of just before the rejected promise is built; nothing holds a pointer into them in any of those windows, since `execute_simple_s3_request` borrows them only for the synchronous `sign_request` call and stores the resulting owned `SignResult`.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/js/bun/s3/s3-queueSize-validation.test.ts: 3 pass, 0 fail; test/js/bun/s3/s3-connection-close.test.ts: 7 pass, 0 fail; test/js/bun/s3/s3-storage-class.test.ts: 2 pass, 7 fail; test/js/bun/s3/s3-requester-pays.test.ts: 2 pass, 8 fail.
The identical 15 failures (s3-storage-class, s3-requester-pays) also occur on main with the same "S3Error: egress denied, host not on allowlist" network error from the build environment, so they are pre-existing and unrelated to this change.
