### PR TITLE
paths: Path owns its pooled buffer as a PoolGuard

### DIFF
--- a/src/paths/Path.rs
+++ b/src/paths/Path.rs
@@ -5,8 +5,8 @@
 // `const fn from_u8` so monomorphization is preserved.
 
 use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
 
+use crate::path_buffer_pool::{PathBufferPoolT, PoolGuard, PoolStorage};
 use crate::{
     MAX_PATH_BYTES, PATH_MAX_WIDE, PathBuffer, SEP, SEP_POSIX, SEP_WINDOWS, WPathBuffer,
     resolve_path as path,
@@ -189,7 +189,7 @@ pub trait PathUnit: crate::PathChar {
     /// `opts.notPathUnit()`
     type Other: PathUnit;
     /// The fixed-size buffer type (`PathBuffer` / `WPathBuffer`).
-    type Buffer: 'static;
+    type Buffer: PoolStorage;
     /// `opts.maxPathLength()` for this unit.
     const MAX_PATH: usize;
     /// `[:0]const u8` → `ZStr`, `[:0]const u16` → `WStr` (length-carrying NUL-terminated slice).
@@ -200,14 +200,6 @@ pub trait PathUnit: crate::PathChar {
     /// # Safety
     /// `ptr[..=len]` must be valid for reads for `'a`, and `ptr[len]` must be `0`.
     unsafe fn zslice_from_raw<'a>(ptr: *const Self, len: usize) -> &'a Self::ZSlice;
-
-    /// `bun.path_buffer_pool.get()` / `bun.w_path_buffer_pool.get()`
-    // LIFETIMES.tsv classifies `Buf.pooled` as OWNED → Box<PathBuffer>; the
-    // underlying pool hands out heap buffers and reclaims them in `deinit`.
-    // Modeled as Box with put-back in `Path`'s Drop impl below (the pool's
-    // RAII guard type is not generic over unit).
-    fn pool_get() -> Box<Self::Buffer>;
-    fn pool_put(buf: Box<Self::Buffer>);
 
     fn buffer_as_mut_slice(buf: &mut Self::Buffer) -> &mut [Self];
     fn buffer_as_slice(buf: &Self::Buffer) -> &[Self];
@@ -271,12 +263,6 @@ impl PathUnit for u8 {
         // `ptr[..=len]` is valid for reads for `'a` and `ptr[len] == 0`.
         unsafe { ZStr::from_raw(ptr, len) }
     }
-    fn pool_get() -> Box<PathBuffer> {
-        crate::path_buffer_pool::get().into_box()
-    }
-    fn pool_put(buf: Box<PathBuffer>) {
-        crate::path_buffer_pool::put(buf)
-    }
     #[inline]
     fn buffer_as_mut_slice(buf: &mut PathBuffer) -> &mut [u8] {
         &mut buf[..]
@@ -320,12 +306,6 @@ impl PathUnit for u16 {
         // `ptr[..=len]` is valid for reads for `'a` and `ptr[len] == 0`.
         unsafe { WStr::from_raw(ptr, len) }
     }
-    fn pool_get() -> Box<WPathBuffer> {
-        crate::w_path_buffer_pool::get().into_box()
-    }
-    fn pool_put(buf: Box<WPathBuffer>) {
-        crate::w_path_buffer_pool::put(buf)
-    }
     #[inline]
     fn buffer_as_mut_slice(buf: &mut WPathBuffer) -> &mut [u16] {
         &mut buf[..]
@@ -357,10 +337,7 @@ impl PathUnit for u16 {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct Buf<U: PathUnit, const SEP_OPT: u8> {
-    // LIFETIMES.tsv: OWNED → Box<PathBuffer> (pool.get() in init(); pool.put() in deinit()).
-    // Wrapped in ManuallyDrop so `Path::drop` can move the Box back into the pool
-    // without leaving a dangling Box behind for the field destructor.
-    pooled: ManuallyDrop<Box<U::Buffer>>,
+    pooled: PoolGuard<U::Buffer>,
     len: usize,
 }
 
@@ -618,14 +595,12 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
         // match BufType::Pool
         Self {
             _buf: Buf {
-                pooled: ManuallyDrop::new(U::pool_get()),
+                pooled: PathBufferPoolT::<U::Buffer>::get(),
                 len: 0,
             },
             _unit: PhantomData,
         }
     }
-
-    // `deinit` → impl Drop (below). Body returns the buffer to the pool.
 
     pub fn init_top_level_dir() -> Self {
         debug_assert!(crate::fs::FileSystem::instance_loaded());
@@ -852,21 +827,13 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
     /// nominally distinct, hence this explicit conversion.
     #[inline]
     pub fn into_sep<const NEW_SEP: u8>(self) -> Path<U, KIND, NEW_SEP, CHECK> {
-        // Explicit field move (not `transmute`): `Path`/`Buf` are `repr(Rust)`, so
-        // Rust gives no layout-compat guarantee between distinct const-generic
-        // instantiations. Rebuilding field-by-field is layout-agnostic and
-        // optimizes to the same no-op move.
-        let mut this = ManuallyDrop::new(self);
-        let len = this._buf.len;
-        // SAFETY: `pooled` was initialized in `init()` and is taken exactly once
-        // here; `this` is wrapped in `ManuallyDrop` so `Path::drop` will not run
-        // and observe the now-uninitialized field.
-        let pooled = unsafe { ManuallyDrop::take(&mut this._buf.pooled) };
+        // Not `transmute`: `repr(Rust)` gives no layout guarantee across instantiations.
+        let Path {
+            _buf: Buf { pooled, len },
+            ..
+        } = self;
         Path {
-            _buf: Buf {
-                pooled: ManuallyDrop::new(pooled),
-                len,
-            },
+            _buf: Buf { pooled, len },
             _unit: PhantomData,
         }
     }
@@ -1287,17 +1254,6 @@ impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8>
                     .append_other(<U::Other>::id_from_u16(words), add_separator);
             }
         }
-    }
-}
-
-impl<U: PathUnit, const KIND: u8, const SEP_OPT: u8, const CHECK: u8> Drop
-    for Path<U, KIND, SEP_OPT, CHECK>
-{
-    fn drop(&mut self) {
-        // match BufType::Pool
-        // SAFETY: `pooled` is initialized in `init()` and never taken before this; Drop runs once.
-        let pooled = unsafe { ManuallyDrop::take(&mut self._buf.pooled) };
-        U::pool_put(pooled);
     }
 }
 

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -20,10 +20,6 @@ pub mod w_path_buffer_pool {
     pub fn get() -> PoolGuard<WPathBuffer> {
         PathBufferPoolT::<WPathBuffer>::get()
     }
-    #[inline]
-    pub(crate) fn put(buf: Box<WPathBuffer>) {
-        PathBufferPoolT::<WPathBuffer>::put(buf)
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/paths/path_buffer_pool.rs
+++ b/src/paths/path_buffer_pool.rs
@@ -10,6 +10,7 @@
 
 use core::cell::RefCell;
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
 
 use crate::{PathBuffer, WPathBuffer};
@@ -74,12 +75,12 @@ impl<T: PoolStorage> PathBufferPoolT<T> {
         // Zero-allocate on the (rare) cache-miss path — see
         // `PoolStorage::new_boxed` for the soundness/perf justification.
         let buf = T::with_pool(|p| p.borrow_mut().pop()).unwrap_or_else(T::new_boxed);
-        PoolGuard { buf: Some(buf) }
+        PoolGuard {
+            buf: ManuallyDrop::new(buf),
+        }
     }
 
-    /// Manual return path. Prefer dropping
-    /// the `PoolGuard` instead.
-    pub(crate) fn put(buf: Box<T>) {
+    fn put(buf: Box<T>) {
         T::with_pool(|p| {
             let mut p = p.borrow_mut();
             if p.len() < POOL_CAP {
@@ -92,30 +93,29 @@ impl<T: PoolStorage> PathBufferPoolT<T> {
 
 /// RAII guard returned by `PathBufferPoolT::get()`.
 pub struct PoolGuard<T: PoolStorage> {
-    buf: Option<Box<T>>,
+    buf: ManuallyDrop<Box<T>>,
 }
 
 impl<T: PoolStorage> Deref for PoolGuard<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        // SAFETY-ish: `buf` is always `Some` until `Drop`.
-        self.buf.as_deref().unwrap()
+        &self.buf
     }
 }
 
 impl<T: PoolStorage> DerefMut for PoolGuard<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        self.buf.as_deref_mut().unwrap()
+        &mut self.buf
     }
 }
 
 impl<T: PoolStorage> Drop for PoolGuard<T> {
     fn drop(&mut self) {
-        if let Some(buf) = self.buf.take() {
-            PathBufferPoolT::<T>::put(buf);
-        }
+        // SAFETY: `buf` is taken only here, and `drop` runs at most once.
+        let buf = unsafe { ManuallyDrop::take(&mut self.buf) };
+        PathBufferPoolT::<T>::put(buf);
     }
 }
 
@@ -125,26 +125,10 @@ pub type path_buffer_pool = PathBufferPoolT<PathBuffer>;
 pub type w_path_buffer_pool = PathBufferPoolT<WPathBuffer>;
 
 /// `bun.path_buffer_pool.get()` — convenience wrapper returning the RAII guard.
-/// `Path<U>` callers store this in a `ManuallyDrop` and explicitly `put` on
-/// reset, so also expose `into_box`/free `put`.
 pub type Guard = PoolGuard<PathBuffer>;
 #[inline]
 pub fn get() -> PoolGuard<PathBuffer> {
     PathBufferPoolT::<PathBuffer>::get()
-}
-#[inline]
-pub(crate) fn put(buf: Box<PathBuffer>) {
-    PathBufferPoolT::<PathBuffer>::put(buf)
-}
-
-impl<T: PoolStorage> PoolGuard<T> {
-    /// Extract the `Box` without returning it to the pool (for `ManuallyDrop`
-    /// owners that will `put` explicitly later). `Drop` is a no-op once `buf`
-    /// is `None`, so no leak.
-    #[inline]
-    pub(crate) fn into_box(mut self) -> Box<T> {
-        self.buf.take().unwrap()
-    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## What

`Path<U, ..>` (the `AbsPath`/`RelPath` builder in `src/paths/Path.rs`) kept its pooled buffer as `ManuallyDrop<Box<U::Buffer>>`, obtained it through `PathUnit::pool_get()` (which called `path_buffer_pool::get().into_box()` to unwrap the pool's own RAII guard), and gave it back from a manual `impl Drop for Path`. That `Drop` impl was also the reason `into_sep` had to wrap `self` in `ManuallyDrop` and `unsafe { ManuallyDrop::take(..) }` the field out before rebuilding the value under the new const parameter.

The pool's guard is already generic over both buffer types (`PoolGuard<T: PoolStorage>`, implemented for `PathBuffer` and `WPathBuffer`), so `Buf` now owns it directly:

```rust
// before
pub trait PathUnit { type Buffer: 'static; fn pool_get() -> Box<Self::Buffer>; fn pool_put(buf: Box<Self::Buffer>); .. }
struct Buf<U, ..> { pooled: ManuallyDrop<Box<U::Buffer>>, len: usize }
impl Drop for Path<..> { fn drop(&mut self) { U::pool_put(unsafe { ManuallyDrop::take(&mut self._buf.pooled) }) } }

// after
pub trait PathUnit { type Buffer: PoolStorage; .. }
struct Buf<U, ..> { pooled: PoolGuard<U::Buffer>, len: usize }
```

`init()` calls `PathBufferPoolT::<U::Buffer>::get()`, `into_sep` is a plain destructuring move, and the buffer accessors are unchanged (they deref-coerce through the guard exactly as they did through `ManuallyDrop<Box<_>>`). Deleted as dead by this change: `impl Drop for Path`, `PathUnit::pool_get`/`pool_put` and their two impls, `PoolGuard::into_box`, and the `pub(crate)` `put` shims in `path_buffer_pool.rs` and `lib.rs`; `PathBufferPoolT::put` becomes private with `PoolGuard::drop` as its only caller.

With `into_box` gone, the `None` state of `PoolGuard`'s `Option<Box<T>>` no longer exists, so the guard stores `ManuallyDrop<Box<T>>`: `Deref`/`DerefMut` are field projections and `Drop` is one take followed by the same `put` as before. Removes two unsafe blocks from `Path.rs` and adds one in `PoolGuard::drop`, net one fewer.

## Why

Ownership of the buffer and its return to the pool are now stated by the field type (`PoolGuard<U::Buffer>`) instead of by a `ManuallyDrop` field plus a `Drop` impl two hundred lines away, and a guard without a buffer is no longer representable. `PoolGuard<T>` is a single `Box` pointer like the field it replaces, so `Path` keeps its 16 byte layout and its `Option` niche, `init` and drop execute the same pool `get`/`put` as before, and every existing `PoolGuard` deref loses its `unwrap` branch; as a side effect `Option<PoolGuard<T>>` (used in `src/libarchive`) shrinks from 16 to 8 bytes.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/cli/install/isolated-install.test.ts test/cli/install/bun-link.test.ts test/cli/install/bun-install-native-binlink.test.ts: 81 pass, 1 fail (82 tests, 3 files).
The single failure, bun-link.test.ts "should link dependency without crashing" (5s timeout), is pre-existing: it fails identically on main (bun-link.test.ts on main: 3 pass, 1 fail) and is unrelated to this change, which only touches src/paths/Path.rs, src/paths/lib.rs, and src/paths/path_buffer_pool.rs.
