### PR TITLE
sys(windows): create dup() handles non-inheritable so children stop inheriting them

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3955,6 +3955,11 @@ mod windows_impl {
         // CRT-fd-backed `Fd` and ignores the directory/nofollow flags.
         super::openat_windows_a(dir, path.as_bytes(), flags, mode)
     }
+    /// `DuplicateHandle` with `bInheritHandle = FALSE`, the equivalent of the
+    /// POSIX arm's `F_DUPFD_CLOEXEC`: libuv spawns children with
+    /// `bInheritHandles = TRUE`, so an inheritable duplicate would leak into
+    /// every process spawned while it is open. Stdio handed to a child is
+    /// duplicated again (inheritable) by libuv itself, so nothing needs it.
     pub fn dup(fd: Fd) -> Maybe<Fd> {
         // DuplicateHandle on the underlying HANDLE.
         let process = w::kernel32::GetCurrentProcess();
@@ -3966,7 +3971,7 @@ mod windows_impl {
                 process,
                 &mut target,
                 0,
-                w::TRUE,
+                w::FALSE,
                 w::DUPLICATE_SAME_ACCESS,
             )
         };

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1,4 +1,5 @@
 import { ArrayBufferSink, readableStreamToText, spawn, spawnSync } from "bun";
+import { dlopen } from "bun:ffi";
 import { beforeAll, describe, expect, it } from "bun:test";
 import {
   gcTick as _gcTick,
@@ -12,6 +13,7 @@ import {
   isPosix,
   isWindows,
   shellExe,
+  tempDir,
   tmpdirSync,
   withoutAggressiveGC,
 } from "harness";
@@ -1310,6 +1312,84 @@ it.skipIf(isWindows)("leaves a Bun.file(fd) stdout open when stdin stream setup 
   expect(stdout.trim()).toBe("pull unavailable");
   expect(readFileSync(file, "utf8")).toContain("still-open");
   expect(exitCode).toBe(0);
+});
+
+// Bun.file(fd).stream() (like the shell's stdio and cwd handles) works on a
+// dup() of the descriptor. On Windows that duplicate used to be created
+// inheritable, and libuv spawns with bInheritHandles=TRUE, so every child
+// started while one was open got a copy and kept the file open after the
+// parent closed it. POSIX dup() uses F_DUPFD_CLOEXEC; the Windows side must match.
+it.if(isWindows)("handles duplicated for Bun.file(fd).stream() are not inherited by children", async () => {
+  const N = 64;
+  // Bigger than the stream's high-water mark, so each reader parks on its
+  // duplicate instead of reading to EOF and closing it.
+  using dir = tempDir("spawn-dup-inherit", { "data.bin": Buffer.alloc(1024 * 1024) });
+
+  const k32 = dlopen("kernel32.dll", {
+    GetCurrentProcess: { args: [], returns: "ptr" },
+    GetProcessHandleCount: { args: ["ptr", "ptr"], returns: "i32" },
+  });
+  const ownHandleCount = () => {
+    const out = new Uint32Array(1);
+    if (k32.symbols.GetProcessHandleCount(k32.symbols.GetCurrentProcess(), out) === 0) {
+      throw new Error("GetProcessHandleCount failed");
+    }
+    return out[0];
+  };
+
+  // The child reports how many handles it was started with.
+  const spawnHandleCounter = () =>
+    spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { dlopen } from "bun:ffi";
+        const k32 = dlopen("kernel32.dll", {
+          GetCurrentProcess: { args: [], returns: "ptr" },
+          GetProcessHandleCount: { args: ["ptr", "ptr"], returns: "i32" },
+        });
+        const out = new Uint32Array(1);
+        if (k32.symbols.GetProcessHandleCount(k32.symbols.GetCurrentProcess(), out) === 0) {
+          throw new Error("GetProcessHandleCount failed");
+        }
+        console.log(out[0]);
+        `,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  const reportedHandleCount = async (proc: ReturnType<typeof spawnHandleCounter>) => {
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return Number(stdout.trim());
+  };
+
+  const fds = Array.from({ length: N }, () => openSync(join(String(dir), "data.bin"), "r"));
+  const readers: ReadableStreamDefaultReader<Uint8Array>[] = [];
+  try {
+    // Plain descriptors are already non-inheritable; this child is the baseline.
+    await using control = spawnHandleCounter();
+
+    const before = ownHandleCount();
+    for (const fd of fds) readers.push(Bun.file(fd).stream().getReader());
+    // getReader() starts the stream, which dup()s the descriptor: the
+    // duplicates exist in this process while the next child is created.
+    expect(ownHandleCount() - before).toBeGreaterThanOrEqual(N);
+    await using withDuplicates = spawnHandleCounter();
+
+    const [controlCount, withDuplicatesCount] = await Promise.all([
+      reportedHandleCount(control),
+      reportedHandleCount(withDuplicates),
+    ]);
+    // An inheritable dup() hands every one of the N duplicates to the child,
+    // so the difference used to be exactly N.
+    expect(withDuplicatesCount - controlCount).toBeLessThan(N / 2);
+  } finally {
+    await Promise.all(readers.map(reader => reader.cancel()));
+    for (const fd of fds) closeSync(fd);
+  }
 });
 
 it.if(isWindows)("throws a spawn error for a cwd longer than the maximum path length", async () => {


### PR DESCRIPTION
## Problem

On Windows, every handle returned by `bun_sys::dup()` was created inheritable (`DuplicateHandle(..., bInheritHandle = TRUE, ...)`). libuv's `uv_spawn` calls `CreateProcessW` with `bInheritHandles = TRUE` and no handle list (`vendor/libuv/src/win/process.c`), so any process Bun spawned while such a duplicate was open received a copy of it, and kept the underlying file / pipe / directory open after Bun itself had closed the duplicate, for as long as the child lived.

`dup()` backs `Bun.file(fd).stream()` (`FileReader.rs`), a `fetch()` body made from `Bun.file(fd)`, `FileSink` started on an fd (`io/openForWriting.rs`), and the shell: its duplicates of stdin/stdout/stderr and of the cwd directory handle for every subshell / pipeline (`shell/interpreter.rs`, `shell_dup` / `dupe_for_subshell`). The POSIX arm of the same function uses `fcntl(F_DUPFD_CLOEXEC)` precisely so this does not happen.

Measured on Windows x64 with the released `1.4.0-canary` (da3851e57): a `bun -e` child that prints its own `GetProcessHandleCount()`, spawned five times each way while the parent held 64 open fds:

```
parent holds 64 plain fs.openSync() fds:                  164 164 164 164 164
same, plus Bun.file(fd).stream().getReader() on each one:  228 228 228 228 228   (+64, one per dup())
```

## Fix

`src/sys/lib.rs`, Windows `dup()`: pass `FALSE` for `bInheritHandle`. Nothing relies on these duplicates being inheritable:

- When an fd is handed to a child as stdio, libuv duplicates it again itself with `bInheritHandle = TRUE` (`uv__duplicate_handle` in `vendor/libuv/src/win/process-stdio.c`), regardless of the source handle's flag. This covers `Bun.spawn` / `child_process` (`UV_INHERIT_FD` in `spawn/process.rs`) and every shell command, since the shell spawns through the same path.
- Bun's other process-creation paths (`--watch` manager, the bin shim, the crash reporter, `std::process::Command` in `bun_core::util`) do not involve `dup()` at all; the first two hand the child the process's real std handles and set those inheritable themselves.
- Every other handle Bun opens on Windows (`NtCreateFile` paths, libuv's `uv_fs_open`) is already non-inheritable, which is what the 164 / 164 control above shows. `dup()` was the only `DuplicateHandle` call in the tree.

The POSIX arm is unchanged; it already has the CLOEXEC behaviour this gives Windows.

## Verification

New test in `test/js/bun/spawn/spawn.test.ts` (Windows only, since the POSIX `dup()` is already close-on-exec): opens 64 fds, spawns a control child, starts `Bun.file(fd).stream()` on each fd, checks with `GetProcessHandleCount` that this process now holds at least 64 more handles, spawns a second child, and asserts that the second child did not start with (about) 64 more handles than the first.

- Windows x64, released canary (unfixed): fails with `Expected: < 32, Received: 64`.
- Windows x64, debug build of this branch: passes; the same probe as above reads 171 / 171. The rest of `spawn.test.ts` passes there as well (125 pass, 19 platform skips, 3 todo).
- Also checked by hand on the debug build that each Windows `dup()` caller still works: `Bun.file(fd).stream().text()`, `fetch()` with a `Bun.file(fd)` body, `Bun.spawn` with an fd as `stdout`, and shell commands with inherited stdio, pipelines and subshells.
- On POSIX the test is skipped and the compiled code is unchanged.

The same function is touched by #37516 (EBADF for a descriptor that is not open); the two changes are on different lines and `git merge-tree` reports a clean merge either way.
