### PR TITLE
bundler: collapse ParseTask ctx/completion_ctx into one ParentRef

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -111,8 +111,8 @@ pub struct ParseTask {
     pub(crate) emit_decorator_metadata: bool,
     pub(crate) experimental_decorators: bool,
     pub(crate) use_define_for_class_fields: bool,
-    pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>>>,
-    pub completion_ctx: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>>,
+    // BACKREF; `None` only before enqueue (`Default`, runtime source).
+    pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>>,
     // Borrows package_json (resolver arena); valid for the bundle pass.
     pub(crate) package_version: ast::StoreStr,
     pub(crate) package_name: ast::StoreStr,
@@ -248,8 +248,7 @@ impl ParseTask {
         let ctx_ref = unsafe { bun_ptr::ParentRef::from_raw_mut(ctx.cast::<BundleV2<'static>>()) };
         let known_target = ctx_ref.get().transpiler().options.target;
         ParseTask {
-            ctx: Some(ctx_ref.shared()),
-            completion_ctx: Some(ctx_ref),
+            ctx: Some(ctx_ref),
             path: resolve_result.path_pair.primary,
             contents_or_fd: ContentsOrFd::Fd {
                 dir: resolve_result.dirname_fd,
@@ -298,7 +297,6 @@ impl Default for ParseTask {
     fn default() -> Self {
         ParseTask {
             ctx: None,
-            completion_ctx: None,
             path: Fs::Path::init(b""),
             secondary_path_for_commonjs_interop: None,
             contents_or_fd: ContentsOrFd::Contents(b""),
@@ -533,7 +531,6 @@ pub mod parse_worker {
 
         let parse_task = ParseTask {
             ctx: None,
-            completion_ctx: None,
             path: Fs::Path::init_with_namespace(b"runtime", b"bun:runtime"),
             side_effects: bun_ast::SideEffects::NoSideEffectsPureData,
             jsx: options::jsx::Pragma {
@@ -2809,7 +2806,7 @@ pub mod parse_worker {
         };
 
         let result = Box::new(Result {
-            ctx: this.completion_ctx.expect("ParseTask.completion_ctx unset"),
+            ctx: this.ctx.expect("ParseTask.ctx unset"),
             task: EventLoop::Task::default(),
             value,
             // `ExternalFreeFunction`

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3284,8 +3284,7 @@ pub mod bv2_impl {
                 let ctx_mut = bun_ptr::ParentRef::from_raw_mut(
                     std::ptr::from_mut(self).cast::<BundleV2<'static>>(),
                 );
-                (*runtime_parse_task).ctx = Some(ctx_mut.shared());
-                (*runtime_parse_task).completion_ctx = Some(ctx_mut);
+                (*runtime_parse_task).ctx = Some(ctx_mut);
                 (*runtime_parse_task).tree_shaking = true;
                 (*runtime_parse_task).loader = Some(Loader::Js);
             }
@@ -3704,8 +3703,7 @@ pub mod bv2_impl {
                 let ctx_mut = bun_ptr::ParentRef::from_raw_mut(
                     std::ptr::from_mut(self).cast::<BundleV2<'static>>(),
                 );
-                (*task).ctx = Some(ctx_mut.shared());
-                (*task).completion_ctx = Some(ctx_mut);
+                (*task).ctx = Some(ctx_mut);
                 (*task).task.node.next = core::ptr::null_mut();
                 (*task).io_task.node.next = core::ptr::null_mut();
             }
@@ -4806,17 +4804,7 @@ pub mod bv2_impl {
                             let task_val = ParseTask {
                                 // SAFETY: `from_mut(this)` is the live bundle (write provenance);
                                 // outlives the task.
-                                ctx: Some(
-                                    unsafe {
-                                        bun_ptr::ParentRef::from_raw_mut(
-                                            std::ptr::from_mut::<BundleV2>(this)
-                                                .cast::<BundleV2<'static>>(),
-                                        )
-                                    }
-                                    .shared(),
-                                ),
-                                // SAFETY: `this` is the live bundle (write provenance).
-                                completion_ctx: Some(unsafe {
+                                ctx: Some(unsafe {
                                     bun_ptr::ParentRef::from_raw_mut(
                                         std::ptr::from_mut::<BundleV2>(this)
                                             .cast::<BundleV2<'static>>(),
@@ -6706,8 +6694,7 @@ pub mod bv2_impl {
                     new_input_file.loader = loader;
                     let new_source_index: u32 = new_input_file.source.index.0;
                     new_task.source_index = bun_ast::Index(new_source_index);
-                    new_task.ctx = self_ptr.map(|p| p.shared());
-                    new_task.completion_ctx = self_ptr;
+                    new_task.ctx = self_ptr;
                     // SAFETY: value_ptr points into PathToSourceIndexMap storage; no
                     // intervening insert into that map has occurred since get_or_put.
                     unsafe {

--- a/src/ptr/parent_ref.rs
+++ b/src/ptr/parent_ref.rs
@@ -145,14 +145,6 @@ impl<T: ?Sized> ParentRef<T, crate::Mut> {
         // SAFETY: caller contract (a)+(b); `Mut` records write provenance.
         unsafe { &mut *self.ptr.as_ptr() }
     }
-
-    #[inline]
-    pub const fn shared(self) -> ParentRef<T, crate::Shared> {
-        ParentRef {
-            ptr: self.ptr,
-            _provenance: core::marker::PhantomData,
-        }
-    }
 }
 
 impl<T: ?Sized, P> ParentRef<T, P> {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1513,9 +1513,7 @@ pub mod js_bundler {
             // points at a live `AnyEventLoop` owned by the bundle thread /
             // runtime for the duration of the bundle.
             unsafe {
-                let ctx = (*self.parse_task)
-                    .completion_ctx
-                    .expect("ParseTask.completion_ctx unset");
+                let ctx = (*self.parse_task).ctx.expect("ParseTask.ctx unset");
                 // SAFETY: write provenance from `ParseTask::init`; bundle outlives plugin.
                 let any_loop = ctx
                     .assume_mut()


### PR DESCRIPTION
## What

`ParseTask` carried two back-pointers to the same `BundleV2`: `ctx` (a shared `ParentRef`, read by the `ctx()` accessor on the parse threads) and `completion_ctx` (a `Mut` `ParentRef`, copied into `parse_task::Result::ctx` for `on_complete` and used by `Load::on_defer`). All 5 constructor sites (`ParseTask::init`, `enqueue_entry_points_common`, `enqueue_parse_task2`, the onResolve task literal in `on_resolve`, `process_resolve_queue`) filled both from one pointer, and the 2 placeholder sites (`Default`, the runtime source) set both to `None`.

```rust
// before
pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>>>,
pub completion_ctx: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>>,

// after (same shape as ServerComponentParseTask::ctx)
pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>>,
```

The constructor sites now assign one field; the onResolve literal built the pointer twice in two `unsafe` blocks and now builds it once, removing 1 `unsafe` block. The 3 readers are unchanged apart from the field name: `ctx()` still projects `&BundleV2` through `ParentRef::get`, and `run_from_thread_pool_impl` (building `Result`) and `Load::on_defer` in `JSBundler.rs` take their write-provenance copy from the same field. `ParentRef::shared` in `bun_ptr` had these constructors as its only callers and is deleted.

## Why

The type no longer admits a task whose two bundle pointers disagree or where only one is set; there is one back-reference, and the `Mut` marker on it records that completion writes through it. `Option<ParentRef<_, _>>` is `repr(transparent)` over `NonNull` with the `None` niche, so `ParseTask` only loses one pointer-sized field; `ParentRef::get` is the same dereference for both markers and the number of `expect` checks on each path is unchanged.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/bundler/bundler_plugin.test.ts test/bundler/bundler_defer.test.ts test/bundler/bun-build-api.test.ts test/bundler/bundler_edgecase.test.ts: 249 pass, 1 skip, 0 fail (267 tests across 4 files, remainder todo).
