### PR TITLE
bun:test: stop building a matcher diff once pretty-printing a value throws

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,23 +44,25 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(|_| fmt::Error)?;
 
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(|_| fmt::Error)?;
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2928,7 +2928,11 @@ impl ExpectMatcherUtils {
         } else {
             bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
         };
-        let buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n");
+        let mut buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n");
+        use fmt::Write as _;
+        if writeln!(buf, "{diff_formatter}").is_err() {
+            return Err(if global_this.has_exception() { JsError::Thrown } else { JsError::OutOfMemory });
+        }
         bun_jsc::bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 }

--- a/test/js/bun/test/expect-diff-format-throw.test.ts
+++ b/test/js/bun/test/expect-diff-format-throw.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The failure message of toEqual/toStrictEqual (and matcherHint) is a diff of the pretty-printed
+// values. When pretty-printing one of them throws, the exception must not be left pending while
+// the other value is formatted.
+//
+// The pretty-printer reads `$$typeof` to detect React elements, and deepEquals ignores
+// non-enumerable properties, so a non-enumerable throwing `$$typeof` getter only fires while the
+// failure message is being built.
+test.concurrent("matcher failure message when pretty-printing a value throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { expect } = Bun.jest();
+      function value(a) {
+        const o = { a };
+        Object.defineProperty(o, "$$typeof", { get() { throw new Error("getter threw"); } });
+        return o;
+      }
+      function message(fn) {
+        try { fn(); } catch (e) { return e.message; }
+        return "did not throw";
+      }
+      let utils;
+      expect.extend({ captureUtils() { utils = this.utils; return { pass: true, message: () => "" }; } });
+      expect(0).captureUtils();
+      console.log(JSON.stringify([
+        message(() => expect(value(1)).toStrictEqual({ a: 2 })),
+        message(() => expect(value(1)).toEqual({ a: 2 })),
+        message(() => expect({ a: 1 }).toStrictEqual(value(2))),
+        message(() => utils.matcherHint("toFoo", value(1), { a: 2 })),
+      ]));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout:
+      JSON.stringify([
+        "expect(received).toStrictEqual(expected)\n\n",
+        "expect(received).toEqual(expected)\n\n",
+        "expect(received).toStrictEqual(expected)\n\n",
+        "getter threw",
+      ]) + "\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// Same bug as found by the fuzzer: the matcher fails right where the JS stack ran out, so the
+// getter the pretty-printer calls while formatting `received` throws a stack overflow, and
+// formatting `expected` then ran with that exception still pending.
+test.concurrent("matcher failure message when pretty-printing overflows the stack", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { expect } = Bun.jest();
+      const received = { get $$typeof() { return undefined; } };
+      const expected = new Uint8ClampedArray();
+      let ran = false;
+      function recurse() {
+        try { recurse(); } catch {}
+        if (!ran) {
+          ran = true;
+          try { expect(received).toStrictEqual(expected); } catch {}
+        }
+      }
+      recurse();
+      console.log("OK");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+});


### PR DESCRIPTION
### Problem

Fuzzing hit this assertion in a debug build while a failing `toStrictEqual` was building its error message:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Maximum call stack size exceeded.
!exception() || m_vm.hasPendingTerminationException()
JavaScriptCore/ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

The fuzzer's program recursed until the JS stack ran out and then called `Bun.jest().expect(x).toStrictEqual(new Uint8ClampedArray())` at the bottom. It is flaky in that form because pretty-printing the fuzzer's `x` only calls back into JS under leftover state from earlier programs. Any value whose pretty-printing throws reproduces it deterministically, for example a throwing `$$typeof` getter (the printer reads `$$typeof` to detect React elements):

```js
const { expect } = Bun.jest();
const o = { a: 1 };
Object.defineProperty(o, "$$typeof", { get() { throw new Error("boom"); } });
expect(o).toStrictEqual({ a: 2 }); // debug build: assertion above; release: throws "boom"
```

### Cause

`DiffFormatter::fmt` (`src/runtime/test_runner/diff_format.rs`) pretty-prints `received` and `expected` into two buffers and ignored both results (`let _ = ...; // TODO:`, carried over from the Zig version). When printing `received` throws, the exception is still pending while `expected` is printed, and the first JSC call made for it (`JSC__JSValue__getOwn` for the `$$typeof` check, `ASSERT_NO_PENDING_EXCEPTION`) fires the assertion. In release builds it only worked by accident: the second print fails early on the stale exception and `throw_value` refuses to replace a pending exception, so the getter's error escaped instead of the matcher's.

### Fix

The two `?` in `diff_format.rs` are the fix. A failed print now returns `fmt::Error` from `Display`, the same thing the `ZigFormatter` adapter used by the other matchers does, and nothing touches JSC afterwards. `create_error_instance` already handles that case: it clears the exception and throws the matcher error built from what was written so far, so `toEqual` / `toStrictEqual` and the other diff-based matchers now behave like `toBe` does when printing a value throws (`expect(received).toStrictEqual(expected)` with an empty body, instead of the getter's error).

`ExpectMatcherUtils.matcherHint` rendered the same `DiffFormatter` with `format!`, which would now panic when the `Display` impl fails. It writes into the buffer instead and returns the pending exception (or `OutOfMemory` when the printer failed without one), which keeps its current behavior of surfacing the error thrown while printing; previously it returned a string with the exception still pending, which is the same assertion in debug builds.

`utils.stringify` / `printReceived` / `printExpected` have a related panic that is already fixed separately in #36912, so they are not touched here.

### Verification

`test/js/bun/test/expect-diff-format-throw.test.ts`:

- The first test covers `toStrictEqual` and `toEqual` with a throwing `received`, `toStrictEqual` with a throwing `expected`, and `matcherHint`. On the unfixed build the first two cases abort the debug build with the assertion above, and on release 1.4.0 all four cases report `"getter threw"` instead of the matcher message, so it fails on both build types without the fix.
- The second test is the fuzzer's shape: the matcher fails at the bottom of the stack, so the getter the printer calls throws a stack overflow. It aborts the unfixed debug build with the exact assertion from the report and passes with the fix.

Also ran `expect.test.js`, `expect-extend.test.js`, `jest-extended.test.js`, `mock-fn.test.js`, the `expect-*-crash` tests, `expect-label`, `test-test.test.ts` and the snapshot tests against the debug build. `pretty-format-overflow.test.ts` segfaults its child process on a local debug+ASAN build before and after this change (the jest pretty-printer has no stack check; reported separately), which is unrelated to this fix.
