### PR TITLE
test: warm up the import() file-path leak fixture and shorten its loop

### DIFF
--- a/test/cli/run/esm-fixture-leak-small.mjs
+++ b/test/cli/run/esm-fixture-leak-small.mjs
@@ -9,15 +9,23 @@ const rss =
     ? Bun.unsafe.memoryFootprint
     : process.memoryUsage.rss;
 
+// The JS heap and allocator grow by 5-10 MB over the first couple thousand
+// loads and then hold steady. Taking the baseline after that leaves only
+// per-load growth inside the measured window, which is what lets the window be
+// 40k loads instead of the 100k this fixture used to need (20-27s on the 4 vCPU
+// CI agents, against the test's 30s budget).
+const warmupLoads = 2_000;
+const measuredLoads = 40_000;
+
 if (typeof Bun !== "undefined") Bun.gc(true);
-for (let i = 0; i < 5; i++) {
+for (let i = 0; i < warmupLoads; i++) {
   delete require.cache[dest];
   await import(dest);
 }
 if (typeof Bun !== "undefined") Bun.gc(true);
 const baseline = rss();
 
-for (let i = 0; i < 100000; i++) {
+for (let i = 0; i < measuredLoads; i++) {
   delete require.cache[dest];
   await import(dest);
 }
@@ -27,19 +35,10 @@ setTimeout(() => {
   let diff = rss() - baseline;
   diff = (diff / 1024 / 1024) | 0;
   console.log({ leaked: diff + " MB" });
-  // This test seems to be more flaky on slow filesystems.
-  // This used to be 40 MB, but the original version of Bun which this triggered on would reach 120 MB
-  // so we can increase it to 100 and still catch the leak.
-  //
-  // ❯ bunx bun@1.0.0 --smol test/cli/run/esm-fixture-leak-small.mjs
-  // {
-  //   leaked: "100 MB"
-  // }
-  // ❯ bunx bun@1.1.0 --smol test/cli/run/esm-fixture-leak-small.mjs
-  // {
-  //   leaked: "38 MB",
-  // }
-  if (diff >= (isASAN ? 500 : 100)) {
+  // The leak this guards against retained about 1 KB per load (bun 1.0.0
+  // measured 100-120 MB over 100k loads), so 40k loads of it are 40 MB or more.
+  // A non-leaking release build measures 0-7 MB here (20 runs, Linux x64).
+  if (diff >= (isASAN ? 500 : 20)) {
     console.log("\n--fail--\n");
     process.exit(1);
   } else {


### PR DESCRIPTION
### Failure

`test/cli/run/require-cache.test.ts` on the `:alpine: 3.23 x64` lane of build 91764 (#32020, at a commit that only touches http code), red on all four attempts:

```
✗ require.cache > files transpiled and loaded don't leak file paths > via import() [30007.27ms]
  ^ this test timed out after 30000ms.
```

### Cause

The test spawns `esm-fixture-leak-small.mjs`, which did 100k `import()` loads of a one-line module and failed if RSS grew by 100 MB or more. The loop is that long because the fixture only warmed up for 5 loads, so the 5-10 MB the heap and allocator grow by on the way to steady state landed inside the measurement, and the leak signal had to be large enough to clear it.

100k loads cost 8-18s on a release build by themselves. `require-cache.test.ts` is a `describe.concurrent` block whose other fixtures are also CPU bound, and the CI agents have 4 vCPUs, so in CI this fixture runs at a fraction of a core. From the job logs of five main builds between Aug 5 and Aug 11, the file takes 20.8-25.2s on the alpine x64 lane (27.3s on debian x64 in build 91764). Running the file locally pinned to 2 cores reproduces that file time and this fixture finishes at about 0.7 of it, which puts it at roughly 15-18s of its 30s budget on a normal alpine run. The agent that ran build 91764 was about twice as slow (the file took 41-52s on each attempt) and the fixture timed out every time. The other fixtures in the file have 60s budgets; this one has 30s (60s on Windows).

### Fix

Warm up for 2,000 loads before taking the baseline, then measure 40,000 loads against a 20 MB bound. The ASAN bound is unchanged at 500 MB (the quarantine dominates that number). Per-test timeouts are untouched.

### Numbers

Non-leaking build, RSS growth inside the measured window:

| | old (5 warmup, 100k) | new (2k warmup, 40k) |
|---|---|---|
| Linux x64 release | 5-10 MB (6 runs) | 0.9-7.0 MB (20 runs) |
| Windows x64 release | 6.9-9.2 MB (2 runs) | 1.9-5.0 MB (10 runs) |
| Linux debug+ASAN | 412 MB | 240 MB (bound is 500) |

The leak this fixture exists for retained about 1 KB per load (the removed comment recorded 100-120 MB over 100k loads on bun 1.0.0), which is 40 MB or more over the new window. Retaining a 1 KB string per load on purpose measures 42-74 MB on Linux and 56-75 MB on Windows against the 20 MB bound. The old design caught the same leak with a 100-120 MB signal against a 100 MB bound.

Time:

- fixture alone, release: 8.2-17.9s before, 2.4-4.9s after (Linux); 8.0s before, 3.4s after (Windows); 426s before, 189s after (debug+ASAN)
- whole file pinned to 2 cores with the release build, which reproduces the ~21s file time the alpine lane shows on main: `via import()` took 15.6s before and 8.9-9.0s after; file time unchanged at 20-22s since the 60s-budget fixtures now set it

The test passes before and after this change on a healthy machine by design; the change only moves the fixture off the timeout edge, so there is no fail-before proof to give.
