### PR TITLE
node:http2: fix stream id overflow in setNextStreamID and nextStreamID

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8271,24 +8271,21 @@ impl H2FrameParser {
         Ok(JSValue::js_number(result as f64))
     }
 
+    /// `set_next_stream_id` can park `last_stream_id` anywhere in the u32 range, so the step
+    /// saturates; callers that open the stream reject anything above `MAX_STREAM_ID`.
     fn get_next_stream_id(&self) -> u32 {
-        let mut stream_id: u32 = self.last_stream_id.get();
+        let stream_id = self.last_stream_id.get();
         if self.is_server.get() {
             if stream_id.is_multiple_of(2) {
-                stream_id += 2;
+                stream_id.saturating_add(2)
             } else {
-                stream_id += 1;
+                stream_id.saturating_add(1)
             }
+        } else if stream_id.is_multiple_of(2) {
+            stream_id.saturating_add(1)
         } else {
-            if stream_id.is_multiple_of(2) {
-                stream_id += 1;
-            } else if stream_id == 0 {
-                stream_id = 1;
-            } else {
-                stream_id += 2;
-            }
+            stream_id.saturating_add(2)
         }
-        stream_id
     }
 
     #[bun_jsc::host_fn(method)]
@@ -8301,22 +8298,21 @@ impl H2FrameParser {
         debug_assert!(args_list.len() >= 1);
         let stream_id_arg = args_list[0];
         debug_assert!(stream_id_arg.is_number());
-        let mut last_stream_id = stream_id_arg.to_u32();
-        if this.is_server.get() {
-            if last_stream_id.is_multiple_of(2) {
-                last_stream_id -= 2;
+        // Store the id `get_next_stream_id` steps from. A fractional id passes the JS layer's
+        // `id <= 0` check and truncates to 0 here; 0 (and 1 on a client) has no predecessor,
+        // so the subtraction saturates to the initial state instead of wrapping.
+        let next_stream_id = stream_id_arg.to_u32();
+        let last_stream_id = if this.is_server.get() {
+            if next_stream_id.is_multiple_of(2) {
+                next_stream_id.saturating_sub(2)
             } else {
-                last_stream_id -= 1;
+                next_stream_id.saturating_sub(1)
             }
+        } else if next_stream_id.is_multiple_of(2) {
+            next_stream_id.saturating_sub(1)
         } else {
-            if last_stream_id.is_multiple_of(2) {
-                last_stream_id -= 1;
-            } else if last_stream_id == 1 {
-                last_stream_id = 0;
-            } else {
-                last_stream_id -= 2;
-            }
-        }
+            next_stream_id.saturating_sub(2)
+        };
         this.last_stream_id.set(last_stream_id);
         Ok(JSValue::UNDEFINED)
     }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2539,6 +2539,67 @@ it("http2 client.setNextStreamID validates input", async () => {
   });
 });
 
+it("http2 setNextStreamID at the edges of the id space does not overflow", async () => {
+  // 0.5 passes the JS range check (> 0) and reaches the native setter as 0, which used to
+  // underflow (node ends up on stream 1 too). A server parked at 2 ** 32 - 1 used to overflow
+  // when the next id was computed; it has to read back as an unusable id, not wrap to a low one.
+  const fixture = `
+    const http2 = require("node:http2");
+    const result = { client: {}, server: {} };
+    const fail = what => err => {
+      console.error(what, err);
+      process.exit(1);
+    };
+    const server = http2.createServer();
+    server.on("sessionError", fail("server session error"));
+    server.on("stream", stream => {
+      // ServerHttp2Session does not expose setNextStreamID; call the native setter it would wrap.
+      const parser = stream.session[Symbol.for("::bunhttp2native::")];
+      for (const id of [0, 2, 2 ** 32 - 1]) {
+        parser.setNextStreamID(id);
+        result.server[id] = stream.session.state.nextStreamID;
+      }
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const client = http2.connect("http://127.0.0.1:" + server.address().port);
+      client.on("error", fail("client session error"));
+      client.on("connect", () => {
+        for (const id of [0.5, 1]) {
+          client.setNextStreamID(id);
+          result.client[id] = client.state.nextStreamID;
+        }
+        const req = client.request({ ":path": "/" });
+        req.on("error", fail("request error"));
+        req.on("response", headers => {
+          result.response = { streamId: req.id, status: headers[":status"] };
+        });
+        req.resume();
+        req.on("close", () => {
+          console.log(JSON.stringify(result));
+          process.exit(0);
+        });
+        req.end();
+      });
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    client: { 0.5: 1, 1: 1 },
+    server: { 0: 2, 2: 2, 4294967295: 4294967295 },
+    response: { streamId: 1, status: 200 },
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("http2 request.destroy() with error", async () => {
   const server = http2.createServer();
 


### PR DESCRIPTION
### Repro

```js
import http2 from "node:http2";
const server = http2.createServer((req, res) => res.end("ok"));
server.listen(0, "127.0.0.1", () => {
  const c = http2.connect(`http://127.0.0.1:${server.address().port}`);
  c.on("connect", () => {
    c.setNextStreamID(0.5);
    console.log("nextStreamID =", c.state.nextStreamID);
    const r = c.request({ ":path": "/" });
    r.on("response", h => console.log("response on stream", r.id, h[":status"]));
    r.resume();
    r.on("close", () => process.exit(0));
    r.end();
  });
});
```

Debug build:

```
panic: attempt to subtract with overflow
<bun_runtime::api::h2_frame_parser_body::H2FrameParser>::set_next_stream_id
```

Release builds wrap instead of panicking. Node (v26) prints `nextStreamID = 1` and `response on stream 1 200`: the native call is a no-op there because nghttp2 rejects id 0.

### Cause

`setNextStreamID` in `http2.ts` mirrors node's wrapper (`validateNumber` plus `id <= 0 || id > 2 ** 32 - 1`), so a fractional id in (0, 1) is accepted and arrives in `H2FrameParser::set_next_stream_id` as 0 after `to_u32()`. The setter stores the id to step from by subtracting 1 or 2, which underflows for 0 (and the client branch special-cased 1 for the same reason).

`get_next_stream_id` has the same problem in the other direction: the setter accepts the whole u32 range, and once a server session is parked at `2 ** 32 - 1`, computing the next id (`session.state`, `pushStream`) adds past `u32::MAX`:

```
panic: attempt to add with overflow
<bun_runtime::api::h2_frame_parser_body::H2FrameParser>::get_next_stream_id
```

On release that wraps to 0, which `state.nextStreamID` then reports. Today this second site is only reachable through the native handle, because `ServerHttp2Session` does not expose `setNextStreamID` (node does; tracked separately), but it is the same arithmetic.

### Fix

Both steps use `saturating_sub` / `saturating_add` (`src/runtime/api/bun/h2_frame_parser.rs`). An id with nothing to step back from lands on the initial state, so `setNextStreamID(0.5)` leaves a fresh client on stream 1 like node; a parked-out server reads back as an id above `MAX_STREAM_ID`, which `getNextStream` / `request` already reject as out of streams. The `== 1` special case in the setter and the unreachable `== 0` arm in the getter (0 is even) go away with it. No JS change: the wrapper already matches node's validation.

### Verification

New test `http2 setNextStreamID at the edges of the id space does not overflow` in `test/js/node/http2/node-http2.test.js` spawns a fixture that sets 0.5 and 1 on a client, 0, 2 and `2 ** 32 - 1` on a server session, and reads `state.nextStreamID` after each. Without the fix it aborts with the panics above on a debug build, and on the release binary (`USE_SYSTEM_BUN=1`) it fails on the server values (`0` where `2` and `4294967295` are expected). With the fix it passes, along with the rest of `node-http2.test.js` and the ported `test-http2-client-setNextStreamID-errors.js`, `test-http2-no-more-streams.js`, `test-http2-client-destroy.js` and `test-http2-session-stream-state.js`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (2c1bd68de)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [810.80ms]
(pass) node none > Client Basics > should be able to send a POST request [539.14ms]
(pass) node none > Client Basics > constants [18.15ms]
(pass) node none > Client Basics > getDefaultSettings [6.62ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [21.79ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.01ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.08ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.02ms]
(pass) node none > Client Basics > should be able to send data using end [567.86ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [559.13ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.80ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.09ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.06ms]
(pass) node none > Client Basics > is possible to abort request [1.66ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.73ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.60ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.08ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [34.67ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (2c1bd68de)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [833.57ms]
(pass) node none > Client Basics > should be able to send a POST request [551.82ms]
(pass) node none > Client Basics > constants [18.29ms]
(pass) node none > Client Basics > getDefaultSettings [6.84ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [21.99ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.23ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.07ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.09ms]
(pass) node none > Client Basics > should be able to send data using end [579.63ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [568.95ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2c1bd68ded
  features     baseline

22 deps, 107 codegen, 1176 objects in 1152ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [4.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[5/1238] gen bindgenv2
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] fetch zlib
[zlib] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs | 44 +++++++++++-------------
 test/js/node/http2/node-http2.test.js  | 61 ++++++++++++++++++++++++++++++++++
 2 files changed, 81 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs      6      3      0
test/js/node/http2/node-http2.test.js       3      4      0
```

</details>

<!-- robobun:evidence:end -->