### PR TITLE
node:http2: add setNextStreamID to server sessions

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2082,6 +2082,16 @@ class Http2Session extends EventEmitter {
   // run inside it so 'close' doesn't inherit the last stream's frame.
   [bunHTTP2AsyncContextFrame] = $getInternalField($asyncContext, 0);
   [kDeferWriteCallback] = setImmediate;
+  // Defined on the base class like node's, so a server session has it too (there it picks the
+  // id of the next pushed stream):
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1423
+  setNextStreamID(id) {
+    if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();
+
+    validateNumber(id, "id");
+    if (id <= 0 || id > kMaxStreams) throw $ERR_OUT_OF_RANGE("id", `> 0 and <= ${kMaxStreams}`, id);
+    this[bunHTTP2Native]?.setNextStreamID(id);
+  }
   [EventEmitter.captureRejectionSymbol](err, event, ...args) {
     switch (event) {
       case "stream": {
@@ -5675,13 +5685,6 @@ class ClientHttp2Session extends Http2Session {
   ref() {
     const socket = this[bunHTTP2Socket];
     if (typeof socket?.ref === "function") return socket.ref();
-  }
-  setNextStreamID(id) {
-    if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();
-
-    validateNumber(id, "id");
-    if (id <= 0 || id > kMaxStreams) throw $ERR_OUT_OF_RANGE("id", `> 0 and <= ${kMaxStreams}`, id);
-    this.#parser?.setNextStreamID(id);
   }
   setTimeout(msecs, callback) {
     // node's setStreamTimeout: the session owns its own unref'd idle timer under kTimeout

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2082,8 +2082,7 @@ class Http2Session extends EventEmitter {
   // run inside it so 'close' doesn't inherit the last stream's frame.
   [bunHTTP2AsyncContextFrame] = $getInternalField($asyncContext, 0);
   [kDeferWriteCallback] = setImmediate;
-  // Defined on the base class like node's, so a server session has it too (there it picks the
-  // id of the next pushed stream):
+  // Shared by both session types, as in node:
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1423
   setNextStreamID(id) {
     if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2082,7 +2082,6 @@ class Http2Session extends EventEmitter {
   // run inside it so 'close' doesn't inherit the last stream's frame.
   [bunHTTP2AsyncContextFrame] = $getInternalField($asyncContext, 0);
   [kDeferWriteCallback] = setImmediate;
-  // Shared by both session types, as in node:
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1423
   setNextStreamID(id) {
     if (this.destroyed) throw $ERR_HTTP2_INVALID_SESSION();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2539,6 +2539,144 @@ it("http2 client.setNextStreamID validates input", async () => {
   });
 });
 
+// node defines setNextStreamID on Http2Session, so a server session has it as well: there it
+// chooses the id of the next pushed stream.
+it("http2 server session setNextStreamID picks the id of the next pushed stream", async () => {
+  const serverSide = {};
+  const { promise: serverDone, resolve: onServerDone, reject: onServerError } = Promise.withResolvers();
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    const { session } = stream;
+    try {
+      serverSide.beforeSet = session.state.nextStreamID;
+      session.setNextStreamID(100);
+      serverSide.afterSet = session.state.nextStreamID;
+    } catch (err) {
+      onServerError(err);
+      stream.respond({ ":status": 500 });
+      stream.end();
+      return;
+    }
+    stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
+      if (err) {
+        onServerError(err);
+        stream.destroy(err);
+        return;
+      }
+      serverSide.pushedId = pushed.id;
+      serverSide.afterPush = session.state.nextStreamID;
+      pushed.respond({ ":status": 200 });
+      pushed.end("pushed");
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+      onServerDone();
+    });
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  try {
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    client.on("error", () => {});
+    const { promise: pushed, resolve: onPushed, reject: onClientError } = Promise.withResolvers();
+    client.on("stream", (pushStream, headers) => {
+      pushStream.on("error", onClientError);
+      pushStream.setEncoding("utf8");
+      let body = "";
+      pushStream.on("data", chunk => (body += chunk));
+      pushStream.on("end", () => onPushed({ id: pushStream.id, path: headers[":path"], body }));
+    });
+    const { promise: response, resolve: onResponse } = Promise.withResolvers();
+    const req = client.request({ ":path": "/" });
+    req.on("error", onClientError);
+    req.setEncoding("utf8");
+    let responseBody = "";
+    req.on("data", chunk => (responseBody += chunk));
+    req.on("end", () => onResponse(responseBody));
+
+    await serverDone;
+    expect(serverSide).toEqual({ beforeSet: 2, afterSet: 100, pushedId: 100, afterPush: 102 });
+    expect(await pushed).toEqual({ id: 100, path: "/pushed", body: "pushed" });
+    expect(await response).toBe("ok");
+    client.close();
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 server session setNextStreamID validates its argument like the client", async () => {
+  const { promise: observed, resolve: onObserved, reject: onUnexpected } = Promise.withResolvers();
+  const server = http2.createServer();
+  server.on("session", session => {
+    const thrownBy = fn => {
+      try {
+        fn();
+        return "did not throw";
+      } catch (err) {
+        return { name: err.name, code: err.code, message: err.message };
+      }
+    };
+    try {
+      const initial = session.state.nextStreamID;
+      const errors = {
+        zero: thrownBy(() => session.setNextStreamID(0)),
+        negative: thrownBy(() => session.setNextStreamID(-1)),
+        tooLarge: thrownBy(() => session.setNextStreamID(2 ** 32)),
+        string: thrownBy(() => session.setNextStreamID("1")),
+        missing: thrownBy(() => session.setNextStreamID()),
+      };
+      const afterRejectedCalls = session.state.nextStreamID;
+      session.destroy();
+      onObserved({
+        initial,
+        errors,
+        afterRejectedCalls,
+        destroyed: thrownBy(() => session.setNextStreamID(2)),
+        // The destroyed check runs before argument validation, as it does on a client session.
+        destroyedMissing: thrownBy(() => session.setNextStreamID()),
+      });
+    } catch (err) {
+      onUnexpected(err);
+    }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  client.on("error", () => {});
+  try {
+    const outOfRange = received => ({
+      name: "RangeError",
+      code: "ERR_OUT_OF_RANGE",
+      message: `The value of "id" is out of range. It must be > 0 and <= 4294967295. Received ${received}`,
+    });
+    const invalidType = received => ({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "id" argument must be of type number. Received ${received}`,
+    });
+    const invalidSession = {
+      name: "Error",
+      code: "ERR_HTTP2_INVALID_SESSION",
+      message: "The session has been destroyed",
+    };
+    expect(await observed).toEqual({
+      initial: 2,
+      errors: {
+        zero: outOfRange("0"),
+        negative: outOfRange("-1"),
+        tooLarge: outOfRange("4294967296"),
+        string: invalidType("type string ('1')"),
+        missing: invalidType("undefined"),
+      },
+      afterRejectedCalls: 2,
+      destroyed: invalidSession,
+      destroyedMissing: invalidSession,
+    });
+  } finally {
+    client.destroy();
+    server.close();
+  }
+});
+
 it("http2 request.destroy() with error", async () => {
   const server = http2.createServer();
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2574,10 +2574,10 @@ it("http2 server session setNextStreamID picks the id of the next pushed stream"
   });
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
 
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
   try {
-    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
-    client.on("error", () => {});
     const { promise: pushed, resolve: onPushed, reject: onClientError } = Promise.withResolvers();
+    client.on("error", onClientError);
     client.on("stream", (pushStream, headers) => {
       pushStream.on("error", onClientError);
       pushStream.setEncoding("utf8");
@@ -2593,12 +2593,13 @@ it("http2 server session setNextStreamID picks the id of the next pushed stream"
     req.on("data", chunk => (responseBody += chunk));
     req.on("end", () => onResponse(responseBody));
 
-    await serverDone;
+    // Promise.all: an error on either side fails the test right away instead of stalling it.
+    const [, pushedStream, body] = await Promise.all([serverDone, pushed, response]);
     expect(serverSide).toEqual({ beforeSet: 2, afterSet: 100, pushedId: 100, afterPush: 102 });
-    expect(await pushed).toEqual({ id: 100, path: "/pushed", body: "pushed" });
-    expect(await response).toBe("ok");
-    client.close();
+    expect(pushedStream).toEqual({ id: 100, path: "/pushed", body: "pushed" });
+    expect(body).toBe("ok");
   } finally {
+    client.destroy();
     server.close();
   }
 });
@@ -2641,7 +2642,7 @@ it("http2 server session setNextStreamID validates its argument like the client"
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
 
   const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
-  client.on("error", () => {});
+  client.on("error", onUnexpected);
   try {
     const outOfRange = received => ({
       name: "RangeError",


### PR DESCRIPTION
### Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("stream", stream => {
  const { session } = stream;
  session.setNextStreamID(10);
  console.log("nextStreamID =", session.state.nextStreamID);
  stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
    console.log("pushed stream id =", pushed.id);
    pushed.respond({ ":status": 200 }); pushed.end();
    stream.respond({ ":status": 200 }); stream.end();
  });
});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("stream", pushed => pushed.resume());
  const req = client.request({ ":path": "/" });
  req.resume();
  req.on("close", () => { client.close(); server.close(); });
});
```

Node v26.3.0:

```
nextStreamID = 10
pushed stream id = 10
```

Bun 1.4.0 (and main):

```
TypeError: session.setNextStreamID is not a function.
```

### Cause

Node defines `setNextStreamID` once on `Http2Session` ([core.js#L1423](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1423)), so both `ClientHttp2Session` and `ServerHttp2Session` have it; on a server it sets the id used by the next `pushStream()`. Bun's copy of the method lived only on `ClientHttp2Session`, so server sessions (the object handed to the server's `session` event and `stream.session`) had nothing to call.

### Fix

Move the method to the shared `Http2Session` base class in `src/js/node/http2.ts`. The body is the existing client implementation unchanged (destroyed check, `validateNumber`, the `> 0 and <= 4294967295` range check, then the native setter), except that it reaches the parser through the `[bunHTTP2Native]` getter both subclasses already define instead of the client's private `#parser` field. The native side, `H2FrameParser::set_next_stream_id`, already has a server branch; `getNextStream()` (which `pushStream()` uses to allocate the promised stream) reads the id it stores, so the only missing piece was the JS method.

Two things this PR deliberately leaves as they are:

- `setNextStreamID(2 ** 32 - 1)` on a server, or a fractional id below 1 on either side, reaches the native stream id arithmetic that #37542 makes saturating (and that #37553 stops reaching at all); the client method has exposed the same arithmetic all along. The tests here stay away from those values, so this is independent of the order these land in, but one of those two is what makes such inputs well behaved on debug builds.
- nghttp2 (and therefore node) silently ignores an id with the wrong parity for the side or one lower than the current next id, while Bun's native setter rounds the parity and allows moving backwards. That is pre-existing behavior shared with the client method, unchanged here and fixed natively in #37553; the assertions below only use values on which both agree (checked against node v26.3.0).

### Verification

Two tests added next to `http2 client.setNextStreamID validates input` in `test/js/node/http2/node-http2.test.js`:

- `http2 server session setNextStreamID picks the id of the next pushed stream`: from the server's `stream` handler, `state.nextStreamID` goes 2 -> 100 after `setNextStreamID(100)`, the pushed stream gets id 100, `state.nextStreamID` is 102 afterwards, and the client receives the push (and its body) on stream 100. The expected values are what node prints for the same sequence.
- `http2 server session setNextStreamID validates its argument like the client`: on the session from the server's `session` event, 0 / -1 / 2 ** 32 throw `RangeError` `ERR_OUT_OF_RANGE`, a string or a missing argument throw `TypeError` `ERR_INVALID_ARG_TYPE` (exact node messages), the rejected calls leave `state.nextStreamID` alone, and after `destroy()` both `setNextStreamID(2)` and `setNextStreamID()` throw `ERR_HTTP2_INVALID_SESSION` (destroyed check first, as on the client).

Both fail on the released binary with `session.setNextStreamID is not a function` and pass with this change. The whole file (349 tests) still passes, as do the ported client-side node tests that cover the moved implementation: `test-http2-client-setNextStreamID-errors.js`, `test-http2-no-more-streams.js` (functional use of the client method), and `test-http2-client-destroy.js` (destroyed-session ordering). Upstream node v26.3.0 has no server-side test for this method (only `test-http2-client-setNextStreamID-errors.js`, already ported), hence the hand-written tests.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (9bece839b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [832.08ms]
(pass) node none > Client Basics > should be able to send a POST request [549.30ms]
(pass) node none > Client Basics > constants [18.50ms]
(pass) node none > Client Basics > getDefaultSettings [7.24ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.78ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.49ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.48ms]
(pass) node none > Client Basics > should be able to send data using end [580.31ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [570.62ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 2 failed, 6 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.00ms]
(pass) node none > Client Basics > getDefaultSettings [0.19ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.49ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > is possible to abort request [2.02ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.84ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.83ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.20ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [41.62ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (9bece839b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [885.46ms]
(pass) node none > Client Basics > should be able to send a POST request [603.70ms]
(pass) node none > Client Basics > constants [19.66ms]
(pass) node none > Client Basics > getDefaultSettings [8.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [24.50ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [6.42ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.48ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.58ms]
(pass) node none > Client Basics > should be able to send data using end [641.79ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [632.21ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9bece839bb
  features     baseline

22 deps, 107 codegen, 1176 objects in 1012ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [23.00ms]
[3/1238] gen bindgenv2
[4/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch picohttpparser
[picohttpparser] up to date
[7/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [6.00ms]
[8/1237] fetch zlib
[zlib] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  |  15 ++--
 test/js/node/http2/node-http2.test.js | 139 ++++++++++++++++++++++++++++++++++
 2 files changed, 147 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       9      4      0
test/js/node/http2/node-http2.test.js      4      3      0
```

</details>

<!-- robobun:evidence:end -->