### PR TITLE
sys(windows): dup() of a descriptor that is not open fails with EBADF instead of returning a process handle

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3956,13 +3956,22 @@ mod windows_impl {
         super::openat_windows_a(dir, path.as_bytes(), flags, mode)
     }
     pub fn dup(fd: Fd) -> Maybe<Fd> {
-        // DuplicateHandle on the underlying HANDLE.
+        // DuplicateHandle on the underlying HANDLE. A uv fd that is not open
+        // (and `Fd::INVALID`) decodes to INVALID_HANDLE_VALUE, which is the
+        // same value as the GetCurrentProcess() pseudo handle: DuplicateHandle
+        // accepts it and hands back a handle to this process instead of
+        // failing, so it has to be rejected before the call.
+        let source = fd.native();
+        if source == w::INVALID_HANDLE_VALUE {
+            return Err(Error::new(E::EBADF, Tag::dup).with_fd(fd));
+        }
         let process = w::kernel32::GetCurrentProcess();
         let mut target: w::HANDLE = core::ptr::null_mut();
+        // SAFETY: FFI; `target` is valid for the write.
         let out = unsafe {
             w::kernel32::DuplicateHandle(
                 process,
-                fd.native() as w::HANDLE,
+                source,
                 process,
                 &mut target,
                 0,

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -219,6 +219,48 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
     expect(await res.text()).toBe("ok");
     expect(res.status).toBe(200);
     expect({ contentLength, received }).toEqual({ contentLength: String(fileSize - 10), received: fileSize - 10 });
+  });
+});
+
+// An fd-backed body is dup()ed before it is read. On Windows a descriptor that
+// is not open used to be reported as EMFILE: it maps to INVALID_HANDLE_VALUE,
+// which DuplicateHandle accepts as the current-process pseudo handle.
+describe.concurrent("Bun.file(fd) body whose descriptor is not open", () => {
+  const dupSyscall = isWindows ? "dup" : "fcntl";
+
+  test("descriptor that was never opened rejects with EBADF", async () => {
+    const fd = 1 << 20;
+    const promise = fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(fd) });
+    // The body fails before anything is connected.
+    expect(Bun.peek.status(promise)).toBe("rejected");
+    await expect(promise).rejects.toMatchObject({ code: "EBADF", syscall: dupSyscall, fd });
+  });
+
+  test("descriptor that was closed rejects with EBADF", async () => {
+    // A fresh process, so nothing can reuse the number between close and fetch.
+    using dir = tempDir("fetch-closed-fd-body", { "upload.txt": "hello" });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { openSync, closeSync } = require("fs");
+        const fd = openSync("upload.txt", "r");
+        closeSync(fd);
+        fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(fd) }).then(
+          () => console.log(JSON.stringify({ resolved: true })),
+          err => console.log(JSON.stringify({ code: err.code, syscall: err.syscall, fdMatches: err.fd === fd })),
+        );
+        `,
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ code: "EBADF", syscall: dupSyscall, fdMatches: true });
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/util/bun-file-fd-read.test.ts
+++ b/test/js/bun/util/bun-file-fd-read.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { closeSync, openSync } from "fs";
-import { isWindows, tempDir } from "harness";
+import { closeSync, openSync, readFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Reading a Bun.file() backed by a file descriptor goes through
@@ -48,5 +48,64 @@ describe.skipIf(isWindows)("Bun.file(fd) read", () => {
 
     expect(await withFd(path, fd => Bun.file(fd).text())).toBe("");
     expect((await withFd(path, fd => Bun.file(fd).arrayBuffer())).byteLength).toBe(0);
+  });
+});
+
+// stream() dup()s the descriptor when the stream starts. On Windows a
+// descriptor that is not open used to be reported as EMFILE: it maps to
+// INVALID_HANDLE_VALUE, which DuplicateHandle accepts as the current-process
+// pseudo handle.
+describe.concurrent("Bun.file(fd).stream() on a descriptor that is not open", () => {
+  const dupSyscall = isWindows ? "dup" : "fcntl";
+
+  test("descriptor that was never opened fails with EBADF", async () => {
+    const fd = 1 << 20;
+    let error: unknown;
+    try {
+      await Bun.file(fd).stream().text();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toMatchObject({ code: "EBADF", syscall: dupSyscall, fd });
+  });
+
+  test("descriptor that was closed fails with EBADF", async () => {
+    // A fresh process, so nothing can reuse the number between close and stream().
+    using dir = tempDir("bun-file-closed-fd-stream", { "fd-closed.txt": "hello" });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { openSync, closeSync } = require("fs");
+        const fd = openSync("fd-closed.txt", "r");
+        closeSync(fd);
+        try {
+          await Bun.file(fd).stream().text();
+          console.log(JSON.stringify({ resolved: true }));
+        } catch (err) {
+          console.log(JSON.stringify({ code: err.code, syscall: err.syscall, fdMatches: err.fd === fd }));
+        }
+        `,
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ code: "EBADF", syscall: dupSyscall, fdMatches: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test("descriptor that is open still streams", async () => {
+    // This file rather than a tempDir: the stream closes its copy of the
+    // descriptor asynchronously, which would race the directory removal.
+    const fd = openSync(import.meta.path, "r");
+    try {
+      expect(await Bun.file(fd).stream().text()).toBe(readFileSync(import.meta.path, "utf8"));
+    } finally {
+      closeSync(fd);
+    }
   });
 });


### PR DESCRIPTION
## Problem

On Windows, using a descriptor number that is not open with an API that duplicates it reports `EMFILE` instead of `EBADF`:

```js
await fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(1 << 20) });
// Windows: EMFILE: too many open files, open      { code: "EMFILE", syscall: "open" }
// Linux:   EBADF: bad file descriptor, fcntl       { code: "EBADF", syscall: "fcntl", fd: 1048576 }

await Bun.file(1 << 20).stream().text();
// Windows: EMFILE: too many open files, dup       { code: "EMFILE", syscall: "dup" }
// Linux:   EBADF: bad file descriptor, fcntl       { code: "EBADF", syscall: "fcntl", fd: 1048576 }
```

Same result for a descriptor that was opened with `fs.openSync()` and then closed. Reproduced on Windows x64 with `bun 1.4.0-canary` (da3851e57); `Bun.file(fd).text()`, which does not dup, already reports `EBADF` on both platforms.

## Cause

The Windows `bun_sys::dup` (`src/sys/lib.rs`) passes `fd.native()` straight to `DuplicateHandle`. For a libuv-kind fd (which is what every JS-visible fd is on Windows) `native()` goes through `uv_get_osfhandle`, which returns `INVALID_HANDLE_VALUE` for an index that is not open; `Fd::INVALID` decodes to the same value. `INVALID_HANDLE_VALUE` is `(HANDLE)-1`, which is also the pseudo handle `GetCurrentProcess()` returns, and `DuplicateHandle` explicitly accepts a pseudo handle as its source: it returns a real handle to the current process. So `dup()` succeeded and returned a process handle. The failure only surfaced when the caller tried to turn that handle into a CRT fd (`make_lib_uv_owned`, in `node_fs` `read_file_with_options` for fetch and in `FileReader::open_file_blob` for `stream()`); both of those sites report any `_open_osfhandle` failure as a hard-coded `EMFILE`.

Every other kernel32/ntdll call we make on `INVALID_HANDLE_VALUE` fails with `ERROR_INVALID_HANDLE` (which maps to `EBADF`); `DuplicateHandle` is the one call where the value is meaningful, so the check belongs in `dup()` itself rather than at its callers. The posix `dup` (`fcntl(F_DUPFD_CLOEXEC)`) fails with `EBADF` for the same input, and the Windows arm already tags its errors with `Tag::dup` and the fd, so the result is the same error shape on both platforms apart from the syscall name (`dup` vs `fcntl`):

```
EBADF: bad file descriptor, dup   { code: "EBADF", syscall: "dup", fd: 1048576 }
```

## Fix

`dup()` on Windows returns `EBADF` (with the fd attached) when the fd decodes to `INVALID_HANDLE_VALUE`, before calling `DuplicateHandle`. Valid fds are unaffected; the other Windows callers of `dup()` (the shell's dup of stdio and of the cwd handle) only ever pass open handles and keep working (checked `echo`, subshells and pipelines with stdio inherited and ignored).

## Tests

- `test/js/bun/http/fetch-file-upload.test.ts`: `fetch()` with a `Bun.file(fd)` body rejects with `EBADF` from the dup for a never-opened descriptor and for one that was closed (the latter in a child process so the number cannot be reused in between).
- `test/js/bun/util/bun-file-fd-read.test.ts`: the same two cases for `Bun.file(fd).stream()`, plus a check that an open descriptor still streams.

The assertions are the same on every platform (`code: "EBADF"`, `fd`, and the syscall the error comes from), so on POSIX, where the behaviour was already right, they only guard parity.

Windows x64, release canary without the fix: the four negative tests fail (`EMFILE` received, `EBADF` expected); the positive one passes. Windows x64, debug build with the fix: both files pass (16 pass, 3 pre-existing Windows skips). Linux debug (ASAN): both files pass; since the bug is Windows-only, the new tests pass on Linux with and without the change.

Related, not overlapping: #37501 changes the class of the fetch body rejection (and leaves the Windows errno alone), #37509 fixes the CRT fd slot that the same fetch path leaks for a valid fd on Windows. Both compose with this change.
