### PR TITLE
strings: carry RawSlice<u8> in ZigStringSlice borrowed variants

### DIFF
--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -43,6 +43,7 @@ use crate::strings;
 #[path = "identifier.rs"]
 pub mod identifier;
 
+use crate::RawSlice;
 use core::sync::atomic::{AtomicUsize, Ordering};
 pub use wtf::{WTFStringImpl, WTFStringImplExt, WTFStringImplStruct};
 
@@ -989,15 +990,11 @@ impl String {
             // hand back a non-owning `WtfBorrowed` view pinned by it; a second
             // ref would be redundant since `underlying` already keeps the impl
             // alive.
-            if let ZigStringSlice::Static(ptr, len) = slice {
+            if let ZigStringSlice::Static(bytes) = slice {
                 self.ref_();
                 let string_impl = self.wtf_ptr();
                 return SliceWithUnderlyingString {
-                    utf8: ZigStringSlice::WtfBorrowed {
-                        string_impl,
-                        ptr,
-                        len,
-                    },
+                    utf8: ZigStringSlice::WtfBorrowed { string_impl, bytes },
                     underlying: *self,
                     #[cfg(debug_assertions)]
                     did_report_extra_memory_debug: false,
@@ -1546,7 +1543,7 @@ impl ZigString {
         if self.is_16bit() {
             return ZigStringSlice::Owned(self.to_owned_slice());
         }
-        ZigStringSlice::Static(Self::untagged(self.tagged_ptr()), self.len)
+        self.to_slice_borrowed()
     }
 
     /// `ZigString.sliceZBuf` — `Display`-format into `buf`, NUL-terminate, and
@@ -1643,7 +1640,15 @@ impl ZigString {
             }
             // None ⇒ all-ASCII; safe to borrow as-is.
         }
-        ZigStringSlice::Static(Self::untagged(self.tagged_ptr()), self.len)
+        self.to_slice_borrowed()
+    }
+
+    /// Caller must ensure `len != 0` (empty strings may carry a null pointer) and `!is_16bit()`.
+    #[inline]
+    fn to_slice_borrowed(&self) -> ZigStringSlice {
+        let ptr = Self::untagged(self.tagged_ptr());
+        // SAFETY: per the doc comment, `ptr` is non-null and addresses `len` initialized bytes.
+        ZigStringSlice::from_utf8_never_free(unsafe { core::slice::from_raw_parts(ptr, self.len) })
     }
 
     /// `ZigString.toOwnedSlice` — allocate a fresh UTF-8 `Vec<u8>` regardless
@@ -1697,7 +1702,7 @@ impl ZigString {
 /// ownership.
 pub enum ZigStringSlice {
     /// Borrowed; never freed (`fromUTF8NeverFree`).
-    Static(*const u8, usize),
+    Static(RawSlice<u8>),
     /// Heap-owned; Drop frees via global mimalloc.
     Owned(Vec<u8>),
     /// Backed by a WTFStringImpl ref; Drop derefs it. Stored as raw ptr to
@@ -1706,8 +1711,7 @@ pub enum ZigStringSlice {
     /// (which takes `*const`); refcount mutation happens on the C++ side.
     WTF {
         string_impl: *const wtf::WTFStringImplStruct,
-        ptr: *const u8,
-        len: usize,
+        bytes: RawSlice<u8>,
     },
     /// Borrowed view of a `WTFStringImpl`'s all-ASCII Latin-1 buffer that does
     /// **not** hold its own refcount: the enclosing
@@ -1723,8 +1727,7 @@ pub enum ZigStringSlice {
     /// [`clone_ref`]: ZigStringSlice::clone_ref
     WtfBorrowed {
         string_impl: *const wtf::WTFStringImplStruct,
-        ptr: *const u8,
-        len: usize,
+        bytes: RawSlice<u8>,
     },
 }
 impl Default for ZigStringSlice {
@@ -1733,9 +1736,10 @@ impl Default for ZigStringSlice {
     }
 }
 impl ZigStringSlice {
-    pub const EMPTY: Self = Self::Static(core::ptr::null(), 0);
+    pub const EMPTY: Self = Self::Static(RawSlice::EMPTY);
+    #[inline]
     pub fn from_utf8_never_free(s: &[u8]) -> Self {
-        Self::Static(s.as_ptr(), s.len())
+        Self::Static(RawSlice::new(s))
     }
     pub fn init_owned(v: Vec<u8>) -> Self {
         Self::Owned(v)
@@ -1757,16 +1761,10 @@ impl ZigStringSlice {
     #[inline]
     pub fn slice(&self) -> &[u8] {
         match self {
-            Self::Static(p, l) if *l == 0 => &[],
-            // SAFETY: constructor guarantees ptr/len describe a valid slice for self's lifetime.
-            Self::Static(p, l) => unsafe { core::slice::from_raw_parts(*p, *l) },
+            Self::Static(bytes) | Self::WTF { bytes, .. } | Self::WtfBorrowed { bytes, .. } => {
+                bytes.slice()
+            }
             Self::Owned(v) => v.as_slice(),
-            Self::WTF { ptr, len, .. } | Self::WtfBorrowed { ptr, len, .. } if *len == 0 => &[],
-            // SAFETY: WTF/WtfBorrowed views are pinned (own ref / `underlying`
-            // ref respectively); latin1 buffer valid while the pin is held.
-            Self::WTF { ptr, len, .. } | Self::WtfBorrowed { ptr, len, .. } => unsafe {
-                core::slice::from_raw_parts(*ptr, *len)
-            },
         }
     }
 }
@@ -1899,9 +1897,10 @@ impl ZigStringSlice {
     #[inline]
     pub fn length(&self) -> usize {
         match self {
-            Self::Static(_, l) => *l,
+            Self::Static(bytes) | Self::WTF { bytes, .. } | Self::WtfBorrowed { bytes, .. } => {
+                bytes.len()
+            }
             Self::Owned(v) => v.len(),
-            Self::WTF { len, .. } | Self::WtfBorrowed { len, .. } => *len,
         }
     }
 
@@ -1934,18 +1933,9 @@ impl ZigStringSlice {
     /// drops the utf8 view).
     pub fn clone_ref(&self) -> Self {
         match self {
-            Self::Static(p, l) => Self::Static(*p, *l),
+            Self::Static(bytes) => Self::Static(*bytes),
             Self::Owned(v) => Self::Owned(v.clone()),
-            Self::WTF {
-                string_impl,
-                ptr,
-                len,
-            }
-            | Self::WtfBorrowed {
-                string_impl,
-                ptr,
-                len,
-            } => {
+            Self::WTF { string_impl, bytes } | Self::WtfBorrowed { string_impl, bytes } => {
                 // SAFETY: invariant of the WTF/WtfBorrowed variants is that
                 // `string_impl` points at a live `WTF::StringImpl` for as long
                 // as `self` exists; bumping its refcount yields a second owner
@@ -1953,8 +1943,7 @@ impl ZigStringSlice {
                 unsafe { (**string_impl).r#ref() };
                 Self::WTF {
                     string_impl: *string_impl,
-                    ptr: *ptr,
-                    len: *len,
+                    bytes: *bytes,
                 }
             }
         }
@@ -1987,7 +1976,7 @@ pub mod zig_string {
         /// several dependents call `.empty()`.
         #[inline]
         pub const fn empty() -> Self {
-            Self::Static(core::ptr::null(), 0)
+            Self::EMPTY
         }
     }
 }

--- a/src/bun_core/string/wtf.rs
+++ b/src/bun_core/string/wtf.rs
@@ -1,3 +1,4 @@
+use crate::RawSlice;
 use crate::string::ZigStringSlice;
 use crate::strings;
 
@@ -34,7 +35,6 @@ impl WTFStringImplExt for WTFStringImplStruct {
     #[inline]
     fn to_latin1_slice(&self) -> ZigStringSlice {
         self.r#ref();
-        let s = self.latin1_slice();
         // ZigStringSlice::WTF derefs `self` on Drop.
         // SAFETY: `self` is a live WTF::StringImpl with refcount just bumped above;
         // we store only a `*const` (never materialize `&mut`) and the matching
@@ -42,8 +42,7 @@ impl WTFStringImplExt for WTFStringImplStruct {
         // interior mutability, same as `r#ref`/`deref` already rely on.
         ZigStringSlice::WTF {
             string_impl: std::ptr::from_ref::<Self>(self),
-            ptr: s.as_ptr(),
-            len: s.len(),
+            bytes: RawSlice::new(self.latin1_slice()),
         }
     }
 
@@ -89,11 +88,9 @@ impl WTFStringImplExt for WTFStringImplStruct {
             }
 
             // All-ASCII Latin-1: borrow the impl's own bytes, no refcount bump.
-            let s = self.latin1_slice();
             return ZigStringSlice::WtfBorrowed {
                 string_impl: std::ptr::from_ref::<Self>(self),
-                ptr: s.as_ptr(),
-                len: s.len(),
+                bytes: RawSlice::new(self.latin1_slice()),
             };
         }
 


### PR DESCRIPTION
## What

`ZigStringSlice` in `src/bun_core/string/mod.rs` spelled the borrowed byte view three times, once per borrowed variant, as a separate `*const u8` plus `usize`, and the empty value was the in-band sentinel `Static(ptr::null(), 0)` (spelled out in both `EMPTY` and `empty()`). Because a null data pointer was a legal payload, `slice()` needed two `len == 0` guard arms in front of two `from_raw_parts` unsafe blocks, and `length()`, `clone_ref()` and the `WtfBorrowed` construction in `String::to_thread_safe_slice` each re-spelled the pair. The borrowed variants now carry `bun_core::RawSlice<u8>`, the type this crate already uses for holder-lifetime `*const [T]` fields:

```rust
// before
Static(*const u8, usize),
WTF { string_impl: *const WTFStringImplStruct, ptr: *const u8, len: usize },
WtfBorrowed { string_impl: *const WTFStringImplStruct, ptr: *const u8, len: usize },
pub const EMPTY: Self = Self::Static(core::ptr::null(), 0);

// after
Static(RawSlice<u8>),
WTF { string_impl: *const WTFStringImplStruct, bytes: RawSlice<u8> },
WtfBorrowed { string_impl: *const WTFStringImplStruct, bytes: RawSlice<u8> },
pub const EMPTY: Self = Self::Static(RawSlice::EMPTY);
```

`from_utf8_never_free` wraps with `RawSlice::new`, `empty()` returns `EMPTY`, the two `WTFStringImplExt` constructors in `wtf.rs` pass `RawSlice::new(self.latin1_slice())`, and `to_thread_safe_slice` moves the `bytes` payload from the `Static` it matched into the `WtfBorrowed` it builds. The 3 readers (`slice()`, `length()`, `clone_ref()`) bind the single payload in one or-pattern arm each; `slice()` is now `bytes.slice()` with no guard arms and no unsafe. The two `ZigString` sites (`to_slice`, `to_slice_fast`) that built `Static` directly from the untagged pointer and `len` share a new private `to_slice_borrowed` helper holding the one `from_raw_parts` call, so the change removes 2 unsafe blocks and adds 1. `from_utf8_never_free` gains `#[inline]` because it is now on the `#[inline] to_slice` path. The only uses of these variants outside `bun_core` are two `matches!(.., Static(..))` / `matches!(.., WTF { .. })` checks in `webcore/Blob.rs`, which compile unchanged. No dependency changes.

## Why

A borrowed payload is now one value whose type says it is a view into storage owned by someone else (the caller for `Static`, the held ref for `WTF`, the enclosing `underlying` for `WtfBorrowed`), and a null pointer is no longer a representable payload, so the `len == 0` special cases in `slice()` go away rather than being re-checked on every read. `RawSlice<u8>` is `#[repr(transparent)]` over `*const [u8]`, the same two words it replaces, so each variant and the 32-byte enum keep their layout (`shell/interpreter.rs` sizes `ZigStringSlice` for GC accounting), `RawSlice::new` and `slice()` are pointer casts, `to_slice_borrowed` produces exactly the untagged pointer and `len` the two sites stored before, and `slice()` drops two branches without gaining any.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/util/bunstring-tothreadsafe.test.ts test/js/web/fetch/blob.test.ts test/js/node/path/join.test.js test/js/node/path/zero-length-strings.test.js: 50 pass, 0 fail (4 files).
