### PR TITLE
ffi: own TinyCC states through an RAII StateHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,6 @@ dependencies = [
  "enum-map",
  "enumset",
  "libc",
- "scopeguard",
  "strum",
  "thiserror",
 ]

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -208,7 +208,7 @@ impl Offsets {
 }
 
 // R-2 (host-fn re-entrancy): the JS-exposed `close()` method takes `&self`;
-// per-field interior mutability via `Cell` (Copy) / `JsCell` (non-Copy).
+// per-field interior mutability via `Cell` / `JsCell`.
 // `close()` does not itself re-enter JS, but routing mutation through
 // `UnsafeCell`-backed fields suppresses `noalias` on the `&Self` the codegen
 // shim materialises from `m_ctx`, which is the systemic R-2 guarantee.
@@ -217,7 +217,7 @@ pub struct FFI {
     pub dylib: JsCell<Option<bun_sys::DynLib>>,
     pub functions: JsCell<StringArrayHashMap<Function>>,
     pub closed: Cell<bool>,
-    pub shared_state: Cell<Option<NonNull<TCC::State>>>,
+    pub shared_state: Cell<Option<TCC::StateHandle>>,
 }
 
 impl Default for FFI {
@@ -615,7 +615,7 @@ impl CompileC {
     pub(crate) fn compile(
         &mut self,
         global_this: &JSGlobalObject,
-    ) -> crate::Result<NonNull<TCC::State>> {
+    ) -> crate::Result<TCC::StateHandle> {
         let tcc_options_owned: ZBox;
         let compile_options: &ZStr = if !self.flags.is_empty() {
             &self.flags
@@ -629,7 +629,7 @@ impl CompileC {
         };
 
         // TODO: correctly handle invalid user-provided options
-        let state_ptr = match TCC::State::init::<CompileC, true>(&TCC::Config {
+        let mut handle = match TCC::State::init::<CompileC, true>(&TCC::Config {
             options: Some(NonNull::from(compile_options)),
             output_type: TCC::OutputFormat::Memory,
             err: TCC::ConfigErr {
@@ -646,9 +646,7 @@ impl CompileC {
                 return Err(crate::Error::DeferredErrors);
             }
         };
-        // SAFETY: `state_ptr` was just returned non-null by `TCC::State::init`;
-        // we hold the only reference for the rest of this function.
-        let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
+        let state: &mut TCC::State = &mut handle;
 
         if let Some(compiler_rt_dir) = CompilerRT::dir() {
             if state.add_sys_include_path(compiler_rt_dir).is_err() {
@@ -886,13 +884,13 @@ impl CompileC {
                 ));
                 return Err(crate::Error::JSError);
             };
-            entry.value_ptr.symbol_from_dynamic_library = Some(sym.as_ptr().cast::<c_void>());
+            entry.value_ptr.symbol_from_dynamic_library = Some(sym.as_ptr());
         }
 
         self.error_check()
             .map_err(|_| crate::Error::DeferredErrors)?;
 
-        Ok(state_ptr)
+        Ok(handle)
     }
 }
 
@@ -1174,8 +1172,8 @@ impl FFI {
         }
 
         // Now we compile the code with tinycc.
-        let mut tcc_state: Option<NonNull<TCC::State>> = match compile_c.compile(global_this) {
-            Ok(s) => Some(s),
+        let tcc_state = match compile_c.compile(global_this) {
+            Ok(s) => s,
             Err(err) => match err {
                 crate::Error::DeferredErrors => {
                     let mut combined: Vec<u8> = Vec::new();
@@ -1204,12 +1202,6 @@ impl FFI {
                 }
             },
         };
-        let _tcc_guard = scopeguard::guard(&mut tcc_state, |s| {
-            if let Some(state) = s {
-                // SAFETY: state is a valid TCC::State pointer from compile()
-                unsafe { TCC::State::destroy(state.as_ptr()) };
-            }
-        });
 
         let napi_env = make_napi_env_if_needed(compile_c.symbols.map.values(), global_this);
 
@@ -1246,7 +1238,7 @@ impl FFI {
                         global_this,
                         &str,
                         u32::try_from(function.arg_types.len()).expect("int cast"),
-                        compiled.ptr.cast_const(),
+                        compiled.entry().as_ptr().cast_const(),
                         true,
                         function.symbol_from_dynamic_library,
                     );
@@ -1259,7 +1251,7 @@ impl FFI {
         // TODO: pub const new = bun.TrivialNew(FFI)
         let lib = Box::new(FFI {
             dylib: JsCell::new(None),
-            shared_state: Cell::new(scopeguard::ScopeGuard::into_inner(_tcc_guard).take()),
+            shared_state: Cell::new(Some(tcc_state)),
             functions: JsCell::new(core::mem::take(&mut compile_c.symbols.map)),
             closed: Cell::new(false),
         });
@@ -1356,10 +1348,7 @@ impl FFI {
         if let Some(dylib) = self.dylib.replace(None) {
             dylib.close();
         }
-        if let Some(state) = self.shared_state.take() {
-            // SAFETY: state is a valid TCC::State pointer; we have exclusive ownership
-            unsafe { TCC::State::destroy(state.as_ptr()) };
-        }
+        drop(self.shared_state.take());
         self.functions.with_mut(|f| f.clear_retaining_capacity());
     }
 
@@ -1925,7 +1914,6 @@ pub(super) fn generate_symbols(
 pub struct Function {
     pub symbol_from_dynamic_library: Option<*mut c_void>,
     pub base_name: ZBox,
-    pub state: Option<NonNull<TCC::State>>,
 
     pub return_type: ABIType,
     pub arg_types: Vec<ABIType>,
@@ -1939,21 +1927,10 @@ impl Default for Function {
         Self {
             symbol_from_dynamic_library: None,
             base_name: ZBox::default(),
-            state: None,
             return_type: ABIType::Void,
             arg_types: Vec::new(),
             step: Step::Pending,
             threadsafe: false,
-        }
-    }
-}
-
-impl Drop for Function {
-    fn drop(&mut self) {
-        // base_name, arg_types, Step::Failed.msg are owned and freed by drop glue.
-        if let Some(state) = self.state.take() {
-            // SAFETY: state is a valid TCC::State pointer; we own it
-            unsafe { TCC::State::destroy(state.as_ptr()) };
         }
     }
 }
@@ -2021,7 +1998,7 @@ impl Function {
         } else {
             zstr!("-std=c11 -nostdlib -Wl,--export-all-symbols")
         };
-        let state = match TCC::State::init::<Function, false>(&TCC::Config {
+        let mut handle = match TCC::State::init::<Function, false>(&TCC::Config {
             options: Some(NonNull::from(tcc_options)),
             output_type: TCC::OutputFormat::Memory,
             err: TCC::ConfigErr {
@@ -2032,20 +2009,7 @@ impl Function {
             Ok(s) => s,
             Err(_) => return Err(crate::Error::TCCMissing),
         };
-
-        self.state = Some(state);
-        let _guard = scopeguard::guard(std::ptr::from_mut::<Function>(self), |this_ptr| {
-            // SAFETY: this_ptr is &mut self for the duration of compile()
-            if matches!(unsafe { &(*this_ptr).step }, Step::Failed { .. }) {
-                // SAFETY: as above.
-                if let Some(s) = unsafe { (*this_ptr).state.take() } {
-                    // SAFETY: we own the state
-                    unsafe { TCC::State::destroy(s.as_ptr()) };
-                }
-            }
-        });
-        // SAFETY: state is non-null, just stored above
-        let state = unsafe { self.state.unwrap().as_mut() };
+        let state: &mut TCC::State = &mut handle;
 
         if let Some(env) = napi_env {
             // `env` is the live VM-owned napi env; process-lifetime.
@@ -2089,15 +2053,12 @@ impl Function {
             return Ok(());
         }
 
-        let Some(symbol) = state.get_symbol(zstr!("JSFunctionCall")) else {
+        let Some(compiled) = Compiled::new(handle) else {
             self.fail(b"missing generated symbol in source code");
             return Ok(());
         };
 
-        self.step = Step::Compiled(Compiled {
-            ptr: symbol.as_ptr().cast::<c_void>(),
-            ..Default::default()
-        });
+        self.step = Step::Compiled(compiled);
         Ok(())
     }
 
@@ -2290,15 +2251,27 @@ pub enum Step {
     Failed { msg: Box<[u8]> },
 }
 
-pub struct Compiled {
-    pub ptr: *mut c_void,
-}
+/// A state whose relocated code defines the trampoline entry point. The state
+/// owns the code, and [`Self::entry`] hands the entry point out as a borrow of
+/// it, so within Rust the address cannot outlive the state. The one copy that
+/// leaves Rust is baked into the JS function, which `close()` invalidates
+/// along with everything else in the library.
+pub struct Compiled(TCC::StateHandle);
 
-impl Default for Compiled {
-    fn default() -> Self {
-        Self {
-            ptr: core::ptr::null_mut(),
-        }
+impl Compiled {
+    const ENTRY: &'static ZStr = zstr!("JSFunctionCall");
+
+    /// `None` if the code does not define the entry point; the state is
+    /// deleted in that case.
+    fn new(state: TCC::StateHandle) -> Option<Self> {
+        state.get_symbol(Self::ENTRY)?;
+        Some(Self(state))
+    }
+
+    pub fn entry(&self) -> TCC::SymbolAddr<'_> {
+        self.0
+            .get_symbol(Self::ENTRY)
+            .expect("Compiled::new checked that the entry point is defined")
     }
 }
 

--- a/src/tcc_sys/Cargo.toml
+++ b/src/tcc_sys/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 bun_opaque.workspace = true
 strum.workspace = true
 bstr.workspace = true
-scopeguard.workspace = true
 const_format.workspace = true
 enum-map.workspace = true
 enumset.workspace = true

--- a/src/tcc_sys/lib.rs
+++ b/src/tcc_sys/lib.rs
@@ -2,6 +2,6 @@
 #![warn(unused_must_use)]
 pub mod tcc;
 pub use tcc::{
-    Config, ConfigErr, Error, ErrorFunc, OutputFormat, State, Symbol, SymbolCallback, TCCErrorFunc,
-    TCCState,
+    Config, ConfigErr, Error, ErrorFunc, OutputFormat, State, StateHandle, Symbol, SymbolAddr,
+    SymbolCallback, TCCErrorFunc, TCCState,
 };

--- a/src/tcc_sys/tcc.rs
+++ b/src/tcc_sys/tcc.rs
@@ -1,4 +1,5 @@
 use core::ffi::{c_char, c_int, c_void};
+use core::marker::PhantomData;
 use core::ptr::NonNull;
 
 use bun_core::ZStr;
@@ -126,8 +127,55 @@ pub type SymbolCallback =
     unsafe extern "C" fn(ctx: *mut c_void, name: *const c_char, val: *const Symbol);
 
 bun_opaque::opaque_ffi! {
-    /// Opaque TinyCC compilation state. Always handled via `*mut State` / `&mut State`.
+    /// Opaque TinyCC compilation state. Owned by a [`StateHandle`], used via `&mut State`.
     pub struct State;
+}
+
+/// Dropping this `tcc_delete`s the state together with the code relocated into it.
+#[repr(transparent)]
+pub struct StateHandle(NonNull<State>);
+
+/// The address of a symbol in the code relocated into a [`State`]. The state
+/// owns the memory it points into, so this borrows the state: it cannot be
+/// kept past the [`StateHandle`] whose `Drop` unmaps that memory. Passing it
+/// on to something outliving the borrow goes through [`as_ptr`](Self::as_ptr).
+#[derive(Clone, Copy)]
+pub struct SymbolAddr<'state> {
+    addr: NonNull<c_void>,
+    state: PhantomData<&'state State>,
+}
+
+impl SymbolAddr<'_> {
+    #[inline]
+    pub fn as_ptr(self) -> *mut c_void {
+        self.addr.as_ptr()
+    }
+}
+
+impl core::ops::Deref for StateHandle {
+    type Target = State;
+    #[inline]
+    fn deref(&self) -> &State {
+        // SAFETY: `self.0` came from `tcc_new` and is deleted only in `Drop`.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl core::ops::DerefMut for StateHandle {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut State {
+        // SAFETY: as in `Deref`; `&mut self` makes this the only live borrow.
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl Drop for StateHandle {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from `tcc_new` and this handle is its only
+        // owner, so it has not been deleted yet.
+        unsafe { tcc_delete(self.0.as_ptr()) }
+    }
 }
 
 pub struct ConfigErr<ErrCtx> {
@@ -160,23 +208,18 @@ where
 
 impl State {
     /// Create a new TCC compilation context
-    pub(crate) fn new() -> Result<NonNull<State>, bun_alloc::AllocError> {
+    pub(crate) fn new() -> Result<StateHandle, bun_alloc::AllocError> {
         // SAFETY: tcc_new has no preconditions.
-        NonNull::new(unsafe { tcc_new() }).ok_or(bun_alloc::AllocError)
+        NonNull::new(unsafe { tcc_new() })
+            .map(StateHandle)
+            .ok_or(bun_alloc::AllocError)
     }
 
     /// Create and initialize a new TCC compilation context
     pub fn init<ErrCtx, const VALIDATE_OPTIONS: bool>(
         config: &Config<ErrCtx>,
-    ) -> Result<NonNull<State>, Error> {
-        let state_ptr = State::new()?;
-        // errdefer state.destroy() — State is an FFI handle without Drop, so use scopeguard.
-        let guard = scopeguard::guard(state_ptr, |p| {
-            // SAFETY: p was returned by tcc_new and has not yet been deleted.
-            unsafe { tcc_delete(p.as_ptr()) }
-        });
-        // SAFETY: state_ptr is valid and uniquely owned for the duration of this fn.
-        let state: &mut State = unsafe { &mut *state_ptr.as_ptr() };
+    ) -> Result<StateHandle, Error> {
+        let mut state = State::new()?;
 
         // setOutputType has side effects that are conditional on existing
         // options, so this must be called after setOptions
@@ -207,18 +250,7 @@ impl State {
 
         state.set_output_type(config.output_type)?;
 
-        let state_ptr = scopeguard::ScopeGuard::into_inner(guard);
-        Ok(state_ptr)
-    }
-
-    /// Free a TCC compilation context
-    ///
-    /// # Safety
-    /// `s` must have been returned by [`State::new`]/[`State::init`] and not yet freed.
-    pub unsafe fn destroy(s: *mut State) {
-        // opaque FFI handle — kept as explicit destroy fn, not `impl Drop`.
-        // SAFETY: caller's contract guarantees `s` is a live `tcc_new` handle not yet deleted.
-        unsafe { tcc_delete(s) }
+        Ok(state)
     }
 
     /// Set error/warning display callback
@@ -409,9 +441,15 @@ impl State {
         Ok(())
     }
 
-    /// Return symbol value or NULL if not found
-    pub fn get_symbol(&mut self, name: &ZStr) -> Option<NonNull<Symbol>> {
-        // SAFETY: self is a valid *mut TCCState; name is NUL-terminated.
-        NonNull::new(unsafe { tcc_get_symbol(self, name.as_ptr()) }.cast::<Symbol>())
+    /// Look a symbol up in the relocated code; `None` if it is not defined.
+    /// A lookup, so it only needs `&self`, and the address it returns borrows
+    /// `self` (see [`SymbolAddr`]).
+    pub fn get_symbol(&self, name: &ZStr) -> Option<SymbolAddr<'_>> {
+        // SAFETY: self is a valid TCCState; name is NUL-terminated.
+        let addr = NonNull::new(unsafe { tcc_get_symbol(self.as_mut_ptr(), name.as_ptr()) })?;
+        Some(SymbolAddr {
+            addr,
+            state: PhantomData,
+        })
     }
 }

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -10,7 +10,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "fs";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, rss, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 // TODO: we need to install build-essential and Apple SDK in CI.
@@ -100,6 +100,57 @@ describe.skipIf(isASAN)("given an add(a, b) function", () => {
     }).toThrow(/"subtract" is missing/);
   });
 }); // </given add(a, b) function>
+
+// This path does not hit TinyCC's setjmp/longjmp error handling (the source
+// compiles; the lookup of the missing symbol just returns NULL), so unlike the
+// rest of the cc() coverage it also runs under ASAN.
+describe("given a source that compiles but lacks a requested symbol", () => {
+  // The 1 MiB initialised array is relocated into the TinyCC state before the
+  // missing symbol is noticed, so a state that is not freed on that error path
+  // costs about 1 MiB per attempt: 600 attempts grew RSS by 618 MiB on a build
+  // that leaked it. Under ASAN a build that frees it still grew by about 200 MiB,
+  // because the quarantine holds freed memory (256 MiB of it at most), hence the
+  // looser bound there.
+  const attempts = 600;
+  const allowedGrowthMiB = isASAN ? 400 : 64;
+  const source = /* c */ `
+    static char big[1048576] = {1};
+    int present(void) { return big[0]; }
+  `;
+  let dir: string;
+
+  beforeAll(() => {
+    dir = tempDirWithFiles("bun-ffi-cc-test", {
+      "present.c": source,
+    });
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("frees the compilation state of every failed cc() call", () => {
+    const attempt = () =>
+      expect(() =>
+        cc({
+          source: path.join(dir, "present.c"),
+          symbols: {
+            missing: { returns: "int", args: [] },
+          },
+        }),
+      ).toThrow(/missing/);
+
+    for (let i = 0; i < 10; i++) attempt();
+    Bun.gc(true);
+    const baseline = rss();
+    for (let i = 0; i < attempts; i++) attempt();
+    Bun.gc(true);
+    const grownMiB = (rss() - baseline) / 1024 / 1024;
+    expect(grownMiB, `RSS grew by ${grownMiB.toFixed(1)} MiB over ${attempts} failed cc() calls`).toBeLessThan(
+      allowedGrowthMiB,
+    );
+  });
+});
 
 describe("given a source file with syntax errors", () => {
   const source = /* c */ `


### PR DESCRIPTION
## What

`bun_tcc_sys::State::init` returned a bare `NonNull<State>`, and freeing was the separate `unsafe fn State::destroy`. Its only user, `src/runtime/ffi/ffi_body.rs`, balanced that by hand in four places: `FFI.shared_state: Cell<Option<NonNull<State>>>` destroyed in `do_close`, `Function.state: Option<NonNull<State>>` destroyed by an `impl Drop for Function` plus a scopeguard over `*mut Function` inside `Function::compile`, a second scopeguard in `cc()` covering the state returned by `CompileC::compile`, and `CompileC::compile` itself, whose 16 error exits (2 of them macOS only) after the state was created destroyed nothing, so every failed `cc()` compile leaked its `TCCState` together with the relocated code. `Step::Compiled(Compiled { ptr: *mut c_void })` pointed into one of those states without anything in the types saying which one, and `Compiled` had a `Default` impl producing a null function pointer only so the constructor could write `..Default::default()`.

`bun_tcc_sys` now defines the owner next to the handle, following `bun_http::lshpack::HpackHandle`:

```rust
#[repr(transparent)]
pub struct StateHandle(NonNull<State>);   // Deref/DerefMut to State, tcc_delete on Drop

impl State {
    pub fn init<ErrCtx, const VALIDATE_OPTIONS: bool>(config: &Config<ErrCtx>) -> Result<StateHandle, Error>
}
```

`State::destroy` and the errdefer scopeguard inside `init` are gone. In `ffi_body.rs`, `CompileC::compile` returns `crate::Result<TCC::StateHandle>` (each of its 16 error exits now drops the state), `cc()` moves that handle straight into `FFI.shared_state: Cell<Option<TCC::StateHandle>>` and loses its scopeguard, `do_close` becomes `drop(self.shared_state.take())`, and the compiled trampoline is its state:

```rust
// bun_tcc_sys
pub struct SymbolAddr<'state> { addr: NonNull<c_void>, state: PhantomData<&'state State> }
impl State { pub fn get_symbol(&self, name: &ZStr) -> Option<SymbolAddr<'_>> }

// ffi_body.rs
pub struct Compiled(TCC::StateHandle);
impl Compiled {
    fn new(state: TCC::StateHandle) -> Option<Self>;   // None (state deleted) if JSFunctionCall is not defined
    pub fn entry(&self) -> TCC::SymbolAddr<'_>;
}
```

The first version of this PR kept a separate `ptr` next to a `_state` field that existed only to be dropped, with a comment to say so; review asked for the lifetime to be enforced rather than described. Now `get_symbol` returns an address that borrows the state it was looked up in, so an entry point cannot be held past the `StateHandle` that unmaps it (and the lookup takes `&self`, since it is one), and `Compiled::new` is the only way to build a `Compiled`, so one whose entry point is missing is unrepresentable and `entry()` cannot fail. The lookup runs once more than before, when the JS function is created; it is a symbol table lookup per `cc()` symbol, next to a C compile. The one place the address leaves the borrow is where it is baked into the JS function (`entry().as_ptr()`), whose validity is bounded by `close()` exactly like the dlsym addresses next to it.

`Function` loses its `state` field and its `Drop` impl, `Function::compile` keeps the handle in a local until `Compiled::new` takes it (every `fail(..)` return drops it, which is what the scopeguard did), `impl Default for Compiled` is deleted, and the single reader in `cc()` uses `compiled.entry().as_ptr()`. Both `State::init` call sites are unchanged apart from the binding. `bun_tcc_sys` no longer uses `scopeguard`, so that dependency is dropped from its `Cargo.toml`. Removes 11 unsafe blocks (8 in `ffi_body.rs`, 3 in `tcc.rs`) and the unsafe `destroy` function; adds the 3 in `StateHandle`'s `Deref`, `DerefMut` and `Drop`.

## Why

Who frees a TinyCC state is now answered by the type: a `StateHandle` frees it when dropped, a symbol address cannot outlive the state it was looked up in, a `Function` in `Step::Pending` or `Step::Failed` cannot own a state, and a `Compiled` without an entry point is unrepresentable. `StateHandle` is `repr(transparent)` over `NonNull<State>` and keeps the null niche, so `Option<StateHandle>` is still one pointer, `FFI` and `Step` keep their size, `Function` drops one field, and the auto traits are unchanged; the `Deref` impls are inlined pointer reinterpretations and the drop glue runs at exactly the points where `destroy` and the scopeguards ran. The only behavior difference is that the error exits of `CompileC::compile` now free the state they used to leak; `cc.test.ts` gains a test for it (600 `cc()` calls that compile a 1 MiB initialised array and then fail on a missing symbol must not grow RSS by 64 MiB, or 400 MiB under ASAN because of its quarantine: the unfixed build grew by 614 MiB, the fixed ASAN debug build by about 200 MiB).

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for `bun_tcc_sys` and `bun_runtime`. Debug build succeeds. bun bd test test/js/bun/ffi/cc.test.ts test/js/bun/ffi/ffi.test.js test/js/bun/ffi/ffi-error-messages.test.ts on the first version: 156 pass, 37 skip, 2 todo, 0 fail; cc.test.ts on the current one (ASAN debug build, which runs the new leak test): 6 pass, 32 skip, 1 todo, 0 fail, the leak test passing in 2.9 s.

Rebased onto main (squashed into one commit). The only conflicts were with the change on main that made `Function.base_name` a plain `ZBox` instead of an `Option`: this branch removes the neighbouring `state` field, so the struct and its `Default` were merged by hand (main's `base_name`, no `state`), plus the import lists at the top of cc.test.ts. cc.test.ts re-run on the rebased debug build: 6 pass, 33 skip, 0 fail, the new leak test included.