### PR TITLE
fs_router: make MatchedRoute non-self-referential

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -222,7 +222,7 @@ impl Routes {
         &mut self,
         _: &[u8],
         url_path: &URLPath,
-        params: &'p mut route_param::List<'p>,
+        params: &mut route_param::List<'p>,
     ) -> Option<Match<'p>> {
         // Trim trailing slash
         let mut path = url_path.path;
@@ -265,7 +265,6 @@ impl Routes {
                 // SAFETY: points into a Box<Route> owned by self.list; valid for &self.
                 let index = unsafe { index_ptr.as_ref() };
                 return Some(Match {
-                    params: std::ptr::from_mut(params),
                     name: index.name,
                     pathname: url_path.pathname,
                     file_path: index.abs_path.as_bytes(),
@@ -281,7 +280,6 @@ impl Routes {
             // self.list, which outlives self.
             let route = unsafe { &*route_ptr };
             return Some(Match {
-                params: std::ptr::from_mut(params),
                 name: route.name,
                 pathname: url_path.pathname,
                 file_path: route.abs_path.as_bytes(),
@@ -1069,26 +1067,19 @@ pub struct Match<'a> {
     pub file_path: &'a [u8],
     /// route name, like `"posts/[id]"`
     pub name: &'a [u8],
-
-    // NOTE: raw `*mut` (not `&'a mut`).
-    // `MatchedRoute` (bun_runtime) stores this self-referentially — a
-    // `&'a mut List` here would be invalidated under Stacked Borrows the
-    // moment any `&mut MatchedRoute` is taken.
-    pub params: *mut route_param::List<'a>,
     pub query_string: &'a [u8],
 }
 
 impl<'a> Match<'a> {
-    /// Widen all borrowed slices to `'static` for self-referential storage.
+    /// Widen all borrowed slices to `'static`.
     ///
     /// Field-by-field move (no bitwise reinterpret). Used by `MatchedRoute`
-    /// (bun_runtime), which moves the backing `pathname_backing` buffer into
-    /// the same heap-stable `Box` that holds this `Match` — see the SAFETY
-    /// note at that call site for the full invariant.
+    /// (bun_runtime), which stores the result next to the `pathname_backing`
+    /// buffer it borrows; see the SAFETY note at that call site for the full
+    /// invariant.
     ///
     /// # Safety
-    /// Caller guarantees every borrowed slice (and `*params`' element slices)
-    /// outlives the returned value.
+    /// Caller guarantees every borrowed slice outlives the returned value.
     #[inline]
     #[allow(unsafe_op_in_unsafe_fn)]
     pub unsafe fn detach_lifetime(self) -> Match<'static> {
@@ -1105,9 +1096,6 @@ impl<'a> Match<'a> {
             pathname: d(self.pathname),
             file_path: d(self.file_path),
             name: d(self.name),
-            // Raw pointer; lifetime parameter on the pointee is phantom for the
-            // pointer value itself.
-            params: self.params.cast::<route_param::List<'static>>(),
             query_string: d(self.query_string),
         }
     }

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -20,7 +20,6 @@ pub(crate) mod kind_enum {
 }
 
 use bun_paths::strings;
-use core::cell::UnsafeCell;
 
 use bun_alloc::Arena as ArenaAllocator;
 use bun_ast as Log;
@@ -593,7 +592,7 @@ impl FileSystemRouter {
             return Ok(JSValue::NULL);
         }
 
-        // SAFETY: self-ref construction prelude — `route` below borrows these bytes via
+        // SAFETY: `route` below borrows these bytes via
         // `URLPath`, and `path` is then MOVED into the same `MatchedRoute` Box that stores
         // `route`. Borrowck can't see that the allocation travels with the borrow, so we
         // detach the slice from `path`'s ownership here. The bytes stay valid: `path` is
@@ -613,11 +612,10 @@ impl FileSystemRouter {
             }
         };
         let mut params = route_param::List::default();
-        // `defer params.deinit(allocator)` → Drop
         // SAFETY: R-2 — short-lived `&mut Router` for the route lookup;
         // `match_page_with_allocator` is pure (no JS re-entry), and the returned
-        // `Match<'p>` borrows `params`/`path_bytes`, not `*router`, so the
-        // exclusive borrow ends at the `;`.
+        // `Match<'p>` borrows `path_bytes`, not `*router`, so the exclusive borrow
+        // ends at the `;`.
         let Some(route) = unsafe { this.router.get_mut() }
             .routes
             .match_page_with_allocator(b"", &url_path, &mut params)
@@ -641,6 +639,7 @@ impl FileSystemRouter {
         // values borrow are owned by the same heap-stable Box and freed on finalize.
         let result = MatchedRoute::init(
             route,
+            params,
             path,
             this.origin,
             this.asset_prefix,
@@ -648,13 +647,7 @@ impl FileSystemRouter {
         )
         .expect("unreachable");
 
-        // Note: `result` is a self-referential `Box<MatchedRoute>` (`route` points
-        // at `route_holder` inside this very allocation). The trait `JsClass::to_js(self)`
-        // would deref-move the value OUT of the Box and re-box it at a new address,
-        // leaving the self-ref pointers dangling (ASAN use-after-poison). Hand the
-        // existing allocation straight to the C++ wrapper instead.
-        // Ownership transfers to the GC wrapper (freed via
-        // `MatchedRouteClass__finalize`); the leak lives once in `to_js_boxed`.
+        // Ownership transfers to the GC wrapper (freed via `MatchedRouteClass__finalize`).
         Ok(MatchedRoute::to_js_boxed(result, global_this))
     }
 
@@ -713,30 +706,20 @@ impl FileSystemRouter {
 
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct MatchedRoute {
-    /// Self-referential: always points at `self.route_holder`. See `init`.
-    // Note: `Match<'a>` borrows (a) the resolver's process-lifetime DirnameStore for
-    // `name`/`file_path`/`basename`/`path` and (b) `self.pathname_backing` for
-    // `pathname`/`query_string`/param values. Both are stable for `Self`'s lifetime, so
-    // the stored `'static` is the standard self-referential erasure — see `init`.
-    pub(crate) route: *const RouterMatch<'static>,
-    // Note: `route_holder`/`params_list_holder` are wrapped in `UnsafeCell` because
-    // `route` (above) and `route_holder.params` hold raw self-referential pointers into
-    // them. Without `UnsafeCell`, taking `&mut MatchedRoute` (as `get_params`/`get_query`
-    // do) would assert unique access to these fields under Stacked Borrows and invalidate
-    // the stored pointers — UB on next deref.
-    pub(crate) route_holder: UnsafeCell<RouterMatch<'static>>,
+    // `'static` is erased in `init`: every slice is either genuinely `'static`
+    // (resolver DirnameStore) or points into `pathname_backing` below.
+    pub(crate) route: RouterMatch<'static>,
+    pub(crate) params: route_param::List<'static>,
     // R-2: lazily populated by `get_query`/`get_params` (now `&self`).
     pub(crate) query_string_map: JsCell<Option<QueryStringMap>>,
     pub(crate) param_map: JsCell<Option<QueryStringMap>>,
-    pub(crate) params_list_holder: UnsafeCell<route_param::List<'static>>,
-    /// Owns the bytes that `route_holder.pathname`/`query_string` and the param values in
-    /// `params_list_holder` borrow. Freed by Drop on finalize.
+    /// Owns the bytes that `route.pathname`/`query_string` and the param values in
+    /// `params` borrow. Released in `deinit`, after those views.
     pub(crate) pathname_backing: ZigStringSlice,
     // BACKREF — interned `RefString`s; we hold +1 (bumped in `init`, released in
     // `deinit`). The interned allocation outlives every `MatchedRoute`.
     pub(crate) origin: Option<BackRef<RefString>>,
     pub(crate) asset_prefix: Option<BackRef<RefString>>,
-    pub(crate) needs_deinit: bool,
     pub(crate) base_dir: Option<BackRef<RefString>>,
 }
 
@@ -744,72 +727,46 @@ impl MatchedRoute {
     // Note: `pub const js = jsc.Codegen.JSMatchedRoute; toJS/fromJS/fromJSDirect`
     // wired by `#[bun_jsc::JsClass]` — deleted.
 
-    #[inline]
-    fn route(&self) -> &RouterMatch<'static> {
-        // SAFETY: `self.route` always points at `self.route_holder` (UnsafeCell, set in
-        // `init`); the Box is never moved after construction (heap-stable), and no `&mut`
-        // to `route_holder`'s contents is live concurrently with this read.
-        unsafe { &*self.route }
-    }
-
-    #[inline]
-    fn params(&self) -> &route_param::List<'static> {
-        // SAFETY: `route().params` always points at `self.params_list_holder` (UnsafeCell,
-        // set in `init`); heap-stable Box, no concurrent `&mut` to its contents.
-        unsafe { &*self.route().params }
-    }
-
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_name(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(this.route().name, global_this))
+        Ok(zs_to_js(this.route.name, global_this))
     }
 
     pub(crate) fn init(
         match_: RouterMatch<'_>,
+        params: route_param::List<'_>,
         pathname_backing: ZigStringSlice,
         origin: Option<BackRef<RefString>>,
         asset_prefix: Option<BackRef<RefString>>,
         base_dir: BackRef<RefString>,
     ) -> Result<Box<MatchedRoute>, bun_alloc::AllocError> {
-        // SAFETY: `match_.params` points at the caller's stack `route_param::List`, which is
-        // live for this call. Clone its contents into our own holder before re-pointing.
-        let params_list = unsafe { (*match_.params).clone() };
-
-        // SAFETY: self-referential lifetime erasure — `RouterMatch<'_>` borrows two
-        // backing stores —
-        //   (a) `name`/`file_path`/`basename`/`path` slice the resolver's DirnameStore
-        //       (process-lifetime arena — `bun_router` paths are `Interned`), so are
+        // SAFETY: lifetime erasure. `match_` and `params` borrow two backing stores:
+        //   (a) `name`/`file_path` and the param `name`s slice the resolver's DirnameStore
+        //       (process-lifetime arena, `bun_router` paths are `Interned`), so are
         //       genuinely `'static`;
         //   (b) `pathname`/`query_string` and the param `value`s slice `pathname_backing`,
-        //       which we move into the same heap-stable Box below. The Box is never moved
-        //       after construction (JsClass m_ctx payload), so those bytes are valid for
-        //       `Self`'s lifetime.
-        // `params` is a raw `*mut`; re-pointed at `params_list_holder` below before any
-        // read through it. This is the standard Rust self-referential pattern (no
-        // `Pin`/ouroboros because JsClass codegen owns the Box<Self>); it does NOT extend
-        // a borrow past its allocation — ownership was transferred, not leaked.
-        let match_static: RouterMatch<'static> = unsafe { match_.detach_lifetime() };
+        //       whose bytes live out of line and which is owned by the `MatchedRoute` built
+        //       below (released in `deinit`), so they are valid for `Self`'s lifetime.
+        let route: RouterMatch<'static> = unsafe { match_.detach_lifetime() };
         // `route_param::List<'a>` = `Vec<Param<'a>>`; rebuild from raw parts to
         // erase the element lifetime (identical layout, no realloc).
-        let params_list: route_param::List<'static> = {
-            let mut v = core::mem::ManuallyDrop::new(params_list);
+        let params: route_param::List<'static> = {
+            let mut v = core::mem::ManuallyDrop::new(params);
             let (ptr, len, cap) = (v.as_mut_ptr(), v.len(), v.capacity());
             // SAFETY: same allocation, same element layout; per the SAFETY note
             // above, every `Param`'s borrowed bytes outlive `Self`.
             unsafe { Vec::from_raw_parts(ptr.cast::<route_param::Param<'static>>(), len, cap) }
         };
 
-        let mut route = Box::new(MatchedRoute {
-            route_holder: UnsafeCell::new(match_static),
-            route: core::ptr::null(),
-            asset_prefix,
-            origin,
-            base_dir: Some(base_dir),
+        let matched = Box::new(MatchedRoute {
+            route,
+            params,
             query_string_map: JsCell::new(None),
             param_map: JsCell::new(None),
-            params_list_holder: UnsafeCell::new(params_list),
             pathname_backing,
-            needs_deinit: true,
+            origin,
+            asset_prefix,
+            base_dir: Some(base_dir),
         });
         // Note: `base_dir.ref()` / `o.ref()` / `prefix.ref()` — bump refcounts.
         // Each is a live interned `RefString` (caller-provided BackRef).
@@ -820,14 +777,8 @@ impl MatchedRoute {
         if let Some(p) = asset_prefix {
             p.ref_();
         }
-        // Self-referential wiring: `route` → `route_holder`; `route_holder.params` →
-        // `params_list_holder`. Both targets are `UnsafeCell` so the raw pointers stay
-        // valid under Stacked Borrows across later `&mut MatchedRoute` accesses.
-        route.route = route.route_holder.get();
-        // SAFETY: sole access to `route_holder` contents at this point.
-        unsafe { (*route.route_holder.get()).params = route.params_list_holder.get() };
 
-        Ok(route)
+        Ok(matched)
     }
 
     // Note: `deinit` is called only from `finalize`; not exposed as `Drop` because
@@ -839,13 +790,8 @@ impl MatchedRoute {
     fn deinit(mut this: Box<MatchedRoute>) {
         this.query_string_map.set(None);
         this.param_map.set(None);
-        if this.needs_deinit {
-            // We own the `path` allocation from `match` as
-            // `pathname_backing`; dropping it (and `params_list_holder`) here releases the
-            // borrowed bytes BEFORE `route_holder`'s slices would dangle on Box drop.
-            this.pathname_backing = ZigStringSlice::EMPTY;
-            *this.params_list_holder.get_mut() = route_param::List::default();
-        }
+        this.params = route_param::List::default();
+        this.pathname_backing = ZigStringSlice::EMPTY;
 
         if let Some(p) = this.origin.take() {
             p.get().deref();
@@ -860,7 +806,7 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_file_path(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(this.route().file_path, global_this))
+        Ok(zs_to_js(this.route.file_path, global_this))
     }
 
     pub fn finalize(self: Box<Self>) {
@@ -869,15 +815,12 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_pathname(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(this.route().pathname, global_this))
+        Ok(zs_to_js(this.route.pathname, global_this))
     }
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_kind(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(
-            kind_enum::classify(this.route().name),
-            global_this,
-        ))
+        Ok(zs_to_js(kind_enum::classify(this.route.name), global_this))
     }
 
     pub(crate) fn create_query_object(
@@ -940,7 +883,7 @@ impl MatchedRoute {
             URL::default()
         };
         bun_object::get_public_path_with_asset_prefix(
-            this.route().file_path,
+            this.route.file_path,
             if let Some(ref base_dir) = this.base_dir {
                 base_dir.leak()
             } else {
@@ -960,17 +903,17 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_params(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        if this.params().is_empty() {
+        if this.params.is_empty() {
             return Ok(JSValue::create_empty_object(global_this, 0));
         }
 
         if this.param_map.get().is_none() {
-            let route = this.route();
+            let route = &this.route;
             let scanner = CombinedScanner::init(
                 b"",
                 route.pathname_without_leading_slash(),
                 route.name,
-                this.params(),
+                &this.params,
             );
             this.param_map
                 .set(QueryStringMap::init_with_scanner(scanner)?);
@@ -984,21 +927,20 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_query(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        let route = this.route();
-        if route.query_string.is_empty() && this.params().is_empty() {
+        let route = &this.route;
+        if route.query_string.is_empty() && this.params.is_empty() {
             return Ok(JSValue::create_empty_object(global_this, 0));
         } else if route.query_string.is_empty() {
             return Self::get_params(this, global_this);
         }
 
         if this.query_string_map.get().is_none() {
-            let route = this.route();
-            if !this.params().is_empty() {
+            if !this.params.is_empty() {
                 let scanner = CombinedScanner::init(
                     route.query_string,
                     route.pathname_without_leading_slash(),
                     route.name,
-                    this.params(),
+                    &this.params,
                 );
                 this.query_string_map
                     .set(QueryStringMap::init_with_scanner(scanner)?);


### PR DESCRIPTION
## What

`MatchedRoute` (`src/runtime/api/filesystem_router.rs`), the payload behind the object returned by `FileSystemRouter.match()`, was built as a self-referential struct. `route: *const Match<'static>` was set to null in the struct literal and then pointed at the sibling field `route_holder`; `route_holder.params` (a raw `*mut route_param::List` in `bun_router::Match`) was pointed at the sibling field `params_list_holder`; both holders were wrapped in `UnsafeCell` so those pointers stayed valid across `&mut MatchedRoute`; `route()` and `params()` dereferenced them in `unsafe` for every getter; `match()` used `to_js_boxed` specifically so the Box was not re-boxed at a new address; and a `needs_deinit: bool` that was only ever set to `true` guarded the release in `deinit`.

Nothing the struct borrows lives inside the struct: `name`/`file_path` (and the param names) slice the process-lifetime `DirnameStore`, and `pathname`/`query_string`/param values slice the bytes owned by `pathname_backing`, a `ZigStringSlice` whose every variant points at out-of-line storage. The struct's own address was never what kept anything alive.

```rust
// before
pub struct MatchedRoute {
    route: *const Match<'static>,                       // -> route_holder
    route_holder: UnsafeCell<Match<'static>>,           // .params -> params_list_holder
    params_list_holder: UnsafeCell<route_param::List<'static>>,
    needs_deinit: bool,
    ..
}
pub struct Match<'a> { .., pub params: *mut route_param::List<'a>, .. }
fn match_page_with_allocator<'p>(.., params: &'p mut List<'p>) -> Option<Match<'p>>

// after
pub struct MatchedRoute {
    route: Match<'static>,
    params: route_param::List<'static>,
    ..
}
pub struct Match<'a> { pathname, file_path, name, query_string: &'a [u8] }
fn match_page_with_allocator<'p>(.., params: &mut List<'p>) -> Option<Match<'p>>
```

`bun_router::Match` (`src/router/lib.rs`) loses its `params` pointer at its two construction sites and in `detach_lifetime`; the pointer existed only so `MatchedRoute` could store it self-referentially, as its comment said. `match_page_with_allocator` (one caller) now takes the list as an ordinary `&mut`, so the caller moves the filled list into `MatchedRoute::init` instead of `init` cloning it back out through the raw pointer. `init` builds the struct in one literal; the two lifetime erasures it already performed (`detach_lifetime` and the `Vec::from_raw_parts` rebuild of the list) are unchanged. The 13 accessor call sites in the getters (`route()` 8, `params()` 5) become direct field reads (a redundant rebinding of `route` in `get_query` is dropped), `deinit` releases the list and the bytes unconditionally, and the `UnsafeCell` import goes away. `match()` still hands the Box that `init` allocates to `to_js_boxed`, but that is now only a matter of not allocating twice, so the comment justifying it by address stability is gone. Removes 4 `unsafe` blocks (`route()`, `params()`, the clone in `init`, the pointer wiring in `init`) and adds none; `MatchedRoute` goes from 10 fields to 8 and `Match` from 5 to 4.

## Why

The ownership story is now visible from the types: `MatchedRoute` owns a `Match`, a param list and the `pathname_backing` bytes the first two borrow, and `Match` is a plain bundle of `&'a [u8]` (covariant in `'a`) rather than something carrying a raw pointer into a struct in another crate. Layout-wise `Match` loses one pointer and `MatchedRoute` loses that pointer, its own `route` pointer and the bool, while `UnsafeCell` is `repr(transparent)` so turning the holders into plain fields moves nothing; the getters read a field instead of loading a stored pointer first, and the only work removed is the clone of the param list in `init`. Nothing is added on any path.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/util/filesystem_router.test.ts: 33 pass, 0 fail.
