### PR TITLE
postgres: hold statement refs in an owning StatementRef newtype

### DIFF
--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -22,13 +22,14 @@ use core::ptr::NonNull;
 use crate::jsc::{EventLoopTimerState, EventLoopTimerTag};
 use crate::postgres::AuthenticationState;
 use crate::postgres::PostgresSQLQuery;
-use crate::postgres::PostgresSQLStatement;
 use crate::postgres::data_cell as DataCell;
 use crate::postgres::error_jsc::{create_postgres_error, postgres_error_to_js};
 use crate::postgres::postgres_request as PostgresRequest;
 use crate::postgres::postgres_request::MessageType;
 use crate::postgres::postgres_sql_query::{self, Status as QueryStatus};
-use crate::postgres::postgres_sql_statement::{Error as StatementError, Status as StatementStatus};
+use crate::postgres::postgres_sql_statement::{
+    Error as StatementError, StatementRef, Status as StatementStatus,
+};
 use crate::postgres::sasl::SASLStatus;
 use crate::shared::CachedStructure as PostgresCachedStructure;
 use crate::shared::connection_ctor_args::{self, ConnectionCtorArgs};
@@ -53,7 +54,8 @@ bun_core::define_scoped_log!(debug, Postgres, visible);
 
 const MAX_PIPELINE_SIZE: usize = u16::MAX as usize; // about 64KB per connection
 
-type PreparedStatementsMap = StringHashMap<*mut PostgresSQLStatement>;
+// `None`: slot reserved by `get_or_put` in `PostgresSQLQuery::do_run`, statement not stored yet.
+type PreparedStatementsMap = StringHashMap<Option<StatementRef>>;
 
 pub mod js {
     pub use crate::jsc::codegen::JSPostgresSQLConnection::*;
@@ -1410,10 +1412,6 @@ impl PostgresSQLConnection {
         unsafe {
             (*this).disconnect();
             (*this).stop_timers();
-            for stmt_ptr in (*this).statements.get().values() {
-                // statements map owns a ref to each statement.
-                PostgresSQLStatement::deref(*stmt_ptr);
-            }
             // statements/requests/write_buffer/read_buffer/backend_parameters dropped below.
 
             // `free_sensitive` is the C-string variant; here we
@@ -2975,15 +2973,10 @@ impl PostgresSQLConnection {
                         stmt.error_response = Some(
                             crate::postgres::postgres_sql_statement::Error::Protocol(err),
                         );
-                        if self
+                        // Releases the map's ref; the request still holds its own.
+                        let _ = self
                             .statements
-                            .with_mut(|m| m.remove(&stmt.signature.name[..]))
-                            .is_some()
-                        {
-                            // SAFETY: `stmt` is a live `Box`-allocated statement; the
-                            // request still holds its own ref so this cannot drop to 0.
-                            unsafe { PostgresSQLStatement::deref(core::ptr::from_mut(stmt)) };
-                        }
+                            .with_mut(|m| m.remove(&stmt.signature.name[..]));
                     }
                 }
                 // If `err` was not moved into stmt above, it drops here automatically.

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -17,7 +17,7 @@ use super::command_tag_jsc::CommandTagJsc;
 use super::error_jsc::postgres_error_to_js;
 use super::postgres_request as PostgresRequest;
 use super::postgres_sql_connection;
-use super::postgres_sql_statement::Status as StatementStatus;
+use super::postgres_sql_statement::{StatementRef, Status as StatementStatus};
 use bun_sql::postgres::CommandTag;
 use bun_sql::postgres::PostgresProtocol as protocol;
 use bun_sql::postgres::any_postgres_error::AnyPostgresError;
@@ -38,7 +38,7 @@ pub use crate::jsc::codegen::JSPostgresSQLQuery as js;
 // previous `from_mut(self)` raw-pointer dances papered over.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLQuery {
-    pub(crate) statement: Cell<Option<*mut PostgresSQLStatement>>,
+    statement: JsCell<Option<StatementRef>>,
     pub(crate) query: BunString,
     pub(crate) cursor_name: BunString,
 
@@ -54,13 +54,11 @@ pub struct PostgresSQLQuery {
     pub(crate) flags: Cell<Flags>,
 }
 
-// On drop: deref the statement (if any), then deref query/cursor_name.
 // `BunString` is `Copy` (FFI by-value, NO `Drop`), so the
 // +1 ref taken by `to_bun_string` in `call()` must be released here explicitly.
 // `destroy` is `heap::take` in `deref_`.
 impl Drop for PostgresSQLQuery {
     fn drop(&mut self) {
-        self.release_statement();
         self.query.deref();
         self.cursor_name.deref();
     }
@@ -69,7 +67,7 @@ impl Drop for PostgresSQLQuery {
 impl Default for PostgresSQLQuery {
     fn default() -> Self {
         Self {
-            statement: Cell::new(None),
+            statement: JsCell::new(None),
             query: BunString::empty(),
             cursor_name: BunString::empty(),
             this_value: JsCell::new(JsRef::empty()),
@@ -144,9 +142,8 @@ impl PostgresSQLQuery {
     /// raw-pointer derefs at every protocol dispatch site in
     /// `PostgresSQLConnection::on`.
     ///
-    /// SAFETY (encapsulated): when `Some`, the pointer is a live `heap::alloc`
-    /// payload kept alive by the intrusive ref this query holds (`ref_()` taken
-    /// at `statement.set(Some(_))`). All mutation is single-JS-thread so the
+    /// SAFETY (encapsulated): the pointee is kept alive by the [`StatementRef`]
+    /// this query holds in `statement`. All mutation is single-JS-thread so the
     /// `&mut` is exclusive for the borrow's lifetime; callers must not hold two
     /// results live simultaneously (the request FIFO never does).
     #[inline]
@@ -154,22 +151,10 @@ impl PostgresSQLQuery {
     pub(crate) fn statement_mut(&self) -> Option<&mut PostgresSQLStatement> {
         // SAFETY: see doc comment — intrusive ref held by `self` keeps the
         // pointee alive; single-JS-thread exclusivity.
-        self.statement.get().map(|p| unsafe { &mut *p })
-    }
-
-    /// Release the intrusive ref this query holds on its `statement`, clearing
-    /// the field. One audited deref here replaces the per-site
-    /// `this.statement.set(None)` + `PostgresSQLStatement::deref(stmt)` pair on
-    /// `Drop` and `do_run`'s error paths (6 callers).
-    #[inline]
-    pub(crate) fn release_statement(&self) {
-        if let Some(stmt) = self.statement.take() {
-            // SAFETY: when `Some`, `stmt` is a live `heap::alloc` payload kept
-            // alive by the intrusive ref this query took when it was stored
-            // into `self.statement` (`ref_()` / `init_exact_refs`). This
-            // releases exactly that ref; may free if no other refs remain.
-            unsafe { PostgresSQLStatement::deref(stmt) };
-        }
+        self.statement
+            .get()
+            .as_ref()
+            .map(|stmt| unsafe { &mut *stmt.as_ptr() })
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -500,7 +485,7 @@ impl PostgresSQLQuery {
         // Shared cleanup for every error-return path below: drop any statement
         // ref this query took plus the speculative `ref_()` above.
         let release_query_ref = || {
-            this.release_statement();
+            this.statement.set(None);
             // SAFETY: undoes the speculative `this.ref_()` above; count was ≥2, never frees here.
             unsafe { Self::deref(this_ptr) };
         };
@@ -520,15 +505,13 @@ impl PostgresSQLQuery {
         if this.flags.get().simple {
             bun_core::scoped_log!(Postgres, "executeQuery");
 
-            // PostgresSQLStatement is intrusively refcounted; allocate a fresh box and
-            // hand ownership to `this.statement` (count = 1).
             // NOTE: PostgresSQLStatement implements Drop, so functional-record-update
             // (`..Default::default()`) is forbidden (E0509). Build + mutate instead.
-            let stmt: *mut PostgresSQLStatement = {
+            let stmt = {
                 let mut s = PostgresSQLStatement::default();
                 s.signature = Signature::empty();
                 s.status = StatementStatus::Parsing;
-                bun_core::heap::into_raw(Box::new(s))
+                StatementRef::new(s)
             };
             // Query is simple and it's the only owner of the statement
             this.statement.set(Some(stmt));
@@ -614,8 +597,8 @@ impl PostgresSQLQuery {
         'enqueue: {
             // Note: `connection_entry_value` is a *mut into connection.statements value slot;
             // holding a `&mut` across other &mut connection borrows below trips borrowck, so
-            // store the raw `*mut *mut PostgresSQLStatement` and re-dereference at use sites.
-            let mut connection_entry_value: Option<*mut *mut PostgresSQLStatement> = None;
+            // store the raw `*mut Option<StatementRef>` and re-dereference at use sites.
+            let mut connection_entry_value: Option<*mut Option<StatementRef>> = None;
             if !connection
                 .flags
                 .get()
@@ -628,26 +611,20 @@ impl PostgresSQLQuery {
                     .statements
                     .get()
                     .get(&signature.name[..])
-                    .copied();
-                if let Some(stmt_ptr) = existing_stmt {
-                    this.statement.set(Some(stmt_ptr));
+                    .and_then(|slot| slot.clone());
+                if let Some(existing_stmt) = existing_stmt {
+                    this.statement.set(Some(existing_stmt));
                     // Route the `&mut` through the audited `statement_mut()`
-                    // accessor (just set above ⇒ `Some`); `stmt_ptr` is kept
-                    // only for the explicit `deref(stmt_ptr)` cleanup below.
+                    // accessor (just set above ⇒ `Some`).
                     let stmt = this.statement_mut().expect("statement set above");
-                    stmt.ref_();
                     drop(signature);
 
                     match stmt.status {
                         StatementStatus::Failed => {
-                            this.statement.set(None);
                             // `error_response` is `Some` when status == Failed.
                             let error_response =
                                 stmt.error_response.as_ref().unwrap().to_js(global_object)?;
-                            // SAFETY: drop the ref we took above.
-                            unsafe { PostgresSQLStatement::deref(stmt_ptr) };
-                            // SAFETY: undoes the speculative `this.ref_()` above; count was ≥2, never frees here.
-                            unsafe { Self::deref(this_ptr) };
+                            release_query_ref();
                             return Err(global_object.throw_value(error_response));
                         }
                         StatementStatus::Prepared => {
@@ -704,7 +681,7 @@ impl PostgresSQLQuery {
                 // this block needs no further `&mut` to the map.
                 let entry_value_ptr = match connection.statements.with_mut(|s| {
                     s.get_or_put(&signature.name)
-                        .map(|e| std::ptr::from_mut::<*mut PostgresSQLStatement>(e.value_ptr))
+                        .map(|e| std::ptr::from_mut::<Option<StatementRef>>(e.value_ptr))
                 }) {
                     Ok(v) => v,
                     Err(err) => {
@@ -793,46 +770,26 @@ impl PostgresSQLQuery {
                 // advance() will send Parse+Describe+Bind+Execute atomically via
                 // parseAndBindAndExecute(), preventing PgBouncer from splitting them.
             }
-            {
-                // we only have connection_entry_value if we are using named prepared statements
-                if let Some(entry_value) = connection_entry_value {
-                    connection
-                        .prepared_statement_id
-                        .set(connection.prepared_statement_id.get() + 1);
-                    // ref_count starts at 2 (one for this.statement,
-                    // one for the connection.statements map).
-                    let stmt = {
-                        let mut s = PostgresSQLStatement::default();
-                        s.signature = signature;
-                        s.init_exact_refs(2);
-                        s.status = if did_write {
-                            StatementStatus::Parsing
-                        } else {
-                            StatementStatus::Pending
-                        };
-                        bun_core::heap::into_raw(Box::new(s))
-                    };
-                    this.statement.set(Some(stmt));
-
-                    // SAFETY: `entry_value` points into `connection.statements` and the map has
-                    // not been mutated since `get_or_put`. `get_or_put` runs only after the
-                    // existing-entry probe missed, so the slot it hands back was
-                    // default-initialised to null and a plain store is fine.
-                    unsafe { *entry_value = stmt };
+            let stmt = {
+                let mut s = PostgresSQLStatement::default();
+                s.signature = signature;
+                s.status = if did_write {
+                    StatementStatus::Parsing
                 } else {
-                    let stmt = {
-                        let mut s = PostgresSQLStatement::default();
-                        s.signature = signature;
-                        s.status = if did_write {
-                            StatementStatus::Parsing
-                        } else {
-                            StatementStatus::Pending
-                        };
-                        bun_core::heap::into_raw(Box::new(s))
-                    };
-                    this.statement.set(Some(stmt));
-                }
+                    StatementStatus::Pending
+                };
+                StatementRef::new(s)
+            };
+            // we only have connection_entry_value if we are using named prepared statements
+            if let Some(entry_value) = connection_entry_value {
+                connection
+                    .prepared_statement_id
+                    .set(connection.prepared_statement_id.get() + 1);
+                // SAFETY: `entry_value` points into `connection.statements` and the map has
+                // not been mutated since `get_or_put`.
+                unsafe { *entry_value = Some(stmt.clone()) };
             }
+            this.statement.set(Some(stmt));
         }
 
         if connection

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -1,4 +1,5 @@
 use core::cell::Cell;
+use core::ptr::NonNull;
 
 use crate::jsc::{JSGlobalObject, JSValue, JsResult};
 
@@ -7,6 +8,7 @@ use crate::postgres::signature::Signature;
 use crate::shared::cached_structure::CachedStructure as PostgresCachedStructure;
 use crate::shared::sql_data_cell::{Flags as DataCellFlags, dedupe_columns};
 
+use bun_ptr::CellRefCounted;
 use bun_sql::postgres::any_postgres_error::AnyPostgresError;
 use bun_sql::postgres::postgres_protocol as protocol;
 use bun_sql::postgres::postgres_types::int4;
@@ -19,8 +21,7 @@ bun_core::declare_scope!(Postgres, visible);
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLStatement {
     pub(crate) cached_structure: PostgresCachedStructure,
-    // Private — intrusive refcount invariant; reach via `ref_()`/`deref()` or
-    // [`Self::init_exact_refs`] at construction time.
+    // Private: every ref counted here is held by a `StatementRef`.
     ref_count: Cell<u32>,
     pub(crate) fields: Vec<protocol::FieldDescription>,
     pub(crate) parameters: Box<[int4]>,
@@ -49,6 +50,41 @@ impl Default for PostgresSQLStatement {
     }
 }
 
+/// One owned ref on a heap-allocated [`PostgresSQLStatement`]: `Clone` takes
+/// another ref, `Drop` releases it (freeing the statement with the last one).
+#[repr(transparent)]
+pub(crate) struct StatementRef(NonNull<PostgresSQLStatement>);
+
+impl StatementRef {
+    /// Adopts the ref that [`PostgresSQLStatement::default`] starts the count with.
+    #[inline]
+    pub(crate) fn new(statement: PostgresSQLStatement) -> Self {
+        debug_assert_eq!(statement.ref_count.get(), 1);
+        Self(bun_core::heap::alloc_nn(statement))
+    }
+
+    /// Live for as long as any `StatementRef` to this statement exists.
+    #[inline]
+    pub(crate) fn as_ptr(&self) -> *mut PostgresSQLStatement {
+        self.0.as_ptr()
+    }
+}
+
+impl Clone for StatementRef {
+    #[inline]
+    fn clone(&self) -> Self {
+        PostgresSQLStatement::ref_nn(self.0);
+        Self(self.0)
+    }
+}
+
+impl Drop for StatementRef {
+    #[inline]
+    fn drop(&mut self) {
+        PostgresSQLStatement::deref_nn(self.0);
+    }
+}
+
 pub enum Error {
     Protocol(protocol::ErrorResponse),
     PostgresError(AnyPostgresError),
@@ -72,17 +108,6 @@ impl Error {
 pub use bun_sql::shared::statement_status::Status;
 
 impl PostgresSQLStatement {
-    /// Set the initial intrusive
-    /// refcount at construction time, before any `ref_()`/`deref()`. The
-    /// `ref_count` field is private (refcount invariant), so callers building
-    /// a statement with >1 owner (query + connection-map entry) go through
-    /// this instead of writing the field directly.
-    #[inline]
-    pub(crate) fn init_exact_refs(&mut self, n: u32) {
-        debug_assert!(n > 0);
-        self.ref_count.set(n);
-    }
-
     pub(crate) fn check_for_duplicate_fields(&mut self) {
         if !self.needs_duplicate_check {
             return;


### PR DESCRIPTION
## What

`PostgresSQLStatement` derives `CellRefCounted`, but both of its holders stored bare pointers and balanced the count by hand. `PostgresSQLQuery.statement` was a `Cell<Option<*mut PostgresSQLStatement>>` and the connection's prepared statement map was a `StringHashMap<*mut PostgresSQLStatement>`, so `do_run` called `ref_()` on a map hit and `init_exact_refs(2)` when it created a named statement, and the matching `deref` calls were spread over `release_statement`, the failed-statement path of `do_run`, the `ErrorResponse` handler in `PostgresSQLConnection::on` and a loop in `PostgresSQLConnection::deinit`.

```rust
// before
pub(crate) statement: Cell<Option<*mut PostgresSQLStatement>>;        // PostgresSQLQuery
type PreparedStatementsMap = StringHashMap<*mut PostgresSQLStatement>; // PostgresSQLConnection

// after (PostgresSQLStatement.rs)
#[repr(transparent)]
pub(crate) struct StatementRef(NonNull<PostgresSQLStatement>);
impl StatementRef {
    pub(crate) fn new(statement: PostgresSQLStatement) -> Self; // adopts the count Default starts with
    pub(crate) fn as_ptr(&self) -> *mut PostgresSQLStatement;
}
impl Clone for StatementRef { .. PostgresSQLStatement::ref_nn(self.0) .. }
impl Drop for StatementRef { .. PostgresSQLStatement::deref_nn(self.0) .. }

statement: JsCell<Option<StatementRef>>;                            // PostgresSQLQuery, now private
type PreparedStatementsMap = StringHashMap<Option<StatementRef>>;  // None: slot reserved by get_or_put
```

The 3 creation sites in `do_run` call `StatementRef::new`; the named-statement branch stores `Some(stmt.clone())` into the reserved map slot instead of pre-counting with `init_exact_refs(2)`, which also makes its two creation blocks identical, so one remains. The map hit clones the entry out of the map and the failed-statement arm uses the same `release_query_ref` cleanup as the other error paths. Releases are now drops of the slots: `Drop for PostgresSQLQuery` no longer has a statement step, `release_query_ref` sets the field to `None`, the `ErrorResponse` handler just removes the map entry, and the loop in `deinit` is gone because dropping the map releases its refs. `release_statement` and `init_exact_refs` are deleted. The 7 readers in `PostgresSQLConnection` still go through `statement_mut()`, which keeps the one audited raw dereference and now reads it from the `StatementRef`. This removes 4 `unsafe` blocks and adds none; `StatementRef` itself is safe code on top of `heap::alloc_nn`, `ref_nn` and `deref_nn`.

The MySQL side stores its statement pointer in a different shape (`MySQLQuery.statement: *mut MySQLStatement`, no cell) and is left for a separate change.

## Why

Holding a `StatementRef` is now the same thing as owning one ref on the statement: a query or map slot cannot be dropped without releasing it, a second holder can only be made by `Clone`, and the map release in the `ErrorResponse` handler applies to whatever entry was actually removed instead of to the request's pointer. The refs the map held were previously released in the middle of `deinit`; they are now released when the `statements` field is dropped at the end of the same function, and nothing in between reads a statement. `StatementRef` is `repr(transparent)` over `NonNull`, so `Option<StatementRef>` is pointer sized: map values keep their size and `PostgresSQLQuery` shrinks by 8 bytes (`Option<*mut T>` had no niche). `Clone` and `Drop` compile to the increment and decrement the deleted calls made; the overwritten slots in `do_run` always hold `None`, so their drop glue is a never-taken discriminant test, and the only added work is one increment when a named statement is created, in place of `init_exact_refs(2)`.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/sql/postgres-error-then-datarow.test.ts test/js/sql/postgres-prepared-pipeline-reorder.test.ts test/js/sql/postgres-split-prepare-reorder.test.ts test/js/sql/sql-prepare-false.test.ts: 15 pass, 0 fail (15 tests across 4 files).
