### PR TITLE
resolver: don't abort on a package.json sideEffects entry longer than the join buffer

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -294,12 +294,16 @@ impl SideEffects {
 /// borrowing `abs(&self) -> &[u8]` (lib.rs); that wins method resolution at
 /// call-sites that only need a transient borrow.
 trait FileSystemPackageJsonExt {
-    fn join(&self, parts: &[&[u8]]) -> &'static [u8];
+    /// Joins into the thread-local join buffer, or into `spill` when the
+    /// result does not fit it. Valid until the next join on this thread.
+    fn join<'a>(&self, spill: &'a mut Vec<u8>, parts: &[&[u8]]) -> &'a [u8];
     fn normalize(&self, str: &[u8]) -> Box<[u8]>;
 }
 impl FileSystemPackageJsonExt for crate::fs::FileSystem {
-    fn join(&self, parts: &[&[u8]]) -> &'static [u8] {
-        resolve_path::resolve_path::join::<resolve_path::resolve_path::platform::Loose>(parts)
+    fn join<'a>(&self, spill: &'a mut Vec<u8>, parts: &[&[u8]]) -> &'a [u8] {
+        resolve_path::resolve_path::join_spill::<resolve_path::resolve_path::platform::Loose>(
+            spill, parts,
+        )
     }
     fn normalize(&self, str: &[u8]) -> Box<[u8]> {
         // Collapses `.`/`..`/dup-separators only; does NOT join against cwd.
@@ -718,6 +722,9 @@ impl PackageJSON {
                     }
                 }
 
+                // Heap fallback for joined patterns that do not fit the thread-local join buffer.
+                let mut spill: Vec<u8> = Vec::new();
+
                 // If the array is empty, treat it as false (no side effects)
                 if !has_globs && !has_exact {
                     package_json.side_effects = SideEffects::False;
@@ -737,7 +744,7 @@ impl PackageJSON {
                             let joined: [&[u8]; 2] =
                                 [json_source.path.name().dir_with_trailing_slash(), name];
 
-                            let pattern = r_fs.join(&joined);
+                            let pattern = r_fs.join(&mut spill, &joined);
 
                             if strings::contains_char(name, b'*')
                                 || strings::contains_char(name, b'?')
@@ -771,7 +778,7 @@ impl PackageJSON {
                             let joined: [&[u8]; 2] =
                                 [json_source.path.name().dir_with_trailing_slash(), name];
 
-                            let pattern = r_fs.join(&joined);
+                            let pattern = r_fs.join(&mut spill, &joined);
                             // Normalize pattern to use forward slashes for cross-platform compatibility
                             let normalized_pattern = Self::normalize_path_for_glob(pattern)
                                 .unwrap_or_else(|_| pattern.to_vec());
@@ -787,8 +794,8 @@ impl PackageJSON {
                             let joined: [&[u8]; 2] =
                                 [json_source.path.name().dir_with_trailing_slash(), name];
 
-                            let _ =
-                                map.insert(StringHashMapUnownedKey::init(r_fs.join(&joined)), ());
+                            let pattern = r_fs.join(&mut spill, &joined);
+                            let _ = map.insert(StringHashMapUnownedKey::init(pattern), ());
                         }
                     }
                     package_json.side_effects = SideEffects::Map(map);

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -9,6 +9,11 @@ import { dedent, itBundled } from "../expectBundled";
 
 // To understand what `dce: true` is doing, see ../expectBundled.md's "dce: true" section
 
+// Longer than the largest path buffer on any platform (Windows: 32767 * 3 + 1 bytes).
+const longSideEffectsSegment = Buffer.alloc(100_000, "x").toString();
+// A Buffer skips expectBundled's dedent(), which takes seconds per 100 KB line in a debug build.
+const packageJsonWithSideEffects = (sideEffects: string[]) => Buffer.from(JSON.stringify({ sideEffects }));
+
 describe("bundler", () => {
   itBundled("dce/PackageJsonSideEffectsFalseKeepNamedImportES6", {
     files: {
@@ -748,6 +753,72 @@ describe("bundler", () => {
     dce: true,
     run: {
       stdout: "specific side effect\nglob1 side effect\nglob2 side effect\nused",
+    },
+  });
+  // Every "sideEffects" entry is joined onto the package directory when the
+  // package.json is parsed. A joined entry longer than the fixed path buffer
+  // used to abort the process, so these run `bun build` as a subprocess.
+  itBundled("dce/PackageJsonSideEffectsExactEntryLongerThanPathBuffer", {
+    backend: "cli",
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import "demo-pkg/effects/effect.js";
+        import "demo-pkg/lib/other.js";
+        console.log("done");
+      `,
+      "/Users/user/project/node_modules/demo-pkg/effects/effect.js": `console.log("effect side effect");`,
+      "/Users/user/project/node_modules/demo-pkg/lib/other.js": `console.log("other side effect - should be tree shaken");`,
+      "/Users/user/project/node_modules/demo-pkg/package.json": packageJsonWithSideEffects([
+        "./effects/effect.js",
+        `./${longSideEffectsSegment}.js`,
+      ]),
+    },
+    dce: true,
+    run: {
+      stdout: "effect side effect\ndone",
+    },
+  });
+  itBundled("dce/PackageJsonSideEffectsGlobEntryLongerThanPathBuffer", {
+    backend: "cli",
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import "demo-pkg/effects/effect.js";
+        import "demo-pkg/lib/other.js";
+        console.log("done");
+      `,
+      "/Users/user/project/node_modules/demo-pkg/effects/effect.js": `console.log("effect side effect");`,
+      "/Users/user/project/node_modules/demo-pkg/lib/other.js": `console.log("other side effect - should be tree shaken");`,
+      // Only the long pattern marks effect.js, so the pattern itself has to survive and match.
+      "/Users/user/project/node_modules/demo-pkg/package.json": packageJsonWithSideEffects([
+        `./{effects,${longSideEffectsSegment}}/*.js`,
+      ]),
+    },
+    dce: true,
+    run: {
+      stdout: "effect side effect\ndone",
+    },
+  });
+  itBundled("dce/PackageJsonSideEffectsMixedEntriesLongerThanPathBuffer", {
+    backend: "cli",
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import "demo-pkg/lib/specific.js";
+        import "demo-pkg/effects/effect.js";
+        import "demo-pkg/lib/other.js";
+        console.log("done");
+      `,
+      "/Users/user/project/node_modules/demo-pkg/lib/specific.js": `console.log("specific side effect");`,
+      "/Users/user/project/node_modules/demo-pkg/effects/effect.js": `console.log("effect side effect");`,
+      "/Users/user/project/node_modules/demo-pkg/lib/other.js": `console.log("other side effect - should be tree shaken");`,
+      "/Users/user/project/node_modules/demo-pkg/package.json": packageJsonWithSideEffects([
+        "./lib/specific.js",
+        `./${longSideEffectsSegment}.js`,
+        `./{effects,${longSideEffectsSegment}}/*.js`,
+      ]),
+    },
+    dce: true,
+    run: {
+      stdout: "specific side effect\neffect side effect\ndone",
     },
   });
   itBundled("dce/PackageJsonSideEffectsGlobDeepPattern", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -752,6 +752,40 @@ describe("package.json exports targets longer than the maximum path length", () 
   );
 });
 
+describe("package.json sideEffects entries longer than the maximum path length", () => {
+  // Parsing a package.json joins every "sideEffects" entry onto the package
+  // directory. An entry that did not fit the path buffer aborted the process
+  // as soon as the package was required, at runtime as well as in `bun build`.
+  const longSegment = Buffer.alloc(100_000, "s").toString();
+
+  it.concurrent.each([
+    ["exact", [`./${longSegment}.js`]],
+    ["glob", [`./${longSegment}/*.js`]],
+    ["mixed", ["./index.js", `./${longSegment}.js`, `./${longSegment}/*.js`]],
+  ])("requires a package whose sideEffects array has an oversized %s entry", async (_kind, sideEffects) => {
+    using dir = tempDir("resolver-side-effects-long-entry", {
+      "node_modules/long-side-effects/package.json": JSON.stringify({
+        name: "long-side-effects",
+        main: "index.js",
+        sideEffects,
+      }),
+      "node_modules/long-side-effects/index.js": "module.exports = 3;\n",
+      "index.js": `console.log(require("long-side-effects"));\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "3\n", stderr: "", exitCode: 0 });
+  });
+});
+
 // A package.json `imports` entry whose value is a bare package specifier
 // (e.g. `"#res": "@myproject/resolver"`) is handed back to package-resolve
 // for a second pass. Per the Node.js packages spec these are URL-like


### PR DESCRIPTION
### Repro

Any package.json the resolver parses (project root or a dependency) whose `"sideEffects"` array has an entry that, joined onto the package directory, is about 4096 bytes or longer:

```sh
mkdir -p se/node_modules/z && cd se
bun -e 'const fs = require("fs");
fs.writeFileSync("node_modules/z/package.json", JSON.stringify({ name: "z", main: "index.js", sideEffects: ["./" + "s".repeat(5000) + ".js"] }));
fs.writeFileSync("node_modules/z/index.js", "module.exports = 3;");
fs.writeFileSync("index.js", "console.log(require(\"z\"))");'
bun index.js
```

```
panic: range end index 5025 out of range for slice of length 4095
```

(exit 134; expected output is `3`). Same abort for a glob entry and for `bun build` of anything importing the package, since both go through `PackageJSON::parse`. Reproduced with the 1.4.0 canary on Linux x64 and Windows x64.

### Cause

The `sideEffects` block in `src/resolver/package_json.rs` builds each pattern with the local `FileSystemPackageJsonExt::join` shim, which forwards to `bun_paths::resolve_path::join`. That writes the normalized join into the fixed 4096-byte thread-local `JOIN_BUF` (the output starts at offset 1, hence the 4095) with no length check, so a long entry panics in every one of the three branches (mixed, globs only, exact only), on every platform.

### Fix

The shim now takes a spill `Vec` and forwards to the existing `join_spill`, which uses the thread-local buffer when the result fits and grows the `Vec` otherwise. One `Vec` is hoisted above the three loops, the same shape as `GlobWalker::bun_join` and the recursive `readdir`. Each branch either hashes the joined pattern (`StringHashMapUnownedKey::init`) or copies it into the glob list before the next iteration, so borrowing it from the spill buffer is sufficient and no `resolve_path.rs` changes are needed.

Keeping the entry, rather than skipping it or failing the parse, is the behaviour the field's consumers expect: the length of an entry says nothing about what it matches. A long glob (for example a large brace group) can match ordinary files in the package and is honoured exactly like a short one, and a long exact entry keeps its usual meaning of matching nothing while leaving the other entries of the array in effect. Webpack and esbuild accept such entries as well; only the fixed buffer made them fatal here.

### Tests

- `test/bundler/esbuild/dce.test.ts`: three `itBundled` cases next to the other `sideEffects` glob tests, one per branch (exact only, globs only, mixed). They use `backend: "cli"` so the abort is contained to the `bun build` child, and they check the tree-shaking result: the normal entries still apply, and in the glob and mixed cases only the 100 KB brace pattern marks `effects/effect.js`, so it has to be stored and matched rather than dropped.
- `test/js/bun/resolve/resolve.test.ts`: `require()` of a package with an oversized exact, glob, and mixed `sideEffects` array prints `3` and exits 0.

All six fail on the unmodified binary with the panic above (`SIGABRT` / exit 134) and pass with this change against a debug build on Linux; the `resolve.test.ts` cases were also checked against a debug build on Windows x64 (the `itBundled` suite does not currently run there). The full `dce.test.ts` and `resolve.test.ts` files pass against the debug build.
