### PR TITLE
error printer: print the properties and cause of an Error thrown through a JSC exception

### DIFF
--- a/src/jsc/Exception.rs
+++ b/src/jsc/Exception.rs
@@ -19,7 +19,9 @@ impl Exception {
         JSC__Exception__getStackTrace(self, global, stack);
     }
 
-    pub fn value(&self) -> JSValue {
+    /// The `JSC::Exception` cell itself as a `JSValue`, not the value it wraps;
+    /// `JSValue::to_error` unwraps it.
+    pub fn as_js_value(&self) -> JSValue {
         JSC__Exception__asJSValue(self)
     }
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4773,7 +4773,7 @@ impl VirtualMachine {
         let mut formatter = crate::console_object::Formatter::new(self.global());
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
-            exception.value(),
+            exception.as_js_value(),
             Some(exception),
             exception_list,
             &mut formatter,
@@ -5114,6 +5114,9 @@ impl VirtualMachine {
         self.run_error_handler(value, None);
     }
 
+    /// `value` is the thrown value or, from [`Self::print_exception`], the
+    /// `JSC::Exception` cell wrapping it (see [`Self::print_error_instance_js`]).
+    ///
     /// Note: takes runtime bools and the concrete `bun_core::io::Writer`.
     pub fn print_errorlike_object(
         &mut self,
@@ -5318,7 +5321,7 @@ impl VirtualMachine {
         exception: &Exception,
     ) -> JSValue {
         let jsc_vm = global_object.bun_vm().as_mut();
-        let _ = jsc_vm.uncaught_exception(global_object, exception.value(), false);
+        let _ = jsc_vm.uncaught_exception(global_object, exception.as_js_value(), false);
         JSValue::UNDEFINED
     }
 
@@ -5832,7 +5835,10 @@ impl VirtualMachine {
     }
 
     /// JS-value variant of the error printer; see
-    /// [`Self::print_error_instance_body`].
+    /// [`Self::print_error_instance_body`]. `error_instance` may be the
+    /// `JSC::Exception` cell wrapping the thrown value: `toZigException` takes
+    /// the throw-site stack from the cell, but the body has to be handed the
+    /// wrapped Error itself to print its own properties and `cause` chain.
     fn print_error_instance_js(
         &mut self,
         error_instance: JSValue,
@@ -5898,10 +5904,14 @@ impl VirtualMachine {
         );
         error_instance.ensure_still_alive();
 
+        let error_value = match error_instance.to_error() {
+            Some(err) if err.js_type() == jsc::JSType::ErrorInstance => err,
+            _ => error_instance,
+        };
         let result = self.print_error_instance_body(
             // SAFETY: see above.
             unsafe { &mut *exception },
-            error_instance,
+            error_value,
             None, // Note: `exception_list` was already
             // consumed by `remap_zig_exception` above (only writer).
             formatter,

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("name property is used for function calls in Error.stack", () => {
@@ -148,4 +148,122 @@ test("Async functions frame should be included in stack trace", async () => {
         at async foo (file:NN:NN)
         at async <anonymous> (file:NN:NN)"
   `);
+});
+
+// A test body that throws synchronously and an uncaught exception thrown from a
+// callback both reach the error printer wrapped in the JSC exception that unwound
+// the stack, whereas a rejection arrives as the Error itself. Both forms have to
+// print the same details.
+describe("errors printed from an uncaught exception", () => {
+  const throwErrorWithDetails = /* js */ `
+    const err = new Error("outer failure", { cause: new Error("inner cause") });
+    err.code = "ERR_FIXTURE";
+    err.detail = 42;
+    throw err;
+  `;
+
+  test.concurrent("bun test prints the properties and cause of a synchronously thrown error", async () => {
+    using dir = tempDir("sync-throw-details", {
+      "my.test.js": `import { test } from "bun:test";\ntest("sync throw", () => {${throwErrorWithDetails}});\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "my.test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "my.test.js:
+      1 | import { test } from "bun:test";
+      2 | test("sync throw", () => {
+      3 |     const err = new Error("outer failure", { cause: new Error("inner cause") });
+      4 |     err.code = "ERR_FIXTURE";
+      5 |     err.detail = 42;
+      6 |     throw err;
+                    ^
+      error: outer failure
+       detail: 42,
+         code: "ERR_FIXTURE"
+          at <anonymous> (file:NN:NN)
+
+      1 | import { test } from "bun:test";
+      2 | test("sync throw", () => {
+      3 |     const err = new Error("outer failure", { cause: new Error("inner cause") });
+                                                                  ^
+      error: inner cause
+          at <anonymous> (file:NN:NN)
+      (fail) sync throw
+
+       0 pass
+       1 fail
+      Ran 1 test across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("an uncaught exception thrown from a callback prints the properties and cause", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `setTimeout(() => {${throwErrorWithDetails}});`],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+      "1 | setTimeout(() => {
+      2 |     const err = new Error("outer failure", { cause: new Error("inner cause") });
+      3 |     err.code = "ERR_FIXTURE";
+      4 |     err.detail = 42;
+      5 |     throw err;
+                    ^
+      error: outer failure
+       detail: 42,
+         code: "ERR_FIXTURE"
+          at <anonymous> (file:NN:NN)
+
+      1 | setTimeout(() => {
+      2 |     const err = new Error("outer failure", { cause: new Error("inner cause") });
+                                                                  ^
+      error: inner cause
+          at <anonymous> (file:NN:NN)
+
+      Bun v<bun-version>"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("a synchronously thrown resolve error is still printed once", async () => {
+    using dir = tempDir("sync-throw-resolve-message", {
+      "my.test.js": `import { test } from "bun:test";\ntest("sync require", () => {\n  require("./does-not-exist");\n});\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "my.test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // Debug builds add an internal `require` frame, which also moves the divot.
+    const withoutStackFrames = stderr
+      .split("\n")
+      .filter(line => !/^\s*(at |\^\s*$)/.test(line))
+      .join("\n");
+    expect(normalizeBunSnapshot(withoutStackFrames, String(dir))).toMatchInlineSnapshot(`
+      "my.test.js:
+      1 | import { test } from "bun:test";
+      2 | test("sync require", () => {
+      ResolveMessage: Cannot find module './does-not-exist'
+      Require stack:
+      - <dir>/my.test.js
+      (fail) sync require
+
+       0 pass
+       1 fail
+      Ran 1 test across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### What

When a test body throws synchronously, or a callback throws an uncaught exception, the printed error is missing everything except its name, message, and stack: own properties, the `code` line, and the `cause` chain are all dropped. The same error thrown from an async test (or rejected) prints all of them.

```js
// my.test.js
import { test } from "bun:test";
test("sync throw", () => {
  const err = new Error("outer failure", { cause: new Error("inner cause") });
  err.code = "ERR_FIXTURE";
  err.detail = 42;
  throw err;
});
```

Before (`bun test my.test.js`, source preview lines elided; the same code inside a `setTimeout` callback under `bun -e` prints the same way):

```
error: outer failure
      at <anonymous> (/tmp/prdemo/my.test.js:6:9)
(fail) sync throw
```

After, which is what an `async` version of the same test already printed:

```
error: outer failure
 detail: 42,
   code: "ERR_FIXTURE"

      at <anonymous> (/tmp/prdemo/my.test.js:6:9)

error: inner cause
      at <anonymous> (/tmp/prdemo/my.test.js:3:55)
(fail) sync throw
```

This is what was behind the handoff that led here: a `using` resource whose dispose threw during a failing test printed only `SuppressedError: ` with no trace of either error. See "Related" below.

### Cause

Both entry points (`BunTest::on_uncaught_exception` after `try_take_exception`, and `report_uncaught_exception`) hand `run_error_handler` the `JSC::Exception` cell rather than the thrown value. That is deliberate: `JSC__Exception__asJSValue` returns the cell, and `toZigException` looks through it to take the stack of the throw site. But `print_error_instance_js` also passed the cell on to `print_error_instance_body`, where `is_error_instance` checks `js_type() == ErrorInstance`. An `Exception` cell is not an `ErrorInstance`, so the whole block that prints the `code`, the own properties, and the non-enumerable `cause` (and anything other PRs add to that block) was skipped. Rejections and top-level throws pass the Error itself, which is why only the synchronous and callback cases were affected.

This is not a regression; the Zig version had the same shape.

### Fix

`print_error_instance_js` keeps passing the cell to `remap_zig_exception`, so the stack, source preview, and divot are unchanged, and passes the Error the exception wraps (`JSValue::to_error`, the existing helper for exactly this unwrap) to `print_error_instance_body`. Values that are not an `ErrorInstance` are passed through as before. Unwrapping everything would turn the current

```
ResolveMessage: Cannot find module './does-not-exist'
Require stack:
- /tmp/x/my.test.js
```

for a synchronous `require()` of a missing module into that plus a second `error: Cannot find module ...` block from the non-Error fallback, since `BuildMessage`/`ResolveMessage` are only intercepted before the body when they arrive bare. How non-Error values thrown through an exception should render (plain objects, internal messages, `AggregateError` members) is a rendering decision that this PR leaves as it is today; the third test pins the `ResolveMessage` case.

`Exception::value()` is renamed to `as_js_value()`: it returns the cell, not the value, and the old name is how this read as if the body was already getting the Error. Two call sites.

### Related

- #36662 adds `.error`/`.suppressed` printing for `SuppressedError` to the same body block. It fixes `console.error(se)` and a top-level `using` throw, but on its own a failing test body with a throwing dispose still prints a bare `SuppressedError: `, because that error arrives through the exception cell. With both changes the test prints `SuppressedError:`, then `error: dispose failed`, then the `expect(received).toBe(expected)` block (verified by building the two together). The same applies to the other open changes to that block (#35172 non-Error causes, #36602 `AggregateError` members): with this change they also take effect for synchronous test failures and uncaught callback exceptions.
- If #35723 lands, the `ErrorInstance` check in `print_error_instance_js` should become its `is_error_like()` so function-style Error subclasses get the same treatment.

### Verification

`test/js/bun/test/stack.test.ts` (the file holding the existing own-property printing tests) gains three spawned cases: the `bun test` failure above, the same error thrown from `setTimeout` under `bun -e`, and the synchronous missing-module `require()` whose output must stay single. The first two fail on the current release build on Linux and Windows and pass with the fix on both; the third passes on both builds (it only guards the `ErrorInstance` check) and leaves the stack frames and divot out of its snapshot because debug builds add an internal `require` frame there. Running `test/js/bun/test` and `test/cli/test` against this build showed no other output changes; the few failures there were unrelated to the diff (a full disk while they ran, plus two snapshot tests whose mismatches were a `[4.08s]` timing suffix and missing ANSI codes).
