### PR TITLE
tls: own +1 X509 refs with OwnedX509 and pass them to JS by value

### DIFF
--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -313,6 +313,59 @@ impl Drop for OwnedSslCtx {
     }
 }
 
+/// Owns one `X509` reference; `X509_free`s it on drop. Construct from a
+/// pointer that already carries a +1 (`SSL_get_peer_certificate`,
+/// `X509_STORE_CTX_get1_issuer`) or take a new one with [`OwnedX509::up_ref`].
+///
+/// `#[repr(transparent)]` over `NonNull`, so it is passed across FFI exactly
+/// like the `X509*` it wraps and `Option<OwnedX509>` has the layout of a
+/// nullable one.
+#[repr(transparent)]
+pub struct OwnedX509(core::ptr::NonNull<X509>);
+
+impl OwnedX509 {
+    /// Takes the +1 `raw` carries; `None` when `raw` is null.
+    ///
+    /// # Safety
+    /// `raw` must be null or carry a reference the caller is giving up.
+    pub unsafe fn from_raw(raw: *mut X509) -> Option<Self> {
+        core::ptr::NonNull::new(raw).map(Self)
+    }
+
+    /// Takes a reference of its own to `cert`.
+    pub fn up_ref(cert: &mut X509) -> Self {
+        X509_up_ref(cert);
+        Self(core::ptr::NonNull::from(cert))
+    }
+
+    pub fn as_ptr(&self) -> *mut X509 {
+        self.0.as_ptr()
+    }
+}
+
+impl core::ops::Deref for OwnedX509 {
+    type Target = X509;
+    fn deref(&self) -> &X509 {
+        // SAFETY: the reference we own keeps the certificate alive until `Drop`.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl core::ops::DerefMut for OwnedX509 {
+    fn deref_mut(&mut self) -> &mut X509 {
+        // SAFETY: as in `Deref`; `X509` is an opaque ZST handle, so the `&mut`
+        // covers no bytes that anything else could alias.
+        unsafe { self.0.as_mut() }
+    }
+}
+
+impl Drop for OwnedX509 {
+    fn drop(&mut self) {
+        // SAFETY: we own exactly one reference, released once.
+        unsafe { X509_free(self.0.as_ptr()) }
+    }
+}
+
 /// Owns the `STACK_OF(GENERAL_NAME)` that `X509V3_EXT_d2i` returns for a
 /// subjectAltName extension. Frees every `GENERAL_NAME` and then the stack.
 pub struct GeneralNames(core::ptr::NonNull<struct_stack_st_GENERAL_NAME>);
@@ -523,6 +576,14 @@ impl SSL {
             sk_X509_value(cert_chain, 0).as_mut()
         }
     }
+
+    /// The peer's leaf certificate as a reference of our own; `None` when the
+    /// peer sent none.
+    pub fn peer_certificate(&self) -> Option<OwnedX509> {
+        // SAFETY: `self` is a live SSL; `SSL_get_peer_certificate` returns a
+        // new reference (or null), which `OwnedX509` takes over.
+        unsafe { OwnedX509::from_raw(SSL_get_peer_certificate(self)) }
+    }
 }
 
 impl Drop for GeneralNames {
@@ -691,6 +752,9 @@ unsafe extern "C" {
     pub fn d2i_X509(out: *mut *mut X509, inp: *mut *const u8, len: c_long) -> *mut X509;
     pub fn i2d_X509(x: *mut X509, outp: *mut *mut u8) -> c_int;
     pub fn X509_free(x509: *mut X509);
+    // Opaque-ZST `&X509` is a bare non-null pointer to BoringSSL; the call
+    // only bumps the refcount, so there is no caller-side precondition.
+    safe fn X509_up_ref(x509: &X509) -> c_int;
     pub fn X509_get_subject_name(x509: *const X509) -> *mut X509_NAME;
     pub fn X509_get_ext_by_NID(x: *const X509, nid: c_int, lastpos: c_int) -> c_int;
     pub fn X509_get_ext(x: *const X509, loc: c_int) -> *mut X509_EXTENSION;

--- a/src/runtime/api/bun/x509.rs
+++ b/src/runtime/api/bun/x509.rs
@@ -1,4 +1,4 @@
-use bun_boringssl_sys::X509;
+use bun_boringssl_sys::{OwnedX509, X509};
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
 pub fn to_js(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
@@ -7,16 +7,19 @@ pub fn to_js(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValu
     })
 }
 
-pub(crate) fn to_js_object(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+pub(crate) fn to_js_object(cert: OwnedX509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
     Ok(Bun__X509__toJS(cert, global_object))
 }
 
 // `X509`/`JSGlobalObject` are opaque `repr(C)` handles; `&mut`/`&` are
 // ABI-identical to non-null pointers, so the validity proof is in the type.
+// `OwnedX509` is `repr(transparent)` over such a pointer; passing it by value
+// hands its reference to the C++ side, which wraps it in an owning
+// `ncrypto::X509Pointer`.
 unsafe extern "C" {
     safe fn Bun__X509__toJSLegacyEncoding(
         cert: &mut X509,
         global_object: &JSGlobalObject,
     ) -> JSValue;
-    safe fn Bun__X509__toJS(cert: &mut X509, global_object: &JSGlobalObject) -> JSValue;
+    safe fn Bun__X509__toJS(cert: OwnedX509, global_object: &JSGlobalObject) -> JSValue;
 }

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -19,6 +19,8 @@ use crate::api::bun_x509 as X509;
 pub(super) mod ffi {
     use super::boringssl::{SSL, SSL_CTX, X509, X509_STORE, X509_STORE_CTX, struct_stack_st_X509};
     use core::ffi::{c_char, c_int, c_long, c_uint, c_void};
+    use core::marker::PhantomData;
+    use core::ptr::NonNull;
 
     // Re-export the one decl whose `*const c_char` NUL-terminated arg keeps a
     // genuine caller precondition; the rest are re-declared `safe fn` below.
@@ -65,7 +67,6 @@ pub(super) mod ffi {
     unsafe extern "C" {
         // ── SSL session/handshake info ───────────────────────────────────
         pub(crate) safe fn SSL_get_version(ssl: &SSL) -> *const c_char;
-        pub(crate) safe fn SSL_get_peer_certificate(ssl: &SSL) -> *mut X509;
         pub(crate) safe fn SSL_get_certificate(ssl: &SSL) -> *mut X509;
         pub(crate) safe fn SSL_set_max_send_fragment(ssl: &SSL, max_send_fragment: usize) -> c_int;
         // SAFETY (unsafe fn): `buf` must be writable for `count` bytes.
@@ -134,7 +135,6 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_CIPHER_get_version(cipher: &SSL_CIPHER) -> *const c_char;
 
         // ── X509 ─────────────────────────────────────────────────────────
-        pub(crate) safe fn X509_up_ref(x: &X509) -> c_int;
         // ffi-safe-fn: BoringSSL's `sk_value` takes `const OPENSSL_STACK *` and
         // returns the element at `i` (or NULL if out-of-range — see
         // `crypto/stack/stack.cc`); it never dereferences past the header it
@@ -250,21 +250,20 @@ pub(super) mod ffi {
         // object stack and `OPENSSL_sk_num(NULL)` returns 0.
         pub(crate) fn X509_STORE_get0_objects(store: *mut X509_STORE) -> *mut c_void;
         pub(crate) fn OPENSSL_sk_num(sk: *const c_void) -> usize;
-        // The process-wide default root store; up-refs before returning, so
-        // the caller owns a reference it must release with X509_STORE_free.
-        pub(crate) fn us_get_shared_default_ca_store() -> *mut X509_STORE;
-        pub(crate) fn X509_STORE_free(store: *mut X509_STORE);
-        // X509_STORE_CTX lifecycle for issuer lookups; `new` allocates,
-        // `init` borrows the store, `free` releases. Used to extend the peer
-        // certificate chain through the local trust store.
-        pub(crate) fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
-        pub(crate) fn X509_STORE_CTX_init(
+        // The process-wide default root store, up-ref'd for the caller; only
+        // `SharedStore` below holds and releases it. No arguments, so there is
+        // no caller-side precondition.
+        safe fn us_get_shared_default_ca_store() -> *mut X509_STORE;
+        fn X509_STORE_free(store: *mut X509_STORE);
+        // X509_STORE_CTX lifecycle; only `StoreCtx` below drives it.
+        safe fn X509_STORE_CTX_new() -> *mut X509_STORE_CTX;
+        fn X509_STORE_CTX_init(
             ctx: *mut X509_STORE_CTX,
             store: *mut X509_STORE,
             x509: *mut X509,
             chain: *mut struct_stack_st_X509,
         ) -> c_int;
-        pub(crate) fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
+        fn X509_STORE_CTX_free(ctx: *mut X509_STORE_CTX);
         // Writes a +1 X509 reference to `*issuer` on success (> 0).
         pub(crate) fn X509_STORE_CTX_get1_issuer(
             issuer: *mut *mut X509,
@@ -273,6 +272,64 @@ pub(super) mod ffi {
         ) -> c_int;
         // Returns X509_V_OK (0) when `issuer` could have issued `subject`.
         pub(crate) fn X509_check_issued(issuer: *mut X509, subject: *mut X509) -> c_int;
+    }
+
+    /// Our reference to the process-wide default root store, released on drop.
+    pub(crate) struct SharedStore(NonNull<X509_STORE>);
+
+    impl SharedStore {
+        pub(crate) fn default_roots() -> Option<Self> {
+            NonNull::new(us_get_shared_default_ca_store()).map(Self)
+        }
+    }
+
+    impl core::ops::Deref for SharedStore {
+        type Target = X509_STORE;
+        fn deref(&self) -> &X509_STORE {
+            // SAFETY: the reference we own keeps the store alive until `Drop`.
+            unsafe { self.0.as_ref() }
+        }
+    }
+
+    impl Drop for SharedStore {
+        fn drop(&mut self) {
+            // SAFETY: releases the one reference `default_roots` took.
+            unsafe { X509_STORE_free(self.0.as_ptr()) }
+        }
+    }
+
+    /// An `X509_STORE_CTX` set up for issuer lookups in the store it was
+    /// initialized with, which BoringSSL requires to outlive it (`'s`).
+    /// Freed on drop.
+    pub(crate) struct StoreCtx<'s>(NonNull<X509_STORE_CTX>, PhantomData<&'s X509_STORE>);
+
+    impl<'s> StoreCtx<'s> {
+        /// `None` when BoringSSL cannot allocate or initialize the context.
+        pub(crate) fn new(store: &'s X509_STORE) -> Option<Self> {
+            let ctx = Self(NonNull::new(X509_STORE_CTX_new())?, PhantomData);
+            // SAFETY: `ctx` is freshly allocated and `store` outlives it for
+            // `'s`; the certificate and untrusted chain may be null.
+            let initialized = unsafe {
+                X509_STORE_CTX_init(
+                    ctx.0.as_ptr(),
+                    store.as_mut_ptr(),
+                    core::ptr::null_mut(),
+                    core::ptr::null_mut(),
+                )
+            } == 1;
+            initialized.then_some(ctx)
+        }
+
+        pub(crate) fn as_ptr(&self) -> *mut X509_STORE_CTX {
+            self.0.as_ptr()
+        }
+    }
+
+    impl Drop for StoreCtx<'_> {
+        fn drop(&mut self) {
+            // SAFETY: allocated by `X509_STORE_CTX_new` in `new`, freed once here.
+            unsafe { X509_STORE_CTX_free(self.0.as_ptr()) }
+        }
     }
 }
 use crate::node::StringOrBuffer;
@@ -360,9 +417,8 @@ pub(super) fn get_peer_x509_certificate(
     let Some(ssl_ptr) = this.socket.get().ssl() else {
         return Ok(JSValue::UNDEFINED);
     };
-    let cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-    if !cert.is_null() {
-        return X509::to_js_object(boringssl::X509::opaque_mut(cert), global);
+    if let Some(cert) = boringssl::SSL::opaque_ref(ssl_ptr).peer_certificate() {
+        return X509::to_js_object(cert, global);
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -377,9 +433,10 @@ pub(super) fn get_x509_certificate(
     };
     let cert = ffi::SSL_get_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
     if !cert.is_null() {
-        // X509_up_ref bumps the refcount before handing to JS.
-        ffi::X509_up_ref(boringssl::X509::opaque_ref(cert));
-        return X509::to_js_object(boringssl::X509::opaque_mut(cert), global);
+        return X509::to_js_object(
+            boringssl::OwnedX509::up_ref(boringssl::X509::opaque_mut(cert)),
+            global,
+        );
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -461,13 +518,8 @@ pub(super) fn get_peer_certificate(
 
     if abbreviated {
         if is_server_ssl {
-            // SSL_get_peer_certificate returns a +1 reference; we must free it.
-            // X509::to_js only borrows the pointer (X509View is non-owning).
-            let cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-            if !cert.is_null() {
-                // SAFETY: `c` is the +1 X509 reference returned by SSL_get_peer_certificate; we own it.
-                let _guard = scopeguard::guard(cert, |c| unsafe { boringssl::X509_free(c) });
-                return X509::to_js(boringssl::X509::opaque_mut(cert), global);
+            if let Some(mut cert) = boringssl::SSL::opaque_ref(ssl_ptr).peer_certificate() {
+                return X509::to_js(&mut cert, global);
             }
         }
 
@@ -482,21 +534,15 @@ pub(super) fn get_peer_certificate(
         return X509::to_js(boringssl::X509::opaque_mut(cert), global);
     }
 
-    let mut cert: *mut boringssl::X509 = core::ptr::null_mut();
-    if is_server_ssl {
-        // SSL_get_peer_certificate returns a +1 reference; we must free it.
-        cert = ffi::SSL_get_peer_certificate(boringssl::SSL::opaque_ref(ssl_ptr));
-    }
-    let _guard = scopeguard::guard(cert, |c| {
-        if !c.is_null() {
-            // SAFETY: `c` is the +1 X509 reference returned by SSL_get_peer_certificate; we own it.
-            unsafe { boringssl::X509_free(c) };
-        }
-    });
+    let cert = if is_server_ssl {
+        boringssl::SSL::opaque_ref(ssl_ptr).peer_certificate()
+    } else {
+        None
+    };
 
     let cert_chain = ffi::SSL_get_peer_cert_chain(boringssl::SSL::opaque_ref(ssl_ptr));
-    let first_cert: *mut boringssl::X509 = if !cert.is_null() {
-        cert
+    let first_cert: *mut boringssl::X509 = if let Some(cert) = &cert {
+        cert.as_ptr()
     } else if !cert_chain.is_null() {
         ffi::sk_X509_value(boringssl::struct_stack_st_X509::opaque_ref(cert_chain), 0)
     } else {
@@ -520,7 +566,7 @@ pub(super) fn get_peer_certificate(
     let mut prev_obj: JSValue = first_obj;
     let mut last_cert: *mut boringssl::X509 = first_cert;
     if !cert_chain.is_null() {
-        let mut i: usize = if cert.is_null() { 1 } else { 0 };
+        let mut i: usize = if cert.is_none() { 1 } else { 0 };
         loop {
             let next =
                 ffi::sk_X509_value(boringssl::struct_stack_st_X509::opaque_ref(cert_chain), i);
@@ -539,79 +585,68 @@ pub(super) fn get_peer_certificate(
     // certificate is reached, the way Node's getPeerCertificate(true) walks
     // X509_STORE_CTX_get1_issuer to surface the root that completed
     // verification even though the peer never sent it.
-    let mut last_is_self_issued = false;
-    // SAFETY: the store ctx is created, initialized against the live SSL_CTX's
-    // store, used only within this scope and freed before returning; every
-    // issuer returned by get1_issuer is a +1 reference collected in `extras`
-    // and released after its fields have been copied into JS values and the
-    // terminal self-issued check has run.
-    unsafe {
-        let mut store = ffi::SSL_CTX_get_cert_store(boringssl::SSL_CTX::opaque_ref(
+    let last_is_self_issued = {
+        let ctx_store = ffi::SSL_CTX_get_cert_store(boringssl::SSL_CTX::opaque_ref(
             ffi::SSL_get_SSL_CTX(boringssl::SSL::opaque_ref(ssl_ptr)),
         ));
         // A context built without an explicit `ca` (and without requestCert,
         // which installs the shared roots) carries an empty store and the
         // issuer walk would stop at whatever the peer sent. Fall back to the
         // process-wide default roots the way Node's per-context store always
-        // contains the bundled roots. The getter up-refs, so the temporary
-        // reference is released after the walk.
-        let mut shared_store: *mut boringssl::X509_STORE = core::ptr::null_mut();
-        if store.is_null() || ffi::OPENSSL_sk_num(ffi::X509_STORE_get0_objects(store)) == 0 {
-            shared_store = ffi::us_get_shared_default_ca_store();
-            if !shared_store.is_null() {
-                store = shared_store;
-            }
-        }
-        let store_ctx = ffi::X509_STORE_CTX_new();
-        if !store_ctx.is_null() {
-            if !store.is_null()
-                && ffi::X509_STORE_CTX_init(
-                    store_ctx,
-                    store,
-                    core::ptr::null_mut(),
-                    core::ptr::null_mut(),
-                ) == 1
-            {
-                let mut extras: Vec<*mut boringssl::X509> = Vec::new();
+        // contains the bundled roots.
+        // SAFETY: `ctx_store` is non-null here and owned by the live SSL_CTX;
+        // `get0_objects` only borrows its object stack.
+        let shared_store = if ctx_store.is_null()
+            || unsafe { ffi::OPENSSL_sk_num(ffi::X509_STORE_get0_objects(ctx_store)) } == 0
+        {
+            ffi::SharedStore::default_roots()
+        } else {
+            None
+        };
+        let store: Option<&boringssl::X509_STORE> = match &shared_store {
+            Some(shared) => Some(shared),
+            None if ctx_store.is_null() => None,
+            None => Some(boringssl::X509_STORE::opaque_ref(ctx_store)),
+        };
+        match store.and_then(ffi::StoreCtx::new) {
+            Some(store_ctx) => {
+                // Keeps every issuer alive while `last_cert` points at the newest one.
+                let mut extras: Vec<boringssl::OwnedX509> = Vec::new();
                 // Cap the walk so a cyclic store cannot loop forever.
-                while extras.len() < 16 && ffi::X509_check_issued(last_cert, last_cert) != 0 {
-                    let mut issuer: *mut boringssl::X509 = core::ptr::null_mut();
-                    if ffi::X509_STORE_CTX_get1_issuer(&raw mut issuer, store_ctx, last_cert) <= 0
-                        || issuer.is_null()
-                    {
-                        break;
-                    }
-                    match X509::to_js(boringssl::X509::opaque_mut(issuer), global) {
-                        Ok(obj) => {
-                            prev_obj.put(global, b"issuerCertificate", obj);
-                            prev_obj = obj;
+                while extras.len() < 16 {
+                    // SAFETY: `last_cert` is `first_cert` (kept alive by `cert` or by
+                    // the SSL's chain), another entry of that chain, or the last
+                    // issuer in `extras`; all outlive the walk. `get1_issuer` stores
+                    // a +1 reference in `issuer` when it returns > 0, which
+                    // `OwnedX509` takes over.
+                    let issuer = unsafe {
+                        if ffi::X509_check_issued(last_cert, last_cert) == 0 {
+                            break;
                         }
-                        Err(e) => {
-                            boringssl::X509_free(issuer);
-                            for extra in extras {
-                                boringssl::X509_free(extra);
-                            }
-                            ffi::X509_STORE_CTX_free(store_ctx);
-                            if !shared_store.is_null() {
-                                ffi::X509_STORE_free(shared_store);
-                            }
-                            return Err(e);
+                        let mut issuer: *mut boringssl::X509 = core::ptr::null_mut();
+                        if ffi::X509_STORE_CTX_get1_issuer(
+                            &raw mut issuer,
+                            store_ctx.as_ptr(),
+                            last_cert,
+                        ) <= 0
+                        {
+                            break;
                         }
-                    }
+                        boringssl::OwnedX509::from_raw(issuer)
+                    };
+                    let Some(mut issuer) = issuer else { break };
+                    let obj = X509::to_js(&mut issuer, global)?;
+                    prev_obj.put(global, b"issuerCertificate", obj);
+                    prev_obj = obj;
+                    last_cert = issuer.as_ptr();
                     extras.push(issuer);
-                    last_cert = issuer;
                 }
-                last_is_self_issued = ffi::X509_check_issued(last_cert, last_cert) == 0;
-                for extra in extras {
-                    boringssl::X509_free(extra);
-                }
+                // SAFETY: as above; `extras` is still alive.
+                unsafe { ffi::X509_check_issued(last_cert, last_cert) == 0 }
             }
-            ffi::X509_STORE_CTX_free(store_ctx);
+            None => false,
         }
-        if !shared_store.is_null() {
-            ffi::X509_STORE_free(shared_store);
-        }
-    }
+    };
 
     // A self-issued terminal certificate references itself, like Node.
     if last_is_self_issued {


### PR DESCRIPTION
## What

`bun_x509::to_js` and `bun_x509::to_js_object` were both typed `&mut X509`, but only the first borrows: `Bun__X509__toJS` adopts the pointer into an `ncrypto::X509Pointer`, so `to_js_object` consumes a reference, and the two callers in `tls_socket_functions.rs` documented that in comments (one handing over the +1 from `SSL_get_peer_certificate`, the other calling `X509_up_ref` first). `get_peer_certificate` balanced its own +1 references by hand: a scopeguard for the abbreviated server path, a null-checking scopeguard for the detailed path, and a 65 line `unsafe` block for the trust-store walk whose error arm freed the current issuer, every entry of `extras: Vec<*mut X509>`, the `X509_STORE_CTX` and the shared root store, and whose success path freed the same things again.

`bun_boringssl_sys` now owns the reference next to `OwnedSslCtx`:

```rust
#[repr(transparent)]
pub struct OwnedX509(NonNull<X509>);   // from_raw (adopts a +1), up_ref, as_ptr, Deref/DerefMut to X509, X509_free on Drop

impl SSL {
    pub fn peer_certificate(&self) -> Option<OwnedX509>   // SSL_get_peer_certificate
}
```

`to_js_object(cert: OwnedX509, ..)` and the `Bun__X509__toJS` extern take it by value, so the transfer is the signature; `to_js` keeps `&mut X509`. Both `to_js_object` callers and the three `SSL_get_peer_certificate` sites move to `SSL::peer_certificate()` / `OwnedX509::up_ref`, and the local `SSL_get_peer_certificate` and `X509_up_ref` declarations go away. In the detailed `get_peer_certificate` path the peer certificate is an `Option<OwnedX509>` local, the issuers are a `Vec<OwnedX509>`, each issuer is adopted the moment `X509_STORE_CTX_get1_issuer` returns it, and two RAII types local to the file's `ffi` module hold the lookup state:

```rust
pub(crate) struct SharedStore(NonNull<X509_STORE>);                                     // X509_STORE_free on Drop
pub(crate) struct StoreCtx<'s>(NonNull<X509_STORE_CTX>, PhantomData<&'s X509_STORE>);  // new(&'s X509_STORE), X509_STORE_CTX_free on Drop
```

The `X509_STORE_CTX_new`, `_init`, `_free`, `X509_STORE_free` and `us_get_shared_default_ca_store` externs become private to that module. The nine hand-written free calls and the duplicated error arm disappear (the `to_js` failure is now a `?`); what remains `unsafe` in `get_peer_certificate` is three blocks around the four FFI calls that take the raw `last_cert` / store pointers. The new types add eight single-call unsafe blocks (`Deref`, `DerefMut`, `Drop`, `peer_certificate`, the two `Drop`s, `StoreCtx::new` and `SharedStore::deref`). `FetchTasklet.rs` (scopeguard around a `d2i_X509` result) and `node/quic/tls.rs` (manual `X509_free` calls) are the remaining hand-balanced X509 sites and are left for follow-ups that can now use `OwnedX509` and `SSL::peer_certificate`.

## Why

Whether an `X509` handle is borrowed or owned is now in the type (`&mut X509` versus `OwnedX509`), passing one to JS by value makes the hand-over to the C++ owner explicit, and `StoreCtx<'s>` encodes BoringSSL's documented requirement that the store outlive the context, so the declaration order that used to be a comment is checked by the borrow checker. `OwnedX509`, `SharedStore` and `StoreCtx` are `NonNull` newtypes with the layout of the pointers they replace (`Option<OwnedX509>` is still one nullable pointer, and the `repr(transparent)` argument keeps the extern ABI, so the C++ side is untouched); `Drop` issues the same frees at the same scope exits as the manual code did, in the same order. The one piece of removed work is the `X509_STORE_CTX` that was allocated and immediately freed when the context had no store at all.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/http/bun-connect-x509.test.ts test/js/node/tls/node-tls-context.test.ts test/js/node/tls/node-tls-server.test.ts`: 83 pass, 4 fail (node-tls-context 17/17 pass, incl. the `getPeerCertificate(true)` chain tests that cover the rewritten `get_peer_certificate` path).

The 4 failures are pre-existing and identical on main in this environment (all 3 bun-connect-x509 tests: example.com DNS timeout / ECONNREFUSED on localhost before any X509 call; node-tls-server "SNICallback runs even when the requested servername matches the bind hostname": ECONNREFUSED 127.0.0.1), so `getPeerX509Certificate` / `getX509Certificate` were not directly exercised here.
