### PR TITLE
resolver: don't abort on a package.json browser map key longer than 1024 bytes

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -13,8 +13,12 @@ use bun_core::{ZStr, strings};
 // callers must not re-enter the accessor while a previous borrow is alive.
 thread_local! {
     static PARSER_JOIN_INPUT_BUFFER: UnsafeCell<[u8; 4096]> = const { UnsafeCell::new([0u8; 4096]) };
-    static PARSER_BUFFER: UnsafeCell<[u8; 1024]> = const { UnsafeCell::new([0u8; 1024]) };
+    static PARSER_BUFFER: UnsafeCell<[u8; PARSER_BUFFER_LEN]> =
+        const { UnsafeCell::new([0u8; PARSER_BUFFER_LEN]) };
 }
+
+/// Output capacity of [`normalize_string`].
+const PARSER_BUFFER_LEN: usize = 1024;
 
 /// Project `&'static mut` into a thread-local `UnsafeCell<[u8; N]>` scratch
 /// buffer. One `unsafe` site for all `PARSER_BUFFER` / `PARSER_JOIN_INPUT_BUFFER`
@@ -1260,10 +1264,30 @@ impl Platform {
     }
 }
 
+/// `str` must normalize into [`PARSER_BUFFER_LEN`] bytes; for input of
+/// arbitrary length use [`normalize_string_spill`].
 pub fn normalize_string<const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(str: &[u8]) -> &mut [u8] {
     // returns slice into thread-local PARSER_BUFFER; valid until the
     // next call on this thread.
     PARSER_BUFFER.with(|b| normalize_string_buf::<ALLOW_ABOVE_ROOT, P, false>(str, tl_buf_mut(b)))
+}
+
+/// [`normalize_string`] (thread-local buffer) when the result fits, otherwise
+/// into `spill` (grown as needed). `spill` is untouched in the common case.
+pub fn normalize_string_spill<'a, const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(
+    spill: &'a mut Vec<u8>,
+    str: &'a [u8],
+) -> &'a [u8] {
+    // Normalizing only removes bytes, except that on Windows a drive-relative
+    // `C:` becomes `C:.` and a bare UNC volume gains its trailing separator.
+    let needed = str.len() + 1;
+    if needed <= PARSER_BUFFER_LEN {
+        return normalize_string::<ALLOW_ABOVE_ROOT, P>(str);
+    }
+    if spill.len() < needed {
+        spill.resize(needed, 0);
+    }
+    normalize_string_buf::<ALLOW_ABOVE_ROOT, P, false>(str, &mut spill[..])
 }
 
 pub fn normalize_buf<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut [u8] {
@@ -2428,3 +2452,113 @@ pub fn posix_to_platform_in_place<T: PathChar>(path_buffer: &mut [T]) {
 // `PathChar` is now canonical at `crate::path_char`; re-export for callers
 // that still path through `resolve_path::PathChar`.
 pub use crate::PathChar;
+
+// Run with `cargo test -p bun_paths` (also the Miri lane, `bun run rust:miri -p bun_paths`).
+// Normalizing reaches `bun_core::strings`' byte searches, whose highway kernels
+// are only linked into the full binary, so the two they reference are satisfied
+// below with scalar stubs (the simdutf counterparts live in string_paths.rs).
+// Under Miri the wrappers take their own scalar path and never call these.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Returns `haystack_len` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_index_of_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: test stub; callers pass a valid (ptr, len) pair.
+        let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        haystack
+            .iter()
+            .position(|&b| b == needle)
+            .unwrap_or(haystack_len)
+    }
+
+    /// Returns `text_len` when no byte of `chars` occurs, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_index_of_any_char(
+        text: *const u8,
+        text_len: usize,
+        chars: *const u8,
+        chars_len: usize,
+    ) -> usize {
+        // SAFETY: test stub; callers pass valid (ptr, len) pairs.
+        let (text, chars) = unsafe {
+            (
+                core::slice::from_raw_parts(text, text_len),
+                core::slice::from_raw_parts(chars, chars_len),
+            )
+        };
+        text.iter()
+            .position(|b| chars.contains(b))
+            .unwrap_or(text_len)
+    }
+
+    #[test]
+    fn normalize_string_spill_leaves_spill_untouched_when_the_input_fits() {
+        let mut spill = Vec::new();
+        let out =
+            normalize_string_spill::<true, platform::Loose>(&mut spill, b"./lib/../dist/./x.js");
+        assert_eq!(out, b"dist/x.js");
+        assert!(spill.is_empty());
+    }
+
+    #[test]
+    fn normalize_string_spill_spills_input_longer_than_the_thread_local_buffer() {
+        let segment = vec![b'b'; PARSER_BUFFER_LEN * 3];
+        let mut input = b"./".to_vec();
+        input.extend_from_slice(&segment);
+        input.extend_from_slice(b"/./x.js");
+        let mut expected = segment;
+        expected.extend_from_slice(b"/x.js");
+
+        let mut spill = Vec::new();
+        let out = normalize_string_spill::<true, platform::Loose>(&mut spill, &input);
+        assert_eq!(out, &expected[..]);
+        assert!(!spill.is_empty());
+    }
+
+    #[test]
+    fn normalize_string_spill_reuses_the_spill_across_calls() {
+        let long = vec![b'a'; PARSER_BUFFER_LEN + 1];
+        let longer = vec![b'c'; PARSER_BUFFER_LEN * 2];
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_string_spill::<true, platform::Loose>(&mut spill, &long),
+            &long[..]
+        );
+        assert_eq!(
+            normalize_string_spill::<true, platform::Loose>(&mut spill, &longer),
+            &longer[..]
+        );
+        // A shorter input after a longer one must not leak the previous tail.
+        assert_eq!(
+            normalize_string_spill::<true, platform::Loose>(&mut spill, &long),
+            &long[..]
+        );
+    }
+
+    #[test]
+    fn normalize_string_spill_accounts_for_outputs_that_grow_by_one_byte() {
+        // A bare UNC volume exactly as long as the thread-local buffer
+        // normalizes to one byte more than its input.
+        let mut unc = b"\\\\".to_vec();
+        unc.resize(PARSER_BUFFER_LEN, b's');
+
+        let mut spill = Vec::new();
+        let out = normalize_string_spill::<true, platform::Windows>(&mut spill, &unc);
+        assert_eq!(out.len(), PARSER_BUFFER_LEN + 1);
+        assert_eq!(&out[..unc.len()], &unc[..]);
+        assert_eq!(out[unc.len()], SEP_WINDOWS);
+
+        let mut spill = Vec::new();
+        assert_eq!(
+            normalize_string_spill::<true, platform::Windows>(&mut spill, b"c:"),
+            b"C:."
+        );
+    }
+}

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -286,28 +286,13 @@ impl SideEffects {
 // exposes the inherent forwarder (tsconfig_json.rs).
 // `bun_bundler::cache::JSON_CACHE_VTABLE` wires it to `bun_parsers::json`.
 
-/// Thin extension trait that delegates to
-/// `bun_paths::resolve_path` and returns owned `Box<[u8]>` so no `'static`
-/// lifetime is fabricated from a threadlocal scratch buffer (forbidden per
-/// docs/PORTING.md §Forbidden patterns — "`unsafe { &*(p as *const _) }` to
-/// extend a lifetime"). `crate::fs::FileSystem` already has an inherent
-/// borrowing `abs(&self) -> &[u8]` (lib.rs); that wins method resolution at
-/// call-sites that only need a transient borrow.
+/// Thin extension trait that delegates to `bun_paths::resolve_path`.
 trait FileSystemPackageJsonExt {
     fn join(&self, parts: &[&[u8]]) -> &'static [u8];
-    fn normalize(&self, str: &[u8]) -> Box<[u8]>;
 }
 impl FileSystemPackageJsonExt for crate::fs::FileSystem {
     fn join(&self, parts: &[&[u8]]) -> &'static [u8] {
         resolve_path::resolve_path::join::<resolve_path::resolve_path::platform::Loose>(parts)
-    }
-    fn normalize(&self, str: &[u8]) -> Box<[u8]> {
-        // Collapses `.`/`..`/dup-separators only; does NOT join against cwd.
-        let out = resolve_path::resolve_path::normalize_string::<
-            true,
-            resolve_path::resolve_path::platform::Auto,
-        >(str);
-        Box::from(&*out)
     }
 }
 
@@ -624,9 +609,8 @@ impl PackageJSON {
                     // The value is an object
 
                     // Remap all files in the browser field
+                    let mut key_spill: Vec<u8> = Vec::new();
                     for prop in obj.get().properties() {
-                        let _key_str = prop.key.slice();
-
                         // Normalize the path so we can compare against it without getting
                         // confused by "./". There is no distinction between package paths and
                         // relative paths for these values because some tools (i.e. Browserify)
@@ -636,21 +620,24 @@ impl PackageJSON {
                         // import of "foo", but that's actually not a bug. Or arguably it's a
                         // bug in Browserify but we have to replicate this bug because packages
                         // do this in the wild.
-                        let key: Box<[u8]> = FileSystemPackageJsonExt::normalize(r_fs, _key_str);
+                        let key: &[u8] = resolve_path::resolve_path::normalize_string_spill::<
+                            true,
+                            resolve_path::platform::Auto,
+                        >(&mut key_spill, prop.key.slice());
 
                         match &prop.value {
                             js_ast::E::JsonValue::String(str) => {
                                 // If this is a string, it's a replacement package
                                 package_json
                                     .browser_map
-                                    .put(&key, Box::from(str.slice()))
+                                    .put(key, Box::from(str.slice()))
                                     .expect("unreachable");
                             }
                             js_ast::E::JsonValue::Boolean(boolean) => {
                                 if !*boolean {
                                     package_json
                                         .browser_map
-                                        .put(&key, Box::default())
+                                        .put(key, Box::default())
                                         .expect("unreachable");
                                 }
                             }

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -484,6 +484,95 @@ it.skipIf(isWindows)("browser map resolution handles relative paths longer than 
   expect(exitCode).toBe(0);
 });
 
+// Parsing a package.json normalized every key of the "browser" map into a fixed
+// 1024-byte threadlocal buffer without a bounds check, so a longer key aborted
+// the process (`panic: range end index 1103 out of range for slice of length
+// 1024`) as soon as the package.json was read, whatever the target.
+describe.concurrent("browser map with a key longer than 1024 bytes", () => {
+  const longKey = Buffer.alloc(1100, "k").toString();
+
+  it("does not crash reading the package.json of a dependency at runtime", async () => {
+    using dir = tempDir("resolver-browser-long-key-runtime", {
+      "node_modules/dep/package.json": JSON.stringify({
+        name: "dep",
+        main: "index.js",
+        browser: { [`./${longKey}.js`]: "./browser.js" },
+      }),
+      "node_modules/dep/index.js": "module.exports = 1;",
+      "index.js": `console.log(require("dep"));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("still applies the other entries of the map to a browser build", async () => {
+    using dir = tempDir("resolver-browser-long-key-build", {
+      "package.json": JSON.stringify({
+        name: "pkg",
+        browser: {
+          [`./${longKey}.js`]: "./unused.js",
+          "./node-only.js": "./browser-only.js",
+        },
+      }),
+      "entry.js": `import { x } from "./node-only.js"; console.log(x);`,
+      "node-only.js": `export const x = "node-only";`,
+      "browser-only.js": `export const x = "browser-only";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=browser", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain('"browser-only"');
+    expect(stdout).not.toContain('"node-only"');
+    expect(exitCode).toBe(0);
+  });
+
+  // Looking a specifier up in the map goes through a PATH_MAX-sized buffer,
+  // which on macOS is itself 1024 bytes, so a key this long can only ever be
+  // matched on Linux and Windows.
+  it.skipIf(isMacOS)("remaps a package path that long in a browser build", async () => {
+    using dir = tempDir("resolver-browser-long-key-remap", {
+      "package.json": JSON.stringify({
+        name: "pkg",
+        browser: { [longKey]: "./shim.js" },
+      }),
+      "entry.js": `import { x } from ${JSON.stringify(longKey)}; console.log(x);`,
+      "shim.js": `export const x = "remapped";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=browser", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain('"remapped"');
+    expect(exitCode).toBe(0);
+  });
+});
+
 // ESModule.Package.parse scanned the entire specifier for an `@` to split off a
 // version. For wildcard `exports` maps the matched substring can contain `@`
 // (e.g. `ember-source/@ember/renderer/...`, `pkg/@scope/sub`) — those `@`s


### PR DESCRIPTION
## Reproduction

Any package.json the resolver reads (a dependency in `node_modules`, or the project's own) whose `"browser"` object has a key longer than 1024 bytes:

```sh
mkdir -p node_modules/x && cd node_modules/x
bun -e 'require("fs").writeFileSync("package.json", JSON.stringify({ name: "x", main: "index.js", browser: { ["./" + "b".repeat(1100) + ".js"]: "./y.js" } }))'
echo 'module.exports = 1;' > index.js && cd ../..
echo 'console.log(require("x"))' > index.js
bun index.js
```

```
panic: range end index 1103 out of range for slice of length 1024
```

The process aborts (exit 134) as soon as the package.json is parsed, so it happens at runtime too, not only for `--target=browser` (the browser map is read regardless of target because parsed package.json files are cached). Expected: prints `1`; the mapping is just an entry that nothing matches.

## Cause

`PackageJSON::parse` (`src/resolver/package_json.rs`) normalizes every browser map key with `resolve_path::normalize_string`, which writes its output into the thread-local `PARSER_BUFFER`, a fixed `[u8; 1024]` (`src/paths/resolve_path.rs`), with no bounds check. Keys are arbitrary strings from the package.json, so any key whose normalized form is longer than the buffer aborts. The parse side had this limit since the Zig version (same 1024-byte `parser_buffer`).

## Fix

Add `resolve_path::normalize_string_spill`, the `normalize_string` counterpart of the existing `join_spill` / `join_z_spill`: it uses the thread-local buffer when the result is known to fit and otherwise normalizes into a caller-owned `Vec` that is grown as needed (untouched in the common case, so the fast path allocates nothing). The browser map loop uses it with one `Vec` hoisted out of the loop, the same shape as the `join_spill` callers in `fs.readdir` and `Bun.Glob`. `StringArrayHashMap::put` already copies the key, so the intermediate `Box<[u8]>` the old shim allocated per entry is gone as well.

The capacity check is `input.len() + 1`: normalizing only removes bytes, except that on Windows a drive-relative `C:` normalizes to `C:.` and a bare UNC volume gains its trailing separator, both one byte longer than the input. The unit test below pins the boundary case (a UNC volume exactly 1024 bytes long); dropping the `+ 1` makes it fail with the same out-of-range panic.

The remaining `normalize_string` callers (`FileSystem::normalize` used by the install folder resolver, the shell `rm` check being fixed in #37521, and a Windows-only path in `run_command.rs`) are separate call sites and can move to the new helper independently; the `sideEffects` entries a few lines below the browser map go through the 4096-byte join buffer instead and are tracked separately too.

## Verification

`test/js/bun/resolve/resolve.test.ts`, next to the existing browser-map long-path test: a dependency with an over-long key is required at runtime, a browser build with an over-long key still applies the other entries of the map, and (Linux/Windows, where PATH_MAX allows the lookup) a bare specifier of that length is actually remapped through the over-long key.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/resolve.test.ts -t "browser map with a key longer"
  3 fail (each child aborts with the panic above)

bun bd test test/js/bun/resolve/resolve.test.ts
  76 pass, 2 skip
bun bd test test/bundler/bundler_browser.test.ts test/bundler/esbuild/packagejson.test.ts
  all pass (browser map behavior for normal keys is unchanged)

cargo test -p bun_paths            18 pass (4 new, covering the fast path, the spill, spill reuse, and the +1 boundary)
bun run rust:miri -p bun_paths     18 pass
```

The new unit tests are the first in `bun_paths` to reach `bun_core::strings`' byte searches, so the test module defines scalar stubs for the two highway kernels they reference, the same way `string_paths.rs` stubs simdutf; under Miri the wrappers take their own scalar path and the stubs are never called.
