### PR TITLE
Stop running builtin modules' lazy accessors when they are imported as ESM

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "09e477744721074f73a67eba197c6103afb9eab6";
+export const WEBKIT_VERSION = "7b763944f0ecd0e18cb9ac89a04ef994e3ccb4ae";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -86,18 +86,18 @@ static JSC::JSPromise* resolvedInternalPromise(JSC::JSGlobalObject* globalObject
 }
 
 // Converts an object from InternalModuleRegistry into { ...obj, default: obj }
-static JSC::SyntheticSourceProvider::SyntheticSourceGenerator generateInternalModuleSourceCode(JSC::JSGlobalObject* globalObject, InternalModuleRegistry::Field moduleId)
+static JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator generateInternalModuleSourceCode(JSC::JSGlobalObject* globalObject, InternalModuleRegistry::Field moduleId)
 {
     return [moduleId](JSC::JSGlobalObject* lexicalGlobalObject,
                JSC::Identifier moduleKey,
                Vector<JSC::Identifier, 4>& exportNames,
-               JSC::MarkedArgumentBuffer& exportValues) -> void {
+               JSC::MarkedArgumentBuffer& exportValues) -> JSC::JSObject* {
         auto& vm = JSC::getVM(lexicalGlobalObject);
         GlobalObject* globalObject = uncheckedDowncast<GlobalObject>(lexicalGlobalObject);
         auto throwScope = DECLARE_THROW_SCOPE(vm);
 
         JSValue requireResult = globalObject->internalModuleRegistry()->requireId(globalObject, vm, moduleId);
-        RETURN_IF_EXCEPTION(throwScope, void());
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         auto* object = requireResult.getObject();
         ASSERT_WITH_MESSAGE(object, "Expected object from requireId %s", moduleKey.string().string().utf8().data());
 
@@ -105,21 +105,33 @@ static JSC::SyntheticSourceProvider::SyntheticSourceGenerator generateInternalMo
 
         PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
         object->getOwnPropertyNames(object, globalObject, properties, DontEnumPropertiesMode::Exclude);
-        RETURN_IF_EXCEPTION(throwScope, void());
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
 
         auto len = properties.size() + 1;
         exportNames.reserveCapacity(len);
         exportValues.ensureCapacity(len);
 
         bool hasDefault = false;
+        bool hasLazyExports = false;
 
         for (auto& entry : properties) {
             if (entry == vm.propertyNames->defaultKeyword) [[unlikely]] {
                 hasDefault = true;
             }
             exportNames.append(entry);
-            JSValue value = object->get(globalObject, entry);
-            RETURN_IF_EXCEPTION(throwScope, void());
+
+            PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty);
+            bool hasOwn = object->methodTable()->getOwnPropertySlot(object, globalObject, entry, slot);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
+            if (hasOwn && !slot.isValue()) {
+                // Accessors are how builtins defer loading (fs.ReadStream pulls in node:stream); JSC reads them off `object` on first binding.
+                exportValues.append(JSValue());
+                hasLazyExports = true;
+                continue;
+            }
+
+            JSValue value = hasOwn ? slot.getValue(globalObject, entry) : object->get(globalObject, entry);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             exportValues.append(value);
         }
 
@@ -127,6 +139,8 @@ static JSC::SyntheticSourceProvider::SyntheticSourceGenerator generateInternalMo
             exportNames.append(vm.propertyNames->defaultKeyword);
             exportValues.append(object);
         }
+
+        return hasLazyExports ? object : nullptr;
     };
 }
 
@@ -1036,7 +1050,7 @@ static JSValue fetchESMSourceCode(
         default: {
             if (tag & SyntheticModuleType::InternalModuleRegistryFlag) {
                 constexpr auto mask = (SyntheticModuleType::InternalModuleRegistryFlag - 1);
-                auto source = JSC::SourceCode(JSC::SyntheticSourceProvider::create(generateInternalModuleSourceCode(globalObject, static_cast<InternalModuleRegistry::Field>(tag & mask)), JSC::SourceOrigin(URL(makeString("builtins://"_s, moduleKey))), moduleKey));
+                auto source = JSC::SourceCode(JSC::SyntheticSourceProvider::createWithLazyExports(generateInternalModuleSourceCode(globalObject, static_cast<InternalModuleRegistry::Field>(tag & mask)), JSC::SourceOrigin(URL(makeString("builtins://"_s, moduleKey))), moduleKey));
                 RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(vm, WTF::move(source))));
             } else {
                 auto&& provider = Zig::SourceProvider::create(globalObject, res->result.value, JSC::SourceProviderSourceType::Module, true);

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -1,0 +1,232 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Builtins implemented in src/js are exposed to ESM importers by turning their CommonJS exports object into a
+// synthetic module. Some of those objects define accessors so that the expensive part of the module is only
+// loaded by whoever touches it. node:fs is the clearest case: each of its stream classes is a getter that
+// require()s internal/fs/streams (and with it the node:stream stack) and then replaces itself with a data
+// property, so "is it still an accessor on the exports object" is a direct readout of whether importing the
+// module as ESM ran the getter.
+//
+// Every scenario gets its own process because a binding can only be materialized once.
+
+const STREAMS = ["ReadStream", "WriteStream", "FileReadStream", "FileWriteStream", "Utf8Stream"] as const;
+type Kind = "accessor" | "value";
+
+/** Expected descriptor kinds: everything is still an accessor except the names listed as materialized. */
+function kinds(...materialized: (typeof STREAMS)[number][]): Record<string, Kind> {
+  return Object.fromEntries(STREAMS.map(name => [name, materialized.includes(name) ? "value" : "accessor"]));
+}
+
+// `import fs from "node:fs"` here is itself an import of the module under test; the default export is the
+// exports object, which is also the thing whose property descriptors we inspect.
+const helper = `
+  import fs from "node:fs";
+  export const STREAMS = ${JSON.stringify(STREAMS)};
+  export function kinds() {
+    return Object.fromEntries(
+      STREAMS.map(name => [name, typeof Object.getOwnPropertyDescriptor(fs, name).get === "function" ? "accessor" : "value"]),
+    );
+  }
+  export function print(result) {
+    console.log(JSON.stringify(result));
+  }
+  export { fs };
+`;
+
+async function run(files: Record<string, string>, args: string[] = ["entry.mjs"]) {
+  using dir = tempDir("builtin-esm-lazy-exports", { "helper.mjs": helper, ...files });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+async function runEntry(entry: string, extraFiles: Record<string, string> = {}) {
+  const { stdout, stderr, exitCode } = await run({ ...extraFiles, "entry.mjs": entry });
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+test.concurrent("importing the module does not run its accessors", async () => {
+  const result = await runEntry(`
+    import fs, { readFileSync } from "node:fs";
+    import { kinds, print } from "./helper.mjs";
+    const ns = await import("node:fs");
+    print({ defaultIsExportsObject: ns.default === fs, readFileSync: typeof readFileSync, kinds: kinds() });
+  `);
+  expect(result).toEqual({ defaultIsExportsObject: true, readFileSync: "function", kinds: kinds() });
+});
+
+test.concurrent("a named import materializes exactly the binding it links", async () => {
+  const result = await runEntry(`
+    import { ReadStream } from "node:fs";
+    import { fs, kinds, print } from "./helper.mjs";
+    print({ kinds: kinds(), isTheClass: typeof ReadStream === "function" && ReadStream === fs.ReadStream });
+  `);
+  expect(result).toEqual({ kinds: kinds("ReadStream"), isTheClass: true });
+});
+
+test.concurrent("a namespace export materializes when it is read, not on import or `in`", async () => {
+  const result = await runEntry(`
+    import * as ns from "node:fs";
+    import { fs, kinds, print } from "./helper.mjs";
+    const afterImport = kinds();
+    // [[HasProperty]] does not read the binding. ([[GetOwnProperty]], e.g. hasOwnProperty or Object.keys, does.)
+    const present = "WriteStream" in ns;
+    const afterIn = kinds();
+    const WriteStream = ns.WriteStream;
+    print({
+      afterImport,
+      present,
+      afterIn,
+      afterRead: kinds(),
+      isTheClass: typeof WriteStream === "function" && WriteStream === fs.WriteStream,
+      secondReadIsStable: ns.WriteStream === WriteStream,
+    });
+  `);
+  expect(result).toEqual({
+    afterImport: kinds(),
+    present: true,
+    afterIn: kinds(),
+    afterRead: kinds("WriteStream"),
+    isTheClass: true,
+    secondReadIsStable: true,
+  });
+});
+
+test.concurrent("a deferred namespace (import defer) materializes on read as well", async () => {
+  const result = await runEntry(`
+    import defer * as ns from "node:fs";
+    import { fs, kinds, print } from "./helper.mjs";
+    const afterImport = kinds();
+    const FileReadStream = ns.FileReadStream;
+    print({
+      afterImport,
+      afterRead: kinds(),
+      isTheClass: typeof FileReadStream === "function" && FileReadStream === fs.FileReadStream,
+    });
+  `);
+  expect(result).toEqual({ afterImport: kinds(), afterRead: kinds("FileReadStream"), isTheClass: true });
+});
+
+test.concurrent("import() namespace: same export list as before, enumerating it materializes everything", async () => {
+  const result = await runEntry(`
+    import { STREAMS, fs, kinds, print } from "./helper.mjs";
+    const exportsKeys = Object.keys(fs);
+    const ns = await import("node:fs");
+    const afterImport = kinds();
+    const isTheClass = ns.Utf8Stream === fs.Utf8Stream && typeof ns.Utf8Stream === "function";
+    const afterRead = kinds();
+    const namespaceKeys = Object.keys(ns);
+    print({
+      afterImport,
+      isTheClass,
+      afterRead,
+      afterKeys: kinds(),
+      keysMatch: namespaceKeys.sort().join() === [...exportsKeys, "default"].sort().join(),
+      allAreTheClasses: STREAMS.every(name => typeof ns[name] === "function" && ns[name] === fs[name]),
+    });
+  `);
+  expect(result).toEqual({
+    afterImport: kinds(),
+    isTheClass: true,
+    afterRead: kinds("Utf8Stream"),
+    afterKeys: kinds(...STREAMS),
+    keysMatch: true,
+    allAreTheClasses: true,
+  });
+});
+
+test.concurrent("re-exports bind through to the builtin's own binding", async () => {
+  const result = await runEntry(
+    `
+      // Linking this import is what materializes FileWriteStream, through the export *.
+      import { FileWriteStream } from "./reexport.mjs";
+      import * as reexported from "./reexport.mjs";
+      import { fs, kinds, print } from "./helper.mjs";
+      const afterLink = kinds();
+      const Renamed = reexported.Renamed;
+      const afterRenamedRead = kinds();
+      const viaStar = reexported.ReadStream;
+      print({
+        afterLink,
+        afterRenamedRead,
+        afterStarRead: kinds(),
+        linked: typeof FileWriteStream === "function" && FileWriteStream === fs.FileWriteStream,
+        renamed: typeof Renamed === "function" && Renamed === fs.FileReadStream,
+        viaStar: typeof viaStar === "function" && viaStar === fs.ReadStream,
+      });
+    `,
+    {
+      "reexport.mjs": `
+        export * from "node:fs";
+        export { FileReadStream as Renamed } from "node:fs";
+      `,
+    },
+  );
+  expect(result).toEqual({
+    afterLink: kinds("FileWriteStream"),
+    afterRenamedRead: kinds("FileWriteStream", "FileReadStream"),
+    afterStarRead: kinds("FileWriteStream", "FileReadStream", "ReadStream"),
+    linked: true,
+    renamed: true,
+    viaStar: true,
+  });
+});
+
+test.concurrent("accessors on other builtins bind to what require() returns", async () => {
+  const result = await runEntry(`
+    import assert, { AssertionError } from "node:assert";
+    import * as timers from "node:timers";
+    import * as stream from "node:stream";
+    import { createRequire } from "node:module";
+    import { print } from "./helper.mjs";
+    const require = createRequire(import.meta.url);
+    print({
+      // node:assert's exports object is a function; AssertionError is an accessor defined on it.
+      assertIsFunction: typeof assert === "function",
+      assertionError: typeof AssertionError === "function" && AssertionError === require("node:assert").AssertionError,
+      timersPromises: timers.promises === require("node:timers/promises"),
+      streamPromises: stream.promises === require("node:stream/promises"),
+    });
+  `);
+  expect(result).toEqual({ assertIsFunction: true, assertionError: true, timersPromises: true, streamPromises: true });
+});
+
+test.concurrent("spyOn and mock.module on an imported builtin", async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "lazy.test.ts": `
+        import { expect, mock, spyOn, test } from "bun:test";
+        import * as ns from "node:fs";
+        import { fs, kinds } from "./helper.mjs";
+
+        test("spyOn reads (and so materializes) the binding it wraps", () => {
+          expect(kinds()).toEqual(${JSON.stringify(kinds())});
+          spyOn(ns, "WriteStream");
+          expect(kinds()).toEqual(${JSON.stringify(kinds("WriteStream"))});
+          expect(ns.WriteStream).not.toBe(fs.WriteStream);
+          mock.restore();
+          expect(ns.WriteStream).toBe(fs.WriteStream);
+        });
+
+        test("mock.module writes into a binding nothing has read, without running its getter", () => {
+          mock.module("node:fs", () => ({ ReadStream: "mocked" }));
+          expect(ns.ReadStream).toBe("mocked");
+          expect(kinds()).toEqual(${JSON.stringify(kinds("WriteStream"))});
+        });
+      `,
+    },
+    ["test", "lazy.test.ts"],
+  );
+  expect(stderr).toContain(" 2 pass");
+  expect(stderr).toContain(" 0 fail");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Builtins implemented in `src/js` are handed to ES module importers by `generateInternalModuleSourceCode` (`src/jsc/bindings/ModuleLoader.cpp`), which snapshots the builtin's CommonJS exports object into a synthetic module record. It did that with `object->get()` on every own enumerable property, so every accessor on the exports object ran at import time. Those accessors are the builtins' lazy-loading mechanism, which means they only ever helped `require()` callers:

- `node:fs`: `ReadStream`, `WriteStream`, `FileReadStream`, `FileWriteStream`, `Utf8Stream` each `require("internal/fs/streams")`, which loads the whole `node:stream` stack.
- `node:tls`: `rootCertificates` parses the bundled CA store, `DEFAULT_CIPHERS` queries BoringSSL.
- `node:http`: `globalAgent` instantiates the agent. `node:timers` / `node:stream`: `promises` load `timers/promises` and `stream/promises`. `node:assert`: `AssertionError` loads `internal/assert/assertion_error`. `node:repl`, `node:events`, `node:buffer`, `node:os` have a few more.

#35541 is about to turn more of these into accessors (`fs.promises` among them), which this path would immediately defeat for the most common import style there is.

## Repro

```js
// probe.mjs, run as `bun --expose-internals probe.mjs esm` vs `... require`
const mode = process.argv[2];
const { createRequire } = await import("node:module");
let t = performance.now();
if (mode === "esm") await import("node:fs"); else createRequire(import.meta.url)("node:fs");
const fsMs = performance.now() - t;
t = performance.now();
createRequire(import.meta.url)("internal/fs/streams");
console.log(mode, "node:fs", fsMs.toFixed(1), "ms; internal/fs/streams afterwards", (performance.now() - t).toFixed(1), "ms");
```

bun 1.4.0 (release): `esm node:fs 13.3 ms; internal/fs/streams afterwards 0.2 ms` (already loaded) vs `require node:fs 7.8 ms; internal/fs/streams afterwards 5.0 ms`. On a debug build the difference is ~370ms per process, and `test/harness.ts` does `import fs from "node:fs"`, so every test file paid it.

The directly observable form, which the tests use: the `node:fs` getters replace themselves with data properties when they run, so after `import fs from "node:fs"`, `Object.getOwnPropertyDescriptor(fs, "ReadStream")` had a `value` instead of a `get`.

## Fix

An ES module binding cannot be made lazy from the embedder side: once the record exists, named imports read the exporting environment's slot directly (`ModuleVar`) and namespace reads go through `getValue()` in `JSModuleNamespaceObject`, so the slot has to hold the value before anything binds to it. The engine half is oven-sh/WebKit#408, merged as 7b763944f0ec. `WEBKIT_VERSION` moves from 09e477744721 (what main pins) to that sha; it is the only commit between the two:

- `SyntheticModuleRecord::tryCreateWithExportNamesAndValues()` gets an overload taking a source object; an export whose value is the empty `JSValue` is declared but left in TDZ.
- `materializeLazyExport()` fills such a slot from `source[name]` the first time something binds to it: `CyclicModuleRecord::initializeEnvironment` when an importer links a named import that resolves to it (directly or through `export *` / `export { x } from` chains), `JSModuleNamespaceObject::getOwnPropertySlotCommon` when a namespace read finds the slot empty (it then re-reads and installs the value the same way as before, so the namespace IC still applies), and `WebAssemblyModuleRecord::initializeImports`, which snapshots imported bindings directly (unreachable in bun today, reachable once #35587 lands). It is a no-op for a slot that already has a value, so `overrideExportValue` (what `mock.module` and `spyOn` use) keeps winning, `*namespace*` is skipped, a getter that re-enters keeps the first value that landed, and an exception from the getter propagates and leaves the slot for the next attempt. The write uses the same `symbolTablePutTouchWatchpointSet` the eager path used for its one write, so IC / DFG behaviour after materialization is identical to an eagerly built record; the baseline namespace IC already bails to the slow path on an empty slot and the DFG only folds loads that went through an installed IC.
- `SyntheticSourceProvider::createWithLazyExports()` takes a generator that returns the source object, and `makeModule` passes it through. Records built any other way (JSON modules, `vm.SyntheticModule`, every existing `create()` caller) have no source object and take a pointer test on the new paths.

The bun half is `generateInternalModuleSourceCode`: it now looks each property up with `getOwnPropertySlot`, snapshots data properties exactly as before, declares everything else (accessors) as a lazy export, and returns the exports object as the source. A builtin without accessors (most of them) produces a record identical to the old one. `require()` of a builtin never went through this function (`fetchCommonJSModule` returns the registry object), so it is unaffected. The engine change is inert without this opt-in: building the new WebKit with the old `ModuleLoader.cpp` still fails the new tests the same way the release does.

### Why this is the right behaviour

Node builds the ESM facade of a builtin by reading the getters too, so the old behaviour was not wrong, just expensive, and there is no compat reason to keep it. The only observable difference is *when* an accessor export is sampled: at import before, at the point something first binds to it now. Data properties still snapshot at import. A namespace export or named import of an accessor is a snapshot either way (that is what `module.syncBuiltinESMExports()` exists for), and the later sample is never staler than the old one. Everything an importer can do with the export resolves to the same object `require()` would hand out, which is what the tests check for each binding path.

`Object.keys(ns)`, `hasOwnProperty`, spread, and `console.log(ns)` still materialize what they touch, because `[[GetOwnProperty]]` has to produce the value; `in` ([[HasProperty]]) does not. Plugin `loader: "object"` modules and user CommonJS imported from ESM are deliberately not touched: those expose user objects whose getter timing is user-visible (#36677 is about that), whereas builtins' accessors are our own lazy-loading idiom.

## Tests

`test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`, next to the other module-system behaviour tests in that directory. Each case runs in its own process (a binding can only be materialized once) and checks both that importing left the `node:fs` accessors untouched and that the binding is the real class once used, for: default + named data import, named import of an accessor (exactly that one materializes), `import * as`, `import defer * as`, dynamic `import()` including `Object.keys` and that the export list is unchanged, `export *` and `export { x as y } from` re-exports (named import through the star and a read off the re-exporter's namespace, which exercises materializing on a record other than the namespace's own), accessors on `node:assert` (a function exports object), `node:timers` and `node:stream`, and `spyOn` / `mock.module` on an already imported builtin. 7 of the 8 cases fail on the current eager code (everything reports `value`); the `assert`/`timers`/`stream` identity case is a regression guard.

With the fix, the probe above reports `internal/fs/streams` as not loaded after `import("node:fs")` (debug build: 338ms to load it afterwards in both modes, versus 10ms before because the import had already loaded it). Also run on the new build: `test/js/node/fs/fs.test.ts` (covers the existing `export { ReadStream, WriteStream } from "node:fs"` and `export * from "node:fs"` fixtures), the `test/js/bun/resolve` module tests, `test/js/bun/test/mock/mock-module*.test.ts`, `node-module-module.test.js`, `buffer-inspectmaxbytes.test.ts` (which pins that a named import of an accessor is a snapshot), and the events / os / timers / assert / tls-internals / node-http suites, all green apart from two failures that are identical on the released binary in this environment (`os.userInfo`, the http proxy test).

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
bun test v1.4.0 (435641a6b)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
132 |       afterKeys: kinds(),
133 |       keysMatch: namespaceKeys.sort().join() === [...exportsKeys, "default"].sort().join(),
134 |       allAreTheClasses: STREAMS.every(name => typeof ns[name] === "function" && ns[name] === fs[name]),
135 |     });
136 |   `);
137 |   expect(result).toEqual({
                       ^
error: expect(received).toEqual(expected)

  {
    "afterImport": {
-     "FileReadStream": "accessor",
-     "FileWriteStream": "accessor",
-     "ReadStream": "accessor",
-     "Utf8Stream": "accessor",
-     "WriteStream": "accessor",
+     "FileReadStream": "value",
+     "FileWriteStream": "value",
+     "ReadStream": "value",
+     "Utf8Stream": "value",
+     "WriteStream": "value",
    },
    "afterKeys": {
      "FileReadStream": "value",
      "FileWriteStream": "value",
      "ReadStream": "value",
      "Utf8Stream": "value",
      "WriteStream": "value",
    },
    "after
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
68 |   const result = await runEntry(`
69 |     import { ReadStream } from "node:fs";
70 |     import { fs, kinds, print } from "./helper.mjs";
71 |     print({ kinds: kinds(), isTheClass: typeof ReadStream === "function" && ReadStream === fs.ReadStream });
72 |   `);
73 |   expect(result).toEqual({ kinds: kinds("ReadStream"), isTheClass: true });
                      ^
error: expect(received).toEqual(expected)

  {
    "isTheClass": true,
    "kinds": {
-     "FileReadStream": "accessor",
-     "FileWriteStream": "accessor",
+     "FileReadStream": "value",
+     "FileWriteStream": "value",
      "ReadStream": "value",
-     "Utf8Stream": "accessor",
-     "WriteStream": "accessor",
+     "Utf8Stream": "value",
+     "WriteStream": "value",
    },
  }

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:73:18)
89 |       afterRead: kinds(),
90 |       isTheClass: typeof WriteStream === "function" && WriteStream === fs.WriteStream,
91 |       secondReadIsStable: ns.WriteStream === WriteStream,
92 |     })
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
bun test v1.4.0 (435641a6b)

test/js/bun/resolve/builtin-esm-lazy-exports.test.ts:
(pass) importing the module does not run its accessors [1746.65ms]
(pass) a named import materializes exactly the binding it links [2145.14ms]
(pass) a namespace export materializes when it is read, not on import or `in` [2175.43ms]
(pass) a deferred namespace (import defer) materializes on read as well [2720.80ms]
(pass) import() namespace: same export list as before, enumerating it materializes everything [2873.44ms]
(pass) re-exports bind through to the builtin's own binding [2232.58ms]
(pass) spyOn and mock.module on an imported builtin [2125.50ms]
(pass) accessors on other builtins bind to what require() returns [2735.47ms]

 8 pass
 0 fail
 24 expect() calls
Ran 8 tests across 1 file. [8.97s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     435641a6bd
  features     baseline

22 deps, 107 codegen, 1176 objects in 1540ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1238] fetch zlib
[zlib] up to date
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] fetch picohttpparser
[picohttpparser] up to date
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[11/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 src/jsc/bindings/ModuleLoader.cpp                  |  28 ++-
 .../bun/resolve/builtin-esm-lazy-exports.test.ts   | 232 +++++++++++++++++++++
 3 files changed, 254 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
scripts/build/deps/webkit.ts                              3      3      0
src/jsc/bindings/ModuleLoader.cpp                         1      3      0
test/js/bun/resolve/builtin-esm-lazy-exports.test.ts      0      0      0
```

</details>

<!-- robobun:evidence:end -->