### PR TITLE
jsc: make SavedSourceMap own its hash table

### DIFF
--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -1,7 +1,6 @@
 #![warn(unused_must_use)]
 
 use core::ffi::c_void;
-use core::ptr;
 use std::sync::Arc;
 
 use bun_collections::{HashMap, IdentityContext, TaggedPtrUnion};
@@ -13,47 +12,23 @@ use bun_sourcemap::{self as SourceMap, InternalSourceMap, ParsedSourceMap};
 use bun_threading::Mutex;
 use bun_wyhash::hash;
 
+#[derive(Default)]
 pub struct SavedSourceMap {
-    /// This is a pointer to the map located on the VirtualMachine struct
-    pub map: *mut HashTable,
-    pub(crate) mutex: Mutex,
-}
-
-impl Default for SavedSourceMap {
-    fn default() -> Self {
-        Self {
-            map: ptr::null_mut(),
-            mutex: Mutex::default(),
-        }
-    }
+    /// Only accessed between [`Self::lock`] and [`Self::unlock`].
+    map: HashTable,
+    mutex: Mutex,
 }
 
 impl SavedSourceMap {
-    // In-place init — `this` is a pre-allocated field on VirtualMachine; `map` is a sibling field backref.
-
-    /// Mutable access to the sibling `HashTable` on `VirtualMachine`.
-    ///
-    /// # Safety invariant
-    /// `self.map` is set in [`Self::init`] to a non-null pointer at a sibling
-    /// field on `VirtualMachine` and is never reassigned; the pointee outlives
-    /// `self`. Exclusive access is upheld by `&mut self` (and, for table
-    /// mutation, by `self.mutex` which callers must hold).
-    #[inline]
-    fn map_mut(&mut self) -> &mut HashTable {
-        debug_assert!(!self.map.is_null());
-        // SAFETY: see invariant above — non-null sibling backref, lives as long as `self`.
-        unsafe { &mut *self.map }
-    }
-
     #[inline]
     pub(crate) fn lock(&mut self) {
         self.mutex.lock();
-        self.map_mut().unlock_pointers();
+        self.map.unlock_pointers();
     }
 
     #[inline]
     pub(crate) fn unlock(&mut self) {
-        self.map_mut().lock_pointers();
+        self.map.lock_pointers();
         self.mutex.unlock();
     }
 }
@@ -147,7 +122,7 @@ impl SavedSourceMap {
         // backing has no key-slot pointer to hand out, and the key is a u64 hash
         // we already have in hand.
         let key = hash(path);
-        let Some(&ptr) = self.map_mut().get(&key) else {
+        let Some(&ptr) = self.map.get(&key) else {
             self.unlock();
             return;
         };
@@ -165,7 +140,7 @@ impl SavedSourceMap {
             false
         };
         if refers_to_provider {
-            self.map_mut().remove(&key);
+            self.map.remove(&key);
             // SAFETY: `old_value` was stored by us; the table's ownership of
             // it ends here.
             unsafe { Self::release_value(old_value) };
@@ -177,7 +152,7 @@ impl SavedSourceMap {
 // Keys are
 // already wyhash u64s, so use the passthrough hasher; `bun_collections`'
 // zig_hash_map uses an 80% max load factor.
-pub type HashTable = HashMap<u64, *mut c_void, IdentityContext<u64>>;
+type HashTable = HashMap<u64, *mut c_void, IdentityContext<u64>>;
 
 impl bun_js_printer::OnSourceMapChunk for SavedSourceMap {
     fn on_source_map_chunk(
@@ -191,24 +166,14 @@ impl bun_js_printer::OnSourceMapChunk for SavedSourceMap {
 
 impl Drop for SavedSourceMap {
     fn drop(&mut self) {
-        {
-            self.lock();
-            let map = self.map_mut();
-            for val in map.values() {
-                let value = Value::from(Some(*val));
-                // SAFETY: values were stored by us and are live until table
-                // teardown.
-                unsafe { Self::release_value(value) };
-            }
-            self.unlock();
+        self.lock();
+        for val in self.map.values() {
+            let value = Value::from(Some(*val));
+            // SAFETY: values were stored by us and are live until table
+            // teardown.
+            unsafe { Self::release_value(value) };
         }
-
-        self.map_mut().unlock_pointers();
-        // The HashTable storage is owned by the sibling `saved_source_map_table`
-        // field on VirtualMachine; `deinit()` resets it to an empty default in
-        // place, so the VM's later (or absent) drop of that field is a no-op —
-        // no double free.
-        self.map_mut().deinit();
+        self.unlock();
     }
 }
 
@@ -230,7 +195,7 @@ impl SavedSourceMap {
             };
             if incoming.mapping_count() == 0 {
                 self.lock();
-                let contains = self.map_mut().contains_key(&hash(source.path.text));
+                let contains = self.map.contains_key(&hash(source.path.text));
                 self.unlock();
                 if contains {
                     return Ok(());
@@ -271,7 +236,7 @@ impl SavedSourceMap {
 
         // `bun_collections::HashMap` derefs to `std::collections::HashMap`, so
         // the std `entry()` API is used directly.
-        match self.map_mut().entry(hash(path)) {
+        match self.map.entry(hash(path)) {
             Entry::Occupied(mut o) => {
                 let old_value = Value::from(Some(*o.get()));
                 // SAFETY: `old_value` was stored by us and is live until
@@ -299,7 +264,7 @@ impl SavedSourceMap {
         self.lock();
 
         // This mapping entry is only valid while the mutex is locked
-        let Some(mapping) = self.map_mut().get_mut(&h) else {
+        let Some(mapping) = self.map.get_mut(&h) else {
             self.unlock();
             return SourceMap::ParseUrl::default();
         };
@@ -362,7 +327,7 @@ impl SavedSourceMap {
 
             self.lock();
             // does not have a valid source map. let's not try again
-            if let Some(removed) = self.map_mut().remove(&h) {
+            if let Some(removed) = self.map.remove(&h) {
                 // SAFETY: whatever occupies the slot now was stored by us;
                 // the table's ownership of it ends here.
                 unsafe { Self::release_value(Value::from(Some(removed))) };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -232,10 +232,6 @@ pub struct VirtualMachine {
     // stored as the enum's `u8` repr.
     pub(crate) default_verbose_fetch: core::cell::Cell<Option<u8>>,
 
-    /// Do not access this field directly! It exists in the VirtualMachine struct so
-    /// that we don't accidentally make a stack copy of it; only use it through
-    /// `source_mappings`.
-    pub(crate) saved_source_map_table: crate::saved_source_map::HashTable,
     pub source_mappings: SavedSourceMap,
 
     // BACKREF — `&'a mut Arena` in spirit; caller-owned (web_worker) and
@@ -2481,12 +2477,7 @@ impl VirtualMachine {
             let _ = (*regular).tasks.ensure_unused_capacity(64);
             addr_of_mut!((*vm).event_loop).write(regular);
 
-            // `source_mappings.map` is a sibling-field backref onto
-            // `saved_source_map_table`.
-            addr_of_mut!((*vm).saved_source_map_table)
-                .write(crate::saved_source_map::HashTable::default());
             addr_of_mut!((*vm).source_mappings).write(SavedSourceMap::default());
-            (*addr_of_mut!((*vm).source_mappings)).map = addr_of_mut!((*vm).saved_source_map_table);
         }
 
         // High-tier per-VM state — Transpiler / Timer::All / entry_point.
@@ -4701,8 +4692,7 @@ impl VirtualMachine {
 
         drop_source_code_printer();
 
-        // Note: `SavedSourceMap`'s `Drop` frees
-        // each stored map and `deinit()`s the sibling `saved_source_map_table`.
+        // `SavedSourceMap`'s `Drop` frees each stored map along with its table.
         drop(core::mem::take(&mut self.source_mappings));
 
         // Drain cron jobs BEFORE taking rare_data off `self`: the teardown


### PR DESCRIPTION
## What

`bun_jsc::SavedSourceMap` (`src/jsc/SavedSourceMap.rs`) did not own the table it manages. The table was a separate `saved_source_map_table` field on `VirtualMachine` (documented as "do not access this field directly"), `SavedSourceMap` held a `pub map: *mut HashTable` pointing at it, `VirtualMachine::init` wrote both fields and then patched the pointer in by hand, and `Default` produced a `SavedSourceMap` with a null `map`. All 11 table accesses in the file went through `map_mut()`, a `debug_assert!(!null)` plus `unsafe { &mut *self.map }`, and `Drop` had to `deinit()` the sibling table in place so the VM's copy would not be freed twice.

```rust
// before
pub struct SavedSourceMap {
    pub map: *mut HashTable,   // points at vm.saved_source_map_table
    pub(crate) mutex: Mutex,
}
fn map_mut(&mut self) -> &mut HashTable { unsafe { &mut *self.map } }

// after
#[derive(Default)]
pub struct SavedSourceMap {
    map: HashTable,
    mutex: Mutex,
}
```

Nine of those accesses now read `self.map` directly; the other two were the `unlock_pointers()` and `deinit()` calls at the end of `Drop`, which are deleted together with `map_mut()` itself (removes 1 unsafe block) and the double-free comment, since `Drop` now only releases the stored values under the mutex and the table frees its own storage afterwards. In `VirtualMachine.rs` the `saved_source_map_table` field, its `HashTable::default()` write and the backref assignment in `init` are deleted; the single `source_mappings.write(SavedSourceMap::default())` remains, and the `destroy()` comment is updated. `HashTable` becomes a private alias since the VM field was its only outside user. The 10 users of `vm.source_mappings` outside these two files (6 in `bun_runtime` and `bun_sourcemap_jsc`, 4 elsewhere in `bun_jsc`) only call methods and are unchanged.

## Why

Ownership of the table is now stated by the field type: a `SavedSourceMap` always has a valid (possibly empty) table, so the null-`map` state that `Default` used to produce, and that `mem::take` in `destroy()` left behind in the VM, is no longer representable, and the lifetime comment on `map_mut()` is replaced by ordinary field access. It is zero-cost: the table moves from one VM field into the adjacent one (the VM shrinks by one pointer), each access loses a pointer load and a debug assertion, `Default` and `Drop` do the same work they did before (`deinit()` was already `*self = Self::default()`), and `init` already wrote both fields with `ptr::write`, so no new checks, allocations or copies are introduced.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/js/bun/sourcemap/internal-sourcemap.test.ts: 6 pass, 0 fail; test/js/bun/sourcemap/negative-vlq-mapping.test.ts: 10 pass, 0 fail; test/cli/test/coverage.test.ts: 12 pass, 0 fail.
test/js/web/workers/worker.test.ts: 33 pass, 3 fail on this branch and identically on main with the debug build (pre-existing, timing-sensitive "terminate() races and lifecycle edges" tests: message flood, preload with un-awaited import(), fs.readFile completions), so unrelated to this change.
