### PR TITLE
jsc: to_external_u16 takes an owned Vec<u16> instead of (ptr, len)

### DIFF
--- a/src/jsc/ZigString.rs
+++ b/src/jsc/ZigString.rs
@@ -26,19 +26,17 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-/// Hand a globally-allocated
-/// UTF-16 buffer to JSC as an external string. Ownership of `ptr[0..len]`
-/// transfers to JSC on success; on the too-long path the buffer is freed
-/// here, a `STRING_TOO_LONG` error is thrown, and `.zero` is returned.
+/// Hand an owned UTF-16 buffer to JSC as an external string; JSC frees it
+/// through `ZigString__freeGlobal` when the string is collected. On the
+/// too-long path the buffer is dropped here, a `STRING_TOO_LONG` error is
+/// thrown, and `.zero` is returned.
 ///
-/// # Safety
-/// `ptr` must have been allocated by the global mimalloc allocator
-/// (via `heap::alloc`/`Vec::into_raw_parts`/`bun.default_allocator`) and
-/// must not be used by the caller after this returns.
-pub unsafe fn to_external_u16(ptr: *const u16, len: usize, global: &JSGlobalObject) -> JSValue {
-    if len > BunString::max_length() {
-        // SAFETY: caller contract — `ptr` came from the default (global) allocator.
-        unsafe { bun_alloc::default_alloc::free(ptr.cast_mut().cast::<core::ffi::c_void>()) };
+/// `buf` must be non-empty: for `len == 0` JSC returns the shared empty
+/// string without adopting the buffer, so any capacity it had would leak.
+pub fn to_external_u16(buf: Vec<u16>, global: &JSGlobalObject) -> JSValue {
+    debug_assert!(!buf.is_empty());
+    if buf.len() > BunString::max_length() {
+        drop(buf);
         // Propagation of the throw is intentionally swallowed.
         let _ = global
             .err(
@@ -48,8 +46,10 @@ pub unsafe fn to_external_u16(ptr: *const u16, len: usize, global: &JSGlobalObje
             .throw();
         return JSValue::ZERO;
     }
-    // SAFETY: ptr/len describe a globally-allocated UTF-16 buffer; ownership
-    // transfers to JSC (freed via the external-string finalizer).
+    let len = buf.len();
+    let ptr = buf.leak().as_ptr();
+    // SAFETY: `ptr[..len]` is the leaked buffer of a global-allocator `Vec`;
+    // JSC owns it from here and frees it via `ZigString__freeGlobal`.
     unsafe { ZigString__toExternalU16(ptr, len, global) }
 }
 

--- a/src/jsc/bun_string_jsc.rs
+++ b/src/jsc/bun_string_jsc.rs
@@ -169,20 +169,13 @@ fn slice_with_underlying_string_to_js_with_options(
         // `ZigStringSlice` encodes ownership in the variant:
         // `Owned`/`WTF` ⇒ allocated, `Static` ⇒ borrowed.
         if this.utf8.is_allocated() {
-            if let Some(utf16) = strings::to_utf16_alloc(this.utf8.slice(), false, false)
+            if let Some(mut utf16) = strings::to_utf16_alloc(this.utf8.slice(), false, false)
                 .map_err(|_| global_object.throw_out_of_memory())?
             {
                 // Drop the now-unused utf8 allocation.
                 this.utf8 = ZigStringSlice::default();
-                // Ownership of `utf16` is transferred to JSC as an
-                // external string; do not drop it here.
-                let mut utf16 = core::mem::ManuallyDrop::new(utf16);
                 utf16.shrink_to_fit();
-                // SAFETY: `utf16` was allocated by the global allocator and is
-                // wrapped in `ManuallyDrop`; ownership transfers to JSC here.
-                return Ok(unsafe {
-                    zig_string::to_external_u16(utf16.as_ptr(), utf16.len(), global_object)
-                });
+                return Ok(zig_string::to_external_u16(utf16, global_object));
             } else if let Some((ptr, len)) = this.utf8.take_owned_raw() {
                 // Ownership of the utf8 bytes is transferred to JSC via
                 // `to_external_value`; `take_owned_raw` already cleared `utf8`

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1701,21 +1701,6 @@ impl ZigStringJsc for bun_core::ZigString {
     }
 }
 
-/// Free-function form of `ZigString.toExternalU16` for callers that import
-/// `bun_core::ZigString`. Forwards to the canonical impl in [`zig_string`].
-///
-/// # Safety
-/// See [`zig_string::to_external_u16`].
-#[inline]
-pub unsafe fn zig_string_to_external_u16(
-    ptr: *const u16,
-    len: usize,
-    global: &JSGlobalObject,
-) -> JSValue {
-    // SAFETY: caller upholds `to_external_u16`'s contract.
-    unsafe { crate::zig_string::to_external_u16(ptr, len, global) }
-}
-
 /// Extension trait providing JSC-aware methods on `bun_sys::Error` (`bun.sys.Error`).
 pub trait SysErrorJsc {
     fn to_system_error(&self) -> SystemError;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2650,7 +2650,7 @@ impl BlobExt for Blob {
                     return Err(global.throw_out_of_memory());
                 }
             };
-            if let Some(external) = converted {
+            if let Some(mut external) = converted {
                 if LIFETIME != Lifetime::Temporary {
                     self.set_is_ascii_flag(false);
                 }
@@ -2661,17 +2661,8 @@ impl BlobExt for Blob {
                     // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
                     unsafe { drop(bun_core::heap::take(raw_bytes)) };
                 }
-                // Ownership of the UTF-16 buffer transfers to JSC's external-string
-                // finalizer (which calls back into the default allocator's `free`).
-                // `into_raw` is the explicit ownership-transfer-to-FFI API; the
-                // matching free lives on the C++ side.
-                let len = external.len();
-                let ptr = bun_core::heap::into_raw(external.into_boxed_slice())
-                    .cast::<u16>()
-                    .cast_const();
-                // SAFETY: `ptr` came from `heap::into_raw` on a global-allocator
-                // `Box<[u16]>`; ownership transfers to JSC's external-string finalizer.
-                return Ok(unsafe { zig_string_to_external_u16(ptr, len, global) });
+                external.shrink_to_fit();
+                return Ok(jsc::zig_string::to_external_u16(external, global));
             }
 
             if LIFETIME != Lifetime::Temporary {
@@ -6219,9 +6210,8 @@ fn resolve_file_stat(store: &StoreRef) {
 
 // ──────────────────────────────────────────────────────────────────────────
 // `ZigString` JSC methods (`to_js`, `to_external_value`, `external`,
-// `to_json_object`, `with_encoding`) live on `bun_jsc::ZigStringJsc`;
-// `zig_string_to_external_u16` is the free-fn form re-exported from
-// `bun_jsc`. Only Blob-local extension traits remain here.
+// `to_json_object`, `with_encoding`) live on `bun_jsc::ZigStringJsc`.
+// Only Blob-local extension traits remain here.
 // ──────────────────────────────────────────────────────────────────────────
 mod zigstring_blob_ext {
     /// Local shim for allocator-identity queries on
@@ -6241,7 +6231,6 @@ mod zigstring_blob_ext {
         }
     }
 }
-use bun_jsc::zig_string_to_external_u16;
 use zigstring_blob_ext::ZigStringSliceBlobExt as _;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -6799,18 +6788,11 @@ impl Internal {
 
     pub(crate) fn to_string_owned(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         let bytes_without_bom = strings::without_utf8_bom(&self.bytes);
-        if let Some(out) = strings::to_utf16_alloc(bytes_without_bom, false, false)
+        if let Some(mut out) = strings::to_utf16_alloc(bytes_without_bom, false, false)
             .map_err(|_| global_this.throw_out_of_memory())?
         {
-            let out_len = out.len();
-            // Ownership transfers to JSC's external-string finalizer.
-            let out_ptr = bun_core::heap::into_raw(out.into_boxed_slice())
-                .cast::<u16>()
-                .cast_const();
-            // SAFETY: `out_ptr` came from `heap::into_raw` on a global-allocator
-            // `Box<[u16]>`; ownership transfers to JSC's external-string finalizer.
-            let return_value =
-                unsafe { jsc::zig_string::to_external_u16(out_ptr, out_len, global_this) };
+            out.shrink_to_fit();
+            let return_value = jsc::zig_string::to_external_u16(out, global_this);
             return_value.ensure_still_alive();
             self.bytes = Vec::new();
             return Ok(return_value);

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -300,19 +300,11 @@ impl TextDecoder {
                 //
                 // => The reason we need to encode it is because TextDecoder "latin1" is actually CP1252, while WebKit latin1 is 8-bit utf-16
                 let out_length = strings::element_length_cp1252_into_utf16(buffer_slice);
-                let mut bytes = vec![0u16; out_length].into_boxed_slice();
+                let mut bytes = vec![0u16; out_length];
 
                 let out = strings::copy_cp1252_into_utf16(&mut bytes, buffer_slice);
-                // The boxed slice is a tight allocation (no excess capacity).
-                // SAFETY: `bytes` was allocated by the global allocator; `into_raw`
-                // transfers ownership of the buffer to JSC's external-string finalizer.
-                Ok(unsafe {
-                    jsc::zig_string::to_external_u16(
-                        bun_core::heap::into_raw(bytes).cast::<u16>(),
-                        out.written as usize,
-                        global_this,
-                    )
-                })
+                bytes.truncate(out.written as usize);
+                Ok(jsc::zig_string::to_external_u16(bytes, global_this))
             }
             EncodingLabel::Utf8 => {
                 // Prepend the partial UTF-8 sequence carried over from the
@@ -399,7 +391,6 @@ impl TextDecoder {
                             });
                         }
                     }
-                    let len = decoded.len();
                     // `to_external_u16` returns `jsEmptyString` and never
                     // calls `free_global_string` for `len == 0`, so a
                     // zero-length decode (e.g. a buffered partial sequence
@@ -407,15 +398,12 @@ impl TextDecoder {
                     // `fatal: false`) would strand the `Vec`'s reserved
                     // backing store. Drop it here and return the canonical
                     // empty string instead.
-                    if len == 0 {
+                    if decoded.is_empty() {
                         drop(decoded);
                         return Ok(ZigString::EMPTY.to_js(global_this));
                     }
                     // PERF: Vec::leak may retain excess capacity — profile if it shows up on a hot path.
-                    let ptr = decoded.leak().as_mut_ptr();
-                    // SAFETY: `ptr` was leaked from a global-allocator `Vec<u16>`;
-                    // ownership transfers to JSC's external-string finalizer.
-                    return Ok(unsafe { jsc::zig_string::to_external_u16(ptr, len, global_this) });
+                    return Ok(jsc::zig_string::to_external_u16(decoded, global_this));
                 }
 
                 // All-ASCII input needed no conversion. `ZigString::init(..).to_js`
@@ -481,14 +469,8 @@ impl TextDecoder {
                     return Ok(ZigString::EMPTY.to_js(global_this));
                 }
 
-                // Transfer ownership of the backing allocation to JSC; freed via
-                // free_global_string -> mi_free when the string is collected.
-                let len = decoded.len();
                 // PERF: Vec::leak may retain excess capacity — profile if it shows up on a hot path.
-                let ptr = decoded.leak().as_mut_ptr();
-                // SAFETY: `ptr` was leaked from a global-allocator `Vec<u16>`;
-                // ownership transfers to JSC's external-string finalizer.
-                Ok(unsafe { jsc::zig_string::to_external_u16(ptr, len, global_this) })
+                Ok(jsc::zig_string::to_external_u16(decoded, global_this))
             }
 
             // Handle all other encodings using WebKit's TextCodec


### PR DESCRIPTION
## What

`bun_jsc::zig_string::to_external_u16` hands a UTF-16 buffer to JSC as an external string (`ZigString__toExternalU16`, freed later through `free_global_string` and `ZigString__freeGlobal`). It took a raw `(ptr, len)` pair, so it was an `unsafe fn` whose `# Safety` text said the buffer had to come from the global allocator and belong to JSC afterwards, and on the too-long path it freed the buffer itself with `bun_alloc::default_alloc::free`. `bun_jsc::zig_string_to_external_u16` in `lib.rs` was a second `unsafe fn` forwarding to it. All six callers already held a `Vec<u16>` and leaked it by hand immediately before the call: `ManuallyDrop` in `bun_string_jsc.rs`, `Vec::leak` twice in `TextDecoder.rs`, and `heap::into_raw(..into_boxed_slice())` once in `TextDecoder.rs` and twice in `Blob.rs`.

```rust
// before
pub unsafe fn to_external_u16(ptr: *const u16, len: usize, global: &JSGlobalObject) -> JSValue

let len = external.len();
let ptr = bun_core::heap::into_raw(external.into_boxed_slice()).cast::<u16>().cast_const();
// SAFETY: ...
return Ok(unsafe { zig_string_to_external_u16(ptr, len, global) });

// after
pub fn to_external_u16(buf: Vec<u16>, global: &JSGlobalObject) -> JSValue

external.shrink_to_fit();
return Ok(jsc::zig_string::to_external_u16(external, global));
```

The function now takes the `Vec<u16>` by value: the too-long path drops it and the success path calls `Vec::leak` and passes the resulting pointer and length to the FFI call, which is the one `unsafe` block left. The six call sites pass their `Vec` directly. The two `Blob.rs` sites and `bun_string_jsc.rs` keep the shrink that `into_boxed_slice()` or `shrink_to_fit()` performed before; the two `TextDecoder.rs` sites that used `Vec::leak` keep the excess capacity as before; the `TextDecoder.rs` latin1 site builds a plain `vec![0u16; n]` and truncates it to `out.written` instead of passing that length separately; the two sites that guard against an empty result keep their guards, and `to_external_u16` documents and `debug_assert`s that requirement, since JSC returns the shared empty string for `len == 0` without adopting the buffer. `zig_string_to_external_u16` and its import in `Blob.rs` are deleted; `Blob.rs` calls `jsc::zig_string::to_external_u16` at both sites, as one of them already did. This removes 8 `unsafe` blocks and 9 SAFETY comments and makes the remaining function safe.

## Why

Ownership of the buffer is now in the signature: a caller gives up its `Vec<u16>` by moving it, so using it afterwards or dropping it as well does not compile, and the allocator requirement holds by construction because the `Vec` was allocated by the global allocator that `ZigString__freeGlobal` frees with. It is zero-cost: `Vec::leak` yields exactly the pointer and length the callers computed by hand, dropping the `Vec` on the too-long path issues the same single free as `default_alloc::free` did, the shrinks that happened before still happen at the same sites and nowhere else, and the C++ function and its finalizer are unchanged. The only added instruction is the length compare inside `Vec::truncate` at the latin1 site, where `copy_cp1252_into_utf16` always fills the whole buffer.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/web/encoding/text-decoder.test.js test/js/web/encoding/text-decoder-wpt.test.ts test/js/web/fetch/utf8-bom.test.ts test/js/web/fetch/body.test.ts: 875 pass, 4 skip, 0 fail (879 tests across 4 files).
