### PR TITLE
cli: stop aborting on absolute script paths longer than 1024 bytes on Windows

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2787,22 +2787,37 @@ impl RunCommand {
         // absolute vs. simple-relative vs. `..`/`~`-prefixed).
         let open_len: usize = if paths::is_absolute(target) {
             // `PosixToWinNormalizer::resolve_cwd` prepends the cwd drive
-            // letter on Windows for `/abs` paths; then, on Windows only,
-            // `normalize_string` canonicalizes
-            // separators. Both are no-ops on POSIX (`resolve_cwd` returns the
-            // input slice untouched).
+            // letter on Windows for `/abs` paths; then, on Windows only, the
+            // separators are canonicalized straight into `script_name_buf`.
+            // Both are no-ops on POSIX (`resolve_cwd` returns the input slice
+            // untouched).
             let mut win_resolver = paths::resolve_path::PosixToWinNormalizer::default();
-            let resolved = win_resolver
-                .resolve_cwd(target)
-                .unwrap_or_else(|_| panic!("Could not resolve path"));
-            #[cfg(windows)]
-            let resolved: &[u8] =
-                paths::resolve_path::normalize_string::<false, paths::platform::Windows>(resolved);
-            if resolved.len() >= MAX_PATH_BYTES {
+            let Ok(resolved) = win_resolver.resolve_cwd(target) else {
                 return false;
-            }
-            script_name_buf[..resolved.len()].copy_from_slice(resolved);
-            resolved.len()
+            };
+            #[cfg(windows)]
+            let len = {
+                // Normalizing writes at most one byte more than it reads (a
+                // bare `\\server\share` gains its trailing separator), and
+                // the NUL terminator needs one more.
+                if resolved.len() + 1 >= MAX_PATH_BYTES {
+                    return false;
+                }
+                paths::resolve_path::normalize_string_buf::<false, paths::platform::Windows, false>(
+                    resolved,
+                    &mut script_name_buf.0,
+                )
+                .len()
+            };
+            #[cfg(not(windows))]
+            let len = {
+                if resolved.len() >= MAX_PATH_BYTES {
+                    return false;
+                }
+                script_name_buf[..resolved.len()].copy_from_slice(resolved);
+                resolved.len()
+            };
+            len
         } else if !target.starts_with(b"..") && target[0] != b'~' {
             // open relative to cwd as-is
             if target.len() >= MAX_PATH_BYTES {

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
+import { dirname, join } from "path";
 
 let cwd: string;
 
@@ -49,4 +50,60 @@ test.if(isWindows)("[windows] A file in drive root runs", async () => {
   } catch {
     rmSync(path);
   }
+});
+
+// On Windows, `bun <absolute path>` normalized the path into a fixed 1024-byte
+// scratch buffer before checking its length, so any longer path aborted the
+// process ("range end index N out of range for slice of length 1024") instead
+// of being opened. Windows itself allows paths up to 32767 characters.
+describe.concurrent.skipIf(!isWindows)("[windows] absolute script path longer than 1024 bytes", () => {
+  async function run(args: string[], cwd?: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("an existing script runs", async () => {
+    // 6 directories of 200 characters each, so the path is long regardless of
+    // where the temporary directory lives (a single component may not exceed
+    // 255 characters).
+    const deep = Array.from({ length: 6 }, () => Buffer.alloc(200, "d").toString()).join("/");
+    using dir = tempDir("run-long-abs-path", {
+      [`${deep}/script.js`]: `console.log("ran");`,
+    });
+    const script = join(String(dir), deep, "script.js");
+    expect(script).toMatch(/^[A-Za-z]:\\/);
+    expect(script.length).toBeGreaterThan(1024);
+
+    const variants = {
+      backslashes: await run([script]),
+      "forward slashes": await run([script.replaceAll("\\", "/")]),
+      // Resolved against the drive of the cwd first.
+      "no drive letter": await run([script.slice(2)], dirname(String(dir))),
+      "bun run": await run(["run", script]),
+    };
+    const ran = { stdout: "ran\n", stderr: "", exitCode: 0 };
+    expect(variants).toEqual({
+      backslashes: ran,
+      "forward slashes": ran,
+      "no drive letter": ran,
+      "bun run": ran,
+    });
+  });
+
+  test("a missing script is reported as not found", async () => {
+    const missing = "C:\\" + Buffer.alloc(1100, "a").toString() + ".js";
+    for (const args of [[missing], ["run", missing]]) {
+      const { stdout, stderr, exitCode } = await run(args);
+      expect(stdout).toBe("");
+      expect(stderr).toContain(`Module not found "${missing}"`);
+      expect(exitCode).toBe(1);
+    }
+  });
 });


### PR DESCRIPTION
## Reproduction

Windows only. Run a script by an absolute path longer than 1024 bytes (the file does not need to exist):

```powershell
bun ("C:\" + ("a" * 1100) + ".js")
```

```
panic: range end index 1106 out of range for slice of length 1024
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

Exit code 3. Same with `bun run <path>`, with forward slashes, and with a drive-less `\dir\file.js`. A script that does exist at such a path cannot be run at all; a 1000 byte path works fine. Windows allows paths up to 32767 characters, and `MAX_PATH_BYTES` on Windows is 98302.

## Cause

`RunCommand::maybe_open_with_bun_js` (`src/runtime/cli/run_command.rs`) handles absolute targets with

```rust
let resolved = normalize_string::<false, Windows>(resolved);   // Windows only
if resolved.len() >= MAX_PATH_BYTES { return false; }
```

`normalize_string` writes its output into `PARSER_BUFFER`, a thread-local `[u8; 1024]` in `src/paths/resolve_path.rs`, with plain slice indexing, so the length check on the next line never runs for a target of 1024 bytes or more. The target is `argv` as typed by the user, so nothing bounds it before this point. The Zig version had the same buffer and the same order of operations; this is not a regression.

## Fix

Check the length first, then normalize straight into `script_name_buf`, the `PathBuffer` the function already owns and opens from. The bound is `resolved.len() + 1 >= MAX_PATH_BYTES`: normalizing grows a path by at most one byte (a bare `\\server\share` gets its trailing separator appended; everything else is copied at most once, and `.`/`..` segments and repeated separators only shrink it), and the NUL terminator needs one more byte. A target rejected by that check could not be opened anyway, so it takes the same `return false` fall-through as before, which ends in the regular "Module not found" error. POSIX keeps its existing copy and `>= MAX_PATH_BYTES` check unchanged; the normalize call was Windows-only before as well.

`PosixToWinNormalizer::resolve_cwd` failing (it returns `ENAMETOOLONG` when a drive-less path plus the cwd root does not fit a `PathBuffer`, or when `getcwd` fails) used to `panic!("Could not resolve path")` in the same spot. It now returns `false` like every other failure in this probe, so the caller falls through to the normal lookup and error message.

`normalize_string` is itself `normalize_string_buf` pointed at the thread-local buffer, so the normalization applied to paths that used to fit is exactly the same; the only change for them is which buffer receives the output.

## Verification

Two Windows-only cases added to `test/cli/run/run_command.test.ts`: an existing script at a ~1270 byte path must run when given with backslashes, forward slashes, without a drive letter, and via `bun run`; a missing 1106 byte `C:\aaa...a.js` must print `Module not found` and exit 1 for both `bun <path>` and `bun run <path>`.

On Windows x64 (Server 2019, `LongPathsEnabled` = 0):

- `USE_SYSTEM_BUN=1 bun test test/cli/run/run_command.test.ts` (canary at da3851e57): both new tests fail, every child aborts with `panic: range end index N out of range for slice of length 1024`.
- `bun bd test test/cli/run/run_command.test.ts`: 5 pass.
- Manually with the debug build: existing scripts at 422 and 1227 byte paths run in all four spellings; `C:\`, `\\localhost\c$` and missing files in each spelling report `Module not found` and exit 1.

On Linux the new tests skip; `bun bd test test/cli/run/run_command.test.ts` passes and `bun <existing abs>`, `bun <missing abs>`, `bun /tmp` behave as before.

The fall-through for over-long paths on POSIX (where `MAX_PATH_BYTES` is 1024 or 4096) still aborts inside the resolver's `load_as_file`; that is a separate buffer and is fixed by #35857.
