### PR TITLE
bake: store Route.part as RoutePart instead of Part<'static>

### DIFF
--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -75,11 +75,7 @@ pub type DynamicRouteMap = ArrayHashMap<EncodedPattern, RouteIndex, EffectiveUrl
 
 /// A logical route, for which layouts are looked up on after resolving a route.
 pub struct Route {
-    // Payload bytes borrow from the sibling `pattern_string_arena` field — a
-    // self-referential borrow Rust lifetimes cannot express, so it is detached
-    // to `'static` via `to_owned_part()` at insertion. See `to_owned_part` for
-    // the safety invariant (arena outlives every `Route`).
-    pub(crate) part: Part<'static>,
+    pub(crate) part: RoutePart,
     pub r#type: TypeIndex,
 
     pub(crate) parent: Option<RouteIndex>,
@@ -178,7 +174,7 @@ impl FrameworkRouter {
             debug_assert!(strings::has_prefix(&ty.abs_root, root));
 
             routes.push(Route {
-                part: Part::Text(b""),
+                part: RoutePart::new(Part::Text(b"")),
                 r#type: TypeIndex::init(u8::try_from(type_index).expect("int cast")),
                 parent: None,
                 next_sibling: None,
@@ -393,14 +389,10 @@ impl<'a> EncodedPatternIterator<'a> {
         ));
         let payload = &self.pattern
             [self.offset + size_of::<u32>()..self.offset + size_of::<u32>() + header.len()];
-        let part = match header.tag() {
-            PartTag::Text => Part::Text(payload),
-            PartTag::Param => Part::Param(payload),
-            PartTag::CatchAllOptional => Part::CatchAllOptional(payload),
-            PartTag::CatchAll => Part::CatchAll(payload),
-            PartTag::Group => Part::Group(payload),
-        };
-        (part, size_of::<u32>() + header.len())
+        (
+            Part::new(header.tag(), payload),
+            size_of::<u32>() + header.len(),
+        )
     }
 }
 
@@ -502,6 +494,27 @@ enum PartTag {
     Group = 4,
 }
 
+/// `Part` stored in a `Route`; the payload is owned by the router's `pattern_string_arena`.
+pub(crate) struct RoutePart {
+    tag: PartTag,
+    payload: bun_ptr::RawSlice<u8>,
+}
+
+impl RoutePart {
+    #[inline]
+    fn new(part: Part<'_>) -> Self {
+        Self {
+            tag: part.tag(),
+            payload: bun_ptr::RawSlice::new(part.payload()),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get(&self) -> Part<'_> {
+        Part::new(self.tag, self.payload.slice())
+    }
+}
+
 /// `packed struct(u32) { tag: u3, len: u29 }`
 #[repr(transparent)]
 #[derive(Copy, Clone)]
@@ -532,6 +545,17 @@ impl SerializedHeader {
 }
 
 impl<'a> Part<'a> {
+    #[inline]
+    fn new(tag: PartTag, payload: &'a [u8]) -> Self {
+        match tag {
+            PartTag::Text => Part::Text(payload),
+            PartTag::Param => Part::Param(payload),
+            PartTag::CatchAllOptional => Part::CatchAllOptional(payload),
+            PartTag::CatchAll => Part::CatchAll(payload),
+            PartTag::Group => Part::Group(payload),
+        }
+    }
+
     #[inline]
     fn payload(&self) -> &'a [u8] {
         match *self {
@@ -1060,7 +1084,7 @@ impl FrameworkRouter {
             'outer: loop {
                 let mut next = self.route_ptr(route_index).first_child;
                 while let Some(current) = next {
-                    if current_part.eql(&self.route_ptr(current).part) {
+                    if current_part.eql(&self.route_ptr(current).part.get()) {
                         match next_part(&mut static_it, &mut dynamic_it) {
                             None => break 'brk current, // found it!
                             Some(p) => current_part = p,
@@ -1076,10 +1100,7 @@ impl FrameworkRouter {
 
                 // Must add to this child
                 let mut new_route_index = self.new_route(Route {
-                    // SAFETY: `current_part` borrows from `pattern_string_arena`
-                    // (owned by `self`), which outlives every `Route` stored in
-                    // `self.routes`.
-                    part: unsafe { current_part.to_owned_part() },
+                    part: RoutePart::new(current_part),
                     r#type: ty,
                     parent: Some(route_index),
                     first_child: None,
@@ -1099,10 +1120,7 @@ impl FrameworkRouter {
                 // inserting routes simpler to implement, but could technically be avoided.
                 while let Some(next_part_val) = next_part(&mut static_it, &mut dynamic_it) {
                     let newer_route_index = self.new_route(Route {
-                        // SAFETY: `next_part_val` borrows from
-                        // `pattern_string_arena` (owned by `self`), which
-                        // outlives every `Route` stored in `self.routes`.
-                        part: unsafe { next_part_val.to_owned_part() },
+                        part: RoutePart::new(next_part_val),
                         r#type: ty,
                         parent: Some(new_route_index),
                         first_child: None,
@@ -1155,39 +1173,6 @@ impl FrameworkRouter {
             }
         }
         Ok(())
-    }
-}
-
-// `Part` stored in `Route` borrows from the router's own `pattern_string_arena`.
-// Rust cannot express that self-referential borrow, so `to_owned_part` detaches
-// the lifetime when storing into `Route`.
-impl<'a> Part<'a> {
-    /// Detach the borrow lifetime so this `Part` can be stored in `Route`.
-    ///
-    /// # Safety
-    /// Every payload slice must point into `FrameworkRouter::pattern_string_arena`
-    /// (or other storage that outlives the owning `FrameworkRouter`).
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn to_owned_part(self) -> Part<'static> {
-        // Variant-by-variant detach (no bitcast). `d` stays `unsafe fn` so a
-        // safe-signature wrapper does not hide the lifetime-widen.
-        #[inline(always)]
-        unsafe fn d(s: &[u8]) -> &'static [u8] {
-            // SAFETY: (`Interned::assume` — Population B, holder-backed) every
-            // payload slice points into `FrameworkRouter::pattern_string_arena`,
-            // which is owned by the `FrameworkRouter` and freed only on
-            // router drop/reset — strictly after every `Route` holding a
-            // `Part<'static>` is gone. NOT process-lifetime; a `'bump`
-            // parameter on `Part` would model this more precisely.
-            unsafe { bun_ptr::Interned::assume(s) }.as_bytes()
-        }
-        match self {
-            Part::Text(s) => Part::Text(d(s)),
-            Part::Param(s) => Part::Param(d(s)),
-            Part::CatchAllOptional(s) => Part::CatchAllOptional(d(s)),
-            Part::CatchAll(s) => Part::CatchAll(d(s)),
-            Part::Group(s) => Part::Group(d(s)),
-        }
     }
 }
 
@@ -1899,7 +1884,7 @@ impl JSFrameworkRouter {
     fn route_to_json(&self, global: &JSGlobalObject, route_index: RouteIndex) -> JsResult<JSValue> {
         let route = self.router.route_ptr(route_index);
         let obj = JSValue::create_empty_object(global, 4);
-        obj.put(global, b"part", Self::part_to_js(global, &route.part)?);
+        obj.put(global, b"part", Self::part_to_js(global, route.part.get())?);
         obj.put(
             global,
             b"page",
@@ -1938,7 +1923,7 @@ impl JSFrameworkRouter {
     ) -> JsResult<JSValue> {
         let route = self.router.route_ptr(route_index);
         let obj = JSValue::create_empty_object(global, 4);
-        obj.put(global, b"part", Self::part_to_js(global, &route.part)?);
+        obj.put(global, b"part", Self::part_to_js(global, route.part.get())?);
         obj.put(
             global,
             b"page",
@@ -2021,7 +2006,7 @@ impl JSFrameworkRouter {
         Ok(obj)
     }
 
-    fn part_to_js(global: &JSGlobalObject, part: &Part<'_>) -> JsResult<JSValue> {
+    fn part_to_js(global: &JSGlobalObject, part: Part<'_>) -> JsResult<JSValue> {
         let mut rendered: Vec<u8> = Vec::new();
         part.to_string_for_internal_use(&mut ByteFmtWriter::new(&mut rendered))
             .expect("ByteFmtWriter is infallible");

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -985,8 +985,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         // Fetch the output file fresh at each use site instead of binding it.
 
         // Count how many JS+CSS files associated with this route and prepare `pattern`
-        pattern.prepend_part(route.part);
-        match route.part {
+        let part = route.part.get();
+        pattern.prepend_part(part);
+        match part {
             framework_router::Part::Param(name) => {
                 params_buf.push(name);
             }
@@ -1007,8 +1008,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         let mut next: Option<framework_router::RouteIndex> = route.parent;
         while let Some(parent_index) = next {
             let parent = router.route_ptr(parent_index);
-            pattern.prepend_part(parent.part);
-            match parent.part {
+            let part = parent.part.get();
+            pattern.prepend_part(part);
+            match part {
                 framework_router::Part::Param(name) => {
                     params_buf.push(name);
                 }


### PR DESCRIPTION
## What

`Route.part` in `src/runtime/bake/FrameworkRouter.rs` was typed `Part<'static>`, but the payload bytes live in the router's own `pattern_string_arena`. The `'static` was produced at the two insertion sites in `FrameworkRouter::insert` by `unsafe fn to_owned_part`, whose inner `unsafe fn d` widened each payload with `bun_ptr::Interned::assume`; the documentation of that function says it is only for process-lifetime bytes and tells callers to use `RawSlice<u8>` for bytes owned by a holder, and the SAFETY comment on the call itself noted that the arena is not process-lifetime. The same file already stores other slices of that arena the documented way (`EncodedPattern::data`, `StaticPattern::route_path`, both `bun_ptr::RawSlice<u8>`).

`Route.part` is now a `RoutePart`, a tag plus a `RawSlice` of the payload, and readers rebuild a `Part` that borrows from the route:

```rust
// before
pub struct Route { pub(crate) part: Part<'static>, .. }
part: unsafe { current_part.to_owned_part() },          // 2 insertion sites
current_part.eql(&self.route_ptr(current).part)

// after
pub(crate) struct RoutePart { tag: PartTag, payload: bun_ptr::RawSlice<u8> }
impl RoutePart {
    fn new(part: Part<'_>) -> Self;                      // safe
    pub(crate) fn get(&self) -> Part<'_>;
}
pub struct Route { pub(crate) part: RoutePart, .. }
part: RoutePart::new(current_part),
current_part.eql(&self.route_ptr(current).part.get())
```

The 3 construction sites (the root route in `init_empty` and the 2 in `insert`) use `RoutePart::new`; the 5 readers (the `eql` comparison in `insert`, the 2 `part_to_js` calls in `route_to_json` / `route_to_json_inverse`, and the 2 `prepend_part` + `match` pairs in `production.rs`) call `.get()`, with `production.rs` binding the `Part` once per route so `prepend_part` and the `match` share it. `part_to_js` takes the `Copy` `Part` by value like `PatternBuffer::prepend_part` already does. The tag-to-variant match that `get()` needs is the one `EncodedPatternIterator::read_with_size` already contained, so it moves to `Part::new(tag, payload)` and both use it. `to_owned_part` and its `#[allow(unsafe_op_in_unsafe_fn)]` are deleted: this removes 3 `unsafe` blocks and 2 `unsafe fn`s and adds none.

## Why

The type now says what the deleted comments said: a route's part is a view into storage owned by the router, and `get()` hands out a `Part` whose lifetime is the borrow of the route, so the payload can no longer be copied out as a `&'static [u8]` and outlive the router (`RoutePart` is neither `Copy` nor constructible outside the module). `RoutePart` is a one-byte tag plus a `#[repr(transparent)]` fat pointer, 24 bytes like `Part<'_>`, so `Route` keeps its layout (and `memory_cost` its value); `RawSlice::new` and `slice()` are pointer casts and `get()` is the tag match the iterator already performed, on the route insertion and production build paths only.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds; bun bd test test/bake/framework-router.test.ts test/bake/dev/ssg-pages-router.test.ts test/bake/dev/production.test.ts: 53 pass, 0 fail across 3 files.
