### PR TITLE
node:http2: send session.goaway() error codes above 2^31-1 unchanged

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6869,7 +6869,6 @@ impl H2FrameParser {
         if !error_code_arg.is_number() {
             return Err(global_object.throw(format_args!("Expected errorCode to be a number")));
         }
-        // u32 like node's Uint32Value: an i32 read saturates codes above 0x7fffffff on the wire.
         let error_code = ErrorCode(error_code_arg.to_u32());
 
         let mut last_stream_id = this.last_peer_stream_id.get();

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6869,7 +6869,8 @@ impl H2FrameParser {
         if !error_code_arg.is_number() {
             return Err(global_object.throw(format_args!("Expected errorCode to be a number")));
         }
-        let error_code = error_code_arg.to_int32();
+        // u32 like node's Uint32Value: an i32 read saturates codes above 0x7fffffff on the wire.
+        let error_code = ErrorCode(error_code_arg.to_u32());
 
         let mut last_stream_id = this.last_peer_stream_id.get();
         if callframe.arguments_count() >= 2 {
@@ -6894,20 +6895,14 @@ impl H2FrameParser {
                     if let Some(array_buffer) = opaque_data_arg.as_array_buffer(global_object) {
                         // Own the bytes: write() re-enters JS on JS-backed sockets and can detach this.
                         let copied = array_buffer.byte_slice().to_vec();
-                        this.send_go_away(
-                            0,
-                            ErrorCode(error_code as u32),
-                            &copied,
-                            last_stream_id,
-                            false,
-                        );
+                        this.send_go_away(0, error_code, &copied, last_stream_id, false);
                         return Ok(JSValue::UNDEFINED);
                     }
                 }
             }
         }
 
-        this.send_go_away(0, ErrorCode(error_code as u32), b"", last_stream_id, false);
+        this.send_go_away(0, error_code, b"", last_stream_id, false);
         Ok(JSValue::UNDEFINED)
     }
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1929,6 +1929,47 @@ it("http2 session.goaway() sends custom data", async done => {
   });
 });
 
+// GOAWAY's error code is an unsigned 32-bit field: codes above 2^31-1 must reach the peer as
+// passed (node reads the argument with Uint32Value). Client and server sessions share the native
+// goaway(), and opaqueData selects between its two send paths, so the cases vary both.
+it.each([
+  ["server", 0xffffffff, Buffer.from([0xde, 0xad, 0xbe, 0xef])],
+  ["server", 0x80000000, undefined],
+  ["client", 0xffffffff, undefined],
+  ["client", 0x80000000, Buffer.from([0xde, 0xad, 0xbe, 0xef])],
+])("http2 %s session.goaway() sends an error code of %d unchanged", async (sender, code, opaqueData) => {
+  const server = http2.createServer();
+  const { promise: goawayReceived, resolve: onGoaway } = Promise.withResolvers();
+  const onGoawayEvent = (receivedCode, lastStreamID, receivedData) =>
+    onGoaway({ code: receivedCode, lastStreamID, opaqueData: receivedData });
+  server.on("session", session => {
+    if (sender === "server") session.goaway(code, 0, opaqueData);
+    else session.on("goaway", onGoawayEvent);
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  // A non-zero GOAWAY destroys the session that receives it with ERR_HTTP2_SESSION_ERROR.
+  client.on("error", () => {});
+  try {
+    if (sender === "client") {
+      await new Promise(resolve => client.once("connect", resolve));
+      client.goaway(code, 0, opaqueData);
+    } else {
+      client.on("goaway", onGoawayEvent);
+    }
+
+    expect(await goawayReceived).toEqual({
+      code,
+      lastStreamID: 0,
+      opaqueData: opaqueData ?? Buffer.alloc(0),
+    });
+  } finally {
+    client.destroy();
+    server.close();
+  }
+});
+
 it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a JS Duplex", async () => {
   // The cork-flush path re-enters JS (onWrite → Duplex _write) when the transport is a JS
   // stream. If that JS detaches the opaqueData ArrayBuffer mid-write, the GOAWAY payload must

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1938,27 +1938,26 @@ it.each([
   ["client", 0xffffffff, undefined],
   ["client", 0x80000000, Buffer.from([0xde, 0xad, 0xbe, 0xef])],
 ])("http2 %s session.goaway() sends an error code of %d unchanged", async (sender, code, opaqueData) => {
-  const server = http2.createServer();
-  const { promise: goawayReceived, resolve: onGoaway } = Promise.withResolvers();
+  const { promise: goawayReceived, resolve: onGoaway, reject } = Promise.withResolvers();
   const onGoawayEvent = (receivedCode, lastStreamID, receivedData) =>
     onGoaway({ code: receivedCode, lastStreamID, opaqueData: receivedData });
+  // The receiving side emits 'goaway' before it tears the session down with ERR_HTTP2_SESSION_ERROR,
+  // so the error and close events below only settle the promise when the frame never arrived.
+  const server = http2.createServer();
+  server.on("sessionError", reject);
   server.on("session", session => {
+    session.on("close", () => reject(new Error("server session closed before 'goaway'")));
     if (sender === "server") session.goaway(code, 0, opaqueData);
     else session.on("goaway", onGoawayEvent);
   });
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
 
   const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
-  // A non-zero GOAWAY destroys the session that receives it with ERR_HTTP2_SESSION_ERROR.
-  client.on("error", () => {});
+  client.on("error", reject);
+  client.on("close", () => reject(new Error("client session closed before 'goaway'")));
+  if (sender === "client") client.once("connect", () => client.goaway(code, 0, opaqueData));
+  else client.on("goaway", onGoawayEvent);
   try {
-    if (sender === "client") {
-      await new Promise(resolve => client.once("connect", resolve));
-      client.goaway(code, 0, opaqueData);
-    } else {
-      client.on("goaway", onGoawayEvent);
-    }
-
     expect(await goawayReceived).toEqual({
       code,
       lastStreamID: 0,


### PR DESCRIPTION
### Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("session", s => s.goaway(0xffffffff, 0, Buffer.from("big")));
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("error", () => {});
  client.on("goaway", code => {
    console.log(code.toString(16));
    client.destroy();
    server.close();
  });
});
```

Bun 1.4.0 and main print `7fffffff`; Node v26.3.0 prints `ffffffff`. Any code in `(0x7fffffff, 0xffffffff]` comes out as `0x7fffffff` (`0x80000000` does too), and a client session's `goaway()` is affected the same way since both session classes call the same native method. The receiving side is reporting what is on the wire: it decodes the frame's 4 error-code bytes directly.

### Cause

`H2FrameParser.goaway()` in `src/runtime/api/bun/h2_frame_parser.rs` read the code with `JSValue::to_int32()` and then cast it to `u32` for the frame. `to_int32()` saturates doubles outside the `i32` range (`src/jsc/JSValue.rs`), so every code above `2^31 - 1` became `i32::MAX` before the cast. The frame writer itself (`send_go_away`) and the receive path (`handle_go_away_frame`, `on_go_away`) already handle the full 32 bits; only this argument read was signed.

### Fix

The fixing line is `let error_code = ErrorCode(error_code_arg.to_u32());`; the two `send_go_away` call sites just take the value instead of rebuilding it.

Why this is the right read: the GOAWAY error code is an unsigned 32-bit field (RFC 9113 section 6.8) and Node's binding reads the argument with `Uint32Value`, so every integer in `[0, 2^32 - 1]` has to reach the wire as passed. That is exactly the range `ServerHttp2Session#goaway()` validates today (`validateInteger(code, "code", 0, kMaxUint32)`) and the range #37554 makes the client session validate, and within it `to_u32()` is the identity. It is also how the other two error-code reads in this file already work (`rst_stream()` and `emit_error_to_all_streams()` both use `to_u32()`), so `goaway()` now matches its siblings.

`to_u32()` clamps where V8's `Uint32Value` wraps, which only differs for inputs outside that range. Those are rejected by the JS layer on the server today, and on the client once #37554 lands; in the meantime `client.goaway(-1)` goes out as `0` where it used to go out as `0xffffffff` (the `i32` value `-1` reinterpreted as `u32`), and `client.goaway(2 ** 32)` goes out as `0xffffffff` instead of `0x7fffffff` (Node: `0`). The other numeric reads in this file are deliberately left alone; none of them is an error code, and the `lastStreamId` read a few lines below is intentionally signed.

### Verification

`test/js/node/http2/node-http2.test.js`: "http2 %s session.goaway() sends an error code of %d unchanged" sends `0xffffffff` and `0x80000000` from a server session and from a client session and checks the peer's `'goaway'` event reports the same code (plus `lastStreamID` and the opaque data). The four cases cover both session classes and both send paths of the native method (with and without opaqueData). Session error and close events on both ends reject the awaited promise, so a GOAWAY that never surfaces fails with its cause instead of a timeout (both receivers emit `'goaway'` before tearing the session down, so on the passing path those listeners are no-ops). All four cases fail on the released binary (each receives `2147483647`) and pass with the debug build.

The rest of `node-http2.test.js` (351 tests) and the ported Node goaway/shutdown tests (`test-http2-goaway-opaquedata`, `test-http2-server-shutdown-*`, `test-http2-session-graceful-close`, `test-http2-client-destroy`, `test-http2-goaway-delayed-request`, `test-http2-session-cleanup-on-nghttp2-goaway`) pass with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (91c2fbdc9)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [877.38ms]
(pass) node none > Client Basics > should be able to send a POST request [593.05ms]
(pass) node none > Client Basics > constants [19.01ms]
(pass) node none > Client Basics > getDefaultSettings [7.52ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [23.71ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.55ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.22ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.28ms]
(pass) node none > Client Basics > should be able to send data using end [611.64ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [597.61ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 4 failed, 6 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.96ms]
(pass) node none > Client Basics > getDefaultSettings [0.17ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.42ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [2.21ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.82ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.69ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.17ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [37.37ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (91c2fbdc9)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [936.36ms]
(pass) node none > Client Basics > should be able to send a POST request [668.40ms]
(pass) node none > Client Basics > constants [19.24ms]
(pass) node none > Client Basics > getDefaultSettings [7.99ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [25.76ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [6.52ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.49ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.95ms]
(pass) node none > Client Basics > should be able to send data using end [709.30ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [703.40ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     91c2fbdc9a
  features     baseline

22 deps, 107 codegen, 1176 objects in 1110ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] fetch zlib
[zlib] up to date
[3/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [43.00ms]
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] subst deps/zlib/zlib.h
[6/1237] gen .bind.ts → GeneratedBindings.cpp
[7/1237] fetch nodejs (prebuilt)
[nodejs] up to date
[8/1237] fetch picohttpparser
[picohttpparser] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [1.00ms]
[11/1237] subst deps/zlib/zconf.h
[12/1188] gen bindgenv2
[13/1188] gen JSBuffer.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs | 12 +++-------
 test/js/node/http2/node-http2.test.js  | 40 ++++++++++++++++++++++++++++++++++
 2 files changed, 43 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs      8      5      0
test/js/node/http2/node-http2.test.js       5      5      0
```

</details>

**root cause** · written by the author bot

H2FrameParser.goaway() read the JS error code with to_int32(), which saturates any double above 2^31-1, so GOAWAY codes in (0x7fffffff, 0xffffffff] were written to the wire as 0x7fffffff even though the GOAWAY error code field is unsigned 32-bit and Node sends the value unchanged via ToUint32. The fix reads the argument with to_u32() after the existing is_number() guard and constructs the ErrorCode once from that value for both send_go_away call sites, which is the identity over the 0 to kMaxUint32 range the JS layer already validates and matches how rst_stream() and emit_error_to_all_strea…

<!-- robobun:evidence:end -->