### PR TITLE
crash_handler: symbolize frame 0 of a fault trace at the fault pc, not one byte before it

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -66,6 +66,28 @@ pub static WINDOWS_SEGFAULT_HANDLE: core::sync::atomic::AtomicPtr<core::ffi::c_v
 pub struct StackTrace<'a> {
     pub index: usize,
     pub instruction_addresses: &'a [usize],
+    /// `instruction_addresses[0]` is the faulting instruction itself (the pc a
+    /// fault handler was given) rather than a return address. See
+    /// [`Self::symbol_address`].
+    pub first_frame_is_exact_pc: bool,
+}
+
+impl StackTrace<'_> {
+    /// The address to symbolize for frame `i`.
+    ///
+    /// A return address points one past its call instruction, so it is stepped
+    /// back into the call; looked up as is, a call that ends a line (or a
+    /// function) is attributed to whatever follows it. A fault pc already is the
+    /// instruction to blame and must not be stepped back, or a fault on the first
+    /// instruction of a function is attributed to the function before it.
+    pub fn symbol_address(&self, i: usize) -> usize {
+        let addr = self.instruction_addresses[i];
+        if i == 0 && self.first_frame_is_exact_pc {
+            addr
+        } else {
+            addr.saturating_sub(1)
+        }
+    }
 }
 
 /// Fixed 31-frame stack-trace buffer.
@@ -85,6 +107,7 @@ impl StoredTrace {
         StackTrace {
             index: self.index,
             instruction_addresses: &self.data,
+            first_frame_is_exact_pc: false,
         }
     }
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -776,7 +776,15 @@ mod draft {
         /// becomes frame 0. POSIX: `fp` is the saved frame-pointer register and
         /// the walk follows the fp chain. Windows: `fp` is the `*const CONTEXT`
         /// from `EXCEPTION_POINTERS` and the walk uses `RtlVirtualUnwind`.
-        Fault { pc: usize, fp: usize },
+        /// `exact_pc`: `pc` is the faulting instruction itself, as opposed to
+        /// already pointing past it the way a trap leaves it (see
+        /// `signal_pc_is_exact`); decides whether frame 0 is symbolized as is
+        /// or stepped back like a return address.
+        Fault {
+            pc: usize,
+            fp: usize,
+            exact_pc: bool,
+        },
         /// A trace was already captured upstream.
         ErrorReturn(&'a StackTrace<'a>),
         /// Walk the current stack and trim the capture machinery above this PC.
@@ -1027,7 +1035,7 @@ mod draft {
                     let trace_buf: StackTrace;
 
                     let trace: &StackTrace = 'blk: {
-                        let idx: usize = match seed {
+                        let (idx, first_frame_is_exact_pc): (usize, bool) = match seed {
                             TraceSeed::ErrorReturn(ert) => break 'blk ert,
                             // For an actual fault the signal/exception handler hands
                             // us the saved register context. Seeding the walk from
@@ -1036,19 +1044,22 @@ mod draft {
                             // `SA_ONSTACK` altstack, so its own frame chain is
                             // disjoint from the faulting thread's, and release builds
                             // strip the unwind tables a CFI-based capture would need.
-                            TraceSeed::Fault { pc, fp } => {
-                                bun_core::debug::capture_from_context(pc, fp, &mut addr_buf)
-                            }
+                            TraceSeed::Fault { pc, fp, exact_pc } => (
+                                bun_core::debug::capture_from_context(pc, fp, &mut addr_buf),
+                                exact_pc,
+                            ),
                             TraceSeed::BeginAddr(addr) => {
-                                debug::capture_stack_trace(addr, &mut addr_buf)
+                                (debug::capture_stack_trace(addr, &mut addr_buf), false)
                             }
-                            TraceSeed::None => {
-                                debug::capture_stack_trace(debug::return_address(), &mut addr_buf)
-                            }
+                            TraceSeed::None => (
+                                debug::capture_stack_trace(debug::return_address(), &mut addr_buf),
+                                false,
+                            ),
                         };
                         trace_buf = StackTrace {
                             index: idx,
                             instruction_addresses: &addr_buf,
+                            first_frame_is_exact_pc,
                         };
                         break 'blk &trace_buf;
                     };
@@ -1568,6 +1579,25 @@ mod draft {
         }
     }
 
+    /// Whether the pc saved in the signal context is the instruction that raised
+    /// `sig`. Faults (SIGSEGV, SIGBUS, SIGILL, SIGFPE) are reported before the
+    /// instruction completes, so it is. Traps are reported after it: x86_64
+    /// `int3` (WTF's CRASH()) leaves pc on the byte following it, and SIGABRT is
+    /// delivered on return from the kill(2) that raised it. For those, stepping
+    /// back one byte like a return address lands inside the instruction that
+    /// trapped.
+    #[cfg(unix)]
+    fn signal_pc_is_exact(sig: c_int) -> bool {
+        // The exception among traps: the kernel leaves pc on an aarch64 `brk`
+        // itself (which is also why a handler that returns re-traps forever).
+        const TRAP_LEAVES_PC_ON_INSTRUCTION: bool = cfg!(target_arch = "aarch64");
+        match sig {
+            libc::SIGABRT => false,
+            libc::SIGTRAP => TRAP_LEAVES_PC_ON_INSTRUCTION,
+            _ => true,
+        }
+    }
+
     #[cfg(unix)]
     extern "C" fn handle_segfault_posix(sig: c_int, info: *mut libc::siginfo_t, ctx: *mut c_void) {
         // SAFETY: kernel provides a valid siginfo_t; `si_addr` reads the per-platform
@@ -1586,7 +1616,11 @@ mod draft {
                 _ => unreachable!(),
             },
             match fault_context_from_ucontext(ctx) {
-                Some((pc, fp)) => TraceSeed::Fault { pc, fp },
+                Some((pc, fp)) => TraceSeed::Fault {
+                    pc,
+                    fp,
+                    exact_pc: signal_pc_is_exact(sig),
+                },
                 None => TraceSeed::None,
             },
         );
@@ -1818,6 +1852,7 @@ mod draft {
             let trace = StackTrace {
                 index: idx,
                 instruction_addresses: &addr_buf,
+                first_frame_is_exact_pc: false,
             };
 
             if debug_trace {
@@ -1902,6 +1937,7 @@ mod draft {
             let stack = StackTrace {
                 index: n,
                 instruction_addresses: &addrs,
+                first_frame_is_exact_pc: false,
             };
             let _ = writeln!(
                 stderr,
@@ -1968,6 +2004,8 @@ mod draft {
     #[cfg(windows)]
     static WINDOWS_EXE_IMAGE_END: AtomicUsize = AtomicUsize::new(0);
 
+    /// For every code classified here `ExceptionAddress` is the faulting
+    /// instruction itself, hence `exact_pc: true` at the three callers.
     #[cfg(windows)]
     fn classify_exception_windows(
         record: &bun_sys::windows::EXCEPTION_RECORD,
@@ -2038,6 +2076,7 @@ mod draft {
             TraceSeed::Fault {
                 pc,
                 fp: info.ContextRecord as usize,
+                exact_pc: true,
             },
         );
     }
@@ -2079,6 +2118,7 @@ mod draft {
             TraceSeed::Fault {
                 pc,
                 fp: context as usize,
+                exact_pc: true,
             },
         );
     }
@@ -2099,6 +2139,7 @@ mod draft {
             TraceSeed::Fault {
                 pc,
                 fp: info.ContextRecord as usize,
+                exact_pc: true,
             },
         );
     }
@@ -2426,10 +2467,23 @@ mod draft {
     }
 
     impl StackLine {
-        /// `None` implies the trace is not known.
-        fn from_address(addr: usize, name_bytes: &mut [u8]) -> Option<StackLine> {
+        /// One frame of `trace`, as bun.report expects it. `None` implies the
+        /// frame is not known.
+        ///
+        /// POSIX strings carry the address to symbolize
+        /// (`StackTrace::symbol_address`), which bun.report hands to
+        /// llvm-symbolizer unchanged. Windows strings carry the addresses as
+        /// captured: bun.report treats the first frame as the fault pc and steps
+        /// the frames after it back itself, so adjusting here as well would step
+        /// return addresses back twice.
+        fn from_frame(
+            trace: &StackTrace,
+            frame: usize,
+            name_bytes: &mut [u8],
+        ) -> Option<StackLine> {
             #[cfg(windows)]
             {
+                let addr = trace.instruction_addresses[frame];
                 let module = bun_sys::windows::get_module_handle_from_address(addr)?;
 
                 let base_address = module as usize;
@@ -2462,7 +2516,7 @@ mod draft {
             }
             #[cfg(target_os = "macos")]
             {
-                let address = if addr == 0 { 0 } else { addr - 1 };
+                let address = trace.symbol_address(frame);
 
                 let image_count = bun_sys::c::_dyld_image_count();
 
@@ -2545,7 +2599,7 @@ mod draft {
             #[cfg(not(any(windows, target_os = "macos")))]
             {
                 let _ = name_bytes;
-                let address = addr.saturating_sub(1);
+                let address = trace.symbol_address(frame);
                 let m = bun_sys::elf::find_loaded_module(address)?;
                 return Some(StackLine {
                     address: i32::try_from(address - m.base_address).expect("int cast"),
@@ -2631,8 +2685,8 @@ mod draft {
 
         let mut name_bytes: [u8; 1024] = [0; 1024];
 
-        for &addr in &opts.trace.instruction_addresses[0..opts.trace.index] {
-            let line = StackLine::from_address(addr, &mut name_bytes);
+        for frame in 0..opts.trace.index {
+            let line = StackLine::from_frame(opts.trace, frame, &mut name_bytes);
             StackLine::write_encoded(line.as_ref(), writer)?;
         }
 
@@ -3268,8 +3322,8 @@ mod draft {
         });
 
         let mut name_bytes: [u8; 1024] = [0; 1024];
-        for &addr in &trace.instruction_addresses[0..trace.index] {
-            let Some(line) = StackLine::from_address(addr, &mut name_bytes) else {
+        for frame in 0..trace.index {
+            let Some(line) = StackLine::from_frame(trace, frame, &mut name_bytes) else {
                 continue;
             };
             argv.push(format!("0x{:X}", line.address).into_bytes());
@@ -3373,15 +3427,15 @@ mod draft {
             if frame_index >= limits.frame_count {
                 break;
             }
-            let return_address = stack_trace.instruction_addresses[frame_index];
-            let source = match get_source_at_address(debug_info, return_address - 1)? {
+            let address = stack_trace.symbol_address(frame_index);
+            let source = match get_source_at_address(debug_info, address)? {
                 Some(s) => s,
                 None => {
-                    let module_name = debug_info.get_module_name_for_address(return_address - 1);
+                    let module_name = debug_info.get_module_name_for_address(address);
                     print_line_info(
                         out_stream,
                         None,
-                        return_address - 1,
+                        address,
                         b"???",
                         module_name.as_deref().unwrap_or(b"???"),
                         tty_config,
@@ -3424,7 +3478,7 @@ mod draft {
             print_line_info(
                 out_stream,
                 source.source_location.as_ref(),
-                return_address - 1,
+                address,
                 &source.symbol_name,
                 &source.compile_unit_name,
                 tty_config,

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -119,6 +119,12 @@ export const cssInternals = {
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
   segfault: () => void;
+  /** Faults (SIGILL / illegal instruction) on the first instruction of a function. */
+  faultAtFunctionEntry: () => void;
+  /** POSIX only. Traps (int3 / brk) on the first instruction of a function. */
+  trapAtFunctionEntry?: () => void;
+  /** Crashes with a one-frame trace holding `faultAtFunctionEntry`'s entry as a return address. */
+  functionEntryAsReturnAddress: () => void;
   panic: () => void;
   rootError: () => void;
   outOfMemory: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -23,6 +23,16 @@ pub(crate) mod js_bindings {
             ("getFeatureData", __jsc_host_js_get_feature_data),
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
+            (
+                "faultAtFunctionEntry",
+                __jsc_host_js_fault_at_function_entry,
+            ),
+            #[cfg(unix)]
+            ("trapAtFunctionEntry", __jsc_host_js_trap_at_function_entry),
+            (
+                "functionEntryAsReturnAddress",
+                __jsc_host_js_function_entry_as_return_address,
+            ),
             ("panic", __jsc_host_js_panic),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
@@ -124,6 +134,91 @@ pub(crate) mod js_bindings {
         }
         #[allow(unreachable_code)]
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// Faults on its very first instruction, so a crash report's frame 0 is
+    /// exactly this function's entry address. Symbolized as the fault pc it is,
+    /// frame 0 names this function; stepped back one byte the way a return
+    /// address is, it names whatever the linker placed before it.
+    #[cfg(target_arch = "x86_64")]
+    #[unsafe(naked)]
+    extern "C" fn fault_at_function_entry() -> ! {
+        core::arch::naked_asm!("ud2")
+    }
+    #[cfg(target_arch = "aarch64")]
+    #[unsafe(naked)]
+    extern "C" fn fault_at_function_entry() -> ! {
+        core::arch::naked_asm!("udf #0")
+    }
+
+    /// Trap-class counterpart of `fault_at_function_entry`: the kernel reports
+    /// x86_64 `int3` with pc already past it and aarch64 `brk` with pc on it,
+    /// and the report has to resolve frame 0 to this function either way.
+    #[cfg(all(unix, target_arch = "x86_64"))]
+    #[unsafe(naked)]
+    extern "C" fn trap_at_function_entry() -> ! {
+        core::arch::naked_asm!("int3", "ud2")
+    }
+    #[cfg(all(unix, target_arch = "aarch64"))]
+    #[unsafe(naked)]
+    extern "C" fn trap_at_function_entry() -> ! {
+        core::arch::naked_asm!("brk #0")
+    }
+
+    #[bun_jsc::host_fn]
+    fn js_fault_at_function_entry(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        #[cfg(unix)]
+        if Environment::ENABLE_ASAN {
+            // No fault handlers are installed under ASAN (see `js_segfault`), so
+            // hand the handler what SIGILL would have delivered: pc on the
+            // instruction itself.
+            let pc = fault_at_function_entry as *const () as usize;
+            crash_handler::crash_handler(
+                crash_handler::CrashReason::IllegalInstruction(pc),
+                crash_handler::TraceSeed::Fault {
+                    pc,
+                    fp: 0,
+                    exact_pc: true,
+                },
+            );
+        }
+        fault_at_function_entry()
+    }
+
+    /// Only meaningful with the real signal handler installed: under ASAN the
+    /// trap simply kills the process.
+    #[cfg(unix)]
+    #[bun_jsc::host_fn]
+    fn js_trap_at_function_entry(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        trap_at_function_entry()
+    }
+
+    /// Control for the two hooks above: the same entry address reported as an
+    /// ordinary return-address frame, which the report steps back one byte.
+    #[bun_jsc::host_fn]
+    fn js_function_entry_as_return_address(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        let frames = [fault_at_function_entry as *const () as usize];
+        let trace = bun_core::StackTrace {
+            index: frames.len(),
+            instruction_addresses: &frames,
+            first_frame_is_exact_pc: false,
+        };
+        crash_handler::crash_handler(
+            crash_handler::CrashReason::IllegalInstruction(frames[0]),
+            crash_handler::TraceSeed::ErrorReturn(&trace),
+        )
     }
 
     #[bun_jsc::host_fn]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8678,7 +8678,7 @@ pub mod elf {
 
     /// Walk loaded ELF objects
     /// via `dl_iterate_phdr`, returning the one whose `PT_LOAD` segment contains
-    /// `address`. Shared by `bun_crash_handler::StackLine::from_address` and
+    /// `address`. Shared by `bun_crash_handler::StackLine::from_frame` and
     /// `bun_jsc::btjs::SelfInfo::lookup_module_dl` / `lookup_module_name_dl`.
     #[cfg(not(any(windows, target_os = "macos")))]
     pub fn find_loaded_module(address: usize) -> Option<LoadedModule> {

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,6 +12,7 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error(
-    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
+    "usage: bun fixture-crash.js <segfault|segfaultInDll|faultAtFunctionEntry|trapAtFunctionEntry|functionEntryAsReturnAddress|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
   );
+  process.exit(2);
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -43,6 +43,123 @@ test.if(isDebug && isLinux && hasSymbolizer)(
   60_000, // symbolizing the debug binary takes several seconds
 );
 
+// Frame 0 of a fault trace is the faulting instruction itself; every other
+// frame is a return address, which points one past its call and is therefore
+// symbolized one byte back so it lands inside the call. Applying that step to
+// the fault pc as well blames the instruction before the fault. The hook
+// faults on the first instruction of a function, where the skew is most
+// visible: one byte back is the padding (or the function) before it.
+test.if(isDebug && isLinux && hasSymbolizer)(
+  "a fault on the first instruction of a function is symbolized to that function",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "faultAtFunctionEntry"],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Illegal instruction at address");
+    expect(exitCode).not.toBe(0);
+
+    const firstFrame = stdout.split("\n").find(line => line.trim().length > 0);
+    expect(firstFrame ?? "<no frames printed>").toContain("::fault_at_function_entry");
+  },
+  60_000, // symbolizing the debug binary takes several seconds
+);
+
+// The same property at the trace-string level, which is what bun.report
+// decodes, on every platform and build flavor. All three approaches crash with
+// frame 0 holding the entry address of one and the same function:
+// `faultAtFunctionEntry` / `trapAtFunctionEntry` really fault / trap on its
+// first instruction, `functionEntryAsReturnAddress` reports the address as an
+// ordinary return-address frame. Frames are encoded image-relative, so the
+// offsets are comparable across the two processes regardless of ASLR, and the
+// return-address encoding is by definition one below the function's entry.
+describe.concurrent("fault trace strings encode frame 0 as the faulting instruction", () => {
+  const VLQ_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  // Source-map style VLQ, as bun.report's decoder reads it: 5 data bits per
+  // character, bit 32 continues, bit 0 of the assembled value is the sign.
+  function decodeVLQ(encoded: string, start: number): { value: number; end: number } {
+    let assembled = 0;
+    let scale = 1;
+    let i = start;
+    for (;;) {
+      const digit = VLQ_ALPHABET.indexOf(encoded[i] ?? "");
+      if (digit < 0) throw new Error(`no VLQ at index ${i} of ${JSON.stringify(encoded)}`);
+      i++;
+      assembled += (digit & 31) * scale;
+      scale *= 32;
+      if ((digit & 32) === 0) break;
+    }
+    const magnitude = Math.floor(assembled / 2);
+    return { value: assembled % 2 === 1 ? -magnitude : magnitude, end: i };
+  }
+
+  // Trace string layout (see `encode_trace_string`): platform char, command
+  // char, trace-string version char, 7-char commit, packed features as two
+  // VLQs, then one VLQ per frame.
+  function decodeFrameZero(trace: string): number {
+    let i = 1 + 1 + 1 + 7;
+    i = decodeVLQ(trace, i).end;
+    i = decodeVLQ(trace, i).end;
+    return decodeVLQ(trace, i).value;
+  }
+
+  async function frameZeroOf(approach: string): Promise<number> {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        path.join(import.meta.dir, "fixture-crash.js"),
+        approach,
+        // Debug builds otherwise symbolize locally instead of printing the
+        // trace string.
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Printed as `{report url}/{x.y.z}/{trace string}`; the report url is
+    // empty in `noReportEnv`.
+    const version = Bun.version.match(/^\d+\.\d+\.\d+/)![0];
+    const trace = stderr.match(new RegExp(`/${version.replaceAll(".", "\\.")}/(\\S+)`));
+    expect(trace, `no trace string in:\n${stderr}`).not.toBeNull();
+    expect(exitCode).not.toBe(0);
+    return decodeFrameZero(trace![1]);
+  }
+
+  test("fault pc is not stepped back like a return address", async () => {
+    const [fault, asReturnAddress] = await Promise.all([
+      frameZeroOf("faultAtFunctionEntry"),
+      frameZeroOf("functionEntryAsReturnAddress"),
+    ]);
+    expect(asReturnAddress).toBeGreaterThan(0);
+    if (isWindows) {
+      // Windows trace strings carry every address as captured; bun.report
+      // steps the frames after the first back itself.
+      expect(fault).toBe(asReturnAddress);
+    } else {
+      expect(fault).toBe(asReturnAddress + 1);
+    }
+  });
+
+  // The kernel reports an x86_64 `int3` with pc already past it (stepping back
+  // is what lands on the trap, exactly like a return address) but an aarch64
+  // `brk` with pc on the instruction; either way the report must resolve to
+  // the function that trapped. Needs the real signal handler, which ASAN
+  // builds do not install, and Windows claims no trap-class exceptions.
+  test.skipIf(isASAN || isWindows)("trap pc resolves to the trapping instruction", async () => {
+    const [trap, asReturnAddress] = await Promise.all([
+      frameZeroOf("trapAtFunctionEntry"),
+      frameZeroOf("functionEntryAsReturnAddress"),
+    ]);
+    expect(trap).toBe(asReturnAddress + 1);
+  });
+});
+
 // `crash()` resets fatal-signal dispositions to SIG_DFL before re-raising so
 // that JS-registered listeners (`process.on("SIGABRT")` etc., installed by
 // npm's widely-used signal-exit package) cannot swallow the termination. A


### PR DESCRIPTION
### What

For a real fault (SIGSEGV/SIGBUS/SIGILL/SIGFPE, Windows access violation) frame 0 of the crash report is symbolized one instruction too early. Sentry group BUN-3K0V (macOS arm64) is a typical case: bun.report shows frame 0 as `SentinelLinkedList.h:61` (`setNext`, line 240 of `SentinelLinkedList::remove`), while the `str` that actually faults on address `0x8` is the next instruction, 4 bytes later, on line 241 (`setPrev`). Every fault report has this skew; it points people at the wrong statement, and when the fault is on the first instruction of a function it names the previous function (or nothing at all).

Repro against the debug build with this branch's test hook, which faults on the first instruction of a function:

```
$ llvm-symbolizer --exe build/debug/bun-debug 0xDF08734 0xDF08733
bun_runtime::api::crash_handler_jsc::js_bindings::fault_at_function_entry   <- the fault pc (frame 0 after this change)
??                                                                           <- pc - 1, what frame 0 encoded before
```

### Cause

`crash_handler()` seeds a fault trace from the signal/exception context, so `instruction_addresses[0]` is the exact faulting pc (`capture_from_context` stores `out[0] = pc`); frames 1.. are return addresses. `StackLine::from_address` then subtracted 1 from every address before computing the image-relative offset (macOS `addr - 1`, Linux `saturating_sub(1)`). That step is correct for return addresses, which point one past their call, but for frame 0 of a fault trace it lands on the instruction before the fault. Both consumers applied it to frame 0: `encode_trace_string` (the trace string bun.report decodes, and bun.report passes POSIX addresses to llvm-symbolizer unchanged) and the debug-build `spawn_symbolizer`; `write_stack_trace` (debug builds on macOS/Windows) had its own unconditional `return_address - 1`. Panic traces are unaffected because all of their frames are return addresses.

### Fix

* `bun_core::StackTrace` gains `first_frame_is_exact_pc`, and `StackTrace::symbol_address(i)` is the one place that decides which address to symbolize: frame 0 as is when it is an exact pc, `addr - 1` otherwise. `from_address` becomes `from_frame` and uses it, as does `write_stack_trace`.
* `TraceSeed::Fault` carries `exact_pc`, set by the producer that knows the semantics. `handle_segfault_posix` decides per signal (`signal_pc_is_exact`): faults are reported with pc on the instruction, so they are exact. Trap-class signals are not: the kernel reports an x86_64 `int3` (what WTF's `CRASH()`/`RELEASE_ASSERT` executes) with pc already past it, and SIGABRT on return from the kill(2) that raised it, so for those the `- 1` step stays and still lands on the trapping instruction, i.e. the current behavior for JSC release-assert crashes is preserved. `brk` on aarch64 is the one trap reported with pc on the instruction (which is also why a returning SIGTRAP handler re-traps there), so it is exact. Every code `classify_exception_windows` accepts is a fault whose `ExceptionAddress` is the faulting instruction, so the three Windows call sites pass `exact_pc: true`.
* The trace string format does not change, and bun.report needs no change: on POSIX it symbolizes exactly the address we encode, and on Windows the string keeps carrying raw addresses because bun.report already treats the first frame as the fault pc and steps the later frames back itself (`adjustBunAddresses` in its `backend/symbolize.ts`); adjusting on the Windows side as well would step return addresses back twice. `from_frame` documents this contract. (Windows panic traces are symbolized one past the call by that decoder heuristic; that is a bun.report-side item and is not touched here.)

### Why this is the right layer

The -1 is a property of what kind of address a frame holds, and only the code that seeds the trace knows that, so the flag travels with the trace and every consumer (wire encoding, local symbolizer, local printer) gets it from one helper. Storing `pc + 1` at capture time instead would keep the consumers unchanged but would put a wrong address into the data that the Windows wire format, the WTF fallback printer, and the reason address all report verbatim.

### Tests

`test/cli/run/run-crash-handler.test.ts`, using three new `bun:internal-for-testing` hooks. `faultAtFunctionEntry` and `trapAtFunctionEntry` call naked functions whose first instruction is `ud2`/`udf #0` and `int3`/`brk #0` respectively, so frame 0 of the report is exactly that function's entry; `functionEntryAsReturnAddress` crashes with a one-frame trace holding the same entry address as an ordinary return-address frame.

* Trace string (all platforms, all build flavors): decode frame 0 of the fault run and of the control run; the fault offset must be the control offset + 1 on POSIX (the control is, by definition of the return-address convention, entry - 1) and equal on Windows, pinning the decoder contract above. The trap variant asserts the same relation, which on x86_64 checks that int3 keeps the step and on aarch64 that brk is exact; it runs on the non-ASAN lanes, where the real signal handler is installed (ASAN builds install none, so `faultAtFunctionEntry` invokes the handler directly with the SIGILL context there, the same way the existing `segfault` hook does).
* Debug Linux: the llvm-symbolizer output for the fault names `::fault_at_function_entry` as the first frame (before this change it is `??`, see above).

Without the fix the old encoder subtracts 1 from the fault pc as well, so the fault run encodes the same offset as the control (in the run above: `0xDF08733` for both instead of `0xDF08734` vs `0xDF08733`), and the first test fails; on the released binary the hooks do not exist, so both tests fail at the trace-string check. With the change `bun bd test test/cli/run/run-crash-handler.test.ts` passes (16 pass, trap variant skipped under ASAN as intended), and `cargo check -p bun_crash_handler` passes for the x86_64-pc-windows-msvc, aarch64-apple-darwin and x86_64-unknown-freebsd targets, which cover the platform-specific branches touched.
