### PR TITLE
fetch: do not pool HTTP/1.0 responses unless they say Connection: keep-alive

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -418,7 +418,9 @@ impl HTTPClient<'_> {
         };
         let should_continue = self.handle_response_metadata(&mut response)?;
         // h2/h3 framing delimits the body; chunked transfer-encoding and the
-        // HTTP/1.1 "no Content-Length ⇒ no keep-alive" rule don't apply.
+        // HTTP/1.x persistence rules (no Content-Length ⇒ no keep-alive, and the
+        // HTTP/1.0 default that the synthetic `minor_version: 0` above trips)
+        // don't apply.
         self.state.transfer_encoding = Encoding::Identity;
         if self.state.response_stage == ResponseStage::BodyChunk {
             self.state.response_stage = ResponseStage::Body;
@@ -4790,6 +4792,7 @@ impl<'a> HTTPClient<'a> {
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
         let mut content_codings: u32 = 0;
+        let mut has_keep_alive_token = false;
         for (header_i, header) in response.headers.list.iter().enumerate() {
             match hash_header_name(header.name()) {
                 h if h == hash_header_const(b"Content-Length") => {
@@ -4885,8 +4888,10 @@ impl<'a> HTTPClient<'a> {
                 }
                 h if h == hash_header_const(b"Connection") => {
                     // `close` on any field line, any status, is sticky (RFC 9110 §5.3, RFC 9112 §9.6).
-                    if connection_header_keep_alive(header.value()) == Some(false) {
-                        self.state.flags.allow_keepalive = false;
+                    match connection_header_keep_alive(header.value()) {
+                        Some(false) => self.state.flags.allow_keepalive = false,
+                        Some(true) => has_keep_alive_token = true,
+                        None => {}
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {
@@ -4973,6 +4978,14 @@ impl<'a> HTTPClient<'a> {
             self.flags.proxy_tunneling = false;
             self.flags.disable_keepalive = true;
             is_proxy_connect_failure = true;
+        }
+
+        // RFC 9112 §9.3: an HTTP/1.0 response is non-persistent unless it says
+        // `Connection: keep-alive`. Deliberately below the CONNECT return above:
+        // proxies commonly answer CONNECT with `HTTP/1.0 200`, which says nothing
+        // about the tunneled origin, whose own response is what gets judged here.
+        if response.minor_version == 0 && !has_keep_alive_token {
+            self.state.flags.allow_keepalive = false;
         }
 
         let status_code = response.status_code;

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -73,28 +73,51 @@ test("fetch does not reuse a pooled TLS connection for a request with a differen
   expect(plain).not.toBe(overrideA);
 });
 
-// RFC 9112 §9.6: a server's `Connection: close` applies regardless of status
-// code. Previously bun only honored it for 2xx, so a 4xx/5xx with
-// `Connection: close` was pooled; a concurrent fetch that picked the pooled
-// socket before the server's FIN landed failed with ECONNRESET. Subprocess
-// so the pool can't leak into other tests. The server here keeps the socket
-// open and answers every request on it, so the connection count is exactly
-// how many times bun dialed (pooled reuse => 1, correct => 4).
+// Whether a completed response leaves its connection in the keep-alive pool is
+// decided from the status line and the Connection header:
+//   - RFC 9112 §9.6: `close` ends persistence whatever the status code (bun used
+//     to honour it on 2xx only, so a 4xx/5xx with `Connection: close` was
+//     pooled and the next fetch raced the server's FIN into ECONNRESET), and it
+//     wins over a keep-alive token on the same or another Connection line.
+//   - RFC 9112 §9.3: an HTTP/1.0 response is persistent only if it says
+//     `Connection: keep-alive`; a bare Keep-Alive header is not that. bun never
+//     looked at the version, so every HTTP/1.0 response with a Content-Length
+//     was pooled and, since nearly every HTTP/1.0 server closes after
+//     responding, the next fetch (or a followed redirect's hop) was written
+//     onto a dying socket. Node and curl dial again here.
+// The server below keeps every socket open and answers each request on the
+// connection it arrived on, so `connections` is exactly how many times bun
+// dialed for four sequential fetches: pooled => 1, not pooled => 4. Subprocess
+// so the pool can't leak between rows.
 test.concurrent.each([
-  [200, "close"],
-  [400, "close"],
-  [413, "close"],
-  [500, "close"],
-  [200, "close, keep-alive"],
-  [200, "Keep-Alive ,\tClose"],
-  [200, "upgrade, close"],
-  [200, "close\\r\\nConnection: keep-alive"],
-] as const)("a %d response with Connection: %s is not pooled", async (status, connection) => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+  ["HTTP/1.1 200 X", ["Connection: close"], 4],
+  ["HTTP/1.1 400 X", ["Connection: close"], 4],
+  ["HTTP/1.1 413 X", ["Connection: close"], 4],
+  ["HTTP/1.1 500 X", ["Connection: close"], 4],
+  ["HTTP/1.1 200 X", ["Connection: close, keep-alive"], 4],
+  ["HTTP/1.1 200 X", ["Connection: Keep-Alive ,\tClose"], 4],
+  ["HTTP/1.1 200 X", ["Connection: upgrade, close"], 4],
+  ["HTTP/1.1 200 X", ["Connection: close", "Connection: keep-alive"], 4],
+  ["HTTP/1.1 200 X", [], 1],
+  ["HTTP/1.1 404 X", [], 1],
+  ["HTTP/1.0 200 X", [], 4],
+  ["HTTP/1.0 404 X", [], 4],
+  ["HTTP/1.0 200 X", ["Keep-Alive: timeout=5"], 4],
+  ["HTTP/1.0 200 X", ["Connection: keep-alive"], 1],
+  ["HTTP/1.0 404 X", ["Connection: Keep-Alive"], 1],
+  ["HTTP/1.0 200 X", ["Connection: keep-alive, close"], 4],
+  ["HTTP/1.0 200 X", ["Connection: keep-alive", "Connection: close"], 4],
+  ["HTTP/1.0 200 X", ["Connection: close", "Connection: keep-alive"], 4],
+] as [statusLine: string, headers: string[], connections: number][])(
+  "%s %j: four fetches use %d connection(s)",
+  async (statusLine, headers, connections) => {
+    const status = Number(statusLine.split(" ")[1]);
+    const head = [statusLine, ...headers, "Content-Length: 2"].join("\r\n") + "\r\n\r\nok";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         import net from "node:net";
         let connections = 0;
         const server = net.createServer(sock => {
@@ -105,7 +128,7 @@ test.concurrent.each([
             buf += d.toString("latin1");
             while (buf.includes("\\r\\n\\r\\n")) {
               buf = buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4);
-              sock.write("HTTP/1.1 ${status} X\\r\\nContent-Length: 2\\r\\nConnection: ${connection}\\r\\n\\r\\nok");
+              sock.write(${JSON.stringify(head)});
             }
           });
         });
@@ -121,19 +144,119 @@ test.concurrent.each([
         console.log(JSON.stringify({ statuses, connections }));
         process.exit(0);
         `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-  expect({ result, exitCode }).toEqual({
-    result: { statuses: [status, status, status, status], connections: 4 },
-    exitCode: 0,
-  });
-});
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({
+      result: { statuses: [status, status, status, status], connections },
+      exitCode: 0,
+    });
+  },
+);
+
+// Through a CONNECT proxy two status lines arrive on one connection. The
+// proxy's reply to CONNECT only describes the hop to the proxy (tinyproxy,
+// Apache mod_proxy_connect and older Squid all answer it with `HTTP/1.0 200`),
+// so its version must not decide anything; the origin's response travelling
+// inside the tunnel decides whether the tunnel is pooled, and its HTTP/1.0
+// status line counts like a direct one. `tunnels` is how many times bun dialed
+// the proxy for three sequential fetches: a pooled tunnel serves all three.
+// Subprocess so the pool is private and so the machine's own NO_PROXY /
+// HTTP_PROXY can't make fetch bypass the explicit proxy.
+test.concurrent.each([
+  ["HTTP/1.0 200 Connection established", "HTTP/1.1 200 OK", 1],
+  ["HTTP/1.0 200 Connection established", "HTTP/1.0 200 OK\r\nConnection: keep-alive", 1],
+  ["HTTP/1.1 200 Connection established", "HTTP/1.0 200 OK", 3],
+] as [connectReply: string, originHead: string, tunnels: number][])(
+  "CONNECT answered %j, origin answering %j: three fetches open %d tunnel(s)",
+  async (connectReply, originHead, tunnels) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import net from "node:net";
+        import { createServer as createTlsServer } from "node:tls";
+        // Answers every request on the connection it arrived on and never
+        // closes, so a tunnel bun pooled keeps working and shows up as reuse.
+        const origin = createTlsServer(${JSON.stringify(tls)}, sock => {
+          sock.on("error", () => {});
+          let buf = "";
+          sock.on("data", d => {
+            buf += d.toString("latin1");
+            while (buf.includes("\\r\\n\\r\\n")) {
+              buf = buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4);
+              sock.write(${JSON.stringify(originHead + "\r\nContent-Length: 2\r\n\r\nok")});
+            }
+          });
+        });
+        origin.listen(0, "127.0.0.1");
+        await new Promise(r => origin.on("listening", r));
+
+        let tunnels = 0;
+        const proxy = net.createServer(client => {
+          tunnels++;
+          client.on("error", () => {});
+          let head = "";
+          const onHead = chunk => {
+            head += chunk.toString("latin1");
+            if (!head.includes("\\r\\n\\r\\n")) return;
+            client.off("data", onHead);
+            // bun sends nothing more until it has the reply, so piping right
+            // after writing it can't miss any tunnel bytes.
+            const upstream = net.connect(origin.address().port, "127.0.0.1", () => {
+              client.write(${JSON.stringify(connectReply + "\r\n\r\n")});
+              client.pipe(upstream);
+              upstream.pipe(client);
+            });
+            upstream.on("error", () => client.destroy());
+          };
+          client.on("data", onHead);
+        });
+        proxy.listen(0, "127.0.0.1");
+        await new Promise(r => proxy.on("listening", r));
+
+        const responses = [];
+        for (let i = 0; i < 3; i++) {
+          const res = await fetch("https://localhost:" + origin.address().port + "/", {
+            proxy: "http://127.0.0.1:" + proxy.address().port,
+            tls: { rejectUnauthorized: false },
+          });
+          responses.push(res.status + ":" + (await res.text()));
+        }
+        console.log(JSON.stringify({ responses, tunnels }));
+        process.exit(0);
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({
+      result: { responses: ["200:ok", "200:ok", "200:ok"], tunnels },
+      exitCode: 0,
+    });
+  },
+  // Subprocess start plus up to three TLS handshakes takes ~2s on a debug
+  // ASAN build here; leave room for slower CI runners.
+  20_000,
+);
 
 // A reused keep-alive connection reset during a streaming PUT must reject with
 // ECONNRESET, not retry: the stream body is already consumed, and the retry
@@ -375,6 +498,8 @@ test("a completed streaming POST keeps its connection in the keep-alive pool", a
 //   /302, /303, /307  bodyless redirect to /legit on a reusable connection
 //   /302-close        the same 302 with Connection: close
 //   /302-body         a 302 that carries a body
+//   /302-http10       the same 302 from an HTTP/1.0 server (socket left open)
+//   /302-http10-ka    ... that says Connection: keep-alive
 //   anything else     200 whose body is "<method>:<request body length>"
 const redirectServer = `
   import net from "node:net";
@@ -397,6 +522,8 @@ const redirectServer = `
           "/302": "302 Found",
           "/302-close": "302 Found",
           "/302-body": "302 Found",
+          "/302-http10": "302 Found",
+          "/302-http10-ka": "302 Found",
           "/303": "303 See Other",
           "/307": "307 Temporary Redirect",
         }[path];
@@ -407,6 +534,10 @@ const redirectServer = `
           sock.end("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n");
         } else if (path === "/302-body") {
           sock.write("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 5\\r\\n\\r\\nmoved");
+        } else if (path === "/302-http10") {
+          sock.write("HTTP/1.0 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\n\\r\\n");
+        } else if (path === "/302-http10-ka") {
+          sock.write("HTTP/1.0 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\nConnection: keep-alive\\r\\n\\r\\n");
         } else {
           sock.write("HTTP/1.1 " + redirect + "\\r\\nLocation: /legit\\r\\nContent-Length: 0\\r\\n\\r\\n");
         }
@@ -430,10 +561,14 @@ test.concurrent.each([
   ["GET -> 302", "/302", "{}", "GET:0", 1],
   ["POST -> 303 (hop is a bodyless GET)", "/303", '{ method: "POST", body: "payload" }', "GET:0", 1],
   ["POST -> 307 (hop resends the body)", "/307", '{ method: "POST", body: "payload" }', "POST:7", 1],
+  ["GET -> HTTP/1.0 302 with Connection: keep-alive", "/302-http10-ka", "{}", "GET:0", 1],
   // Not reusable, so every fetch dials once more for the hop; the hop's own
-  // connection is pooled and carries the next fetch's 3xx.
+  // connection is pooled and carries the next fetch's 3xx. The HTTP/1.0 row is
+  // what python -m http.server and its kind send: bun used to pool that
+  // connection and write the hop onto it while the server was closing it.
   ["GET -> 302 with Connection: close", "/302-close", "{}", "GET:0", 5],
   ["GET -> 302 carrying a body", "/302-body", "{}", "GET:0", 5],
+  ["GET -> HTTP/1.0 302", "/302-http10", "{}", "GET:0", 5],
 ])("redirect keep-alive: %s", async (_, path, init, hopBody, connections) => {
   await using proc = Bun.spawn({
     cmd: [


### PR DESCRIPTION
`fetch()` returns the connection that carried an HTTP/1.0 response to the keep-alive pool as long as the response had a Content-Length, whether or not the server said `Connection: keep-alive`.

### Repro

Raw server that answers every request with `HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\nok` and leaves the socket open, counting accepted connections:

```js
import net from "node:net";
let connections = 0;
const server = net.createServer(sock => {
  connections++;
  sock.on("data", () => sock.write("HTTP/1.0 200 OK\r\nContent-Length: 2\r\n\r\nok"));
}).listen(0, "127.0.0.1", async () => {
  const url = `http://127.0.0.1:${server.address().port}/`;
  for (let i = 0; i < 4; i++) await (await fetch(url)).text();
  console.log(connections); // bun 1.4.0 and main: 1, node (http.Agent keepAlive) and undici: 4
  process.exit();
});
```

Adding `Connection: keep-alive` to the response is what should make this print 1 (and does, in bun and node alike).

Real HTTP/1.0 servers (`python -m http.server`, and most other respond-and-close servers) close the socket right after the response, so in practice the pooled socket races the server's FIN: the next fetch to that origin is written onto it and only succeeds because `on_close` retries idempotent requests on reused connections. A POST loses that race with ECONNRESET. Since #37451 the hop of a followed redirect takes the 3xx's connection back out of the pool synchronously, which makes the race a certainty for an HTTP/1.0 3xx (#37522 separately gates that release on the hop being idempotent; the HTTP/1.0 default underneath is still wrong and this fix is independent of it).

### Cause

`handle_response_metadata` never looks at `response.minor_version`. `allow_keepalive` starts out `true` and is only cleared by `Connection: close`, missing framing, or an upgrade, so an HTTP/1.0 response with a Content-Length falls through to HTTP/1.1's persistent default.

### Fix

The `Connection` header arm now also records whether any field line carried a `keep-alive` token (`close` still clears `allow_keepalive` on the spot, so it stays sticky across lines and wins over `keep-alive`). After the header loop, an HTTP/1.0 response without such a token clears `allow_keepalive`.

Why this is the right rule: RFC 9112 section 9.3 makes an HTTP/1.0 response non-persistent unless it carries `Connection: keep-alive` (that header is how HTTP/1.0 keep-alive was negotiated in the first place, and bun already sends `Connection: keep-alive` on its requests, so servers that support it will answer with it). Node's HTTP parser (`shouldKeepAlive`), undici and curl all implement the same rule; the numbers in the repro are node's. Only `Connection` is consulted: a `Keep-Alive:` parameters header on its own does not count, same as in node and curl.

The check is placed after the early return for a proxy's 2xx reply to CONNECT on purpose. tinyproxy, Apache mod_proxy_connect and older Squid answer CONNECT with `HTTP/1.0 200 Connection established`; that status line describes the hop to the proxy, and since `state` is not reset between the CONNECT reply and the tunneled response, clearing `allow_keepalive` there would stop every tunnel through such a proxy from being pooled. The origin's response inside the tunnel goes through the same function later and is judged on its own version, exactly like a direct connection. The h2/h3 sessions feed a synthetic `minor_version: 0` through this function too; they already overwrite `allow_keepalive` right afterwards because HTTP/1.x persistence rules do not apply to them, and the comment there now says so.

### Tests

`test/js/web/fetch/fetch-keepalive.test.ts`:

- The `Connection: close` table is generalised to status line + header lines + expected connection count and gains HTTP/1.0 rows: no Connection header (200 and 404), `Keep-Alive:` header alone, `Connection: keep-alive` (both spellings, still pooled), and `keep-alive` combined with `close` on one line or across two lines in either order (still not pooled). HTTP/1.1 without a Connection header is pinned as still pooled.
- A CONNECT-proxy table: `HTTP/1.0 200` CONNECT reply with an HTTP/1.1 origin still pools the tunnel, so does an HTTP/1.0 origin that says keep-alive, and an HTTP/1.0 origin without it makes each fetch open a new tunnel.
- The redirect table gains an HTTP/1.0 302 (hop and later fetches dial again, like the `Connection: close` row) and an HTTP/1.0 302 with `Connection: keep-alive` (one connection throughout).

Without the `src/http/lib.rs` change, main fails exactly the five rows that describe the bug (three direct, the HTTP/1.0-origin tunnel row and the HTTP/1.0 302 row, each with one connection instead of 4 / 3 / 5); with it all 36 tests in the file pass. `fetch-redirect`, `fetch-connection-header`, `fetch-url-after-redirect`, `fetch-proxy-connect-tunnel-split-envelope`, `fetch-http2-client`, `fetch-http3-client`, `client-fetch`, `proxy.test.ts`, `proxy-stress-protocol` (which has an HTTP/1.0-origin-through-tunnel group), `proxy-stress-matrix` and `proxy-stress-concurrent` pass on the debug build as well.

Note: #37522 rewrites the redirect section of the same test file; whichever of the two lands second needs its two HTTP/1.0 redirect rows moved over. The `lib.rs` changes do not overlap.

This is the half of #35545 that #36370 did not pick up.
