### PR TITLE
threading: put Semaphore permits behind Guarded<usize>

### DIFF
--- a/src/threading/Semaphore.rs
+++ b/src/threading/Semaphore.rs
@@ -5,23 +5,12 @@
 //! Only the subset Bun uses is ported (`wait`/`post`); `timedWait` is omitted
 //! because no Rust caller needs it and it would pull in a monotonic timer.
 
-use core::cell::UnsafeCell;
-
-use crate::{Condition, Mutex};
+use crate::{Condition, Guarded};
 
 pub struct Semaphore {
-    mutex: Mutex,
+    permits: Guarded<usize>,
     cond: Condition,
-    /// Guarded by `mutex`. `UnsafeCell` because `wait`/`post` take `&self`.
-    permits: UnsafeCell<usize>,
 }
-
-// SAFETY: `permits` is only read/written while `mutex` is held; `Mutex` and
-// `Condition` are themselves `Sync`/`Send`.
-unsafe impl Sync for Semaphore {}
-// SAFETY: `Mutex`, `Condition`, and `UnsafeCell<usize>` are all `Send`; the
-// semaphore holds no thread-affine state.
-unsafe impl Send for Semaphore {}
 
 impl Default for Semaphore {
     fn default() -> Self {
@@ -33,37 +22,30 @@ impl Semaphore {
     /// Const-init with zero permits.
     pub(crate) const fn new() -> Self {
         Self {
-            mutex: Mutex::new(),
+            permits: Guarded::new(0),
             cond: Condition::new(),
-            permits: UnsafeCell::new(0),
         }
     }
 
     /// Blocks until a permit is available, then consumes one.
     pub fn wait(&self) {
-        self.mutex.lock();
-        scopeguard::defer! { self.mutex.unlock(); }
+        let mut permits = self.permits.lock();
 
-        // SAFETY: `mutex` is held for every access to `permits` below.
-        while unsafe { *self.permits.get() } == 0 {
-            self.cond.wait(&self.mutex);
+        while *permits == 0 {
+            self.cond.wait_guarded(&mut permits);
         }
 
-        // SAFETY: `mutex` is still held (released only by the scopeguard on return).
-        unsafe { *self.permits.get() -= 1 };
-        // SAFETY: `mutex` is still held; this is the sole accessor of `permits`.
-        if unsafe { *self.permits.get() } > 0 {
+        *permits -= 1;
+        if *permits > 0 {
             self.cond.signal();
         }
     }
 
     /// Adds one permit and wakes one waiter.
     pub fn post(&self) {
-        self.mutex.lock();
-        scopeguard::defer! { self.mutex.unlock(); }
+        let mut permits = self.permits.lock();
 
-        // SAFETY: `mutex` is held.
-        unsafe { *self.permits.get() += 1 };
+        *permits += 1;
         self.cond.signal();
     }
 }


### PR DESCRIPTION
## What

`bun_threading::Semaphore` kept its permit count in an `UnsafeCell<usize>` beside a bare `Mutex`, with hand-written `unsafe impl Send` and `unsafe impl Sync`, and `wait()` and `post()` locked the mutex, registered a `scopeguard::defer!` to unlock it, and then went through four `unsafe { *self.permits.get() }` dereferences, each with a SAFETY comment saying the mutex was still held.

The count is now a `Guarded<usize>` (the crate's existing mutex-plus-value type) and both methods hold its guard for the critical section, with `wait()` parking through the existing `Condition::wait_guarded`:

```rust
pub struct Semaphore {
    permits: Guarded<usize>,
    cond: Condition,
}

pub fn wait(&self) {
    let mut permits = self.permits.lock();
    while *permits == 0 {
        self.cond.wait_guarded(&mut permits);
    }
    *permits -= 1;
    if *permits > 0 {
        self.cond.signal();
    }
}
```

`post()` still increments and signals while the lock is held, and `wait()` still signals the next waiter before unlocking, so the lock and wake ordering is unchanged. The `const fn new()` stays `const` through `Guarded::new`, so `RawRwLock::new()` and the `static` `RwLock`s built on it are unaffected, and both users (`RwLock.rs` and `fs_events.rs`, which only call `new`/`default`, `wait` and `post`) compile unchanged. Removes the 4 unsafe blocks and the 2 unsafe impls; the file has no `unsafe` left.

## Why

The permit count is now only reachable through a lock guard, so "which mutex protects `permits`" is stated by the field type instead of by four comments, and `Send`/`Sync` follow from the field types (`Guarded<usize>` and `Condition`) instead of being asserted. `Guarded<usize>` is the same `UnsafeCell<usize>` and `Mutex` grouped into one field: `Semaphore` stays 24 bytes in release and 32 in debug builds, and `RawRwLock`, which embeds it, keeps its size too. In the release build `lock()`, the guard's drop and `wait_guarded()` inline to the same `Mutex::lock`/`unlock` and `Condition::wait` calls the scopeguard version produced; no guard object is materialized and no branch is added.

`Channel` in the same crate has the same `UnsafeCell` plus `Mutex` shape and is deliberately not converted here: putting its fifo and its `is_closed` flag behind one `Guarded` grows the struct by 8 bytes of padding on targets where `Mutex` is 4 bytes, and the flag has had no setter since the unused `close()` was deleted, so that conversion belongs together with removing the dead flag.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/test/test-timers.test.ts test/js/node/watch/fs.watch.test.ts: 50 pass, 6 skip, 0 fail (56 tests across 2 files).
