### PR TITLE
shell(mv): report ENAMETOOLONG instead of panicking when a source name does not fit the path buffers

### DIFF
--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -603,20 +603,26 @@ impl ShellMvBatchedTask {
         buf: &mut PathBuffer,
     ) -> Result<(), bun_sys::Error> {
         let base = resolve_path::basename(src.as_bytes());
-        let len =
-            resolve_path::normalize_buf::<bun_paths::platform::Auto>(base, &mut buf[..]).len();
-        if len + 1 >= bun_paths::MAX_PATH_BYTES {
-            return Err(bun_sys::Error::from_code(
+        // `normalize_buf_z` writes into `buf` unchecked, so over-long names are
+        // rejected before it runs. Normalizing grows a name by at most one byte
+        // (`""` becomes `"."`); the NUL needs one more.
+        let result = if base.len() + 1 >= bun_paths::MAX_PATH_BYTES {
+            Err(bun_sys::Error::from_code(
                 bun_sys::E::ENAMETOOLONG,
                 bun_sys::Tag::rename,
-            ));
-        }
-        buf[len] = 0;
-        let path_in_dir = ZStr::from_buf(buf.as_slice(), len);
-        Self::do_rename(cwd, src, target_fd, path_in_dir).map_err(|e| {
-            // Surface `target/basename(src)` as the failing path.
-            let joined = resolve_path::join_z::<bun_paths::platform::Auto>(&[target, base]);
-            e.with_path(joined.as_bytes())
+            ))
+        } else {
+            let path_in_dir =
+                resolve_path::normalize_buf_z::<bun_paths::platform::Auto>(base, &mut buf[..]);
+            Self::do_rename(cwd, src, target_fd, path_in_dir)
+        };
+        result.map_err(|e| {
+            // Surface `target/basename(src)` as the failing path. Both are
+            // argv-sized, so the join may outgrow the thread-local buffer.
+            let mut spill = Vec::new();
+            let joined =
+                resolve_path::join_spill::<bun_paths::platform::Auto>(&mut spill, &[target, base]);
+            e.with_path(joined)
         })
     }
 

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { bunEnv, bunExe, isPosix, isWindows, tempDir } from "harness";
 import {
   accessSync,
   chmodSync,
@@ -65,6 +65,63 @@ describe("mv", async () => {
     .exitCode(20 /* ENOTDIR */)
     .stderr("mv: a: Not a directory\n")
     .runAsTest("move dir -> file fails");
+
+  // Moving into a directory copied basename(src) into a PATH_MAX buffer before
+  // checking its length, and on failure joined `target/basename` in the
+  // fixed-size thread-local join buffer, so a long enough source name aborted
+  // the whole process. Runs in a child process so the abort shows up as a
+  // failed assertion.
+  test("source names that do not fit the path buffers are reported, not a crash", async () => {
+    const segment = Buffer.alloc(240, "d").toString();
+    const deep = join(segment, segment);
+    using dir = tempDir("mv-long-source", { "target": {}, [segment]: { [segment]: {} }, "short.txt": "" });
+    // Longer than PATH_MAX on every POSIX platform (1024 on macOS, 4096 on Linux).
+    const overPathMax = Buffer.alloc(5000, "a").toString();
+    // Fits the Linux path buffer (the kernel still rejects it, NAME_MAX is
+    // 255), but `deep/` + this name does not fit the 4096-byte join buffer.
+    const overJoinBuffer = Buffer.alloc(3700, "b").toString();
+
+    const fixture = /* ts */ `
+      import { $ } from "bun";
+      import { existsSync } from "node:fs";
+      $.nothrow();
+      const { OVER_PATH_MAX, OVER_JOIN_BUFFER, DEEP } = process.env;
+      // A failing mv exits with the raw errno, which differs per platform.
+      const run = async (...args: string[]) => {
+        const { exitCode, stderr } = await $\`mv \${args}\`.quiet();
+        return { failed: exitCode !== 0, stderr: stderr.toString() };
+      };
+      const results = {
+        intoDir: await run(OVER_PATH_MAX!, "target"),
+        intoDeepDir: await run(OVER_JOIN_BUFFER!, DEEP!),
+        multiple: {
+          ...(await run("short.txt", OVER_PATH_MAX!, "target")),
+          shortMoved: existsSync("target/short.txt"),
+        },
+      };
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, OVER_PATH_MAX: overPathMax, OVER_JOIN_BUFFER: overJoinBuffer, DEEP: deep },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+
+    // Which errno Windows reports for an over-long name is up to the OS; what
+    // matters is that mv reported the failure and the process survived.
+    const tooLong = (path: string) =>
+      isWindows ? expect.stringMatching(/^mv: /) : `mv: ${path}: File name too long\n`;
+    expect(JSON.parse(stdout)).toEqual({
+      intoDir: { failed: true, stderr: tooLong(`target/${overPathMax}`) },
+      intoDeepDir: { failed: true, stderr: tooLong(`${deep}/${overJoinBuffer}`) },
+      multiple: { failed: true, stderr: tooLong(`target/${overPathMax}`), shortMoved: true },
+    });
+    expect(exitCode).toBe(0);
+  });
 
   // POSIX `mv` must fall back to copy+unlink when `rename()` returns EXDEV
   // (source and destination on different filesystems). Requires a writable


### PR DESCRIPTION
## Reproduction

```sh
mkdir -p /tmp/mvp/target && cd /tmp/mvp && bun -e 'const r = await Bun.$`mv ${"a".repeat(5000)} target`.nothrow().quiet(); console.log("exit", r.exitCode);'
```

```
panic: range end index 5000 out of range for slice of length 4096
oh no: Bun has crashed.
```

The process aborts (exit 134). Expected: `mv: target/aaaa...: File name too long`, a non-zero exit code from `mv`, and the script keeps running. On Linux the name has to be longer than 4096 bytes, on macOS longer than 1024.

A second shape needs a much shorter name. With a 3700-byte source name (the kernel rejects it, `NAME_MAX` is 255) and a target directory whose path is about 480 bytes, the abort moves to the error reporting instead:

```
panic: range end index 4182 out of range for slice of length 4094
```

`mv a b dir/` with one over-long operand hits the same code, so it aborts too.

## Cause

When the target is an existing directory, `ShellMvBatchedTask::move_in_dir` (`src/runtime/shell/builtin/mv.rs`) does two things with unbounded argv-sized input and fixed-size buffers:

1. It normalizes `basename(src)` into a `PathBuffer` (`MAX_PATH_BYTES`, 4096 on Linux, 1024 on macOS) and only checks the resulting length afterwards. `normalize_buf` copies with plain slice indexing, so a name that does not fit panics before the check runs.
2. When `renameat` fails, it builds the `target/basename` shown in the error message with `resolve_path::join_z`, which writes into the 4096-byte thread-local join buffer on every platform. A target path plus source name that do not fit together panic there, even when each one fits the path buffer on its own. Because of this, on Linux every name from 4094 bytes up crashed one way or the other.

`move_multiple_into_dir` goes through the same function, which is the multi-operand case.

## Fix

`move_in_dir` now checks `basename(src)` against the buffer before normalizing. The bound is the same one the old post-check enforced (`len + 1 >= MAX_PATH_BYTES`): normalizing never grows a name by more than one byte (`""` becomes `"."`), so a name that passes still leaves room for the NUL. Names that fail get the same `ENAMETOOLONG` error the old check produced, and that error now goes through the same path as a failed `renameat`, so it is reported as `mv: target/<name>: File name too long` like every other length rather than the path-less `mv: File name too long` the old check printed for names that happened to land exactly on the boundary.

The error path joins `target` and the name with `join_spill`, the existing helper that falls back to a caller-owned `Vec` when the thread-local buffer is too small (`Bun.Glob` and the `rm` fix in #37521 use it the same way). The join result is boxed into the error right away, so the spill vector is only live inside the closure and is never allocated when the path fits.

The limit enforced here is only the size of `mv`'s own scratch buffer; whether a shorter name is acceptable to the filesystem (`NAME_MAX`) is still left to the kernel, as before. Behavior for every name that fits is unchanged: the old and new binaries print identical messages and exit codes for `""`, `.`, `..`, `/`, `dir/`, nested and plain files, a missing source and a 1100-byte name. The exit status of a failing `mv` is still the raw errno; #32278 changes that across builtins, so it is left alone here and the new test only asserts that `mv` failed. The same scratch-buffer pattern in `mkdir` and `touch` is tracked separately.

## Verification

New case in `test/js/bun/shell/commands/mv.test.ts`. It runs `mv` in a child process (so the abort shows up as a failed assertion instead of taking the runner down) and covers the three shapes above: a 5000-byte name into a directory, a 3700-byte name into a two-level 481-byte directory (fits the Linux path buffer, overflows the join buffer; the same sizes stay creatable under macOS's 1024-byte `PATH_MAX`), and `mv short.txt <5000-byte name> target`, which additionally checks that `short.txt` was moved before the bad operand was reported. Each of the three crashes the unfixed binary on its own. On POSIX it asserts the exact `mv: <target>/<name>: File name too long` message; on Windows, where the errno for such a name is up to the OS, it only asserts that `mv` reported a failure.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/mv.test.ts -t "path buffers"`: fails, the child aborts with the first panic above.
- `bun bd test test/js/bun/shell/commands/mv.test.ts`: 13 pass.
