### PR TITLE
node:http2: make setNextStreamID ignore the ids nghttp2 rejects

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8271,9 +8271,7 @@ impl H2FrameParser {
         Ok(JSValue::js_number(result as f64))
     }
 
-    /// Lowest id of this side's parity (RFC 9113 §5.1.1: even for a server, odd for a client)
-    /// above `last_stream_id`. Every path that stores into `last_stream_id` bounds it by
-    /// `MAX_STREAM_ID` (31-bit wire ids, `set_next_stream_id` below), so the step cannot overflow.
+    /// First id of this side's parity above `last_stream_id`, which never exceeds `MAX_STREAM_ID`.
     fn get_next_stream_id(&self) -> u32 {
         let stream_id = self.last_stream_id.get();
         if self.is_server.get() {
@@ -8289,12 +8287,7 @@ impl H2FrameParser {
         }
     }
 
-    /// Node hands `setNextStreamID(id)` to `nghttp2_session_set_next_stream_id`, which ignores an
-    /// id of the peer's parity, one that does not fit in 31 bits (node passes an int32) and one
-    /// below the current next id (the JS wrapper already threw on non-numbers and on ids outside
-    /// 1..=2^32-1). Match that instead of rounding the id to this side's parity or moving the
-    /// counter back over ids already used on the wire. An id equal to the current next id changes
-    /// nothing in either implementation.
+    /// Node's setNextStreamID is `nghttp2_session_set_next_stream_id`: invalid ids are ignored.
     #[bun_jsc::host_fn(method)]
     pub(crate) fn set_next_stream_id(
         this: &Self,
@@ -8313,8 +8306,7 @@ impl H2FrameParser {
         {
             return Ok(JSValue::UNDEFINED);
         }
-        // Same parity as, and above, the current next id: at least last_stream_id + 2, and
-        // get_next_stream_id() steps from it to exactly next_stream_id.
+        // Above the next id with this side's parity, so this still moves `last_stream_id` forward.
         this.last_stream_id.set(next_stream_id - 2);
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8271,23 +8271,30 @@ impl H2FrameParser {
         Ok(JSValue::js_number(result as f64))
     }
 
-    /// `set_next_stream_id` can park `last_stream_id` anywhere in the u32 range, so the step
-    /// saturates; callers that open the stream reject anything above `MAX_STREAM_ID`.
+    /// Lowest id of this side's parity (RFC 9113 §5.1.1: even for a server, odd for a client)
+    /// above `last_stream_id`. Every path that stores into `last_stream_id` bounds it by
+    /// `MAX_STREAM_ID` (31-bit wire ids, `set_next_stream_id` below), so the step cannot overflow.
     fn get_next_stream_id(&self) -> u32 {
         let stream_id = self.last_stream_id.get();
         if self.is_server.get() {
             if stream_id.is_multiple_of(2) {
-                stream_id.saturating_add(2)
+                stream_id + 2
             } else {
-                stream_id.saturating_add(1)
+                stream_id + 1
             }
         } else if stream_id.is_multiple_of(2) {
-            stream_id.saturating_add(1)
+            stream_id + 1
         } else {
-            stream_id.saturating_add(2)
+            stream_id + 2
         }
     }
 
+    /// Node hands `setNextStreamID(id)` to `nghttp2_session_set_next_stream_id`, which ignores an
+    /// id of the peer's parity, one that does not fit in 31 bits (node passes an int32) and one
+    /// below the current next id (the JS wrapper already threw on non-numbers and on ids outside
+    /// 1..=2^32-1). Match that instead of rounding the id to this side's parity or moving the
+    /// counter back over ids already used on the wire. An id equal to the current next id changes
+    /// nothing in either implementation.
     #[bun_jsc::host_fn(method)]
     pub(crate) fn set_next_stream_id(
         this: &Self,
@@ -8298,22 +8305,17 @@ impl H2FrameParser {
         debug_assert!(args_list.len() >= 1);
         let stream_id_arg = args_list[0];
         debug_assert!(stream_id_arg.is_number());
-        // Store the id `get_next_stream_id` steps from. A fractional id passes the JS layer's
-        // `id <= 0` check and truncates to 0 here; 0 (and 1 on a client) has no predecessor,
-        // so the subtraction saturates to the initial state instead of wrapping.
         let next_stream_id = stream_id_arg.to_u32();
-        let last_stream_id = if this.is_server.get() {
-            if next_stream_id.is_multiple_of(2) {
-                next_stream_id.saturating_sub(2)
-            } else {
-                next_stream_id.saturating_sub(1)
-            }
-        } else if next_stream_id.is_multiple_of(2) {
-            next_stream_id.saturating_sub(1)
-        } else {
-            next_stream_id.saturating_sub(2)
-        };
-        this.last_stream_id.set(last_stream_id);
+        let local_parity = u32::from(!this.is_server.get());
+        if next_stream_id % 2 != local_parity
+            || next_stream_id > MAX_STREAM_ID
+            || next_stream_id <= this.get_next_stream_id()
+        {
+            return Ok(JSValue::UNDEFINED);
+        }
+        // Same parity as, and above, the current next id: at least last_stream_id + 2, and
+        // get_next_stream_id() steps from it to exactly next_stream_id.
+        this.last_stream_id.set(next_stream_id - 2);
         Ok(JSValue::UNDEFINED)
     }
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2741,6 +2741,9 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
   const readState = ({ nextStreamID, lastProcStreamID }) => [nextStreamID, lastProcStreamID];
   const server = http2.createServer();
   const serverSide = Promise.withResolvers();
+  const pushed = Promise.withResolvers();
+  const failure = Promise.withResolvers();
+  server.on("sessionError", failure.reject);
   server.on("stream", (stream, headers) => {
     if (headers[":path"] !== "/first") {
       stream.respond();
@@ -2763,10 +2766,10 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
       seen["set 105 (odd)"] = set(105);
       seen["set 50 (below next)"] = set(50);
       seen["set 100 (equal to next)"] = set(100);
-      stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
-        if (err) return serverSide.reject(err);
-        pushed.respond();
-        pushed.end();
+      stream.pushStream({ ":path": "/pushed" }, (err, pushedStream) => {
+        if (err) return failure.reject(err);
+        pushedStream.respond();
+        pushedStream.end();
       });
       seen["after pushStream"] = session.state.nextStreamID;
       seen["set 50 after pushStream"] = set(50);
@@ -2776,39 +2779,34 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
       seen["set 2 ** 31 - 2 (highest even)"] = set(2 ** 31 - 2);
       serverSide.resolve(seen);
     } catch (err) {
-      serverSide.reject(err);
+      failure.reject(err);
     }
     stream.respond();
     stream.end();
   });
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
   const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
-  try {
-    await new Promise((resolve, reject) => {
-      client.once("connect", resolve);
-      client.once("error", reject);
+  client.on("error", failure.reject);
+  client.once("stream", (pushedStream, pushHeaders) => {
+    pushedStream.resume();
+    pushed.resolve({ id: pushedStream.id, path: pushHeaders[":path"] });
+  });
+  const set = id => {
+    client.setNextStreamID(id);
+    return client.state.nextStreamID;
+  };
+  const request = path =>
+    new Promise((resolve, reject) => {
+      const req = client.request({ ":path": path });
+      let status;
+      req.on("error", reject);
+      req.on("response", responseHeaders => (status = responseHeaders[":status"]));
+      req.on("close", () => resolve({ id: req.id, status }));
+      req.resume();
+      req.end();
     });
-    const pushed = new Promise(resolve =>
-      client.once("stream", (pushedStream, pushHeaders) => {
-        pushedStream.resume();
-        resolve({ id: pushedStream.id, path: pushHeaders[":path"] });
-      }),
-    );
-    const set = id => {
-      client.setNextStreamID(id);
-      return client.state.nextStreamID;
-    };
-    const request = path =>
-      new Promise((resolve, reject) => {
-        const req = client.request({ ":path": path });
-        let status;
-        req.on("error", reject);
-        req.on("response", responseHeaders => (status = responseHeaders[":status"]));
-        req.on("close", () => resolve({ id: req.id, status }));
-        req.resume();
-        req.end();
-      });
-
+  const run = async () => {
+    await new Promise(resolve => client.once("connect", resolve));
     const seen = { "initial [next, lastProc]": readState(client.state) };
     client.setNextStreamID(1);
     seen["set 1 (equal to next) [next, lastProc]"] = readState(client.state);
@@ -2827,8 +2825,11 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
     seen["set 2 ** 31 + 1 (not 31-bit)"] = set(2 ** 31 + 1);
     seen["set 2 ** 32 - 1 (not 31-bit)"] = set(2 ** 32 - 1);
     seen["set 2 ** 31 - 1 (highest odd)"] = set(2 ** 31 - 1);
+    return { client: seen, server: await serverSide.promise, pushed: await pushed.promise };
+  };
 
-    expect({ client: seen, server: await serverSide.promise, pushed: await pushed }).toEqual({
+  try {
+    expect(await Promise.race([run(), failure.promise])).toEqual({
       client: {
         "initial [next, lastProc]": [1, 0],
         "set 1 (equal to next) [next, lastProc]": [1, 0],

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2671,8 +2671,8 @@ it("http2 client.setNextStreamID validates input", async () => {
 
 it("http2 setNextStreamID at the edges of the id space does not overflow", async () => {
   // 0.5 passes the JS range check (> 0) and reaches the native setter as 0, which used to
-  // underflow (node ends up on stream 1 too). A server parked at 2 ** 32 - 1 used to overflow
-  // when the next id was computed; it has to read back as an unusable id, not wrap to a low one.
+  // underflow (node ends up on stream 1 too). 2 ** 32 - 1 passes the JS range check as well but
+  // is not a 31-bit stream id: node ignores it, and computing the next id from it used to overflow.
   const fixture = `
     const http2 = require("node:http2");
     const result = { client: {}, server: {} };
@@ -2724,10 +2724,132 @@ it("http2 setNextStreamID at the edges of the id space does not overflow", async
   expect(stderr).toBe("");
   expect(JSON.parse(stdout.trim())).toEqual({
     client: { 0.5: 1, 1: 1 },
-    server: { 0: 2, 2: 2, 4294967295: 4294967295 },
+    server: { 0: 2, 2: 2, 4294967295: 2 },
     response: { streamId: 1, status: 200 },
   });
   expect(exitCode).toBe(0);
+});
+
+it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding them or moving backwards", async () => {
+  // Expected values come from node v26.3.0, where setNextStreamID ends up in
+  // nghttp2_session_set_next_stream_id: an id of the peer's parity, an id that is not above the
+  // current next id, or one that does not fit in 31 bits leaves the session untouched. The server
+  // side is checked while handling the client's first stream (id 1), where node reports 2 as the
+  // server's next id too.
+  const server = http2.createServer();
+  const serverSide = Promise.withResolvers();
+  server.on("stream", (stream, headers) => {
+    if (headers[":path"] !== "/first") {
+      stream.respond();
+      stream.end();
+      return;
+    }
+    try {
+      const { session } = stream;
+      // ServerHttp2Session does not expose setNextStreamID; call the native setter it would wrap.
+      const parser = session[Symbol.for("::bunhttp2native::")];
+      const set = id => {
+        parser.setNextStreamID(id);
+        return session.state.nextStreamID;
+      };
+      const seen = { initial: session.state.nextStreamID };
+      seen["set 100"] = set(100);
+      seen["set 101 (odd)"] = set(101);
+      seen["set 50 (below next)"] = set(50);
+      seen["set 100 (equal to next)"] = set(100);
+      stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
+        if (err) return serverSide.reject(err);
+        pushed.respond();
+        pushed.end();
+      });
+      seen["after pushStream"] = session.state.nextStreamID;
+      seen["set 50 after pushStream"] = set(50);
+      seen["set 2 ** 31 (not 31-bit)"] = set(2 ** 31);
+      seen["set 2 ** 32 - 2 (not 31-bit)"] = set(2 ** 32 - 2);
+      seen["set 2 ** 31 - 2 (highest even)"] = set(2 ** 31 - 2);
+      serverSide.resolve(seen);
+    } catch (err) {
+      serverSide.reject(err);
+    }
+    stream.respond();
+    stream.end();
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  try {
+    await new Promise((resolve, reject) => {
+      client.once("connect", resolve);
+      client.once("error", reject);
+    });
+    const pushed = new Promise(resolve =>
+      client.once("stream", (pushedStream, pushHeaders) => {
+        pushedStream.resume();
+        resolve({ id: pushedStream.id, path: pushHeaders[":path"] });
+      }),
+    );
+    const set = id => {
+      client.setNextStreamID(id);
+      return client.state.nextStreamID;
+    };
+    const request = path =>
+      new Promise((resolve, reject) => {
+        const req = client.request({ ":path": path });
+        let status;
+        req.on("error", reject);
+        req.on("response", responseHeaders => (status = responseHeaders[":status"]));
+        req.on("close", () => resolve({ id: req.id, status }));
+        req.resume();
+        req.end();
+      });
+
+    const seen = { initial: client.state.nextStreamID };
+    seen["request /first"] = await request("/first");
+    seen["set 11"] = set(11);
+    seen["set 12 (even)"] = set(12);
+    seen["set 5 (below next)"] = set(5);
+    seen["set 11 (equal to next)"] = set(11);
+    seen["request /second"] = await request("/second");
+    seen["after /second"] = client.state.nextStreamID;
+    seen["set 5 after /second"] = set(5);
+    seen["request /third"] = await request("/third");
+    seen["set 2 ** 31 + 1 (not 31-bit)"] = set(2 ** 31 + 1);
+    seen["set 2 ** 32 - 1 (not 31-bit)"] = set(2 ** 32 - 1);
+    seen["set 2 ** 31 - 1 (highest odd)"] = set(2 ** 31 - 1);
+
+    expect({ client: seen, server: await serverSide.promise, pushed: await pushed }).toEqual({
+      client: {
+        initial: 1,
+        "request /first": { id: 1, status: 200 },
+        "set 11": 11,
+        "set 12 (even)": 11,
+        "set 5 (below next)": 11,
+        "set 11 (equal to next)": 11,
+        "request /second": { id: 11, status: 200 },
+        "after /second": 13,
+        "set 5 after /second": 13,
+        "request /third": { id: 13, status: 200 },
+        "set 2 ** 31 + 1 (not 31-bit)": 15,
+        "set 2 ** 32 - 1 (not 31-bit)": 15,
+        "set 2 ** 31 - 1 (highest odd)": 2 ** 31 - 1,
+      },
+      server: {
+        initial: 2,
+        "set 100": 100,
+        "set 101 (odd)": 100,
+        "set 50 (below next)": 100,
+        "set 100 (equal to next)": 100,
+        "after pushStream": 102,
+        "set 50 after pushStream": 102,
+        "set 2 ** 31 (not 31-bit)": 102,
+        "set 2 ** 32 - 2 (not 31-bit)": 102,
+        "set 2 ** 31 - 2 (highest even)": 2 ** 31 - 2,
+      },
+      pushed: { id: 100, path: "/pushed" },
+    });
+  } finally {
+    client.close();
+    server.close();
+  }
 });
 
 it("http2 request.destroy() with error", async () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2671,8 +2671,9 @@ it("http2 client.setNextStreamID validates input", async () => {
 
 it("http2 setNextStreamID at the edges of the id space does not overflow", async () => {
   // 0.5 passes the JS range check (> 0) and reaches the native setter as 0, which used to
-  // underflow (node ends up on stream 1 too). 2 ** 32 - 1 passes the JS range check as well but
-  // is not a 31-bit stream id: node ignores it, and computing the next id from it used to overflow.
+  // underflow (node ends up on stream 1 too). 2 ** 32 - 1 passes the JS range check as well; on a
+  // server it is ignored as an odd id (node ignores it too), where it used to be stored and
+  // overflow the next id computation. The 31-bit bound itself is covered by the next test.
   const fixture = `
     const http2 = require("node:http2");
     const result = { client: {}, server: {} };
@@ -2735,7 +2736,9 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
   // nghttp2_session_set_next_stream_id: an id of the peer's parity, an id that is not above the
   // current next id, or one that does not fit in 31 bits leaves the session untouched. The server
   // side is checked while handling the client's first stream (id 1), where node reports 2 as the
-  // server's next id too.
+  // server's next id too. The "equal to next" rows also read lastProcStreamID: it is the one value
+  // that tells an ignored call apart from one that re-stores the current position.
+  const readState = ({ nextStreamID, lastProcStreamID }) => [nextStreamID, lastProcStreamID];
   const server = http2.createServer();
   const serverSide = Promise.withResolvers();
   server.on("stream", (stream, headers) => {
@@ -2752,9 +2755,12 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
         parser.setNextStreamID(id);
         return session.state.nextStreamID;
       };
-      const seen = { initial: session.state.nextStreamID };
+      const seen = { "initial [next, lastProc]": readState(session.state) };
+      parser.setNextStreamID(2);
+      seen["set 2 (equal to next) [next, lastProc]"] = readState(session.state);
       seen["set 100"] = set(100);
       seen["set 101 (odd)"] = set(101);
+      seen["set 105 (odd)"] = set(105);
       seen["set 50 (below next)"] = set(50);
       seen["set 100 (equal to next)"] = set(100);
       stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
@@ -2764,6 +2770,7 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
       });
       seen["after pushStream"] = session.state.nextStreamID;
       seen["set 50 after pushStream"] = set(50);
+      seen["set 104 (lowest id above next)"] = set(104);
       seen["set 2 ** 31 (not 31-bit)"] = set(2 ** 31);
       seen["set 2 ** 32 - 2 (not 31-bit)"] = set(2 ** 32 - 2);
       seen["set 2 ** 31 - 2 (highest even)"] = set(2 ** 31 - 2);
@@ -2802,46 +2809,58 @@ it("http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding th
         req.end();
       });
 
-    const seen = { initial: client.state.nextStreamID };
+    const seen = { "initial [next, lastProc]": readState(client.state) };
+    client.setNextStreamID(1);
+    seen["set 1 (equal to next) [next, lastProc]"] = readState(client.state);
     seen["request /first"] = await request("/first");
+    seen["set 5 (lowest id above next)"] = set(5);
+    seen["request /second"] = await request("/second");
     seen["set 11"] = set(11);
     seen["set 12 (even)"] = set(12);
-    seen["set 5 (below next)"] = set(5);
+    seen["set 14 (even)"] = set(14);
+    seen["set 7 (below next)"] = set(7);
     seen["set 11 (equal to next)"] = set(11);
-    seen["request /second"] = await request("/second");
-    seen["after /second"] = client.state.nextStreamID;
-    seen["set 5 after /second"] = set(5);
     seen["request /third"] = await request("/third");
+    seen["after /third"] = client.state.nextStreamID;
+    seen["set 7 after /third"] = set(7);
+    seen["request /fourth"] = await request("/fourth");
     seen["set 2 ** 31 + 1 (not 31-bit)"] = set(2 ** 31 + 1);
     seen["set 2 ** 32 - 1 (not 31-bit)"] = set(2 ** 32 - 1);
     seen["set 2 ** 31 - 1 (highest odd)"] = set(2 ** 31 - 1);
 
     expect({ client: seen, server: await serverSide.promise, pushed: await pushed }).toEqual({
       client: {
-        initial: 1,
+        "initial [next, lastProc]": [1, 0],
+        "set 1 (equal to next) [next, lastProc]": [1, 0],
         "request /first": { id: 1, status: 200 },
+        "set 5 (lowest id above next)": 5,
+        "request /second": { id: 5, status: 200 },
         "set 11": 11,
         "set 12 (even)": 11,
-        "set 5 (below next)": 11,
+        "set 14 (even)": 11,
+        "set 7 (below next)": 11,
         "set 11 (equal to next)": 11,
-        "request /second": { id: 11, status: 200 },
-        "after /second": 13,
-        "set 5 after /second": 13,
-        "request /third": { id: 13, status: 200 },
+        "request /third": { id: 11, status: 200 },
+        "after /third": 13,
+        "set 7 after /third": 13,
+        "request /fourth": { id: 13, status: 200 },
         "set 2 ** 31 + 1 (not 31-bit)": 15,
         "set 2 ** 32 - 1 (not 31-bit)": 15,
         "set 2 ** 31 - 1 (highest odd)": 2 ** 31 - 1,
       },
       server: {
-        initial: 2,
+        "initial [next, lastProc]": [2, 1],
+        "set 2 (equal to next) [next, lastProc]": [2, 1],
         "set 100": 100,
         "set 101 (odd)": 100,
+        "set 105 (odd)": 100,
         "set 50 (below next)": 100,
         "set 100 (equal to next)": 100,
         "after pushStream": 102,
         "set 50 after pushStream": 102,
-        "set 2 ** 31 (not 31-bit)": 102,
-        "set 2 ** 32 - 2 (not 31-bit)": 102,
+        "set 104 (lowest id above next)": 104,
+        "set 2 ** 31 (not 31-bit)": 104,
+        "set 2 ** 32 - 2 (not 31-bit)": 104,
         "set 2 ** 31 - 2 (highest even)": 2 ** 31 - 2,
       },
       pushed: { id: 100, path: "/pushed" },


### PR DESCRIPTION
Follow-up to #37542 (now on main), rebased on top of it.

### Repro

```js
import http2 from "node:http2";
const server = http2.createServer((req, res) => res.end());
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("connect", () => {
    const set = id => (client.setNextStreamID(id), client.state.nextStreamID);
    console.log("nextStreamID after setNextStreamID(11), (12), (5):", set(11), set(12), set(5));
    client.setNextStreamID(11);
    const first = client.request();
    first.resume();
    first.on("close", () => {
      client.setNextStreamID(5);
      const second = client.request();
      second.resume();
      second.on("close", () => {
        console.log("stream ids used:", first.id, second.id);
        process.exit();
      });
    });
  });
});
```

```
node v26.3.0:                                              bun 1.4.0:
nextStreamID after setNextStreamID(11), (12), (5): 11 11 11    11 13 5
stream ids used: 11 13                                      11 5
```

Node ignores the even id on a client and the id below the current next one; bun rounds the first up and moves the counter back for the second, and the next request goes out on stream 5 after stream 11 was already used on the connection. A server session does the same through the native setter (`101` reads back as `102`, `50` is accepted after stream 100 was pushed), and both sides accept ids above `2 ** 31 - 1`, after which `state.nextStreamID` reads back `2147483649` or `4294967295` and the next `request()` fails with `ERR_HTTP2_OUT_OF_STREAMS`; node ignores those too.

The backwards case matters on the wire: a new stream id has to be higher than every id the endpoint used before (RFC 9113 section 5.1.1). Against a node server the second request above just hangs, because nghttp2 drops the header block for a non-increasing id without answering on it, while the same call on node is a no-op. (bun's own server answers it; that leniency is a separate server-side issue.)

### Cause

`H2FrameParser::set_next_stream_id` (`src/runtime/api/bun/h2_frame_parser.rs`) stored `id - 1` or `id - 2` depending on the id's parity, so an id of the peer's parity came back out of `get_next_stream_id()` rounded up, any id was accepted no matter where the counter already was, and nothing bounded it by the 31-bit stream id space. Node's `setNextStreamID` hands the id to `nghttp2_session_set_next_stream_id`, which rejects (and node then silently ignores) an id of the wrong parity, an id below the session's current next id and, because node converts the argument with `Int32Value`, anything above `2 ** 31 - 1`.

### Fix

The setter is a no-op unless the id has this side's parity, is at most `MAX_STREAM_ID` and is above the current `get_next_stream_id()`; it then stores `id - 2`, which both sides step from to exactly `id`. An id equal to the current next id is a no-op as well, which is what nghttp2 accepting it amounts to; treating it as a no-op (rather than re-storing `id - 2`) is what keeps `last_stream_id`, and with it `state.lastProcStreamID`, from moving. The JS wrapper already mirrors node's own checks (non-numbers, `<= 0` and `> 2 ** 32 - 1` throw), so what throws and what is ignored now matches node for every input.

One deliberate difference: bun's parser keeps a single `last_stream_id` high-water mark for both directions (received client streams bump it on a server), so "current next id" on a server session is that merged value. A server id below a client stream that was already received is therefore ignored here, where nghttp2, with its own counter per direction, would accept it. The alternative, letting the setter move the shared mark back below streams the peer already opened, would also corrupt what `lastProcStreamID`, the legacy GOAWAY paths and the engine's late-RST_STREAM tolerance read from it. The only thing that differs in that case is which even ids later pushes get; splitting the counter is a larger change than this fix and nothing in the ported suites depends on it.

With the setter bounded, every write to `last_stream_id` stays within `MAX_STREAM_ID` (wire ids are masked to 31 bits, `getNextStream`/`request` reject above it), so the saturating step #37542 added to `get_next_stream_id` can no longer trigger; it goes back to plain arithmetic with the invariant noted on the function. #37542's test still passes with one expectation changed: `2 ** 32 - 1` on a server now leaves the next id at `2`, which is node's value, instead of reading back `4294967295`.

### Verification

New test `http2 setNextStreamID ignores the ids nghttp2 rejects instead of rounding them or moving backwards` in `test/js/node/http2/node-http2.test.js` drives a client and a server session through wrong-parity ids (both the adjacent one and one two steps out, since the adjacent one reads back the same whether or not parity is checked), ids below and equal to the current next id (the equal rows also read `lastProcStreamID`, which is what distinguishes an ignored call from one that re-stores the position), the lowest accepted id on each side, and both ends of the 31-bit range, with real traffic in between: the ids the requests actually go out on, and a `pushStream()` landing on stream 100. Every expected value was taken from running the same sequence on node v26.3.0 (`session.setNextStreamID` on the server there). On the released bun the test fails with 14 differing values; with this branch it passes, as do the rest of `node-http2.test.js`, `h2-conformance.test.ts`, `node-http2-streams-rehash.test.ts`, `h2-push-refusal-staged.test.ts`, and the ported `test-http2-client-setNextStreamID-errors.js`, `test-http2-no-more-streams.js` (sets `2 ** 31 - 1` on a client and must still get that stream), `test-http2-client-destroy.js`, `test-http2-session-stream-state.js` and the server push tests.

Node v26.3.0 has no further upstream test for this (`test-http2-client-setNextStreamID-errors.js` only covers the throwing paths), hence the test here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (503253618)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [816.08ms]
(pass) node none > Client Basics > should be able to send a POST request [540.68ms]
(pass) node none > Client Basics > constants [17.98ms]
(pass) node none > Client Basics > getDefaultSettings [6.84ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.69ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.20ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.09ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.07ms]
(pass) node none > Client Basics > should be able to send data using end [571.52ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [560.48ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 12 failed, 6 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.89ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.41ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [2.15ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.82ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [6.32ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.48ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [52.61ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (503253618)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [999.40ms]
(pass) node none > Client Basics > should be able to send a POST request [701.83ms]
(pass) node none > Client Basics > constants [18.92ms]
(pass) node none > Client Basics > getDefaultSettings [7.37ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [24.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.56ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.40ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.47ms]
(pass) node none > Client Basics > should be able to send data using end [733.17ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [721.59ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1056ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 20s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+503253618
[build] done
bun test v1.4.0-canary.1 (503253618)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.84ms]
(pass) node none > Client Basics > getDefaultSettings [0.18ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.40ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too sm
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs |  36 ++++----
 test/js/node/http2/node-http2.test.js  | 148 ++++++++++++++++++++++++++++++++-
 2 files changed, 160 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs     13      7      0
test/js/node/http2/node-http2.test.js       6     13      0
```

</details>

<!-- robobun:evidence:end -->
