### PR TITLE
lsquic: let a late pacer tick send what the connection was held back from sending

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -690,6 +690,20 @@ static void us_quic_prepare_ssl_ctx(SSL_CTX *ssl) {
     SSL_CTX_set_early_data_enabled(ssl, 0);
 }
 
+/* Both engines are only ticked from an event loop (see "process driver"
+ * above), so every RTT lsquic measures includes whatever the loop ran between
+ * two ticks. lsquic's default "adaptive" CC (es_cc_algo 3) makes a permanent
+ * choice from a connection's handshake RTT, BBRv1 above 1.5 ms, which any JS
+ * work during the handshake exceeds even on loopback. BBRv1 then models loop
+ * latency as the path: the only bandwidth it can observe is one cwnd per loop
+ * iteration, so cwnd never grows in startup and, once startup ends, shrinks to
+ * the 4-packet minimum; a busy server then moves ~7 KB per loop iteration.
+ * Cubic only reacts to loss, which a slow loop doesn't produce, and is what
+ * adaptive mode picks on a quiet loop anyway. */
+static void us_quic_use_cubic(struct lsquic_engine_settings *settings) {
+    settings->es_cc_algo = 1;
+}
+
 us_quic_socket_context_t *us_create_quic_socket_context(
     struct us_loop_t *loop, struct us_bun_socket_context_options_t options,
     unsigned int ext_size, unsigned int idle_timeout_s)
@@ -706,6 +720,7 @@ us_quic_socket_context_t *us_create_quic_socket_context(
     ctx->ssl_ctx = ssl;
 
     lsquic_engine_init_settings(&ctx->settings, LSENG_HTTP_SERVER);
+    us_quic_use_cubic(&ctx->settings);
     ctx->settings.es_versions = LSQUIC_DF_VERSIONS & LSQUIC_IETF_VERSIONS;
     ctx->settings.es_ecn = 0;
     /* QPACK can expand small dynamic-table refs into large header lists; cap
@@ -1170,6 +1185,7 @@ us_quic_socket_context_t *us_create_quic_client_context(
     ctx->stream_ext_size = stream_ext_size;
 
     lsquic_engine_init_settings(&ctx->settings, LSENG_HTTP);
+    us_quic_use_cubic(&ctx->settings);
     ctx->settings.es_versions = (1u << LSQVER_I001);
     ctx->settings.es_ecn = 0;
     ctx->settings.es_max_header_list_size = 64 * 1024;

--- a/patches/lsquic/cubic-llp64-overflow.patch
+++ b/patches/lsquic/cubic-llp64-overflow.patch
@@ -1,0 +1,35 @@
+--- a/src/liblsquic/lsquic_cubic.c
++++ b/src/liblsquic/lsquic_cubic.c
+@@ -204,11 +204,14 @@ lsquic_cubic_loss (void *cong_ctl)
+     struct lsquic_cubic *const cubic = cong_ctl;
+     LSQ_DEBUG("%s(cubic)", __func__);
+     cubic->cu_epoch_start = 0;
++    /* bun: the window fields are unsigned long, which is 32 bits on Windows
++     * (LLP64), so widen before multiplying; see lsquic_cubic_pacing_rate. */
+     if (FAST_CONVERGENCE && cubic->cu_cwnd < cubic->cu_last_max_cwnd)
+-        cubic->cu_last_max_cwnd = cubic->cu_cwnd * TWO_MINUS_BETA_OVER_TWO / 1024;
++        cubic->cu_last_max_cwnd = (uint64_t) cubic->cu_cwnd
++                                        * TWO_MINUS_BETA_OVER_TWO / 1024;
+     else
+         cubic->cu_last_max_cwnd = cubic->cu_cwnd;
+-    cubic->cu_cwnd = cubic->cu_cwnd * ONE_MINUS_BETA / 1024;
++    cubic->cu_cwnd = (uint64_t) cubic->cu_cwnd * ONE_MINUS_BETA / 1024;
+     cubic->cu_tcp_cwnd = cubic->cu_cwnd;
+     cubic->cu_ssthresh = cubic->cu_cwnd;
+     LSQ_INFO("loss detected, last_max_cwnd: %lu, cwnd: %lu",
+@@ -266,7 +269,14 @@ lsquic_cubic_pacing_rate (void *cong_ctl, int in_recovery)
+     srtt = lsquic_rtt_stats_get_srtt(cubic->cu_rtt_stats);
+     if (srtt == 0)
+         srtt = 50000;
+-    bandwidth = cubic->cu_cwnd * 1000000 / srtt;
++    /* bun: cu_cwnd is unsigned long, 32 bits on Windows (LLP64), so this
++     * product wrapped for every window above 4 KB and the pacing rate came
++     * out as (cwnd * 10^6 mod 2^32) / srtt: a Cubic connection on Windows
++     * was paced at a more or less random rate, usually a small fraction of
++     * cwnd/srtt.  Reported upstream as a Windows throughput problem that went
++     * away with pacing disabled or BBR selected:
++     * https://github.com/litespeedtech/lsquic/issues/391 */
++    bandwidth = (uint64_t) cubic->cu_cwnd * 1000000 / srtt;
+     if (in_slow_start(cubic))
+         pacing_rate = bandwidth * 2;
+     else if (in_recovery)

--- a/patches/lsquic/pacer-late-tick-credit.patch
+++ b/patches/lsquic/pacer-late-tick-credit.patch
@@ -1,0 +1,302 @@
+pacer: let a late tick send what the connection was held back from sending
+
+lsquic's pacer (a port of Chromium's PacingSender) expects to be
+ticked about when it asked to be: when it blocks a packet it sets
+PA_LAST_SCHED_DELAYED and the engine wakes the connection up at
+pa_next_sched, about a clock granularity (1 ms) later, so the
+"making up for lost time" branch only ever had timer slop to cover.
+
+Bun's engines are ticked from the event loop, so the next tick comes
+when the application's JS is done, tens of milliseconds later on a
+busy server, by which time everything in flight has been acknowledged.
+Two paths in lsquic_pacer_packet_scheduled() then threw the time the
+connection had been held back for away and restarted pacing from now:
+
+  * n_in_flight == 0 replenished the burst tokens, and the token path
+    resets pa_next_sched and clears PA_LAST_SCHED_DELAYED;
+  * in the making-up branch, pa_last_delayed + delay <= now was taken
+    to mean application-limited, which any gap between two ticks
+    satisfies, so making up could never span two ticks.
+
+Either way such a tick released ten packets plus one granularity's
+worth, however wide the window was.  Which ticks were affected came
+down to whether the ACKs had been read before the tick: node:quic's
+driver ticks after reading them, so every iteration of a busy loop was
+one of these (a tenth to a fifth of the window per iteration); the
+HTTP/3 server's driver also ticks before reading them, and those ticks
+still had packets in flight and did make up, so it moved about half a
+window per iteration.
+
+Now:
+
+  * a connection the pacer held back does not get the restart burst,
+    and the making-up branch runs until it has caught up, so a late
+    tick sends what was due since the previous one at the pacing rate,
+    within the congestion window;
+  * tick_in bounds how far behind the schedule may lag: to the tick
+    before the last one that scheduled a packet (pa_credit_since,
+    replacing pa_last_delayed).  A promptly ticked, window-limited
+    connection therefore holds a gap or two between ACKs' worth of
+    credit at most and stays paced instead of accumulating credit that
+    would come out as a burst.  It is the tick before rather than the
+    sending tick itself because the loop drivers tick a connection
+    twice in a row, before and after reading the ACKs that arrived
+    during the iteration; whatever room the first tick finds left in
+    the window must not cost the second one the iteration's worth;
+  * tick_out drops the credit when a tick ends with the window open
+    and the connection not having used it: that is what application-
+    limited actually looks like.  send_ctl passes the window state in,
+    so lsquic_send_ctl_tick_out moves out of the header.  The old
+    "empty tick" reset also fired on every tick a window-limited
+    connection spent waiting for ACKs, i.e. on the ticks the credit
+    is for; pa_n_scheduled and PA_DELAYED_ON_TICK_IN only served it
+    and go away;
+  * lsquic_pacer_delayed(), which the connection's next tick time and
+    send_ctl's app-limited checks are built on, now means that the
+    pacer is blocking right now (schedule in the future).  With the
+    flag kept across ticks it would otherwise have the engine tick a
+    connection whose schedule is in the past, i.e. one waiting for
+    ACKs, continuously.
+
+--- a/src/liblsquic/lsquic_pacer.h
++++ b/src/liblsquic/lsquic_pacer.h
+@@ -9,7 +9,12 @@
+     const struct lsquic_conn
+                    *pa_conn;             /* Used for logging */
+     lsquic_time_t   pa_next_sched;
+-    lsquic_time_t   pa_last_delayed;
++    lsquic_time_t   pa_credit_since;    /* How far behind pa_now the schedule
++                                         * may lag: the tick before the last
++                                         * one that scheduled a packet.  See
++                                         * lsquic_pacer_tick_in().
++                                         */
++    lsquic_time_t   pa_prev_tick;       /* pa_now of the previous tick */
+     lsquic_time_t   pa_now;
+ 
+     /* All tick times are in microseconds */
+@@ -17,10 +22,14 @@
+     unsigned        pa_clock_granularity;
+ 
+     unsigned        pa_burst_tokens;
+-    unsigned        pa_n_scheduled;     /* Within single tick */
+     enum {
++        /* The pacer held a packet back.  While this is set, either the
++         * pacer is blocking (pa_next_sched is in the future: the connection
++         * is ticked then) or the connection is making up for lost time
++         * (pa_next_sched is in the past) and is waiting for the congestion
++         * window.  See lsquic_pacer.c.
++         */
+         PA_LAST_SCHED_DELAYED   = (1 << 0),
+-        PA_DELAYED_ON_TICK_IN   = (1 << 1),
+     }               pa_flags;
+ #ifndef NDEBUG
+     struct {
+@@ -42,8 +51,11 @@
+ void
+ lsquic_pacer_tick_in (struct pacer *, lsquic_time_t);
+ 
++/* `cwnd_has_room' is whether the congestion controller would have let the
++ * connection send more when the tick ended.
++ */
+ void
+-lsquic_pacer_tick_out (struct pacer *);
++lsquic_pacer_tick_out (struct pacer *, int cwnd_has_room);
+ 
+ int
+ lsquic_pacer_can_schedule (struct pacer *, unsigned n_in_flight);
+@@ -58,10 +70,17 @@
+ void
+ lsquic_pacer_disable_burst_tokens (struct pacer *);
+ 
++/* Whether the pacer is what is holding the connection back right now, in
++ * which case lsquic_pacer_next_sched() is when to tick it again.  It is not
++ * while the connection is making up for lost time: that connection is waiting
++ * for the congestion window, and ticking it on the pacer's account would have
++ * the engine tick it continuously until an ACK arrives.
++ */
+ static inline int
+ lsquic_pacer_delayed (const struct pacer *pacer)
+ {
+-    return pacer->pa_flags & PA_LAST_SCHED_DELAYED;
++    return (pacer->pa_flags & PA_LAST_SCHED_DELAYED)
++        && pacer->pa_next_sched > pacer->pa_now;
+ }
+ 
+ static inline lsquic_time_t 
+--- a/src/liblsquic/lsquic_pacer.c
++++ b/src/liblsquic/lsquic_pacer.c
+@@ -44,19 +44,50 @@
+ }
+ 
+ 
++/* bun: the engine is only ticked from an event loop, so a tick can come long
++ * after the pacer asked for one (the loop was busy running the application),
++ * by which time everything that was in flight has usually been acknowledged.
++ * This function used to restart pacing from "now" on such a tick, either
++ * through the burst tokens, handed out whenever nothing is in flight, or
++ * through the making-up branch's per-packet application-limited guess, which
++ * any gap between two ticks trips.  Such a tick got ten packets plus one clock
++ * granularity's worth however much the connection was owed, and on a busy
++ * loop about every other tick was one, so the connection moved about half a
++ * window per loop iteration.
++ *
++ * Now a connection the pacer has held back (PA_LAST_SCHED_DELAYED) keeps
++ * pa_next_sched where it is, and a later tick may send what was due between
++ * then and now at the pacing rate, within the congestion window.  The credit
++ * is bounded to the last couple of ticks (lsquic_pacer_tick_in), so a promptly
++ * ticked connection gets a gap or two between ACKs' worth at most and stays
++ * paced, and it is dropped when a tick ends with the window open and nothing
++ * more to send (lsquic_pacer_tick_out): that connection is application-limited
++ * and restarts like an idle one, with the burst tokens.
++ */
+ void
+ lsquic_pacer_packet_scheduled (struct pacer *pacer, unsigned n_in_flight,
+                             int in_recovery, tx_time_f tx_time, void *tx_ctx)
+ {
+     lsquic_time_t delay, sched_time;
+-    int app_limited, making_up;
++    int making_up;
+ 
+ #ifndef NDEBUG
+     ++pacer->pa_stats.n_scheduled;
+ #endif
+-    ++pacer->pa_n_scheduled;
+-
+-    if (n_in_flight == 0 && !in_recovery)
++    sched_time = pacer->pa_now;
++    /* The tick before this one rather than this one: the event loop often
++     * ticks a connection twice in a row, once before and once after reading
++     * the ACKs that were waiting, and whatever room the first of those finds
++     * in the window must not cost the second one the gap before them both.
++     */
++    pacer->pa_credit_since = pacer->pa_prev_tick;
++
++    /* A held-back connection with nothing in flight is not idle: the ACKs
++     * came in while the engine was not being ticked.  It makes up for that
++     * time below rather than restarting with a burst.
++     */
++    if (n_in_flight == 0 && !in_recovery
++                            && !(pacer->pa_flags & PA_LAST_SCHED_DELAYED))
+     {
+         pacer->pa_burst_tokens = 10;
+         LSQ_DEBUG("%s: replenish tokens: %u", __func__, pacer->pa_burst_tokens);
+@@ -67,33 +98,24 @@
+         --pacer->pa_burst_tokens;
+         pacer->pa_flags &= ~PA_LAST_SCHED_DELAYED;
+         pacer->pa_next_sched = 0;
+-        pacer->pa_last_delayed = 0;
+         LSQ_DEBUG("%s: tokens: %u", __func__, pacer->pa_burst_tokens);
+         return;
+     }
+ 
+-    sched_time = pacer->pa_now;
+     delay = tx_time(tx_ctx);
+     if (pacer->pa_flags & PA_LAST_SCHED_DELAYED)
+     {
+         pacer->pa_next_sched += delay;
+-        app_limited = pacer->pa_last_delayed != 0
+-            && pacer->pa_last_delayed + delay <= sched_time;
+         making_up = pacer->pa_next_sched <= sched_time;
+-        LSQ_DEBUG("making up: %d; app limited; %d", making_up, app_limited);
+-        if (making_up && !app_limited)
+-            pacer->pa_last_delayed = sched_time;
+-        else
+-        {
++        LSQ_DEBUG("making up: %d", making_up);
++        if (!making_up)
+             pacer->pa_flags &= ~PA_LAST_SCHED_DELAYED;
+-            pacer->pa_last_delayed = 0;
+-        }
+     }
+     else
+         pacer->pa_next_sched = MAX(pacer->pa_next_sched + delay,
+                                                     sched_time + delay);
+-    LSQ_DEBUG("next_sched is set to %"PRIu64" usec from now",
+-                                pacer->pa_next_sched - pacer->pa_now);
++    LSQ_DEBUG("next_sched is set to %"PRId64" usec from now",
++                    (int64_t) (pacer->pa_next_sched - pacer->pa_now));
+ }
+ 
+ 
+@@ -147,22 +169,37 @@
+ lsquic_pacer_tick_in (struct pacer *pacer, lsquic_time_t now)
+ {
+     assert(now >= pacer->pa_now);
++    pacer->pa_prev_tick = pacer->pa_now;
+     pacer->pa_now = now;
+-    if (pacer->pa_flags & PA_LAST_SCHED_DELAYED)
+-        pacer->pa_flags |= PA_DELAYED_ON_TICK_IN;
+-    pacer->pa_n_scheduled = 0;
++    /* The schedule cannot lag behind the ticks on which the connection last
++     * sent: it is owed the time it has been held back since, not the time it
++     * spent waiting on the congestion window before that (or the credit would
++     * grow without bound on a window-limited connection and come out as a
++     * burst).
++     */
++    if ((pacer->pa_flags & PA_LAST_SCHED_DELAYED)
++                        && pacer->pa_next_sched < pacer->pa_credit_since)
++    {
++        LSQ_DEBUG("credit bounded to %"PRIu64" usec",
++                                            now - pacer->pa_credit_since);
++        pacer->pa_next_sched = pacer->pa_credit_since;
++    }
+ }
+ 
+ 
+ void
+-lsquic_pacer_tick_out (struct pacer *pacer)
++lsquic_pacer_tick_out (struct pacer *pacer, int cwnd_has_room)
+ {
+-    if ((pacer->pa_flags & PA_DELAYED_ON_TICK_IN)
+-            && pacer->pa_n_scheduled == 0
+-                && pacer->pa_now > pacer->pa_next_sched)
++    /* The pacer would have let more go out and so would the congestion
++     * controller: the application had nothing more to send.  Drop the credit
++     * so that it does not come out as a burst when it has something again.
++     */
++    if ((pacer->pa_flags & PA_LAST_SCHED_DELAYED)
++            && pacer->pa_next_sched <= pacer->pa_now
++                && cwnd_has_room)
+     {
+-        LSQ_DEBUG("tick passed without scheduled packets: reset delayed flag");
++        LSQ_DEBUG("tick ended with pacer and cwnd open: app-limited, reset "
++                                                            "delayed flag");
+         pacer->pa_flags &= ~PA_LAST_SCHED_DELAYED;
+     }
+-    pacer->pa_flags &= ~PA_DELAYED_ON_TICK_IN;
+ }
+--- a/src/liblsquic/lsquic_send_ctl.h
++++ b/src/liblsquic/lsquic_send_ctl.h
+@@ -329,12 +329,8 @@
+     (ctl)->sc_flags &= ~SC_APP_LIMITED;
+ }
+ 
+-static inline void
+-lsquic_send_ctl_tick_out (lsquic_send_ctl_t *ctl)
+-{
+-    if ((ctl)->sc_flags & SC_PACE)
+-        lsquic_pacer_tick_out(&(ctl)->sc_pacer);
+-}
++void
++lsquic_send_ctl_tick_out (lsquic_send_ctl_t *ctl);
+ 
+ static inline lsquic_time_t
+ lsquic_send_ctl_next_pacer_time (lsquic_send_ctl_t *ctl)
+--- a/src/liblsquic/lsquic_send_ctl.c
++++ b/src/liblsquic/lsquic_send_ctl.c
+@@ -1862,6 +1862,15 @@
+ }
+ 
+ 
++void
++lsquic_send_ctl_tick_out (struct lsquic_send_ctl *ctl)
++{
++    if (ctl->sc_flags & SC_PACE)
++        lsquic_pacer_tick_out(&ctl->sc_pacer,
++            send_ctl_all_bytes_out(ctl) < ctl->sc_ci->cci_get_cwnd(CGP(ctl)));
++}
++
++
+ int
+ lsquic_send_ctl_pacer_blocked (struct lsquic_send_ctl *ctl)
+ {

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -128,6 +128,12 @@ export const lsquic: Dependency = {
     // never be encrypted and the peer idled out instead of learning of the
     // close. Select the PNS by handshake progress, as ngtcp2 does.
     "patches/lsquic/connection-close-pns.patch",
+    // Cubic keeps its windows in unsigned long, 32 bits on Windows, and
+    // multiplied them unwidened: the pacing rate (cwnd * 10^6 / srtt) wrapped
+    // for every window, so Cubic connections on Windows were paced at a
+    // garbage rate (litespeedtech/lsquic#391). quic.c pins both engines to
+    // Cubic, so every HTTP/3 connection on Windows would hit it.
+    "patches/lsquic/cubic-llp64-overflow.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -134,6 +134,12 @@ export const lsquic: Dependency = {
     // garbage rate (litespeedtech/lsquic#391). quic.c pins both engines to
     // Cubic, so every HTTP/3 connection on Windows would hit it.
     "patches/lsquic/cubic-llp64-overflow.patch",
+    // The pacer assumes it is re-ticked about when it asked to be (~1 ms);
+    // Bun's engines are ticked from the event loop, so on a busy loop a tick
+    // arrives long after that with everything acked, and the pacer restarted
+    // from scratch (10 packets + 1 ms worth) instead of sending what the
+    // connection was owed. Let such a tick make up for the time it was held.
+    "patches/lsquic/pacer-late-tick-credit.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1305,32 +1305,50 @@ describe("Bun.serve HTTP/3 production", () => {
 // Both QUIC engines (Bun.serve's and the fetch client's) are only ticked from
 // an event loop, so every RTT lsquic measures includes whatever that loop ran
 // in between. quic.c pins the congestion controller to Cubic: lsquic's default
-// "adaptive" mode settles on BBRv1 for good as soon as a connection's early RTT
-// samples exceed 1.5 ms, and BBRv1 then models loop latency as the path. Its
-// window target is bandwidth x min RTT, where the "bandwidth" it can observe
-// on a busy loop is one window per loop iteration and the min RTT is whatever
-// the quickest moment of the connection looked like, so once it leaves startup
-// the window shrinks round after round until it sits at the 4-packet minimum.
-// Cubic only reacts to loss, which a slow loop does not produce.
+// "adaptive" mode settles on BBRv1 for good when a connection's handshake RTT
+// is over 1.5 ms, and BBRv1 then models loop latency as the path. Its window
+// target is bandwidth x min RTT, where the only bandwidth it can observe on a
+// busy loop is one window per loop iteration and the min RTT is the quickest
+// round trip the connection ever saw, so as soon as it leaves startup the
+// window drops to the 4-packet minimum and stays there. Cubic only reacts to
+// loss, which a slow loop does not produce.
 //
 // The fixture counts its own event loop iterations and paces them with
-// Bun.sleepSync: 5 ms per iteration while the connection is set up (so the
-// handshake RTTs that adaptive mode decides on are well over 1.5 ms), idle for
-// a moment once the transfer starts (so the controller's min RTT is the real
-// loopback RTT, as it would be for any connection that saw one quick round
-// trip), then 12 ms per iteration for ITERATIONS iterations. Only the second
-// half of those is asserted on, which leaves either controller ample rounds to
-// settle. Over those 60 iterations Cubic moves several MiB (it is bounded by
-// the receiver's UDP buffer: 3.5-7 MiB with Linux's 208 KiB default on a debug
-// build), a collapsed BBRv1 window moves ~7 KiB per iteration, 0.4-0.5 MiB.
+// Bun.sleepSync. It sleeps 5 ms per iteration while the connection is set up,
+// so adaptive mode would choose BBRv1; /quiet then stops the sleeping, and the
+// round trips made while the loop is idle give both engines a genuine loopback
+// RTT sample (any real connection has one from a quiet moment); the transfer
+// itself then runs with BUSY_ITERATION_MS of work per iteration for ITERATIONS
+// iterations. Only the second half of those is asserted on, which leaves
+// either controller ample rounds to settle.
+//
+// What a healthy connection moves per iteration is bounded by the receiver's
+// UDP buffer and by lsquic's pacer, which lets about ten packets plus one
+// millisecond's worth through per engine tick, so the numbers are modest but
+// far apart: over the measured 60 iterations a collapsed BBRv1 window moves
+// 5-6 packets per iteration, ~0.4 MiB in total, while Cubic moves several MiB
+// (4-13 MiB on Linux and Windows debug builds).
 describe("Bun.serve HTTP/3 congestion control", () => {
   const ITERATIONS = 120;
+  // Comfortably longer than the idle round trips even on a debug build, where
+  // they take 1-2 ms: once out of startup, each round multiplies BBRv1's window
+  // by about 2 x minRTT / iteration, so this has it at the minimum within a
+  // few rounds.
+  const BUSY_ITERATION_MS = 12;
   // Larger than any window either controller reaches here, so every tick is
   // limited by the congestion window, not by how much the application had
   // queued. (Application-limited rounds never let BBRv1 leave startup, which
   // is why a response made of small chunks does not show the collapse.)
   const CHUNK_SIZE = 512 * 1024;
   const MIN_SECOND_HALF_BYTES = 1024 * 1024;
+
+  // Two round trips: lsquic takes no bandwidth/RTT sample for a packet sent
+  // before the connection had its first acknowledgment
+  // (lsquic_bw_sampler_packet_acked), so the first one only primes the
+  // sampler and the second is the one the controller measures.
+  async function quietRoundTrips(port: number) {
+    for (let i = 0; i < 2; i++) await fetchH3(port, "/quiet").then(r => r.bytes());
+  }
 
   const script = `
     const tls = ${JSON.stringify(tls)};
@@ -1345,27 +1363,32 @@ describe("Bun.serve HTTP/3 congestion control", () => {
       if (busyMs) Bun.sleepSync(busyMs);
       setImmediate(spin);
     })();
-    function startTransfer() {
-      busyMs = 0;
-      setTimeout(() => { windowStart = iterations; busyMs = 12; }, 20);
+    function openWindow() {
+      windowStart = iterations;
+      busyMs = ${BUSY_ITERATION_MS};
     }
-    // Iterations since the busy window opened; negative before that.
-    const elapsed = () => iterations - windowStart;
-    const inSecondHalf = () => elapsed() >= ITERATIONS / 2;
+    const inSecondHalf = () => iterations - windowStart >= ITERATIONS / 2;
+    const windowClosed = () => iterations - windowStart >= ITERATIONS;
     let download = { chunks: 0, secondHalfChunks: 0 };
     const server = Bun.serve({
       port: 0, tls, http3: true, http1: false,
       async fetch(req) {
         const { pathname } = new URL(req.url);
+        if (pathname === "/quiet") {
+          busyMs = 0;
+          // A few packets' worth so the client acknowledges it right away
+          // instead of waiting out its delayed-ACK timer.
+          return new Response(Buffer.alloc(4096, "quiet"));
+        }
         if (pathname === "/download") {
-          startTransfer();
+          openWindow();
           download = { chunks: 0, secondHalfChunks: 0 };
           return new Response(new ReadableStream({
             // pull() runs once the previous chunk has been handed to lsquic in
             // full, so chunks pulled during the second half of the window are
-            // the chunks the connection actually moved during it (+-1).
+            // the chunks the connection moved during it (+-1).
             pull(ctrl) {
-              if (elapsed() >= ITERATIONS) return ctrl.close();
+              if (windowClosed()) return ctrl.close();
               download.chunks++;
               if (inSecondHalf()) download.secondHalfChunks++;
               ctrl.enqueue(CHUNK);
@@ -1374,10 +1397,10 @@ describe("Bun.serve HTTP/3 congestion control", () => {
         }
         if (pathname === "/download/stats") return Response.json(download);
         if (pathname === "/upload") {
-          startTransfer();
+          openWindow();
           let total = 0, secondHalf = 0;
           for await (const chunk of req.body) {
-            if (elapsed() >= ITERATIONS) break;
+            if (windowClosed()) break;
             total += chunk.length;
             if (inSecondHalf()) secondHalf += chunk.length;
           }
@@ -1393,6 +1416,7 @@ describe("Bun.serve HTTP/3 congestion control", () => {
 
   test("a response body keeps flowing while the server's event loop is busy", async () => {
     await withCustomServer(script, async port => {
+      await quietRoundTrips(port);
       const body = await fetchH3(port, "/download").then(r => r.bytes());
       const { chunks, secondHalfChunks } = (await fetchH3(port, "/download/stats").then(r => r.json())) as {
         chunks: number;
@@ -1407,20 +1431,23 @@ describe("Bun.serve HTTP/3 congestion control", () => {
   // server's loop delays every ACK, so its RTT samples are inflated the same way.
   test("a streamed request body keeps flowing while the server's event loop is busy", async () => {
     await withCustomServer(script, async port => {
+      await quietRoundTrips(port);
       const chunk = Buffer.alloc(CHUNK_SIZE, "cwnd");
       let responded = false;
+      let enqueued = 0;
       const res = await fetchH3(port, "/upload", {
         method: "POST",
         body: new ReadableStream({
           pull(ctrl) {
-            if (responded) ctrl.close();
-            else ctrl.enqueue(chunk);
+            if (responded) return ctrl.close();
+            enqueued++;
+            ctrl.enqueue(chunk);
           },
         }),
       });
       responded = true;
       const { total, secondHalf } = (await res.json()) as { total: number; secondHalf: number };
-      expect(total).toBeGreaterThanOrEqual(secondHalf);
+      expect(total).toBeLessThanOrEqual(enqueued * CHUNK_SIZE);
       expect(secondHalf).toBeGreaterThanOrEqual(MIN_SECOND_HALF_BYTES);
     });
   });

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1301,3 +1301,127 @@ describe("Bun.serve HTTP/3 production", () => {
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
 });
+
+// Both QUIC engines (Bun.serve's and the fetch client's) are only ticked from
+// an event loop, so every RTT lsquic measures includes whatever that loop ran
+// in between. quic.c pins the congestion controller to Cubic: lsquic's default
+// "adaptive" mode settles on BBRv1 for good as soon as a connection's early RTT
+// samples exceed 1.5 ms, and BBRv1 then models loop latency as the path. Its
+// window target is bandwidth x min RTT, where the "bandwidth" it can observe
+// on a busy loop is one window per loop iteration and the min RTT is whatever
+// the quickest moment of the connection looked like, so once it leaves startup
+// the window shrinks round after round until it sits at the 4-packet minimum.
+// Cubic only reacts to loss, which a slow loop does not produce.
+//
+// The fixture counts its own event loop iterations and paces them with
+// Bun.sleepSync: 5 ms per iteration while the connection is set up (so the
+// handshake RTTs that adaptive mode decides on are well over 1.5 ms), idle for
+// a moment once the transfer starts (so the controller's min RTT is the real
+// loopback RTT, as it would be for any connection that saw one quick round
+// trip), then 12 ms per iteration for ITERATIONS iterations. Only the second
+// half of those is asserted on, which leaves either controller ample rounds to
+// settle. Over those 60 iterations Cubic moves several MiB (it is bounded by
+// the receiver's UDP buffer: 3.5-7 MiB with Linux's 208 KiB default on a debug
+// build), a collapsed BBRv1 window moves ~7 KiB per iteration, 0.4-0.5 MiB.
+describe("Bun.serve HTTP/3 congestion control", () => {
+  const ITERATIONS = 120;
+  // Larger than any window either controller reaches here, so every tick is
+  // limited by the congestion window, not by how much the application had
+  // queued. (Application-limited rounds never let BBRv1 leave startup, which
+  // is why a response made of small chunks does not show the collapse.)
+  const CHUNK_SIZE = 512 * 1024;
+  const MIN_SECOND_HALF_BYTES = 1024 * 1024;
+
+  const script = `
+    const tls = ${JSON.stringify(tls)};
+    const ITERATIONS = ${ITERATIONS};
+    const CHUNK = Buffer.alloc(${CHUNK_SIZE}, "cwnd");
+    let busyMs = 5;
+    let iterations = 0;
+    let windowStart = Infinity;
+    (function spin() {
+      iterations++;
+      if (iterations >= windowStart + ITERATIONS) busyMs = 0;
+      if (busyMs) Bun.sleepSync(busyMs);
+      setImmediate(spin);
+    })();
+    function startTransfer() {
+      busyMs = 0;
+      setTimeout(() => { windowStart = iterations; busyMs = 12; }, 20);
+    }
+    // Iterations since the busy window opened; negative before that.
+    const elapsed = () => iterations - windowStart;
+    const inSecondHalf = () => elapsed() >= ITERATIONS / 2;
+    let download = { chunks: 0, secondHalfChunks: 0 };
+    const server = Bun.serve({
+      port: 0, tls, http3: true, http1: false,
+      async fetch(req) {
+        const { pathname } = new URL(req.url);
+        if (pathname === "/download") {
+          startTransfer();
+          download = { chunks: 0, secondHalfChunks: 0 };
+          return new Response(new ReadableStream({
+            // pull() runs once the previous chunk has been handed to lsquic in
+            // full, so chunks pulled during the second half of the window are
+            // the chunks the connection actually moved during it (+-1).
+            pull(ctrl) {
+              if (elapsed() >= ITERATIONS) return ctrl.close();
+              download.chunks++;
+              if (inSecondHalf()) download.secondHalfChunks++;
+              ctrl.enqueue(CHUNK);
+            },
+          }));
+        }
+        if (pathname === "/download/stats") return Response.json(download);
+        if (pathname === "/upload") {
+          startTransfer();
+          let total = 0, secondHalf = 0;
+          for await (const chunk of req.body) {
+            if (elapsed() >= ITERATIONS) break;
+            total += chunk.length;
+            if (inSecondHalf()) secondHalf += chunk.length;
+          }
+          return Response.json({ total, secondHalf });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    console.error("PORT=" + server.port);
+    process.stdin.on("data", () => {});
+    ${STOP_ON_STDIN_END}
+  `;
+
+  test("a response body keeps flowing while the server's event loop is busy", async () => {
+    await withCustomServer(script, async port => {
+      const body = await fetchH3(port, "/download").then(r => r.bytes());
+      const { chunks, secondHalfChunks } = (await fetchH3(port, "/download/stats").then(r => r.json())) as {
+        chunks: number;
+        secondHalfChunks: number;
+      };
+      expect(body.length).toBe(chunks * CHUNK_SIZE);
+      expect(secondHalfChunks * CHUNK_SIZE).toBeGreaterThanOrEqual(MIN_SECOND_HALF_BYTES);
+    });
+  });
+
+  // The fetch client's engine sees the same thing from the other side: the
+  // server's loop delays every ACK, so its RTT samples are inflated the same way.
+  test("a streamed request body keeps flowing while the server's event loop is busy", async () => {
+    await withCustomServer(script, async port => {
+      const chunk = Buffer.alloc(CHUNK_SIZE, "cwnd");
+      let responded = false;
+      const res = await fetchH3(port, "/upload", {
+        method: "POST",
+        body: new ReadableStream({
+          pull(ctrl) {
+            if (responded) ctrl.close();
+            else ctrl.enqueue(chunk);
+          },
+        }),
+      });
+      responded = true;
+      const { total, secondHalf } = (await res.json()) as { total: number; secondHalf: number };
+      expect(total).toBeGreaterThanOrEqual(secondHalf);
+      expect(secondHalf).toBeGreaterThanOrEqual(MIN_SECOND_HALF_BYTES);
+    });
+  });
+});

--- a/test/js/node/quic/busy-loop-pacer-fixture.ts
+++ b/test/js/node/quic/busy-loop-pacer-fixture.ts
@@ -1,0 +1,92 @@
+// Sends on one stream from a process whose event loop is busy, and reports
+// over IPC how much the session put on the wire during each loop iteration
+// next to the congestion window it had at the time. Spawned by
+// quic-endpoint.test.ts, which is the receiving end.
+//
+//   busy-loop-pacer-fixture.ts listen          send on the first stream the
+//                                              peer opens
+//   busy-loop-pacer-fixture.ts connect <port>  open a stream to the test's
+//                                              server and send on it
+//
+// Each iteration blocks the thread for BUSY_MS, so the engine is ticked once
+// per iteration, long after the pacer wanted it to be, and by then everything
+// sent the previous iteration has been acknowledged. What such a tick is
+// allowed to send is the pacer's decision; the window (Cubic, which only
+// reacts to loss, so it is wide open here) is what it should be allowed.
+//
+// Running out of data legitimately ends an iteration early, so the chunks the
+// body is made of are never less than several windows' worth, however large
+// the window gets on the machine running this, which keeps the iterations
+// spent running out and refilling a small minority. (The chunks are not simply
+// huge because node:quic's outbound path copies what is left of a chunk on
+// every write, so feeding it a very large one stalls the loop noticeably; the
+// iteration that refills already runs long, and the test counts it as at most
+// one window's worth.)
+import { createPrivateKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { connect, listen } from "node:quic";
+
+const keysDir = join(import.meta.dir, "..", "test", "fixtures", "keys");
+const key = createPrivateKey(readFileSync(join(keysDir, "agent1-key.pem")));
+const cert = readFileSync(join(keysDir, "agent1-cert.pem"));
+
+const ITERATIONS = 40;
+// Long enough that the receiving test process has acknowledged an entire
+// window's worth well before the next tick even on a slow debug build, so
+// what a tick sends is down to the pacer and not to ACKs still on their way.
+const BUSY_MS = 20;
+const CHUNK_WINDOWS = 8;
+const MIN_CHUNK = 2 * 1024 * 1024;
+
+const [mode, portArg] = process.argv.slice(2);
+const cc = "cubic";
+
+let session: Awaited<ReturnType<typeof connect>>;
+let iterations = 0;
+// One entry per iteration boundary: the session's cumulative bytes sent and
+// its window at that moment. Consecutive entries bracket one busy iteration.
+const samples: { sent: number; cwnd: number }[] = [];
+
+function spin() {
+  const stats = session.stats;
+  samples.push({ sent: Number(stats.bytesSent), cwnd: Number(stats.cwnd) });
+  if (iterations++ === ITERATIONS) {
+    process.send!({ samples });
+    // Graceful: chunks() returns on its next pull, the stream ends with a FIN
+    // and the CONNECTION_CLOSE that follows lets the test's side finish too.
+    session.close();
+    return;
+  }
+  Bun.sleepSync(BUSY_MS);
+  setImmediate(spin);
+}
+
+async function* chunks() {
+  setImmediate(spin);
+  while (iterations <= ITERATIONS) {
+    yield Buffer.alloc(Math.max(MIN_CHUNK, CHUNK_WINDOWS * Number(session.stats.cwnd)), "pace");
+  }
+}
+
+function sendOn(stream: Awaited<ReturnType<typeof session.createBidirectionalStream>>) {
+  stream.closed.catch(() => {});
+  stream.setBody(chunks());
+}
+
+if (mode === "listen") {
+  const endpoint = await listen(
+    s => {
+      session = s;
+      s.closed.catch(() => {});
+      s.onstream = sendOn;
+    },
+    { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"], cc },
+  );
+  process.send!({ port: endpoint.address.port });
+} else {
+  session = await connect(`127.0.0.1:${portArg}`, { alpn: "quic-test", verifyPeer: "manual", cc });
+  session.closed.catch(() => {});
+  await session.opened;
+  sendOn(await session.createBidirectionalStream());
+}

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -310,3 +310,133 @@ describe("endpoint.close() while a session is live", () => {
     expect({ announced, resolved }).toEqual({ announced: 1, resolved: true });
   });
 });
+
+// lsquic's pacer expects to be ticked about when it asks to be (it lets a
+// connection run one clock granularity, 1 ms, ahead of its schedule and has
+// the engine wake it up then). Bun's engines are ticked from the event loop,
+// so on a busy loop the next tick comes whenever JS is done, by which time
+// everything in flight has been acknowledged. The pacer used to take that as a
+// restart, hand out its ten burst tokens and then let through one more
+// millisecond's worth, so however wide the window was, an iteration of a busy
+// loop moved ten packets plus a sliver of it: a tenth to a fifth of the window
+// here. The pacer-late-tick-credit vendor patch lets such a tick send what was
+// due since the last one, which on a busy loop is the window.
+//
+// busy-loop-pacer-fixture.ts samples the session's bytes sent and window at
+// every iteration boundary of its busy loop; asserted on is the share of its
+// window that an iteration of the second half moved, on average. Debug builds
+// measure about 0.9 on Linux and 0.75 to 0.9 on Windows with the patch and
+// 0.1 to 0.25 without it, for both engines (listen() builds one, connect() the
+// other). What keeps the patched figure below 1 is the sender running out of
+// data every so often (the fixture sizes its chunks to last a good many
+// iterations, and refilling costs it an iteration or two each time) and, on
+// Windows, the occasional iteration whose ACKs get processed over more than
+// the two ticks the patch credits a late tick back to.
+//
+// This needs Cubic's pacing rate to be sane, which on Windows it is not without
+// the cubic-llp64-overflow patch (the rate wraps in 32-bit arithmetic): paced
+// at that rate a busy connection moves about 1 KiB per iteration here.
+describe.concurrent("pacing on a busy event loop", () => {
+  const MIN_MEAN_WINDOW_SHARE = 0.4;
+  const fixture = join(import.meta.dir, "busy-loop-pacer-fixture.ts");
+  type Sample = { sent: number; cwnd: number };
+  type Report = { samples: Sample[] };
+
+  // Mean, over the iterations of the second half, of the share of its window
+  // each iteration moved. An iteration counts for at most one window: the one
+  // in which the sender refills its data takes longer than the others (see
+  // the fixture) and moves more, and must not make up for the rest.
+  function meanWindowShareMoved({ samples }: Report) {
+    const secondHalf = samples.slice(Math.floor(samples.length / 2));
+    let total = 0;
+    for (let i = 1; i < secondHalf.length; i++) {
+      total += Math.min(1, (secondHalf[i].sent - secondHalf[i - 1].sent) / secondHalf[i - 1].cwnd);
+    }
+    return total / (secondHalf.length - 1);
+  }
+
+  // The receiving side has to keep reading, or flow control rather than the
+  // pacer would be what limits the sender.
+  async function drain(stream: any) {
+    for await (const _ of stream);
+  }
+
+  function spawnSender(args: string[]) {
+    const port = Promise.withResolvers<number>();
+    const report = Promise.withResolvers<Report>();
+    const proc = Bun.spawn({
+      cmd: [bunExe(), fixture, ...args],
+      env: bunEnv,
+      stderr: "pipe",
+      ipc(message: { port: number } | Report) {
+        if ("port" in message) port.resolve(message.port);
+        else report.resolve(message);
+      },
+    });
+    // A fixture that dies early fails the test instead of hanging it.
+    const died = proc.exited.then(async code => {
+      throw new Error(`fixture exited with code ${code} before reporting:\n${await proc.stderr.text()}`);
+    });
+    died.catch(() => {});
+    return {
+      proc,
+      port: () => Promise.race([port.promise, died]),
+      report: () => Promise.race([report.promise, died]),
+    };
+  }
+
+  // Debug builds spend about two seconds just loading node:quic in the
+  // fixture, and the busy loop itself runs for over a second.
+  const TIMEOUT = 30_000;
+
+  test(
+    "a busy server session (listen engine) sends a window per loop iteration",
+    async () => {
+      const sender = spawnSender(["listen"]);
+      await using _proc = sender.proc;
+      const client = await connect(`127.0.0.1:${await sender.port()}`, { alpn: "quic-test", verifyPeer: "manual" });
+      const closed = client.closed.then(
+        () => {},
+        () => {},
+      );
+      await client.opened;
+      // A stream only reaches the peer once something is sent on it.
+      const stream = await client.createBidirectionalStream({ body: "go" });
+      stream.closed.catch(() => {});
+      const draining = drain(stream);
+      const report = await sender.report();
+      await draining;
+      await closed;
+      expect(meanWindowShareMoved(report)).toBeGreaterThanOrEqual(MIN_MEAN_WINDOW_SHARE);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a busy client session (connect engine) sends a window per loop iteration",
+    async () => {
+      const closed = Promise.withResolvers<void>();
+      const draining = Promise.withResolvers<Promise<void>>();
+      await using server = await listen(
+        (s: any) => {
+          s.closed.then(closed.resolve, closed.resolve);
+          s.onstream = (stream: any) => {
+            stream.closed.catch(() => {});
+            // Nothing to send back. Ending this side is what lets the fixture's
+            // stream, and so its graceful session close, finish.
+            stream.setBody(null);
+            draining.resolve(drain(stream));
+          };
+        },
+        { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"] },
+      );
+      const sender = spawnSender(["connect", String(server.address.port)]);
+      await using _proc = sender.proc;
+      const report = await sender.report();
+      await draining.promise;
+      await closed.promise;
+      expect(meanWindowShareMoved(report)).toBeGreaterThanOrEqual(MIN_MEAN_WINDOW_SHARE);
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
> Stacked on #37455: the first three commits here are that PR, and this one should land after it. Its `cubic-llp64-overflow` fix is a prerequisite for this change, not just for its tests (see "Windows" under Verification).

### Problem

A QUIC connection sending from a process whose event loop is busy moves far less per loop iteration than its congestion window allows, even with Cubic and a wide open window. `BUN_DEBUG_lsquic=1` on such a process shows, tick after tick:

```
pacer: lsquic_pacer_packet_scheduled: replenish tokens: 10
pacer: lsquic_pacer_packet_scheduled: tokens: 9
...
pacer: next_sched is set to 108 usec from now
pacer: next_sched is set to 216 usec from now
...
pacer: lsquic_pacer_can_schedule: 0
```

i.e. ten burst tokens, then about one millisecond's worth at the pacing rate, then nothing until the next tick, however large the window is. Measured with the new fixture (a `node:quic` sender blocking its loop for 20 ms per iteration, `cc: "cubic"`, reporting `stats.bytesSent` and `stats.cwnd` at every iteration boundary), on a Linux debug build, bytes moved per iteration / window at the start of it, second half of the run:

```
listen engine:   30/270 30/270 30/270 30/270 31/270 ...   (mean share of the window: 0.12 to 0.22)
connect engine:  28/224 28/224 28/224 28/224 28/224 ...   (0.12 to 0.17)
```

The HTTP/3 server (`Bun.serve({ http3 })`) is affected on about every other tick: its driver also ticks the engine before reading the iteration's ACKs (`us_internal_loop_pre`), and that tick still has packets in flight so it does make up, which is why its busy-loop numbers in #37455 come out at roughly half a window per iteration. Seen from a client receiving a large static body from a server sleeping 12 ms per iteration (with #37455's Cubic change applied locally), the per-iteration bursts were bimodal: a window (115 to 145 KiB) on some iterations and 15 to 19 KiB (10 packets plus 1 ms worth) on 7 to 35 % of them depending on the run; with this change every iteration moved 109 to 130 KiB.

### Cause

lsquic's pacer is a port of Chromium's `PacingSender` and assumes it is re-ticked about when it asks to be: when it blocks a packet it sets `PA_LAST_SCHED_DELAYED`, the engine wakes the connection at `pa_next_sched` (about `es_clock_granularity`, 1 ms, later), and the "making up for lost time" branch only ever has timer slop to cover. Bun's engines are ticked from the event loop, so the next tick comes when JS is done, by which time everything in flight has been acknowledged, and two paths in `lsquic_pacer_packet_scheduled()` then discard the time the connection was held back for and restart pacing from now:

- `n_in_flight == 0` replenishes the burst tokens, and the token path resets `pa_next_sched` and clears the flag;
- in the making-up branch, `pa_last_delayed + delay <= now` is taken to mean application-limited, and any gap between two ticks satisfies it, so a making-up run never spans two ticks.

Whether a given tick hits one of these depends on whether the ACKs were read before it (`node:quic`'s driver: always; the h3 server's `loop_pre` tick: no, its `loop_post` tick: yes), which is where the every-tick vs. every-other-tick difference between the two drivers comes from.

### Fix

`patches/lsquic/pacer-late-tick-credit.patch` (the patch header has the full description):

- A connection the pacer has held back no longer gets the restart tokens, and the making-up branch runs until the schedule has caught up, so a late tick sends what was due since the previous one, at the pacing rate and within the window. On a busy loop that is the window (the pacing rate is `gain * cwnd / srtt` and the srtt of such a connection is about one loop iteration).
- `tick_in` bounds how far behind `now` the schedule may lag: to the tick before the last one that scheduled a packet. This is what keeps a promptly ticked connection paced: a window-limited transfer on an idle loop sends on every ACK, so it can hold at most a gap or two between ACKs' worth of credit, and a stretch ACK still gets roughly the same couple of packets plus one granularity's worth immediately and the rest paced, as before. The bound is the tick before the sending one, not the sending one itself, because both drivers tick a connection twice in a row, before and after reading the ACKs that arrived during the iteration: with the bound on the sending tick, the first tick of the pair finding a few packets of room left in the window cost the second one the whole iteration's credit (one iteration in three moved 12 to 28 KiB in the fixture; with the tick-before bound the series is flat).
- `tick_out` drops the credit when a tick ends with the window open and the connection not having used it, which is what application-limited actually looks like (an idle connection restarts with the burst tokens as before). `send_ctl` passes the window state in, so `lsquic_send_ctl_tick_out` moves out of the header. This replaces the old "a tick passed without scheduling anything" reset, which also fired on every tick a window-limited connection spent waiting for ACKs, i.e. exactly the ticks the credit is for; `pa_n_scheduled` and `PA_DELAYED_ON_TICK_IN` only served that reset and go away.
- `lsquic_pacer_delayed()`, which `ci_next_tick_time` and `send_ctl`'s app-limited checks are built on, now means the pacer is blocking right now (schedule in the future). With the flag kept across ticks it would otherwise have made the engine re-tick a connection waiting for ACKs continuously, since its schedule is in the past; as a side effect `send_ctl_could_send` now also reports a connection that ran out of data while it still had credit as app-limited to the congestion controller, which it is.

The congestion controller only enters through `cci_pacing_rate` (the `delay` per packet), exactly as before, so Cubic and BBRv1 connections go through the same pacer paths; the one CC-visible difference is that `send_ctl_could_send` now reports a connection that ran out of data while still holding credit as application-limited, which BBR's bandwidth sampler and Cubic's growth both want to know (before, such a connection was never reported as application-limited while the flag was set).

Nothing in Bun's own code changes: both h3 engines and `node:quic`'s engines share the pacer and all three drivers have the late-tick property, and an engine that is ticked promptly goes through exactly the same paths as before except for the slightly larger (bounded) credit noted above.

### Verification

New tests in `test/js/node/quic/quic-endpoint.test.ts` ("pacing on a busy event loop"), one per engine, with `busy-loop-pacer-fixture.ts` as the sender. The assertion is the mean, over the second half's iterations, of `min(1, bytes moved / window)` (an iteration counts for at most one window because the one that refills the sender's data runs long and moves more), required to be at least 0.4:

- with the patch registered: 0.88 to 0.97 over six runs per engine locally, the test file passes (`bun bd test test/js/node/quic/quic-endpoint.test.ts`, 9/9);
- with the patch line commented out of `lsquic.ts` and rebuilt: 0.22 (listen engine) and 0.17 (connect engine), both tests fail; six further runs of the fixture against that build measured 0.12 to 0.22.

The test uses `node:quic` rather than `Bun.serve` because it exposes per-session bytes sent and window, so the figure can be taken on the sending side at every iteration, and because it lets the test pin `cc: "cubic"` (both h3 engines currently leave lsquic's adaptive default, which picks BBRv1 on a busy loop; #37455 deals with that; this change does not depend on that part of it).

**Windows.** The first CI run failed both new tests on both Windows lanes with a mean share of 0.005 to 0.013, and a Windows debug build of this branch alone reproduces it: 1 to 10 KiB per iteration against a window of 150 to 240 KiB that keeps growing. That is the Cubic pacing-rate wrap #37455 fixes (`cu_cwnd * 1000000` in a 32-bit `unsigned long`, so the rate is a more or less random fraction of the real one and, since the window then grows while almost nothing is sent, gets re-rolled until it lands somewhere tiny and stays there). It also shows why that fix has to land first: before this change a busy Cubic connection on Windows still moved its ten burst tokens per tick whatever the rate said, and this change removes that floor, so on its own it would turn such a connection from slow into nearly stalled. Stacked on #37455 the same Windows build measures 0.73 to 0.91 over six runs across both engines (it sits a little below Linux because an iteration's ACKs are occasionally processed over more than the two ticks the credit bound reaches back to, which costs that iteration; noted in the test).

Also passing on this build: `serve-http3.test.ts`, `quic-stream.test.ts`, `quic-sni.test.ts` (56), `fetch-http3-client.test.ts`, `serve-protocols.test.ts` (73), and the node `test-quic-stream-bidi-large`, `writer-backpressure`, `stream-slow-consumer`, `flow-control-block-resume` and `h3-post-request` tests.

Not claimed: a throughput improvement for the busy h3 server on loopback. There, each full-window burst overruns the receiver's default UDP buffer, and the resulting losses hold the window at roughly what that buffer absorbs, so the totals of a busy transfer look similar before and after (what changes is that every iteration now moves that window instead of every other one); the buffer sizing is #37452.

While building the fixture I ran into two `node:quic` issues outside this change, both tracked separately: `drain_outbound` in `stream.rs` copies the whole remaining outbound buffer on every write, so a multi-MiB `setBody` chunk is fed quadratically, and while such a chunk is being fed a `setImmediate` loop in the same process stalls for 100 to 500 ms at a time. The fixture sidesteps both by keeping its chunks moderate, and the test by counting the refilling iteration as at most one window.
