### PR TITLE
resolver: don't abort the browser map lookup on a specifier longer than a path buffer

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5153,6 +5153,14 @@ impl<'a> Resolver<'a> {
             return None;
         }
 
+        // Every candidate below is built in a PathBuffer: `cleaned`, the "./"-prefixed
+        // copy, and `check_path`'s `<path>/index` probe (the longest; its join may also
+        // use one spare byte). A specifier that does not fit is simply not remapped;
+        // ordinary resolution bounds its own buffers.
+        if input_path.len() + BROWSER_MAP_INDEX_SUFFIX.len() >= MAX_PATH_BYTES {
+            return None;
+        }
+
         // Normalize the path so we can compare against it without getting confused by "./"
         let cleaned = self
             .fs_ref()
@@ -6716,6 +6724,10 @@ pub(crate) struct BrowserMapPath<'b> {
     pub(crate) map: &'b BrowserMap,
 }
 
+/// The longest thing the browser-map lookup appends to a candidate path; it
+/// sizes the length guard in `Resolver::check_browser_map`.
+const BROWSER_MAP_INDEX_SUFFIX: &str = const_format::concatcp!(SEP_STR, "index");
+
 impl<'b> BrowserMapPath<'b> {
     /// On a match only `self.remapped` is updated; the matched candidate may
     /// borrow threadlocal scratch buffers and must never be stored back into
@@ -6762,10 +6774,7 @@ impl<'b> BrowserMapPath<'b> {
 
         let index_path: &[u8] = {
             let trimmed = strings::trim_right(path_to_check, &[SEP]);
-            let parts = [
-                trimmed,
-                const_format::concatcp!(SEP_STR, "index").as_bytes(),
-            ];
+            let parts = [trimmed, BROWSER_MAP_INDEX_SUFFIX.as_bytes()];
             ResolvePath::join_string_buf(
                 bufs!(tsconfig_base_url),
                 &parts,

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -444,6 +444,116 @@ describe("When CJS and ESM are mixed", () => {
   });
 });
 
+// When the importing package has a "browser" map, every bare specifier is copied
+// into fixed-size path buffers (normalized, with "/index" appended, and with "./"
+// prepended) without a length check, so a specifier that did not fit aborted the
+// build:
+//   panic: range end index 5000 out of range for slice of length 4096
+// Such a specifier cannot be remapped; it has to fall through to ordinary
+// resolution exactly like it does when there is no "browser" map.
+describe.concurrent("browser map lookup of a bare specifier that does not fit a path buffer", () => {
+  // MAX_PATH_BYTES in src/bun_core/util.rs
+  const maxPathBytes = { linux: 4096, darwin: 1024, win32: 32767 * 3 + 1 }[process.platform] ?? 1024;
+  const packageJsonWithBrowserMap = JSON.stringify({ name: "pkg", browser: { "./a.js": "./b.js" } });
+
+  async function bunBuild(dir: string, entry: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--target=browser", entry],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.each([
+    // The shortest specifier that overflowed: it fits on its own, `<specifier>/index` does not.
+    ["specifier + '/index' does not fit", maxPathBytes - "/index".length],
+    // The specifier itself overflows the buffer it is normalized into.
+    ["specifier does not fit", maxPathBytes + 1000],
+  ])("bun build reports the unresolved import (%s)", async (_, length) => {
+    const specifier = Buffer.alloc(length, "x").toString();
+    using dir = tempDir("resolver-browser-map-long-specifier", {
+      "package.json": packageJsonWithBrowserMap,
+      "entry.js": `import ${JSON.stringify(specifier)};`,
+    });
+
+    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.js");
+
+    expect(stderr).toContain(`error: Could not resolve: "${specifier}"`);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  it("Bun.build reports the unresolved import", async () => {
+    const specifier = Buffer.alloc(maxPathBytes + 1000, "x").toString();
+    using dir = tempDir("resolver-browser-map-long-specifier-api", {
+      "package.json": packageJsonWithBrowserMap,
+      "entry.js": `import ${JSON.stringify(specifier)};`,
+      "build.js": `
+        const result = await Bun.build({ entrypoints: ["./entry.js"], target: "browser", throw: false });
+        console.log(JSON.stringify({ success: result.success, messages: result.logs.map(log => log.message) }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      success: false,
+      messages: [expect.stringContaining(`Could not resolve: "${specifier}"`)],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("still resolves the specifier through node_modules", async () => {
+    // Normalizes down to "b", so the normalized copy and the "/index" probe fit; what
+    // overflowed here was the "./"-prefixed copy of the raw specifier that the lookup
+    // also tries. Ordinary resolution has no trouble with it.
+    const segment = "x/../";
+    const segments = Math.ceil((maxPathBytes + 100) / segment.length);
+    const specifier = Buffer.alloc(segments * segment.length, segment).toString() + "b";
+    using dir = tempDir("resolver-browser-map-long-specifier-node-modules", {
+      "package.json": packageJsonWithBrowserMap,
+      "node_modules/b/index.js": `export const x = "resolved through node_modules";`,
+      "entry.js": `import {x} from ${JSON.stringify(specifier)}; console.log(x);`,
+    });
+
+    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.js");
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain(`"resolved through node_modules"`);
+    expect(exitCode).toBe(0);
+  });
+
+  it("still remaps a long specifier that does fit", async () => {
+    // Long enough to matter on every platform, while staying inside macOS's 1024-byte
+    // path buffer (and the 1 KiB buffer "browser" keys are normalized through when
+    // package.json is parsed).
+    const specifier = Buffer.alloc(1000, "x").toString();
+    using dir = tempDir("resolver-browser-map-long-specifier-remapped", {
+      "package.json": JSON.stringify({ name: "pkg", browser: { [specifier]: "./shim.js" } }),
+      "shim.js": `export const x = "remapped by the browser map";`,
+      "entry.js": `import {x} from ${JSON.stringify(specifier)}; console.log(x);`,
+    });
+
+    const { stdout, stderr, exitCode } = await bunBuild(String(dir), "entry.js");
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain(`"remapped by the browser map"`);
+    expect(exitCode).toBe(0);
+  });
+});
+
 // The "browser" map resolver copied the normalized input path into a 512-byte
 // threadlocal buffer without a bounds check. Paths inside deep directory trees
 // can easily exceed 512 bytes while still being well under MAX_PATH_BYTES.


### PR DESCRIPTION
## Reproduction

Any `--target=browser` build (CLI, `Bun.build()`, dev server) whose importing package has a `"browser"` object, when a bare import specifier is at least `MAX_PATH_BYTES - 6` bytes long (4090 on Linux, 1018 on macOS):

```sh
bun -e 'const fs = require("fs");
fs.writeFileSync("package.json", JSON.stringify({ name: "root", browser: { "./a.js": "./b.js" } }));
fs.writeFileSync("entry.js", `import ${JSON.stringify("x".repeat(5000))};`)'
bun build --target=browser entry.js
```

```
panic: range end index 5000 out of range for slice of length 4096
```

The process aborts (exit 134). Without the `browser` field, or with any other target, the same build prints `error: Could not resolve: "xxx..."` and exits 1. The specifier does not have to be a nonsense name: a specifier made of `x/../` segments that normalizes down to a real package aborts as well (see below), while it resolves fine without the `browser` field.

## Cause

`Resolver::check_browser_map` (`src/resolver/resolver.rs`) runs for every bare specifier when the enclosing package has a non-empty browser map (twice per specifier for browser builds: once from the node polyfill check, once from `check_package_path`). It copies the specifier into three fixed-size `PathBuffer` scratch buffers without checking its length:

- `normalize_buf(bufs!(check_browser_map), input_path)`, which overflows once the specifier itself is longer than the buffer (the repro above);
- `BrowserMapPath::check_path`'s implicit index probe, `join_string_buf(bufs!(tsconfig_base_url), [path, "/index"])`, which overflows 6 bytes earlier (the join writes its result at offset 1 on POSIX, so the shortest aborting specifier is `MAX_PATH_BYTES - 6` bytes);
- the `"./" + specifier` copy into `bufs!(abs_to_rel)`, which is what a long specifier that normalizes down to something short overflows (`x/../x/../.../b`).

Relative specifiers never get here with anything this long; they are resolved through `abs_buf_checked` first. Only package paths (and, in theory, the absolute-path variant when the package directory is shorter than 7 bytes) reach these copies with an unbounded length.

## Fix

One length check at the top of `check_browser_map`, sized by the longest candidate the lookup builds (the `/index` probe, now a named constant shared with `check_path`): a specifier that does not fit is not looked up in the browser map and continues through ordinary resolution, which bounds its own buffers (`resolve_without_remapping` uses `abs_buf_checked`, `load_node_modules` joins on the heap).

Why bailing out is the right behavior rather than building the candidates on the heap: a browser map entry names a file or a package, and nothing that long can be either, so there is no real mapping such a specifier could hit. Skipping the candidate that does not fit is also what `match_tsconfig_paths` already does for the same shape of scratch buffer (`tsconfig_match_full_buf3`). The one observable difference from an unbounded lookup is deliberate and is pinned by a test: a specifier of at least `MAX_PATH_BYTES - 6` bytes that normalizes down to a mapped name (thousands of `x/../` segments) is no longer remapped and instead resolves like it would without the `browser` field. Below that length the lookup is unchanged; I verified by hand that a 4089-byte `x/../...b` specifier is still remapped by a `b.js` entry on Linux and a 4090-byte one falls through.

#37526 fixes the parse-side counterpart (a browser map key longer than the 1 KiB normalization buffer); the two do not touch the same code.

## Verification

`test/js/bun/resolve/resolve.test.ts`, next to the existing browser-map buffer test. Four of the five new cases abort on the unfixed build, each at a different one of the copies above:

- `bun build` with a specifier of exactly `MAX_PATH_BYTES - 6` bytes (the `/index` probe) and of `MAX_PATH_BYTES + 1000` bytes (the normalized copy): `Could not resolve`, exit 1;
- `Bun.build({ target: "browser", throw: false })` with the long specifier: `success: false` with the `Could not resolve` log, process exits 0;
- a `x/../...b` specifier longer than the buffer (the `"./"` copy) with `node_modules/b` present still resolves to `node_modules/b`, proving the specifier falls through instead of failing;
- a 1000-byte specifier that is in the browser map is still remapped (passes before and after; guards against over-tightening the check).

Lengths are derived from `MAX_PATH_BYTES` per platform, so the cases overflow on macOS and Windows too. Existing browser-field suites (`test/bundler/esbuild/packagejson.test.ts`, `test/bundler/bundler_browser.test.ts`, `test/js/bun/resolve/resolve-error.test.ts`) pass with the debug build.
