### PR TITLE
node:http2: add the server getter to ServerHttp2Session

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4683,6 +4683,12 @@ class ServerHttp2Session extends Http2Session {
     process.nextTick(emitConnectNT, this, socket);
   }
 
+  // undefined for performServerHandshake() sessions; node never clears it, not even on destroy().
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (ServerHttp2Session#server)
+  get server() {
+    return this[kServer];
+  }
+
   get originSet() {
     if (this.encrypted) {
       return Array.from(initOriginSet(this));

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4423,6 +4423,68 @@ it("remoteSettings/localSettings are never null before the peer's SETTINGS arriv
   }
 });
 
+// node's ServerHttp2Session exposes the Http2Server/Http2SecureServer that accepted the connection
+// as a `server` getter on its prototype (still set after the session is destroyed);
+// performServerHandshake() sessions have no owning server and ClientHttp2Session has no such
+// property at all. Bun had no getter, so `session.server` was undefined everywhere.
+describe.concurrent("ServerHttp2Session.server", () => {
+  async function acceptOneSession(server, scheme, connectOptions) {
+    const accepted = Promise.withResolvers();
+    server.on("session", accepted.resolve);
+    server.on("error", accepted.reject);
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`${scheme}://127.0.0.1:${server.address().port}`, connectOptions);
+    client.on("error", accepted.reject);
+    try {
+      const session = await accepted.promise;
+      expect(session.server).toBe(server);
+      // node's shape: an accessor on the prototype, not an own property written by the constructor.
+      expect(Object.hasOwn(session, "server")).toBe(false);
+      const { get, set, enumerable, configurable } = Object.getOwnPropertyDescriptor(
+        Object.getPrototypeOf(session),
+        "server",
+      );
+      expect({ get: typeof get, set, enumerable, configurable }).toEqual({
+        get: "function",
+        set: undefined,
+        enumerable: false,
+        configurable: true,
+      });
+      // The client side never gets one.
+      expect("server" in client).toBe(false);
+
+      const closed = new Promise(resolve => session.once("close", resolve));
+      session.destroy();
+      await closed;
+      expect(session.destroyed).toBe(true);
+      expect(session.server).toBe(server);
+    } finally {
+      client.destroy();
+      await new Promise(resolve => server.close(resolve));
+    }
+  }
+
+  it("is the Http2Server that accepted the connection", async () => {
+    await acceptOneSession(http2.createServer(), "http");
+  });
+
+  it("is the Http2SecureServer that accepted the connection", async () => {
+    await acceptOneSession(http2.createSecureServer(TLS_CERT), "https", TLS_OPTIONS);
+  });
+
+  it("is undefined for a performServerHandshake() session", () => {
+    const [clientSide, serverSide] = duplexPair();
+    const session = http2.performServerHandshake(serverSide);
+    try {
+      expect("server" in session).toBe(true);
+      expect(session.server).toBeUndefined();
+    } finally {
+      session.destroy();
+      clientSide.destroy();
+    }
+  });
+});
+
 describe("frames issued from inside a user-supplied Duplex transport's _write", () => {
   // A transport wrapper that sends a frame of its own from its _write (a keepalive ping, a
   // settings update, a goaway, another request) must see that frame sequenced AFTER the unit


### PR DESCRIPTION
### Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("session", s => {
  console.log(s.server === server ? "true" : typeof s.server);
  s.destroy();
  server.close();
});
server.listen(0, "127.0.0.1", () => {
  http2.connect(`http://127.0.0.1:${server.address().port}`).on("error", () => {});
});
```

Node v26.3.0 prints `true`. Bun 1.4.0 (and main) prints `undefined`. The same holds for `createSecureServer()` sessions and for `stream.session.server` inside a `stream` handler.

### Cause

Node's `ServerHttp2Session` has a `server` getter returning the `Http2Server` / `Http2SecureServer` that accepted the connection ([core.js, `ServerHttp2Session`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js), `get server() { return this[kServer]; }`; `@types/node` declares it as `readonly server`). Bun's `ServerHttp2Session` constructor already stores the server under `kServer` (and `destroy()`, `sessionOnError` and the `stream` dispatch read it back), but nothing exposed it, so the property fell through to `undefined`.

### Fix

Add `get server() { return this[kServer]; }` to `ServerHttp2Session` in `src/js/node/http2.ts`. That is the whole change to `src/`; the surrounding behavior already matched node:

- `connectionListener` (plain, TLS, and the raw-socket upgrade path) constructs the session with the owning server, so the getter returns it for every accepted session.
- `performServerHandshake()` constructs it with `undefined`, which is what node returns there too.
- `destroy()` does not clear `kServer`; node's `cleanupSession` does not either, so `session.server` stays readable after the session is gone, as in node.
- `ClientHttp2Session` is untouched: node's client sessions have no `server` property.

The getter lives on the prototype like node's, so the observable shape (non-enumerable accessor, no setter, not an own property) is the same as node's. Checked by running the assertions below against node v26.3.0.

### Verification

New `ServerHttp2Session.server` block in `test/js/node/http2/node-http2.test.js`:

- `is the Http2Server that accepted the connection` and `is the Http2SecureServer that accepted the connection`: `session.server` is the server by identity, the property is a prototype accessor with node's attributes, the client session has no `server` property, and the value is still the server after `session.destroy()`.
- `is undefined for a performServerHandshake() session`: `"server" in session` is true and the value is `undefined`.

All three fail on the released binary (`Received: undefined` / `"server" in session` is false) and pass with this change. The whole file (350 tests) still passes, as do the ported `test-http2-perform-server-handshake.js`, `test-http2-server-sessionerror.js`, `test-http2-server-session-destroy.js`, `test-http2-server-timeout.js` and `test-http2-createsecureserver-options.js`. Upstream node has no test that reads `session.server`, hence the hand-written tests.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (6644415eb)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [843.30ms]
(pass) node none > Client Basics > should be able to send a POST request [551.47ms]
(pass) node none > Client Basics > constants [18.40ms]
(pass) node none > Client Basics > getDefaultSettings [7.02ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.06ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.13ms]
(pass) node none > Client Basics > should be able to send data using end [580.12ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [571.28ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 3 failed, 6 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.05ms]
(pass) node none > Client Basics > getDefaultSettings [0.17ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.38ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.73ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.70ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.65ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.34ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [33.32ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (6644415eb)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [843.15ms]
(pass) node none > Client Basics > should be able to send a POST request [565.56ms]
(pass) node none > Client Basics > constants [18.78ms]
(pass) node none > Client Basics > getDefaultSettings [7.23ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.74ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.35ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.25ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.18ms]
(pass) node none > Client Basics > should be able to send data using end [594.79ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [584.81ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6644415eb5
  features     baseline

22 deps, 107 codegen, 1176 objects in 966ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [12.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1238] gen bindgenv2
[5/1238] fetch picohttpparser
[picohttpparser] up to date
[6/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[7/1238] fetch zlib
[zlib] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  |  6 ++++
 test/js/node/http2/node-http2.test.js | 62 +++++++++++++++++++++++++++++++++++
 2 files changed, 68 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       9      2      0
test/js/node/http2/node-http2.test.js      2      4      0
```

</details>

**self-review** · no surviving concerns

12 concerns were raised and did not survive verification.

**root cause** · written by the author bot

Bun's ServerHttp2Session stored the owning Http2Server or Http2SecureServer in its internal kServer slot at construction but never exposed it publicly, so session.server evaluated to undefined where node returns the server that accepted the connection. The fix adds a server getter to ServerHttp2Session that returns that stored value, so sessions created by createServer and createSecureServer report their server while sessions created by performServerHandshake still return undefined, matching node. ClientHttp2Session is deliberately left without the getter because node's client sessions do n…

<!-- robobun:evidence:end -->