### PR TITLE
fetch: release the CRT fd behind a Bun.file(fd) request body on Windows

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1694,7 +1694,17 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let opened_fd_res: bun_sys::Result<bun_sys::Fd> = {
                 let store = body.store().expect("needs_to_read_file implies store");
                 match &store.data.as_file().pathlike {
-                    PathOrFileDescriptor::Fd(fd) => bun_sys::dup(*fd),
+                    // On Windows `dup` yields a raw HANDLE. `read_file` below goes
+                    // through libuv, which would wrap that HANDLE in a CRT fd it
+                    // never releases, so hand the HANDLE to libuv here: closing the
+                    // uv fd then releases the CRT slot and the HANDLE together.
+                    // `open` already returns a uv fd; on POSIX this is the identity.
+                    PathOrFileDescriptor::Fd(fd) => bun_sys::dup(*fd).and_then(|duped| {
+                        duped.make_lib_uv_owned_for_syscall(
+                            bun_sys::Tag::dup,
+                            bun_sys::ErrorCase::CloseOnFail,
+                        )
+                    }),
                     PathOrFileDescriptor::Path(path) => {
                         let zpath = path.slice_z(&mut open_path_buf);
                         let flags = if cfg!(windows) {

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -219,6 +219,73 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
     expect(await res.text()).toBe("ok");
     expect(res.status).toBe(200);
     expect({ contentLength, received }).toEqual({ contentLength: String(fileSize - 10), received: fileSize - 10 });
+  });
+});
+
+// A file body that cannot go through sendfile (small bodies; always on Windows)
+// is opened, or dup()ed for Bun.file(fd), read and closed again per upload. On
+// Windows dup() hands back a raw HANDLE and the read goes through libuv, which
+// used to wrap the HANDLE in a CRT fd that nothing released: one of the 8192
+// CRT slots leaked per upload, and after ~8190 uploads fetch(Bun.file(fd)) and
+// every fs.openSync() in the process failed with EMFILE. Descriptors are handed
+// out lowest-free-first on every platform, so the number openSync() returns
+// after a batch of uploads shows whether the per-upload descriptor was released.
+describe.each(["Bun.file(path)", "Bun.file(fd)"])("%s upload releases its descriptor", kind => {
+  test.concurrent("lowest free fd is unchanged after 100 uploads", async () => {
+    using dir = tempDir("fetch-file-upload-fd", { "body.txt": "hello" });
+    const script = /* js */ `
+      import fs from "node:fs";
+
+      using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          return new Response(await req.text());
+        },
+      });
+
+      // Held open for the whole run so every probe below lands above it.
+      const fd = fs.openSync("body.txt", "r");
+      const body = () => ${kind === "Bun.file(fd)" ? "Bun.file(fd)" : 'Bun.file("body.txt")'};
+
+      async function upload() {
+        const res = await fetch(server.url, { method: "POST", body: body() });
+        const echoed = await res.text();
+        if (res.status !== 200) throw new Error("upload failed with status " + res.status);
+        return echoed;
+      }
+
+      function lowestFreeFd() {
+        const probe = fs.openSync("body.txt", "r");
+        fs.closeSync(probe);
+        return probe;
+      }
+
+      // Only checked once: the duplicate of fd shares its file position, so for
+      // Bun.file(fd) the later uploads dup, read straight to EOF and close.
+      const first = await upload();
+      if (first !== "hello") throw new Error("unexpected echoed body: " + JSON.stringify(first));
+
+      const before = lowestFreeFd();
+      const N = 100;
+      for (let i = 0; i < N; i++) await upload();
+      const after = lowestFreeFd();
+
+      console.log(JSON.stringify({ before, after }));
+      // Leaking the per-upload descriptor costs exactly one slot per upload.
+      if (after - before >= N / 2) {
+        throw new Error("leaked " + (after - before) + " descriptors over " + N + " uploads");
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.includes('"after"'), stderr, exitCode }).toEqual({ stdout: true, stderr: "", exitCode: 0 });
   });
 });
 


### PR DESCRIPTION
## Problem

On Windows, every `fetch(url, { body: Bun.file(fd) })` leaks one CRT fd slot. The UCRT fd table holds 8192 entries, so a process that uploads from an open fd in a loop ends up with every further upload rejecting, and every unrelated `fs.openSync()` failing, with:

```
EMFILE: too many open files, open
```

Repro (Windows, `bun 1.4.0-canary.1+da3851e57`):

```js
import fs from "node:fs";
fs.writeFileSync("body.txt", "hello");
const fd = fs.openSync("body.txt", "r");
using server = Bun.serve({ port: 0, fetch: async req => new Response(await req.text()) });
for (let i = 0; i < 9000; i++) {
  await fetch(server.url, { method: "POST", body: Bun.file(fd) }); // rejects with EMFILE at i = 8187
}
fs.openSync("body.txt", "r"); // EMFILE: too many open files, open 'body.txt'
```

After 100 uploads the next `fs.openSync()` returns a descriptor number exactly 100 higher than before the loop.

## Cause

`fetch_impl` (src/runtime/webcore/fetch.rs, `needs_to_read_file`) dups the blob's fd and, since sendfile is never eligible on Windows, hands the duplicate to `NodeFS::read_file` and then closes it. On Windows `bun_sys::dup` returns a HANDLE-backed `Fd`, while `read_file_with_options` reads through libuv and therefore calls `make_lib_uv_owned()` on its input, which wraps the HANDLE in a freshly allocated CRT fd. `read_file_with_options` only closes the fd it opened itself (path inputs), which is the right contract for an fd it borrows, and fetch.rs then closes the raw HANDLE directly. The CRT slot is never released, and it now refers to a closed handle value.

`Bun.file(path)` bodies are unaffected: `bun_sys::open` already returns a libuv-kind fd on Windows. The other `read_file` callers (`fs.readFile*` with a JS fd, FormData serialization and `tls` blobs, which read the Blob store's own fd) all pass libuv-kind fds too, since JS-visible fds and the stdio stores are built with `Fd::from_uv`. The dup in fetch.rs was the one place a HANDLE-backed fd reached this function.

## Fix

Make the duplicate libuv-owned right after `dup()`, the same way `FileReader::open_file_blob` already does for its dup of a blob fd (`make_lib_uv_owned_for_syscall(Tag::dup, CloseOnFail)`). `read_file` then uses the fd as is, and the existing close in fetch.rs goes through `uv_fs_close`, which releases the CRT slot and the HANDLE together: one allocation, one close. On POSIX the call is the identity, so the sendfile and read paths there are unchanged. If `_open_osfhandle` itself fails, `CloseOnFail` closes the duplicate and the promise rejects with `EMFILE` from `dup`, as before.

The fd supplier is the right place for this (it is what the `Fd::uv()` contract in bun_core asks for); releasing the slot inside `read_file_with_options` instead would mean closing a handle the caller still owns.

## Test

`test/js/bun/http/fetch-file-upload.test.ts`: for both `Bun.file(path)` and `Bun.file(fd)` bodies, a child process does 100 uploads to a local server and checks that the lowest free descriptor number (`fs.openSync` hands them out lowest-free-first on every platform) has not moved. A leaked per-upload descriptor moves it by exactly 100.

Windows x64, canary without the fix:

```
error: leaked 100 descriptors over 100 uploads
(fail) Bun.file(fd) upload releases its descriptor > lowest free fd is unchanged after 100 uploads
(pass) Bun.file(path) upload releases its descriptor > lowest free fd is unchanged after 100 uploads
```

Windows x64, debug build with the fix: the whole file passes (13 tests), and the 9000-upload repro above completes with the probe unchanged. Linux debug (ASAN): the file passes as well; the POSIX path has no CRT layer, so there the new tests pass with and without this change and only guard the dup/close pairing.
