### PR TITLE
node:http2: add the goawayCode and goawayLastStreamID session getters

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -409,6 +409,8 @@ const kReceivedGoaway = Symbol("receivedGoaway");
 // The error code carried by a received GOAWAY; like Node's state.goawayCode it
 // takes precedence over the destroy code when streams are torn down.
 const kGoawayCode = Symbol("goawayCode");
+// The Last-Stream-ID carried by a received GOAWAY (Node's state.goawayLastStreamID).
+const kGoawayLastStreamID = Symbol("goawayLastStreamID");
 const kReleaseUnannouncedStream = Symbol("releaseUnannouncedStream");
 const kGoawaySent = Symbol("goawaySent");
 
@@ -2082,6 +2084,13 @@ class Http2Session extends EventEmitter {
   // run inside it so 'close' doesn't inherit the last stream's frame.
   [bunHTTP2AsyncContextFrame] = $getInternalField($asyncContext, 0);
   [kDeferWriteCallback] = setImmediate;
+  // The GOAWAY this side received (not one it sent), like node's Http2Session getters.
+  get goawayCode() {
+    return this[kGoawayCode] || NGHTTP2_NO_ERROR;
+  }
+  get goawayLastStreamID() {
+    return this[kGoawayLastStreamID] || 0;
+  }
   [EventEmitter.captureRejectionSymbol](err, event, ...args) {
     switch (event) {
       case "stream": {
@@ -4454,6 +4463,7 @@ class ServerHttp2Session extends Http2Session {
       if (!self) return;
       if (self.destroyed) return;
       self[kGoawayCode] = errorCode;
+      self[kGoawayLastStreamID] = lastStreamId;
       self.emit("goaway", errorCode, lastStreamId, opaqueData || Buffer.allocUnsafe(0));
       if (errorCode === constants.NGHTTP2_NO_ERROR) {
         // Graceful shutdown: no new streams, existing ones may finish.
@@ -5449,6 +5459,7 @@ class ClientHttp2Session extends Http2Session {
       if (!self) return;
       if (self.destroyed) return;
       self[kGoawayCode] = errorCode;
+      self[kGoawayLastStreamID] = lastStreamId;
       // node: once a GOAWAY is received, new streams cannot be created on this session -
       // request() throws ERR_HTTP2_GOAWAY_SESSION (clients like grpc rely on the throw to
       // fail over to a fresh connection).

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2156,6 +2156,136 @@ it("http2 client receives 'goaway' when the server rejects a stream", async () =
   }
 });
 
+// node's Http2Session#goawayCode / #goawayLastStreamID report the GOAWAY frame this side
+// received (0 / 0 until one arrives). Expected values below were checked against node v26.3.0.
+describe.concurrent("http2 session goawayCode / goawayLastStreamID", () => {
+  const goawayState = session => ({ goawayCode: session.goawayCode, goawayLastStreamID: session.goawayLastStreamID });
+  const noGoaway = { goawayCode: 0, goawayLastStreamID: 0 };
+
+  // One connected session, seen from both ends. The server answers every request immediately.
+  async function connectedPair() {
+    const server = http2.createServer();
+    server.on("stream", stream => stream.respond({ ":status": 200 }, { endStream: true }));
+    const { promise: serverSessionPromise, resolve: onServerSession } = Promise.withResolvers();
+    server.once("session", onServerSession);
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { promise: connected, resolve: onConnect } = Promise.withResolvers();
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`, onConnect);
+    client.on("error", () => {});
+    const serverSession = await serverSessionPromise;
+    serverSession.on("error", () => {});
+    await connected;
+    return { server, client, serverSession };
+  }
+
+  async function requestOnce(client) {
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.resume();
+    await new Promise(resolve => req.once("close", resolve));
+  }
+
+  // Resolves with the 'goaway' event arguments and what the getters reported while it was emitted.
+  function goawayReceived(session) {
+    return new Promise(resolve =>
+      session.once("goaway", (code, lastStreamID) =>
+        resolve({ args: [code, lastStreamID], getters: goawayState(session) }),
+      ),
+    );
+  }
+
+  function closed(session) {
+    return new Promise(resolve => session.once("close", resolve));
+  }
+
+  it("are getters that report 0 / 0 on client and server sessions before any GOAWAY is received", async () => {
+    const { server, client, serverSession } = await connectedPair();
+    try {
+      expect(goawayState(client)).toEqual(noGoaway);
+      expect(goawayState(serverSession)).toEqual(noGoaway);
+      for (const session of [client, serverSession]) {
+        for (const name of ["goawayCode", "goawayLastStreamID"]) {
+          let proto = Object.getPrototypeOf(session);
+          while (proto !== null && !Object.hasOwn(proto, name)) proto = Object.getPrototypeOf(proto);
+          const descriptor = proto === null ? undefined : Object.getOwnPropertyDescriptor(proto, name);
+          expect(typeof descriptor?.get).toBe("function");
+          expect(descriptor.set).toBeUndefined();
+        }
+      }
+    } finally {
+      client.destroy();
+      serverSession.destroy();
+      server.close();
+    }
+  });
+
+  it("client session reports the code and last stream id of the GOAWAY the server sent", async () => {
+    const { server, client, serverSession } = await connectedPair();
+    try {
+      await requestOnce(client); // stream 1, so a Last-Stream-ID of 1 names a real stream
+      const received = goawayReceived(client);
+      const clientClosed = closed(client);
+      serverSession.goaway(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM, 1);
+      // Sending a GOAWAY does not count as receiving one.
+      expect(goawayState(serverSession)).toEqual(noGoaway);
+
+      const expected = { goawayCode: http2.constants.NGHTTP2_ENHANCE_YOUR_CALM, goawayLastStreamID: 1 };
+      expect(await received).toEqual({ args: [expected.goawayCode, expected.goawayLastStreamID], getters: expected });
+      // A GOAWAY with an error code destroys the receiving session; the values survive that.
+      await clientClosed;
+      expect(client.destroyed).toBe(true);
+      expect(goawayState(client)).toEqual(expected);
+    } finally {
+      client.destroy();
+      serverSession.destroy();
+      server.close();
+    }
+  });
+
+  it("server session reports the code and last stream id of the GOAWAY the client sent", async () => {
+    const { server, client, serverSession } = await connectedPair();
+    try {
+      const received = goawayReceived(serverSession);
+      const serverSessionClosed = closed(serverSession);
+      // From a client, Last-Stream-ID names a server-initiated (even) stream.
+      client.goaway(http2.constants.NGHTTP2_CANCEL, 2);
+      expect(goawayState(client)).toEqual(noGoaway);
+
+      const expected = { goawayCode: http2.constants.NGHTTP2_CANCEL, goawayLastStreamID: 2 };
+      expect(await received).toEqual({ args: [expected.goawayCode, expected.goawayLastStreamID], getters: expected });
+      await serverSessionClosed;
+      expect(serverSession.destroyed).toBe(true);
+      expect(goawayState(serverSession)).toEqual(expected);
+    } finally {
+      client.destroy();
+      serverSession.destroy();
+      server.close();
+    }
+  });
+
+  it("a graceful GOAWAY leaves goawayCode at 0 but still records the last stream id", async () => {
+    const { server, client, serverSession } = await connectedPair();
+    try {
+      await requestOnce(client);
+      const received = goawayReceived(client);
+      const clientClosed = closed(client);
+      // No explicit Last-Stream-ID: like node, the last stream the server processed (1) goes out.
+      serverSession.goaway();
+      expect(goawayState(serverSession)).toEqual(noGoaway);
+
+      const expected = { goawayCode: http2.constants.NGHTTP2_NO_ERROR, goawayLastStreamID: 1 };
+      expect(await received).toEqual({ args: [0, 1], getters: expected });
+      // NO_ERROR starts a graceful close; with no streams left the session closes on its own.
+      await clientClosed;
+      expect(goawayState(client)).toEqual(expected);
+    } finally {
+      client.destroy();
+      serverSession.destroy();
+      server.close();
+    }
+  });
+});
+
 it(
   "http2 server with minimal maxSessionMemory handles multiple requests",
   async () => {


### PR DESCRIPTION
### Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("session", s => console.log("server:", s.goawayCode, s.goawayLastStreamID));
server.on("stream", stream => stream.session.goaway(http2.constants.NGHTTP2_ENHANCE_YOUR_CALM, 1));
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("error", () => {});
  client.on("connect", () => {
    console.log("client:", client.goawayCode, client.goawayLastStreamID);
    client.request({ ":path": "/" }).on("error", () => {});
  });
  client.on("goaway", (code, lastStreamID) =>
    console.log("event:", code, lastStreamID, "getters:", client.goawayCode, client.goawayLastStreamID),
  );
  client.on("close", () => {
    console.log("after close:", client.goawayCode, client.goawayLastStreamID);
    server.close();
  });
});
```

node v26.3.0 (and this branch):

```
server: 0 0
client: 0 0
event: 11 1 getters: 11 1
after close: 11 1
```

bun 1.4.0 and main:

```
server: undefined undefined
client: undefined undefined
event: 11 1 getters: undefined undefined
after close: undefined undefined
```

### Cause

Node's `Http2Session` (lib/internal/http2/core.js) has two getters describing the GOAWAY frame the session received:

```js
get goawayCode()         { return this[kState].goawayCode || NGHTTP2_NO_ERROR; }
get goawayLastStreamID() { return this[kState].goawayLastStreamID || 0; }
```

`onGoawayData` fills both in before emitting `'goaway'`, and they keep their values after the session is destroyed. Neither `ClientHttp2Session` nor `ServerHttp2Session` in `src/js/node/http2.ts` defined them. The received code was already tracked (`kGoawayCode`, used to pick the rst code of streams torn down by the GOAWAY); the received Last-Stream-ID was passed to the event and then dropped.

### Fix

Store the received Last-Stream-ID next to the code in both `onGoAway` handlers (before `'goaway'` is emitted, as in node) and define the two getters once on the shared `Http2Session` base class, where node defines them. They describe received GOAWAYs only: a `goaway()` this side sends does not touch them, same as node.

This is a plain node compat gap. Code written for node that reads these (for example `session.goawayCode !== NGHTTP2_NO_ERROR` to tell a graceful shutdown from an errored one) gets `undefined` on bun today, so such a check treats every session as errored. No type or docs changes: node does not document these getters and `@types/node` does not declare them, they are just part of the `Http2Session` surface.

### Verification

Four tests added to `test/js/node/http2/node-http2.test.js` (`describe "http2 session goawayCode / goawayLastStreamID"`). All four fail on bun 1.4.0 and pass with this change; the same scenarios run as a standalone script under node v26.3.0 and under the fixed debug build print identical output.

- both properties are getters (no setter) and report `0` / `0` on a fresh client and server session
- server sends `goaway(ENHANCE_YOUR_CALM, 1)`: the client reports `11` / `1` inside the `'goaway'` event and still after it was destroyed; the server's own getters stay `0` / `0`
- client sends `goaway(CANCEL, 2)`: the server session reports `8` / `2`, with the same persistence check
- server sends a bare `goaway()`: the client reports `0` / `1` (the implicit last processed stream id)

With the debug build, `node-http2.test.js` (351 pass, 6 skip), `h2-conformance.test.ts` and the vendored node http2 goaway/shutdown tests pass.
