### PR TITLE
fetch: hold the AbortSignal as Option<AbortSignalRef>, drop SignalRef

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -55,7 +55,7 @@ use bun_core::{String as BunString, Tag as BunStringTag, ZigStringSlice};
 use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
-use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
+use bun_jsc::{AbortSignalRef, HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
 use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
@@ -114,27 +114,6 @@ pub(crate) fn s3_credentials_from_env(
         env.session_token.clone(),
         env.insecure_http,
     )
-}
-
-/// RAII guard for the `+1` `AbortSignal` ref taken in `extract_signal`,
-/// released on every exit path. `take()` disarms the guard when ownership is
-/// handed to `FetchOptions`.
-struct SignalRef(Option<NonNull<AbortSignal>>);
-impl SignalRef {
-    #[inline]
-    fn take(&mut self) -> Option<*mut AbortSignal> {
-        self.0.take().map(|p| p.as_ptr())
-    }
-}
-impl Drop for SignalRef {
-    fn drop(&mut self) {
-        if let Some(sig) = self.0.take() {
-            // `sig` was obtained from `AbortSignal::ref_()` which bumped the
-            // C++ intrusive refcount; the pointee outlives this `BackRef`
-            // until `unref()` releases that +1.
-            bun_ptr::BackRef::from(sig).unref();
-        }
-    }
 }
 
 /// RAII guard for the `+1` `FetchHeaders` ref returned by
@@ -441,10 +420,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     let mut proxy: Option<ZigURL> = None;
     let mut redirect_type: FetchRedirect = FetchRedirect::Follow;
-    // AbortSignal is intrusive-refcounted; the +1 from `ref_()` is released by
-    // `SignalRef`'s Drop on every early-return path, and disarmed via `take()`
-    // when ownership is moved into `FetchOptions`.
-    let mut signal = SignalRef(None);
     // Custom Hostname
     let mut hostname: Option<Box<[u8]>> = None;
     let mut range: Option<bun_core::ZBox> = None;
@@ -470,8 +445,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     let mut check_server_identity: JSValue = JSValue::ZERO;
 
     // signal/unix_socket_path/url_proxy_buffer/headers/body/hostname/range/
-    // ssl_config are all owning types whose Drop runs on early return
-    // (`signal` via `SignalRef`).
+    // ssl_config are all owning types whose Drop runs on early return.
 
     let options_object: Option<JSValue> = 'brk: {
         if let Some(options) = args.next_eat() {
@@ -1128,16 +1102,14 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // WebIDL `AbortSignal?` member: present iff not undefined. A present `null`
     // detaches (no fallback to the input Request's signal); a present non-null
     // non-AbortSignal is a TypeError.
-    signal.0 = 'extract_signal: {
+    let signal: Option<AbortSignalRef> = 'extract_signal: {
         if let Some(options) = options_object {
             if let Some(signal_) = options.get(global_this, "signal")? {
                 if signal_.is_null() {
                     break 'extract_signal None;
                 }
-                if let Some(signal__) = AbortSignal::from_js(signal_) {
-                    // `AbortSignal` is an opaque ZST FFI handle (S008) — safe
-                    // `*mut → &` via `opaque_deref`; `ref_` bumps refcount.
-                    break 'extract_signal NonNull::new(bun_opaque::opaque_deref(signal__).ref_());
+                if let Some(signal_ref) = AbortSignal::ref_from_js(signal_) {
+                    break 'extract_signal Some(signal_ref);
                 }
                 let err = ctx.to_type_error(
                     jsc::ErrorCode::INVALID_ARG_TYPE,
@@ -1157,10 +1129,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
 
         if let Some(req) = request_mut!() {
-            if let Some(signal_) = req.abort_signal() {
-                break 'extract_signal NonNull::new(signal_.ref_());
-            }
-            break 'extract_signal None;
+            break 'extract_signal req.abort_signal().cloned();
         }
 
         if let Some(options) = request_init_object {
@@ -1168,10 +1137,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 if signal_.is_null() {
                     break 'extract_signal None;
                 }
-                if let Some(signal__) = AbortSignal::from_js(signal_) {
-                    // `AbortSignal` is an opaque ZST FFI handle (S008) — safe
-                    // `*mut → &` via `opaque_deref`; `ref_` bumps refcount.
-                    break 'extract_signal NonNull::new(bun_opaque::opaque_deref(signal__).ref_());
+                if let Some(signal_ref) = AbortSignal::ref_from_js(signal_) {
+                    break 'extract_signal Some(signal_ref);
                 }
                 let err = ctx.to_type_error(
                     jsc::ErrorCode::INVALID_ARG_TYPE,
@@ -1621,8 +1588,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     // Fetch spec step 11: reject synchronously for a pre-aborted signal. Runs
     // after body/header extraction so Request-constructor errors (GET+body,
     // already-used body) win and `request.bodyUsed` is set, matching Node.
-    if let Some(sig) = signal.0 {
-        let sig = bun_ptr::BackRef::from(sig);
+    if let Some(sig) = &signal {
         if sig.aborted() {
             let reason = sig.js_reason(global_this);
             if let HTTPRequestBody::ReadableStream(stream_ref) = &body {
@@ -2081,7 +2047,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         proxy: proxy_static,
         proxy_headers: proxy_headers.take(),
         url_proxy_buffer: url_proxy_boxed,
-        signal: signal.take(),
+        signal,
         global_this: Some(global_this.into()),
         ssl_config: ssl_config.take(),
         hostname: hostname.take(),

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -19,7 +19,8 @@ use bun_io::KeepAlive;
 use bun_jsc::debugger::AsyncTaskTracker;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
-    self as jsc, GlobalRef, JSGlobalObject, JSValue, JsResult, StringJsc, StrongOptional,
+    self as jsc, AbortSignalRef, GlobalRef, JSGlobalObject, JSValue, JsResult, StringJsc,
+    StrongOptional,
 };
 use bun_sys::FdExt;
 use bun_threading::Mutex;
@@ -128,10 +129,7 @@ pub struct FetchTasklet {
     /// We always clone url and proxy (if informed)
     pub(crate) url_proxy_buffer: Box<[u8]>,
 
-    // WebCore::AbortSignal is C++-refcounted (intrusive). Model as
-    // raw ptr; ref/unref via `bun_jsc::AbortSignal`
-    // methods (see clear_abort_signal / queue).
-    pub(crate) signal: Option<*mut AbortSignal>,
+    pub(crate) signal: Option<AbortSignalRef>,
     pub(crate) signals: Signals,
     pub(crate) signal_store: http::signals::Store,
     pub(crate) has_schedule_callback: AtomicBool,
@@ -289,7 +287,7 @@ impl HTTPRequestBody {
 impl FetchTasklet {
     // ───── raw-ptr field accessors (centralised unsafe) ───────────────────
     //
-    // `signal` / `sink` / `native_response` are intrusive-refcounted heap
+    // `sink` / `native_response` are intrusive-refcounted heap
     // objects that this tasklet holds one strong ref on while the field is
     // `Some`. They are never reborrowed through any other path on the JS
     // thread, so a single `&` / `&mut` derived here is the sole live borrow.
@@ -355,13 +353,9 @@ impl FetchTasklet {
         }
     }
 
-    /// `Some(&AbortSignal)` while we hold a strong ref on the C++-owned
-    /// `WebCore::AbortSignal*` (taken in `queue`, released in
-    /// `clear_abort_signal`).
     #[inline]
     fn abort_signal(&self) -> Option<&AbortSignal> {
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST handle — safe `*const → &`.
-        self.signal.map(|p| bun_opaque::opaque_deref(p))
+        self.signal.as_deref()
     }
 
     /// True iff an attached AbortSignal has fired.
@@ -1303,14 +1297,8 @@ impl FetchTasklet {
         let Some(signal) = self.signal.take() else {
             return;
         };
-        // `signal` is a live C++-owned WebCore::AbortSignal*; we hold one ref
-        // (taken in `fetch.rs` before populating FetchOptions). Order matters:
-        // cleanNativeBindings first, then unref + pending_activity_unref.
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe `*const → &`.
-        let signal = bun_opaque::opaque_deref(signal);
         signal.clean_native_bindings(std::ptr::from_mut(self).cast::<c_void>());
         signal.pending_activity_unref();
-        signal.unref();
     }
 
     fn on_reject(&mut self) -> BodyValueError {
@@ -2126,12 +2114,7 @@ impl FetchTasklet {
                 http::HTTPRequestBody::Sendfile(*sendfile);
         }
 
-        if let Some(signal) = fetch_tasklet.signal {
-            // `signal` is a live C++-owned WebCore::AbortSignal* (already ref'd by
-            // the caller before populating `fetch_options.signal`).
-            // `add_listener` returns `self`, so the field already holds the right ptr.
-            // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe `*const → &`.
-            let signal = bun_opaque::opaque_deref(signal);
+        if let Some(signal) = &fetch_tasklet.signal {
             signal.pending_activity_ref();
             signal.add_listener(fetch_tasklet_ptr.cast::<c_void>(), Self::__abort_listener_c);
         }
@@ -2697,7 +2680,7 @@ pub struct FetchOptions {
     pub(crate) proxy: Option<ZigURL<'static>>,
     pub(crate) proxy_headers: Option<Headers>,
     pub(crate) url_proxy_buffer: Box<[u8]>,
-    pub(crate) signal: Option<*mut AbortSignal>,
+    pub(crate) signal: Option<AbortSignalRef>,
     pub global_this: Option<GlobalRef>,
     // Custom Hostname
     pub(crate) hostname: Option<Box<[u8]>>,


### PR DESCRIPTION
## What

`fetch_impl` (`src/runtime/webcore/fetch.rs`) took a `+1` on the request's `AbortSignal` with hand-written `ref_()` calls and parked the raw pointer in a private `SignalRef(Option<NonNull<AbortSignal>>)` Drop guard, whose `take()` disarmed it when the pointer was moved into `FetchOptions.signal: Option<*mut AbortSignal>`. `FetchTasklet::get` moved that pointer into `FetchTasklet.signal: Option<*mut AbortSignal>` (`src/runtime/webcore/fetch/FetchTasklet.rs`), every reader went through `bun_opaque::opaque_deref`, and `clear_abort_signal` released the ref with an explicit `unref()` after `clean_native_bindings` and `pending_activity_unref`.

All three now hold `Option<AbortSignalRef>`, the `ExternalShared<AbortSignal>` that `Request`, `Response::BodyAbortListener`, `node_fs` and `node_fs_watcher` already use for the same C++ object.

```rust
// before
struct SignalRef(Option<NonNull<AbortSignal>>);   // private Drop guard in fetch.rs
signal.0 = 'extract_signal: {
    // options object / request-init object:
    if let Some(signal__) = AbortSignal::from_js(signal_) {
        break 'extract_signal NonNull::new(bun_opaque::opaque_deref(signal__).ref_());
    }
    // fetch(request):
    if let Some(signal_) = req.signal.get() {
        break 'extract_signal NonNull::new(signal_.ref_());
    }
    ..
};
pub(crate) signal: Option<*mut AbortSignal>,       // FetchOptions and FetchTasklet
fn abort_signal(&self) -> Option<&AbortSignal> { self.signal.map(|p| bun_opaque::opaque_deref(p)) }
signal.clean_native_bindings(..); signal.pending_activity_unref(); signal.unref();

// after
let signal: Option<AbortSignalRef> = 'extract_signal: {
    if let Some(signal_ref) = AbortSignal::ref_from_js(signal_) {
        break 'extract_signal Some(signal_ref);
    }
    break 'extract_signal req.signal.get().clone();
    ..
};
pub(crate) signal: Option<AbortSignalRef>,
fn abort_signal(&self) -> Option<&AbortSignal> { self.signal.as_deref() }
let Some(signal) = self.signal.take() else { return };
signal.clean_native_bindings(..); signal.pending_activity_unref();   // dropping `signal` is the unref
```

In `fetch.rs` the three extraction sites use `AbortSignal::ref_from_js` (options object and request-init object; the `signal is not of type AbortSignal` rejection is unchanged) or clone the `Request`'s own `AbortSignalRef`, the pre-abort check borrows the `Option`, and the `FetchOptions` literal moves it. In `FetchTasklet.rs` the two fields change type, `abort_signal()` becomes `as_deref()`, the listener registration in `get` borrows the field, and `clear_abort_signal` drops the taken value instead of calling `unref()` by hand. `SignalRef`, its `take()`, and the three `opaque_deref` conversions are deleted; the two comments describing the raw-pointer protocol go with them. No `unsafe` blocks are added or removed.

## Why

Who owns the `+1` on the signal is now stated by the field types: `fetch_impl` holds it for the duration of argument processing (every one of the early returns after extraction releases it through `AbortSignalRef`'s Drop, which `SignalRef` re-implemented locally), `FetchOptions` carries it, and `FetchTasklet` owns it until `clear_abort_signal` takes it out; a `FetchTasklet` or `FetchOptions` that is dropped while still holding the pointer can no longer leak it. This is zero-cost: `Option<ExternalShared<AbortSignal>>` is one word through the `NonNull` niche where `Option<*mut AbortSignal>` was two, so both structs shrink; the same `ref()`/`unref()`/`pendingActivity` FFI calls are issued at the same program points (`clear_data` always runs `clear_abort_signal` before the tasklet box is freed, so the field's drop glue sees `None`); and the `Deref` reads replace `opaque_deref` calls that each carried a null check, while `ref_from_js` drops the `NonNull::new` check on the value `ref_()` returned.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds; bun bd test test/js/web/fetch/fetch.test.ts fetch-abort-stream-body.test.ts fetch-abort-queued.test.ts fetch-leak.test.ts: 354 pass, 1 skip, 42 fail (fetch-abort-stream-body 6 pass/1 skip and fetch-abort-queued 1 pass are fully green; all AbortSignal tests in fetch.test.ts and the abort/leak tests in fetch-leak.test.ts pass).
The 42 failures (41 in fetch.test.ts: sandbox `localhost`/IPv6 ConnectionRefused or egress-proxy responses, chmod-000 reads succeeding as root, debug-build "utf16 ... (with gc)" and redirect timeouts; 1 in fetch-leak.test.ts: "Sending URLSearchParams > does not leak" 120s debug timeout) are the identical set that fails on main in this environment, so they are pre-existing and unrelated to this change.
