### PR TITLE
bake: own StaticRoute and HTMLBundleRoute refs via Drop types

### DIFF
--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1118,6 +1118,11 @@ pub struct OccupiedEntry<'a, K, V, C, A: MapAllocator = Global> {
 }
 
 impl<'a, K, V, C, A: MapAllocator> OccupiedEntry<'a, K, V, C, A> {
+    /// Position of the entry in `keys()` / `values()` (indexmap parity).
+    #[inline]
+    pub fn index(&self) -> usize {
+        self.idx
+    }
     #[inline]
     pub fn get(&self) -> &V {
         &self.map.values[self.idx]
@@ -1139,6 +1144,11 @@ pub struct VacantEntry<'a, K, V, C, A: MapAllocator = Global> {
 }
 
 impl<'a, K, V, C, A: MapAllocator> VacantEntry<'a, K, V, C, A> {
+    /// Position [`insert`](Self::insert) will append the entry at (indexmap parity).
+    #[inline]
+    pub fn index(&self) -> usize {
+        self.map.keys.len()
+    }
     pub fn insert(self, value: V) -> &'a mut V {
         let i = self.map.push_entry(self.key, value, self.hash);
         &mut self.map.values[i]
@@ -2098,6 +2108,28 @@ mod index_tests {
         let gop = m.get_or_put(2654435761).unwrap();
         assert!(gop.found_existing);
         assert_eq!(*gop.value_ptr, 1);
+    }
+
+    #[test]
+    fn entry_index_matches_entry_position() {
+        let mut m: ArrayHashMap<u64, u64> = ArrayHashMap::new();
+        // Past INDEX_THRESHOLD so both the linear and the indexed lookup run.
+        for i in 0..32u64 {
+            let MapEntry::Vacant(v) = m.entry(i * 7) else {
+                panic!("fresh key must be vacant");
+            };
+            assert_eq!(v.index(), i as usize);
+            v.insert(i);
+            assert_eq!(m.keys()[i as usize], i * 7);
+        }
+        for i in 0..32u64 {
+            let MapEntry::Occupied(o) = m.entry(i * 7) else {
+                panic!("inserted key must be occupied");
+            };
+            assert_eq!(o.index(), i as usize);
+            assert_eq!(m.values()[i as usize], i);
+        }
+        assert!(matches!(m.entry(1), MapEntry::Vacant(v) if v.index() == 32));
     }
 
     #[test]

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1196,23 +1196,6 @@ impl Drop for DevServer {
         }
         self.bundler_framework_views.clear();
 
-        for rb in &mut self.route_bundles {
-            if let Some(bundle) = rb.client_bundle.take() {
-                // SAFETY: stored ref from `StaticRoute::init_*`; no live borrow.
-                unsafe { StaticRoute::deref_(bundle.as_ptr()) };
-            }
-            if let route_bundle::Data::Html(html) = &mut rb.data {
-                if let Some(cached) = html.cached_response.take() {
-                    // SAFETY: stored ref from `init_from_any_blob`; no live borrow.
-                    unsafe { StaticRoute::deref_(cached.as_ptr()) };
-                }
-                // SAFETY: paired with the `ref_` taken in
-                // `get_or_put_route_bundle` when this bundle was created; the
-                // raw `html_bundle` field has no Drop, so release it here.
-                unsafe { bun_ptr::RefCount::<HTMLBundleRoute>::deref(html.html_bundle) };
-            }
-        }
-
         debug_assert!(self.magic == Magic::Valid);
         // self.magic = undefined — no Rust equivalent; freed memory.
     }
@@ -1775,7 +1758,7 @@ fn on_js_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
                 Ok(b) => b,
                 Err(e) => bun_core::handle_oom(Err(e)),
             };
-        let response = StaticRoute::init_from_any_blob(
+        let response = route_bundle::StaticRouteRef::init_from_any_blob(
             crate::webcore::blob::Any::from_array_list(json_bytes),
             crate::server::static_route::InitFromBytesOptions {
                 server: dev.server,
@@ -1783,10 +1766,8 @@ fn on_js_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
                 ..Default::default()
             },
         );
-        // SAFETY: `init_from_any_blob` returns a fresh ref_count=1 box.
-        scopeguard::defer! { unsafe { StaticRoute::deref_(response) } };
-        // SAFETY: `response` is live until `_deref` runs after this returns.
-        unsafe { StaticRoute::on_request(response, bun_uws::AnyRequest::H1(req), resp) };
+        // SAFETY: `response` holds a ref for the duration of the call.
+        unsafe { StaticRoute::on_request(response.as_ptr(), bun_uws::AnyRequest::H1(req), resp) };
         return;
     }
 
@@ -1826,8 +1807,8 @@ fn on_asset_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
         return not_found(resp);
     };
     req.set_yield(false);
-    // SAFETY: asset is a live `*mut StaticRoute` held by the content-addressable store
-    unsafe { StaticRoute::on(asset, resp) };
+    // SAFETY: `dev.assets` holds a ref on `asset` for as long as it is stored.
+    unsafe { StaticRoute::on(asset.as_ptr(), resp) };
 }
 
 pub(super) use bun_core::fmt::parse_hex_to_int;
@@ -2354,8 +2335,6 @@ fn check_route_failures(
 }
 
 impl DevServer {
-    // `&(...)` is deliberate — sidesteps dangerous_implicit_autorefs.
-    #[allow(clippy::needless_borrow)]
     fn append_route_entry_points_if_not_stale(
         &mut self,
         entry_points: &mut EntryPointList,
@@ -2403,9 +2382,10 @@ impl DevServer {
                 }
             }
             route_bundle::Data::Html(html) => {
-                // SAFETY: html_bundle is a live *mut HTMLBundleRoute (held strong by route_bundle::Html)
-                let bundle_path = unsafe { &(&(*html.html_bundle).bundle).path };
-                entry_points.append(bundle_path, entry_point_list::Flags::CLIENT)?;
+                entry_points.append(
+                    &html.html_bundle.bundle.path,
+                    entry_point_list::Flags::CLIENT,
+                )?;
             }
         }
 
@@ -2748,9 +2728,13 @@ impl DevServer {
             route_bundle::Data::Html(_)
         ));
 
-        // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in this fn.
-        let blob: *mut StaticRoute = match unsafe { (*route_bundle).data.html().cached_response } {
-            Some(b) => b.as_ptr(),
+        // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in
+        // this fn; the shared reborrow ends with this statement.
+        let cached: Option<*mut StaticRoute> =
+            unsafe { (*route_bundle).data.html().cached_response.as_ref() }
+                .map(route_bundle::StaticRouteRef::as_ptr);
+        let blob: *mut StaticRoute = match cached {
+            Some(blob) => blob,
             None => 'generate: {
                 // SAFETY: `generate_html_payload` reads `route_bundle.data` /
                 // `client_graph` and never reallocates `route_bundles`. No
@@ -2761,7 +2745,7 @@ impl DevServer {
                 }
                 .expect("oom");
 
-                let route_ptr = StaticRoute::init_from_any_blob(
+                let response = route_bundle::StaticRouteRef::init_from_any_blob(
                     crate::webcore::AnyBlob::from_owned_slice(payload),
                     crate::server::static_route::InitFromBytesOptions {
                         mime_type: Some(&MimeType::HTML),
@@ -2770,13 +2754,10 @@ impl DevServer {
                         ..Default::default()
                     },
                 );
+                let blob = response.as_ptr();
                 // SAFETY: per-access reborrow; no other `&` into `*route_bundle` live.
-                // `route_ptr` is the fresh heap-alloc'd StaticRoute (write provenance, non-null).
-                unsafe {
-                    (*route_bundle).data.html_mut().cached_response =
-                        Some(bun_ptr::BackRef::from_raw_mut(route_ptr))
-                };
-                break 'generate route_ptr;
+                unsafe { (*route_bundle).data.html_mut().cached_response = Some(response) };
+                break 'generate blob;
             }
         };
         // SAFETY: blob is a live boxed StaticRoute owned by html.cached_response
@@ -2800,8 +2781,6 @@ const SCRIPT_UNREF_PAYLOAD: &str = concat!(
 );
 
 impl DevServer {
-    // `&(...)` is deliberate — sidesteps dangerous_implicit_autorefs.
-    #[allow(clippy::needless_borrow)]
     fn generate_html_payload(
         &mut self,
         route_bundle_index: route_bundle::Index,
@@ -2812,10 +2791,7 @@ impl DevServer {
         // is read-only in this fn — `&RouteBundle` suffices.
         let html = route_bundle.data.html();
         debug_assert!(route_bundle.server_state == route_bundle::State::Loaded);
-        debug_assert!(
-            // SAFETY: `html_bundle` is a live `*mut HTMLBundleRoute` held strong by `route_bundle::Html`.
-            unsafe { (*html.html_bundle).dev_server_id.get() } == Some(route_bundle_index)
-        );
+        debug_assert!(html.html_bundle.dev_server_id.get() == Some(route_bundle_index));
         debug_assert!(html.cached_response.is_none());
         let script_injection_offset = html.script_injection_offset.unwrap().get_usize();
         let bundled_html = html.bundled_html_text.as_ref().unwrap();
@@ -2827,8 +2803,7 @@ impl DevServer {
         let after_head_end = &bundled_html[script_injection_offset..];
 
         let mut display_name = strings::without_suffix_comptime(
-            // SAFETY: html_bundle is a live *mut HTMLBundleRoute (held strong by route_bundle::Html)
-            paths::basename(unsafe { &(&(*html.html_bundle).bundle).path }),
+            paths::basename(&html.html_bundle.bundle.path),
             b".html",
         );
         // TODO: function for URL safe chars
@@ -2959,9 +2934,12 @@ impl DevServer {
         // immediately decays to a raw pointer.
         let route_bundle: *mut RouteBundle =
             unsafe { &mut *self_ptr }.route_bundle_ptr(bundle_index);
-        // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in this fn.
-        let client_bundle: *mut StaticRoute = match unsafe { (*route_bundle).client_bundle } {
-            Some(cb) => cb.as_ptr(),
+        // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in
+        // this fn; the shared reborrow ends with this statement.
+        let cached: Option<*mut StaticRoute> = unsafe { (*route_bundle).client_bundle.as_ref() }
+            .map(route_bundle::StaticRouteRef::as_ptr);
+        let client_bundle: *mut StaticRoute = match cached {
+            Some(client_bundle) => client_bundle,
             None => 'generate: {
                 // SAFETY: `generate_client_bundle` reads `*route_bundle` and
                 // never reallocates `route_bundles`; no `&mut` into
@@ -2969,7 +2947,7 @@ impl DevServer {
                 let payload =
                     unsafe { Self::generate_client_bundle(&mut *self_ptr, &*route_bundle) }
                         .expect("oom");
-                let route_ptr = StaticRoute::init_from_any_blob(
+                let bundle = route_bundle::StaticRouteRef::init_from_any_blob(
                     crate::webcore::AnyBlob::from_owned_slice(payload),
                     crate::server::static_route::InitFromBytesOptions {
                         mime_type: Some(&MimeType::JAVASCRIPT),
@@ -2978,13 +2956,10 @@ impl DevServer {
                         ..Default::default()
                     },
                 );
-                // SAFETY: per-access reborrow; `route_ptr` is the fresh
-                // heap-alloc'd StaticRoute (write provenance, non-null); the
-                // route bundle holds its counted ref.
-                unsafe {
-                    (*route_bundle).client_bundle = Some(bun_ptr::BackRef::from_raw_mut(route_ptr))
-                };
-                break 'generate route_ptr;
+                let client_bundle = bundle.as_ptr();
+                // SAFETY: per-access reborrow; no other `&` into `*route_bundle` live.
+                unsafe { (*route_bundle).client_bundle = Some(bundle) };
+                break 'generate client_bundle;
             }
         };
         // SAFETY: shared, statement-scoped read of `*route_bundle`.
@@ -4514,12 +4489,7 @@ pub(super) fn finalize_bundle(
                     route_bundle::Data::Framework(fw_bundle) => {
                         fw_bundle.cached_css_file_array.clear_without_deallocation()
                     }
-                    route_bundle::Data::Html(html) => {
-                        if let Some(blob) = html.cached_response.take() {
-                            // Arc<StaticRoute> drop = .deref()
-                            let _ = blob;
-                        }
-                    }
+                    route_bundle::Data::Html(html) => html.cached_response = None,
                 }
             }
             // SAFETY: statement-scoped read; no `&mut` into `*route_bundle` is live.
@@ -4569,8 +4539,7 @@ pub(super) fn finalize_bundle(
                 let n = bun_core::fmt::bytes_to_hex_lower(&content_hash.to_ne_bytes(), &mut hex);
                 w_all!(&hex[..n]);
                 let css_data: &[u8] = match dev.assets.get(content_hash) {
-                    // SAFETY: pointer is a live intrusively-refcounted `StaticRoute` held by `dev.assets`.
-                    Some(route) => &unsafe { &*route }.blob.internal_blob().bytes,
+                    Some(route) => &route.blob.internal_blob().bytes,
                     None => b"",
                 };
                 w_int!(u32, u32::try_from(css_data.len()).expect("int cast"));
@@ -4806,11 +4775,7 @@ pub(super) fn finalize_bundle(
                     // / `dev.router` / `dev.server_graph` reads below stay disjoint.
                     break 'brk match &dev.route_bundles[route_bundle_index.get() as usize].data {
                         route_bundle::Data::Html(html) => {
-                            Some(dev.relative_path(
-                                &mut *buf,
-                                // SAFETY: `html_bundle` is held strong by `route_bundle::Html`; live here.
-                                &unsafe { &*html.html_bundle }.bundle.path,
-                            ))
+                            Some(dev.relative_path(&mut *buf, &html.html_bundle.bundle.path))
                         }
                         route_bundle::Data::Framework(fw) => 'file_name: {
                             let route = dev.router.route_ptr(fw.route_index);
@@ -5299,12 +5264,9 @@ impl DevServer {
                     let file = &mut self.client_graph.bundled_files.values_mut()
                         [incremental_graph_index.get() as usize];
                     file.html_route_bundle_index = Some(bundle_index);
-                    // Bump the intrusive refcount; matched by the
-                    // `html_bundle` deref in `DevServer`'s `Drop`.
-                    // SAFETY: `html` is a live IntrusiveRc-managed allocation.
-                    unsafe { bun_ptr::RefCount::<HTMLBundleRoute>::ref_(html) };
                     break 'brk route_bundle::Data::Html(route_bundle::Html {
-                        html_bundle: html,
+                        // SAFETY: `html` is a live IntrusiveRc-managed allocation.
+                        html_bundle: unsafe { bun_ptr::RefPtr::init_ref(html) },
                         bundled_file: incremental_graph_index,
                         script_injection_offset: None,
                         cached_response: None,

--- a/src/runtime/bake/dev_server/assets.rs
+++ b/src/runtime/bake/dev_server/assets.rs
@@ -1,12 +1,12 @@
 //! `DevServer.Assets` — content-addressable store on `/_bun/asset/{hash}.ext`.
 
-use bun_collections::{ArrayHashMap, StringArrayHashMap};
+use bun_collections::{ArrayHashMap, MapEntry, StringArrayHashMap};
 use bun_core::{fmt as bun_fmt, scoped_log};
 use bun_http::MimeType::MimeType;
 
 use super::memory_cost::{memory_cost_array_hash_map, memory_cost_array_list};
+use super::route_bundle::StaticRouteRef;
 use super::{ASSET_PREFIX, DevServer, FileKind, Magic};
-use crate::server::StaticRoute;
 use crate::server::static_route::InitFromBytesOptions;
 use crate::webcore::AnyBlob;
 
@@ -20,10 +20,8 @@ pub struct Assets {
     /// keys.
     pub(crate) path_map: StringArrayHashMap<EntryIndex>,
     /// Content-addressable store. Multiple paths can point to the same content
-    /// hash, tracked by `refs`. One ref held to each `StaticRoute` while stored
-    /// (`StaticRoute` is intrusively ref-counted).
-    // SAFETY: `*mut StaticRoute` is an intrusive RefPtr; `deref_()` on remove.
-    pub(crate) files: ArrayHashMap<u64, *mut StaticRoute>,
+    /// hash, tracked by `refs`.
+    pub(crate) files: ArrayHashMap<u64, StaticRouteRef>,
     /// Parallel to `files`. Never `0`.
     pub(crate) refs: Vec<u32>,
     /// When mutating `files`'s keys, the map must be reindexed to function.
@@ -104,19 +102,16 @@ impl Assets {
             // When there is one reference to the asset, the entry can be
             // replaced in-place with the new asset.
             if self.refs[entry_index.get_usize()] == 1 {
-                let prev = self.files.values()[entry_index.get_usize()];
-                // SAFETY: `prev` is a live intrusively-refcounted StaticRoute we hold one ref to.
-                unsafe { StaticRoute::deref_(prev) };
-
                 self.files.keys_mut()[entry_index.get_usize()] = content_hash;
-                self.files.values_mut()[entry_index.get_usize()] = StaticRoute::init_from_any_blob(
-                    contents,
-                    InitFromBytesOptions {
-                        mime_type: Some(mime_type),
-                        server,
-                        ..Default::default()
-                    },
-                );
+                self.files.values_mut()[entry_index.get_usize()] =
+                    StaticRouteRef::init_from_any_blob(
+                        contents,
+                        InitFromBytesOptions {
+                            mime_type: Some(mime_type),
+                            server,
+                            ..Default::default()
+                        },
+                    );
                 // `ArrayHashMap<u64, _>` keys the entry on the hash itself.
                 self.needs_reindex = true;
                 debug_assert_eq!(self.files.count(), self.refs.len());
@@ -128,23 +123,28 @@ impl Assets {
         }
 
         self.reindex_if_needed()?;
-        let file_index_gop = self.files.get_or_put(content_hash)?;
-        let file_index = file_index_gop.index;
-        if !file_index_gop.found_existing {
-            *file_index_gop.value_ptr = StaticRoute::init_from_any_blob(
-                contents,
-                InitFromBytesOptions {
-                    mime_type: Some(mime_type),
-                    server,
-                    ..Default::default()
-                },
-            );
-            self.refs.push(1);
-        } else {
-            self.refs[file_index] += 1;
-            // Release the owned blob on the duplicate-content path.
-            contents.detach();
-        }
+        let file_index = match self.files.entry(content_hash) {
+            MapEntry::Vacant(vacant) => {
+                let file_index = vacant.index();
+                vacant.insert(StaticRouteRef::init_from_any_blob(
+                    contents,
+                    InitFromBytesOptions {
+                        mime_type: Some(mime_type),
+                        server,
+                        ..Default::default()
+                    },
+                ));
+                self.refs.push(1);
+                file_index
+            }
+            MapEntry::Occupied(occupied) => {
+                let file_index = occupied.index();
+                self.refs[file_index] += 1;
+                // Release the owned blob on the duplicate-content path.
+                contents.detach();
+                file_index
+            }
+        };
         let entry = EntryIndex::init(u32::try_from(file_index).expect("int cast"));
         self.path_map.values_mut()[path_index] = entry;
         debug_assert_eq!(self.files.count(), self.refs.len());
@@ -155,8 +155,6 @@ impl Assets {
         debug_assert!(dec_count > 0);
         self.refs[index.get_usize()] -= dec_count;
         if self.refs[index.get_usize()] == 0 {
-            // SAFETY: value is a live intrusively-refcounted StaticRoute we hold one ref to.
-            unsafe { StaticRoute::deref_(self.files.values()[index.get_usize()]) };
             self.files.swap_remove_at(index.get_usize());
             self.refs.swap_remove(index.get_usize());
             // `swap_remove` moved the entry that was at the old last index into
@@ -194,10 +192,10 @@ impl Assets {
     }
 
     /// Look up a `StaticRoute` by content hash.
-    pub fn get(&self, content_hash: u64) -> Option<*mut StaticRoute> {
+    pub(crate) fn get(&self, content_hash: u64) -> Option<&StaticRouteRef> {
         debug_assert!(self.owner().magic == Magic::Valid);
         debug_assert_eq!(self.files.count(), self.refs.len());
-        self.files.get(&content_hash).copied()
+        self.files.get(&content_hash)
     }
 
     /// `Assets.memoryCost`.
@@ -205,23 +203,11 @@ impl Assets {
         let mut cost: usize = 0;
         // `StringArrayHashMap` derefs to its inner `ArrayHashMap<Box<[u8]>, V, _>`.
         cost += memory_cost_array_hash_map(&self.path_map);
-        for &blob in self.files.values() {
-            // SAFETY: every stored StaticRoute pointer is live while held in `files`.
-            cost += unsafe { (*blob).memory_cost() };
+        for blob in self.files.values() {
+            cost += blob.memory_cost();
         }
         cost += memory_cost_array_hash_map(&self.files);
         cost += memory_cost_array_list(&self.refs);
         cost
-    }
-}
-
-impl Drop for Assets {
-    fn drop(&mut self) {
-        // path_map/files/refs storage is freed by their own Drop; only the
-        // manual StaticRoute derefs remain.
-        for &blob in self.files.values() {
-            // SAFETY: we hold one ref to each stored StaticRoute; release it.
-            unsafe { StaticRoute::deref_(blob) };
-        }
     }
 }

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -5,7 +5,9 @@ use super::jsc;
 use super::serialized_failure::SerializedFailure;
 use super::source_map_store;
 use crate::bake::framework_router;
+use crate::server::static_route::InitFromBytesOptions;
 use crate::server::{StaticRoute, html_bundle::HTMLBundleRoute};
+use crate::webcore::AnyBlob;
 
 /// `bun.GenericIndex(u30, RouteBundle)`.
 pub enum RouteBundleMarker {}
@@ -33,22 +35,59 @@ pub struct Framework {
     pub(crate) evaluate_failure: Option<SerializedFailure>,
 }
 
+/// The one ref DevServer holds on a [`StaticRoute`] it built (client bundle,
+/// rendered HTML page, asset, source map response); released on drop. The
+/// `StaticRoute::on*` handlers take their own ref per in-flight response, so
+/// the route itself may outlive this handle.
+pub(crate) struct StaticRouteRef(bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>);
+
+impl StaticRouteRef {
+    pub(crate) fn init_from_any_blob(blob: AnyBlob, options: InitFromBytesOptions<'_>) -> Self {
+        let route = StaticRoute::init_from_any_blob(blob, options);
+        // SAFETY: `route` is the fresh `heap::into_raw` allocation (non-null,
+        // write provenance) carrying one ref, which this handle owns until
+        // `Drop` releases it, so the pointee outlives the `BackRef`.
+        Self(unsafe { bun_ptr::BackRef::from_raw_mut(route) })
+    }
+
+    /// For the `StaticRoute::on*` handlers, which take the route as the
+    /// `*mut` they register as uws userdata.
+    #[inline]
+    pub(crate) fn as_ptr(&self) -> *mut StaticRoute {
+        self.0.as_ptr()
+    }
+}
+
+impl core::ops::Deref for StaticRouteRef {
+    type Target = StaticRoute;
+    #[inline]
+    fn deref(&self) -> &StaticRoute {
+        self.0.get()
+    }
+}
+
+impl Drop for StaticRouteRef {
+    #[inline]
+    fn drop(&mut self) {
+        <StaticRoute as bun_ptr::CellRefCounted>::deref_nn(self.0.into());
+    }
+}
+
 pub struct Html {
-    /// SHARED (LIFETIMES.tsv): DevServer increments the route's intrusive
-    /// refcount via `.initRef(html)` when storing; `.deref()` on drop.
-    /// Stored as raw ptr because `HTMLBundleRoute` does not yet impl
-    /// `bun_ptr::RefCounted` (gated server-side).
-    // TODO: switch to bun_ptr::RefPtr<HTMLBundleRoute> once the RefCounted impl is real.
-    pub(crate) html_bundle: *mut HTMLBundleRoute,
+    /// Ref taken in `get_or_put_route_bundle`; `RefPtr` has no `Drop`, so
+    /// `Drop for Html` releases it.
+    pub(crate) html_bundle: bun_ptr::RefPtr<HTMLBundleRoute>,
     pub(crate) bundled_file: incremental_graph::ClientFileIndex,
     pub(crate) script_injection_offset: Option<ByteOffset>,
     pub(crate) bundled_html_text: Option<Box<[u8]>>,
-    /// SHARED (LIFETIMES.tsv): deinit calls `cached_response.deref()`.
-    /// Stored as [`BackRef`](bun_ptr::BackRef) — the slot holds an intrusive
-    /// ref (bumped at store time, released in `invalidate_client_bundle`/drop),
-    /// so while `Some` the pointee strictly outlives the field; readers go
-    /// through safe `Option::as_deref` (no raw `NonNull::as_ref`).
-    pub(crate) cached_response: Option<bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>>,
+    /// The rendered page, built on first request.
+    pub(crate) cached_response: Option<StaticRouteRef>,
+}
+
+impl Drop for Html {
+    fn drop(&mut self) {
+        self.html_bundle.deref();
+    }
 }
 
 pub enum Data {
@@ -88,12 +127,8 @@ impl RouteBundle {
         &mut self,
         source_maps: &mut source_map_store::SourceMapStore,
     ) {
-        if let Some(bundle) = self.client_bundle.take() {
+        if self.client_bundle.take().is_some() {
             source_maps.unref(self.source_map_id());
-            // SAFETY: `client_bundle` was produced by `StaticRoute::init_*`
-            // (heap::alloc) and has its own ref held by this struct; no
-            // outstanding `&`/`&mut` borrow exists across this call.
-            unsafe { StaticRoute::deref_(bundle.as_ptr()) };
         }
         self.client_script_generation = {
             let mut buf = [0u8; 4];
@@ -102,12 +137,7 @@ impl RouteBundle {
         };
         match &mut self.data {
             Data::Framework(fw) => fw.cached_client_bundle_url.clear_without_deallocation(),
-            Data::Html(html) => {
-                if let Some(cached) = html.cached_response.take() {
-                    // SAFETY: see `client_bundle` note above.
-                    unsafe { StaticRoute::deref_(cached.as_ptr()) };
-                }
-            }
+            Data::Html(html) => html.cached_response = None,
         }
     }
 }
@@ -126,12 +156,8 @@ pub(crate) enum UnresolvedIndex {
 pub struct RouteBundle {
     pub(crate) server_state: State,
     pub(crate) data: Data,
-    /// SHARED (LIFETIMES.tsv): deinit calls `blob.deref()`.
-    /// Stored as [`BackRef`](bun_ptr::BackRef) — the slot holds an intrusive
-    /// ref (bumped at store time, released in `invalidate_client_bundle`/drop),
-    /// so while `Some` the pointee strictly outlives the field; readers go
-    /// through safe `Option::as_deref` (no raw `NonNull::as_ref`).
-    pub(crate) client_bundle: Option<bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>>,
+    /// The route's client-side script, built on first request.
+    pub(crate) client_bundle: Option<StaticRouteRef>,
     pub(crate) client_script_generation: u32,
     pub(crate) active_viewers: u32,
 }
@@ -165,10 +191,3 @@ impl RouteBundle {
         cost
     }
 }
-
-// Zig `RouteBundle.deinit` equivalent, split across two mechanisms:
-//   - Drop: `Framework` StrongOptional fields (= .deinit()) and
-//     `Html.bundled_html_text` Box<[u8]> (= allocator.free()).
-//   - `DevServer`'s `Drop` (explicit): `client_bundle`, `Html.cached_response`
-//     (BackRef, no Drop) and `Html.html_bundle` (raw ptr, no Drop) each hold
-//     an intrusive ref that is deref'd there.


### PR DESCRIPTION
## What

DevServer keeps a +1 intrusive ref on every `StaticRoute` it builds (`RouteBundle.client_bundle`, `Html.cached_response`, the values of `Assets.files`, and a temporary for the `.js.map` response in `on_js_request`) and on the `HTMLBundleRoute` behind each HTML route bundle (`Html.html_bundle`). The slots were typed as non-owning pointers (`Option<BackRef<StaticRoute, Mut>>`, `*mut StaticRoute`, `*mut HTMLBundleRoute`), so each release was spelled out by hand: in `invalidate_client_bundle`, in `Assets::replace_path` / `unref_by_index` / `Drop for Assets`, in a `scopeguard::defer!` in `on_js_request`, and in a loop at the end of `Drop for DevServer`. Two sites in `finalize_bundle` took the `cached_response` handle out of its slot without releasing it (the HTML chunk loop, where `invalidate_client_bundle` then found the slot already empty, and the `had_adjusted_edges` loop, whose `let _ = blob;` released nothing because `BackRef` is `Copy` and has no `Drop`), so the rendered page leaked on every rebuild of an HTML route that had been served since its last invalidation.

```rust
// before (route_bundle.rs)
pub(crate) html_bundle: *mut HTMLBundleRoute,
pub(crate) cached_response: Option<bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>>,
pub(crate) client_bundle: Option<bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>>,
pub(crate) files: ArrayHashMap<u64, *mut StaticRoute>,           // assets.rs

// after
pub(crate) struct StaticRouteRef(bun_ptr::BackRef<StaticRoute, bun_ptr::Mut>);
impl StaticRouteRef {
    pub(crate) fn init_from_any_blob(blob: AnyBlob, options: InitFromBytesOptions<'_>) -> Self;
    pub(crate) fn as_ptr(&self) -> *mut StaticRoute;              // for StaticRoute::on*
}
impl Deref for StaticRouteRef { type Target = StaticRoute; .. }
impl Drop for StaticRouteRef { .. CellRefCounted::deref_nn(self.0.into()) }

pub(crate) html_bundle: bun_ptr::RefPtr<HTMLBundleRoute>,        // released by Drop for Html
pub(crate) cached_response: Option<StaticRouteRef>,
pub(crate) client_bundle: Option<StaticRouteRef>,
pub(crate) files: ArrayHashMap<u64, StaticRouteRef>,
```

`StaticRouteRef` lives in `route_bundle.rs`; its only constructor wraps `StaticRoute::init_from_any_blob` and adopts the ref that constructor creates, so the one `unsafe` block (`BackRef::from_raw_mut` on the fresh allocation) is inside the type and `Deref` and `Drop` are safe code. The 5 creation sites (`on_js_request`, `on_html_request_with_bundle`, `on_js_request_with_bundle`, and both branches of `Assets::replace_path`) call it directly. `invalidate_client_bundle` and the two `finalize_bundle` sites become `take()` / `= None`; `Assets::replace_path` overwrites the slot, `unref_by_index` lets `swap_remove_at` drop the value, `Drop for Assets` and the loop in `Drop for DevServer` are deleted, and the `defer!` in `on_js_request` becomes the local's drop. `html_bundle` is created with `RefPtr::init_ref` where `RefCount::ref_` was called and released by a new `Drop for Html`; its 4 readers use `Deref` instead of raw dereferences, which also retires the two `#[allow(clippy::needless_borrow)]` attributes that existed for those expressions. `Assets::get` returns `Option<&StaticRouteRef>` (2 callers) and becomes `pub(crate)` to match the type. Overall this removes 15 `unsafe` blocks and adds 1.

`Assets::replace_path` used `ArrayHashMap::get_or_put`, which requires `V: Default` because it appends a defaulted slot; the owning handle has no default, so the lookup now goes through the existing `entry()` API, and `OccupiedEntry` / `VacantEntry` in `bun_collections` gain `index()` (with a unit test) so the entry position is still available without a second lookup.

## Why

Ownership of these refs is now stated by the slot types: a `StaticRouteRef` or a `RouteBundle` holding one cannot be dropped without releasing, and a copy that outlives the slot cannot be made, which is exactly the mistake the two leaking sites made; fixing those leaks is the only behavioural difference. `BackRef` is `repr(transparent)` over `NonNull`, so `Option<StaticRouteRef>` and the map value column stay 8 bytes, `RefPtr` is a `NonNull` in release builds, `Deref` and `as_ptr` compile to the field read the raw pointer was, the `Drop` bodies are the same `deref` calls the deleted code made, and `entry()` performs the same single hash and probe as `get_or_put`. The refs that `Drop for DevServer` released at the end of its body are now released when the `route_bundles` field is dropped a moment later; nothing in between touches them, and neither `StaticRoute`'s nor `Route`'s destructor reads `DevServer` (the asset routes were already released by `Assets`' field-order drop).

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/bake/dev/html.test.ts test/bake/dev/css.test.ts test/bake/dev/sourcemap.test.ts test/bake/deinitialization.test.ts: 28 pass, 0 fail across 4 files (deinitialization.test.ts's inner run: 10 pass, 0 fail).
