### PR TITLE
tls: SSLContextCache map owns Box<Entry>; ctx is Cell<Option<NonNull>>

### DIFF
--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -24,6 +24,7 @@ use core::ffi::{c_int, c_long, c_void};
 use core::ptr::{self, NonNull};
 
 use bun_boringssl_sys as boringssl;
+use bun_boringssl_sys::OwnedSslCtx;
 use bun_collections::array_hash_map::{ArrayHashContext, ArrayHashMap, MapEntry};
 use bun_threading::Mutex;
 use bun_uws as uws;
@@ -76,13 +77,13 @@ struct Entry {
 impl Entry {
     /// Points `ctx`'s ex_data slot at `self` so `bun_ssl_ctx_cache_on_free`
     /// can tombstone it. Fails only on OOM.
-    fn attach(&self, ctx: *mut boringssl::SSL_CTX) -> bool {
-        // SAFETY: `ctx` is the live SSL_CTX the caller just built. The slot
-        // receives a pointer derived from `&self`; the callback only reads it
-        // back as `&Entry` and writes through the `Cell`.
+    fn attach(&self, ctx: &OwnedSslCtx) -> bool {
+        // SAFETY: `ctx` holds a ref on the SSL_CTX, so it is live for this
+        // call. The slot receives a pointer derived from `&self`; the callback
+        // only reads it back as `&Entry` and writes through the `Cell`.
         unsafe {
             boringssl::SSL_CTX_set_ex_data(
-                ctx,
+                ctx.as_ptr(),
                 c::us_ssl_ctx_cache_ex_idx(),
                 ptr::from_ref(self).cast_mut().cast::<c_void>(),
             ) == 1
@@ -136,6 +137,10 @@ impl SSLContextCache {
         // which has a reason to serialize, and holding a non-reentrant SRWLock
         // across an SSL_CTX_free that *did* tombstone would self-deadlock.
         let ctx = opts.create_ssl_context(err)?;
+        // SAFETY: `create_ssl_context` returns a +1 ref that is ours; `ctx`
+        // now owns it, and either hands it to the caller (`into_raw`) or frees
+        // it by being dropped.
+        let ctx = unsafe { OwnedSslCtx::from_raw(ctx) }.expect("create_ssl_context returned null");
 
         let _guard = self.mutex.lock_guard();
 
@@ -151,31 +156,31 @@ impl SSLContextCache {
                 let entry: &Entry = occupied.get();
                 if let Some(existing) = entry.ctx.get() {
                     let existing = existing.as_ptr();
-                    // SAFETY: existing is still live (not tombstoned); ctx is the fresh
-                    // CTX we just built and own.
-                    unsafe {
-                        boringssl::SSL_CTX_up_ref(existing);
-                        boringssl::SSL_CTX_free(ctx);
-                    }
+                    // SAFETY: existing is still live (not tombstoned) and the
+                    // tombstone write is serialized by the mutex we hold.
+                    unsafe { boringssl::SSL_CTX_up_ref(existing) };
+                    // Ours was never attached, so dropping `ctx` on return
+                    // frees it without reaching `bun_ssl_ctx_cache_on_free`.
                     return Some(existing);
                 }
                 // Tombstone: adopt the rebuilt CTX into the existing slot.
                 // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if
                 // it did, the entry would never tombstone and `entry.ctx` would dangle
-                // after the CTX is freed. Don't cache it; caller still owns the ref.
-                if entry.attach(ctx) {
-                    entry.ctx.set(NonNull::new(ctx));
+                // after the CTX is freed. Don't cache it; the caller gets the ref
+                // either way.
+                if entry.attach(&ctx) {
+                    entry.ctx.set(NonNull::new(ctx.as_ptr()));
                 }
-                return Some(ctx);
+                return Some(ctx.into_raw());
             }
             MapEntry::Vacant(vacant) => {
                 let entry: &Entry = vacant.insert(Box::new(Entry {
-                    ctx: Cell::new(NonNull::new(ctx)),
+                    ctx: Cell::new(NonNull::new(ctx.as_ptr())),
                     owner: owner_ptr,
                 }));
-                if !entry.attach(ctx) {
+                if !entry.attach(&ctx) {
                     self.map.swap_remove(&d);
-                    return Some(ctx);
+                    return Some(ctx.into_raw());
                 }
             }
         }
@@ -185,7 +190,7 @@ impl SSLContextCache {
             self.ops_since_compact = 0;
             self.compact_locked();
         }
-        Some(ctx)
+        Some(ctx.into_raw())
     }
 
     /// Reclaim tombstoned entries. Locked variant — callers hold `self.mutex`.

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -3,7 +3,7 @@
 //! The map holds **zero** refs on the cached `SSL_CTX*`. An `SSL_CTX` ex_data
 //! slot stores a back-pointer to the heap `Entry`; BoringSSL's `CRYPTO_EX_free`
 //! callback (registered once in `openssl.c`'s `us_ex_idx_init`) tombstones the
-//! entry (`entry.ctx = null`) when the real refcount hits 0. The next
+//! entry (`entry.ctx` becomes `None`) when the real refcount hits 0. The next
 //! `get_or_create` for that digest sees the tombstone and rebuilds.
 //!
 //! Race-freedom relies on the per-VM instance only being touched from the JS
@@ -19,11 +19,12 @@
 //! `tls.ts` SHA-256/WeakRef memo: every path that turns an `SSLConfig` into an
 //! `SSL_CTX*` goes through here, so one config = one CTX per process.
 
+use core::cell::Cell;
 use core::ffi::{c_int, c_long, c_void};
-use core::ptr;
+use core::ptr::{self, NonNull};
 
 use bun_boringssl_sys as boringssl;
-use bun_collections::array_hash_map::{ArrayHashContext, ArrayHashMap};
+use bun_collections::array_hash_map::{ArrayHashContext, ArrayHashMap, MapEntry};
 use bun_threading::Mutex;
 use bun_uws as uws;
 use bun_uws::create_bun_socket_error_t;
@@ -33,7 +34,7 @@ use crate::api::server::server_config::SSLConfig;
 
 #[derive(Default)]
 pub struct SSLContextCache {
-    map: ArrayHashMap<Digest, *mut Entry, DigestContext>,
+    map: ArrayHashMap<Digest, Box<Entry>, DigestContext>,
     mutex: Mutex,
     ops_since_compact: u32,
 }
@@ -58,15 +59,35 @@ impl ArrayHashContext<Digest> for DigestContext {
     }
 }
 
-pub struct Entry {
-    /// Nulled by `bun_ssl_ctx_cache_on_free` when BoringSSL drops the last
-    /// ref. Tombstoned entries are reclaimed on the next `get_or_create` for
-    /// the same digest, or by the periodic compact.
-    pub ctx: *mut boringssl::SSL_CTX,
+/// Owned by `SSLContextCache::map`; boxed because the `SSL_CTX`'s ex_data slot
+/// holds its address. Only ever reached through `&Entry` (map lookups and
+/// `bun_ssl_ctx_cache_on_free`), hence the `Cell`.
+struct Entry {
+    /// `None` once `bun_ssl_ctx_cache_on_free` ran because BoringSSL dropped
+    /// the last ref. Tombstoned entries are reclaimed on the next
+    /// `get_or_create` for the same digest, or by the periodic compact.
+    ctx: Cell<Option<NonNull<boringssl::SSL_CTX>>>,
     /// BACKREF: the cache outlives every `Entry` it allocates (Drop clears
     /// ex_data first so the `CRYPTO_EX_free` callback never sees a dangling
     /// owner).
-    pub(crate) owner: bun_ptr::BackRef<SSLContextCache>,
+    owner: bun_ptr::BackRef<SSLContextCache>,
+}
+
+impl Entry {
+    /// Points `ctx`'s ex_data slot at `self` so `bun_ssl_ctx_cache_on_free`
+    /// can tombstone it. Fails only on OOM.
+    fn attach(&self, ctx: *mut boringssl::SSL_CTX) -> bool {
+        // SAFETY: `ctx` is the live SSL_CTX the caller just built. The slot
+        // receives a pointer derived from `&self`; the callback only reads it
+        // back as `&Entry` and writes through the `Cell`.
+        unsafe {
+            boringssl::SSL_CTX_set_ex_data(
+                ctx,
+                c::us_ssl_ctx_cache_ex_idx(),
+                ptr::from_ref(self).cast_mut().cast::<c_void>(),
+            ) == 1
+        }
+    }
 }
 
 impl SSLContextCache {
@@ -101,16 +122,12 @@ impl SSLContextCache {
     ) -> Option<*mut boringssl::SSL_CTX> {
         {
             let _guard = self.mutex.lock_guard();
-            if let Some(entry) = self.map.get(&d) {
-                // SAFETY: map values are live heap Entries (heap::alloc below); freed only
-                // via compact_locked / Drop, both of which hold this mutex.
-                let entry = unsafe { &**entry };
-                if !entry.ctx.is_null() {
-                    let ctx = entry.ctx;
-                    // SAFETY: ctx non-null and tombstone write is serialized by this mutex.
-                    unsafe { boringssl::SSL_CTX_up_ref(ctx) };
-                    return Some(ctx);
-                }
+            if let Some(ctx) = self.map.get(&d).and_then(|entry| entry.ctx.get()) {
+                let ctx = ctx.as_ptr();
+                // SAFETY: ctx is still live (not tombstoned) and the tombstone write
+                // is serialized by this mutex.
+                unsafe { boringssl::SSL_CTX_up_ref(ctx) };
+                return Some(ctx);
             }
         }
 
@@ -129,56 +146,38 @@ impl SSLContextCache {
 
         // Re-check: another caller may have inserted while we were building.
         // Prefer the already-cached one and drop ours so callers converge.
-        let gop = bun_core::handle_oom(self.map.get_or_put(d));
-        if gop.found_existing {
-            // SAFETY: existing map value is a live heap Entry (see above).
-            let entry = unsafe { &mut **gop.value_ptr };
-            if !entry.ctx.is_null() {
-                let existing = entry.ctx;
-                // SAFETY: existing non-null; ctx is the fresh CTX we just built and own.
-                unsafe {
-                    boringssl::SSL_CTX_up_ref(existing);
-                    boringssl::SSL_CTX_free(ctx);
+        match self.map.entry(d) {
+            MapEntry::Occupied(occupied) => {
+                let entry: &Entry = occupied.get();
+                if let Some(existing) = entry.ctx.get() {
+                    let existing = existing.as_ptr();
+                    // SAFETY: existing is still live (not tombstoned); ctx is the fresh
+                    // CTX we just built and own.
+                    unsafe {
+                        boringssl::SSL_CTX_up_ref(existing);
+                        boringssl::SSL_CTX_free(ctx);
+                    }
+                    return Some(existing);
                 }
-                return Some(existing);
-            }
-            // Tombstone — adopt the rebuilt CTX into the existing slot.
-            // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if
-            // it did, the entry would never tombstone and `entry.ctx` would dangle
-            // after the CTX is freed. Don't cache it; caller still owns the ref.
-            // SAFETY: ctx is a valid SSL_CTX*; entry is a valid heap pointer.
-            if unsafe {
-                boringssl::SSL_CTX_set_ex_data(
-                    ctx,
-                    c::us_ssl_ctx_cache_ex_idx(),
-                    std::ptr::from_mut::<Entry>(entry).cast::<c_void>(),
-                )
-            } != 1
-            {
+                // Tombstone: adopt the rebuilt CTX into the existing slot.
+                // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if
+                // it did, the entry would never tombstone and `entry.ctx` would dangle
+                // after the CTX is freed. Don't cache it; caller still owns the ref.
+                if entry.attach(ctx) {
+                    entry.ctx.set(NonNull::new(ctx));
+                }
                 return Some(ctx);
             }
-            entry.ctx = ctx;
-            return Some(ctx);
-        }
-
-        let entry = bun_core::heap::into_raw(Box::new(Entry {
-            ctx,
-            owner: owner_ptr,
-        }));
-        *gop.value_ptr = entry;
-        // SAFETY: ctx is a valid SSL_CTX*; entry is a fresh non-null heap pointer.
-        if unsafe {
-            boringssl::SSL_CTX_set_ex_data(
-                ctx,
-                c::us_ssl_ctx_cache_ex_idx(),
-                entry.cast::<c_void>(),
-            )
-        } != 1
-        {
-            self.map.swap_remove(&d);
-            // SAFETY: entry was just heap-allocated above and not yet published to ex_data.
-            drop(unsafe { bun_core::heap::take(entry) });
-            return Some(ctx);
+            MapEntry::Vacant(vacant) => {
+                let entry: &Entry = vacant.insert(Box::new(Entry {
+                    ctx: Cell::new(NonNull::new(ctx)),
+                    owner: owner_ptr,
+                }));
+                if !entry.attach(ctx) {
+                    self.map.swap_remove(&d);
+                    return Some(ctx);
+                }
+            }
         }
 
         self.ops_since_compact += 1;
@@ -193,12 +192,7 @@ impl SSLContextCache {
     fn compact_locked(&mut self) {
         let mut i: usize = 0;
         while i < self.map.count() {
-            let entry = self.map.values()[i];
-            // SAFETY: map values are live heap Entries; we hold the mutex.
-            if unsafe { (*entry).ctx.is_null() } {
-                // SAFETY: entry was heap-allocated in get_or_create_digest; ex_data
-                // back-pointer is already moot (ctx == null means CRYPTO_EX_free ran).
-                drop(unsafe { bun_core::heap::take(entry) });
+            if self.map.values()[i].ctx.get().is_none() {
                 self.map.swap_remove_at(i);
             } else {
                 i += 1;
@@ -234,11 +228,11 @@ pub(crate) extern "C" fn bun_ssl_ctx_cache_on_free(
     if ptr.is_null() {
         return;
     }
-    // SAFETY: non-null ptr is the *Entry we stored via SSL_CTX_set_ex_data; the
+    // SAFETY: non-null ptr is the `&Entry` that `Entry::attach` published; the
     // owning cache outlives every SSL_CTX it hands out (Drop clears ex_data first).
-    let entry: &mut Entry = unsafe { bun_ptr::callback_ctx::<Entry>(ptr) };
+    let entry = unsafe { &*ptr.cast::<Entry>() };
     let _guard = entry.owner.mutex.lock_guard();
-    entry.ctx = ptr::null_mut();
+    entry.ctx.set(None);
 }
 
 impl Drop for SSLContextCache {
@@ -248,24 +242,21 @@ impl Drop for SSLContextCache {
     /// `SSL_CTX_free` here.
     fn drop(&mut self) {
         let _guard = self.mutex.lock_guard();
-        for &entry in self.map.values() {
-            // SAFETY: map values are live heap Entries; we hold the mutex.
-            let e = unsafe { &*entry };
-            if !e.ctx.is_null() {
-                // SAFETY: ctx non-null; clearing the ex_data slot we set.
+        for entry in self.map.values() {
+            if let Some(ctx) = entry.ctx.get() {
+                // SAFETY: ctx is still live (not tombstoned); clearing the ex_data
+                // slot `Entry::attach` set.
                 unsafe {
                     boringssl::SSL_CTX_set_ex_data(
-                        e.ctx,
+                        ctx.as_ptr(),
                         c::us_ssl_ctx_cache_ex_idx(),
                         ptr::null_mut(),
                     );
                 }
             }
-            // SAFETY: entry was heap-allocated in get_or_create_digest and is removed
-            // from any ex_data above, so no other path can reach it.
-            drop(unsafe { bun_core::heap::take(entry) });
         }
-        // map storage freed by its own Drop
+        // Entries and map storage are freed by the map's own Drop, after every
+        // ex_data back-pointer above has been cleared.
     }
 }
 


### PR DESCRIPTION
## What

`SSLContextCache` (`src/runtime/api/bun/SSLContextCache.rs`) is the per-VM weak `SSL_CTX*` cache keyed by config digest. Its map stored `*mut Entry` even though the map is the only owner of every entry (allocated with `heap::into_raw` on a miss, freed with `heap::take` in the compaction loop, the `set_ex_data` failure path and `Drop`), so the hit path, the re-check after building a context, `compact_locked` and `Drop` each dereferenced a raw pointer, and `get_or_put` (which needs `V: Default`) left a transient null value in the map between insertion and the store of the real pointer. `Entry.ctx` was a `*mut SSL_CTX` whose null value meant "tombstoned"; the BoringSSL `CRYPTO_EX_free` callback (`bun_ssl_ctx_cache_on_free`) wrote that null through a `&mut Entry` it materialised before taking the cache mutex, while `get_or_create_digest` reads the same entry through `&Entry` under the mutex.

```rust
// before
map: ArrayHashMap<Digest, *mut Entry, DigestContext>,
pub struct Entry {
    pub ctx: *mut boringssl::SSL_CTX,                  // null == tombstoned
    pub(crate) owner: bun_ptr::BackRef<SSLContextCache>,
}

// after
map: ArrayHashMap<Digest, Box<Entry>, DigestContext>,
struct Entry {
    ctx: Cell<Option<NonNull<boringssl::SSL_CTX>>>,     // None == tombstoned
    owner: bun_ptr::BackRef<SSLContextCache>,
}
```

The hit path becomes `self.map.get(&d).and_then(|entry| entry.ctx.get())`. The miss path uses `self.map.entry(d)`: `Occupied` re-checks `ctx.get()` and otherwise adopts the rebuilt context into the tombstoned entry, `Vacant` inserts a `Box<Entry>` and removes it again (dropping the `Box`) if `SSL_CTX_set_ex_data` fails. Both arms publish the entry through one new helper, `Entry::attach`, which is the only place that turns `&Entry` into the `void*` stored in the ex_data slot. Following review, the context built on the miss path is held as a `bun_boringssl_sys::OwnedSslCtx` from the moment `create_ssl_context` returns it: `attach` takes `&OwnedSslCtx`, so its argument proves the context is live rather than relying on callers to only pass a freshly built one; the lost-race path frees ours by dropping it (on return, after the lock is released) instead of calling `SSL_CTX_free`; and the three returns hand the +1 to the caller with `into_raw()`. `compact_locked` keeps its swap-remove loop, now on `ctx.get().is_none()`, and `Drop` only clears the ex_data slot of still-live contexts; the entries themselves are freed by the map's own `Drop`. The callback reads the slot back as `&Entry`, takes the owner's mutex and calls `ctx.set(None)`. Unsafe blocks in the file go from 13 to 6 (the sixth is the `OwnedSslCtx::from_raw` adopting the +1 from `create_ssl_context`) (the four raw `Entry` derefs and the three `heap::take` frees are gone, and the two `SSL_CTX_set_ex_data` publish sites are merged into `attach`); the remaining five are FFI calls plus the callback's deref of the ex_data pointer. The `get_or_create*` signatures used by `Listener`, `SecureContext`, `hw_exports` and `jsc_hooks`, and the `extern "C"` signature registered from `openssl.c`, are unchanged. 1 file, 77 insertions, 86 deletions.

## Why

Ownership of an `Entry` is now stated by the map's value type (the map allocates it, `swap_remove` and the map's `Drop` free it), the two states of an entry are `Some`/`None` instead of a null sentinel, and the callback no longer needs a `&mut Entry` that aliases the `&Entry` lookups hold under the same mutex: the tombstone write goes through a `Cell` via a pointer derived from `&Entry`, which is exactly what interior mutability permits. It is zero-cost: `Box<Entry>` and `Cell<Option<NonNull<SSL_CTX>>>` are each one pointer with a null niche, so `Entry` and the map's value column keep their layout; `ctx.get()` compiles to the same null test as `is_null()`; `entry()` is the same single hash lookup `get_or_put` performed and avoids writing the placeholder slot; `NonNull::new` on the miss path re-tests a pointer `create_ssl_context` already null-checked before returning `Some`, on a path that has just parsed certificates; and every `Box` is freed at the same points (`swap_remove`, map `Drop`) with the same allocator as the `heap::take` calls it replaces.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/node/tls/ssl-ctx-cache.test.ts test/js/node/tls/tls-connect-socket-churn.test.ts test/js/node/tls/node-tls-context.test.ts: 34 pass, 0 fail across 3 files.

