### PR TITLE
server: make StaticRouteLike dispatch safe via ThisPtr and NonNull

### DIFF
--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -3,12 +3,12 @@
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::mem::size_of;
-use core::ptr::NonNull;
 
 use bun_core::strings;
 use bun_http::Method;
 use bun_io::FileType;
 use bun_paths::resolve_path;
+use bun_ptr::ThisPtr;
 use bun_resolver::fs::StatHash;
 use bun_sys::{self, Fd, File};
 use bun_uws::{AnyRequest, AnyResponse};
@@ -103,34 +103,23 @@ impl DirectoryRoute {
         drop(File::from_fd(this.root_fd.get()));
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn on_head_request(this: *mut DirectoryRoute, req: AnyRequest, resp: AnyResponse) {
-        Self::on(NonNull::new(this).unwrap(), req, resp, Method::HEAD);
+    pub fn on_head_request(this: ThisPtr<DirectoryRoute>, req: AnyRequest, resp: AnyResponse) {
+        Self::on(this, req, resp, Method::HEAD);
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn on_request(this: *mut DirectoryRoute, req: AnyRequest, resp: AnyResponse) {
+    pub fn on_request(this: ThisPtr<DirectoryRoute>, req: AnyRequest, resp: AnyResponse) {
         let method = Method::find(req.method()).unwrap_or(Method::GET);
-        Self::on(NonNull::new(this).unwrap(), req, resp, method);
+        Self::on(this, req, resp, method);
     }
 
-    // `this_ptr` (not `&self`) because it is stashed as `FileResponseStream`'s
+    // `ThisPtr` (not `&self`) because it is stashed as `FileResponseStream`'s
     // ctx userdata; `on_stream_complete` may drop the last ref after a reload,
     // and `Box::from_raw` on a `&self`-derived pointer is UB under Stacked
     // Borrows. See src/CLAUDE.md §Pointer provenance at FFI boundaries.
-    fn on(
-        this_ptr: NonNull<DirectoryRoute>,
-        mut req: AnyRequest,
-        resp: AnyResponse,
-        method: Method,
-    ) {
-        let this = bun_ptr::BackRef::from(this_ptr);
+    fn on(this: ThisPtr<DirectoryRoute>, mut req: AnyRequest, resp: AnyResponse, method: Method) {
         debug_assert!(this.server.get().is_some());
         this.ref_();
-        let guard = ResponseGuard {
-            route: this_ptr,
-            resp,
-        };
+        let guard = ResponseGuard { route: this, resp };
         if let Some(mut server) = this.server.get() {
             server.on_pending_request();
             resp.timeout(server.config().idle_timeout);
@@ -371,11 +360,11 @@ impl DirectoryRoute {
         (ms, buf, len)
     }
 
-    fn on_response_complete(this: NonNull<DirectoryRoute>, resp: AnyResponse) {
+    fn on_response_complete(this: ThisPtr<DirectoryRoute>, resp: AnyResponse) {
         resp.clear_aborted();
         resp.clear_on_writable();
         resp.clear_timeout();
-        if let Some(mut server) = bun_ptr::BackRef::from(this).server.get() {
+        if let Some(mut server) = this.server.get() {
             server.on_static_request_complete();
         }
         // SAFETY: intrusive refcount; `ref_()` in `on()` pairs with this.
@@ -385,7 +374,7 @@ impl DirectoryRoute {
 
 /// Releases the route ref (and file, if any) on every non-streaming return.
 struct ResponseGuard {
-    route: NonNull<DirectoryRoute>,
+    route: ThisPtr<DirectoryRoute>,
     resp: AnyResponse,
 }
 
@@ -402,11 +391,14 @@ impl Drop for ResponseGuard {
 }
 
 fn on_stream_complete(ctx: *mut c_void, resp: AnyResponse) {
-    DirectoryRoute::on_response_complete(NonNull::new(ctx.cast()).unwrap(), resp);
+    // SAFETY: `ctx` is the route handed over by `ResponseGuard::into_ctx`; the
+    // ref taken in `on()` keeps it live until this completion callback.
+    DirectoryRoute::on_response_complete(unsafe { ThisPtr::new(ctx.cast()) }, resp);
 }
 
 fn on_stream_error(ctx: *mut c_void, resp: AnyResponse, _err: bun_sys::Error) {
-    DirectoryRoute::on_response_complete(NonNull::new(ctx.cast()).unwrap(), resp);
+    // SAFETY: see `on_stream_complete` above.
+    DirectoryRoute::on_response_complete(unsafe { ThisPtr::new(ctx.cast()) }, resp);
 }
 
 // `Stat` is ~144 bytes; boxing it would add a heap alloc on the hot path.

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1,9 +1,11 @@
+use core::ptr::NonNull;
 use std::io::Write as _;
 
 use bun_core::ZBox;
 
 use bun_collections::StringHashMap;
 use bun_core::strings;
+use bun_ptr::ThisPtr;
 use bun_uws_sys as uws;
 use bun_wyhash::Wyhash;
 
@@ -309,26 +311,20 @@ impl ServerConfig {
 // NOTE: free `extern "C"` fns are monomorphized per `<SSL, T>` and registered
 // via the raw `c::uws_method_handler` overload.
 
-/// # Safety
-/// `entry` must be a live route pointer that outlives `app` — it is registered
-/// as the uWS userdata and dereferenced from request callbacks for the lifetime
-/// of the app.
-// Forwards `entry` to `T::set_server` and to uWS as opaque userdata without
-// dereferencing it here; not_unsafe_ptr_arg_deref is a false positive on
-// opaque-token forwarding.
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
+/// `entry` becomes the uWS userdata of every handler registered here; the route
+/// table's ref keeps it live for as long as the registrations exist (they are
+/// cleared before the table is dropped on reload).
 pub(crate) fn apply_static_route<const SSL: bool, T>(
     server: AnyServer,
     app: &mut uws::NewApp<SSL>,
-    entry: *mut T,
+    entry: NonNull<T>,
     path: &[u8],
     method: http_method::Optional,
     path_has_user_head_route: bool,
 ) where
     T: StaticRouteLike<SSL>,
 {
-    // SAFETY: caller passes a live route pointer for the lifetime of the app.
-    unsafe { T::set_server(entry, server) };
+    bun_ptr::BackRef::from(entry).set_server(server);
 
     // Trampolines: uWS hands us an opaque `uws_res*`, a live `Request*`, and the
     // user_data pointer (= `entry`). Cast back to the typed `Response<SSL>` /
@@ -338,10 +334,9 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
         req: *mut uws::Request,
         user_data: *mut core::ffi::c_void,
     ) {
-        // SAFETY: uWS invokes this with non-null `resp`/`req` for the duration
-        // of the callback; `user_data` is the `entry` pointer registered below,
-        // kept alive by the route table for the lifetime of the app.
-        let route = user_data.cast::<T>();
+        // SAFETY: `user_data` is the `entry` registered below; the route table's
+        // ref keeps it live for as long as the registration exists.
+        let route = unsafe { ThisPtr::new(user_data.cast::<T>()) };
         let resp = uws::NewAppResponse::<SSL>::cast_res(resp);
         // `Response<SSL>` is a `#[repr(C)]` opaque over `uws_res`; pointer cast
         // selects the matching `AnyResponse` variant for the const-generic SSL flag.
@@ -350,10 +345,7 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
         } else {
             bun_uws_sys::AnyResponse::TCP(resp.cast())
         };
-        // SAFETY: `route`, `req`, and `resp` are non-null and valid for the
-        // duration of this uWS callback (see invariants established above);
-        // `on_request` only dereferences them while this frame is live.
-        unsafe { T::on_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp) };
+        T::on_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp);
     }
 
     extern "C" fn head<const SSL: bool, T: StaticRouteLike<SSL>>(
@@ -362,19 +354,17 @@ pub(crate) fn apply_static_route<const SSL: bool, T>(
         user_data: *mut core::ffi::c_void,
     ) {
         // SAFETY: see `handler` above.
-        let route = user_data.cast::<T>();
+        let route = unsafe { ThisPtr::new(user_data.cast::<T>()) };
         let resp = uws::NewAppResponse::<SSL>::cast_res(resp);
         let any_resp = if SSL {
             bun_uws_sys::AnyResponse::SSL(resp.cast())
         } else {
             bun_uws_sys::AnyResponse::TCP(resp.cast())
         };
-        // SAFETY: `route`, `req`, and `resp` validity is guaranteed by uWS for
-        // the callback's duration — same invariants as `handler` above.
-        unsafe { T::on_head_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp) };
+        T::on_head_request(route, bun_uws_sys::AnyRequest::H1(req), any_resp);
     }
 
-    let user_data = entry.cast::<core::ffi::c_void>();
+    let user_data = entry.as_ptr().cast::<core::ffi::c_void>();
     // Only answer HEAD from an entry that serves GET (HEAD must mirror GET,
     // RFC 9110 section 9.3.2) or HEAD itself, and never displace an explicit HEAD
     // handler route: uWS keeps the last registration for the same method and path.
@@ -404,40 +394,32 @@ fn serves_head(method: &http_method::Optional) -> bool {
     }
 }
 
-/// # Safety
-/// `entry` must be a live route pointer that outlives `app` — it is registered
-/// as the uWS userdata and dereferenced from request callbacks for the lifetime
-/// of the app.
-// Forwards `entry` to `T::set_server` and to uWS as opaque userdata without
-// dereferencing it here; not_unsafe_ptr_arg_deref is a false positive on
-// opaque-token forwarding.
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
+/// HTTP/3 twin of [`apply_static_route`]; `entry` has the same lifetime contract.
 pub(crate) fn apply_static_route_h3<T>(
     server: AnyServer,
     app: &mut uws::h3::App,
-    entry: *mut T,
+    entry: NonNull<T>,
     path: &[u8],
     method: http_method::Optional,
     path_has_user_head_route: bool,
 ) where
     T: StaticRouteLike<false>,
 {
-    // SAFETY: caller passes a live route pointer for the lifetime of the app.
-    unsafe { T::set_server(entry, server) };
+    bun_ptr::BackRef::from(entry).set_server(server);
 
     fn handler<T: StaticRouteLike<false>>(
         route: &mut T,
         req: &mut uws::h3::Request,
         resp: &mut uws::h3::Response,
     ) {
-        // SAFETY: `route` is the `entry` userdata kept alive by the route table.
-        unsafe {
-            T::on_request(
-                route,
-                bun_uws_sys::AnyRequest::H3(req),
-                bun_uws_sys::AnyResponse::H3(resp),
-            )
-        };
+        // SAFETY: `route` is the `entry` registered below; the route table's ref
+        // keeps it live for as long as the registration exists.
+        let route = unsafe { ThisPtr::new(core::ptr::from_mut(route)) };
+        T::on_request(
+            route,
+            bun_uws_sys::AnyRequest::H3(req),
+            bun_uws_sys::AnyResponse::H3(resp),
+        );
     }
     fn head<T: StaticRouteLike<false>>(
         route: &mut T,
@@ -445,111 +427,104 @@ pub(crate) fn apply_static_route_h3<T>(
         resp: &mut uws::h3::Response,
     ) {
         // SAFETY: see `handler` above.
-        unsafe {
-            T::on_head_request(
-                route,
-                bun_uws_sys::AnyRequest::H3(req),
-                bun_uws_sys::AnyResponse::H3(resp),
-            )
-        };
+        let route = unsafe { ThisPtr::new(core::ptr::from_mut(route)) };
+        T::on_head_request(
+            route,
+            bun_uws_sys::AnyRequest::H3(req),
+            bun_uws_sys::AnyResponse::H3(resp),
+        );
     }
 
+    let user_data = entry.as_ptr();
     if !path_has_user_head_route && serves_head(&method) {
-        app.head(path, entry, head::<T>);
+        app.head(path, user_data, head::<T>);
     }
     match method {
-        http_method::Optional::Any => app.any(path, entry, handler::<T>),
+        http_method::Optional::Any => app.any(path, user_data, handler::<T>),
         http_method::Optional::Method(m) => {
             let mut iter = m.iter();
             while let Some(method_) = iter.next() {
-                app.method(method_, path, entry, handler::<T>);
+                app.method(method_, path, user_data, handler::<T>);
             }
         }
     }
 }
 
 /// Per-route trait that `apply_static_route{,_h3}` monomorphizes over
-/// (`StaticRoute`/`FileRoute`/`HTMLBundle.Route`).
-/// Receivers are raw `*mut Self` because the route is registered as the uWS
-/// userdata pointer and the inherent impls (`StaticRoute::on_request` etc.) need
-/// `*mut` to mutate state and stash `self` into onAborted callbacks.
-pub(crate) trait StaticRouteLike<const SSL: bool>: 'static {
-    /// SAFETY: `this` is a live route pointer for the lifetime of the app.
-    unsafe fn set_server(this: *mut Self, server: AnyServer);
-    /// SAFETY: `this` is a live route pointer; `req`/`resp` carry FFI handles
-    /// valid for the duration of the uWS callback.
-    unsafe fn on_request(
-        this: *mut Self,
+/// (`StaticRoute`/`FileRoute`/`DirectoryRoute`/`HTMLBundle.Route`).
+/// The request handlers take a `ThisPtr` rather than `&self` because the
+/// inherent impls stash the route pointer as onAborted/stream userdata and
+/// release refs through it.
+pub(crate) trait StaticRouteLike<const SSL: bool>: Sized + 'static {
+    fn set_server(&self, server: AnyServer);
+    fn on_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     );
-    /// SAFETY: see `on_request`.
-    unsafe fn on_head_request(
-        this: *mut Self,
+    fn on_head_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     );
 }
 
 impl<const SSL: bool> StaticRouteLike<SSL> for super::StaticRoute {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live; `server` is a Cell so &mut
-        // is not required.
-        unsafe { (*this).server.set(Some(server)) };
+    fn set_server(&self, server: AnyServer) {
+        self.server.set(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
+    fn on_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
-        // SAFETY: forwarded to the inherent impl with the same contract.
-        unsafe { Self::on_request(this, req, resp) }
+        // SAFETY: the `ThisPtr` invariant is the inherent fn's contract: a live
+        // heap route, whose root provenance `as_ptr` hands back unchanged.
+        unsafe { Self::on_request(this.as_ptr(), req, resp) }
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
+    fn on_head_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
-        // SAFETY: forwarded to the inherent impl with the same contract.
-        unsafe { Self::on_head_request(this, req, resp) }
+        // SAFETY: see `on_request` above.
+        unsafe { Self::on_head_request(this.as_ptr(), req, resp) }
     }
 }
 
 impl<const SSL: bool> StaticRouteLike<SSL> for super::FileRoute {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live.
-        unsafe { (*this).set_server(Some(server)) };
+    fn set_server(&self, server: AnyServer) {
+        self.set_server(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
+    fn on_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
-        Self::on_request(this, req, resp)
+        Self::on_request(this.as_ptr(), req, resp)
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
+    fn on_head_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
-        Self::on_head_request(this, req, resp)
+        Self::on_head_request(this.as_ptr(), req, resp)
     }
 }
 
 impl<const SSL: bool> StaticRouteLike<SSL> for super::DirectoryRoute {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live.
-        unsafe { (*this).set_server(Some(server)) };
+    fn set_server(&self, server: AnyServer) {
+        self.set_server(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
+    fn on_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
         Self::on_request(this, req, resp)
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
+    fn on_head_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
@@ -558,23 +533,22 @@ impl<const SSL: bool> StaticRouteLike<SSL> for super::DirectoryRoute {
 }
 
 impl<const SSL: bool> StaticRouteLike<SSL> for super::html_bundle::Route {
-    unsafe fn set_server(this: *mut Self, server: AnyServer) {
-        // SAFETY: caller guarantees `this` is live.
-        unsafe { (*this).server.set(Some(server)) };
+    fn set_server(&self, server: AnyServer) {
+        self.server.set(Some(server));
     }
-    unsafe fn on_request(
-        this: *mut Self,
+    fn on_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
-        Self::on_request(this, req, resp)
+        Self::on_request(this.as_ptr(), req, resp)
     }
-    unsafe fn on_head_request(
-        this: *mut Self,
+    fn on_head_request(
+        this: ThisPtr<Self>,
         req: bun_uws_sys::AnyRequest,
         resp: bun_uws_sys::AnyResponse,
     ) {
-        Self::on_head_request(this, req, resp)
+        Self::on_head_request(this.as_ptr(), req, resp)
     }
 }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2468,7 +2468,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, StaticRoute>(
                         any_server,
                         app,
-                        p.as_ptr(),
+                        *p,
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2479,7 +2479,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                p.as_ptr(),
+                                *p,
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2491,7 +2491,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, FileRoute>(
                         any_server,
                         app,
-                        p.as_ptr(),
+                        *p,
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2502,7 +2502,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                p.as_ptr(),
+                                *p,
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2514,7 +2514,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, DirectoryRoute>(
                         any_server,
                         app,
-                        p.as_ptr(),
+                        *p,
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2525,7 +2525,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                p.as_ptr(),
+                                *p,
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,
@@ -2537,7 +2537,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     server_config::apply_static_route::<SSL, html_bundle::Route>(
                         any_server,
                         app,
-                        r.as_ptr(),
+                        r.data,
                         &entry.path,
                         entry.method,
                         path_has_user_head_route,
@@ -2548,7 +2548,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 any_server,
                                 // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.
                                 bun_opaque::opaque_deref_mut(h3_app),
-                                r.as_ptr(),
+                                r.data,
                                 &entry.path,
                                 entry.method,
                                 path_has_user_head_route,


### PR DESCRIPTION
## What

`StaticRouteLike` (`src/runtime/server/ServerConfig.rs`), the trait that `apply_static_route` and `apply_static_route_h3` monomorphize over for `StaticRoute`, `FileRoute`, `DirectoryRoute` and `html_bundle::Route`, declared all three of its methods as `unsafe fn`s taking `this: *mut Self`, and the two registration helpers took `entry: *mut T` under a `#[allow(clippy::not_unsafe_ptr_arg_deref)]`. Between the trait, its four impls and the two helpers that was 15 `unsafe fn`s and 12 `unsafe` blocks, most of them `unsafe { (*this).server.set(..) }` or a forwarding call.

```rust
// before
pub(crate) trait StaticRouteLike<const SSL: bool>: 'static {
    unsafe fn set_server(this: *mut Self, server: AnyServer);
    unsafe fn on_request(this: *mut Self, req: AnyRequest, resp: AnyResponse);
    unsafe fn on_head_request(this: *mut Self, req: AnyRequest, resp: AnyResponse);
}
pub(crate) fn apply_static_route<const SSL: bool, T>(.., entry: *mut T, ..)

// after
pub(crate) trait StaticRouteLike<const SSL: bool>: Sized + 'static {
    fn set_server(&self, server: AnyServer);
    fn on_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse);
    fn on_head_request(this: ThisPtr<Self>, req: AnyRequest, resp: AnyResponse);
}
pub(crate) fn apply_static_route<const SSL: bool, T>(.., entry: NonNull<T>, ..)
```

The helpers set the server through `bun_ptr::BackRef::from(entry)` (the same shape `AnyRoute::memory_cost` already uses), register `entry.as_ptr()` as the uWS userdata, and the two HTTP/1 `extern "C"` trampolines and the two HTTP/3 closures each wrap the incoming pointer once with `ThisPtr::new`; those four constructions are the remaining `unsafe` in the helpers. The four impls become safe: `set_server` writes the `Cell` directly or calls the existing inherent setter, `FileRoute` and `html_bundle::Route` forward `this.as_ptr()` to their unchanged inherent handlers, `StaticRoute` keeps one `unsafe` forwarding call per handler because its inherent handlers are still `unsafe fn(*mut Self)` (converting those is a separate change), and `DirectoryRoute` forwards the `ThisPtr` itself.

`DirectoryRoute` (`src/runtime/server/DirectoryRoute.rs`) now carries the `ThisPtr` through `on_request`, `on_head_request`, `on`, `ResponseGuard` and `on_response_complete`, where it previously accepted a `*mut` and rebuilt a `NonNull` with `NonNull::new(..).unwrap()`; the two `FileResponseStream` completion callbacks construct the `ThisPtr` from the raw `ctx` pointer. This deletes four per-request null checks, two more clippy allows and the two `BackRef::from` re-wraps, and adds two `unsafe` blocks at the ctx round trip. The eight `set_routes` arms in `src/runtime/server/mod.rs` pass the `NonNull` stored in `AnyRoute` (`*p`) or `RefPtr::data` for HTML routes instead of `.as_ptr()`.

Net across the three files: 15 `unsafe fn`s removed, 12 `unsafe` blocks removed and 8 added (4 `ThisPtr::new` in the helpers, 2 `StaticRoute` forwards, 2 in the directory stream callbacks), 4 clippy allows and 4 `unwrap()`s removed.

## Why

The liveness of a static route during dispatch is now stated by the types: `NonNull<T>` at registration (the route table owns the ref), `ThisPtr<Self>` inside the handlers (constructed exactly where the userdata pointer comes back from uWS or `FileResponseStream`, with the argument in one SAFETY comment per entry point), and `&self` for `set_server`, which never needed a raw pointer. `ThisPtr` and `BackRef` are `repr(transparent)` over `NonNull`, `ThisPtr::new` only debug-asserts, and `Deref` compiles to the same load as `(*this).field`, so the registered pointer value and the per-request code are unchanged except for the four removed null checks.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/http/serve-directory-routes.test.ts, test/js/bun/http/bun-serve-static.test.ts, test/js/bun/http/bun-serve-html.test.ts, test/js/bun/http/serve-http3.test.ts: 141 pass, 2 skip, 0 fail (143 tests across 4 files).
