### PR TITLE
node:http: make NodeHTTPResponse UpgradeCTX a three-state enum

### DIFF
--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -123,61 +123,68 @@ impl Flags {
     }
 }
 
-pub struct UpgradeCTX {
-    pub(crate) context: *mut uws_sys::WebSocketUpgradeContext,
-    // request will be detached when go async
-    pub(crate) request: *mut uws_sys::Request,
-
-    // we need to store this, if we wanna to enable async upgrade
-    pub(crate) sec_websocket_key: Box<[u8]>,
-    pub(crate) sec_websocket_protocol: Box<[u8]>,
-    pub(crate) sec_websocket_extensions: Box<[u8]>,
+pub(crate) enum UpgradeCTX {
+    /// Not a WebSocket upgrade request, or the upgrade context was already used or discarded.
+    None,
+    /// `request` is only readable while the request handler is still running.
+    Live {
+        context: ptr::NonNull<uws_sys::WebSocketUpgradeContext>,
+        request: ptr::NonNull<uws_sys::Request>,
+    },
+    /// The `sec-websocket-*` headers `upgrade` needs, copied out before the request goes away.
+    Saved {
+        context: ptr::NonNull<uws_sys::WebSocketUpgradeContext>,
+        key: Box<[u8]>,
+        protocol: Box<[u8]>,
+        extensions: Box<[u8]>,
+    },
 }
 
-impl Default for UpgradeCTX {
-    fn default() -> Self {
-        Self {
-            context: ptr::null_mut(),
-            request: ptr::null_mut(),
-            sec_websocket_key: Box::default(),
-            sec_websocket_protocol: Box::default(),
-            sec_websocket_extensions: Box::default(),
-        }
-    }
-}
+const _: () = assert!(core::mem::size_of::<UpgradeCTX>() <= 64);
 
 impl UpgradeCTX {
-    // this can be called multiple times
-    // Mid-lifetime reset, not a destructor.
-    fn reset(&mut self) {
-        // Dropping the taken value frees the old `Box<[u8]>` headers; raw
-        // pointers are nulled. Nothing from the old value is reused.
-        drop(core::mem::take(self));
+    fn preserve_web_socket_headers_if_needed(&mut self) {
+        let Self::Live { context, request } = self else {
+            return;
+        };
+        *self = Self::Saved {
+            context: *context,
+            key: Box::from(Self::live_header(request, b"sec-websocket-key")),
+            protocol: Box::from(Self::live_header(request, b"sec-websocket-protocol")),
+            extensions: Box::from(Self::live_header(request, b"sec-websocket-extensions")),
+        };
     }
 
-    fn preserve_web_socket_headers_if_needed(&mut self) {
-        if !self.request.is_null() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref. We
-            // null `self.request` immediately after reading headers so it
-            // cannot be used past its native lifetime.
-            let request = bun_opaque::opaque_deref(self.request.cast_const());
-            self.request = ptr::null_mut();
-
-            let sec_websocket_key = request.header(b"sec-websocket-key").unwrap_or(b"");
-            let sec_websocket_protocol = request.header(b"sec-websocket-protocol").unwrap_or(b"");
-            let sec_websocket_extensions =
-                request.header(b"sec-websocket-extensions").unwrap_or(b"");
-
-            if !sec_websocket_key.is_empty() {
-                self.sec_websocket_key = Box::<[u8]>::from(sec_websocket_key);
-            }
-            if !sec_websocket_protocol.is_empty() {
-                self.sec_websocket_protocol = Box::<[u8]>::from(sec_websocket_protocol);
-            }
-            if !sec_websocket_extensions.is_empty() {
-                self.sec_websocket_extensions = Box::<[u8]>::from(sec_websocket_extensions);
-            }
+    fn sec_websocket_key(&self) -> &[u8] {
+        match self {
+            Self::None => b"",
+            Self::Live { request, .. } => Self::live_header(request, b"sec-websocket-key"),
+            Self::Saved { key, .. } => key,
         }
+    }
+
+    fn sec_websocket_protocol(&self) -> &[u8] {
+        match self {
+            Self::None => b"",
+            Self::Live { request, .. } => Self::live_header(request, b"sec-websocket-protocol"),
+            Self::Saved { protocol, .. } => protocol,
+        }
+    }
+
+    fn sec_websocket_extensions(&self) -> &[u8] {
+        match self {
+            Self::None => b"",
+            Self::Live { request, .. } => Self::live_header(request, b"sec-websocket-extensions"),
+            Self::Saved { extensions, .. } => extensions,
+        }
+    }
+
+    /// Takes `&NonNull` so the returned view is bounded by the borrow of the `Live` state.
+    fn live_header<'a>(request: &'a ptr::NonNull<uws_sys::Request>, name: &[u8]) -> &'a [u8] {
+        // S008: `uws::Request` is an `opaque_ffi!` ZST, safe deref.
+        bun_opaque::opaque_deref(request.as_ptr())
+            .header(name)
+            .unwrap_or(b"")
     }
 }
 
@@ -541,10 +548,10 @@ impl NodeHTTPResponse {
         sec_websocket_protocol: ZigString,
         sec_websocket_extensions: ZigString,
     ) -> bool {
-        let upgrade_ctx = self.upgrade_context.get().context;
-        if upgrade_ctx.is_null() {
-            return false;
-        }
+        let upgrade_ctx = match *self.upgrade_context.get() {
+            UpgradeCTX::None => return false,
+            UpgradeCTX::Live { context, .. } | UpgradeCTX::Saved { context, .. } => context,
+        };
         // `AnyServer` is a `Copy` type-erased pointer; copy it so the
         // `&mut self`-taking accessor can be called from this `&self` body.
         // The pointee is the long-lived server, not `*self`.
@@ -575,13 +582,7 @@ impl NodeHTTPResponse {
 
         let sec_websocket_protocol_value: &[u8] = 'brk: {
             if sec_websocket_protocol.len == 0 {
-                if !upgrade_context.request.is_null() {
-                    // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-                    let request = bun_opaque::opaque_deref(upgrade_context.request.cast_const());
-                    break 'brk request.header(b"sec-websocket-protocol").unwrap_or(b"");
-                } else {
-                    break 'brk &upgrade_context.sec_websocket_protocol;
-                }
+                break 'brk upgrade_context.sec_websocket_protocol();
             }
             sec_websocket_protocol_str = Some(sec_websocket_protocol.to_slice());
             break 'brk sec_websocket_protocol_str.as_ref().unwrap().slice();
@@ -589,25 +590,13 @@ impl NodeHTTPResponse {
 
         let sec_websocket_extensions_value: &[u8] = 'brk: {
             if sec_websocket_extensions.len == 0 {
-                if !upgrade_context.request.is_null() {
-                    // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-                    let request = bun_opaque::opaque_deref(upgrade_context.request.cast_const());
-                    break 'brk request.header(b"sec-websocket-extensions").unwrap_or(b"");
-                } else {
-                    break 'brk &upgrade_context.sec_websocket_extensions;
-                }
+                break 'brk upgrade_context.sec_websocket_extensions();
             }
             sec_websocket_extensions_str = Some(sec_websocket_extensions.to_slice());
             break 'brk sec_websocket_extensions_str.as_ref().unwrap().slice();
         };
 
-        let websocket_key: &[u8] = if !upgrade_context.request.is_null() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST — safe deref.
-            let request = bun_opaque::opaque_deref(upgrade_context.request.cast_const());
-            request.header(b"sec-websocket-key").unwrap_or(b"")
-        } else {
-            &upgrade_context.sec_websocket_key
-        };
+        let websocket_key = upgrade_context.sec_websocket_key();
 
         if let Some(raw_response) = self.raw_response.take() {
             self.update_flags(|f| f.insert(Flags::UPGRADED));
@@ -615,9 +604,8 @@ impl NodeHTTPResponse {
             // and will have its own lifecycle management
             let vm = self.server.global_this().bun_vm().as_mut();
             self.poll_ref.with_mut(|r| r.unref(vm));
-            // S008: `WebSocketUpgradeContext` is an `opaque_ffi!` ZST — safe deref
-            // (`upgrade_ctx` checked non-null above).
-            let ctx = bun_opaque::opaque_deref_mut(upgrade_ctx);
+            // S008: `WebSocketUpgradeContext` is an `opaque_ffi!` ZST, safe deref.
+            let ctx = bun_opaque::opaque_deref_mut(upgrade_ctx.as_ptr());
             let _ = raw_response.upgrade::<ServerWebSocket>(
                 ws,
                 websocket_key,
@@ -636,13 +624,13 @@ impl NodeHTTPResponse {
         // freed when uWS adopts the socket above, so set_on_aborted_handler
         // (which would call preserve_web_socket_headers_if_needed) must not run
         // post-upgrade — it would read freed header views.
-        self.upgrade_context.with_mut(|c| c.reset());
+        self.upgrade_context.set(UpgradeCTX::None);
 
         true
     }
 
     pub(crate) fn maybe_stop_reading_body(&self, vm: &mut VirtualMachine, this_value: JSValue) {
-        self.upgrade_context.with_mut(|c| c.reset()); // we can discard the upgrade context now
+        self.upgrade_context.set(UpgradeCTX::None); // we can discard the upgrade context now
 
         let flags = self.flags.get();
         if (flags.contains(Flags::UPGRADED)
@@ -742,7 +730,7 @@ impl NodeHTTPResponse {
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
-        self.upgrade_context.with_mut(|c| c.reset());
+        self.upgrade_context.set(UpgradeCTX::None);
 
         self.buffered_request_body_data_during_pause
             .with_mut(|b| b.clear_and_free());
@@ -2765,12 +2753,12 @@ pub(crate) unsafe extern "C" fn NodeHTTPResponse__createForJS(
         // 1 - the JS object
         // 1 - the Server handler.
         ref_count: Cell::new(3),
-        upgrade_context: JsCell::new(UpgradeCTX {
-            context: upgrade_ctx,
-            request,
-            sec_websocket_key: Box::default(),
-            sec_websocket_protocol: Box::default(),
-            sec_websocket_extensions: Box::default(),
+        upgrade_context: JsCell::new(match ptr::NonNull::new(upgrade_ctx) {
+            Some(context) => UpgradeCTX::Live {
+                context,
+                request: ptr::NonNull::from(request_ref),
+            },
+            None => UpgradeCTX::None,
         }),
         server: any_server_from_packed(any_server_tag),
         raw_response: Cell::new(Some(raw_response)),


### PR DESCRIPTION
## What

`UpgradeCTX` in `src/runtime/server/NodeHTTPResponse.rs` (the `upgrade_context: JsCell<UpgradeCTX>` field of every `NodeHTTPResponse`) was a struct of two nullable raw pointers and three `Box<[u8]>` header copies. Its phases were implicit: `context` null meant "not an upgrade request", a non-null `request` meant the uws request was still readable, a null `request` with a non-null `context` meant `preserve_web_socket_headers_if_needed` had already copied the three `sec-websocket-*` headers into the boxes, and `reset()` (`mem::take`) returned it to the null state. `upgrade()` null-checked `context` once and `request` three more times (once per header), and `createForJS` stored `request` even when there was no upgrade context, so `preserve_web_socket_headers_if_needed` copied three headers for every plain request that outlived its handler even though `upgrade()` can never read them.

```rust
// before
pub struct UpgradeCTX {
    pub(crate) context: *mut uws_sys::WebSocketUpgradeContext,
    pub(crate) request: *mut uws_sys::Request,
    pub(crate) sec_websocket_key: Box<[u8]>,
    pub(crate) sec_websocket_protocol: Box<[u8]>,
    pub(crate) sec_websocket_extensions: Box<[u8]>,
}

// after
pub(crate) enum UpgradeCTX {
    None,
    Live { context: NonNull<WebSocketUpgradeContext>, request: NonNull<uws_sys::Request> },
    Saved { context: NonNull<WebSocketUpgradeContext>, key: Box<[u8]>, protocol: Box<[u8]>, extensions: Box<[u8]> },
}
```

`createForJS` builds `Live` when it is handed an upgrade context and `None` otherwise. `preserve_web_socket_headers_if_needed` is now the `Live` to `Saved` transition and a no-op in the other two states. The three reset sites (`upgrade()`, `maybe_stop_reading_body`, `mark_request_as_done`) store `UpgradeCTX::None`, which drops the saved boxes exactly as the old `mem::take` did, so `reset()` and the `Default` impl are deleted. `upgrade()` matches once at the top for the context (returning `false` on `None`, as the old null check did) and reads each header through `sec_websocket_key()` / `sec_websocket_protocol()` / `sec_websocket_extensions()`, which return the live request's header or the saved copy; the protocol and extensions accessors are still only called when the caller did not pass those headers explicitly, so the header lookups performed are the same as before. All users are in this one file; the `extern "C"` signature of `NodeHTTPResponse__createForJS` is unchanged. The `UpgradeCTX` handling contained no unsafe blocks before and contains none now.

## Why

The three states the code actually goes through are now named variants, so a reader can see from the type that the uws request is only available in `Live`, that the header copies only exist in `Saved`, and that the context is present in both; the "context set but nothing to read from" and "request set but no context" combinations are unrepresentable, and the four hand-written null checks in `upgrade()` become matches. It is zero-cost: the largest variant is a `NonNull` plus three `Box<[u8]>` (56 bytes) and the tag brings the enum to 64 bytes, the same size as the old struct (asserted with a `const` assertion), and the tag test replaces the old null tests. The only work that changes is that requests without an upgrade context no longer copy three headers nobody can read, and `createForJS` tests the incoming context pointer for null once when choosing the variant.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/node/http/node-http.test.ts (143 pass, 1 skip, 1 fail), test/js/first_party/ws/ws.test.ts (47 pass), test/js/node/http/node-http-with-ws.test.ts (2 pass), test/regression/issue/32734.test.ts (2 pass): 194 pass, 1 skip, 1 fail across 4 files.
The single failure, node-http.test.ts "request via http proxy, issue#4295" (connect ECONNREFUSED 127.0.0.1 before any response object exists), fails identically on main (143 pass, 1 skip, 1 fail) and is pre-existing/unrelated to the NodeHTTPResponse.rs UpgradeCTX change.
