### PR TITLE
fetch: only pool a redirecting connection for idempotent hops; derive the pool key in one place

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -944,13 +944,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
             // against get_tls_hostname() — which prefers the Host-header
             // override (client.hostname) over url.hostname — so the override
             // must discriminate the pool key there too, not just for CONNECT
-            // tunnels. proxy_auth_hash() reduces to exactly the override hash
-            // (or 0) for a non-proxied request.
-            let proxy_auth_hash: u64 = if want_tunnel || (SSL && client.http_proxy.is_none()) {
-                client.proxy_auth_hash()
-            } else {
-                0
-            };
+            // tunnels.
+            let proxy_auth_hash = client.pool_auth_hash(SSL, want_tunnel);
 
             if let Some(mut found) = self.existing_socket(
                 client.flags.reject_unauthorized,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1875,11 +1875,7 @@ impl<'a> HTTPClient<'a> {
                             self.get_ssl_ctx::<true>(),
                             self.connected_url.hostname,
                             self.connected_url.get_port_auto(),
-                            if want_tunnel || self.http_proxy.is_none() {
-                                self.proxy_auth_hash()
-                            } else {
-                                0
-                            },
+                            self.pool_auth_hash(true, want_tunnel),
                         );
                     }
                 }
@@ -2299,6 +2295,15 @@ impl<'a> HTTPClient<'a> {
         if any { combined } else { 0 }
     }
 
+    /// The `proxy_auth_hash` pool-key field; `HTTPContext::connect` and every `release_socket` caller must agree on it.
+    pub(crate) fn pool_auth_hash(&self, is_ssl: bool, tunnel: bool) -> u64 {
+        if tunnel || (is_ssl && self.http_proxy.is_none()) {
+            self.proxy_auth_hash()
+        } else {
+            0
+        }
+    }
+
     /// Returns the SSL context for this client - either the custom context
     /// (for mTLS/custom TLS) or the default global context.
     pub(crate) fn get_ssl_ctx<const IS_SSL: bool>(&self) -> *mut GenHttpContext<IS_SSL> {
@@ -2623,6 +2628,8 @@ impl<'a> HTTPClient<'a> {
         } else if keep_alive_possible
             && self.is_request_fully_sent()
             && !socket.is_closed_or_has_error()
+            // The hop goes out on this socket before a FIN sent behind the 3xx is seen; on_close only retries idempotent methods.
+            && self.method.is_idempotent()
             // A direct TLS socket verified against a Host-header override
             // (get_tls_hostname) must not be pooled here: this.url has already
             // been repointed at the redirect destination, so proxy_auth_hash()
@@ -2641,7 +2648,7 @@ impl<'a> HTTPClient<'a> {
                 None,
                 b"",
                 0,
-                0,
+                self.pool_auth_hash(IS_SSL, false),
                 None,
             );
         } else {
@@ -4208,15 +4215,7 @@ impl<'a> HTTPClient<'a> {
                     } else {
                         0
                     },
-                    if had_tunnel || (IS_SSL && self.http_proxy.is_none()) {
-                        // Direct TLS: the handshake verified the peer against
-                        // the Host-header override (get_tls_hostname), so the
-                        // override hash must be part of the pool key. Matches
-                        // the lookup in HTTPContext::connect.
-                        self.proxy_auth_hash()
-                    } else {
-                        0
-                    },
+                    self.pool_auth_hash(IS_SSL, had_tunnel),
                     None,
                 );
             } else {
@@ -4390,7 +4389,7 @@ impl<'a> HTTPClient<'a> {
             None,
             b"",
             0,
-            0,
+            self.pool_auth_hash(IS_SSL, false),
             None,
         );
 

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -370,16 +370,21 @@ test("a completed streaming POST keeps its connection in the keep-alive pool", a
 });
 
 // Raw HTTP/1.1 server for the redirect tests below, bound to 127.0.0.1 (the
-// address fetch() dials). Every request is answered on the connection it came
-// in on, so `connections` is exactly how many times bun dialed.
-//   /302, /303, /307  bodyless redirect to /legit on a reusable connection
-//   /302-close        the same 302 with Connection: close
-//   /302-body         a 302 that carries a body
-//   anything else     200 whose body is "<method>:<request body length>"
-const redirectServer = `
+// address fetch() dials), optionally behind TLS. Every request is answered on
+// the connection it came in on, so `connections` is exactly how many times bun
+// dialed.
+//   /302, /303, /307      bodyless redirect to /legit on a reusable connection
+//   /302-close            the same 302 with Connection: close
+//   /302-end, /307-end    the same bodyless 3xx, after which the server closes
+//                         the connection without having announced it
+//   /302-body             a 302 that carries a body
+//   anything else         200 whose body is "<method>:<request body length>"
+const redirectServer = (https: boolean) => `
   import net from "node:net";
+  import tls from "node:tls";
+  const ca = ${JSON.stringify(tls.cert)};
   let connections = 0;
-  const server = net.createServer(sock => {
+  const onConnection = sock => {
     connections++;
     sock.on("error", () => {});
     let buf = "";
@@ -393,75 +398,157 @@ const redirectServer = `
         if (buf.length < end + 4 + len) return;
         buf = buf.slice(end + 4 + len);
         const [method, path] = head.split(" ");
-        const redirect = {
+        const status = {
           "/302": "302 Found",
           "/302-close": "302 Found",
+          "/302-end": "302 Found",
           "/302-body": "302 Found",
           "/303": "303 See Other",
           "/307": "307 Temporary Redirect",
+          "/307-end": "307 Temporary Redirect",
         }[path];
-        if (!redirect) {
+        if (!status) {
           const body = method + ":" + len;
           sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: " + body.length + "\\r\\n\\r\\n" + body);
         } else if (path === "/302-close") {
-          sock.end("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n");
+          sock.end("HTTP/1.1 " + status + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n");
+        } else if (path.endsWith("-end")) {
+          sock.end("HTTP/1.1 " + status + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\n\\r\\n");
         } else if (path === "/302-body") {
-          sock.write("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 5\\r\\n\\r\\nmoved");
+          sock.write("HTTP/1.1 " + status + "\\r\\nLocation: /legit\\r\\nContent-Length: 5\\r\\n\\r\\nmoved");
         } else {
-          sock.write("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\n\\r\\n");
+          sock.write("HTTP/1.1 " + status + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\n\\r\\n");
         }
       }
     });
-  });
+  };
+  const server = ${https ? `tls.createServer({ cert: ca, key: ${JSON.stringify(tls.key)} }, onConnection)` : "net.createServer(onConnection)"};
   server.listen(0, "127.0.0.1");
   await new Promise(r => server.on("listening", r));
-  const origin = "http://127.0.0.1:" + server.address().port;
+  const origin = "${https ? "https" : "http"}://127.0.0.1:" + server.address().port;
 `;
 
 // A bodyless 3xx on a keep-alive connection leaves that connection as reusable
-// as any other completed exchange, so the hop (and every later fetch) should
-// ride on it: four redirected fetches, one connection. This used to hold only
-// for streamed request bodies; a request whose headers and body went out in a
-// single write was never considered finished by the redirect path, so each
-// redirect closed the connection and dialed again for the hop (5 connections
-// here, one per redirect plus the first). Subprocess so the pool is private to
-// the test.
-test.concurrent.each([
-  ["GET -> 302", "/302", "{}", "GET:0", 1],
-  ["POST -> 303 (hop is a bodyless GET)", "/303", '{ method: "POST", body: "payload" }', "GET:0", 1],
-  ["POST -> 307 (hop resends the body)", "/307", '{ method: "POST", body: "payload" }', "POST:7", 1],
-  // Not reusable, so every fetch dials once more for the hop; the hop's own
-  // connection is pooled and carries the next fetch's 3xx.
-  ["GET -> 302 with Connection: close", "/302-close", "{}", "GET:0", 5],
-  ["GET -> 302 carrying a body", "/302-body", "{}", "GET:0", 5],
-])("redirect keep-alive: %s", async (_, path, init, hopBody, connections) => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      ${redirectServer}
-      const results = [];
-      for (let i = 0; i < 4; i++) {
-        const res = await fetch(origin + ${JSON.stringify(path)}, ${init});
-        results.push(res.status, res.redirected, await res.text());
-      }
-      console.log(JSON.stringify({ results, connections }));
-      process.exit(0);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+// as any other completed exchange, so when the hop can be retried it rides on
+// it, and so does every later fetch: four redirected fetches, one connection.
+// (Until 1.4.0 this held only for streamed request bodies; a request whose
+// headers and body went out in a single write was never considered finished by
+// the redirect path, so each redirect closed the connection and dialed again
+// for the hop.) The hop is written onto that connection before a FIN the
+// server may have sent right behind the 3xx can be seen, which on_close only
+// recovers from by retrying idempotent requests; a hop that kept a
+// non-idempotent method therefore gets a fresh connection instead.
+//
+// The 5-connection rows dial once per fetch: the connection that carried the
+// 3xx is not reused (or, in the "-end" rows, dies under the hop and the hop is
+// retried), while the hop's own connection is pooled and carries the next
+// fetch's 3xx. Subprocess so the pool is private to the test.
+const redirectCases: {
+  name: string;
+  path: string;
+  init?: string;
+  https?: boolean;
+  env?: Record<string, string>;
+  hop: string;
+  connections: number;
+}[] = [
+  { name: "GET -> 302", path: "/302", hop: "GET:0", connections: 1 },
+  {
+    name: "POST -> 303 (hop is a bodyless GET)",
+    path: "/303",
+    init: 'method: "POST", body: "payload"',
+    hop: "GET:0",
+    connections: 1,
+  },
+  {
+    name: "PUT -> 307 (hop resends the body)",
+    path: "/307",
+    init: 'method: "PUT", body: "payload"',
+    hop: "PUT:7",
+    connections: 1,
+  },
+  {
+    name: "POST -> 307 (hop is still a POST)",
+    path: "/307",
+    init: 'method: "POST", body: "payload"',
+    hop: "POST:7",
+    connections: 5,
+  },
+  { name: "GET -> 302 with Connection: close", path: "/302-close", hop: "GET:0", connections: 5 },
+  { name: "GET -> 302 carrying a body", path: "/302-body", hop: "GET:0", connections: 5 },
+  { name: "GET -> 302, server closes unannounced (hop retried)", path: "/302-end", hop: "GET:0", connections: 5 },
+  {
+    name: "PUT -> 307, server closes unannounced (hop retried)",
+    path: "/307-end",
+    init: 'method: "PUT", body: "payload"',
+    hop: "PUT:7",
+    connections: 5,
+  },
+  {
+    name: "POST -> 307, server closes unannounced",
+    path: "/307-end",
+    init: 'method: "POST", body: "payload"',
+    hop: "POST:7",
+    connections: 5,
+  },
+  { name: "https GET -> 302", path: "/302", https: true, init: "tls: { ca }", hop: "GET:0", connections: 1 },
+  // The TLS handshake was verified against the Host header, which the redirect
+  // path cannot key the pool by once the URL has moved on, so it closes.
+  {
+    name: "https GET -> 302 with a Host header override",
+    path: "/302",
+    https: true,
+    init: 'tls: { ca }, headers: { Host: "localhost" }',
+    hop: "GET:0",
+    connections: 5,
+  },
+  // The proxy option is bypassed by NO_PROXY, but its headers still take part
+  // in the key a direct TLS socket is pooled and looked up under; the redirect
+  // release has to use the same key or its sockets are parked unreachably.
+  {
+    name: "https GET -> 302 with a NO_PROXY-bypassed proxy option carrying headers",
+    path: "/302",
+    https: true,
+    init: 'tls: { ca }, proxy: { url: "http://127.0.0.1:9/", headers: { "x-proxy-probe": "1" } }',
+    env: { NO_PROXY: "127.0.0.1" },
+    hop: "GET:0",
+    connections: 1,
+  },
+];
+for (const { name, path, init = "", https = false, env, hop, connections } of redirectCases) {
+  test.concurrent(`redirect keep-alive: ${name}`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        ${redirectServer(https)}
+        const results = [];
+        for (let i = 0; i < 4; i++) {
+          try {
+            const res = await fetch(origin + ${JSON.stringify(path)}, { ${init} });
+            results.push(res.status, res.redirected, await res.text());
+          } catch (e) {
+            results.push(String(e.code ?? e));
+          }
+        }
+        console.log(JSON.stringify({ results, connections }));
+        process.exit(0);
+        `,
+      ],
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-  expect({ result, exitCode }).toEqual({
-    result: { results: Array(4).fill([200, true, hopBody]).flat(), connections },
-    exitCode: 0,
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({
+      result: { results: Array(4).fill([200, true, hop]).flat(), connections },
+      exitCode: 0,
+    });
   });
-});
+}
 
 // What the pooling above must not relax: a response (redirect or final) that
 // arrives while the request body is still going out leaves the connection


### PR DESCRIPTION
Two follow-ups to #37451, which made `do_redirect` hand the connection that carried a bodyless 3xx back to the pool for ordinary requests (before, only streamed bodies got there). Both came out of reviewing that change after it merged.

### 1. A non-idempotent hop could land on a connection the server had just closed

Repro (main after #37451; works on 1.4.0): a raw server that answers `POST /307` with `HTTP/1.1 307 Temporary Redirect`, `Location: /legit`, `Content-Length: 0` and then closes the connection without a `Connection: close` header (this is what every HTTP/1.0 server does, e.g. `python -m http.server`), and answers everything else with a 200.

```js
await fetch(origin + "/307", { method: "POST", body: "payload" }); // main: ECONNRESET, 1.4.0: 200
await fetch(origin + "/302");                                       // 200 on both
```

Cause: `do_redirect` releases the socket and immediately calls `start()`, which takes it straight back out of the pool and writes the hop onto it, all inside the 3xx's own data callback. A FIN the server sent right behind the 3xx is only processed afterwards, and `on_close` retries a request on a reused connection only if its method is idempotent, so the `GET` hop above is retried on a fresh connection while the `POST` hop fails. Before #37451 these hops always dialed fresh.

Fix: the release in `do_redirect` is additionally gated on the hop's method (already rewritten by `handle_response_metadata`, so 301/302/303 hops are `GET`) being idempotent. A hop that kept a non-idempotent method (`POST`/`PATCH` on 307/308, `PATCH` on 301/302) closes the 3xx connection and dials as it did in 1.4.0; idempotent hops keep the reuse and are covered by the existing retry when the connection turns out to be dead. This deliberately trades the reuse for those hops rather than retrying non-idempotent requests or deferring the hop to a later loop iteration; either of those is a wider policy change than this regression needs.

### 2. The redirect release used a different pool key than the lookup

`do_redirect` released direct TLS sockets with `proxy_auth_hash = 0`, while `HTTPContext::connect` looks them up with `proxy_auth_hash()` (and `send_progress_update_without_stage_check` releases with it). They agree unless something feeds into `proxy_auth_hash()` without a proxy being in effect, which happens with `proxy: { url, headers }` when `NO_PROXY` bypasses the proxy: then every followed redirect parked a socket under a key nothing looks up. Each such socket sits in the pool for its 5 minute idle timeout, and the pool has 64 slots, so after enough redirects correctly keyed releases start failing too. With #37451 this went from the rare streamed-body case to every redirect in that configuration. Reproduced with the new test below: 4 redirected https fetches in that configuration dialed 5 connections instead of 1.

Fix: one helper, `HTTPClient::pool_auth_hash(is_ssl, tunnel)`, now produces the key at the lookup, both release sites, `on_preconnect` and the TLS session cache (which is documented as being keyed on the pool tuple). For every site except `do_redirect` this is the expression that was already inlined there (preconnect has no override, proxy headers or proxy, so its value is still 0). Using it in `do_redirect` is sound because the existing Host-override exclusion guarantees `hostname` is unset in the only branch that reaches `proxy_auth_hash()`, so the repointed `url` cannot affect the result, and `reevaluate_proxy_for_redirect` runs after the release, so `http_proxy` still describes the connection being released.

### Tests

The redirect table in `test/js/web/fetch/fetch-keepalive.test.ts` (each row: four redirected fetches against a raw server counting connections, in a subprocess) gains:

* `POST -> 307, server closes unannounced` (fails on main with `ECONNRESET`), plus `GET -> 302` and `PUT -> 307` variants of the same server showing the idempotent hops being retried.
* `POST -> 307` on a reusable connection now expects the hop to dial (was 1 connection after #37451); `PUT -> 307` is added as the idempotent-with-body row that still reuses.
* https rows: plain `GET -> 302` reuses; a Host-header override closes (the exclusion in `do_redirect`); the `NO_PROXY`-bypassed `proxy: { url, headers }` row reuses (fails on main with 5 connections). #37451's tests were all plain http.

The previously added rows are unchanged. Also ran fetch.unix, fetch-redirect, fetch.tls, the proxy suites and fetch-http2-client against the debug build; the only failures were tests that time out identically on an unmodified build in this environment.
