### PR TITLE
websocket: release the proxy tunnel when its TLS handshake fails inside start()

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1156,6 +1156,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 return;
             }
         };
+        // The ref `init` returned stays ours until the proxy adopts it below,
+        // so every early return releases it. `start` has to run under this ref
+        // rather than the proxy's: its synchronous callbacks can fail the
+        // client and drop `proxy`, which would free the tunnel while its
+        // SSLWrapper is still on the stack.
+        // SAFETY: `tunnel` is live and this guard takes over the one ref
+        // `init` returned.
+        let tunnel_ref = unsafe { bun_ptr::ScopedRef::adopt(tunnel.as_ptr()) };
 
         // Use ssl_config if available, otherwise use defaults
         // SAFETY: `this` is live; the borrow covers only `ssl_config` and ends
@@ -1171,25 +1179,27 @@ impl<const SSL: bool> HTTPClient<SSL> {
         };
 
         // Start TLS handshake
-        // SAFETY: `tunnel` was just allocated by `init` (live, ref_count == 1).
+        // SAFETY: `tunnel_ref` keeps the tunnel live across the call.
         if unsafe { WebSocketProxyTunnel::start(tunnel.as_ptr(), &ssl_options, initial_data) }
             .is_err()
         {
-            // SAFETY: release the ref taken by `init`.
-            unsafe { WebSocketProxyTunnel::deref(tunnel.as_ptr()) };
             // SAFETY: no borrow of `*this` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::ProxyTunnelFailed) };
             return;
         }
 
-        // Re-check proxy state: `start` dispatches SSLWrapper callbacks that
-        // can fail the client and take `proxy`.
+        // Re-check proxy state: `start` dispatches SSLWrapper callbacks
+        // synchronously (a TLS alert or non-TLS bytes in `initial_data` fail
+        // the handshake before it returns), and those can fail the client and
+        // take `proxy`. `tunnel_ref` releases the tunnel on this return.
         // SAFETY: `this` is live; the borrow covers only `proxy`.
         let Some(p) = (unsafe { (*this).proxy.as_mut() }) else {
             // SAFETY: no borrow of `*this` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::ProxyTunnelFailed) };
             return;
         };
+        // The proxy owns the ref from here on; `WebSocketProxy::drop` releases it.
+        tunnel_ref.forget();
         p.set_tunnel(Some(tunnel));
         // SAFETY: scoped write; `p` is dead.
         unsafe { (*this).state = State::ProxyTlsHandshake };

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -1,3 +1,4 @@
+import { sslCtxLiveCount } from "bun:internal-for-testing";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as harness from "harness";
 import { tls as tlsCerts } from "harness";
@@ -499,6 +500,93 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
 
     await promise;
     gc();
+  });
+});
+
+describe("wss:// proxy tunnel whose TLS handshake fails inside the CONNECT reply", () => {
+  // The proxy answers CONNECT with 200 and, in the same write, bytes that make
+  // the tunnel's TLS handshake fail while WebSocketProxyTunnel::start() is
+  // still running (the client has not even sent its ClientHello yet). The
+  // upgrade client used to drop its only reference to the tunnel on that
+  // path, leaking the tunnel and the SSL_CTX it had just built, once per
+  // connection attempt.
+  const connectEstablished = Buffer.from("HTTP/1.1 200 Connection Established\r\n\r\n");
+  // TLS record: alert (21), TLS 1.2, 2-byte body: fatal (2) handshake_failure (40).
+  const fatalAlert = Buffer.from([0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28]);
+  // Not a TLS record at all: what a captive portal or a misbehaving proxy
+  // tacks onto its 200.
+  const notTls = Buffer.from("<html><body>sign in to continue</body></html>\r\n");
+  const attempts = 5;
+
+  function listenBadProxy(scheme: "http" | "https", trailer: Buffer) {
+    const connectRequests: string[] = [];
+    const onConnection = (socket: net.Socket) => {
+      let request = "";
+      socket.on("data", chunk => {
+        request += chunk.toString("latin1");
+        if (!request.includes("\r\n\r\n")) return;
+        socket.removeAllListeners("data");
+        connectRequests.push(request.split("\r\n", 1)[0]);
+        socket.end(Buffer.concat([connectEstablished, trailer]));
+      });
+      socket.on("error", () => {});
+    };
+    const server =
+      scheme === "https"
+        ? tls.createServer({ key: tlsCerts.key, cert: tlsCerts.cert }, onConnection)
+        : net.createServer(onConnection);
+    return { server, connectRequests };
+  }
+
+  function attemptThroughProxy(scheme: "http" | "https", port: number) {
+    const { promise, resolve, reject } = Promise.withResolvers<Pick<CloseEvent, "code" | "reason" | "wasClean">>();
+    const ws = new WebSocket("wss://tunnel-target.invalid/", {
+      proxy: `${scheme}://127.0.0.1:${port}`,
+      // The https proxy presents a self-signed cert. Passing a tls config also
+      // makes the tunnel take its TLS options from the user's config rather
+      // than the defaults, so the two schemes cover both of those branches.
+      ...(scheme === "https" ? { tls: { rejectUnauthorized: false } } : {}),
+    });
+    ws.onopen = () => reject(new Error("tunnel handshake unexpectedly succeeded"));
+    ws.onclose = ({ code, reason, wasClean }) => resolve({ code, reason, wasClean });
+    return promise;
+  }
+
+  test.each([
+    ["http", "a fatal TLS alert", fatalAlert],
+    ["http", "non-TLS bytes", notTls],
+    ["https", "a fatal TLS alert", fatalAlert],
+    ["https", "non-TLS bytes", notTls],
+  ] as const)("%s proxy, 200 followed by %s: tunnel is released per attempt", async (scheme, _, trailer) => {
+    const { server, connectRequests } = listenBadProxy(scheme, trailer);
+    const port = await startProxy(server);
+    try {
+      // First attempt absorbs whatever this path allocates once per process
+      // (the shared client SSL_CTX for the https proxy leg) so the steady
+      // state below is exact.
+      expect(await attemptThroughProxy(scheme, port)).toEqual({
+        code: 1015,
+        reason: "TLS handshake failed",
+        wasClean: false,
+      });
+
+      const before = sslCtxLiveCount();
+      const closes: Awaited<ReturnType<typeof attemptThroughProxy>>[] = [];
+      for (let i = 0; i < attempts; i++) closes.push(await attemptThroughProxy(scheme, port));
+      // The tunnel is released inside the socket read that failed the
+      // handshake, before the close event is even queued, so by the time an
+      // attempt resolves the SSL_CTX it built is gone again. Unfixed, this
+      // grows by one per attempt. (<= rather than === because connections
+      // left over from earlier tests in this file may still release their
+      // contexts while this runs.)
+      const leakedSslCtx = sslCtxLiveCount() - before;
+
+      expect(connectRequests).toEqual(Array(attempts + 1).fill("CONNECT tunnel-target.invalid:443 HTTP/1.1"));
+      expect(closes).toEqual(Array(attempts).fill({ code: 1015, reason: "TLS handshake failed", wasClean: false }));
+      expect(leakedSslCtx).toBeLessThanOrEqual(0);
+    } finally {
+      server.close();
+    }
   });
 });
 


### PR DESCRIPTION
### Symptom

Every `wss://` connection attempt through an HTTP(S) proxy whose `200 Connection Established` reply carries bytes that fail the tunnel's TLS handshake immediately leaks the `WebSocketProxyTunnel`, its `SSLWrapper` and the `SSL_CTX` it had just built (about 27 KB of RSS per attempt on a release build, 500 attempts = +13 MB). A proxy that appends a TLS alert is the minimal trigger; a captive portal or misbehaving proxy that tacks an HTML body onto its 200 leaks the same way. A client that retries against such a proxy grows without bound. The close event the user sees is the expected one (`1015 TLS handshake failed`), so nothing hints at the leak.

```ts
import { sslCtxLiveCount } from "bun:internal-for-testing";
import net from "node:net";

// CONNECT proxy that answers 200 and a fatal handshake_failure alert in one write
const proxy = net.createServer(s => s.once("data", () =>
  s.end(Buffer.concat([Buffer.from("HTTP/1.1 200 Connection Established\r\n\r\n"),
                       Buffer.from([0x15, 0x03, 0x03, 0x00, 0x02, 0x02, 0x28])]))));
await new Promise(r => proxy.listen(0, "127.0.0.1", r));

const attempt = () => new Promise(resolve => {
  const ws = new WebSocket("wss://tunnel-target.invalid/", { proxy: `http://127.0.0.1:${proxy.address().port}` });
  ws.onclose = e => resolve(e.code); // 1015 every time
});

const before = sslCtxLiveCount();
for (let i = 0; i < 10; i++) await attempt();
console.log(sslCtxLiveCount() - before); // before: 10, after: 0
```

If the proxy sends the same alert in a later packet instead, nothing leaks; only the synchronous case is affected.

### Cause

`start_proxy_tls_handshake()` in `src/http_jsc/websocket_client/WebSocketUpgradeClient.rs` allocates the tunnel with `WebSocketProxyTunnel::init()` (refcount 1, owned by nobody yet), calls `WebSocketProxyTunnel::start(tunnel, ..., initial_data)` and only afterwards stores it with `p.set_tunnel(Some(tunnel))`, at which point `WebSocketProxy`'s `Drop` becomes responsible for releasing it.

`start()` feeds `initial_data` (whatever followed the proxy's response head in the same read) to the `SSLWrapper` before returning. A fatal alert or non-TLS bytes fail the handshake right there: `on_handshake(false)` -> `terminate(TlsHandshakeFailed)` -> `fail()` -> `tcp.close()` -> `handle_close()` -> `clear_data()` takes `proxy`. Back in `start_proxy_tls_handshake()` the `proxy` re-check sees `None` and returns, but unlike the `start()` error branch next to it, it never released the ref `init()` handed out. The upgrade client itself survives (`handle_data` holds a ref guard), so this is a leak rather than a use after free. The fetch proxy tunnel (`src/http/ProxyTunnel.rs`) stores its tunnel before driving the wrapper and was checked to not leak in the same scenario.

### Fix

The ref returned by `init()` is now held in a `bun_ptr::ScopedRef::adopt` guard for the rest of the function and `forget()`-ed at the one point where ownership moves to the proxy (`set_tunnel`). Both early returns (the `start()` error and the `proxy` re-check) release it on the way out, and the manual `deref` in the error branch goes away.

Driving `start()` under the caller's own ref rather than storing the tunnel in the proxy first is deliberate: the callbacks above drop `proxy` while `SSLWrapper::receive_data` for that very tunnel is still on the stack, so a proxy-owned ref would be the last one and `clear_data()` would free the wrapper out from under itself. The asynchronous path (`WebSocketProxyTunnel::receive`) guards against exactly this with its own `ScopedRef`; keeping the ref in the caller gives `start()` the same guarantee. No other behaviour changes: the tunnel is freed only after `start()` has returned, `terminate()` on the already failed client is a no-op (its WebSocket was detached and the socket closed by the callback), and on success the proxy owns the tunnel exactly as before.

### Verification

`test/js/web/websocket/websocket-proxy.test.ts` gains a `test.each` over {http proxy, https proxy} x {fatal alert, non-TLS bytes}. The http variants use no TLS options (the tunnel builds its defaults), the https variants pass `tls: { rejectUnauthorized: false }` (the tunnel clones the user's config), so both upgrade client instantiations and both option branches are covered. Each case asserts that the attempts actually went through the proxy (`CONNECT tunnel-target.invalid:443 HTTP/1.1` per attempt), that every attempt closes with `1015 TLS handshake failed`, and that `sslCtxLiveCount()` did not grow across 5 attempts after a warm-up one.

* unfixed (release binary and a debug build with `src/` stashed): all four cases fail with `Expected: <= 0, Received: 5`
* fixed debug build: all four pass (110 to 360 ms each under ASAN); the full file passes with `--rerun-each 5`
* `websocket-proxy-tunnel-{upgrade,client}-leak`, `websocket-proxy-close-reentrancy`, `test-ws-bidir-proxy`, `first_party/ws/ws-proxy` and `websocket.test.js` / `websocket-client.test.ts` pass on the fixed build (the only failures in this sandbox are the tests that need the public network or an environment without an ambient `NO_PROXY`, and they fail identically on the unmodified binary)

Found while working on #37487, which fixes a different teardown bug in the same area and does not touch this function.
