### PR TITLE
fetch: reject a FormData body whose Bun.file() cannot be read with a TypeError

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -192,7 +192,14 @@ pub trait BlobExt {
     ) -> Blob
     where
         Self: Sized;
-    fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &mut jsc::DOMFormData) -> Blob
+    /// Serializes `form_data` as `multipart/form-data`, reading its file-backed
+    /// entries eagerly. Returns the first read failure instead of throwing it:
+    /// `Request`/`Response` construction throws it as-is, while a `fetch()`
+    /// body that cannot be read is a network error and rejects as a `TypeError`.
+    fn from_dom_form_data(
+        global_this: &JSGlobalObject,
+        form_data: &mut jsc::DOMFormData,
+    ) -> Result<Blob, bun_sys::Error>
     where
         Self: Sized;
     fn content_type(&self) -> &[u8];
@@ -869,7 +876,10 @@ impl BlobExt for Blob {
         blob
     }
 
-    fn from_dom_form_data(global_this: &JSGlobalObject, form_data: &mut jsc::DOMFormData) -> Blob {
+    fn from_dom_form_data(
+        global_this: &JSGlobalObject,
+        form_data: &mut jsc::DOMFormData,
+    ) -> Result<Blob, bun_sys::Error> {
         // "----WebKitFormBoundary" (22 bytes) + 32 lowercase-hex chars of a fresh UUID.
         const BOUNDARY_PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
         let mut boundary_buf = [0u8; BOUNDARY_PREFIX.len() + 32];
@@ -884,8 +894,7 @@ impl BlobExt for Blob {
         let mut context = FormDataContext {
             joiner: bun_core::string_joiner::StringJoiner::default(),
             boundary,
-            failed: false,
-            global_this,
+            read_error: None,
         };
         // Size the node list up front: a file entry pushes at most 13 slices, a
         // string entry 8, plus 3 for the closing boundary.
@@ -951,12 +960,12 @@ impl BlobExt for Blob {
             (&raw mut context).cast::<c_void>(),
             for_each_thunk,
         );
-        if context.failed {
+        if let Some(err) = context.read_error {
             // Drop the joiner (Drop runs StringJoiner::deinit) so every
             // heap-owned slice already pushed — escaped names, non-ASCII
             // conversions, NodeFS read_file result buffers — is freed.
             drop(context.joiner);
-            return Blob::init_empty(global_this);
+            return Err(err);
         }
 
         context.joiner.push_static(b"--");
@@ -979,7 +988,7 @@ impl BlobExt for Blob {
             .set(BlobContentType::Owned(std::sync::Arc::from(ct)));
         blob.content_type_was_set.set(true);
 
-        blob
+        Ok(blob)
     }
 
     fn content_type(&self) -> &[u8] {
@@ -3859,14 +3868,14 @@ where
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Stack-local helper for `Blob::from_dom_form_data`. `boundary` borrows the
-/// caller's `hex_buf` and `global_this` borrows the incoming `&JSGlobalObject`;
-/// both strictly outlive this struct, so they are stored as plain references
-/// rather than raw pointers.
+/// caller's `boundary_buf`, which strictly outlives this struct, so it is
+/// stored as a plain reference rather than a raw pointer.
 struct FormDataContext<'a> {
     joiner: StringJoiner<'a>,
     boundary: &'a [u8], // borrowed; outlives the joiner
-    failed: bool,
-    global_this: &'a JSGlobalObject,
+    /// First file-backed entry that could not be read; once set, the remaining
+    /// entries are skipped and `from_dom_form_data` returns it.
+    read_error: Option<bun_sys::Error>,
 }
 
 /// Which piece of a `multipart/form-data` entry a string is, selecting the
@@ -3959,12 +3968,11 @@ impl FormDataContext<'_> {
     }
 
     fn on_entry(&mut self, name: ZigString, entry: FormDataEntry<'_>) {
-        if self.failed {
+        if self.read_error.is_some() {
             return;
         }
-        // Copy the borrowed refs out first (disjoint-field reads) so the
+        // Copy the borrowed ref out first (disjoint-field reads) so the
         // long-lived `&mut self.joiner` below doesn't conflict.
-        let global_this = self.global_this;
         let boundary = self.boundary;
         let joiner = &mut self.joiner;
 
@@ -4030,9 +4038,7 @@ impl FormDataContext<'_> {
                             let res = node_fs.read_file(&rf_args, crate::node::fs::Flavor::Sync);
                             match res {
                                 Err(err) => {
-                                    self.failed = true;
-                                    let js_err = err.to_js(global_this);
-                                    let _ = global_this.throw_value(js_err);
+                                    self.read_error = Some(err);
                                 }
                                 Ok(mut result) => {
                                     joiner.push_cloned(result.slice());

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -20,7 +20,7 @@ use crate::webcore::form_data::AsyncFormDataExt as _;
 use bun_core::{String as BunString, ZigString};
 use bun_core::{WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::ZigStringJsc as _;
-use bun_jsc::{JsCell, StringJsc as _};
+use bun_jsc::{JsCell, StringJsc as _, SysErrorJsc as _};
 
 /// Deref the `Value::WTFStringImpl` / `AnyBlob::WTFStringImpl` payload.
 /// Centralises the per-site `(**s)` raw deref at the dozen `match` arms below
@@ -973,9 +973,10 @@ impl Value {
 
         if let Some(form_data) = as_dom_form_data(value) {
             // SAFETY: shim returns a live JSC heap cell.
-            return Ok(Value::Blob(Blob::from_dom_form_data(global_this, unsafe {
-                &mut *form_data
-            })));
+            return match Blob::from_dom_form_data(global_this, unsafe { &mut *form_data }) {
+                Ok(blob) => Ok(Value::Blob(blob)),
+                Err(err) => Err(err.throw(global_this)),
+            };
         }
 
         if let Some(search_params) = as_url_search_params(value) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -26,7 +26,9 @@ use bun_threading::Mutex;
 use bun_url::URL as ZigURL;
 
 use crate::api::bun_x509 as X509;
-use crate::webcore::blob::{Any as AnyBlob, Blob, SizeType as BlobSizeType, Store as BlobStore};
+use crate::webcore::blob::{
+    Any as AnyBlob, Blob, BlobExt as _, SizeType as BlobSizeType, Store as BlobStore,
+};
 use crate::webcore::body::{self, Body, Value as BodyValue, ValueError as BodyValueError};
 use crate::webcore::fetch::fetch_request_body_sink::{FetchRequestBodySink, RequestBodyChunk};
 use crate::webcore::readable_stream::{ReadableStream, Strong as ReadableStreamStrong};
@@ -211,6 +213,18 @@ impl HTTPRequestBody {
     }
 
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<HTTPRequestBody> {
+        if let Some(form_data) = jsc::DOMFormData::from_js(value) {
+            return match Blob::from_dom_form_data(global_this, form_data) {
+                Ok(blob) => Ok(HTTPRequestBody::AnyBlob(AnyBlob::Blob(blob))),
+                // A request body that cannot be read is a network error, so it
+                // rejects the way fetch() reports those: a TypeError that still
+                // carries `code`/`syscall`/`path`.
+                Err(err) => {
+                    let err: jsc::SystemError = err.to_system_error().into();
+                    Err(global_this.throw_value(err.to_type_error_instance(global_this)))
+                }
+            };
+        }
         let mut body_value = BodyValue::from_js(global_this, value)?;
         if matches!(body_value, BodyValue::Used)
             || (matches!(&body_value, BodyValue::Locked(l) if !l.action.is_none() || l.is_disturbed2(global_this)))

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -239,3 +239,91 @@ test("missing file throws the expected error", async () => {
   });
   Bun.gc(true);
 });
+
+// A request body that cannot be read is a network error, so fetch() rejects the
+// way it rejects its other network errors: a TypeError that still carries the
+// system error fields.
+describe("FormData body with a Bun.file() that cannot be read", () => {
+  // The FormData is serialized before anything is connected, so the promise
+  // comes back already rejected; checking that pins the rejection to the body
+  // rather than to the connection this URL would refuse.
+  async function bodyRejection(promise: Promise<Response>): Promise<any> {
+    expect(Bun.peek.status(promise)).toBe("rejected");
+    return await promise.then(
+      () => {
+        throw new Error("fetch() resolved");
+      },
+      error => error,
+    );
+  }
+
+  test.concurrent("fetch(url, { body }) rejects with a TypeError carrying the ENOENT", async () => {
+    using dir = tempDir("fetch-formdata-missing-file", { "present.txt": "present" });
+    const missingPath = join(String(dir), "missing.txt");
+
+    const body = new FormData();
+    body.append("field", "value");
+    body.append("present", Bun.file(join(String(dir), "present.txt")));
+    body.append("missing", Bun.file(missingPath));
+
+    const error = await bodyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body }));
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).toMatchObject({
+      name: "TypeError",
+      code: "ENOENT",
+      syscall: "open",
+      path: missingPath,
+      errno: expect.any(Number),
+    });
+    expect(error.message).toContain("no such file or directory");
+  });
+
+  test.concurrent("fetch({ url, body }) rejects with the same TypeError", async () => {
+    using dir = tempDir("fetch-formdata-missing-file-init", {});
+    const missingPath = join(String(dir), "missing.txt");
+
+    const body = new FormData();
+    body.append("missing", Bun.file(missingPath));
+
+    const error = await bodyRejection(fetch({ url: "http://127.0.0.1:1/", method: "POST", body } as any));
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).toMatchObject({ code: "ENOENT", syscall: "open", path: missingPath });
+  });
+
+  // Opening a directory succeeds and reading it fails, so this covers the error
+  // coming out of the read itself. Not pinned on Windows, where a directory
+  // stats as 0 bytes and the size-bounded read need not fail the same way.
+  test.concurrent.skipIf(isWindows)("a read failure (EISDIR) rejects with a TypeError too", async () => {
+    using dir = tempDir("fetch-formdata-directory", { "subdir/.keep": "" });
+
+    const body = new FormData();
+    body.append("dir", Bun.file(join(String(dir), "subdir")));
+
+    const error = await bodyRejection(fetch("http://127.0.0.1:1/", { method: "POST", body }));
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).toMatchObject({ code: "EISDIR", syscall: "read" });
+  });
+
+  test.concurrent("new Request() and new Response() still throw the system error itself", () => {
+    using dir = tempDir("fetch-formdata-missing-file-ctor", {});
+    const missingPath = join(String(dir), "missing.txt");
+
+    for (const construct of [
+      (body: FormData) => new Response(body),
+      (body: FormData) => new Request("http://localhost/", { method: "POST", body }),
+    ]) {
+      const body = new FormData();
+      body.append("missing", Bun.file(missingPath));
+
+      let error: unknown;
+      try {
+        construct(body);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(Error);
+      expect(error).not.toBeInstanceOf(TypeError);
+      expect(error).toMatchObject({ name: "Error", code: "ENOENT", syscall: "open", path: missingPath });
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

`fetch()` with a `FormData` body that holds a `Bun.file()` which cannot be read rejects with a plain `Error`. Since #35855 the network errors `fetch()` produces are `TypeError`s carrying the system error fields; this rejection was left out:

```js
const body = new FormData();
body.append("f", Bun.file("/definitely/missing/upload"));
try {
  await fetch("http://127.0.0.1:1/", { method: "POST", body });
} catch (e) {
  console.log(e.constructor.name, e instanceof TypeError, e.code, e.syscall);
}
// before: Error false ENOENT open
// after:  TypeError true ENOENT open
```

The same applies to a directory entry (`EISDIR` from the read) and to the object form `fetch({ url, body })`.

**Cause:** `Blob::from_dom_form_data` (`src/runtime/webcore/Blob.rs`) serializes the multipart body eagerly. When the read of a file entry failed, `FormDataContext::on_entry` threw the `bun_sys::Error` on the global right there with `to_js()`, i.e. `SystemError::to_error_instance`, a plain `Error`. `fetch_impl` then saw the pending exception and `reject_on_exception` rejected with whatever had been thrown. The serializer does not know whether it is serving `fetch()` or a `Request`/`Response` constructor, and those two callers want different things.

**Fix:** `from_dom_form_data` returns `Result<Blob, bun_sys::Error>` instead of throwing (`FormDataContext` records the first read failure in place of the `failed` flag; the joiner cleanup on failure is unchanged). Its two callers pick the error class:

* `Body::Value::from_js` (`new Request()`, `new Response()`, `HTMLRewriter.transform`) throws it as the same plain system error as before. It now does so by returning `Err` rather than `Ok(empty blob)` with the exception left pending, which is what its callers already handle.
* `HTTPRequestBody::from_js` (`src/runtime/webcore/fetch/FetchTasklet.rs`, the body extraction both `fetch(url, { body })` and `fetch({ url, body })` go through) handles `FormData` before delegating to `Value::from_js` and materializes the failure with `SystemError::to_type_error_instance`, the binding #35855 added. The two builders share one body in `bindings.cpp`, so `code`, `errno`, `syscall`, `path` and the message are identical; only the prototype differs.

### Why this split

The fetch spec turns a request body that fails to be read into a network error, and `fetch()` rejects every network error with a `TypeError`; Node rejects the equivalent (a body over a missing file) with `TypeError: fetch failed` (cause `ENOENT`). Bun's shape for this since #35855 is the system error fields directly on the `TypeError`, which is what this produces, so `err instanceof TypeError` now identifies a `fetch()` failure whether the body or the connection failed.

The constructors are deliberately unchanged. The spec gives them no reason to throw at all (the eager read is a Bun choice), and everywhere else in Bun a file-backed body that cannot be read surfaces as the plain system error (`Bun.file(p).text()` and `new Response(Bun.file(p)).text()` both reject with `Error { code: "ENOENT" }`); Node likewise hands back the underlying error when a body is consumed outside `fetch()`. Changing their class would widen the change without a spec or Node argument behind it. `test/js/web/html/FormData.test.ts` ("doesnt crash when file is missing") and `FormData-file-error-leak` keep exercising that path and pass unchanged.

#37501 does the same for a bare `body: Bun.file()` in `fetch.rs` and explicitly leaves this `FormData` route out; the two are independent (both add tests at the end of `fetch-file-upload.test.ts`, so whichever lands second needs a trivial rebase). #35792 (streaming `FormData` uploads) keeps unreadable files on this buffered path, so this still applies there.

### How did you verify your code works?

New `describe` block in `test/js/bun/http/fetch-file-upload.test.ts`:

* `fetch(url, { body })` with a string entry, a readable file and a missing file: already rejected when `fetch()` returns (`Bun.peek.status`), `instanceof TypeError`, `{ code: "ENOENT", syscall: "open", path, errno }`, message still names the file
* `fetch({ url, body })`: same
* a directory entry: `TypeError` with `{ code: "EISDIR", syscall: "read" }`, the failure coming out of the read rather than the open (skipped on Windows)
* `new Response(body)` and `new Request(url, { body })` still throw synchronously, still a plain `Error` (not a `TypeError`) with the same fields

The first three fail on the current release (`Expected constructor: TypeError`, received the plain `Error` with the same fields) and pass with this change; the fourth pins the unchanged side. Also run with the debug build: the rest of this file, `test/js/web/html/FormData*.test.ts` (including the file-error leak test), `test/js/web/fetch/{body,body-mixin-errors,body-clone,content-length}` tests, `test/js/bun/http/form-data-set-append.test.js`, the HTMLRewriter suite, and `cargo clippy -p bun_runtime`.
