### PR TITLE
Bun.serve: free a Worker's RequestContext pools when its VM is torn down

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2773,6 +2773,7 @@ pub mod asan {
         safe fn __asan_describe_address(ptr: *const c_void);
         safe fn __lsan_register_root_region(ptr: *const c_void, size: usize);
         safe fn __lsan_unregister_root_region(ptr: *const c_void, size: usize);
+        safe fn __lsan_ignore_object(ptr: *const c_void);
     }
 
     #[inline]
@@ -2817,6 +2818,15 @@ pub mod asan {
         __lsan_unregister_root_region(ptr, size);
         #[cfg(not(bun_asan))]
         let _ = (ptr, size);
+    }
+    /// Tell LSAN that the heap allocation `ptr` points into is kept on
+    /// purpose: neither it nor anything reachable from it is reported.
+    #[inline]
+    pub fn ignore_object(ptr: *const c_void) {
+        #[cfg(bun_asan)]
+        __lsan_ignore_object(ptr);
+        #[cfg(not(bun_asan))]
+        let _ = ptr;
     }
 }
 

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -303,6 +303,13 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         ret
     }
 
+    /// `true` when no slot is claimed. Heap-spilled items of a
+    /// [`Fallback`] are not slots, so they do not count.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.used.find_first_set().is_none()
+    }
+
     pub fn index_of(&self, value: *const T) -> Option<u32> {
         asan::assert_unpoisoned(value.cast::<u8>());
         let start = self.buffer.get().cast::<T>();
@@ -577,9 +584,9 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// buffer is left untouched (uninitialized bytes are a valid bit-pattern
     /// for `MaybeUninit`).
     ///
-    /// The returned allocation is leaked by this function; callers reclaim it
-    /// into a `Box` (typically `Box<ManuallyDrop<Self>>`, so the per-thread
-    /// owner that drops it frees the pool without running slot drop glue).
+    /// The returned allocation is leaked by this function; the per-thread
+    /// owner reclaims it into a `Box` (`Box<ManuallyDrop<Self>>` where the
+    /// slots must not be dropped along with it) and decides when it is freed.
     #[inline]
     pub fn new_boxed() -> NonNull<Self> {
         let mut boxed = Box::<Self>::new_uninit();

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -577,8 +577,9 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// buffer is left untouched (uninitialized bytes are a valid bit-pattern
     /// for `MaybeUninit`).
     ///
-    /// The returned allocation is leaked — callers stash it in a per-thread
-    /// static for the process lifetime.
+    /// The returned allocation is leaked by this function; callers reclaim it
+    /// into a `Box` (typically `Box<ManuallyDrop<Self>>`, so the per-thread
+    /// owner that drops it frees the pool without running slot drop glue).
     #[inline]
     pub fn new_boxed() -> NonNull<Self> {
         let mut boxed = Box::<Self>::new_uninit();

--- a/src/collections/hive_array.rs
+++ b/src/collections/hive_array.rs
@@ -303,8 +303,7 @@ impl<T, const CAPACITY: usize> HiveArray<T, CAPACITY> {
         ret
     }
 
-    /// `true` when no slot is claimed. Heap-spilled items of a
-    /// [`Fallback`] are not slots, so they do not count.
+    /// No slot is claimed (a [`Fallback`]'s heap-spilled items are not slots).
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.used.find_first_set().is_none()
@@ -584,9 +583,8 @@ impl<T, const CAPACITY: usize> Fallback<T, CAPACITY> {
     /// buffer is left untouched (uninitialized bytes are a valid bit-pattern
     /// for `MaybeUninit`).
     ///
-    /// The returned allocation is leaked by this function; the per-thread
-    /// owner reclaims it into a `Box` (`Box<ManuallyDrop<Self>>` where the
-    /// slots must not be dropped along with it) and decides when it is freed.
+    /// The returned allocation is leaked; the caller reclaims it into a `Box`
+    /// and owns it from there.
     #[inline]
     pub fn new_boxed() -> NonNull<Self> {
         let mut boxed = Box::<Self>::new_uninit();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -99,6 +99,11 @@ pub(crate) struct RuntimeState {
     /// has not been proven safe; keep the prior behavior of leaking any
     /// still-occupied slot while still freeing the pool allocation itself.
     pub(crate) body_value_pool: Box<core::mem::ManuallyDrop<crate::webcore::body::HiveAllocator>>,
+    /// The `RequestContext` pools behind every `Bun.serve` on this thread,
+    /// lazily allocated per server type. Owned here (not in a `thread_local!`)
+    /// so that a Worker's pools are freed along with its VM; like
+    /// `body_value_pool`, only the allocations are freed, never the slots.
+    pub(crate) request_pools: crate::server::RequestPools,
     pub(crate) active_handles: ActiveHandles,
     /// The resolver's PackageManager wake-handler context (module queue + VM
     /// handle); the resolver holds a raw pointer to it. Freed with the state.
@@ -237,6 +242,17 @@ pub(crate) fn global_dns_data() -> &'static core::cell::OnceCell<Box<crate::dns_
     // address is stable for the VM's lifetime and only read (interior
     // mutability via `OnceCell`).
     unsafe { &(*state).global_dns_data }
+}
+
+/// Per-VM `Bun.serve` request pools; see [`crate::server::RequestPools`].
+#[inline]
+pub(crate) fn request_pools() -> &'static crate::server::RequestPools {
+    let state = runtime_state();
+    debug_assert!(!state.is_null(), "request_pools before init_runtime_state");
+    // SAFETY: `state` is the live per-thread `RuntimeState` box; the field
+    // address is stable for the VM's lifetime and only read (interior
+    // mutability via `OnceCell`).
+    unsafe { &(*state).request_pools }
 }
 
 /// Recover the [`RuntimeState`] owned by a specific `vm` (not the calling
@@ -398,6 +414,7 @@ unsafe fn init_runtime_state(
                 )
             }
         },
+        request_pools: crate::server::RequestPools::default(),
         active_handles: ActiveHandles::default(),
         wake_ctx: None,
     }));

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -99,10 +99,8 @@ pub(crate) struct RuntimeState {
     /// has not been proven safe; keep the prior behavior of leaking any
     /// still-occupied slot while still freeing the pool allocation itself.
     pub(crate) body_value_pool: Box<core::mem::ManuallyDrop<crate::webcore::body::HiveAllocator>>,
-    /// The `RequestContext` pools behind every `Bun.serve` on this thread,
-    /// lazily allocated per server type. Owned here (not in a `thread_local!`)
-    /// so that a Worker's pools are freed along with its VM (its `Drop` keeps
-    /// a pool that still holds contexts nothing released).
+    /// `Bun.serve`'s `RequestContext` pools. Owned by the VM rather than a
+    /// `thread_local!` so a Worker's are released with it.
     pub(crate) request_pools: crate::server::RequestPools,
     pub(crate) active_handles: ActiveHandles,
     /// The resolver's PackageManager wake-handler context (module queue + VM

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -101,8 +101,8 @@ pub(crate) struct RuntimeState {
     pub(crate) body_value_pool: Box<core::mem::ManuallyDrop<crate::webcore::body::HiveAllocator>>,
     /// The `RequestContext` pools behind every `Bun.serve` on this thread,
     /// lazily allocated per server type. Owned here (not in a `thread_local!`)
-    /// so that a Worker's pools are freed along with its VM; like
-    /// `body_value_pool`, only the allocations are freed, never the slots.
+    /// so that a Worker's pools are freed along with its VM (its `Drop` keeps
+    /// a pool that still holds contexts nothing released).
     pub(crate) request_pools: crate::server::RequestPools,
     pub(crate) active_handles: ActiveHandles,
     /// The resolver's PackageManager wake-handler context (module queue + VM

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -280,13 +280,16 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// via a callback the body fires) early-return instead of re-running the
     /// downgrade/teardown while the outer frame still holds `&mut self`.
     deinit_running: core::cell::Cell<bool>,
+    /// BACKREF to this thread's pool for this server type (see
+    /// [`RequestPools`]); owned by the VM's `RuntimeState`, which outlives
+    /// every server on the thread.
     pub(crate) request_pool:
-        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
+        *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
     /// Null until the H3 listen path runs (`HAS_H3 && config.http3`); never
     /// allocated when `!SSL`. Kept as a raw nullable pointer rather than a
     /// conditional field so the struct stays uniform across monomorphizations.
     pub(crate) h3_request_pool:
-        *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>,
+        *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>,
     /// Authoritative GC root for the `server.stop()` promise. Lazily filled by
     /// `get_all_closed_promise`; read in `deinit_if_we_can` (which can run
     /// after the wrapper is collected, so a wrapper-traced slot would not
@@ -763,8 +766,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             );
         }
 
-        // SAFETY: `request_pool` points at a process-static (or
-        // server-owned) `HiveArray::Fallback`; valid for the server's lifetime.
+        // SAFETY: `request_pool` points at this thread's `RuntimeState`-owned
+        // `HiveArray::Fallback`, which outlives the server (see `RequestPools`).
         // The `HiveSlot` token is leaked deliberately: the slot is recycled by
         // `RequestContext::deinit` via `put_raw`, never via `HiveSlot::Drop`.
         let ctx_slot = std::mem::ManuallyDrop::new(unsafe { (*server.request_pool).claim() })
@@ -2163,7 +2166,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // Plain HTTP servers never allocate the ~816 KB H3 pool; defer to
             // the H3-listen path (`listen()` below) so HTTPS servers that
             // don't enable `config.http3` don't pay either.
-            h3_request_pool: core::ptr::null_mut(),
+            h3_request_pool: core::ptr::null(),
             all_closed_promise: jsc::JSPromiseStrong::default(),
             poll_ref: KeepAlive::default(),
             flags: ServerFlags::default(),
@@ -3404,60 +3407,97 @@ mod trampoline {
 }
 
 // ─── per-monomorphization request pools ──────────────────────────────────────
-// Rust generics cannot own statics, so
-// declare one `thread_local!` per concrete (SSL, DEBUG, H3) combo via macro and
-// hand the leaked pointer back through a trait.
+// One `RequestContext` pool per concrete (SSL, DEBUG, H3) server type, shared
+// by every server of that type on the thread. Rust generics cannot own
+// per-instantiation storage, so the pools are the fields of [`RequestPools`]
+// and the trait maps each server type to its field.
 //
-// THREAD-SAFETY: this MUST be thread-local, not process-global. `hive_array::
-// Fallback::{get,put,claim}` take `&mut self` with no internal synchronization;
-// a process-static would race when two `Bun.serve` instances run on distinct
-// Worker threads (each Worker has its own event loop and may host a server).
+// THREAD-SAFETY: the pools MUST be per-thread, not process-global:
+// `hive_array::Fallback::{claim,put}` have no internal synchronization and
+// every Worker thread may host servers. The per-thread owner is the VM's
+// `RuntimeState` rather than a `thread_local!` so that a Worker's pools are
+// freed with its VM (`deinit_runtime_state` runs after teardown has stopped
+// every server and freed the uSockets loop) instead of being stranded each
+// time a worker thread that served HTTP exits.
 pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
-    fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
+    fn request_pool()
+    -> *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
     fn h3_request_pool()
-    -> *mut request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>;
+    -> *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, true>;
+}
+
+type RequestPool<const SSL: bool, const DEBUG: bool, const H3: bool> =
+    request_context::RequestContextStackAllocator<NewServer<SSL, DEBUG>, SSL, DEBUG, H3>;
+
+/// `ManuallyDrop` inside the `Box`: `RuntimeState` drops after the JSC VM is
+/// gone, and a request that was still unanswered at teardown occupies its
+/// slot then. Its drop glue must not run at that point (for one, it would
+/// hand its body slot back to the already-freed `body_value_pool`), so only
+/// the pool allocation itself is freed, exactly as for `body_value_pool`.
+type RequestPoolSlot<const SSL: bool, const DEBUG: bool, const H3: bool> =
+    core::cell::OnceCell<Box<core::mem::ManuallyDrop<RequestPool<SSL, DEBUG, H3>>>>;
+
+/// This thread's request pools; a field of `RuntimeState`. Each ~816 KB pool
+/// is allocated the first time a server of its type is created on the thread
+/// (the H3 pools when an H3 listener comes up) and lives until the VM is
+/// destroyed.
+#[derive(Default)]
+pub(crate) struct RequestPools {
+    http: RequestPoolSlot<false, false, false>,
+    https: RequestPoolSlot<true, false, false>,
+    debug_http: RequestPoolSlot<false, true, false>,
+    debug_https: RequestPoolSlot<true, true, false>,
+    http_h3: RequestPoolSlot<false, false, true>,
+    https_h3: RequestPoolSlot<true, false, true>,
+    debug_http_h3: RequestPoolSlot<false, true, true>,
+    debug_https_h3: RequestPoolSlot<true, true, true>,
+}
+
+impl RequestPools {
+    fn get<const SSL: bool, const DEBUG: bool, const H3: bool>(
+        slot: impl FnOnce(&Self) -> &RequestPoolSlot<SSL, DEBUG, H3>,
+    ) -> *const RequestPool<SSL, DEBUG, H3> {
+        let pool = slot(crate::jsc_hooks::request_pools()).get_or_init(|| {
+            // `Box::new(RequestPool::init())` builds the ~816 KB pool on the
+            // stack and `memcpy`s it into the heap (no NRVO); `new_boxed`
+            // writes only the 256 B bitset in place.
+            let pool = RequestPool::<SSL, DEBUG, H3>::new_boxed();
+            // SAFETY: `new_boxed` leaks a fully-initialized `Box`; this
+            // reclaims that exact allocation. `ManuallyDrop<T>` is
+            // `repr(transparent)` over `T`, so the cast is a layout no-op.
+            unsafe {
+                bun_core::heap::take(
+                    pool.as_ptr()
+                        .cast::<core::mem::ManuallyDrop<RequestPool<SSL, DEBUG, H3>>>(),
+                )
+            }
+        });
+        // `claim`/`put` take `&self`, so servers only need a shared pointer.
+        // The `Box` keeps it valid until `RuntimeState` drops at the end of VM
+        // teardown, by which point every server on the thread has been
+        // stopped and the JSC VM that could release their contexts is gone.
+        &raw const ***pool
+    }
 }
 
 macro_rules! impl_server_pools {
-    ($(($ssl:literal, $debug:literal)),* $(,)?) => {$(
+    ($(($ssl:literal, $debug:literal, $pool:ident, $h3_pool:ident)),* $(,)?) => {$(
         impl ServerPools<$ssl, $debug> for NewServer<$ssl, $debug> {
-            fn request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, false> {
-                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, false>;
-                thread_local! {
-                    static POOL: core::cell::Cell<*mut Pool> =
-                        const { core::cell::Cell::new(core::ptr::null_mut()) };
-                }
-                POOL.with(|cell| {
-                    let mut p = cell.get();
-                    if p.is_null() {
-                        // `Box::new(Pool::init())` builds the ~816 KB pool on
-                        // the stack and `memcpy`s it into the heap (no NRVO);
-                        // `new_boxed` writes only the 256 B bitset in place.
-                        p = Pool::new_boxed().as_ptr();
-                        cell.set(p);
-                    }
-                    p
-                })
+            fn request_pool() -> *const RequestPool<$ssl, $debug, false> {
+                RequestPools::get(|pools| &pools.$pool)
             }
-            fn h3_request_pool() -> *mut request_context::RequestContextStackAllocator<Self, $ssl, $debug, true> {
-                type Pool = request_context::RequestContextStackAllocator<NewServer<$ssl, $debug>, $ssl, $debug, true>;
-                thread_local! {
-                    static POOL: core::cell::Cell<*mut Pool> =
-                        const { core::cell::Cell::new(core::ptr::null_mut()) };
-                }
-                POOL.with(|cell| {
-                    let mut p = cell.get();
-                    if p.is_null() {
-                        p = Pool::new_boxed().as_ptr();
-                        cell.set(p);
-                    }
-                    p
-                })
+            fn h3_request_pool() -> *const RequestPool<$ssl, $debug, true> {
+                RequestPools::get(|pools| &pools.$h3_pool)
             }
         }
     )*};
 }
-impl_server_pools!((false, false), (true, false), (false, true), (true, true));
+impl_server_pools!(
+    (false, false, http, http_h3),
+    (true, false, https, https_h3),
+    (false, true, debug_http, debug_http_h3),
+    (true, true, debug_https, debug_https_h3),
+);
 
 // ─── FFI ─────────────────────────────────────────────────────────────────────
 mod ffi {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3460,37 +3460,29 @@ impl RequestPools {
 /// leak); such a pool is kept, as the old `thread_local!` kept it, since the
 /// context's drop glue cannot run against the dead VM and freeing the array
 /// under it would only re-attribute what it owns in LeakSanitizer reports.
-/// [`KEPT_POOLS`] keeps those contexts reachable for LSan exactly as before.
+/// LSan is told it is kept on purpose, which also covers what it references,
+/// as the `thread_local!` did.
 impl Drop for RequestPools {
     fn drop(&mut self) {
         fn release<const SSL: bool, const DEBUG: bool, const H3: bool>(
             slot: &mut RequestPoolSlot<SSL, DEBUG, H3>,
-            kept: &core::cell::Cell<*const ()>,
         ) {
             let Some(pool) = slot.take() else { return };
             if pool.hive.is_empty() {
                 drop(pool);
             } else {
-                kept.set(core::ptr::from_ref(&*Box::leak(pool)).cast());
+                bun_core::asan::ignore_object(core::ptr::from_ref(Box::leak(pool)).cast());
             }
         }
-        KEPT_POOLS.with(|kept| {
-            release(&mut self.http, &kept[0]);
-            release(&mut self.https, &kept[1]);
-            release(&mut self.debug_http, &kept[2]);
-            release(&mut self.debug_https, &kept[3]);
-            release(&mut self.http_h3, &kept[4]);
-            release(&mut self.https_h3, &kept[5]);
-            release(&mut self.debug_http_h3, &kept[6]);
-            release(&mut self.debug_https_h3, &kept[7]);
-        });
+        release(&mut self.http);
+        release(&mut self.https);
+        release(&mut self.debug_http);
+        release(&mut self.debug_https);
+        release(&mut self.http_h3);
+        release(&mut self.https_h3);
+        release(&mut self.debug_http_h3);
+        release(&mut self.debug_https_h3);
     }
-}
-
-thread_local! {
-    /// One entry per [`RequestPools`] field; only LeakSanitizer reads them.
-    static KEPT_POOLS: [core::cell::Cell<*const ()>; 8] =
-        const { [const { core::cell::Cell::new(core::ptr::null()) }; 8] };
 }
 
 macro_rules! impl_server_pools {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -280,9 +280,7 @@ pub struct NewServer<const SSL: bool, const DEBUG: bool> {
     /// via a callback the body fires) early-return instead of re-running the
     /// downgrade/teardown while the outer frame still holds `&mut self`.
     deinit_running: core::cell::Cell<bool>,
-    /// BACKREF to this thread's pool for this server type (see
-    /// [`RequestPools`]); owned by the VM's `RuntimeState`, which outlives
-    /// every server on the thread.
+    /// BACKREF to the VM's pool for this server type ([`RequestPools`]).
     pub(crate) request_pool:
         *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>,
     /// Null until the H3 listen path runs (`HAS_H3 && config.http3`); never
@@ -3408,16 +3406,10 @@ mod trampoline {
 
 // ─── per-monomorphization request pools ──────────────────────────────────────
 // One `RequestContext` pool per concrete (SSL, DEBUG, H3) server type, shared
-// by every server of that type on the thread. Rust generics cannot own
-// per-instantiation storage, so the pools are the fields of [`RequestPools`]
-// and the trait maps each server type to its field.
-//
-// THREAD-SAFETY: the pools MUST be per-thread, not process-global:
-// `hive_array::Fallback::{claim,put}` have no internal synchronization and
-// every Worker thread may host servers. The per-thread owner is the VM's
-// `RuntimeState` rather than a `thread_local!` so that a Worker's pools are
-// freed with its VM (see `impl Drop for RequestPools`) instead of being
-// stranded each time a worker thread that served HTTP exits.
+// by the servers of that type on the thread; the trait maps a server type to
+// its [`RequestPools`] field. The pools must be per-thread (`claim`/`put` are
+// unsynchronized and Workers host servers too); they belong to the VM rather
+// than a `thread_local!` so a Worker's do not outlive it.
 pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
     fn request_pool()
     -> *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
@@ -3431,10 +3423,8 @@ type RequestPool<const SSL: bool, const DEBUG: bool, const H3: bool> =
 type RequestPoolSlot<const SSL: bool, const DEBUG: bool, const H3: bool> =
     core::cell::OnceCell<Box<RequestPool<SSL, DEBUG, H3>>>;
 
-/// This thread's request pools; a field of `RuntimeState`, so they live
-/// exactly as long as the VM. Each ~816 KB pool is allocated the first time a
-/// server of its type is created on the thread (the H3 pools once an H3
-/// listener comes up).
+/// The VM's pools (`RuntimeState::request_pools`), each ~816 KB and allocated
+/// by the first server of its type (H3: the first H3 listener).
 #[derive(Default)]
 pub(crate) struct RequestPools {
     http: RequestPoolSlot<false, false, false>,
@@ -3460,27 +3450,17 @@ impl RequestPools {
             // reclaims that exact allocation.
             unsafe { bun_core::heap::take(pool.as_ptr()) }
         });
-        // `claim`/`put` take `&self`, so servers only need a shared pointer.
-        // It stays valid for as long as anything can still hold a context
-        // from the pool (see `Drop` below).
+        // `claim`/`put` take `&self`; valid until `Drop` below.
         &raw const **pool
     }
 }
 
-/// Runs when the VM is destroyed (`deinit_runtime_state`, after teardown has
-/// stopped every server and destroyed the JSC VM, so no context can be claimed
-/// or released any more).
-///
-/// A pool whose slots have all been released is freed: the normal case, and
-/// the one a Worker that served HTTP used to strand. A slot still claimed at
-/// this point is a context that was never released (a leak of its own: a
-/// request whose handler never settled, for instance), and its pool is kept
-/// instead, as the `thread_local!` that used to own the pools kept it: the
-/// context's drop glue must not run against the dead VM, and freeing the
-/// array under it would only turn everything the context owns into leaks
-/// reported against unrelated allocation sites, and a late release into a
-/// use-after-free. The pointer is parked in the thread's [`KEPT_POOLS`] so
-/// that LeakSanitizer still sees those contexts the way it did before.
+/// Runs with the VM's teardown, after every server was stopped and the JSC VM
+/// destroyed. A slot still claimed here is a context nothing released (its own
+/// leak); such a pool is kept, as the old `thread_local!` kept it, since the
+/// context's drop glue cannot run against the dead VM and freeing the array
+/// under it would only re-attribute what it owns in LeakSanitizer reports.
+/// [`KEPT_POOLS`] keeps those contexts reachable for LSan exactly as before.
 impl Drop for RequestPools {
     fn drop(&mut self) {
         fn release<const SSL: bool, const DEBUG: bool, const H3: bool>(
@@ -3508,10 +3488,7 @@ impl Drop for RequestPools {
 }
 
 thread_local! {
-    /// One entry per [`RequestPools`] field, written by its `Drop` for a pool
-    /// that is kept because contexts in it were never released. Only ever
-    /// read by LeakSanitizer; a thread hosts one VM, so each entry is written
-    /// at most once.
+    /// One entry per [`RequestPools`] field; only LeakSanitizer reads them.
     static KEPT_POOLS: [core::cell::Cell<*const ()>; 8] =
         const { [const { core::cell::Cell::new(core::ptr::null()) }; 8] };
 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3416,9 +3416,8 @@ mod trampoline {
 // `hive_array::Fallback::{claim,put}` have no internal synchronization and
 // every Worker thread may host servers. The per-thread owner is the VM's
 // `RuntimeState` rather than a `thread_local!` so that a Worker's pools are
-// freed with its VM (`deinit_runtime_state` runs after teardown has stopped
-// every server and freed the uSockets loop) instead of being stranded each
-// time a worker thread that served HTTP exits.
+// freed with its VM (see `impl Drop for RequestPools`) instead of being
+// stranded each time a worker thread that served HTTP exits.
 pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
     fn request_pool()
     -> *const request_context::RequestContextStackAllocator<Self, SSL, DEBUG, false>;
@@ -3429,18 +3428,13 @@ pub trait ServerPools<const SSL: bool, const DEBUG: bool>: Sized {
 type RequestPool<const SSL: bool, const DEBUG: bool, const H3: bool> =
     request_context::RequestContextStackAllocator<NewServer<SSL, DEBUG>, SSL, DEBUG, H3>;
 
-/// `ManuallyDrop` inside the `Box`: `RuntimeState` drops after the JSC VM is
-/// gone, and a request that was still unanswered at teardown occupies its
-/// slot then. Its drop glue must not run at that point (for one, it would
-/// hand its body slot back to the already-freed `body_value_pool`), so only
-/// the pool allocation itself is freed, exactly as for `body_value_pool`.
 type RequestPoolSlot<const SSL: bool, const DEBUG: bool, const H3: bool> =
-    core::cell::OnceCell<Box<core::mem::ManuallyDrop<RequestPool<SSL, DEBUG, H3>>>>;
+    core::cell::OnceCell<Box<RequestPool<SSL, DEBUG, H3>>>;
 
-/// This thread's request pools; a field of `RuntimeState`. Each ~816 KB pool
-/// is allocated the first time a server of its type is created on the thread
-/// (the H3 pools when an H3 listener comes up) and lives until the VM is
-/// destroyed.
+/// This thread's request pools; a field of `RuntimeState`, so they live
+/// exactly as long as the VM. Each ~816 KB pool is allocated the first time a
+/// server of its type is created on the thread (the H3 pools once an H3
+/// listener comes up).
 #[derive(Default)]
 pub(crate) struct RequestPools {
     http: RequestPoolSlot<false, false, false>,
@@ -3463,21 +3457,63 @@ impl RequestPools {
             // writes only the 256 B bitset in place.
             let pool = RequestPool::<SSL, DEBUG, H3>::new_boxed();
             // SAFETY: `new_boxed` leaks a fully-initialized `Box`; this
-            // reclaims that exact allocation. `ManuallyDrop<T>` is
-            // `repr(transparent)` over `T`, so the cast is a layout no-op.
-            unsafe {
-                bun_core::heap::take(
-                    pool.as_ptr()
-                        .cast::<core::mem::ManuallyDrop<RequestPool<SSL, DEBUG, H3>>>(),
-                )
-            }
+            // reclaims that exact allocation.
+            unsafe { bun_core::heap::take(pool.as_ptr()) }
         });
         // `claim`/`put` take `&self`, so servers only need a shared pointer.
-        // The `Box` keeps it valid until `RuntimeState` drops at the end of VM
-        // teardown, by which point every server on the thread has been
-        // stopped and the JSC VM that could release their contexts is gone.
-        &raw const ***pool
+        // It stays valid for as long as anything can still hold a context
+        // from the pool (see `Drop` below).
+        &raw const **pool
     }
+}
+
+/// Runs when the VM is destroyed (`deinit_runtime_state`, after teardown has
+/// stopped every server and destroyed the JSC VM, so no context can be claimed
+/// or released any more).
+///
+/// A pool whose slots have all been released is freed: the normal case, and
+/// the one a Worker that served HTTP used to strand. A slot still claimed at
+/// this point is a context that was never released (a leak of its own: a
+/// request whose handler never settled, for instance), and its pool is kept
+/// instead, as the `thread_local!` that used to own the pools kept it: the
+/// context's drop glue must not run against the dead VM, and freeing the
+/// array under it would only turn everything the context owns into leaks
+/// reported against unrelated allocation sites, and a late release into a
+/// use-after-free. The pointer is parked in the thread's [`KEPT_POOLS`] so
+/// that LeakSanitizer still sees those contexts the way it did before.
+impl Drop for RequestPools {
+    fn drop(&mut self) {
+        fn release<const SSL: bool, const DEBUG: bool, const H3: bool>(
+            slot: &mut RequestPoolSlot<SSL, DEBUG, H3>,
+            kept: &core::cell::Cell<*const ()>,
+        ) {
+            let Some(pool) = slot.take() else { return };
+            if pool.hive.is_empty() {
+                drop(pool);
+            } else {
+                kept.set(core::ptr::from_ref(&*Box::leak(pool)).cast());
+            }
+        }
+        KEPT_POOLS.with(|kept| {
+            release(&mut self.http, &kept[0]);
+            release(&mut self.https, &kept[1]);
+            release(&mut self.debug_http, &kept[2]);
+            release(&mut self.debug_https, &kept[3]);
+            release(&mut self.http_h3, &kept[4]);
+            release(&mut self.https_h3, &kept[5]);
+            release(&mut self.debug_http_h3, &kept[6]);
+            release(&mut self.debug_https_h3, &kept[7]);
+        });
+    }
+}
+
+thread_local! {
+    /// One entry per [`RequestPools`] field, written by its `Drop` for a pool
+    /// that is kept because contexts in it were never released. Only ever
+    /// read by LeakSanitizer; a thread hosts one VM, so each entry is written
+    /// at most once.
+    static KEPT_POOLS: [core::cell::Cell<*const ()>; 8] =
+        const { [const { core::cell::Cell::new(core::ptr::null()) }; 8] };
 }
 
 macro_rules! impl_server_pools {

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -164,6 +164,9 @@ test.skipIf(!isASAN)(
       ],
       env: {
         ...bunEnv,
+        // The CI runner sets this for every test; set it here too so the
+        // main thread's own per-VM state is not reported when run directly.
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
         ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
         LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
       },
@@ -521,3 +524,130 @@ test(
   },
   timeout,
 );
+
+// Regression: the pool Bun.serve allocates its RequestContexts from lived in a
+// thread_local that nothing ever freed, so every Worker that served HTTP
+// stranded one ~1 MB pool per server type it had used (HTTP, HTTPS) when its
+// thread exited. LSan reports each stranded pool as a direct leak from
+// `ServerPools::request_pool` at process exit, so these cells only run on the
+// ASAN lane. The workers start their servers after a tick on purpose: a server
+// created during module evaluation has JSModuleLoader::evaluateNonVirtual on
+// its allocation stack, which test/leaksan.supp suppresses.
+describe.skipIf(!isASAN)("a Worker that served HTTP frees its request pools when it exits", () => {
+  const leakCheck = {
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+  };
+
+  async function runCell(name: string, files: Record<string, string>, env: Record<string, string> = leakCheck) {
+    using dir = tempDir(`worker-serve-pool-${name}`, files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1", ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  }
+
+  // The 'close' event is dispatched once the worker thread has been joined,
+  // i.e. after everything the worker thread owned is supposed to be gone.
+  const closed = `
+    function closed(worker) {
+      return new Promise((resolve, reject) => {
+        worker.addEventListener("close", resolve);
+        worker.addEventListener("error", e => reject(e.message));
+      });
+    }
+  `;
+
+  test.concurrent(
+    "http servers, worker exits on its own",
+    () =>
+      runCell("http", {
+        "main.ts": `
+          ${closed}
+          // Two workers: each thread allocates (and used to strand) its own pool.
+          for (let i = 0; i < 2; i++) {
+            await closed(new Worker(new URL("./worker.ts", import.meta.url).href));
+          }
+          console.log("ok");
+        `,
+        "worker.ts": `
+          await Bun.sleep(0);
+          // Two servers of the same type share the thread's one pool.
+          const servers = [0, 1].map(() => Bun.serve({ port: 0, fetch: () => new Response("ok") }));
+          for (const server of servers) await (await fetch(server.url)).text();
+          await Promise.all(servers.map(server => server.stop(true)));
+        `,
+      }),
+    timeout,
+  );
+
+  test.concurrent(
+    "https server, worker exits on its own",
+    () =>
+      runCell("https", {
+        "main.ts": `
+          ${closed}
+          await closed(new Worker(new URL("./worker.ts", import.meta.url).href));
+          console.log("ok");
+        `,
+        "tls.json": JSON.stringify({ cert: tls.cert, key: tls.key }),
+        "worker.ts": `
+          import { cert, key } from "./tls.json";
+          await Bun.sleep(0);
+          const server = Bun.serve({ port: 0, tls: { cert, key }, fetch: () => new Response("ok") });
+          await (await fetch(server.url, { tls: { rejectUnauthorized: false } })).text();
+          await server.stop(true);
+        `,
+      }),
+    timeout,
+  );
+
+  // The pool is freed at the very end of the worker's VM teardown, after the
+  // JSC VM is gone. A request that is still being handled when terminate()
+  // lands still occupies a slot at that point, so freeing the pool must not run
+  // that slot's destructor (it would touch the dead VM), and nothing after the
+  // free may touch the pool. Malloc=1 puts JSC's allocations on the system
+  // allocator so ASAN sees either mistake; leak detection has to be off with
+  // it (it surfaces process-lifetime WTF allocations), and it would only
+  // repeat the cells above anyway.
+  test.concurrent(
+    "terminate() with a request still in flight",
+    () =>
+      runCell(
+        "terminate",
+        {
+          "main.ts": `
+            ${closed}
+            const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+            await new Promise((resolve, reject) => {
+              worker.onmessage = resolve;
+              worker.onerror = e => reject(e.message);
+            });
+            const gone = closed(worker);
+            worker.terminate();
+            await gone;
+            console.log("ok");
+          `,
+          "worker.ts": `
+            await Bun.sleep(0);
+            const server = Bun.serve({
+              port: 0,
+              idleTimeout: 0,
+              fetch() {
+                postMessage("in flight");
+                return new Promise(() => {});
+              },
+            });
+            fetch(server.url).catch(() => {});
+          `,
+        },
+        { Malloc: "1", ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") },
+      ),
+    timeout,
+  );
+});

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, tempDir, tls } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -527,16 +528,21 @@ test(
 
 // Regression: the pool Bun.serve allocates its RequestContexts from lived in a
 // thread_local that nothing ever freed, so every Worker that served HTTP
-// stranded one ~1 MB pool per server type it had used (HTTP, HTTPS) when its
-// thread exited. LSan reports each stranded pool as a direct leak from
-// `ServerPools::request_pool` at process exit, so these cells only run on the
-// ASAN lane. The workers start their servers after a tick on purpose: a server
-// created during module evaluation has JSModuleLoader::evaluateNonVirtual on
-// its allocation stack, which test/leaksan.supp suppresses.
-describe.skipIf(!isASAN)("a Worker that served HTTP frees its request pools when it exits", () => {
+// stranded one ~1 MB pool per server type it had used (HTTP, HTTPS, HTTP/3)
+// when its thread exited. The pools now belong to the VM: a pool whose
+// requests have all finished is freed with it, and one that still holds an
+// unfinished request is kept (last two cells). LSan reports a stranded pool as
+// a direct leak from `ServerPools::request_pool` at process exit, so these
+// cells only run on the ASAN lane. The servers are started after a tick on
+// purpose: a server created during module evaluation has
+// JSModuleLoader::evaluateNonVirtual on its allocation stack, which
+// test/leaksan.supp suppresses.
+describe.skipIf(!isASAN)("Bun.serve request pools are released with the VM that used them", () => {
+  const suppressions = join(import.meta.dirname, "../../../leaksan.supp");
+  const detectLeaks = [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":");
   const leakCheck = {
-    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-    LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+    ASAN_OPTIONS: detectLeaks,
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${suppressions}`,
   };
 
   async function runCell(name: string, files: Record<string, string>, env: Record<string, string> = leakCheck) {
@@ -587,7 +593,7 @@ describe.skipIf(!isASAN)("a Worker that served HTTP frees its request pools when
   );
 
   test.concurrent(
-    "https server, worker exits on its own",
+    "https server with http3, worker exits on its own",
     () =>
       runCell("https", {
         "main.ts": `
@@ -599,7 +605,9 @@ describe.skipIf(!isASAN)("a Worker that served HTTP frees its request pools when
         "worker.ts": `
           import { cert, key } from "./tls.json";
           await Bun.sleep(0);
-          const server = Bun.serve({ port: 0, tls: { cert, key }, fetch: () => new Response("ok") });
+          // An HTTPS server uses the HTTPS pool; listening for HTTP/3 as well
+          // allocates the separate H3 pool, which used to be stranded too.
+          const server = Bun.serve({ port: 0, tls: { cert, key }, http3: true, fetch: () => new Response("ok") });
           await (await fetch(server.url, { tls: { rejectUnauthorized: false } })).text();
           await server.stop(true);
         `,
@@ -607,14 +615,15 @@ describe.skipIf(!isASAN)("a Worker that served HTTP frees its request pools when
     timeout,
   );
 
-  // The pool is freed at the very end of the worker's VM teardown, after the
-  // JSC VM is gone. A request that is still being handled when terminate()
-  // lands still occupies a slot at that point, so freeing the pool must not run
-  // that slot's destructor (it would touch the dead VM), and nothing after the
-  // free may touch the pool. Malloc=1 puts JSC's allocations on the system
-  // allocator so ASAN sees either mistake; leak detection has to be off with
-  // it (it surfaces process-lifetime WTF allocations), and it would only
-  // repeat the cells above anyway.
+  // A request that is still being handled when the VM is torn down still
+  // occupies its slot at the very end of teardown, after the JSC VM is gone.
+  // Such a pool is kept, slots untouched: running the context's destructor at
+  // that point is a use-after-free (its body slot, for one, has already been
+  // freed with the VM's body pool), which ASAN reports. Malloc=1 puts JSC's
+  // allocations on the system allocator too, so ASAN also sees the destructor
+  // touching the dead VM; leak detection has to be off with it (it surfaces
+  // process-lifetime WTF allocations), and the kept pool is expected to
+  // outlive the worker thread anyway. The next cell covers the pool itself.
   test.concurrent(
     "terminate() with a request still in flight",
     () =>
@@ -647,6 +656,50 @@ describe.skipIf(!isASAN)("a Worker that served HTTP frees its request pools when
           `,
         },
         { Malloc: "1", ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") },
+      ),
+    timeout,
+  );
+
+  // The same situation on the main thread, which BUN_DESTRUCT_VM_ON_EXIT (set
+  // for every leak-checked test on the ASAN lane) tears down at exit. The kept
+  // pool stays reachable from the thread, so whatever the unreleased context
+  // still references (its server, and depending on how far the request got its
+  // Request, Response, ...) stays as invisible to LSan as it was while the pool
+  // lived in a thread_local; freeing the pool instead would report all of it
+  // against unrelated allocation sites in every test exiting in this state. The
+  // server is the reference every such context holds, so the cell runs with the
+  // suppressions that would normally hide a server removed.
+  test.concurrent(
+    "main thread exits with a request still in flight",
+    () =>
+      runCell(
+        "main-thread",
+        {
+          "lsan.supp": readFileSync(suppressions, "utf8")
+            .split("\n")
+            .filter(line => !/uws|ServerAllConnectionsClosedTask/.test(line))
+            .join("\n"),
+          "main.ts": `
+            await Bun.sleep(0);
+            const server = Bun.serve({
+              port: 0,
+              idleTimeout: 0,
+              fetch() {
+                // Exit once the server is parked on this handler's promise,
+                // which never settles: that request's context is still claimed
+                // when the VM is torn down.
+                setImmediate(() => {
+                  console.log("ok");
+                  process.exit(0);
+                });
+                return new Promise(() => {});
+              },
+            });
+            fetch(server.url).catch(() => {});
+          `,
+        },
+        // LSan opens a relative suppressions path against the child's cwd.
+        { ASAN_OPTIONS: detectLeaks, LSAN_OPTIONS: "print_suppressions=0:suppressions=lsan.supp" },
       ),
     timeout,
   );

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -622,8 +622,7 @@ describe.skipIf(!isASAN)("Bun.serve request pools are released with the VM that 
   // freed with the VM's body pool), which ASAN reports. Malloc=1 puts JSC's
   // allocations on the system allocator too, so ASAN also sees the destructor
   // touching the dead VM; leak detection has to be off with it (it surfaces
-  // process-lifetime WTF allocations), and the kept pool is expected to
-  // outlive the worker thread anyway. The next cell covers the pool itself.
+  // process-lifetime WTF allocations). The next cell covers the pool itself.
   test.concurrent(
     "terminate() with a request still in flight",
     () =>
@@ -662,13 +661,14 @@ describe.skipIf(!isASAN)("Bun.serve request pools are released with the VM that 
 
   // The same situation on the main thread, which BUN_DESTRUCT_VM_ON_EXIT (set
   // for every leak-checked test on the ASAN lane) tears down at exit. The kept
-  // pool stays reachable from the thread, so whatever the unreleased context
-  // still references (its server, and depending on how far the request got its
-  // Request, Response, ...) stays as invisible to LSan as it was while the pool
+  // pool is declared to LSan as kept on purpose, so whatever the unreleased
+  // context still references (its server, and depending on how far the request
+  // got its Request, Response, ...) stays as invisible as it was while the pool
   // lived in a thread_local; freeing the pool instead would report all of it
-  // against unrelated allocation sites in every test exiting in this state. The
-  // server is the reference every such context holds, so the cell runs with the
-  // suppressions that would normally hide a server removed.
+  // against unrelated allocation sites in every test exiting in this state, and
+  // merely parking a pointer to it somewhere is not enough (optimized builds
+  // dropped that store). The server is the reference every such context holds,
+  // so the cell runs with the suppressions that would normally hide one removed.
   test.concurrent(
     "main thread exits with a request still in flight",
     () =>


### PR DESCRIPTION
### What

Every Worker that runs `Bun.serve` (directly or through `node:http`) leaks the per-thread `RequestContext` pool when the worker exits: one pool per server type it used (HTTP, HTTPS, and the separate H3 pool of an `http3: true` server), 816 KB in release and 1.4 MB in debug builds each. With the debug ASAN build:

```ts
// repro.ts
const worker = new Worker("data:text/javascript," + encodeURIComponent(`
  await Bun.sleep(0); // create the server outside module evaluation so leaksan.supp does not hide it
  const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
  await (await fetch(server.url)).text();
  await server.stop(true);
`));
await new Promise(resolve => worker.addEventListener("close", resolve));
```

```
$ BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 bun-debug repro.ts
Direct leak of 1474816 byte(s) in 1 object(s) allocated from:
    ...
    #12 <bun_collections::hive_array::Fallback<RequestContext<NewServer<false, true>, false, true, false>, 2048>>::new_boxed src/collections/hive_array.rs:584
    #13 <NewServer<false, true> as ServerPools<false, true>>::request_pool::{closure#0} src/runtime/server/mod.rs:3436
    #16 <NewServer<false, true> as ServerPools<false, true>>::request_pool src/runtime/server/mod.rs:3430
    #17 NewServer<false, true>::init src/runtime/server/mod.rs:2162
    #18 bun_runtime::api::bun_object::serve src/runtime/api/BunObject.rs:1568
```

Reproduces 6/6 runs, with or without `test/leaksan.supp`; with `http3: true` on a TLS server, `h3_request_pool` is reported as a second object. In CI this was only hidden because workers usually start their server during module evaluation, which puts `JSModuleLoader::evaluateNonVirtual` (suppressed) on the allocation stack; the leak still exists and still costs LSan a symbolizer pass on every ASAN-lane test whose worker serves HTTP.

### Cause

`impl_server_pools!` in `src/runtime/server/mod.rs` kept each pool in a `thread_local! { static POOL: Cell<*mut Pool> }` filled from `Pool::new_boxed()` and never freed. That is a process-lifetime allocation on the main thread, but a Worker thread's TLS goes away with the thread, so the pool is simply stranded.

### Fix

The pools now live on the per-thread `RuntimeState` (`RequestPools`, one lazily allocated slot per `(SSL, DEBUG, H3)` server type), next to `body_value_pool`, which is there for the same reason. `ServerPools` is still the per-monomorphization dispatch; it just maps each server type to its `RequestPools` field. `RuntimeState` is dropped by `deinit_runtime_state` at the end of `VirtualMachine::teardown`, after the stop phase has closed every server and after the JSC VM (and, for a worker, the uSockets loop) is gone, so nothing can claim or release a context any more when `RequestPools::drop` runs. It does this per pool:

- every slot released (the normal case, and the one every worker used to strand): the pool is freed. Dropping it runs no context destructors because there are none left in it.
- a slot still claimed: that context was never released, which is a leak of its own (a request whose handler never settles and is still parked when the VM goes away, for example). The pool is kept, exactly as the `thread_local!` kept it until now, and declared to LeakSanitizer as kept on purpose (`__lsan_ignore_object`, which also covers everything reachable from it, through a new `bun_core::asan::ignore_object` next to the existing root-region helpers). Dropping such a slot would run the context's drop glue against the dead VM (ASAN reports a use-after-free in `HiveRefHandle::drop`, as the context returns its body slot to the body pool freed just before), and just freeing the array under it is not an improvement either: the first version of this PR did that, and on the ASAN lane it turned the unreleased contexts of two unrelated tests (`serve-direct-readable-stream.test.ts`, `fetch-abort-stream-body.test.ts`) into reports of the `Request`/`Response` boxes they own, attributed to request handling. Any test that happens to exit with a request in that state, including timing-dependent abort paths, would have become an ASAN-lane failure. Keeping the pool leaves those pre-existing leaks exactly as visible as they are today (the thread_local made everything hanging off them reachable too); fixing them is separate work, and once a teardown releases its contexts the pool simply gets freed. (An intermediate version parked the kept pointer in a thread_local instead; the optimized ASAN build removed that never-read store and the main-thread cell below caught it, hence the explicit LSan call.)

The pool pointers on `NewServer` become `*const`, since `claim`/`put` take `&self`; `request_pool()` is only called when a server is created, not per request, so nothing on the request path changes. `HiveArray::is_empty` and `asan::ignore_object` are new.

### Tests

`test/js/web/workers/worker-terminate-lifetime.test.ts`, ASAN lane only:

- two workers, each running two HTTP servers, exiting on their own: without the fix LSan reports `2949632 byte(s) in 2 object(s)` from `request_pool` (one pool per worker; the two servers on a thread share it)
- a worker running an HTTPS server with `http3: true`: without the fix two objects, from `request_pool` and `h3_request_pool`
- `terminate()` while a request is still being handled, with `Malloc=1` so JSC memory is visible to ASAN: fails with the use-after-free above if the occupied slot is dropped
- the main thread exiting with a request parked on its handler, leak-checked with the suppressions that normally hide a server removed: the server is only reachable through the unreleased context, so this fails (`13661 byte(s) leaked in 158 allocation(s)`, the server and its uWS app) if the pool is freed instead of kept, or if LSan is not told about the kept pool (that is what failed on the x64-asan lane with the parked-pointer version), and passes both before this PR and with it

The existing dns cell in that file now also sets `BUN_DESTRUCT_VM_ON_EXIT` itself, as the CI runner does, so the whole file passes when run directly with `bun bd test`.

Verified locally: the cells fail/pass as described above against the unfixed build, the always-free variant and this branch, with a plain environment and with the ASAN CI runner's environment variables; the whole file passes (14/14); the two test files that failed on the ASAN lane with the always-free variant pass under the CI runner's environment with this branch; `serve-http3.test.ts` passes; `bun-server.test.ts` has the same three `localhost` connection-refused failures with and without this change (also with the released binary in this container); `cargo clippy -p bun_runtime -p bun_collections` is clean.
