### PR TITLE
Bun.build({ compile }): produce the executable on the bundle thread instead of blocking the event loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,6 @@ dependencies = [
  "bun_bundler",
  "bun_collections",
  "bun_core",
- "bun_dotenv",
  "bun_errno",
  "bun_exe_format",
  "bun_http",

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -150,10 +150,7 @@ impl<C: CompletionStruct> BundleThread<C> {
         let ptr = SendPtr(instance);
         let thread = std::thread::Builder::new()
             .name("Bundler".into())
-            // The same stack as bun's other threads rather than Rust's 2 MiB
-            // default: `Bun.build({ compile })` writes its executable on this
-            // thread, and on Windows that path holds well over half a
-            // megabyte of path buffers on the stack.
+            // `Bun.build({ compile })` writes its executable here; use bun's usual stack.
             .stack_size(bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE as usize)
             .spawn(move || {
                 let ptr = ptr;

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -150,6 +150,11 @@ impl<C: CompletionStruct> BundleThread<C> {
         let ptr = SendPtr(instance);
         let thread = std::thread::Builder::new()
             .name("Bundler".into())
+            // The same stack as bun's other threads rather than Rust's 2 MiB
+            // default: `Bun.build({ compile })` writes its executable on this
+            // thread, and on Windows that path holds well over half a
+            // megabyte of path buffers on the stack.
+            .stack_size(bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE as usize)
             .spawn(move || {
                 let ptr = ptr;
                 // SAFETY: caller guarantees `instance` is valid for 'static; `thread_main`

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1,4 +1,3 @@
-use core::cell::Cell;
 use core::ffi::c_char;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
@@ -126,11 +125,24 @@ pub struct Loader {
     pub quiet: bool,
 
     pub(crate) did_load_process: bool,
-    pub(crate) reject_unauthorized: Cell<Option<bool>>,
+    /// Atomic because the bundle thread asks too, when a cross-target
+    /// `Bun.build({ compile })` downloads its target (see `download_to_path`).
+    pub(crate) reject_unauthorized: bun_core::AtomicCell<TlsRejectUnauthorized>,
 
     // Local POD mirror of `bun_s3_signing::S3Credentials` — see type doc above.
     aws_credentials: Option<S3Credentials>,
 }
+
+/// Memo of [`Loader::get_tls_reject_unauthorized`].
+#[repr(u8)]
+#[derive(Copy, Clone)]
+pub(crate) enum TlsRejectUnauthorized {
+    Unknown,
+    No,
+    Yes,
+}
+// SAFETY: `#[repr(u8)]` with payload-free variants: 1 byte, no padding.
+bun_core::unsafe_impl_atom!(TlsRejectUnauthorized);
 
 static DID_LOAD_CCACHE_PATH: AtomicBool = AtomicBool::new(false);
 // Overwritten on every `load_node_js_config` call. NOT set-once despite the
@@ -291,12 +303,18 @@ impl Loader {
     ///
     /// **Prefer VirtualMachine.getTLSRejectUnauthorized()** for JavaScript, as individual workers could have different settings.
     pub fn get_tls_reject_unauthorized(&self) -> bool {
-        if let Some(reject_unauthorized) = self.reject_unauthorized.get() {
-            return reject_unauthorized;
+        match self.reject_unauthorized.load() {
+            TlsRejectUnauthorized::Yes => return true,
+            TlsRejectUnauthorized::No => return false,
+            TlsRejectUnauthorized::Unknown => {}
         }
         // default: true
         let result = self.get(b"NODE_TLS_REJECT_UNAUTHORIZED") != Some(b"0");
-        self.reject_unauthorized.set(Some(result));
+        self.reject_unauthorized.store(if result {
+            TlsRejectUnauthorized::Yes
+        } else {
+            TlsRejectUnauthorized::No
+        });
         result
     }
 
@@ -575,7 +593,7 @@ impl Loader {
             custom_files_loaded: StringArrayHashMap::default(),
             quiet: false,
             did_load_process: false,
-            reject_unauthorized: Cell::new(None),
+            reject_unauthorized: bun_core::AtomicCell::new(TlsRejectUnauthorized::Unknown),
             aws_credentials: None,
         }
     }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::ffi::c_char;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
@@ -125,23 +126,11 @@ pub struct Loader {
     pub quiet: bool,
 
     pub(crate) did_load_process: bool,
-    /// Also read by the bundle thread (cross-target `Bun.build({ compile })` download).
-    pub(crate) reject_unauthorized: bun_core::AtomicCell<TlsRejectUnauthorized>,
+    pub(crate) reject_unauthorized: Cell<Option<bool>>,
 
     // Local POD mirror of `bun_s3_signing::S3Credentials` — see type doc above.
     aws_credentials: Option<S3Credentials>,
 }
-
-/// Memo of [`Loader::get_tls_reject_unauthorized`].
-#[repr(u8)]
-#[derive(Copy, Clone)]
-pub(crate) enum TlsRejectUnauthorized {
-    Unknown,
-    No,
-    Yes,
-}
-// SAFETY: `#[repr(u8)]` with payload-free variants: 1 byte, no padding.
-bun_core::unsafe_impl_atom!(TlsRejectUnauthorized);
 
 static DID_LOAD_CCACHE_PATH: AtomicBool = AtomicBool::new(false);
 // Overwritten on every `load_node_js_config` call. NOT set-once despite the
@@ -302,18 +291,12 @@ impl Loader {
     ///
     /// **Prefer VirtualMachine.getTLSRejectUnauthorized()** for JavaScript, as individual workers could have different settings.
     pub fn get_tls_reject_unauthorized(&self) -> bool {
-        match self.reject_unauthorized.load() {
-            TlsRejectUnauthorized::Yes => return true,
-            TlsRejectUnauthorized::No => return false,
-            TlsRejectUnauthorized::Unknown => {}
+        if let Some(reject_unauthorized) = self.reject_unauthorized.get() {
+            return reject_unauthorized;
         }
         // default: true
         let result = self.get(b"NODE_TLS_REJECT_UNAUTHORIZED") != Some(b"0");
-        self.reject_unauthorized.store(if result {
-            TlsRejectUnauthorized::Yes
-        } else {
-            TlsRejectUnauthorized::No
-        });
+        self.reject_unauthorized.set(Some(result));
         result
     }
 
@@ -592,7 +575,7 @@ impl Loader {
             custom_files_loaded: StringArrayHashMap::default(),
             quiet: false,
             did_load_process: false,
-            reject_unauthorized: bun_core::AtomicCell::new(TlsRejectUnauthorized::Unknown),
+            reject_unauthorized: Cell::new(None),
             aws_credentials: None,
         }
     }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -125,8 +125,7 @@ pub struct Loader {
     pub quiet: bool,
 
     pub(crate) did_load_process: bool,
-    /// Atomic because the bundle thread asks too, when a cross-target
-    /// `Bun.build({ compile })` downloads its target (see `download_to_path`).
+    /// Also read by the bundle thread (cross-target `Bun.build({ compile })` download).
     pub(crate) reject_unauthorized: bun_core::AtomicCell<TlsRejectUnauthorized>,
 
     // Local POD mirror of `bun_s3_signing::S3Credentials` — see type doc above.

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -98,9 +98,8 @@ pub enum ParseError {
     InvalidTarget,
 }
 
-/// What downloading a target's executable takes from the env loader, copied out
-/// by [`CompileTarget::download_options`] on the thread that owns the loader so
-/// the download itself can run on another one.
+/// Copied out of the env loader by [`CompileTarget::download_options`]; owns its data
+/// because the download may run on another thread.
 pub struct DownloadOptions {
     pub reject_unauthorized: bool,
     /// Proxy for the registry URL, with `NO_PROXY` already applied.

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -185,7 +185,7 @@ impl CompileTarget {
         &self,
         buf: &'a mut PathBuffer,
         version_str: &'a ZStr,
-        _env: &mut bun_dotenv::Loader,
+        _env: &bun_dotenv::Loader,
         needs_download: &mut bool,
     ) -> &'a ZStr {
         if self.is_default() {

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -98,8 +98,7 @@ pub enum ParseError {
     InvalidTarget,
 }
 
-/// Copied out of the env loader by [`CompileTarget::download_options`]; owns its data
-/// because the download may run on another thread.
+/// Env-derived settings for downloading a target's executable; see [`CompileTarget::download_options`].
 pub struct DownloadOptions {
     pub reject_unauthorized: bool,
     /// Proxy for the registry URL, with `NO_PROXY` already applied.

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -98,7 +98,42 @@ pub enum ParseError {
     InvalidTarget,
 }
 
+/// What downloading a target's executable takes from the env loader, copied out
+/// by [`CompileTarget::download_options`] on the thread that owns the loader so
+/// the download itself can run on another one.
+pub struct DownloadOptions {
+    pub reject_unauthorized: bool,
+    /// Proxy for the registry URL, with `NO_PROXY` already applied.
+    pub http_proxy: Option<Box<[u8]>>,
+}
+
+impl Default for DownloadOptions {
+    /// Placeholder until [`CompileTarget::download_options`] fills it in; verifies TLS.
+    fn default() -> Self {
+        Self {
+            reject_unauthorized: true,
+            http_proxy: None,
+        }
+    }
+}
+
 impl CompileTarget {
+    /// Buffer size callers hand to [`Self::to_npm_registry_url`].
+    pub const REGISTRY_URL_BUF_LEN: usize = 2048;
+
+    pub fn download_options(&self, env: &bun_dotenv::Loader) -> DownloadOptions {
+        let mut url_buf = [0u8; Self::REGISTRY_URL_BUF_LEN];
+        // A URL that cannot be built fails the download itself, which reports it.
+        let http_proxy = self.to_npm_registry_url(&mut url_buf).ok().and_then(|url| {
+            env.get_http_proxy_for(&bun_url::URL::parse(url))
+                .map(|proxy| Box::from(proxy.href))
+        });
+        DownloadOptions {
+            reject_unauthorized: env.get_tls_reject_unauthorized(),
+            http_proxy,
+        }
+    }
+
     pub(crate) fn eql(&self, other: &CompileTarget) -> bool {
         self.os == other.os
             && self.arch == other.arch
@@ -185,7 +220,6 @@ impl CompileTarget {
         &self,
         buf: &'a mut PathBuffer,
         version_str: &'a ZStr,
-        _env: &bun_dotenv::Loader,
         needs_download: &mut bool,
     ) -> &'a ZStr {
         if self.is_default() {
@@ -206,7 +240,7 @@ impl CompileTarget {
             return version_str;
         }
 
-        // T1 fallback ignores `_env` (full env-override chain lives in bun_install).
+        // The full cache-dir override chain lives in bun_install; this is its fallback.
         let cache_dir = bun_sys::fetch_cache_directory_path();
         let dest = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
             path::fs::FileSystem::instance().top_level_dir(),

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -14,7 +14,7 @@ use bun_core::Output;
 use bun_core::{String as BunString, ZigString};
 use bun_jsc::ConcurrentTask::ConcurrentTask;
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult};
-use bun_options_types::compile_target::CompileTarget;
+use bun_options_types::compile_target::{CompileTarget, DownloadOptions};
 use bun_options_types::schema::api; // bun.schema.api
 use bun_standalone_graph::StandaloneModuleGraph;
 
@@ -223,6 +223,8 @@ pub mod js_bundler {
 
     pub struct CompileOptions {
         pub(crate) compile_target: CompileTarget,
+        /// Taken from the VM's env on the calling thread; the download runs on the bundle thread.
+        pub(crate) download: DownloadOptions,
         pub(crate) exec_argv: OwnedString,
         pub(crate) executable_path: OwnedString,
         pub(crate) windows_hide_console: bool,
@@ -244,6 +246,7 @@ pub mod js_bundler {
         fn default() -> Self {
             Self {
                 compile_target: CompileTarget::default(),
+                download: DownloadOptions::default(),
                 exec_argv: OwnedString::default(),
                 executable_path: OwnedString::default(),
                 windows_hide_console: false,
@@ -1197,6 +1200,9 @@ pub mod js_bundler {
                 let is_standalone_html = this.target == Target::Browser && has_all_html_entrypoints;
                 if !is_standalone_html {
                     this.target = Target::Bun;
+                    compile.download = compile
+                        .compile_target
+                        .download_options(global_this.bun_vm().env_loader());
 
                     let define_keys = compile.compile_target.define_keys();
                     let define_values = compile.compile_target.define_values();

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -288,7 +288,7 @@ impl JSBundleCompletionTask {
     }
 
     /// Port of `JSBundleCompletionTask.doCompilation`. Bundle thread: nothing in here may touch JS.
-    fn do_compilation(&mut self, output_files: &mut Vec<OutputFile>) -> CompileResult {
+    fn do_compilation(&self, output_files: &mut Vec<OutputFile>) -> CompileResult {
         let compile_options = self
             .config
             .compile
@@ -426,9 +426,7 @@ impl JSBundleCompletionTask {
             root_dir.fd,
             module_prefix,
             outfile_for_executable,
-            // SAFETY: the VM frees its loader only after this build reports
-            // finished (`embedded_work_finished`), which happens after this returns.
-            unsafe { &*self.env },
+            &compile_options.download,
             self.config.format,
             &WindowsOptions {
                 hide_console: compile_options.windows_hide_console,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -558,8 +558,7 @@ impl JSBundleCompletionTask {
         result
     }
 
-    /// Producing the executable copies the whole bun binary (and downloads it
-    /// for a cross target), so it happens here and not in `on_complete` on the JS thread.
+    /// `Bun.build({ compile })`: the bundle becomes the executable before `on_complete` gets it.
     fn compile_on_bundle_thread(&mut self) {
         if self.config.compile.is_none()
             || self.cancelled.load(core::sync::atomic::Ordering::Acquire)

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -287,7 +287,9 @@ impl JSBundleCompletionTask {
         Ok(())
     }
 
-    /// Port of `JSBundleCompletionTask.doCompilation`.
+    /// Port of `JSBundleCompletionTask.doCompilation`. Runs on the bundle
+    /// thread (see `compile_on_bundle_thread`): file system and task-owned
+    /// state only, nothing JS-affine.
     fn do_compilation(&mut self, output_files: &mut Vec<OutputFile>) -> CompileResult {
         let compile_options = self
             .config
@@ -427,9 +429,10 @@ impl JSBundleCompletionTask {
             module_prefix,
             outfile_for_executable,
             // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at
-            // construction; valid for the lifetime of the VirtualMachine, and
-            // nothing inside `to_executable` reaches it otherwise.
-            unsafe { &mut *self.env },
+            // construction; the VM frees it only after this build reports
+            // finished (`embedded_work_finished`, after this returns). Shared
+            // access only, like the bundler's own reads of it on this thread.
+            unsafe { &*self.env },
             self.config.format,
             &WindowsOptions {
                 hide_console: compile_options.windows_hide_console,
@@ -559,6 +562,44 @@ impl JSBundleCompletionTask {
         result
     }
 
+    /// Bundle thread, right before the result is posted back. Producing the
+    /// executable copies and rewrites the whole bun binary (downloading it
+    /// first for a cross target); done from `on_complete`, that stalled the JS
+    /// thread's event loop for the duration. The env loader read here is the
+    /// one bundling just used on this thread, and the VM keeps it alive until
+    /// `complete_on_bundle_thread` reports the build finished. A cancelled
+    /// build's VM is tearing down and no longer wants the result, so it is not
+    /// made to wait for an executable either.
+    fn compile_on_bundle_thread(&mut self) {
+        if self.config.compile.is_none()
+            || self.cancelled.load(core::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
+        let mut build = match core::mem::replace(&mut self.result, BundleV2Result::Pending) {
+            BundleV2Result::Value(build) => build,
+            not_bundled => {
+                self.result = not_bundled;
+                return;
+            }
+        };
+        let compile_result = self.do_compilation(&mut build.output_files);
+        // `to_executable` and the sourcemap write report their failures to
+        // stderr, and nothing else flushes this thread's buffered stderr.
+        bun_core::Output::flush();
+        self.result = match compile_result {
+            CompileResult::Success => BundleV2Result::Value(build),
+            CompileResult::Err(err) => {
+                self.log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!("{}", bstr::BStr::new(err.slice())),
+                );
+                BundleV2Result::Err(bun_bundler::Error::CompilationFailed)
+            }
+        };
+    }
+
     pub(crate) fn on_complete_anytask(ctx: *mut Self) -> bun_event_loop::JsResult<()> {
         crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(ctx).expect("completion")).unregister();
         // For the +1 taken by `complete_on_bundle_thread` enqueue.
@@ -644,7 +685,7 @@ impl JSBundleCompletionTask {
         }
 
         // Copy the BackRef out (it is `Copy`) so `global_this` borrows a local
-        // instead of `*this` — `do_compilation`/`to_js_error` below need `&mut *this`.
+        // instead of `*this` — `to_js_error` below needs `&mut *this`.
         let global_this_ref = this.global_this;
         let global_this = global_this_ref.get();
         // `Strong::swap` ties the returned `&mut JSPromise` to
@@ -654,39 +695,8 @@ impl JSBundleCompletionTask {
         let promise: *mut JSPromise = this.promise.swap();
         let promise = JSPromise::opaque_mut(promise);
 
-        // `do_compilation` borrows `&mut self` while needing
-        // `&mut output_files` from inside `self.result`. Temporarily move the
-        // Vec out via `take` so the method gets a disjoint `&mut self`.
-        if matches!(this.result, BundleV2Result::Value(_)) && this.config.compile.is_some() {
-            let mut output_files = match &mut this.result {
-                BundleV2Result::Value(build) => core::mem::take(&mut build.output_files),
-                // SAFETY: arm checked above.
-                _ => unsafe { core::hint::unreachable_unchecked() },
-            };
-            let compile_result = this.do_compilation(&mut output_files);
-            // `defer compile_result.deinit()` — `CompileResult` is a Rust enum
-            // with owned `Vec<u8>` payloads; drops at end of scope.
-
-            if let CompileResult::Err(err) = &compile_result {
-                // `bun.handleOom(log.addError(..., bun.handleOom(dupe(..))))`
-                this.log.add_error_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!("{}", bstr::BStr::new(err.slice())),
-                );
-                // `this.result.value.deinit()` — owned fields drop with the
-                // overwrite below; `output_files` (moved out above) drops here.
-                drop(output_files);
-                this.result = BundleV2Result::Err(bun_bundler::Error::CompilationFailed);
-            } else {
-                // Put the compacted output_files back.
-                match &mut this.result {
-                    BundleV2Result::Value(build) => build.output_files = output_files,
-                    // SAFETY: arm checked above.
-                    _ => unsafe { core::hint::unreachable_unchecked() },
-                }
-            }
-        }
+        // `Bun.build({ compile })` already produced the executable (or turned
+        // `result` into `Err`) on the bundle thread — see `compile_on_bundle_thread`.
 
         // `to_js_error` borrows `&mut self`, which would overlap a
         // `&mut this.result` match scrutinee. Dispatch the pending/err arms
@@ -1115,6 +1125,7 @@ impl CompletionStruct for JSBundleCompletionTask {
     }
 
     fn complete_on_bundle_thread(&mut self) {
+        self.compile_on_bundle_thread();
         // The bundle thread's last touch of this task and of the VM's memory:
         // hand it back (always queued — the VM waits for it) and stop counting.
         self.bundle_loop

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -287,9 +287,7 @@ impl JSBundleCompletionTask {
         Ok(())
     }
 
-    /// Port of `JSBundleCompletionTask.doCompilation`. Runs on the bundle
-    /// thread (see `compile_on_bundle_thread`): file system and task-owned
-    /// state only, nothing JS-affine.
+    /// Port of `JSBundleCompletionTask.doCompilation`. Bundle thread: nothing in here may touch JS.
     fn do_compilation(&mut self, output_files: &mut Vec<OutputFile>) -> CompileResult {
         let compile_options = self
             .config
@@ -428,10 +426,8 @@ impl JSBundleCompletionTask {
             root_dir.fd,
             module_prefix,
             outfile_for_executable,
-            // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at
-            // construction; the VM frees it only after this build reports
-            // finished (`embedded_work_finished`, after this returns). Shared
-            // access only, like the bundler's own reads of it on this thread.
+            // SAFETY: the VM frees its loader only after this build reports
+            // finished (`embedded_work_finished`), which happens after this returns.
             unsafe { &*self.env },
             self.config.format,
             &WindowsOptions {
@@ -562,14 +558,8 @@ impl JSBundleCompletionTask {
         result
     }
 
-    /// Bundle thread, right before the result is posted back. Producing the
-    /// executable copies and rewrites the whole bun binary (downloading it
-    /// first for a cross target); done from `on_complete`, that stalled the JS
-    /// thread's event loop for the duration. The env loader read here is the
-    /// one bundling just used on this thread, and the VM keeps it alive until
-    /// `complete_on_bundle_thread` reports the build finished. A cancelled
-    /// build's VM is tearing down and no longer wants the result, so it is not
-    /// made to wait for an executable either.
+    /// Producing the executable copies the whole bun binary (and downloads it
+    /// for a cross target), so it happens here and not in `on_complete` on the JS thread.
     fn compile_on_bundle_thread(&mut self) {
         if self.config.compile.is_none()
             || self.cancelled.load(core::sync::atomic::Ordering::Acquire)
@@ -584,8 +574,7 @@ impl JSBundleCompletionTask {
             }
         };
         let compile_result = self.do_compilation(&mut build.output_files);
-        // `to_executable` and the sourcemap write report their failures to
-        // stderr, and nothing else flushes this thread's buffered stderr.
+        // Nothing else flushes this thread's buffered stderr, which the above reports failures to.
         bun_core::Output::flush();
         self.result = match compile_result {
             CompileResult::Success => BundleV2Result::Value(build),
@@ -694,9 +683,6 @@ impl JSBundleCompletionTask {
         // for `result`/`config`/`log` below.
         let promise: *mut JSPromise = this.promise.swap();
         let promise = JSPromise::opaque_mut(promise);
-
-        // `Bun.build({ compile })` already produced the executable (or turned
-        // `result` into `Err`) on the bundle thread — see `compile_on_bundle_thread`.
 
         // `to_js_error` borrows `&mut self`, which would overlap a
         // `&mut this.result` match scrutinee. Dispatch the pending/err arms

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -889,7 +889,7 @@ impl BuildCommand {
                     &opt_public_path,
                     outfile,
                     // SAFETY: `env` is a process-lifetime singleton.
-                    unsafe { &mut *env_ptr },
+                    unsafe { &*env_ptr },
                     opt_output_format,
                     &ctx.bundler_options.windows,
                     ctx.bundler_options

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -889,7 +889,7 @@ impl BuildCommand {
                     &opt_public_path,
                     outfile,
                     // SAFETY: `env` is a process-lifetime singleton.
-                    unsafe { &*env_ptr },
+                    &compile_target.download_options(unsafe { &*env_ptr }),
                     opt_output_format,
                     &ctx.bundler_options.windows,
                     ctx.bundler_options

--- a/src/standalone_graph/Cargo.toml
+++ b/src/standalone_graph/Cargo.toml
@@ -25,7 +25,6 @@ bun_alloc.workspace = true
 bun_core.workspace = true
 bun_bundler.workspace = true
 bun_collections.workspace = true
-bun_dotenv.workspace = true
 bun_exe_format.workspace = true
 bun_http.workspace = true
 bun_parsers.workspace = true

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1654,7 +1654,7 @@ pub use bun_options_types::compile_target::CompileTarget;
 /// two `download*` fns below in this crate.
 pub(crate) fn download_to_path(
     target: &CompileTarget,
-    env: &mut bun_dotenv::Loader,
+    env: &bun_dotenv::Loader,
     dest_z: &ZStr,
 ) -> crate::Result<()> {
     bun_http::http_thread::init(&Default::default());
@@ -1818,7 +1818,7 @@ pub fn to_executable(
     root_dir: Fd,
     module_prefix: &[u8],
     outfile: &[u8],
-    env: &mut bun_dotenv::Loader,
+    env: &bun_dotenv::Loader,
     output_format: Format,
     windows_options: &WindowsOptions,
     compile_exec_argv: &[u8],

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1646,7 +1646,7 @@ pub(crate) fn inject(
 }
 
 use bun_core::Environment::OperatingSystem as CompileTargetOs;
-pub use bun_options_types::compile_target::CompileTarget;
+pub use bun_options_types::compile_target::{CompileTarget, DownloadOptions};
 
 /// Moved up from `bun_options_types` (T3) so it can name
 /// `bun_http::AsyncHTTP` directly
@@ -1654,7 +1654,7 @@ pub use bun_options_types::compile_target::CompileTarget;
 /// two `download*` fns below in this crate.
 pub(crate) fn download_to_path(
     target: &CompileTarget,
-    env: &bun_dotenv::Loader,
+    download: &DownloadOptions,
     dest_z: &ZStr,
 ) -> crate::Result<()> {
     bun_http::http_thread::init(&Default::default());
@@ -1666,7 +1666,7 @@ pub(crate) fn download_to_path(
         // TODO: This is way too much code necessary to send a single HTTP request...
         let mut compressed_archive_bytes =
             Box::new(bun_core::MutableString::init(24 * 1024 * 1024)?);
-        let mut url_buffer = [0u8; 2048];
+        let mut url_buffer = [0u8; CompileTarget::REGISTRY_URL_BUF_LEN];
         let url_str = match target.to_npm_registry_url(&mut url_buffer) {
             Ok(s) => s,
             Err(err) => {
@@ -1681,10 +1681,6 @@ pub(crate) fn download_to_path(
             // `progress.end()` below is sufficient: no fallible call sits between
             // `refresher.start` and it, so every exit path (including the
             // error returns after it) ends the node exactly once.
-            // Note: reshaped for borrowck — `get_http_proxy_for` borrows
-            // `env` for the proxy URL lifetime; read the bool first.
-            let reject_unauthorized = env.get_tls_reject_unauthorized();
-            let http_proxy: Option<bun_url::URL<'_>> = env.get_http_proxy_for(&url);
             let progress = refresher.start(b"Downloading", 0);
 
             let mut async_http = Box::new(bun_http::AsyncHTTP::init_sync(
@@ -1693,13 +1689,13 @@ pub(crate) fn download_to_path(
                 Default::default(),
                 b"",
                 b"",
-                http_proxy,
+                download.http_proxy.as_deref().map(bun_url::URL::parse),
                 None,
                 bun_http::FetchRedirect::Follow,
             ));
             async_http.client.progress_node =
                 core::ptr::NonNull::new(core::ptr::from_mut(progress));
-            async_http.client.flags.reject_unauthorized = reject_unauthorized;
+            async_http.client.flags.reject_unauthorized = download.reject_unauthorized;
             let send_result = async_http.send_sync(&mut compressed_archive_bytes);
 
             progress.end();
@@ -1818,7 +1814,7 @@ pub fn to_executable(
     root_dir: Fd,
     module_prefix: &[u8],
     outfile: &[u8],
-    env: &bun_dotenv::Loader,
+    download: &DownloadOptions,
     output_format: Format,
     windows_options: &WindowsOptions,
     compile_exec_argv: &[u8],
@@ -1870,10 +1866,10 @@ pub fn to_executable(
         let version_zstr = ZStr::from_slice_with_nul(&version_str[..]);
 
         let mut needs_download: bool = true;
-        let dest_z = target.exe_path(&mut exe_path_buf, version_zstr, env, &mut needs_download);
+        let dest_z = target.exe_path(&mut exe_path_buf, version_zstr, &mut needs_download);
 
         if needs_download {
-            if let Err(e) = download_to_path(target, env, dest_z) {
+            if let Err(e) = download_to_path(target, download, dest_z) {
                 return Ok(match e {
                     crate::Error::TargetNotFound => CompileResult::fail_fmt(format_args!(
                         "Target platform '{}' is not available for download. Check if this version of Bun supports this target.",

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -107,8 +107,8 @@ describe("Bun.build compile", () => {
         // milliseconds (about 50ms under a debug build).
         const gaveUp = Promise.withResolvers<Outcome>();
         const giveUp = setTimeout(gaveUp.resolve, 4_000, "did not answer the ping");
-        proc.send("ping");
         try {
+          proc.send("ping");
           outcome = await Promise.race([
             pong.promise,
             gaveUp.promise,

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -72,6 +72,92 @@ describe("Bun.build compile", () => {
     },
   );
 
+  test("the event loop keeps running while the executable is being produced", async () => {
+    // Producing the executable (downloading the target binary for a cross target, then
+    // copying and rewriting it) used to happen on the JS thread between bundling and the
+    // promise settling, so nothing else in that process ran meanwhile. Serve the target
+    // download here and withhold the response until the building process has answered an
+    // IPC ping, which a process whose JS thread is inside the compile step cannot do.
+    using dir = tempDir("build-compile-event-loop", {
+      "app.js": `console.log("hi");`,
+      "build.js": `
+        process.on("message", message => process.send(message));
+        const result = await Bun.build({
+          entrypoints: [import.meta.dir + "/app.js"],
+          compile: { target: process.argv[2], outfile: "app" },
+          throw: false,
+        });
+        console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));
+        process.exit(0);
+      `,
+    });
+    // Any OS other than the host's has to be downloaded; aarch64 never carries a "-baseline" suffix.
+    const target = `bun-${isMacOS ? "linux" : "darwin"}-aarch64`;
+    const [version] = Bun.version.match(/^\d+\.\d+\.\d+/)!;
+
+    type Outcome = "never requested the target" | "answered the ping" | "did not answer the ping";
+    let outcome: Outcome = "never requested the target";
+    const pong = Promise.withResolvers<Outcome>();
+    await using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch() {
+        // A process stuck inside the compile step emits nothing, so that state can only be
+        // observed by giving up on the ping. The unblocked process answers within
+        // milliseconds (about 50ms under a debug build).
+        const gaveUp = Promise.withResolvers<Outcome>();
+        const giveUp = setTimeout(gaveUp.resolve, 4_000, "did not answer the ping");
+        proc.send("ping");
+        try {
+          outcome = await Promise.race([
+            pong.promise,
+            gaveUp.promise,
+            proc.exited.then((): Outcome => "did not answer the ping"),
+          ]);
+        } finally {
+          clearTimeout(giveUp);
+        }
+        return new Response("no such tarball", { status: 404 });
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.js", target],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_COMPILE_TARGET_TARBALL_URL: `${server.url}bun.tgz`,
+        // A fresh cache, so the target is never already on disk.
+        BUN_INSTALL_CACHE_DIR: join(String(dir), "install-cache"),
+        // The download honors these; keep it pointed at the server above.
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      ipc(message) {
+        if (message === "ping") pong.resolve("answered the ping");
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is only diagnostic: the download reports progress there once the response
+    // has been outstanding for 500ms, so it is empty or not depending on the ping's speed.
+    expect({ outcome, stdout, exitCode }, `stderr: ${stderr}`).toEqual({
+      outcome: "answered the ping",
+      stdout:
+        JSON.stringify({
+          success: false,
+          logs: [
+            `Target platform '${target}-v${version}' is not available for download. Check if this version of Bun supports this target.`,
+          ],
+        }) + "\n",
+      exitCode: 0,
+    });
+  });
+
   test("compile with embedded resources uses correct module prefix", async () => {
     using dir = tempDir("build-compile-embedded-resources", {
       "app.js": `

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -72,89 +72,184 @@ describe("Bun.build compile", () => {
     },
   );
 
-  test("the event loop keeps running while the executable is being produced", async () => {
-    // Producing the executable (downloading the target binary for a cross target, then
-    // copying and rewriting it) used to happen on the JS thread between bundling and the
-    // promise settling, so nothing else in that process ran meanwhile. Serve the target
-    // download here and withhold the response until the building process has answered an
-    // IPC ping, which a process whose JS thread is inside the compile step cannot do.
-    using dir = tempDir("build-compile-event-loop", {
-      "app.js": `console.log("hi");`,
-      "build.js": `
-        process.on("message", message => process.send(message));
-        const result = await Bun.build({
-          entrypoints: [import.meta.dir + "/app.js"],
-          compile: { target: process.argv[2], outfile: "app" },
-          throw: false,
-        });
-        console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));
-        process.exit(0);
-      `,
-    });
+  // These never copy the bun binary: the target download is answered with a 404 by a server
+  // in this test, or the template handed in via executablePath is rejected up front.
+  describe.concurrent("producing the executable", () => {
     // Any OS other than the host's has to be downloaded; aarch64 never carries a "-baseline" suffix.
     const target = `bun-${isMacOS ? "linux" : "darwin"}-aarch64`;
     const [version] = Bun.version.match(/^\d+\.\d+\.\d+/)!;
+    const notAvailable =
+      JSON.stringify({
+        success: false,
+        logs: [
+          `Target platform '${target}-v${version}' is not available for download. Check if this version of Bun supports this target.`,
+        ],
+      }) + "\n";
+    // A fresh cache, so the target is never already on disk, and no inherited proxy
+    // configuration, so the download goes where the test points it.
+    const downloadEnv = (dir: string, tarballUrl: string) => ({
+      ...bunEnv,
+      BUN_COMPILE_TARGET_TARBALL_URL: tarballUrl,
+      BUN_INSTALL_CACHE_DIR: join(dir, "install-cache"),
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      NO_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+      no_proxy: undefined,
+    });
+    const notFound = () => new Response("no such tarball", { status: 404 });
 
-    type Outcome = "never requested the target" | "answered the ping" | "did not answer the ping";
-    let outcome: Outcome = "never requested the target";
-    const pong = Promise.withResolvers<Outcome>();
-    await using server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      async fetch() {
-        // A process stuck inside the compile step emits nothing, so that state can only be
-        // observed by giving up on the ping. The unblocked process answers within
-        // milliseconds (about 50ms under a debug build).
-        const gaveUp = Promise.withResolvers<Outcome>();
-        const giveUp = setTimeout(gaveUp.resolve, 4_000, "did not answer the ping");
-        try {
-          proc.send("ping");
-          outcome = await Promise.race([
-            pong.promise,
-            gaveUp.promise,
-            proc.exited.then((): Outcome => "did not answer the ping"),
-          ]);
-        } finally {
-          clearTimeout(giveUp);
-        }
-        return new Response("no such tarball", { status: 404 });
-      },
+    test("the event loop keeps running meanwhile", async () => {
+      // Producing the executable (downloading the target binary for a cross target, then
+      // copying and rewriting it) used to happen on the JS thread between bundling and the
+      // promise settling, so nothing else in that process ran meanwhile. Withhold the
+      // download's response until the building process has answered an IPC ping, which a
+      // process whose JS thread is inside the compile step cannot do.
+      using dir = tempDir("build-compile-event-loop", {
+        "app.js": `console.log("hi");`,
+        "build.js": `
+          process.on("message", message => process.send(message));
+          const result = await Bun.build({
+            entrypoints: [import.meta.dir + "/app.js"],
+            compile: { target: process.argv[2], outfile: "app" },
+            throw: false,
+          });
+          console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));
+          process.exit(0);
+        `,
+      });
+
+      type Outcome = "never requested the target" | "answered the ping" | "did not answer the ping";
+      let outcome: Outcome = "never requested the target";
+      const pong = Promise.withResolvers<Outcome>();
+      await using registry = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch() {
+          // A process stuck inside the compile step emits nothing, so that state can only be
+          // observed by giving up on the ping. The unblocked process answers within
+          // milliseconds (about 50ms under a debug build).
+          const gaveUp = Promise.withResolvers<Outcome>();
+          const giveUp = setTimeout(gaveUp.resolve, 4_000, "did not answer the ping");
+          try {
+            proc.send("ping");
+            outcome = await Promise.race([
+              pong.promise,
+              gaveUp.promise,
+              proc.exited.then((): Outcome => "did not answer the ping"),
+            ]);
+          } finally {
+            clearTimeout(giveUp);
+          }
+          return notFound();
+        },
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.js", target],
+        cwd: String(dir),
+        env: downloadEnv(String(dir), `${registry.url}bun.tgz`),
+        stdout: "pipe",
+        stderr: "pipe",
+        ipc(message) {
+          if (message === "ping") pong.resolve("answered the ping");
+        },
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // stderr is only diagnostic: the download reports progress there once the response
+      // has been outstanding for 500ms, so it is empty or not depending on the ping's speed.
+      expect({ outcome, stdout, exitCode }, `stderr: ${stderr}`).toEqual({
+        outcome: "answered the ping",
+        stdout: notAvailable,
+        exitCode: 0,
+      });
     });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build.js", target],
-      cwd: String(dir),
-      env: {
-        ...bunEnv,
-        BUN_COMPILE_TARGET_TARBALL_URL: `${server.url}bun.tgz`,
-        // A fresh cache, so the target is never already on disk.
-        BUN_INSTALL_CACHE_DIR: join(String(dir), "install-cache"),
-        // The download honors these; keep it pointed at the server above.
-        HTTP_PROXY: undefined,
-        HTTPS_PROXY: undefined,
-        http_proxy: undefined,
-        https_proxy: undefined,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-      ipc(message) {
-        if (message === "ping") pong.resolve("answered the ping");
-      },
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    test.each(["before", "after"])(
+      "the download uses the proxy settings from when Bun.build() was called (HTTP_PROXY set %s the call)",
+      async when => {
+        // Like fetch(), the proxy decision is made on the calling thread when Bun.build() is
+        // called, not read from the environment later by the thread doing the download.
+        using dir = tempDir("build-compile-download-proxy", {
+          "app.js": `console.log("hi");`,
+          "build.js": `
+            const [when, target, proxy] = process.argv.slice(2);
+            if (when === "before") process.env.HTTP_PROXY = proxy;
+            const build = Bun.build({
+              entrypoints: [import.meta.dir + "/app.js"],
+              compile: { target, outfile: "app" },
+              throw: false,
+            });
+            if (when === "after") process.env.HTTP_PROXY = proxy;
+            const result = await build;
+            console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));
+          `,
+        });
+        const requests: string[] = [];
+        const serve = (name: string) =>
+          Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(req) {
+              requests.push(`${name} received ${req.url}`);
+              return notFound();
+            },
+          });
+        await using registry = serve("proxy-less registry");
+        await using proxy = serve("proxy");
+        const tarballUrl = `${registry.url}bun.tgz`;
 
-    // stderr is only diagnostic: the download reports progress there once the response
-    // has been outstanding for 500ms, so it is empty or not depending on the ping's speed.
-    expect({ outcome, stdout, exitCode }, `stderr: ${stderr}`).toEqual({
-      outcome: "answered the ping",
-      stdout:
-        JSON.stringify({
-          success: false,
-          logs: [
-            `Target platform '${target}-v${version}' is not available for download. Check if this version of Bun supports this target.`,
-          ],
-        }) + "\n",
-      exitCode: 0,
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "build.js", when, target, String(proxy.url)],
+          cwd: String(dir),
+          env: downloadEnv(String(dir), tarballUrl),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect({ requests, stdout, exitCode }, `stderr: ${stderr}`).toEqual({
+          requests: [`${when === "before" ? "proxy" : "proxy-less registry"} received ${tarballUrl}`],
+          stdout: notAvailable,
+          exitCode: 0,
+        });
+      },
+    );
+
+    test("a template that cannot be patched reports the cause on stderr", async () => {
+      // The specific failure is printed by the thread producing the executable, whose
+      // buffered stderr nothing else flushes; the build result only carries a generic error.
+      using dir = tempDir("build-compile-bad-template", {
+        "app.js": `console.log("hi");`,
+        "not-bun": "definitely not an executable\n",
+        "build.js": `
+          const result = await Bun.build({
+            entrypoints: [import.meta.dir + "/app.js"],
+            // A Linux target on every host, so it is always the ELF code that rejects the template.
+            compile: { target: "bun-linux-x64", executablePath: import.meta.dir + "/not-bun", outfile: "app" },
+            throw: false,
+          });
+          console.log(JSON.stringify({ success: result.success, errors: result.logs.length }));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode, wroteOutfile: existsSync(join(String(dir), "app")) }).toEqual({
+        stdout: '{"success":false,"errors":1}\n',
+        stderr: "Error initializing ELF file: InvalidElfFile\n",
+        exitCode: 0,
+        wroteOutfile: false,
+      });
     });
   });
 


### PR DESCRIPTION
## What

While `await Bun.build({ compile: { ... } })` is pending, the calling thread's event loop stops once bundling finishes and does not resume until the output executable has been fully written: no timers fire, no child exits or pipe reads are observed. Under a debug build (1 GB binary) that is a 3 to 4 second stall; with a release binary it is about 100ms on NVMe and grows with binary size and disk/antivirus speed. For a cross-compile target the download of the target binary happens on the same synchronous path. Observed in #37496, where every test running concurrently with one `Bun.build({ compile })` reported the compile's duration.

```ts
const gaps = []; let last = performance.now();
setInterval(() => { const now = performance.now(); if (now - last > 200) gaps.push(`${last | 0} -> ${now | 0}`); last = now; }, 1);
await Bun.build({ entrypoints: ["./index.ts"], compile: { outfile: "./app" } });
console.log(gaps);
```

Before (debug build): `build took 4294ms`, one timer gap `144 -> 4304`, 381 interval ticks in total. After: no gaps, about 4200 ticks during the build, same executable written.

## Cause

`JSBundleCompletionTask::on_complete` runs on the JS thread when the bundle thread posts the finished build back. For `compile` it called `do_compilation` right there, i.e. `collect_compile_assets`, `StandaloneModuleGraph::to_executable` (cross-target download, copy of the running binary, read back, ELF/Mach-O/PE patch, full rewrite, rename) and the external sourcemap writes, and only then settled the promise.

## Fix

`complete_on_bundle_thread` now calls `compile_on_bundle_thread` before posting the completion, so the executable is produced on the bundle thread and `on_complete` only reports the result. The result/log mutations are the same as before (`CompileResult::Err` is appended to the log and the result becomes `Err(CompilationFailed)`, so `to_js_error` and the `throw: false` shape are unchanged); they just happen before the hand-off. A build whose VM is tearing down (`cancelled`) skips the step, matching the old code, where `on_complete` returned before compiling.

What the moved step may touch, and how that was made true:

- It previously read the VM's env loader: `download_to_path` looked up `NODE_TLS_REJECT_UNAUTHORIZED` and the proxy variables and handed the HTTP client a proxy URL borrowing the loader's bytes for the whole download. Off the JS thread that is a race with `process.env.HTTP_PROXY = ...` (which replaces the map entry and frees the old bytes). So `CompileTarget::download_options` now copies those two values out on the calling thread (`Config::from_js` for the JS API, so the decision is made when `Bun.build()` is called, like `fetch()`; immediately before `to_executable` for the CLI, i.e. exactly when it was read before), and `to_executable` / `download_to_path` take that `DownloadOptions` instead of a `Loader`. The step now touches task-owned data and the file system only; `self.env` is used solely by the pre-existing `Transpiler::init` call, and `bun_standalone_graph` no longer depends on `bun_dotenv`.
- The download itself is `AsyncHTTP::send_sync`, a blocking wait on the HTTP thread, which works from any thread (it is how the CLI uses it). On main-thread exit the HTTP thread is parked only after `wait_for_embedded_work`, and `embedded_work_finished` is reported after the compile, so a teardown during a download waits for it rather than deadlocking. That wait is not new: before, nothing could even call `process.exit()` until the download returned.
- `inject()` and a failed sourcemap write report their specific cause to stderr. `Output` buffers stderr per thread and nothing else ever flushes the bundle thread's buffer, so the step flushes after compiling (pool workers flush after each task for the same reason). The new stderr test fails if the flush is removed.
- `stop_for_vm_teardown` can still run concurrently with the compile; it only touches atomics and the plugin cell, neither of which `do_compilation` uses. The loop pointer it may wake is the bundle thread's thread-lifetime uws loop, not the per-build `AnyEventLoop`.
- HTML routes and `compile` + `target: "browser"` builds never reach the step (`config.compile` is `None` by then), exactly as before.
- The bundle thread gets `DEFAULT_THREAD_STACK_SIZE` like bun's other threads instead of Rust's 2 MiB default. On Windows `do_compilation` + `to_executable` + `inject` declare well over half a megabyte of `PathBuffer` / `WPathBuffer` locals between them; that fits in 2 MiB, this just removes the question.

`bun build --compile` calls `to_executable` synchronously on its main thread, which is fine since there is no event loop to block; apart from building the `DownloadOptions` at the call site it is untouched. #33621 (mmap the source binary instead of copying it) is complementary: it makes the step cheaper, this takes it off the JS thread. #34353 (stop continuing past an `inject()` failure) is also compatible: it keeps the stderr line the new test asserts and still produces one log entry.

## Tests

All in `test/bundler/bun-build-compile.test.ts`, in a concurrent `describe`. None of them copies the bun binary: the download is answered with a 404 by a server inside the test (`BUN_COMPILE_TARGET_TARBALL_URL` plus a fresh `BUN_INSTALL_CACHE_DIR`, target OS different from the host), or the template is rejected up front. About 0.5s each under a debug build.

- `the event loop keeps running meanwhile`: the server withholds the 404 until the building child has answered an IPC ping. A child whose JS thread is inside the compile step cannot answer, so the unfixed build deterministically reports `outcome: "did not answer the ping"` (the 4s bound only decides how long to wait before saying so; the unblocked child answers in about 50ms under a debug build, 50 to 170ms with every core busy). Also asserts the error produced on the bundle thread comes back through `logs` and that the child exits on its own.
- `the download uses the proxy settings from when Bun.build() was called`, `HTTP_PROXY` set before / after the call: a second server plays proxy; the request must arrive at the proxy in the first case and at the registry in the second. The "after" case fails on the unfixed build and on the first revision of this PR (both read the environment when the download starts).
- `a template that cannot be patched reports the cause on stderr`: `executablePath` pointing at a text file with a Linux target, so the ELF code rejects it on every host; asserts the exact stderr line, one log entry, and no outfile. Passes on the unfixed build (the JS thread's buffer was flushed at exit) and fails if the bundle-thread flush is removed.

Also run on this branch: the rest of `bun-build-compile.test.ts`, `bun-build-compile-sourcemap.test.ts` (sourcemap writes now on the bundle thread), `compile-asset-bunfs.test.ts` (asset collection and the compile error path), `bundler_compile.test.ts -t HelloWorldWithProcessVersionsBunAPI` and its `--compile-executable-path` case (plugins + compile, CLI cross target), `compile-windows-metadata.test.ts`, `standalone.test.ts` (`compile` + browser target), `bun-build-api.test.ts`; all pass. The only CI failure on the previous revision was `worker-transfer-list.test.ts` on the x64-asan lane, a known worker-termination flake (#37267, #34655, #34644).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->