### PR TITLE
shell(rm): stop panicking on operands longer than the path scratch buffers

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -171,18 +171,34 @@ impl Rm {
                             // Check that none of the paths will delete the root.
                             {
                                 let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
+                                // Operands are unbounded user input, so neither
+                                // step may use the fixed-size thread-local
+                                // buffers behind `join` / `normalize_string`.
+                                // Normalizing never grows a path by more than
+                                // one byte.
+                                let mut join_spill = Vec::new();
+                                let mut normalize_buf = Vec::new();
 
                                 for i in args_start..argc {
                                     let path = Builtin::of(interp, cmd).arg_bytes(i);
                                     let resolved: &[u8] = if Platform::AUTO.is_absolute(path) {
                                         path
                                     } else {
-                                        resolve_path::join::<platform::Auto>(&[&cwd, path])
+                                        resolve_path::join_spill::<platform::Auto>(
+                                            &mut join_spill,
+                                            &[&cwd, path],
+                                        )
                                     };
-                                    let normalized = resolve_path::normalize_string::<
+                                    if normalize_buf.len() <= resolved.len() {
+                                        normalize_buf.resize(resolved.len() + 1, 0);
+                                    }
+                                    let normalized = resolve_path::normalize_string_buf::<
                                         false,
                                         platform::Auto,
-                                    >(resolved);
+                                        false,
+                                    >(
+                                        resolved, &mut normalize_buf[..]
+                                    );
                                     let dirname =
                                         resolve_path::dirname::<platform::Auto>(normalized);
                                     if dirname.is_empty() {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
@@ -329,3 +329,65 @@ test.skipIf(process.platform === "win32")(
     expect(exitCode).toBe(0);
   },
 );
+
+// The preserve-root check resolved every operand through the fixed-size
+// thread-local path buffers (1024 bytes for normalizing, 4096 for joining),
+// so an operand longer than either crashed the process before rm ever
+// touched the filesystem. Runs in a child process so the crash shows up as a
+// failed assertion rather than taking the test runner down with it.
+test("operands longer than the path scratch buffers are reported, not a crash", async () => {
+  using dir = tempDir("rm-long-operand", { "short.txt": "" });
+  const long = Buffer.alloc(1100, "a").toString();
+  const longer = Buffer.alloc(8192, "b").toString();
+  const absolute = path.join(String(dir), long);
+  // Joins back down to "/" no matter how long it is, so it still has to be refused.
+  const upToRoot = Buffer.alloc(6000, "../").toString();
+
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    import { existsSync } from "node:fs";
+    $.nothrow();
+    const { LONG, LONGER, ABSOLUTE, UP_TO_ROOT } = process.env;
+    const run = async (...args: string[]) => {
+      const { exitCode, stderr } = await $\`rm \${args}\`.quiet();
+      return { exitCode, stderr: stderr.toString() };
+    };
+    const results = {
+      relative: await run(LONG!),
+      absolute: await run(ABSOLUTE!),
+      overJoinBuffer: await run(LONGER!),
+      mixed: { ...(await run(LONG!, "short.txt")), shortRemoved: !existsSync("short.txt") },
+      upToRoot: UP_TO_ROOT ? await run(UP_TO_ROOT) : undefined,
+    };
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      LONG: long,
+      LONGER: longer,
+      ABSOLUTE: absolute,
+      // The check is effectively a no-op for drive-rooted paths on Windows.
+      ...(isWindows ? {} : { UP_TO_ROOT: upToRoot }),
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+
+  // Which errno an over-long name produces is up to the OS; what matters is
+  // that each operand fails on its own and the others are still processed.
+  const tooLong = (operand: string) =>
+    isWindows ? expect.stringMatching(/^rm: /) : `rm: ${operand}: File name too long\n`;
+  expect(JSON.parse(stdout)).toEqual({
+    relative: { exitCode: 1, stderr: tooLong(long) },
+    absolute: { exitCode: 1, stderr: tooLong(absolute) },
+    overJoinBuffer: { exitCode: 1, stderr: tooLong(longer) },
+    mixed: { exitCode: 1, stderr: tooLong(long), shortRemoved: true },
+    ...(isWindows ? {} : { upToRoot: { exitCode: 1, stderr: 'rm: "/" may not be removed\n' } }),
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Reproduction

```sh
cd /tmp && bun -e 'const r = await Bun.$`rm ${"a".repeat(1100)}`.nothrow().quiet(); console.log("exit", r.exitCode);'
```

```
panic: range end index 1104 out of range for slice of length 1024
oh no: Bun has crashed.
```

The process aborts (exit 134). Expected: `rm: aaaa...: File name too long`, exit code 1, and the script keeps running. Same crash for an absolute operand longer than 1024 bytes, and for a relative operand of roughly 4096 bytes or more (`range end index N out of range for slice of length 4095`, one buffer earlier).

## Cause

Before scheduling anything, `rm` checks that no operand resolves to the root (`src/runtime/shell/builtin/rm.rs`, `ParseOpts` state). For each operand it calls `resolve_path::join(cwd, operand)` and then `resolve_path::normalize_string(resolved)`. Both write into fixed-size thread-local scratch buffers in `src/paths/resolve_path.rs` (`JOIN_BUF`, 4096 bytes, and `PARSER_BUFFER`, 1024 bytes on every platform) with plain slice indexing, so an operand that does not fit panics. Operands come straight from the user, so there is no bound on their length; the shell cwd itself is already bounded to 4 KiB by `cd`.

## Fix

The check now joins through `join_spill` (the existing helper that falls back to a caller-owned `Vec` when the thread-local buffer is too small, as `Bun.Glob` and `fs.readdir` already do) and normalizes into a `Vec` sized to the input via `normalize_string_buf`. The logic of the check is unchanged, only the buffers are.

Skipping the check for over-long operands would have been simpler but is not safe: a long `../../..` chain that joins back down to `/` is still well under `PATH_MAX`, so the kernel would happily act on it. Running the check for every length keeps `rm` refusing it (covered by the `upToRoot` case below), and operands that really are too long fall through to `unlinkat`, which reports `ENAMETOOLONG` through the normal per-operand error path; the other operands of the same invocation are still processed.

## Verification

New case in `test/js/bun/shell/commands/rm.test.ts` runs `rm` in a child process with a 1100-byte relative operand, a 1100-byte absolute operand, an 8192-byte operand (past the join buffer as well), a long operand next to a normal one that must still be removed, and (POSIX) a 6000-byte `../` chain that must still be refused with `"/" may not be removed`.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/rm.test.ts -t "operands longer"`: fails, the child aborts with the panic above.
- `bun bd test test/js/bun/shell/commands/rm.test.ts`: 8 pass.

The same unbounded scratch-buffer pattern in the `mv`, `mkdir` and `touch` builtins, and the separate question of this check also refusing top-level paths like `/app`, are tracked separately; this PR only makes the existing check safe for any operand length.
