### PR TITLE
md: replace the block byte buffer with typed header and line Vecs

### DIFF
--- a/src/md/blocks.rs
+++ b/src/md/blocks.rs
@@ -3,8 +3,6 @@ use crate::helpers;
 use crate::parser::{self, Parser};
 use crate::types::{self, BlockType, Container, Line, OFF, VerbatimLine};
 
-use core::mem::{align_of, size_of};
-
 type BlockHeader = parser::BlockHeader;
 
 impl Parser<'_> {
@@ -211,19 +209,9 @@ impl Parser<'_> {
                         && self.containers[(n_parents - 1) as usize].ch != b'>'
                         && n_brothers + n_children == 0
                         && self.current_block.is_none()
-                        && self.block_bytes.len() > size_of::<BlockHeader>()
+                        && self.blocks.last_type() == Some(BlockType::Li)
                     {
-                        let align_mask_: usize = align_of::<BlockHeader>() - 1;
-                        let top_off = (self.block_bytes.len() - size_of::<BlockHeader>()
-                            + align_mask_)
-                            & !align_mask_;
-                        if top_off + size_of::<BlockHeader>() <= self.block_bytes.len() {
-                            let top_type =
-                                self.block_bytes[self.block_bytes.len() - size_of::<BlockHeader>()];
-                            if top_type == BlockType::Li as u8 {
-                                self.last_list_item_starts_with_two_blank_lines = true;
-                            }
-                        }
+                        self.last_list_item_starts_with_two_blank_lines = true;
                     }
                 }
                 break;
@@ -236,18 +224,14 @@ impl Parser<'_> {
                         && self.containers[(n_parents - 1) as usize].ch != b'>'
                         && n_brothers + n_children == 0
                         && self.current_block.is_none()
-                        && self.block_bytes.len() > size_of::<BlockHeader>()
+                        && self.blocks.last_type() == Some(BlockType::Li)
                     {
-                        let top_type =
-                            self.block_bytes[self.block_bytes.len() - size_of::<BlockHeader>()];
-                        if top_type == BlockType::Li as u8 {
-                            n_parents -= 1;
-                            line.indent = total_indent;
-                            if n_parents > 0 {
-                                line.indent -= line
-                                    .indent
-                                    .min(self.containers[(n_parents - 1) as usize].contents_indent);
-                            }
+                        n_parents -= 1;
+                        line.indent = total_indent;
+                        if n_parents > 0 {
+                            line.indent -= line
+                                .indent
+                                .min(self.containers[(n_parents - 1) as usize].contents_indent);
                         }
                     }
                     self.last_list_item_starts_with_two_blank_lines = false;
@@ -639,8 +623,8 @@ impl Parser<'_> {
             }
         }
 
-        // Flush current leaf block before any container transitions
-        // so that VerbatimLine data stays contiguous after its BlockHeader.
+        // Flush the current leaf block before any container transitions so it
+        // lands in `blocks` ahead of the container headers pushed below.
         if (n_children == 0 && n_parents + n_brothers < self.n_containers)
             || n_brothers > 0
             || n_children > 0
@@ -712,18 +696,17 @@ impl Parser<'_> {
         // Opening code fence: start block but don't include fence line as content
         if line.r#type == LineType::Fencedcode && line.enforce_new_block {
             self.end_current_block()?;
-            self.start_new_block(line)?;
+            self.start_new_block(line);
             self.fence_indent = line.indent;
 
             // Extract info string position and store in block data
-            if let Some(cb_off) = self.current_block {
+            if let Some(hdr) = &mut self.current_block {
                 let fence_count = line.data >> 8;
                 let mut info_beg: OFF = line.beg + fence_count;
                 // Skip whitespace before info string
                 while info_beg < line.end && helpers::is_blank(self.text[info_beg as usize]) {
                     info_beg += 1;
                 }
-                let hdr = self.get_block_header_at(cb_off);
                 hdr.data = info_beg;
                 hdr.flags |= types::BLOCK_FENCED_CODE;
             }
@@ -738,7 +721,7 @@ impl Parser<'_> {
         // Single-line blocks
         if line.r#type == LineType::Hr || line.r#type == LineType::Atxheader {
             self.end_current_block()?;
-            self.start_new_block(line)?;
+            self.start_new_block(line);
             self.add_line_to_current_block(line)?;
             self.end_current_block()?;
             *pivot_line = Line {
@@ -750,8 +733,7 @@ impl Parser<'_> {
 
         // Setext underline changes current block to header
         if line.r#type == LineType::Setextunderline {
-            if let Some(cb_off) = self.current_block {
-                let blk = self.get_block_at(cb_off);
+            if let Some(blk) = &mut self.current_block {
                 blk.block_type = BlockType::H;
                 blk.data = line.data;
                 blk.flags |= types::BLOCK_SETEXT_HEADER;
@@ -776,14 +758,13 @@ impl Parser<'_> {
 
         // Table underline
         if line.r#type == LineType::Tableunderline {
-            if let Some(cb_off) = self.current_block {
+            if let Some(hdr) = &mut self.current_block {
                 if self.current_block_lines.len() > 1 {
                     // GFM: table interrupts paragraph. Split: lines 0..N-2 stay as paragraph,
                     // last line becomes table header.
                     let last_line = self.current_block_lines[self.current_block_lines.len() - 1];
                     // Remove the last line from current paragraph block
                     let _ = self.current_block_lines.pop();
-                    let hdr = self.get_block_header_at(cb_off);
                     hdr.n_lines -= 1;
                     // End the paragraph
                     self.end_current_block()?;
@@ -796,13 +777,12 @@ impl Parser<'_> {
                         data: line.data,
                         ..Line::default()
                     };
-                    self.start_new_block(&header_as_line)?;
+                    self.start_new_block(&header_as_line);
                     self.add_line_to_current_block(&header_as_line)?;
                 } else {
                     // Single line paragraph: convert directly to table
-                    let blk = self.get_block_at(cb_off);
-                    blk.block_type = BlockType::Table;
-                    blk.data = line.data;
+                    hdr.block_type = BlockType::Table;
+                    hdr.data = line.data;
                 }
             }
             // Change pivot to table
@@ -818,7 +798,7 @@ impl Parser<'_> {
 
         // Start new block if needed
         if self.current_block.is_none() {
-            self.start_new_block(line)?;
+            self.start_new_block(line);
             *pivot_line = *line;
         }
 
@@ -831,7 +811,7 @@ impl Parser<'_> {
         Ok(())
     }
 
-    pub(crate) fn start_new_block(&mut self, line: &Line) -> Result<(), parser::Error> {
+    pub(crate) fn start_new_block(&mut self, line: &Line) {
         let block_type: BlockType = match line.r#type {
             LineType::Hr => BlockType::Hr,
             LineType::Atxheader => BlockType::H,
@@ -841,25 +821,20 @@ impl Parser<'_> {
             _ => BlockType::P,
         };
 
-        let aligned = self.append_block_header(BlockHeader {
+        self.current_block = Some(BlockHeader {
             block_type,
-            _pad: [0; 3],
             flags: 0,
             data: line.data,
             n_lines: 0,
-        })?;
-
-        self.current_block = Some(aligned);
+        });
         self.current_block_lines.clear();
-        Ok(())
     }
 
     pub(crate) fn add_line_to_current_block(
         &mut self,
         line: &Line,
     ) -> Result<(), bun_alloc::AllocError> {
-        if let Some(cb_off) = self.current_block {
-            let hdr = self.get_block_header_at(cb_off);
+        if let Some(hdr) = &mut self.current_block {
             hdr.n_lines += 1;
             self.current_block_lines.push(VerbatimLine {
                 beg: line.beg,
@@ -871,25 +846,16 @@ impl Parser<'_> {
     }
 
     pub(crate) fn end_current_block(&mut self) -> Result<(), parser::Error> {
-        if let Some(cb_off) = self.current_block {
-            // Capture the header fields, drop the &mut borrow, then access
-            // other &self fields.
-            let (is_setext, hdr_n_lines) = {
-                let hdr = self.get_block_header_at(cb_off);
-                (
-                    hdr.block_type == BlockType::H && (hdr.flags & types::BLOCK_SETEXT_HEADER) != 0,
-                    hdr.n_lines,
-                )
-            };
-            if is_setext
-                && hdr_n_lines > 0
+        if let Some(mut hdr) = self.current_block.take() {
+            if hdr.block_type == BlockType::H
+                && (hdr.flags & types::BLOCK_SETEXT_HEADER) != 0
+                && hdr.n_lines > 0
                 && self.current_block_lines.len() > 0
                 && self.current_block_lines[0].beg < self.size
                 && self.text[self.current_block_lines[0].beg as usize] == b'['
             {
-                self.consume_ref_defs_from_current_block();
+                self.consume_ref_defs_from_current_block(&mut hdr);
             }
-            let hdr = self.get_block_header_at(cb_off);
 
             // Handle setext heading after ref def consumption
             if hdr.block_type == BlockType::H && (hdr.flags & types::BLOCK_SETEXT_HEADER) != 0 {
@@ -902,6 +868,7 @@ impl Parser<'_> {
                     // keep block open so subsequent lines join this paragraph (md4c behavior)
                     hdr.block_type = BlockType::P;
                     hdr.flags &= !types::BLOCK_SETEXT_HEADER;
+                    self.current_block = Some(hdr);
                     return Ok(()); // Don't close the block!
                 } else {
                     // All lines consumed (shouldn't normally happen)
@@ -909,24 +876,12 @@ impl Parser<'_> {
                 }
             }
 
-            // Write accumulated lines to block_bytes
-            // SAFETY: VerbatimLine is POD; reinterpret slice as bytes for serialization
-            let line_bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(
-                    self.current_block_lines.as_ptr().cast::<u8>(),
-                    self.current_block_lines.len() * size_of::<VerbatimLine>(),
-                )
-            };
-            // The block's lines land in `block_bytes` too (12 bytes per
-            // line), not just its header, so this growth needs the same cap.
-            parser::check_block_bytes_len(self.block_bytes.len() + line_bytes.len())?;
-            self.block_bytes.extend_from_slice(line_bytes);
-            self.current_block = None;
+            self.blocks.push(hdr, &self.current_block_lines)?;
         }
         Ok(())
     }
 
-    pub(crate) fn consume_ref_defs_from_current_block(&mut self) {
+    pub(crate) fn consume_ref_defs_from_current_block(&mut self, hdr: &mut BlockHeader) {
         if self.current_block_lines.is_empty() {
             return;
         }
@@ -994,27 +949,21 @@ impl Parser<'_> {
         self.buffer = merged;
 
         if lines_consumed > 0 {
-            if let Some(cb_off) = self.current_block {
-                let hdr_n_lines = self.get_block_header_at(cb_off).n_lines;
-                if lines_consumed >= hdr_n_lines {
-                    // All lines consumed
-                    self.current_block_lines.clear();
-                    self.get_block_header_at(cb_off).n_lines = 0;
-                } else {
-                    // Remove first lines_consumed lines
-                    let total = self.current_block_lines.len();
-                    let remaining = total - lines_consumed as usize;
-                    // SAFETY: ranges overlap (src after dst); copy_within handles memmove semantics
-                    self.current_block_lines
-                        .copy_within(lines_consumed as usize..total, 0);
-                    self.current_block_lines.truncate(remaining);
-                    self.get_block_header_at(cb_off).n_lines = hdr_n_lines - lines_consumed;
-                }
+            if lines_consumed >= hdr.n_lines {
+                // All lines consumed
+                self.current_block_lines.clear();
+                hdr.n_lines = 0;
+            } else {
+                // Remove first lines_consumed lines
+                let total = self.current_block_lines.len();
+                let remaining = total - lines_consumed as usize;
+                self.current_block_lines
+                    .copy_within(lines_consumed as usize..total, 0);
+                self.current_block_lines.truncate(remaining);
+                hdr.n_lines -= lines_consumed;
             }
         }
     }
-
-    // get_block_header_at / get_block_at moved to parser.rs (shared by containers.rs).
 }
 
 use crate::types::LineType;

--- a/src/md/blocks.rs
+++ b/src/md/blocks.rs
@@ -696,20 +696,18 @@ impl Parser<'_> {
         // Opening code fence: start block but don't include fence line as content
         if line.r#type == LineType::Fencedcode && line.enforce_new_block {
             self.end_current_block()?;
-            self.start_new_block(line);
             self.fence_indent = line.indent;
 
             // Extract info string position and store in block data
-            if let Some(hdr) = &mut self.current_block {
-                let fence_count = line.data >> 8;
-                let mut info_beg: OFF = line.beg + fence_count;
-                // Skip whitespace before info string
-                while info_beg < line.end && helpers::is_blank(self.text[info_beg as usize]) {
-                    info_beg += 1;
-                }
-                hdr.data = info_beg;
-                hdr.flags |= types::BLOCK_FENCED_CODE;
+            let fence_count = line.data >> 8;
+            let mut info_beg: OFF = line.beg + fence_count;
+            // Skip whitespace before info string
+            while info_beg < line.end && helpers::is_blank(self.text[info_beg as usize]) {
+                info_beg += 1;
             }
+            let hdr = self.start_new_block(line);
+            hdr.data = info_beg;
+            hdr.flags |= types::BLOCK_FENCED_CODE;
             *pivot_line = *line;
             return Ok(());
         }
@@ -811,7 +809,7 @@ impl Parser<'_> {
         Ok(())
     }
 
-    pub(crate) fn start_new_block(&mut self, line: &Line) {
+    pub(crate) fn start_new_block(&mut self, line: &Line) -> &mut BlockHeader {
         let block_type: BlockType = match line.r#type {
             LineType::Hr => BlockType::Hr,
             LineType::Atxheader => BlockType::H,
@@ -821,13 +819,13 @@ impl Parser<'_> {
             _ => BlockType::P,
         };
 
-        self.current_block = Some(BlockHeader {
+        self.current_block_lines.clear();
+        self.current_block.insert(BlockHeader {
             block_type,
             flags: 0,
             data: line.data,
             n_lines: 0,
-        });
-        self.current_block_lines.clear();
+        })
     }
 
     pub(crate) fn add_line_to_current_block(

--- a/src/md/containers.rs
+++ b/src/md/containers.rs
@@ -1,10 +1,8 @@
-use core::mem::{align_of, size_of};
-
 use bun_alloc::AllocError;
 
 use crate::autolinks::is_list_bullet;
 use crate::parser::{self, BlockHeader, Parser};
-use crate::types::{self, BlockType, Container, VerbatimLine};
+use crate::types::{self, BlockType, Container};
 
 impl Parser<'_> {
     pub(crate) fn push_container(&mut self, c: &Container) -> Result<(), AllocError> {
@@ -13,11 +11,6 @@ impl Parser<'_> {
         } else {
             self.containers[self.n_containers as usize] = *c;
         }
-
-        // Record block_byte offset in the container.
-        // In range: every `block_bytes` grower enforces `check_block_bytes_len`.
-        let block_off: u32 = u32::try_from(self.block_bytes.len()).expect("int cast");
-        self.containers[self.n_containers as usize].block_byte_off = block_off;
 
         self.n_containers += 1;
         Ok(())
@@ -29,14 +22,15 @@ impl Parser<'_> {
         data: u32,
         flags: u32,
     ) -> Result<(), parser::Error> {
-        self.append_block_header(BlockHeader {
-            block_type,
-            _pad: [0; 3],
-            flags,
-            data,
-            n_lines: 0,
-        })?;
-        Ok(())
+        self.blocks.push(
+            BlockHeader {
+                block_type,
+                flags,
+                data,
+                n_lines: 0,
+            },
+            &[],
+        )
     }
 
     pub(crate) fn enter_child_containers(&mut self, count: u32) -> Result<(), parser::Error> {
@@ -54,11 +48,7 @@ impl Parser<'_> {
                 self.push_container_bytes(BlockType::Quote, 0, types::BLOCK_CONTAINER_OPENER)?;
             } else if ch == b'-' || ch == b'+' || ch == b'*' {
                 // Save opener position for later loose-list patching
-                let align_mask_: usize = align_of::<BlockHeader>() - 1;
-                // In range: every `block_bytes` grower enforces
-                // `check_block_bytes_len`, which leaves alignment headroom.
-                self.containers[idx].block_byte_off =
-                    u32::try_from((self.block_bytes.len() + align_mask_) & !align_mask_).unwrap();
+                self.containers[idx].opener_idx = self.blocks.next_idx();
                 // Unordered list + list item
                 self.push_container_bytes(BlockType::Ul, 0, types::BLOCK_CONTAINER_OPENER)?;
                 self.push_container_bytes(
@@ -72,11 +62,7 @@ impl Parser<'_> {
                 )?;
             } else if ch == b'.' || ch == b')' {
                 // Save opener position for later loose-list patching
-                let align_mask_: usize = align_of::<BlockHeader>() - 1;
-                // In range: every `block_bytes` grower enforces
-                // `check_block_bytes_len`, which leaves alignment headroom.
-                self.containers[idx].block_byte_off =
-                    u32::try_from((self.block_bytes.len() + align_mask_) & !align_mask_).unwrap();
+                self.containers[idx].opener_idx = self.blocks.next_idx();
                 // Ordered list + list item
                 self.push_container_bytes(BlockType::Ol, start, types::BLOCK_CONTAINER_OPENER)?;
                 self.push_container_bytes(
@@ -104,7 +90,7 @@ impl Parser<'_> {
             let is_task = self.containers[idx].is_task;
             let task_mark_off = self.containers[idx].task_mark_off;
             let start = self.containers[idx].start;
-            let block_byte_off = self.containers[idx].block_byte_off;
+            let opener_idx = self.containers[idx].opener_idx as usize;
             let loose_flag: u32 = if is_loose { types::BLOCK_LOOSE_LIST } else { 0 };
 
             // Emit container closer blocks
@@ -112,9 +98,8 @@ impl Parser<'_> {
                 self.push_container_bytes(BlockType::Quote, 0, types::BLOCK_CONTAINER_CLOSER)?;
             } else if ch == b'-' || ch == b'+' || ch == b'*' {
                 // Retroactively patch the opener with loose flag
-                if is_loose && (block_byte_off as usize) < self.block_bytes.len() {
-                    let opener_hdr = self.get_block_header_at(block_byte_off as usize);
-                    opener_hdr.flags |= types::BLOCK_LOOSE_LIST;
+                if is_loose {
+                    self.blocks.headers[opener_idx].flags |= types::BLOCK_LOOSE_LIST;
                 }
                 self.push_container_bytes(
                     BlockType::Li,
@@ -132,9 +117,8 @@ impl Parser<'_> {
                 )?;
             } else if ch == b'.' || ch == b')' {
                 // Retroactively patch the opener with loose flag
-                if is_loose && (block_byte_off as usize) < self.block_bytes.len() {
-                    let opener_hdr = self.get_block_header_at(block_byte_off as usize);
-                    opener_hdr.flags |= types::BLOCK_LOOSE_LIST;
+                if is_loose {
+                    self.blocks.headers[opener_idx].flags |= types::BLOCK_LOOSE_LIST;
                 }
                 self.push_container_bytes(
                     BlockType::Li,
@@ -173,54 +157,17 @@ impl Parser<'_> {
     }
 
     pub(crate) fn process_all_blocks(&mut self) -> Result<(), parser::Error> {
-        let mut off: usize = 0;
-        // Capture the raw ptr/len so we can call &mut self methods inside the
-        // loop. block_bytes is not mutated during process_all_blocks.
-        let bytes_len = self.block_bytes.len();
-        let bytes_ptr = self.block_bytes.as_ptr();
+        // Taken out so the loop can call `&mut self` methods; rendering is the list's last use.
+        let blocks = core::mem::take(&mut self.blocks);
 
         // Reuse containers array for tight/loose tracking (same approach as md4c).
         // The containers are no longer needed for line analysis at this point.
         self.n_containers = 0;
-        let mut block_lines: Vec<VerbatimLine> = Vec::new();
 
-        while off < bytes_len {
-            // Align to BlockHeader
-            let align_mask: usize = align_of::<BlockHeader>() - 1;
-            off = (off + align_mask) & !align_mask;
-            if off + size_of::<BlockHeader>() > bytes_len {
-                break;
-            }
-
-            // SAFETY: off + size_of::<BlockHeader>() <= bytes_len (checked above) and the
-            // block parser wrote a valid BlockHeader at this offset.
-            let hdr: BlockHeader =
-                unsafe { bytes_ptr.add(off).cast::<BlockHeader>().read_unaligned() };
-            off += size_of::<BlockHeader>();
-
+        for (hdr, block_lines) in blocks.iter() {
             let block_type = hdr.block_type;
-            let n_lines = hdr.n_lines;
             let data = hdr.data;
             let flags = hdr.flags;
-
-            // Read lines after header
-            let lines_size = (n_lines as usize) * size_of::<VerbatimLine>();
-            if off + lines_size > bytes_len {
-                break;
-            }
-            block_lines.clear();
-            for li in 0..n_lines as usize {
-                // SAFETY: li < n_lines so off + li*size_of::<VerbatimLine>() is within the
-                // [off, off + lines_size) range bounds-checked above; end_current_block wrote
-                // n_lines contiguous VerbatimLine entries there.
-                block_lines.push(unsafe {
-                    bytes_ptr
-                        .add(off + li * size_of::<VerbatimLine>())
-                        .cast::<VerbatimLine>()
-                        .read_unaligned()
-                });
-            }
-            off += lines_size;
 
             // Handle container openers/closers
             if flags & types::BLOCK_CONTAINER_OPENER != 0 {
@@ -270,12 +217,12 @@ impl Parser<'_> {
             }
             match block_type {
                 BlockType::Hr => {}
-                BlockType::Code => self.process_code_block(&block_lines, data, flags)?,
-                BlockType::Html => self.process_html_block(&block_lines)?,
-                BlockType::Table => self.process_table_block(&block_lines, data)?,
-                BlockType::P => self.process_leaf_block(&block_lines, true)?,
-                BlockType::H => self.process_leaf_block(&block_lines, true)?,
-                _ => self.process_leaf_block(&block_lines, false)?,
+                BlockType::Code => self.process_code_block(block_lines, data, flags)?,
+                BlockType::Html => self.process_html_block(block_lines)?,
+                BlockType::Table => self.process_table_block(block_lines, data)?,
+                BlockType::P => self.process_leaf_block(block_lines, true)?,
+                BlockType::H => self.process_leaf_block(block_lines, true)?,
+                _ => self.process_leaf_block(block_lines, false)?,
             }
             if !is_in_tight_list || block_type != BlockType::P {
                 self.leave_block(block_type, data)?;

--- a/src/md/lib.rs
+++ b/src/md/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 
 pub mod ansi_renderer;
 pub mod autolinks;

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -1,7 +1,6 @@
 // Sub-modules
 
 use core::cell::Cell;
-use core::ffi::c_void;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
@@ -48,13 +47,7 @@ pub(crate) struct Parser<'a> {
 
     // Dynamic arrays
     pub(crate) containers: Vec<Container>,
-    // 4-byte alignment is
-    // load-bearing for the `BlockHeader` reinterpretation in
-    // `get_block_header_at`. Here the invariant rests on (a) offsets being
-    // padded to a multiple of 4 by every writer and (b) the global allocator
-    // returning >=16-byte-aligned bases; `get_block_header_at`
-    // debug-asserts it on every access.
-    pub(crate) block_bytes: Vec<u8>,
+    pub(crate) blocks: BlockList,
     pub(crate) buffer: Vec<u8>,
     pub(crate) emph_delims: Vec<EmphDelim>,
     // Scratch storage recycled by compute_bracket_matches (links.rs) so inline
@@ -71,8 +64,8 @@ pub(crate) struct Parser<'a> {
     // Number of active containers
     pub(crate) n_containers: u32,
 
-    // Current block being built
-    pub(crate) current_block: Option<usize>,
+    // Current block being built; pushed onto `blocks` by end_current_block
+    pub(crate) current_block: Option<BlockHeader>,
     pub(crate) current_block_lines: Vec<VerbatimLine>,
 
     // HTML block tracking
@@ -96,25 +89,11 @@ pub(crate) struct Parser<'a> {
     pub(crate) stack_check: StackCheck,
 }
 
-#[repr(C)]
-pub struct BlockHeader {
+pub(crate) struct BlockHeader {
     pub(crate) block_type: BlockType,
-    pub(crate) _pad: [u8; 3],
     pub(crate) flags: u32,
     pub(crate) data: u32,
     pub(crate) n_lines: u32,
-}
-
-impl Default for BlockHeader {
-    fn default() -> Self {
-        Self {
-            block_type: BlockType::Doc,
-            _pad: [0, 0, 0],
-            flags: 0,
-            data: 0,
-            n_lines: 0,
-        }
-    }
 }
 
 /// `Parser`'s error type: the union of `{ OutOfMemory, JSError, JSTerminated }`
@@ -132,8 +111,7 @@ pub enum ParserError {
     /// The input is longer than [`MAX_INPUT_LEN`], so the parser's `u32`
     /// offset arithmetic cannot address it.
     InputTooLarge,
-    /// The document needs more than [`MAX_BLOCK_BYTES`] of block metadata,
-    /// so the parser's `u32` block offsets cannot address it.
+    /// The document needs more than [`MAX_BLOCK_BYTES`] of block metadata.
     TooManyBlocks,
 }
 
@@ -160,24 +138,14 @@ pub(crate) const MAX_LOOKAHEAD: OFF = 1 + crate::line_analysis::CDATA_OPEN.len()
 /// never to wrap.
 pub const MAX_INPUT_LEN: usize = (OFF::MAX - MAX_LOOKAHEAD) as usize;
 
-/// The most bytes `block_bytes` may hold: a block's offset into the buffer
-/// is stored as a `u32` (`Container.block_byte_off` and the casts that feed
-/// it), and each new header is written at the end of `block_bytes` rounded
-/// up to its alignment, so the buffer must stop one aligned header short of
-/// `OFF::MAX`.
+/// Cap on the block metadata a document may record, in the bytes
+/// [`BlockList::push`] charges (a `BlockHeader` per block, a `VerbatimLine`
+/// per line); it also keeps `Container.opener_idx` representable as a `u32`.
 const MAX_BLOCK_BYTES: usize =
     OFF::MAX as usize - (size_of::<BlockHeader>() + align_of::<BlockHeader>());
 
-// The headroom proof: a buffer filled to the cap can still be aligned up and
-// take one more header without leaving `OFF` range.
-const _: () = assert!(
-    ((MAX_BLOCK_BYTES + (align_of::<BlockHeader>() - 1)) & !(align_of::<BlockHeader>() - 1))
-        + size_of::<BlockHeader>()
-        <= OFF::MAX as usize
-);
-
-/// The runtime block-metadata cap checked by [`check_block_bytes_len`]:
-/// always [`MAX_BLOCK_BYTES`] outside of tests, shrinkable only through
+/// The runtime block-metadata cap checked by [`BlockList::push`]: always
+/// [`MAX_BLOCK_BYTES`] outside of tests, shrinkable only through
 /// [`set_max_block_bytes_for_testing`].
 static BLOCK_BYTES_LIMIT: AtomicUsize = AtomicUsize::new(MAX_BLOCK_BYTES);
 
@@ -190,16 +158,63 @@ pub fn set_max_block_bytes_for_testing(limit: usize) -> usize {
     BLOCK_BYTES_LIMIT.swap(limit.min(MAX_BLOCK_BYTES), Ordering::Relaxed)
 }
 
-/// Rejects growing `block_bytes` to `needed` bytes once the parser's u32
-/// block offsets could no longer address it. Every site that grows the
-/// buffer (`append_block_header`, `end_current_block`) checks this before
-/// appending.
-#[inline]
-pub(crate) fn check_block_bytes_len(needed: usize) -> Result<(), ParserError> {
-    if needed > BLOCK_BYTES_LIMIT.load(Ordering::Relaxed) {
-        return Err(ParserError::TooManyBlocks);
+/// Closed blocks in document order; `lines` holds each header's `n_lines`
+/// lines contiguously in that same order, which is how `iter`/`iter_mut`
+/// pair them without stored offsets.
+#[derive(Default)]
+pub(crate) struct BlockList {
+    pub(crate) headers: Vec<BlockHeader>,
+    pub(crate) lines: Vec<VerbatimLine>,
+}
+
+impl BlockList {
+    /// The only way a block is added, so the block-metadata cap cannot be
+    /// forgotten by a new caller.
+    pub(crate) fn push(
+        &mut self,
+        header: BlockHeader,
+        lines: &[VerbatimLine],
+    ) -> Result<(), ParserError> {
+        debug_assert_eq!(header.n_lines as usize, lines.len());
+        let needed = (self.headers.len() + 1) * size_of::<BlockHeader>()
+            + (self.lines.len() + lines.len()) * size_of::<VerbatimLine>();
+        if needed > BLOCK_BYTES_LIMIT.load(Ordering::Relaxed) {
+            return Err(ParserError::TooManyBlocks);
+        }
+        self.headers.push(header);
+        self.lines.extend_from_slice(lines);
+        Ok(())
     }
-    Ok(())
+
+    /// Index the next pushed block will get; `push` keeps the count far below `u32::MAX`.
+    pub(crate) fn next_idx(&self) -> u32 {
+        u32::try_from(self.headers.len()).expect("int cast")
+    }
+
+    pub(crate) fn last_type(&self) -> Option<BlockType> {
+        self.headers.last().map(|header| header.block_type)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&BlockHeader, &[VerbatimLine])> {
+        let mut lines: &[VerbatimLine] = &self.lines;
+        self.headers.iter().map(move |header| {
+            let (block_lines, rest) = lines.split_at(header.n_lines as usize);
+            lines = rest;
+            (header, block_lines)
+        })
+    }
+
+    pub(crate) fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&mut BlockHeader, &mut [VerbatimLine])> {
+        let mut lines: &mut [VerbatimLine] = &mut self.lines;
+        self.headers.iter_mut().map(move |header| {
+            let (block_lines, rest) =
+                core::mem::take(&mut lines).split_at_mut(header.n_lines as usize);
+            lines = rest;
+            (header, block_lines)
+        })
+    }
 }
 
 /// Callers that size anything from the input length must reject oversized
@@ -213,48 +228,6 @@ pub(crate) fn input_size(text: &[u8]) -> Result<OFF, ParserError> {
 }
 
 impl<'a> Parser<'a> {
-    pub(crate) fn get_block_header_at(&mut self, off: usize) -> &mut BlockHeader {
-        // SAFETY: `off` is produced by start_new_block / push_container_bytes which pad it
-        // to a multiple of `align_of::<BlockHeader>()`, and the global allocator returns
-        // blocks aligned to at least `align_of::<usize>()`, so the resulting pointer is
-        // 4-byte aligned (asserted below). The buffer holds an initialized BlockHeader there.
-        unsafe {
-            let ptr = self
-                .block_bytes
-                .as_mut_ptr()
-                .add(off)
-                .cast::<c_void>()
-                .cast::<BlockHeader>();
-            debug_assert!(ptr.is_aligned());
-            &mut *ptr
-        }
-    }
-
-    #[inline]
-    pub(crate) fn get_block_at(&mut self, off: usize) -> &mut BlockHeader {
-        self.get_block_header_at(off)
-    }
-
-    /// Appends one aligned `BlockHeader` to `block_bytes` and returns its
-    /// byte offset. This is the only way a header is added, so the
-    /// block-metadata cap cannot be forgotten by a new caller.
-    pub(crate) fn append_block_header(
-        &mut self,
-        header: BlockHeader,
-    ) -> Result<usize, ParserError> {
-        let align_mask: usize = align_of::<BlockHeader>() - 1;
-        let aligned = (self.block_bytes.len() + align_mask) & !align_mask;
-        let needed = aligned + size_of::<BlockHeader>();
-        check_block_bytes_len(needed)?;
-        self.block_bytes
-            .reserve(needed.saturating_sub(self.block_bytes.len()));
-        // Zero-fill to `needed`; bytes in [aligned, needed) are immediately
-        // overwritten by the header write below.
-        self.block_bytes.resize(needed, 0);
-        *self.get_block_header_at(aligned) = header;
-        Ok(aligned)
-    }
-
     /// Charge one resolved reference link/image against the reference-definition
     /// output budget (`max_ref_def_output`). On exhaustion the budget is zeroed, so
     /// this and every later reference degrade to literal text (md4c, mity/md4c#238).
@@ -285,7 +258,7 @@ impl<'a> Parser<'a> {
             },
             mark_char_map: MarkCharMap::init_empty(),
             containers: Vec::new(),
-            block_bytes: Vec::new(),
+            blocks: BlockList::default(),
             buffer: Vec::new(),
             emph_delims: Vec::new(),
             bracket_pairs: Vec::new(),
@@ -372,7 +345,7 @@ impl<'a> Parser<'a> {
     // blocks.rs — impl Parser:
     //   process_doc, analyze_line, process_line, start_new_block,
     //   add_line_to_current_block, end_current_block,
-    //   consume_ref_defs_from_current_block, get_block_header_at, get_block_at
+    //   consume_ref_defs_from_current_block
     //
     // containers.rs — impl Parser:
     //   push_container, push_container_bytes, enter_child_containers,

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -168,11 +168,12 @@ pub(crate) struct BlockList {
 }
 
 impl BlockList {
-    /// The only way a block is added, so the block-metadata cap cannot be
-    /// forgotten by a new caller.
+    /// The only way a block is added: it enforces the block-metadata cap and
+    /// sets `n_lines` from `lines`, so the header/line pairing `iter` relies on
+    /// cannot drift from what a caller counted.
     pub(crate) fn push(
         &mut self,
-        header: BlockHeader,
+        mut header: BlockHeader,
         lines: &[VerbatimLine],
     ) -> Result<(), ParserError> {
         debug_assert_eq!(header.n_lines as usize, lines.len());
@@ -181,6 +182,7 @@ impl BlockList {
         if needed > BLOCK_BYTES_LIMIT.load(Ordering::Relaxed) {
             return Err(ParserError::TooManyBlocks);
         }
+        header.n_lines = u32::try_from(lines.len()).expect("int cast");
         self.headers.push(header);
         self.lines.extend_from_slice(lines);
         Ok(())

--- a/src/md/ref_defs.rs
+++ b/src/md/ref_defs.rs
@@ -1,7 +1,7 @@
 use bun_alloc::AllocError;
 
 use crate::helpers;
-use crate::parser::Parser;
+use crate::parser::{BlockList, Parser};
 use crate::types;
 use crate::unicode;
 
@@ -340,7 +340,12 @@ impl Parser<'_> {
     pub(crate) fn build_ref_def_hashtable(&mut self) -> Result<(), AllocError> {
         // Taken out so the loop can call `&mut self` methods while holding a block borrow.
         let mut blocks = core::mem::take(&mut self.blocks);
+        let result = self.consume_ref_defs(&mut blocks);
+        self.blocks = blocks;
+        result
+    }
 
+    fn consume_ref_defs(&mut self, blocks: &mut BlockList) -> Result<(), AllocError> {
         for (hdr, block_lines) in blocks.iter_mut() {
             // Only process paragraph blocks (not container openers/closers)
             if hdr.block_type != types::BlockType::P
@@ -416,7 +421,7 @@ impl Parser<'_> {
             // Restore buffer for reuse on next iteration.
             self.buffer = merged;
 
-            // Update the block: mark consumed lines
+            // Invalidated in place, never removed: `BlockList.lines` is shared by all blocks and split by `n_lines`.
             if lines_consumed > 0 {
                 if lines_consumed as usize >= block_lines.len() {
                     // Entire paragraph is ref defs — flag to skip during rendering
@@ -430,8 +435,6 @@ impl Parser<'_> {
                 }
             }
         }
-
-        self.blocks = blocks;
         Ok(())
     }
 }

--- a/src/md/ref_defs.rs
+++ b/src/md/ref_defs.rs
@@ -1,10 +1,8 @@
-use core::mem::{align_of, size_of};
-
 use bun_alloc::AllocError;
 
 use crate::helpers;
-use crate::parser::{BlockHeader, Parser};
-use crate::types::{self, VerbatimLine};
+use crate::parser::Parser;
+use crate::types;
 use crate::unicode;
 
 /// Maximum raw length of a link label (CommonMark: "a link label can have at
@@ -340,37 +338,10 @@ impl Parser<'_> {
     }
 
     pub(crate) fn build_ref_def_hashtable(&mut self) -> Result<(), AllocError> {
-        let mut off: usize = 0;
-        // Take a raw pointer to block_bytes so we can call &mut self methods
-        // (normalize_label, parse_ref_def via self.buffer) while iterating the
-        // byte buffer. Headers are mutated in-place via raw pointer arithmetic.
-        let bytes_ptr = self.block_bytes.as_mut_ptr();
-        let bytes_len = self.block_bytes.len();
+        // Taken out so the loop can call `&mut self` methods while holding a block borrow.
+        let mut blocks = core::mem::take(&mut self.blocks);
 
-        while off < bytes_len {
-            // Align to BlockHeader
-            let align_mask: usize = align_of::<BlockHeader>() - 1;
-            off = (off + align_mask) & !align_mask;
-            if off + size_of::<BlockHeader>() > bytes_len {
-                break;
-            }
-
-            // SAFETY: off + size_of::<BlockHeader>() <= bytes_len (checked above) and the
-            // block parser wrote a valid BlockHeader at this offset.
-            let mut hdr: BlockHeader =
-                unsafe { bytes_ptr.add(off).cast::<BlockHeader>().read_unaligned() };
-            let hdr_off = off;
-            off += size_of::<BlockHeader>();
-
-            let n_lines = hdr.n_lines as usize;
-            let lines_size = n_lines * size_of::<VerbatimLine>();
-            if off + lines_size > bytes_len {
-                break;
-            }
-
-            let lines_off = off;
-            off += lines_size;
-
+        for (hdr, block_lines) in blocks.iter_mut() {
             // Only process paragraph blocks (not container openers/closers)
             if hdr.block_type != types::BlockType::P
                 || hdr.flags & types::BLOCK_CONTAINER_OPENER != 0
@@ -379,22 +350,13 @@ impl Parser<'_> {
                 continue;
             }
 
-            if n_lines == 0 {
+            if block_lines.is_empty() {
                 continue;
             }
 
             // Merge lines into buffer to parse ref defs
             self.buffer.clear();
-            for li in 0..n_lines {
-                // SAFETY: li < n_lines so lines_off + li*size_of::<VerbatimLine>() is within
-                // the [lines_off, lines_off + lines_size) range bounds-checked above;
-                // end_current_block wrote n_lines contiguous VerbatimLine entries there.
-                let vline: VerbatimLine = unsafe {
-                    bytes_ptr
-                        .add(lines_off + li * size_of::<VerbatimLine>())
-                        .cast::<VerbatimLine>()
-                        .read_unaligned()
-                };
+            for vline in block_lines.iter() {
                 if vline.beg > vline.end || vline.end > self.size {
                     continue;
                 }
@@ -456,42 +418,20 @@ impl Parser<'_> {
 
             // Update the block: mark consumed lines
             if lines_consumed > 0 {
-                if lines_consumed as usize >= n_lines {
+                if lines_consumed as usize >= block_lines.len() {
                     // Entire paragraph is ref defs — flag to skip during rendering
                     hdr.flags |= types::BLOCK_REF_DEF_ONLY;
-                    // SAFETY: hdr_off + size_of::<BlockHeader>() <= bytes_len (checked above);
-                    // writes back the header read at the top of this iteration.
-                    unsafe {
-                        bytes_ptr
-                            .add(hdr_off)
-                            .cast::<BlockHeader>()
-                            .write_unaligned(hdr);
-                    }
                 } else {
                     // Mark consumed lines as invalid (beg > end triggers skip in processLeafBlock)
-                    let mut i: u32 = 0;
-                    while i < lines_consumed {
-                        let line_off = lines_off + (i as usize) * size_of::<VerbatimLine>();
-                        // SAFETY: i < lines_consumed < n_lines so line_off is in-bounds of the
-                        // VerbatimLine array written by end_current_block after this header.
-                        unsafe {
-                            let mut vl = bytes_ptr
-                                .add(line_off)
-                                .cast::<VerbatimLine>()
-                                .read_unaligned();
-                            vl.beg = 1;
-                            vl.end = 0;
-                            bytes_ptr
-                                .add(line_off)
-                                .cast::<VerbatimLine>()
-                                .write_unaligned(vl);
-                        }
-                        i += 1;
+                    for vline in &mut block_lines[..lines_consumed as usize] {
+                        vline.beg = 1;
+                        vline.end = 0;
                     }
                 }
             }
         }
 
+        self.blocks = blocks;
         Ok(())
     }
 }

--- a/src/md/types.rs
+++ b/src/md/types.rs
@@ -191,7 +191,6 @@ impl Default for Line {
 }
 
 /// A verbatim line (stores beg/end offsets plus indent for indented code).
-#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VerbatimLine {
     pub(crate) beg: OFF,
@@ -209,7 +208,8 @@ pub struct Container {
     pub(crate) start: u32,
     pub(crate) mark_indent: u32,
     pub(crate) contents_indent: u32,
-    pub(crate) block_byte_off: u32,
+    /// Index of this list's `Ul`/`Ol` opener in `Parser::blocks` (unused for blockquotes).
+    pub(crate) opener_idx: u32,
 }
 
 pub(crate) const BLOCK_CONTAINER_CLOSER: u32 = 0x01;

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -59,8 +59,8 @@ fn parser_err_to_js(
                 ..Default::default()
             },
         ),
-        // The document, not the input length, overflowed the parser's u32
-        // block offsets, so an `input.byteLength` bound would be misleading.
+        // The document, not the input length, exhausted the parser's block
+        // metadata budget, so an `input.byteLength` bound would be misleading.
         ParserError::TooManyBlocks => global_this
             .err(
                 bun_jsc::ErrCode::OUT_OF_RANGE,

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1282,8 +1282,8 @@ describe("inputs the parser cannot address", () => {
 });
 
 describe("documents whose block metadata the parser cannot address", () => {
-  // Block offsets are u32s too, so `block_bytes` (the flat buffer of block
-  // headers and verbatim-line records) is capped independently of the input
+  // The parser's block metadata (its block headers and verbatim-line records)
+  // is capped in bytes, independently of the input
   // length. Filling the real ~4 GiB cap needs ~256M blocks, so the child
   // shrinks it through `setMaxMarkdownBlockBytesForTesting`
   // (bun:internal-for-testing) and proves the exact boundary: a document
@@ -1294,7 +1294,7 @@ describe("documents whose block metadata the parser cannot address", () => {
     const script = `
       import { setMaxMarkdownBlockBytesForTesting } from "bun:internal-for-testing";
       // One single-line paragraph costs exactly one 16-byte BlockHeader plus
-      // one 12-byte VerbatimLine in block_bytes, with no alignment padding.
+      // one 12-byte VerbatimLine.
       const PARAGRAPH_BYTES = 16 + 12;
       const AT_LIMIT = 40;
       const paragraphs = n => Array.from({ length: n }, (_, i) => "p" + i).join("\\n\\n");
@@ -1337,6 +1337,36 @@ describe("documents whose block metadata the parser cannot address", () => {
     ]);
     expect(exitCode).toBe(0);
   }, 30_000);
+});
+
+describe("blank lines after a closed block inside a list item", () => {
+  // A blank line right after an empty list item ends the list; a closed paragraph or
+  // code block before the blank line must not. The parser used to misread a stored
+  // line indent of 4 as the list-item block type, hence the four-column indents.
+  test.each([
+    [
+      "paragraph continuation line indented four columns",
+      "- foo\n      bar\n  baz\n\n\n  qux\n",
+      "<ul>\n<li>\n<p>foo\nbar\nbaz</p>\n<p>qux</p>\n</li>\n</ul>\n",
+    ],
+    [
+      "fenced code line indented four columns in a bullet item",
+      "- item\n\n  ```\n  a\n      b\n  c\n  ```\n\n  more\n",
+      "<ul>\n<li>\n<p>item</p>\n<pre><code>a\n    b\nc\n</code></pre>\n<p>more</p>\n</li>\n</ul>\n",
+    ],
+    [
+      "fenced code line indented four columns in an ordered item",
+      "1. item\n\n   ```\n   a\n       b\n   c\n   ```\n\n   more\n",
+      "<ol>\n<li>\n<p>item</p>\n<pre><code>a\n    b\nc\n</code></pre>\n<p>more</p>\n</li>\n</ol>\n",
+    ],
+    [
+      "an empty list item followed by a blank line still ends the list",
+      "-\n\n  foo\n",
+      "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    ],
+  ])("%s", (_name, input, expected) => {
+    expect(Markdown.html(input)).toBe(expected);
+  });
 });
 
 // The runtime module loader for .md files (imports, not the Bun.markdown API).


### PR DESCRIPTION
## What

The markdown block parser (`src/md`) recorded its block metadata in `Parser.block_bytes: Vec<u8>`: a `#[repr(C)]` `BlockHeader` (16 bytes, including a hand-written `_pad`) followed by that block's `VerbatimLine` records (12 bytes each). `get_block_header_at` cast into the buffer to hand out `&mut BlockHeader` (12 call sites), `end_current_block` reinterpreted the line `Vec` as bytes to append it, and `build_ref_def_hashtable` and `process_all_blocks` walked the buffer with `read_unaligned`/`write_unaligned` through a raw pointer kept alive across `&mut self` calls. The 4-byte alignment the casts needed was a comment plus a `debug_assert`, `Container.block_byte_off` was a byte offset computed with align masks, and two sites in `analyze_line` peeked at the byte 16 back from the end of `block_bytes` to ask whether the last block was a list item.

```rust
// before
pub(crate) block_bytes: Vec<u8>,
pub(crate) current_block: Option<usize>,            // byte offset of the open leaf's header
pub(crate) fn get_block_header_at(&mut self, off: usize) -> &mut BlockHeader { unsafe { .. } }

// after
pub(crate) blocks: BlockList,
pub(crate) current_block: Option<BlockHeader>,      // the open leaf's header, by value

pub(crate) struct BlockList {
    pub(crate) headers: Vec<BlockHeader>,
    pub(crate) lines: Vec<VerbatimLine>,            // each header's n_lines lines, in header order
}
impl BlockList {
    pub(crate) fn push(&mut self, header: BlockHeader, lines: &[VerbatimLine]) -> Result<(), ParserError>;
    pub(crate) fn iter(&self) -> impl Iterator<Item = (&BlockHeader, &[VerbatimLine])>;
    pub(crate) fn iter_mut(&mut self) -> impl Iterator<Item = (&mut BlockHeader, &mut [VerbatimLine])>;
}
```

`start_new_block` now just stores the header in `current_block` (it can no longer fail, so its 4 callers drop their `?`), the 12 header accesses become `if let Some(hdr) = &mut self.current_block` or plain field access on the taken header (`consume_ref_defs_from_current_block` receives it as `&mut BlockHeader`), and `end_current_block` closes the leaf with one `self.blocks.push(hdr, &self.current_block_lines)`; container openers and closers go through the same `push` with no lines. `push` is the only writer, so it is also the only place the existing byte cap is charged. `build_ref_def_hashtable` and `process_all_blocks` take the list out of `self` and loop over `iter_mut()`/`iter()`, handing each block's line slice straight to `process_code_block`/`process_html_block`/`process_table_block`/`process_leaf_block`. `Container.block_byte_off` becomes `opener_idx`, recorded with `blocks.next_idx()` right before the `Ul`/`Ol` opener is pushed and patched with `blocks.headers[opener_idx]` when a loose list closes; the two list-item peeks become `blocks.last_type() == Some(BlockType::Li)`.

Removes all 8 unsafe blocks in the crate, so `lib.rs` gains `#![forbid(unsafe_code)]`. Deleted along with them: `get_block_header_at`, `get_block_at`, `append_block_header`, `check_block_bytes_len`, the alignment headroom `const` assertion, `BlockHeader`'s unused `Default` impl and `repr(C)`/`_pad`, `VerbatimLine`'s `repr(C)`, the align-mask code in `enter_child_containers`, and the `block_byte_off` write in `push_container` that `enter_child_containers` always overwrote. `MAX_BLOCK_BYTES`, `set_max_block_bytes_for_testing` and the `bun:internal-for-testing` hook are unchanged; a comment in `MarkdownObject.rs` and two in `md-edge-cases.test.ts` that described the byte buffer are updated.

One output difference, pinned by new cases in `test/js/bun/md/md-edge-cases.test.ts`: the md4c issue 6 check ("a list item can begin with at most one blank line") read the byte 16 back from the end of `block_bytes`, which is only a block type when the last closed block had no lines. After a closed block with two or more lines it read the stored indent of the second-to-last line, and an indent of 4 (the `Li` discriminant) made a following blank line end the list, for example a fenced code block inside a list item whose second-to-last line is indented four spaces, followed by a blank line and more item content. The check now reads the real last header; whenever the old byte was a genuine block type the two agree.

`BlockList::push` also sets the header's `n_lines` from the slice it is given (so the pairing `iter` depends on cannot drift from a caller's count), `start_new_block` returns the header it just installed instead of callers re-opening the `Option`, and `build_ref_def_hashtable` restores `blocks` on every exit path.

## Why

The record layout, the alignment requirement and the "each header is followed by exactly `n_lines` lines, and nothing else is appended while a leaf is open" invariant were comments and SAFETY blocks; they are now the types `BlockList`, `Option<BlockHeader>` and `opener_idx: u32`, and a garbage read (the peek above) becomes unrepresentable. Cost is unchanged or lower: `push` charges the same bytes the buffer used to grow by (16 per header, 12 per line; both are multiples of 4, so the old align-up never padded), and the `TooManyBlocks` outcome for any document is the same because every started leaf is pushed before anything is rendered; `Option<BlockHeader>` uses the `BlockType` niche and stays 16 bytes like `Option<usize>`; `Container` keeps its 24-byte layout; two `Vec`s replace the byte buffer plus the per-parse scratch `Vec` that `process_all_blocks` copied every block's lines into, so the allocation count is the same and one copy per block disappears; `split_at` in the iterators is the same one bounds check the byte walk performed per block; the header accesses turn pointer arithmetic into field access. Everything else is compile-time only.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/md/md-edge-cases.test.ts test/js/bun/md/md-spec.test.ts test/js/bun/md/gfm-compat.test.ts test/js/bun/md/md-render-callback.test.ts: 982 pass, 0 fail across 4 files.

