### PR TITLE
test_runner: own extra and cloned entries as Vec<Box<..>>

### DIFF
--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -1,5 +1,6 @@
 //! take Collection phase output and convert to Execution phase input
 
+use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
 use bun_jsc::JsResult;
@@ -10,10 +11,9 @@ use super::execution::{ConcurrentGroup, ExecutionSequence};
 pub(crate) struct Order {
     pub(crate) groups: Vec<ConcurrentGroup>,
     pub(crate) sequences: Vec<ExecutionSequence>,
-    // The ExecutionEntry clones below are allocated via `heap::into_raw(Box::new(...))`;
-    // `BunTest` collects them into
-    // `cloned_hook_entries` after `generate_order_describe` and reclaims the Box
-    // headers (without running `Drop`) in `Drop for BunTest`.
+    // `Box` is load-bearing: `sequences` link these by address; `ManuallyDrop`: the originals own the copied fields.
+    #[expect(clippy::vec_box)]
+    pub(crate) cloned_hook_entries: Vec<Box<ManuallyDrop<ExecutionEntry>>>,
     pub(crate) previous_group_was_concurrent: bool,
     pub(crate) cfg: Config,
 }
@@ -23,6 +23,7 @@ impl Order {
         Order {
             groups: Vec::new(),
             sequences: Vec::new(),
+            cloned_hook_entries: Vec::new(),
             cfg,
             previous_group_was_concurrent: false,
         }
@@ -122,6 +123,14 @@ impl Order {
         Ok(())
     }
 
+    fn clone_hook_entry(&mut self, src: &ExecutionEntry) -> *mut ExecutionEntry {
+        // SAFETY: `src` is live; the copy is never dropped, so the fields it shares with `src` are released once.
+        let copy = Box::new(ManuallyDrop::new(unsafe { core::ptr::read(src) }));
+        self.cloned_hook_entries.push(copy);
+        let entry: &mut ExecutionEntry = self.cloned_hook_entries.last_mut().unwrap();
+        core::ptr::from_mut(entry)
+    }
+
     /// # Safety
     /// `current` must point to a live, uniquely-owned `ExecutionEntry` (Box-owned in
     /// `DescribeScope.entries`) with mutable provenance for the duration of this call. The
@@ -148,14 +157,7 @@ impl Order {
                 // prepend in reverse so they end up in forwards order
                 let mut i: usize = p.before_each.len();
                 while i > 0 {
-                    let src: *const ExecutionEntry = &raw const *p.before_each[i - 1];
-                    // Ownership: `BunTest` collects these clones into `cloned_hook_entries`
-                    // (the post-`generate_order_describe` walk) and frees only the Box
-                    // headers in `Drop for BunTest` — `Drop` must not run on the bitwise
-                    // copy or the originals' Strong/Box fields would be freed twice.
-                    // SAFETY: `src` is valid for reads; `Drop` never runs on the bitwise copy
-                    // (see ownership note above), so duplicated owning fields are not double-freed.
-                    let cloned = bun_core::heap::into_raw(Box::new(unsafe { core::ptr::read(src) }));
+                    let cloned = self.clone_hook_entry(&p.before_each[i - 1]);
                     list.prepend(cloned);
                     i -= 1;
                 }
@@ -173,10 +175,7 @@ impl Order {
                 // SAFETY: parent chain consists of live DescribeScope nodes.
                 let p = unsafe { &*p_ptr };
                 for entry in p.after_each.iter() {
-                    let src: *const ExecutionEntry = &raw const **entry;
-                    // SAFETY: `src` is valid for reads; `Drop` never runs on the bitwise copy
-                    // (see ownership note above), so duplicated owning fields are not double-freed.
-                    let cloned = bun_core::heap::into_raw(Box::new(unsafe { core::ptr::read(src) }));
+                    let cloned = self.clone_hook_entry(entry);
                     list.append(cloned);
                 }
                 parent = p.base.parent;

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 use std::cell::UnsafeCell;
 use std::rc::{Rc, Weak};
@@ -305,13 +306,13 @@ pub mod js_fns {
                         BaseScopeCfg::default(),
                         AddedInPhase::Execution,
                     );
-                    let new_item_ptr = bun_core::heap::into_raw(new_item);
-                    // SAFETY: append_point is a valid linked-list node; new_item_ptr just allocated
+                    bun_test.extra_execution_entries.push(new_item);
+                    let new_item = &mut **bun_test.extra_execution_entries.last_mut().unwrap();
+                    // SAFETY: append_point is a valid linked-list node; new_item is a different allocation
                     unsafe {
-                        (*new_item_ptr).next = (*append_point).next;
-                        (*append_point).next = Some(new_item_ptr);
+                        new_item.next = (*append_point).next;
+                        (*append_point).next = Some(core::ptr::from_mut(new_item));
                     }
-                    bun_test.extra_execution_entries.push(new_item_ptr);
 
                     Ok(JSValue::UNDEFINED)
                 }
@@ -643,10 +644,11 @@ pub struct BunTest {
     /// Whether tests in this file should default to concurrent execution
     pub(crate) default_concurrent: bool,
     pub(crate) first_last: FirstLast,
-    pub(crate) extra_execution_entries: Vec<*mut ExecutionEntry>,
-    /// Heap-boxed bitwise clones of hook entries from `Order::generate_order_test`.
-    /// Only the Box header may be freed in `Drop` — fields alias `DescribeScope` originals.
-    pub(crate) cloned_hook_entries: Vec<*mut ExecutionEntry>,
+    // `Box` is load-bearing: `execution` links these by address (`ManuallyDrop`: see `Order`).
+    #[expect(clippy::vec_box)]
+    pub(crate) extra_execution_entries: Vec<Box<ExecutionEntry>>,
+    #[expect(clippy::vec_box)]
+    pub(crate) cloned_hook_entries: Vec<Box<ManuallyDrop<ExecutionEntry>>>,
     pub(crate) wants_wakeup: bool,
 
     pub(crate) phase: Phase,
@@ -1074,28 +1076,7 @@ impl BunTest {
                 } else {
                     Order::AllOrderResult::EMPTY
                 };
-                let describe_seq_start = order.sequences.len();
                 order.generate_order_describe(&mut self.collection.root_scope)?;
-                let describe_seq_end = order.sequences.len();
-                // Collect hook-entry clones boxed by `generate_order_test` so `Drop` can
-                // reclaim the Box headers. Must run before `extra_execution_entries` are
-                // spliced into the same chains, or the walk would double-free `DescribeScope`
-                // entries.
-                debug_assert!(
-                    self.extra_execution_entries.is_empty(),
-                    "extra_execution_entries must be spliced after the cloned-hook walk"
-                );
-                for seq in &order.sequences[describe_seq_start..describe_seq_end] {
-                    let Some(test_entry) = seq.test_entry else { continue };
-                    let mut cur = seq.first_entry;
-                    while let Some(p) = cur {
-                        if p != test_entry {
-                            self.cloned_hook_entries.push(p.as_ptr());
-                        }
-                        // SAFETY: live linked-list nodes built by `generate_order_test`.
-                        cur = unsafe { p.as_ref() }.next.and_then(NonNull::new);
-                    }
-                }
                 beforeall_order.set_failure_skip_to(&mut order);
                 let afterall_order: Order::AllOrderResult = if self.first_last.last {
                     order.generate_all_order(&root.hook_scope.after_all)?
@@ -1105,6 +1086,7 @@ impl BunTest {
                 afterall_order.set_failure_skip_to(&mut order);
 
                 self.execution.load_from_order(&mut order);
+                self.cloned_hook_entries = order.cloned_hook_entries;
                 debug::dump_order(&self.execution)?;
                 Ok(Advance::Cont)
             }
@@ -1376,16 +1358,6 @@ impl Drop for BunTest {
         if self.timer.state == EventLoopTimerState::ACTIVE {
             // must remove an active timer to prevent UAF (if the timer were to trigger after BunTest deinit)
             vm_timer().remove(&raw mut self.timer);
-        }
-
-        for entry in self.extra_execution_entries.drain(..) {
-            // SAFETY: entries were heap-allocated in generic_hook; we own them
-            unsafe { drop(bun_core::heap::take(entry)); }
-        }
-        for entry in self.cloned_hook_entries.drain(..) {
-            // Reclaim only the Box header — fields alias the `DescribeScope` originals.
-            // SAFETY: heap-boxed by `Order::generate_order_test`; same layout as `ManuallyDrop`.
-            let _ = unsafe { Box::from_raw(entry.cast::<core::mem::ManuallyDrop<ExecutionEntry>>()) };
         }
         // execution, collection, result_queue: dropped automatically
     }


### PR DESCRIPTION
## What

`BunTest` holds two kinds of `ExecutionEntry` that are not owned by the describe tree: the entries spliced into a running sequence by `afterAll` / `afterEach` / `onTestFinished` called from inside a test (`extra_execution_entries`), and the per-test bitwise copies of `beforeEach` / `afterEach` hooks that `Order::generate_order_test` links into each sequence (`cloned_hook_entries`). Both were stored as `Vec<*mut ExecutionEntry>`. The copies were boxed in `Order.rs` and only their raw pointer was kept, so `BunTest::advance` rediscovered them afterwards by walking the `next` chain of every sequence and collecting each node that was not the sequence's `test_entry` (guarded by a `debug_assert!` that no extra entry had been spliced in yet), and `Drop for BunTest` freed the two lists by hand: `heap::take` for the extras and `Box::from_raw` with a cast to `ManuallyDrop` for the copies, since their `name` / `callback` fields alias the originals in the `DescribeScope`.

```rust
// before
pub(crate) extra_execution_entries: Vec<*mut ExecutionEntry>,   // BunTest
pub(crate) cloned_hook_entries: Vec<*mut ExecutionEntry>,       // BunTest, filled by the chain walk

let cloned = bun_core::heap::into_raw(Box::new(unsafe { core::ptr::read(src) }));  // Order.rs, twice

// after
pub(crate) cloned_hook_entries: Vec<Box<ManuallyDrop<ExecutionEntry>>>,  // Order, filled by clone_hook_entry
pub(crate) extra_execution_entries: Vec<Box<ExecutionEntry>>,            // BunTest
pub(crate) cloned_hook_entries: Vec<Box<ManuallyDrop<ExecutionEntry>>>,  // BunTest, moved out of Order

self.execution.load_from_order(&mut order);
self.cloned_hook_entries = order.cloned_hook_entries;
```

`Order` gains `clone_hook_entry`, which pushes the copy and returns the pointer derived from the box once it is in the `Vec`; the two clone loops in `generate_order_test` call it. `generic_hook_impl` pushes the `Box` returned by `ExecutionEntry::create` and links the entry through `last_mut()`, so only the two writes through `append_point` remain `unsafe`. The chain walk in `advance`, its `debug_assert!`, and both loops in `Drop for BunTest` are deleted; the two `Vec` fields are declared before `collection` and `execution`, so field-order drop releases them at the same point the explicit loops did. The ownership protocol comments in `Order.rs` and on the `BunTest` fields go with the code they described. Net result: 4 `unsafe` blocks removed (5 deleted, 1 added in `clone_hook_entry`), 2 files, 27 insertions and 56 deletions.

## Why

Who frees each entry, and whether its fields are dropped, is now stated by the element types: `Box<ExecutionEntry>` for entries `BunTest` fully owns, `Box<ManuallyDrop<ExecutionEntry>>` for copies whose fields belong to the originals, and the copies are owned from the moment they are made instead of being recovered from the intrusive list. `Box<T>` and `Box<ManuallyDrop<T>>` are single pointers like the `*mut T` they replace, so both `Vec`s have the same layout; `Box::new(ManuallyDrop::new(..))` is the same single allocation as before; dropping the `Vec`s performs exactly the frees the deleted loops performed; and the per-file walk over every sequence chain is gone.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/test/jest-hooks.test.ts test/js/bun/test/test-on-test-finished.test.ts test/js/bun/test/test-retry-repeats-basic.test.ts test/js/bun/test/bun_test.test.ts`: 35 pass, 0 fail, 1 todo (36 tests across 4 files).
