### PR TITLE
Bun.serve: release the HTMLBundle ref when an HTML route is dropped

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -150,6 +150,7 @@ pub struct Route {
     // FFI userdata — *Route is recovered from uws callback
     // userdata (on_aborted, JSBundleCompletionTask backref). §Pointers FFI
     // rule → `bun_ptr::RefPtr<HTMLBundle>` + `impl RefCounted`.
+    // Owns one ref on the bundle (taken in `init`, released in `Drop`).
     pub(crate) bundle: IntrusiveRc<HTMLBundle>,
     /// One HTMLBundle.Route can be specified multiple times
     ref_count: RefCount<Route>,
@@ -776,11 +777,12 @@ impl Drop for Route {
     fn drop(&mut self) {
         // pending responses keep a ref to the route
         debug_assert!(self.pending_responses.get().is_empty());
-        // `pending_responses` (Vec) and `bundle` (IntrusiveRc) auto-drop.
         // `state` has no `Drop` glue for the intrusive-pointer variants — release
         // them explicitly.
         // `with_mut` is fine here — refcount==0 so no other `&Route` exists.
         self.state.with_mut(|s| s.deinit());
+        // `IntrusiveRc` has no `Drop`; release the ref `init` took on the bundle.
+        self.bundle.deref();
         // The Box free is handled by IntrusiveRc dealloc.
     }
 }

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isWindows, tempDir } from "harness";
 import { join } from "path";
 
@@ -95,6 +95,97 @@ test.skipIf(!isASAN || isWindows)(
   // the debug binary.
   30_000,
 );
+
+// html_bundle::Route takes a ref on the HTMLBundle it serves and used to be
+// dropped without releasing it, so any HTMLBundle ever passed to Bun.serve
+// outlived its JS wrapper and showed up as a direct leak at VM teardown.
+// test/leaksan.supp hides that report (the bundle is allocated under
+// Bun__transpileFile), so these children run with LSan's built-in
+// suppressions only.
+describe.skipIf(!isASAN || isWindows)("HTMLBundle passed to Bun.serve is freed at VM teardown", () => {
+  const fetchOk = /* js */ `
+    {
+      const res = await fetch(server.url);
+      await res.text();
+      if (res.status !== 200) throw new Error("unexpected status " + res.status);
+    }
+  `;
+  const cases: [name: string, script: string][] = [
+    [
+      "development server (DevServer owns the route)",
+      /* js */ `
+        const server = Bun.serve({ port: 0, development: true, routes: { "/": html }, fetch: () => new Response("no") });
+        ${fetchOk}
+        server.stop(true);
+      `,
+    ],
+    [
+      "development server without hmr (route rebundles on every request)",
+      /* js */ `
+        const server = Bun.serve({ port: 0, development: { hmr: false }, routes: { "/": html }, fetch: () => new Response("no") });
+        ${fetchOk}
+        ${fetchOk}
+        server.stop(true);
+      `,
+    ],
+    [
+      "production server (route owns the built bundle)",
+      /* js */ `
+        const server = Bun.serve({ port: 0, development: false, routes: { "/": html }, fetch: () => new Response("no") });
+        ${fetchOk}
+        server.stop(true);
+      `,
+    ],
+    [
+      "one bundle on two routes of two servers, never requested",
+      /* js */ `
+        const a = Bun.serve({ port: 0, development: false, routes: { "/": html, "/again": html }, fetch: () => new Response("no") });
+        const b = Bun.serve({ port: 0, development: false, routes: { "/": html }, fetch: () => new Response("no") });
+        a.stop(true);
+        b.stop(true);
+      `,
+    ],
+  ];
+
+  test.concurrent.each(cases)(
+    "%s",
+    async (_name, script) => {
+      await using dir = tempDir("html-bundle-teardown-leak", {
+        "index.html": `<!DOCTYPE html><html><body>hi</body></html>`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const { default: html } = await import(process.argv[1]);\n${script}`,
+          join(dir, "index.html"),
+        ],
+        env: {
+          ...bunEnv,
+          BUN_DESTRUCT_VM_ON_EXIT: "1",
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          LSAN_OPTIONS: "print_suppressions=0",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // Development servers log each bundle to stderr ("Bundled page in 3ms: ..."
+      // from the DevServer, "[3ms] bundle index.html 0.05 KB" without hmr); drop
+      // those so a failure shows only the LSan report.
+      const filtered = stderr
+        .split("\n")
+        .filter(l => !l.includes("Bundled page in ") && !l.includes(" bundle index.html "))
+        .join("\n")
+        .trim();
+      expect({ stdout, stderr: filtered, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    },
+    // Same as above: a clean child exits in well under a second, but when a
+    // leak is reported LSan symbolizes it through llvm-symbolizer, which is
+    // slow against the debug binary.
+    30_000,
+  );
+});
 
 // Graceful stop() leaves the keep-alive socket in the uws app's socket group.
 // A NewApp::destroy at lastChanceToFinalize would unlink that group from the


### PR DESCRIPTION
### What

`html_bundle::Route::init` takes a ref on the `HTMLBundle` it serves (`IntrusiveRc::init_ref`), but `Drop for Route` never released it. `IntrusiveRc` is `bun_ptr::RefPtr`, which deliberately has no `Drop` impl (see the type docs in `src/ptr/ref_count.rs`), so the comment in `Route::drop` claiming the field "auto-drops" was wrong and the ref was simply lost. The result: once an `HTMLBundle` had been passed to `Bun.serve` (`routes`/`static`, development or production, DevServer or not), its refcount could never reach zero again, and the bundle outlived its JS wrapper.

A bare `import("./index.html")` with no server does not leak; the JS wrapper's finalizer releases its ref correctly.

### Repro

```sh
echo '<!DOCTYPE html><html><body>hi</body></html>' > /tmp/index.html
BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 ./build/debug/bun-debug -e '
const { default: html } = await import(process.argv[1]);
const server = Bun.serve({ port: 0, development: true, routes: { "/": html }, fetch: () => new Response("no") });
await (await fetch(server.url)).text();
server.stop(true);
' /tmp/index.html
```

Before (debug ASAN build, no suppressions file):

```
Direct leak of 432 byte(s) in 1 object(s) allocated from:
    ...
    #13 <bun_runtime::server::html_bundle::HTMLBundle>::init src/runtime/server/HTMLBundle.rs:116
    #14 bun_runtime::jsc_hooks::transpile_source_code_inner src/runtime/jsc_hooks.rs:3546
    #16 Bun__transpileFile src/jsc/ModuleLoader.rs:361
SUMMARY: AddressSanitizer: 527 byte(s) leaked in 4 allocation(s).
```

(the indirect blocks are the bundle's `path` and, in debug builds, the refcount tracking tables). After: no report, exit 0.

CI never saw this because `test/leaksan.supp` has `leak:Bun__transpileFile`, which matches this allocation stack. The leak still cost the llvm-symbolizer pass LSan needs before it can apply a suppression: the existing "stopped Bun.serve with a static route is freed at VM teardown" test in `bun-serve-html-405.test.ts` goes from ~5.8s to ~0.55s locally with this change.

### Fix

`Route::drop` now calls `self.bundle.deref()`, the same explicit release other `IntrusiveRc` fields in the runtime use (for example `S3Client::drop`). `Route` is the only holder of that ref: `Route::init` is the one place it is taken, the `dedupe_html_bundle_map` slot is a non-owning copy of the `Route` pointer, and the DevServer holds a ref on the `Route` (released in `DevServer`'s `Drop`), not on the bundle. So the bundle's refcount is exactly 1 (JS wrapper) + number of live `Route`s, and releasing one ref per dropped `Route` is the balanced count; the order in which the wrapper's finalizer and the route teardown run does not matter because `HTMLBundle`'s destructor only frees its `path`.

The practical impact is small (one `HTMLBundle` plus its path string per distinct HTML import was kept alive for the life of the process), but the leak was a real refcount imbalance, and it was hiding behind a broad suppression.

### Tests

`test/js/bun/http/bun-serve-html-405.test.ts` gains four ASAN-only children (skipped on non-ASAN builds like the existing teardown tests in that file) that run with `BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1` and only LSan's built-in suppressions, so the `Bun__transpileFile` entry in `leaksan.supp` cannot mask the report. They cover each way a `Route` is owned and torn down:

- `development: true` (DevServer owns the route, released from `DevServer`'s `Drop`)
- `development: { hmr: false }` (route rebundles per request, exercising `State::deinit` alongside the new deref)
- `development: false` (route owns the built `StaticRoute`)
- one bundle on two routes of one server plus a second server, never requested (dedupe map path, two routes, two releases, no double release)

All four fail on the unfixed debug build with the `Direct leak ... HTMLBundle::init` report above and pass with the fix; the rest of the file, `bun-serve-html.test.ts`, `bun-serve-routes.test.ts`, `bake/deinitialization.test.ts`, `bake/dev/html.test.ts`, `bake/dev-and-prod.test.ts` and `bake/serve-plugins-dev-server.test.ts` still pass under the debug ASAN build.
