### PR TITLE
event_loop: replace JsPoster's hand-rolled vtable with Arc<dyn JsPost>

### DIFF
--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -1,4 +1,5 @@
 use core::ptr::NonNull;
+use std::sync::Arc;
 
 use bun_dotenv::Loader as DotEnvLoader;
 use bun_ptr::BackRef;
@@ -528,7 +529,7 @@ impl EventLoopHandle {
 // How code below `bun_jsc` (spawn's waiter thread, the bundler's JS-loop hops,
 // shell/fs work that may serve a JS VM) posts a `ConcurrentTask` to a JS VM
 // from another thread. It is an erased `bun_jsc::VmHandle` clone: `bun_jsc`
-// fills the vtable; holders just call `post`. The VM's teardown closes the
+// implements `JsPost`; holders just call `post`. The VM's teardown closes the
 // underlying handle, after which `post` refuses (returns the task) and the
 // caller releases it on its own thread. Valid for as long as it is held.
 
@@ -541,69 +542,39 @@ pub enum Posted {
     Refused(NonNull<ConcurrentTask>),
 }
 
-pub struct JsPosterVTable {
-    pub post: unsafe fn(data: *const (), task: NonNull<ConcurrentTask>) -> Posted,
+/// What a [`JsPoster`] erases: implemented by `bun_jsc::vm_handle` for a VM's
+/// own loops and for a spawnSync isolated loop. Called from any thread.
+pub trait JsPost: Send + Sync {
+    fn post(&self, task: NonNull<ConcurrentTask>) -> Posted;
     /// `VmHandle::embedded_work_scheduled` / `_finished` (see there).
-    pub embedded_work_scheduled: unsafe fn(data: *const ()),
-    pub embedded_work_finished: unsafe fn(data: *const ()),
-    pub clone: unsafe fn(data: *const ()) -> *const (),
-    pub drop: unsafe fn(data: *const ()),
+    fn embedded_work_scheduled(&self);
+    fn embedded_work_finished(&self);
 }
 
-pub struct JsPoster {
-    data: *const (),
-    vtable: &'static JsPosterVTable,
-}
-
-// SAFETY: `data` is an erased `Arc<VmHandle inner>`; the vtable fns are the
-// thread-safe VmHandle operations.
-unsafe impl Send for JsPoster {}
-// SAFETY: as above.
-unsafe impl Sync for JsPoster {}
+#[derive(Clone)]
+pub struct JsPoster(Arc<dyn JsPost>);
 
 impl JsPoster {
-    /// # Safety
-    /// `data`/`vtable` come from one of `bun_jsc::vm_handle`'s `to_js_poster`
-    /// implementations (`VmHandle` / `LoopHandle` / the isolated poster).
     #[inline]
-    pub unsafe fn from_raw(data: *const (), vtable: &'static JsPosterVTable) -> Self {
-        Self { data, vtable }
+    pub fn new<T: JsPost + 'static>(inner: Arc<T>) -> Self {
+        Self(inner)
     }
 
     /// Queue `task` on the VM this poster was created for and wake it, or hand
     /// it back if the VM has been torn down.
     #[inline]
     pub fn post(&self, task: NonNull<ConcurrentTask>) -> Posted {
-        // SAFETY: vtable contract.
-        unsafe { (self.vtable.post)(self.data, task) }
+        self.0.post(task)
     }
 
-    #[inline]
     /// Count work whose storage the VM (indirectly) owns; it waits for the
     /// matching `embedded_work_finished` before closing. See `VmHandle`.
+    #[inline]
     pub fn embedded_work_scheduled(&self) {
-        // SAFETY: vtable contract.
-        unsafe { (self.vtable.embedded_work_scheduled)(self.data) }
+        self.0.embedded_work_scheduled()
     }
+    #[inline]
     pub fn embedded_work_finished(&self) {
-        // SAFETY: vtable contract.
-        unsafe { (self.vtable.embedded_work_finished)(self.data) }
-    }
-}
-
-impl Clone for JsPoster {
-    fn clone(&self) -> Self {
-        Self {
-            // SAFETY: vtable contract.
-            data: unsafe { (self.vtable.clone)(self.data) },
-            vtable: self.vtable,
-        }
-    }
-}
-
-impl Drop for JsPoster {
-    fn drop(&mut self) {
-        // SAFETY: vtable contract.
-        unsafe { (self.vtable.drop)(self.data) }
+        self.0.embedded_work_finished()
     }
 }

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -36,9 +36,7 @@ pub use ConcurrentTask::{Task, TaskTag, Taskable, task_tag};
 pub use DeferredTaskQueue as deferred_task_queue;
 
 pub use MiniEventLoop::PipeReadBuffer;
-pub use any_event_loop::{
-    AnyEventLoop, EventLoopHandle, EventLoopTask, JsPoster, JsPosterVTable, Posted,
-};
+pub use any_event_loop::{AnyEventLoop, EventLoopHandle, EventLoopTask, JsPost, JsPoster, Posted};
 
 // JS-event-loop arm of `AnyEventLoop` / `EventLoopHandle`. `bun_event_loop` is
 // a lower tier than `bun_jsc`, so it cannot name `jsc::EventLoop` /

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -668,50 +668,25 @@ struct PosterData {
     kind: LoopKind,
 }
 
-unsafe fn poster_post(data: *const (), task: NonNull<ConcurrentTaskItem>) -> Posted {
-    // SAFETY: `data` is a leaked `Arc<PosterData>` pointer (see `to_js_poster`).
-    let d = unsafe { &*data.cast::<PosterData>() };
-    d.handle.post(d.kind, task)
+impl bun_event_loop::JsPost for PosterData {
+    fn post(&self, task: NonNull<ConcurrentTaskItem>) -> Posted {
+        self.handle.post(self.kind, task)
+    }
+    fn embedded_work_scheduled(&self) {
+        self.handle.embedded_work_scheduled()
+    }
+    fn embedded_work_finished(&self) {
+        self.handle.embedded_work_finished()
+    }
 }
-unsafe fn poster_clone(data: *const ()) -> *const () {
-    // SAFETY: as above; bump the Arc count and hand out the same pointer.
-    unsafe { Arc::increment_strong_count(data.cast::<PosterData>()) };
-    data
-}
-unsafe fn poster_drop(data: *const ()) {
-    // SAFETY: as above; balances `into_raw`/`increment_strong_count`.
-    unsafe { drop(Arc::from_raw(data.cast::<PosterData>())) };
-}
-unsafe fn poster_embedded_scheduled(data: *const ()) {
-    // SAFETY: as `poster_post`.
-    unsafe { &*data.cast::<PosterData>() }
-        .handle
-        .embedded_work_scheduled();
-}
-unsafe fn poster_embedded_finished(data: *const ()) {
-    // SAFETY: as `poster_post`.
-    unsafe { &*data.cast::<PosterData>() }
-        .handle
-        .embedded_work_finished();
-}
-static POSTER_VTABLE: bun_event_loop::JsPosterVTable = bun_event_loop::JsPosterVTable {
-    post: poster_post,
-    embedded_work_scheduled: poster_embedded_scheduled,
-    embedded_work_finished: poster_embedded_finished,
-    clone: poster_clone,
-    drop: poster_drop,
-};
 
 impl VmHandle {
     /// An erased poster for `kind`, for code that cannot name `VmHandle`.
     pub fn to_js_poster(&self, kind: LoopKind) -> bun_event_loop::JsPoster {
-        let data = Arc::into_raw(Arc::new(PosterData {
+        bun_event_loop::JsPoster::new(Arc::new(PosterData {
             handle: self.clone(),
             kind,
         }))
-        .cast::<()>();
-        // SAFETY: `data`/vtable pair as documented on `JsPoster::from_raw`.
-        unsafe { bun_event_loop::JsPoster::from_raw(data, &POSTER_VTABLE) }
     }
 }
 
@@ -878,7 +853,13 @@ impl IsolatedPosterInner {
         }
     }
 
-    pub(crate) fn post(&self, task: NonNull<ConcurrentTaskItem>) -> Posted {
+    pub(crate) fn to_js_poster(this: &Arc<Self>) -> bun_event_loop::JsPoster {
+        bun_event_loop::JsPoster::new(Arc::clone(this))
+    }
+}
+
+impl bun_event_loop::JsPost for IsolatedPosterInner {
+    fn post(&self, task: NonNull<ConcurrentTaskItem>) -> Posted {
         self.active.fetch_add(1, Ordering::SeqCst);
         let open = self.open.load(Ordering::SeqCst);
         if open {
@@ -895,33 +876,8 @@ impl IsolatedPosterInner {
         }
     }
 
-    pub(crate) fn to_js_poster(this: &Arc<Self>) -> bun_event_loop::JsPoster {
-        let data = Arc::into_raw(Arc::clone(this)).cast::<()>();
-        // SAFETY: data/vtable pair per `JsPoster::from_raw`.
-        unsafe { bun_event_loop::JsPoster::from_raw(data, &ISOLATED_POSTER_VTABLE) }
-    }
+    // An isolated loop is driven to completion synchronously by its creator on
+    // the JS thread (spawnSync), so its VM cannot tear down under its work.
+    fn embedded_work_scheduled(&self) {}
+    fn embedded_work_finished(&self) {}
 }
-
-unsafe fn isolated_post(data: *const (), task: NonNull<ConcurrentTaskItem>) -> Posted {
-    // SAFETY: leaked Arc<IsolatedPosterInner>.
-    unsafe { &*data.cast::<IsolatedPosterInner>() }.post(task)
-}
-unsafe fn isolated_clone(data: *const ()) -> *const () {
-    // SAFETY: as above.
-    unsafe { Arc::increment_strong_count(data.cast::<IsolatedPosterInner>()) };
-    data
-}
-unsafe fn isolated_drop(data: *const ()) {
-    // SAFETY: as above.
-    unsafe { drop(Arc::from_raw(data.cast::<IsolatedPosterInner>())) };
-}
-// An isolated loop is driven to completion synchronously by its creator on
-// the JS thread (spawnSync), so its VM cannot tear down under its work.
-unsafe fn isolated_embedded_noop(_data: *const ()) {}
-static ISOLATED_POSTER_VTABLE: bun_event_loop::JsPosterVTable = bun_event_loop::JsPosterVTable {
-    post: isolated_post,
-    embedded_work_scheduled: isolated_embedded_noop,
-    embedded_work_finished: isolated_embedded_noop,
-    clone: isolated_clone,
-    drop: isolated_drop,
-};


### PR DESCRIPTION
## What

`bun_event_loop::JsPoster` is how crates below `bun_jsc` (spawn's waiter thread, the bundler's JS-loop hops, `ConcurrentPoster`) post a `ConcurrentTask` to a JS VM from another thread. It was a type-erased pair built by hand: a `*const ()` plus a `&'static JsPosterVTable` with five `unsafe fn` slots (`post`, `embedded_work_scheduled`, `embedded_work_finished`, `clone`, `drop`), hand-written `unsafe impl Send`/`Sync`, an `unsafe fn from_raw` constructor, and manual `Clone`/`Drop` impls that called through the table. `bun_jsc::vm_handle` filled two such tables with nine trampolines that cast the pointer back to an `Arc<PosterData>` or `Arc<IsolatedPosterInner>` leaked with `Arc::into_raw` (`Arc::increment_strong_count` for clone, `Arc::from_raw` for drop).

```rust
// before
pub struct JsPosterVTable { pub post: unsafe fn(*const (), NonNull<ConcurrentTask>) -> Posted, /* 4 more */ }
pub struct JsPoster { data: *const (), vtable: &'static JsPosterVTable }
unsafe impl Send for JsPoster {}
unsafe impl Sync for JsPoster {}
pub unsafe fn from_raw(data: *const (), vtable: &'static JsPosterVTable) -> Self;

// after
pub trait JsPost: Send + Sync {
    fn post(&self, task: NonNull<ConcurrentTask>) -> Posted;
    fn embedded_work_scheduled(&self);
    fn embedded_work_finished(&self);
}
#[derive(Clone)]
pub struct JsPoster(Arc<dyn JsPost>);
pub fn new<T: JsPost + 'static>(inner: Arc<T>) -> Self;
```

`PosterData` and `IsolatedPosterInner` now implement `JsPost` directly (the isolated loop's two `embedded_work_*` methods are the explicit no-ops the old table pointed at, with the same comment), and their `to_js_poster` constructors pass the `Arc` they already allocated to `JsPoster::new`. The two vtable statics and nine trampolines in `VmHandle.rs` are deleted, `lib.rs` exports `JsPost` in place of `JsPosterVTable`, and `JsPoster`'s public `post`/`embedded_work_scheduled`/`embedded_work_finished`/`Clone` surface is unchanged, so none of its holders (`bun_spawn::Process`, `bun_bundler::BundleV2`, `bun_jsc::ConcurrentPoster`, the 9 `.post()` call sites) change. Net: 15 `unsafe` blocks, 10 `unsafe fn`s, the 5 `unsafe fn` pointer slots and both `unsafe impl`s removed; none added. 42 insertions, 117 deletions across 3 files.

## Why

The trait object carries what the comments used to: the pointee is an `Arc` that outlives every holder (`Arc<dyn JsPost>` owns it), and the poster is `Send + Sync` because the implementing types are, which the compiler now checks at each `impl JsPost` instead of `bun_event_loop` asserting it about a type it cannot see. The erasure itself stays because `bun_event_loop` sits below `bun_jsc` and cannot name the implementations. Cost: `Arc<dyn JsPost>` is the same two words (16 bytes) as the old `{data, vtable}` pair and keeps the non-null niche, so `Option<JsPoster>` in `Process` and `BundleV2` stays 16 bytes; the unsized coercion in `JsPoster::new` does not reallocate, so the heap object is the very same `Arc` allocation the trampolines operated on; `post` and `embedded_work_*` are still a single indirect call each, now straight into the impl method (the dispatch additionally reads the payload alignment from the same vtable line to locate the value inside the `Arc`, four ALU instructions on x86-64, on a path that then performs two SeqCst atomics, a queue push and a wakeup once per completed off-thread job); and `clone`/`drop` become the inline `Arc` count operations that previously sat behind an indirect call. No new allocation, check or branch on any path.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/web/workers/worker-refused-completion.test.ts test/js/bun/spawn/spawnSync.test.ts test/js/bun/spawn/spawn.test.ts test/bake/dev/plugins.test.ts: 172 pass, 8 skip, 0 fail across 4 files (spawn.test.ts also re-runs itself with BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: 139 pass, 7 skip, 0 fail).
