### PR TITLE
node:http2: throw ERR_HTTP2_ORIGIN_LENGTH instead of panicking on an oversized origin

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7032,18 +7032,10 @@ impl H2FrameParser {
                 }
                 let origin_string = item.to_slice(global_object)?;
                 let slice = origin_string.slice();
-                if stream
-                    .write_all(&u16::try_from(slice.len()).expect("int cast").to_be_bytes())
-                    .is_err()
-                {
-                    let exception = global_object.to_type_error(
-                        bun_jsc::ErrorCode::HTTP2_ORIGIN_LENGTH,
-                        format_args!("HTTP/2 ORIGIN frames are limited to 16382 bytes"),
-                    );
-                    return Err(global_object.throw_value(exception));
-                }
-
-                if stream.write_all(slice).is_err() {
+                let fits = u16::try_from(slice.len()).is_ok_and(|len| {
+                    stream.write_all(&len.to_be_bytes()).is_ok() && stream.write_all(slice).is_ok()
+                });
+                if !fits {
                     let exception = global_object.to_type_error(
                         bun_jsc::ErrorCode::HTTP2_ORIGIN_LENGTH,
                         format_args!("HTTP/2 ORIGIN frames are limited to 16382 bytes"),

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2859,6 +2859,75 @@ it("http2 client.request() rejects header names longer than 4096 bytes with a ca
   expect(exitCode).toBe(0);
 });
 
+it("http2 session.origin() with several origins rejects one longer than 65535 bytes with a catchable error", async () => {
+  // Each entry of a multi-origin ORIGIN frame carries a 16-bit length prefix.
+  // An entry that does not fit in it must surface as ERR_HTTP2_ORIGIN_LENGTH
+  // like any other oversized origin, not terminate the process. Run in a
+  // subprocess so a crash shows up as a failed assertion instead of taking down
+  // the test runner.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const http2 = require("node:http2");
+      const server = http2.createServer();
+      server.on("session", session => {
+        const huge = "https://" + Buffer.alloc(70000, "a").toString();
+        for (const origins of [
+          [huge, "https://b.example"],
+          ["https://b.example", huge],
+          [{ origin: huge }, "https://b.example"],
+        ]) {
+          try {
+            session.origin(...origins);
+            console.log("NO_ERROR");
+          } catch (err) {
+            console.log("CODE:" + err.code + " NAME:" + err.name);
+          }
+        }
+        // The session is still usable afterwards.
+        session.origin("https://c.example", "https://d.example");
+        console.log("ORIGIN_SENT");
+      });
+      server.on("stream", stream => {
+        stream.respond({ ":status": 200 });
+        stream.end("ok");
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const client = http2.connect("http://127.0.0.1:" + server.address().port);
+        client.on("error", () => {});
+        const req = client.request({ ":path": "/" });
+        req.on("response", headers => {
+          console.log("STATUS:" + headers[":status"]);
+        });
+        req.resume();
+        req.on("close", () => {
+          client.close();
+          server.close();
+        });
+        req.end();
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.split("\n").filter(Boolean)).toEqual([
+    "CODE:ERR_HTTP2_ORIGIN_LENGTH NAME:TypeError",
+    "CODE:ERR_HTTP2_ORIGIN_LENGTH NAME:TypeError",
+    "CODE:ERR_HTTP2_ORIGIN_LENGTH NAME:TypeError",
+    "ORIGIN_SENT",
+    "STATUS:200",
+  ]);
+  expect(exitCode).toBe(0);
+});
+
 it("http2 client.request() propagates a throwing header-value toString() instead of masking it", async () => {
   // Node calls `${value}` and lets the user's exception escape; it must not be
   // replaced with ERR_HTTP2_INVALID_HEADER_VALUE.


### PR DESCRIPTION
### Repro

```js
import http2 from "node:http2";
const server = http2.createServer();
server.on("session", session => {
  try {
    session.origin("https://" + "a".repeat(70000), "https://b.example");
  } catch (e) {
    console.log(e.code); // node: ERR_HTTP2_ORIGIN_LENGTH
  }
  session.destroy();
  server.close();
});
server.listen(0, "127.0.0.1", () => {
  const c = http2.connect(`http://127.0.0.1:${server.address().port}`);
  c.on("error", () => {});
  c.request({ ":path": "/" }).on("error", () => {}).end();
});
```

bun 1.4.0 aborts the whole process:

```
panic: int cast: TryFromIntError(PosOverflow)
```

(`H2FrameParser::origin`, src/runtime/api/bun/h2_frame_parser.rs). Node v26 throws `ERR_HTTP2_ORIGIN_LENGTH`.

### Cause

`origin()` with a single origin goes through the string branch of `H2FrameParser::origin`, which checks the length and throws `ERR_HTTP2_ORIGIN_LENGTH`. With two or more origins the JS wrapper passes an array, and the array branch wrote each entry's 16-bit length prefix with `u16::try_from(slice.len()).expect("int cast")`. The frame buffer overflow check that would have thrown only runs after that cast, so any entry over 65535 bytes panicked first. The wrapper does not cap lengths itself (`new URL()` accepts arbitrarily long hosts, and `{ origin }` objects bypass URL parsing), so this is reachable from the public API.

### Fix

Treat an entry whose length does not fit the 16-bit prefix the same as one that does not fit the frame: throw `ERR_HTTP2_ORIGIN_LENGTH`. The two previously duplicated throws in that branch are folded into one.

`send_alt_svc` has the same cast shape, but the public `altsvc()` wrapper already caps origin + alt at 16382 bytes before calling into native code, so it is left as is.

### Verification

Added a test to `test/js/node/http2/node-http2.test.js` that calls `session.origin()` with an oversized entry in first position, in second position, and as an `{ origin }` object, then sends a normal ORIGIN frame and serves a request on the same session. The fixture prints the same output under Node v26.3.0. It fails on the current release with the panic above and passes with this change; the rest of the file (348 tests) and `test/js/node/test/parallel/test-http2-origin.js` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (548638b86)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [767.60ms]
(pass) node none > Client Basics > should be able to send a POST request [524.99ms]
(pass) node none > Client Basics > constants [19.47ms]
(pass) node none > Client Basics > getDefaultSettings [6.89ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.34ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.17ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.99ms]
(pass) node none > Client Basics > should be able to send data using end [557.28ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [547.02ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.83ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.35ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.67ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.68ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.64ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.09ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [33.94ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (548638b86)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [813.10ms]
(pass) node none > Client Basics > should be able to send a POST request [542.71ms]
(pass) node none > Client Basics > constants [18.11ms]
(pass) node none > Client Basics > getDefaultSettings [6.69ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [21.93ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.92ms]
(pass) node none > Client Basics > should be able to send data using end [570.87ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [560.61ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 836ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/57] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/57] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 20s
[53/57] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[54/57] link bun-profile
[56/57] strip bun
[56/57] bun-profile --revision
1.4.0-canary.1+548638b86
[build] done
bun test v1.4.0-canary.1 (548638b86)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.85ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.38ms]
(pass) node none > Client Basi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs | 16 ++------
 test/js/node/http2/node-http2.test.js  | 69 ++++++++++++++++++++++++++++++++++
 2 files changed, 73 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs      4      1      0
test/js/node/http2/node-http2.test.js       1      1      0
```

</details>

<!-- robobun:evidence:end -->