### PR TITLE
html_rewriter: count RewriterPipe owners with CellRefCounted

### DIFF
--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -57,9 +57,8 @@ pub enum Tag {
     HTTPSServerH3RequestContext,
     DebugHTTPSServerH3RequestContext,
     HTMLRewriterSuspension,
-    /// Task-only tag (never a context cell): frees a `RewriterPipe` whose
-    /// last claim was released from a GC destructor; see
-    /// `RewriterPipe::release_pump_claim`.
+    /// Task-only tag (never a context cell): drops the last ref of a
+    /// `RewriterPipe` on behalf of `RewriterPipe::release_pump_ref`.
     HTMLRewriterPipeFree,
 }
 
@@ -221,13 +220,11 @@ impl DeferredDerefTask {
     pub(crate) fn run_from_js_thread(packed_ptr: usize) {
         let tag = Tag::from_raw((packed_ptr & Self::TAG_MASK) as u8);
         let ctx = (packed_ptr & !Self::TAG_MASK) as *mut c_void;
-        // SAFETY: ctx was packed in `schedule` from a live pointer of the
-        // type indicated by `tag`. The request-context tags hold an intrusive
-        // refcount released here. The HTMLRewriter tags point at a
-        // claim-counted `RewriterPipe`: the suspension task owns the claim
-        // taken in `begin_suspension`, and `HTMLRewriterPipeFree` is
-        // scheduled only by the release of the last claim, so this task is
-        // the sole owner of the allocation it frees. We are on the JS thread.
+        // SAFETY: ctx was packed in `schedule` from a live, non-null pointer
+        // of the type indicated by `tag`, and this task owns one ref on it,
+        // released below (for the HTMLRewriter tags: the ref taken in
+        // `begin_suspension`, or the last ref handed over by
+        // `release_pump_ref`). We are on the JS thread.
         unsafe {
             match tag {
                 Tag::HTTPServerRequestContext => (*ctx.cast::<HTTPServerRequestContext>()).deref(),
@@ -253,7 +250,9 @@ impl DeferredDerefTask {
                     html_rewriter::RewriterPipe::abandon_suspension(back);
                 }
                 Tag::HTMLRewriterPipeFree => {
-                    bun_core::heap::destroy(ctx.cast::<html_rewriter::RewriterPipe>());
+                    <html_rewriter::RewriterPipe as bun_ptr::CellRefCounted>::deref_nn(
+                        NonNull::new_unchecked(ctx.cast::<html_rewriter::RewriterPipe>()),
+                    );
                 }
             }
         }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -694,6 +694,7 @@ pub type HTMLRewriterTransform = RewriterPipe;
 /// when a content handler returns a pending Promise), and emits output either
 /// into a pre-stream buffer or — once JS reads `.body` — a [`ByteStream`]
 /// whose `producer` is [`SourceHandle::HTMLRewriter`].
+#[derive(bun_ptr::CellRefCounted)]
 pub struct RewriterPipe {
     pub(crate) global: GlobalRef,
     /// The owning `JSHTMLRewriterTransform` wrapper cell (whose `m_ctx` is this
@@ -762,56 +763,34 @@ pub struct RewriterPipe {
     /// `m_sinkPtr` (releases via `__controllerDetached`), and a parked
     /// suspension's reaction/abandon task. GC sweeps cells in unspecified
     /// order within a cycle, so whichever owner releases last frees the Box.
-    claims: Cell<u8>,
-    /// `claims` includes a JS-pump controller entry; consumed exactly once by
-    /// [`Self::release_pump_claim`].
+    ref_count: Cell<u32>,
+    /// `ref_count` includes a JS-pump controller entry; consumed exactly once
+    /// by [`Self::release_pump_ref`].
     pump_controller_attached: Cell<bool>,
 }
 
 impl RewriterPipe {
     /// `JSHTMLRewriterTransform` finalizer. Runs during GC sweep: nothing
-    /// here may touch other GC cells, and the other `claims` holders may
-    /// still dispatch into the pipe after this cell is swept. So only
-    /// release the cell's claim; the last holder frees the Box. At VM
-    /// shutdown deferred releases never run, so a still-claimed pipe leaks
-    /// instead of being freed under a live claim.
+    /// here may touch other GC cells, and the other ref holders may still
+    /// dispatch into the pipe after this cell is swept. So only release the
+    /// cell's ref; the last holder frees the Box. At VM shutdown deferred
+    /// releases never run, so a pipe with refs outstanding leaks instead of
+    /// being freed under a live ref.
     pub fn finalize(this: Box<Self>) {
-        this.cell.set(JSValue::ZERO);
-        if this.release_claim() {
-            let _ = Box::into_raw(this);
-            return;
-        }
-        drop(this);
-    }
-
-    #[inline]
-    fn acquire_claim(&self) {
-        self.claims.set(self.claims.get() + 1);
-    }
-
-    /// Releases one claim; `true` while other owners remain (the caller must
-    /// not free the pipe).
-    #[inline]
-    fn release_claim(&self) -> bool {
-        let n = self
-            .claims
-            .get()
-            .checked_sub(1)
-            .expect("RewriterPipe claims underflow");
-        self.claims.set(n);
-        n > 0
+        bun_ptr::finalize_js_box(this, |pipe| pipe.cell.set(JSValue::ZERO));
     }
 
     /// The JS-pump controller detached and can never dispatch into the pipe
-    /// again: release its claim. A last-owner free is deferred to the event
-    /// loop because the C++ caller keeps using the allocation in the same
-    /// frame (the destructor's trailing `__finalize`, the close/end host
+    /// again: release its ref. Releasing the last ref is deferred to the
+    /// event loop because the C++ caller keeps using the allocation in the
+    /// same frame (the destructor's trailing `__finalize`, the close/end host
     /// fns' `__close`/`__endWithSink` on the saved pointer).
-    fn release_pump_claim(&self) {
+    fn release_pump_ref(&self) {
         if !self.pump_controller_attached.replace(false) {
             return;
         }
-        if self.release_claim() {
+        if self.ref_count.get() > 1 {
+            Self::deref_nn(NonNull::from(self));
             return;
         }
         native_promise_context::DeferredDerefTask::schedule(
@@ -823,7 +802,7 @@ impl RewriterPipe {
     /// Queued by the `NativePromiseContext` destructor (via
     /// `DeferredDerefTask`) when the handler's promise was collected without
     /// settling: it will never resume this pipe. Runs on the JS thread,
-    /// outside GC sweep; the suspension's claim keeps `pipe` live until here.
+    /// outside GC sweep; the suspension's ref keeps `pipe` live until here.
     ///
     /// If the Transform cell is still alive (its `cell` backref is set) —
     /// a reader or the output Response keeps the rewrite reachable — fail
@@ -843,11 +822,7 @@ impl RewriterPipe {
         this.fail(webcore::body::ValueError::Message(BunString::static_(
             "HTMLRewriter content handler returned a Promise that will never settle",
         )));
-        if !this.release_claim() {
-            // SAFETY: last owner; no cell, controller, or task points at the
-            // allocation any more.
-            unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
-        }
+        Self::deref_nn(pipe.into());
     }
 
     /// Record a handler's exception for the enclosing lol-html call to pick
@@ -964,7 +939,7 @@ impl RewriterPipe {
             driving: Cell::new(false),
             pending: JsCell::new(WritablePending::default()),
             done: Cell::new(false),
-            claims: Cell::new(1),
+            ref_count: Cell::new(1),
             pump_controller_attached: Cell::new(false),
         });
         // Every field is `Cell`/`JsCell`, so a shared `&RewriterPipe` via
@@ -1044,9 +1019,8 @@ impl RewriterPipe {
         // so it survives as long as user code can reach the output.
         let cell = js_HTMLRewriterTransform::to_js(pipe.as_ptr(), global);
         if !cell.is_cell() {
-            // Ownership was not transferred (allocation of the wrapper failed);
-            // reclaim and drop the Box allocation.
-            bun_ptr::destroy_box_with(pipe.as_ptr(), |_| {});
+            // No wrapper exists to own the initial ref, so drop it here.
+            Self::deref_nn(pipe);
             return Err(global.throw_out_of_memory());
         }
         this.cell.set(cell);
@@ -1167,10 +1141,10 @@ impl RewriterPipe {
         // JS-pump fallback: `assign_to_stream` installs a JS sink wrapper that
         // forwards to `JsSinkType for RewriterPipe`. The controller cell it
         // creates holds `pipe` raw as `m_sinkPtr` and dispatches
-        // `__controllerDetached` from wherever it detaches — including its
-        // GC destructor — so it owns a claim until `release_pump_claim`.
+        // `__controllerDetached` from wherever it detaches (including its
+        // GC destructor), so it owns a ref until `release_pump_ref`.
         this.pump_controller_attached.set(true);
-        this.acquire_claim();
+        this.ref_();
         let assignment_result =
             JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
         assignment_result.ensure_still_alive();
@@ -1562,9 +1536,9 @@ impl RewriterPipe {
         let pipe = core::ptr::from_ref(self).cast_mut();
         let context = native_promise_context::create(&self.global, pipe, cell);
         // The context destructor (promise GC'd unsettled) queues
-        // `abandon_suspension`; this claim keeps the pipe alive until that
+        // `abandon_suspension`; this ref keeps the pipe alive until that
         // task or the settle reaction releases it.
-        self.acquire_claim();
+        self.ref_();
         promise.then_with_value(
             &self.global,
             context,
@@ -1681,12 +1655,12 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
     fn memory_cost(&self) -> usize {
         self.pending_input.get().capacity() + self.output_buffer.get().capacity()
     }
-    // Unlike other sinks, the controller does not own the pipe: its claim is
+    // Unlike other sinks, the controller does not own the pipe: its ref is
     // released by `controller_detached` below, and the free happens wherever
-    // the last claim drops.
+    // the last ref drops.
     fn finalize(&mut self) {}
     fn controller_detached(&mut self) {
-        RewriterPipe::release_pump_claim(self);
+        RewriterPipe::release_pump_ref(self);
     }
     fn write_bytes(&mut self, data: &StreamResult) -> Writable {
         RewriterPipe::write(self, data)
@@ -1780,13 +1754,8 @@ fn on_handler_resolve(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JS
     let pipe = BackRef::from(pipe);
     pipe.release_suspended_wrapper();
     pipe.resume_rewrite();
-    // Balances the `acquire_claim` in `begin_suspension`. Never the last
-    // claim in practice: the context cell roots the Transform cell, so the
-    // cell's own claim is still held while this reaction runs.
-    if !pipe.release_claim() {
-        // SAFETY: last owner (see above; defensive).
-        unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
-    }
+    // Balances the `ref_()` in `begin_suspension`.
+    RewriterPipe::deref_nn(pipe.into());
     Ok(JSValue::UNDEFINED)
 }
 
@@ -1801,12 +1770,8 @@ fn on_handler_reject(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSV
     pipe.fail(webcore::body::ValueError::JSValue(
         jsc::strong::Optional::create(reason, global),
     ));
-    // Balances the `acquire_claim` in `begin_suspension` (see
-    // `on_handler_resolve`).
-    if !pipe.release_claim() {
-        // SAFETY: last owner (defensive; the context cell roots the Transform cell).
-        unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
-    }
+    // Balances the `ref_()` in `begin_suspension`.
+    RewriterPipe::deref_nn(pipe.into());
     Ok(JSValue::UNDEFINED)
 }
 


### PR DESCRIPTION
## What

`RewriterPipe` (`src/runtime/api/html_rewriter.rs`), the native side of one `HTMLRewriter.transform()` call, is shared by up to three owners: the `JSHTMLRewriterTransform` cell, the JS-pump controller's raw `m_sinkPtr`, and a parked handler suspension. It counted them by hand with `claims: Cell<u8>`, `acquire_claim()` and `release_claim() -> bool`, and each of the five release sites read the bool and freed the `Box` itself: `finalize` leaked or dropped the `Box`, `abandon_suspension` and both `.then()` reactions called `heap::destroy` in their own `unsafe` blocks, and `release_pump_claim` dropped the count to zero and scheduled a `Tag::HTMLRewriterPipeFree` task whose arm was another `heap::destroy` (`src/runtime/api/NativePromiseContext.rs`).

The struct now derives `bun_ptr::CellRefCounted` (`ref_count: Cell<u32>`), the same primitive `TextChunk`, `DocType`, `Comment`, `EndTag`, `DocEnd`, `Element` and `AttributeIterator` already use in this file. The two acquire sites (`wire_input`, `begin_suspension`) are `ref_()`, the three inline release sites are `deref_nn`, `finalize` is `bun_ptr::finalize_js_box(this, |pipe| pipe.cell.set(JSValue::ZERO))`, the wrapper-allocation failure path in `init` drops the initial ref with `deref_nn` instead of `destroy_box_with`, and the deferred task arm is a `deref_nn` like the request-context arms beside it. The existing `impl Drop for RewriterPipe` is unchanged; the derive's default `destroy` drops the `Box`, which is what every removed free site did.

```rust
// before
if !this.release_claim() {
    // SAFETY: last owner ...
    unsafe { bun_core::heap::destroy(pipe.as_const_ptr().cast_mut()) };
}

// after
Self::deref_nn(pipe.into());
```

`release_pump_claim` becomes `release_pump_ref` and keeps deferring the final release to the event loop, because the C++ caller keeps using the allocation in the same frame; when other refs remain it calls `deref_nn` inline, and when it holds the last ref it leaves that ref to the task instead of zeroing the count and deferring the free. The `HTMLRewriterPipeFree` tag keeps its name and discriminant, so `NativePromiseContext.h` is untouched. Removes 3 `unsafe` blocks and the two bespoke helpers; two files, +43/-79 lines.

## Why

Who owns a `RewriterPipe` and when it is freed is now stated by the standard refcount type rather than by a `bool` that each caller had to interpret correctly, and the "count is zero but the allocation is still in use" window in the pump-detach path no longer exists. It is zero-cost: `ref_()` and `deref_nn` are the same `Cell` increment and decrement-and-branch the removed helpers compiled to, no path gains an allocation, task or check, and the deferred-release path schedules the same task at the same point. Widening the count from `Cell<u8>` to `Cell<u32>` moves `size_of::<RewriterPipe>()` from 264 to 272 bytes; both sizes are served from the same 320-byte mimalloc size class, so the heap block allocated per `transform()` is unchanged.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. test/js/workerd/html-rewriter.test.js, test/js/workerd/html-rewriter-leak.test.ts, test/js/workerd/html-rewriter-end-error.test.ts, test/regression/issue/htmlrewriter-additional-bugs.test.ts: 153 pass, 1 skip, 0 fail (154 tests across 4 files).
