### PR TITLE
node:http2: coerce outbound header values before taking a stream id

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3454,6 +3454,10 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers[HTTP2_HEADER_AUTHORITY] === undefined && parentRequestHeaders) {
       headers[HTTP2_HEADER_AUTHORITY] = parentRequestHeaders[HTTP2_HEADER_AUTHORITY];
     }
+    // Before the promised id is reserved, so that a pushStream() made from inside a value's
+    // toString() reserves and announces its stream first (see toWireHeaders). Like node, a throwing
+    // coercion throws from pushStream() itself rather than reaching the callback.
+    const wireHeaders = toWireHeaders(headers);
     const pushId = parser.getNextStream();
     if (pushId === -1) {
       throw $ERR_HTTP2_OUT_OF_STREAMS();
@@ -3471,7 +3475,7 @@ class ServerHttp2Stream extends Http2Stream {
     }
     let pushResult;
     try {
-      pushResult = parser.pushPromise(this.id, pushId, headers, sensitiveNames);
+      pushResult = parser.pushPromise(this.id, pushId, wireHeaders, sensitiveNames);
     } catch (err) {
       // pushPromise() throws synchronously on an invalid header block. The pushed stream was
       // already created by getNextStream's streamStart; tear it down without an error so the
@@ -4067,6 +4071,51 @@ function buildSensitiveNames(headers, sensitives) {
     }
   }
   return map;
+}
+
+// Objects are the only header values whose coercion runs user code (toString/valueOf/
+// Symbol.toPrimitive); primitives are left to the native validator, which keeps its exact error
+// behavior for undefined/null/symbol values.
+function coerceHeaderValue(value) {
+  const type = typeof value;
+  return (type === "object" && value !== null) || type === "function" ? `${value}` : value;
+}
+
+// The header block request()/pushStream() hand to the native encoder. The encoder coerces each
+// value while encoding, i.e. after the caller has taken a stream id, so a value whose toString()
+// calls request()/pushStream() again would take the next id yet reach the wire first (RFC 9113
+// §5.1.1 requires ids to increase on the wire; nghttp2 ignores the lower one), with the two blocks'
+// HPACK table updates interleaved. Like node's buildNgHeaderString, coerce everything in JS before
+// an id is taken. Arrays are always copied so native only reads fresh arrays of primitives. The
+// input is not mutated: the object form backs sentHeaders, which node leaves uncoerced as well.
+function toWireHeaders(headers) {
+  if ($isArray(headers)) {
+    // Raw [name, value, ...] form: names are coerced natively as well.
+    const list: any[] = [];
+    for (let i = 0; i < headers.length; i++) {
+      list[i] = coerceHeaderValue(headers[i]);
+    }
+    return list;
+  }
+  let wire = null;
+  const keys = ObjectKeys(headers);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = headers[key];
+    let wireValue;
+    if ($isArray(value)) {
+      wireValue = [];
+      for (let j = 0; j < value.length; j++) {
+        wireValue[j] = coerceHeaderValue(value[j]);
+      }
+    } else {
+      wireValue = coerceHeaderValue(value);
+      if (wireValue === value) continue;
+    }
+    if (wire === null) wire = { ...headers };
+    wire[key] = wireValue;
+  }
+  return wire === null ? headers : wire;
 }
 
 function toHeaderObject(headers, sensitiveHeadersValue) {
@@ -6381,6 +6430,12 @@ class ClientHttp2Session extends Http2Session {
         }
       }
 
+      // Before this request is queued or takes a stream id, so that a request() made from inside a
+      // value's toString() is submitted (or queued) ahead of this one (see toWireHeaders). The raw
+      // (array) form is kept because it preserves duplicate-header interleaving the object form
+      // cannot represent; `headers` itself backs sentHeaders and the diagnostics channels.
+      const wireHeaders = toWireHeaders(rawHeadersList !== null ? rawHeadersList : headers);
+
       // A request made before the socket finished connecting, or while the peer's
       // SETTINGS_MAX_CONCURRENT_STREAMS limit leaves no slot, is not submitted yet — node returns
       // a "pending" stream (no id) and sends its HEADERS frame once the session connects / a slot
@@ -6401,15 +6456,7 @@ class ClientHttp2Session extends Http2Session {
         if (this.#pendingRequests === null) {
           this.#pendingRequests = [];
         }
-        // Preserve both forms: the on-wire (array) form keeps duplicate-header interleaving the
-        // object form cannot represent; the object form is what diagnostics channels publish.
-        this.#pendingRequests.push({
-          req,
-          headers,
-          wireHeaders: rawHeadersList !== null ? rawHeadersList : headers,
-          sensitiveNames,
-          options,
-        });
+        this.#pendingRequests.push({ req, headers, wireHeaders, sensitiveNames, options });
         // node corks every Http2Stream until its native handle is assigned; same here so
         // synchronous writes after a queued request() batch through _writev once the slot frees.
         req.cork();
@@ -6431,7 +6478,6 @@ class ClientHttp2Session extends Http2Session {
       if (onClientStreamCreatedChannel.hasSubscribers) {
         onClientStreamCreatedChannel.publish({ stream: req, headers });
       }
-      const wireHeaders = rawHeadersList !== null ? rawHeadersList : headers;
       if (typeof options === "undefined") {
         this.#parser.request(stream_id, req, wireHeaders, sensitiveNames);
       } else {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3465,12 +3465,6 @@ class ServerHttp2Stream extends Http2Stream {
     if (pushedStream && pushedStream[bunHTTP2Headers] == null) {
       pushedStream[bunHTTP2Headers] = headers;
     }
-    if (onServerStreamCreatedChannel.hasSubscribers) {
-      onServerStreamCreatedChannel.publish({ stream: pushedStream, headers });
-    }
-    if (onServerStreamStartChannel.hasSubscribers) {
-      onServerStreamStartChannel.publish({ stream: pushedStream, headers });
-    }
     let pushResult;
     try {
       pushResult = parser.pushPromise(this.id, pushId, wireHeaders, sensitiveNames);
@@ -3478,6 +3472,10 @@ class ServerHttp2Stream extends Http2Stream {
       // pushPromise() throws synchronously on an invalid header block. The pushed stream was
       // already created by getNextStream's streamStart; tear it down without an error so the
       // callback is the only error channel, matching node.
+      // 'created' (never 'start') still fires: it is the only handle on the stream being torn down.
+      if (onServerStreamCreatedChannel.hasSubscribers) {
+        onServerStreamCreatedChannel.publish({ stream: pushedStream, headers });
+      }
       if (pushedStream && !pushedStream.destroyed) {
         // The PUSH_PROMISE never reached the wire; sending RST_STREAM for the reserved id would
         // be a protocol violation (the peer sees an idle stream). The skipped reset dispatch is
@@ -3488,6 +3486,13 @@ class ServerHttp2Stream extends Http2Stream {
       }
       process.nextTick(callback, err);
       return;
+    }
+    // After the PUSH_PROMISE is written, as in node: a push made by a subscriber announces second.
+    if (onServerStreamCreatedChannel.hasSubscribers) {
+      onServerStreamCreatedChannel.publish({ stream: pushedStream, headers });
+    }
+    if (onServerStreamStartChannel.hasSubscribers) {
+      onServerStreamStartChannel.publish({ stream: pushedStream, headers });
     }
     if (pushResult === -1) {
       // Block not encodable: session failing with COMPRESSION_ERROR. Node still delivers the
@@ -4077,12 +4082,10 @@ function coerceHeaderValue(value) {
   return (type === "object" && value !== null) || type === "function" ? `${value}` : value;
 }
 
-// Coerces the header values in JS before the caller takes a stream id (node: buildNgHeaderString).
-// The native encoder coerces while encoding, so a value whose toString() re-enters request() or
-// pushStream() would take the next id yet reach the wire first (RFC 9113 §5.1.1). Arrays are always
-// copied so native never reads caller-owned storage; the input itself (sentHeaders) is not mutated.
+// Runs before an id is taken: a toString() re-entering request()/pushStream() gets the lower id.
 function toWireHeaders(headers) {
   if ($isArray(headers)) {
+    // Arrays are always copied: native must not read caller-owned storage (accessors, proxies).
     const list: any[] = [];
     for (let i = 0; i < headers.length; i++) {
       list[i] = coerceHeaderValue(headers[i]);
@@ -6422,8 +6425,7 @@ class ClientHttp2Session extends Http2Session {
         }
       }
 
-      // Must precede both the pending queue and getNextStream(): see toWireHeaders. The raw (array)
-      // form keeps duplicate-header interleaving the object form cannot represent.
+      // Must precede both the pending queue and getNextStream(): see toWireHeaders.
       const wireHeaders = toWireHeaders(rawHeadersList !== null ? rawHeadersList : headers);
 
       // A request made before the socket finished connecting, or while the peer's
@@ -6465,9 +6467,6 @@ class ClientHttp2Session extends Http2Session {
       const req = new ClientHttp2Stream(stream_id, this, headers);
       req.authority = authority;
       req[kHeadRequest] = method === HTTP2_METHOD_HEAD;
-      if (onClientStreamCreatedChannel.hasSubscribers) {
-        onClientStreamCreatedChannel.publish({ stream: req, headers });
-      }
       if (typeof options === "undefined") {
         this.#parser.request(stream_id, req, wireHeaders, sensitiveNames);
       } else {
@@ -6484,6 +6483,10 @@ class ClientHttp2Session extends Http2Session {
       process.nextTick(uncorkNT, req);
       setupRequestEndAndSignal(req, options, signal);
       process.nextTick(emitEventNT, req, "ready");
+      // Last, as in node: a request made by a subscriber from here must take the higher id.
+      if (onClientStreamCreatedChannel.hasSubscribers) {
+        onClientStreamCreatedChannel.publish({ stream: req, headers });
+      }
       return req;
     } catch (e: any) {
       if (connectionsCounted) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4082,13 +4082,22 @@ function coerceHeaderValue(value) {
   return (type === "object" && value !== null) || type === "function" ? `${value}` : value;
 }
 
+// Arrays stay arrays but are always copied: native must not read caller-owned storage.
+function toWireHeaderValue(value) {
+  if (!$isArray(value)) return coerceHeaderValue(value);
+  const copy: any[] = [];
+  for (let i = 0; i < value.length; i++) {
+    copy[i] = coerceHeaderValue(value[i]);
+  }
+  return copy;
+}
+
 // Runs before an id is taken: a toString() re-entering request()/pushStream() gets the lower id.
 function toWireHeaders(headers) {
   if ($isArray(headers)) {
-    // Arrays are always copied: native must not read caller-owned storage (accessors, proxies).
     const list: any[] = [];
     for (let i = 0; i < headers.length; i++) {
-      list[i] = coerceHeaderValue(headers[i]);
+      list[i] = toWireHeaderValue(headers[i]);
     }
     return list;
   }
@@ -4097,16 +4106,8 @@ function toWireHeaders(headers) {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const value = headers[key];
-    let wireValue;
-    if ($isArray(value)) {
-      wireValue = [];
-      for (let j = 0; j < value.length; j++) {
-        wireValue[j] = coerceHeaderValue(value[j]);
-      }
-    } else {
-      wireValue = coerceHeaderValue(value);
-      if (wireValue === value) continue;
-    }
+    const wireValue = toWireHeaderValue(value);
+    if (wireValue === value) continue;
     if (wire === null) wire = { ...headers };
     wire[key] = wireValue;
   }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6442,9 +6442,6 @@ class ClientHttp2Session extends Http2Session {
         const req = new ClientHttp2Stream(undefined, this, headers);
         req.authority = authority;
         req[kHeadRequest] = method === HTTP2_METHOD_HEAD;
-        if (onClientStreamCreatedChannel.hasSubscribers) {
-          onClientStreamCreatedChannel.publish({ stream: req, headers });
-        }
         if (this.#pendingRequests === null) {
           this.#pendingRequests = [];
         }
@@ -6454,6 +6451,10 @@ class ClientHttp2Session extends Http2Session {
         req.cork();
         process.nextTick(uncorkNT, req);
         setupRequestEndAndSignal(req, options, signal);
+        // Last, as in node: a request made by a subscriber from here is queued behind this one.
+        if (onClientStreamCreatedChannel.hasSubscribers) {
+          onClientStreamCreatedChannel.publish({ stream: req, headers });
+        }
         return req;
       }
 

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6451,7 +6451,14 @@ class ClientHttp2Session extends Http2Session {
         if (this.#pendingRequests === null) {
           this.#pendingRequests = [];
         }
-        this.#pendingRequests.push({ req, headers, wireHeaders, sensitiveNames, options });
+        this.#pendingRequests.push({
+          req,
+          headers,
+          // Reachable as sentHeaders while queued: snapshot it, as node does.
+          wireHeaders: wireHeaders === headers ? { ...headers } : wireHeaders,
+          sensitiveNames,
+          options,
+        });
         // node corks every Http2Stream until its native handle is assigned; same here so
         // synchronous writes after a queued request() batch through _writev once the slot frees.
         req.cork();

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4077,9 +4077,13 @@ function buildSensitiveNames(headers, sensitives) {
 }
 
 // Only objects run user code when coerced; primitives keep the native validator's exact errors.
-function coerceHeaderValue(value) {
+function isCoercibleHeaderValue(value) {
   const type = typeof value;
-  return (type === "object" && value !== null) || type === "function" ? `${value}` : value;
+  return (type === "object" && value !== null) || type === "function";
+}
+
+function coerceHeaderValue(value) {
+  return isCoercibleHeaderValue(value) ? `${value}` : value;
 }
 
 // Arrays stay arrays but are always copied: native must not read caller-owned storage.
@@ -4101,17 +4105,18 @@ function toWireHeaders(headers) {
     }
     return list;
   }
-  let wire = null;
   const keys = ObjectKeys(headers);
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    const value = headers[key];
-    const wireValue = toWireHeaderValue(value);
-    if (wireValue === value) continue;
-    if (wire === null) wire = { ...headers };
-    wire[key] = wireValue;
+  let i = 0;
+  while (i < keys.length && !isCoercibleHeaderValue(headers[keys[i]])) i++;
+  if (i === keys.length) return headers;
+  // Copied before any coercion runs and coerced in place: nothing a coercion does can reach native.
+  const wire = { ...headers };
+  const wireKeys = ObjectKeys(wire);
+  for (let j = 0; j < wireKeys.length; j++) {
+    const key = wireKeys[j];
+    wire[key] = toWireHeaderValue(wire[key]);
   }
-  return wire === null ? headers : wire;
+  return wire;
 }
 
 function toHeaderObject(headers, sensitiveHeadersValue) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4086,8 +4086,10 @@ function coerceHeaderValue(value) {
 // calls request()/pushStream() again would take the next id yet reach the wire first (RFC 9113
 // §5.1.1 requires ids to increase on the wire; nghttp2 ignores the lower one), with the two blocks'
 // HPACK table updates interleaved. Like node's buildNgHeaderString, coerce everything in JS before
-// an id is taken. Arrays are always copied so native only reads fresh arrays of primitives. The
-// input is not mutated: the object form backs sentHeaders, which node leaves uncoerced as well.
+// an id is taken. Native must only read storage this module created: the object form the callers
+// pass is already their own spread copy (plain data properties), so it is copied only when a value
+// needs coercing, while arrays (the caller's own) are always copied. The input is not mutated: the
+// object form backs sentHeaders, which node leaves uncoerced as well.
 function toWireHeaders(headers) {
   if ($isArray(headers)) {
     // Raw [name, value, ...] form: names are coerced natively as well.

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3454,9 +3454,7 @@ class ServerHttp2Stream extends Http2Stream {
     if (headers[HTTP2_HEADER_AUTHORITY] === undefined && parentRequestHeaders) {
       headers[HTTP2_HEADER_AUTHORITY] = parentRequestHeaders[HTTP2_HEADER_AUTHORITY];
     }
-    // Before the promised id is reserved, so that a pushStream() made from inside a value's
-    // toString() reserves and announces its stream first (see toWireHeaders). Like node, a throwing
-    // coercion throws from pushStream() itself rather than reaching the callback.
+    // Must precede getNextStream(): see toWireHeaders.
     const wireHeaders = toWireHeaders(headers);
     const pushId = parser.getNextStream();
     if (pushId === -1) {
@@ -4073,26 +4071,18 @@ function buildSensitiveNames(headers, sensitives) {
   return map;
 }
 
-// Objects are the only header values whose coercion runs user code (toString/valueOf/
-// Symbol.toPrimitive); primitives are left to the native validator, which keeps its exact error
-// behavior for undefined/null/symbol values.
+// Only objects run user code when coerced; primitives keep the native validator's exact errors.
 function coerceHeaderValue(value) {
   const type = typeof value;
   return (type === "object" && value !== null) || type === "function" ? `${value}` : value;
 }
 
-// The header block request()/pushStream() hand to the native encoder. The encoder coerces each
-// value while encoding, i.e. after the caller has taken a stream id, so a value whose toString()
-// calls request()/pushStream() again would take the next id yet reach the wire first (RFC 9113
-// §5.1.1 requires ids to increase on the wire; nghttp2 ignores the lower one), with the two blocks'
-// HPACK table updates interleaved. Like node's buildNgHeaderString, coerce everything in JS before
-// an id is taken. Native must only read storage this module created: the object form the callers
-// pass is already their own spread copy (plain data properties), so it is copied only when a value
-// needs coercing, while arrays (the caller's own) are always copied. The input is not mutated: the
-// object form backs sentHeaders, which node leaves uncoerced as well.
+// Coerces the header values in JS before the caller takes a stream id (node: buildNgHeaderString).
+// The native encoder coerces while encoding, so a value whose toString() re-enters request() or
+// pushStream() would take the next id yet reach the wire first (RFC 9113 §5.1.1). Arrays are always
+// copied so native never reads caller-owned storage; the input itself (sentHeaders) is not mutated.
 function toWireHeaders(headers) {
   if ($isArray(headers)) {
-    // Raw [name, value, ...] form: names are coerced natively as well.
     const list: any[] = [];
     for (let i = 0; i < headers.length; i++) {
       list[i] = coerceHeaderValue(headers[i]);
@@ -6432,10 +6422,8 @@ class ClientHttp2Session extends Http2Session {
         }
       }
 
-      // Before this request is queued or takes a stream id, so that a request() made from inside a
-      // value's toString() is submitted (or queued) ahead of this one (see toWireHeaders). The raw
-      // (array) form is kept because it preserves duplicate-header interleaving the object form
-      // cannot represent; `headers` itself backs sentHeaders and the diagnostics channels.
+      // Must precede both the pending queue and getNextStream(): see toWireHeaders. The raw (array)
+      // form keeps duplicate-header interleaving the object form cannot represent.
       const wireHeaders = toWireHeaders(rawHeadersList !== null ? rawHeadersList : headers);
 
       // A request made before the socket finished connecting, or while the peer's

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -959,6 +959,7 @@ describe("request()/pushStream() run no user code between taking a stream id and
     ["an object value", probe => ({ ":path": "/outer", "x-probe": probe })],
     ["an array element", probe => ({ ":path": "/outer", "x-probe": ["first", probe] })],
     ["a value in the raw [name, value] array form", probe => [":path", "/outer", "x-probe", probe]],
+    ["an array element in the raw array form", probe => [":path", "/outer", "x-probe", ["first", probe]]],
   ];
 
   const requestWithReenteringValue =

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -983,28 +983,34 @@ describe("request()/pushStream() run no user code between taking a stream id and
     });
   });
 
-  // 'http2.client.stream.created' is published once the outer request is on the wire (node does
-  // the same), so a request made by a subscriber comes second.
-  test("a request() made from a 'http2.client.stream.created' subscriber is sent second, on the higher id", async () => {
-    let requestInner: (() => void) | null = null;
-    const subscriber = ({ headers }: any) => {
-      if (headers[":path"] !== "/outer" || requestInner === null) return;
-      const fn = requestInner;
-      requestInner = null;
-      fn();
-    };
-    diagnosticsChannel.subscribe("http2.client.stream.created", subscriber);
-    try {
-      expect(
-        await clientHeadersOrder((client, inner) => {
-          requestInner = inner;
-          return client.request({ ":path": "/outer" });
-        }),
-      ).toEqual({ wireOrder: [1, 3], ids: { outer: 1, inner: 3 } });
-    } finally {
-      diagnosticsChannel.unsubscribe("http2.client.stream.created", subscriber);
-    }
-  });
+  // 'http2.client.stream.created' is published once the outer request is on the wire, or queued
+  // (node does the same), so a request made by a subscriber comes second either way.
+  test.each([
+    ["connected", false],
+    ["still connecting", true],
+  ])(
+    "a request() made from a 'http2.client.stream.created' subscriber on a %s session is sent second, on the higher id",
+    async (_, requestBeforeConnect) => {
+      let requestInner: (() => void) | null = null;
+      const subscriber = ({ headers }: any) => {
+        if (headers[":path"] !== "/outer" || requestInner === null) return;
+        const fn = requestInner;
+        requestInner = null;
+        fn();
+      };
+      diagnosticsChannel.subscribe("http2.client.stream.created", subscriber);
+      try {
+        expect(
+          await clientHeadersOrder((client, inner) => {
+            requestInner = inner;
+            return client.request({ ":path": "/outer" });
+          }, requestBeforeConnect),
+        ).toEqual({ wireOrder: [1, 3], ids: { outer: 1, inner: 3 } });
+      } finally {
+        diagnosticsChannel.unsubscribe("http2.client.stream.created", subscriber);
+      }
+    },
+  );
 
   // End to end against a real peer: with the blocks encoded in wire order, both requests are
   // answered and each one carries its own headers.

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -9,6 +9,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
+import diagnosticsChannel from "node:diagnostics_channel";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
@@ -902,11 +903,12 @@ const CONTENT_LENGTH_5 = Buffer.concat([Buffer.from([0x0f, 0x0d]), hpackLiteral(
 
 // RFC 9113 §5.1.1: every stream an endpoint opens (client HEADERS) or reserves (server
 // PUSH_PROMISE) must carry a higher id than the ones it sent before; nghttp2 peers ignore a frame
-// that opens a lower id, so the request it carried never gets a response. The header values are
-// coerced while the block is built, so a value whose toString() calls request()/pushStream() again
-// is the one place user code can run between allocating an id and writing the frame that carries
-// it: the nested call must take its id and reach the wire first.
-describe("request()/pushStream() coerce header values before taking a stream id (RFC 9113 §5.1.1)", () => {
+// that opens a lower id, so the request it carried never gets a response. User code that runs while
+// request()/pushStream() is working (a header value's toString(), a diagnostics_channel subscriber)
+// may itself call request()/pushStream(), so none of it may run between taking an id and writing
+// the frame that carries it: header values are coerced before the id is taken, and the channels are
+// published after the frame is written.
+describe("request()/pushStream() run no user code between taking a stream id and writing its frame (RFC 9113 §5.1.1)", () => {
   function valueThatReenters(reenter: () => void) {
     let reentered = false;
     return {
@@ -920,22 +922,23 @@ describe("request()/pushStream() coerce header values before taking a stream id 
     };
   }
 
-  async function clientHeadersOrder(makeOuterHeaders: (probe: object) => any, requestBeforeConnect: boolean) {
+  // Drives `issueOuter` against a raw server and reports the HEADERS stream ids in wire order plus
+  // the ids the two requests ended up with. `requestInner` makes the nested request.
+  async function clientHeadersOrder(
+    issueOuter: (client: http2.ClientHttp2Session, requestInner: () => void) => any,
+    requestBeforeConnect = false,
+  ) {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
     client.on("error", () => {});
     try {
       if (!requestBeforeConnect) await once(client, "connect");
       let inner: any;
-      const outer = client.request(
-        makeOuterHeaders(
-          valueThatReenters(() => {
-            inner = client.request({ ":path": "/inner" });
-            inner.on("error", () => {});
-            inner.end();
-          }),
-        ),
-      );
+      const outer = issueOuter(client, () => {
+        inner = client.request({ ":path": "/inner" });
+        inner.on("error", () => {});
+        inner.end();
+      });
       outer.on("error", () => {});
       outer.end();
       await Promise.all([
@@ -958,10 +961,15 @@ describe("request()/pushStream() coerce header values before taking a stream id 
     ["a value in the raw [name, value] array form", probe => [":path", "/outer", "x-probe", probe]],
   ];
 
+  const requestWithReenteringValue =
+    (makeOuterHeaders: (probe: object) => any) => (client: http2.ClientHttp2Session, requestInner: () => void) =>
+      client.request(makeOuterHeaders(valueThatReenters(requestInner)));
+
+  // The nested request is made while the outer one is still being prepared, so it goes first.
   test.each(headerForms)(
     "a request() made while coercing %s is sent first, on the lower id",
     async (_, makeOuterHeaders) => {
-      expect(await clientHeadersOrder(makeOuterHeaders, false)).toEqual({
+      expect(await clientHeadersOrder(requestWithReenteringValue(makeOuterHeaders))).toEqual({
         wireOrder: [1, 3],
         ids: { inner: 1, outer: 3 },
       });
@@ -969,10 +977,33 @@ describe("request()/pushStream() coerce header values before taking a stream id 
   );
 
   test("requests made before the session connected are coerced when made, so the nested one is queued first", async () => {
-    expect(await clientHeadersOrder(headerForms[0][1], true)).toEqual({
+    expect(await clientHeadersOrder(requestWithReenteringValue(headerForms[0][1]), true)).toEqual({
       wireOrder: [1, 3],
       ids: { inner: 1, outer: 3 },
     });
+  });
+
+  // 'http2.client.stream.created' is published once the outer request is on the wire (node does
+  // the same), so a request made by a subscriber comes second.
+  test("a request() made from a 'http2.client.stream.created' subscriber is sent second, on the higher id", async () => {
+    let requestInner: (() => void) | null = null;
+    const subscriber = ({ headers }: any) => {
+      if (headers[":path"] !== "/outer" || requestInner === null) return;
+      const fn = requestInner;
+      requestInner = null;
+      fn();
+    };
+    diagnosticsChannel.subscribe("http2.client.stream.created", subscriber);
+    try {
+      expect(
+        await clientHeadersOrder((client, inner) => {
+          requestInner = inner;
+          return client.request({ ":path": "/outer" });
+        }),
+      ).toEqual({ wireOrder: [1, 3], ids: { outer: 1, inner: 3 } });
+    } finally {
+      diagnosticsChannel.unsubscribe("http2.client.stream.created", subscriber);
+    }
   });
 
   // End to end against a real peer: with the blocks encoded in wire order, both requests are
@@ -1016,28 +1047,26 @@ describe("request()/pushStream() coerce header values before taking a stream id 
     }
   });
 
-  test("a pushStream() made while coercing another push's header value is reserved and announced first", async () => {
+  // Serves one request whose handler runs `issueOuterPush(push)` (where `push(headers, label)`
+  // pushes and records the id that push ended up with) and reports the promised ids a raw client
+  // saw in its PUSH_PROMISE frames, in wire order, plus the recorded ids.
+  async function pushOrder(issueOuterPush: (push: (headers: any, label: "inner" | "outer") => void) => void) {
     const pushServer = http2.createServer();
     pushServer.on("sessionError", () => {});
-    const pushedIds = Promise.withResolvers<{ inner: number; outer: number }>();
+    const pushedIds = Promise.withResolvers<Record<string, number>>();
     pushServer.on("stream", (stream: any) => {
       stream.on("error", () => {});
-      let innerId = 0;
-      const push = (headers: any, onPushed: (id: number) => void) =>
+      const ids: Record<string, number> = {};
+      const push = (headers: any, label: "inner" | "outer") =>
         stream.pushStream(headers, (err: Error | null, pushed: any) => {
           if (err) return pushedIds.reject(err);
           pushed.on("error", () => {});
           pushed.respond({ ":status": 200 });
           pushed.end();
-          onPushed(pushed.id);
+          ids[label] = pushed.id;
+          if ("inner" in ids && "outer" in ids) pushedIds.resolve(ids);
         });
-      push(
-        {
-          ":path": "/outer",
-          "x-probe": valueThatReenters(() => push({ ":path": "/inner" }, id => (innerId = id))),
-        },
-        outerId => pushedIds.resolve({ inner: innerId, outer: outerId }),
-      );
+      issueOuterPush(push);
       stream.respond({ ":status": 200 });
       stream.end();
     });
@@ -1054,13 +1083,45 @@ describe("request()/pushStream() coerce header values before taking a stream id 
         c.waitFor(f => f.type === FrameType.PUSH_PROMISE && promisedId(f) === 2),
         c.waitFor(f => f.type === FrameType.PUSH_PROMISE && promisedId(f) === 4),
       ]);
-      expect({
+      return {
         wireOrder: c.frames.filter(f => f.type === FrameType.PUSH_PROMISE).map(promisedId),
         ids: await pushedIds.promise,
-      }).toEqual({ wireOrder: [2, 4], ids: { inner: 2, outer: 4 } });
+      };
     } finally {
       c.destroy();
       pushServer.close();
+    }
+  }
+
+  test("a pushStream() made while coercing another push's header value is reserved and announced first", async () => {
+    expect(
+      await pushOrder(push => {
+        const probe = valueThatReenters(() => push({ ":path": "/inner" }, "inner"));
+        push({ ":path": "/outer", "x-probe": probe }, "outer");
+      }),
+    ).toEqual({ wireOrder: [2, 4], ids: { inner: 2, outer: 4 } });
+  });
+
+  // 'http2.server.stream.created' for a pushed stream is published once its PUSH_PROMISE is on the
+  // wire (node does the same), so a push made by a subscriber comes second.
+  test("a pushStream() made from a 'http2.server.stream.created' subscriber is announced second, on the higher id", async () => {
+    let pushInner: (() => void) | null = null;
+    const subscriber = ({ headers }: any) => {
+      if (headers[":path"] !== "/outer" || pushInner === null) return;
+      const fn = pushInner;
+      pushInner = null;
+      fn();
+    };
+    diagnosticsChannel.subscribe("http2.server.stream.created", subscriber);
+    try {
+      expect(
+        await pushOrder(push => {
+          pushInner = () => push({ ":path": "/inner" }, "inner");
+          push({ ":path": "/outer" }, "outer");
+        }),
+      ).toEqual({ wireOrder: [2, 4], ids: { outer: 2, inner: 4 } });
+    } finally {
+      diagnosticsChannel.unsubscribe("http2.server.stream.created", subscriber);
     }
   });
 

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -900,6 +900,217 @@ function requestHeaderBlock(method: "GET" | "POST", extra: Buffer = Buffer.alloc
 
 const CONTENT_LENGTH_5 = Buffer.concat([Buffer.from([0x0f, 0x0d]), hpackLiteral("5")]);
 
+// RFC 9113 §5.1.1: every stream an endpoint opens (client HEADERS) or reserves (server
+// PUSH_PROMISE) must carry a higher id than the ones it sent before; nghttp2 peers ignore a frame
+// that opens a lower id, so the request it carried never gets a response. The header values are
+// coerced while the block is built, so a value whose toString() calls request()/pushStream() again
+// is the one place user code can run between allocating an id and writing the frame that carries
+// it: the nested call must take its id and reach the wire first.
+describe("request()/pushStream() coerce header values before taking a stream id (RFC 9113 §5.1.1)", () => {
+  function valueThatReenters(reenter: () => void) {
+    let reentered = false;
+    return {
+      toString() {
+        if (!reentered) {
+          reentered = true;
+          reenter();
+        }
+        return "outer";
+      },
+    };
+  }
+
+  async function clientHeadersOrder(makeOuterHeaders: (probe: object) => any, requestBeforeConnect: boolean) {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      if (!requestBeforeConnect) await once(client, "connect");
+      let inner: any;
+      const outer = client.request(
+        makeOuterHeaders(
+          valueThatReenters(() => {
+            inner = client.request({ ":path": "/inner" });
+            inner.on("error", () => {});
+            inner.end();
+          }),
+        ),
+      );
+      outer.on("error", () => {});
+      outer.end();
+      await Promise.all([
+        raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1),
+        raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3),
+      ]);
+      return {
+        wireOrder: raw.frames.filter(f => f.type === FrameType.HEADERS).map(f => f.streamId),
+        ids: { inner: inner.id, outer: outer.id },
+      };
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  }
+
+  const headerForms: [string, (probe: object) => any][] = [
+    ["an object value", probe => ({ ":path": "/outer", "x-probe": probe })],
+    ["an array element", probe => ({ ":path": "/outer", "x-probe": ["first", probe] })],
+    ["a value in the raw [name, value] array form", probe => [":path", "/outer", "x-probe", probe]],
+  ];
+
+  test.each(headerForms)(
+    "a request() made while coercing %s is sent first, on the lower id",
+    async (_, makeOuterHeaders) => {
+      expect(await clientHeadersOrder(makeOuterHeaders, false)).toEqual({
+        wireOrder: [1, 3],
+        ids: { inner: 1, outer: 3 },
+      });
+    },
+  );
+
+  test("requests made before the session connected are coerced when made, so the nested one is queued first", async () => {
+    expect(await clientHeadersOrder(headerForms[0][1], true)).toEqual({
+      wireOrder: [1, 3],
+      ids: { inner: 1, outer: 3 },
+    });
+  });
+
+  // End to end against a real peer: with the blocks encoded in wire order, both requests are
+  // answered and each one carries its own headers.
+  test("both the nested and the outer request are answered by an http2 server", async () => {
+    const echoServer = http2.createServer();
+    echoServer.on("stream", (stream: any, headers: any) => {
+      const response: any = { ":status": 200, "x-echo-path": headers[":path"] };
+      if ("x-probe" in headers) response["x-echo-probe"] = headers["x-probe"];
+      stream.respond(response);
+      stream.end();
+    });
+    echoServer.listen(0, "127.0.0.1");
+    await once(echoServer, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(echoServer.address() as net.AddressInfo).port}`);
+    const sessionError = new Promise<never>((_, reject) => client.on("error", reject));
+    try {
+      await once(client, "connect");
+      const answered = (req: any) =>
+        new Promise<any>((resolve, reject) => {
+          req.on("response", (h: any) => resolve({ id: req.id, path: h["x-echo-path"], probe: h["x-echo-probe"] }));
+          req.on("error", reject);
+          req.resume();
+          req.end();
+        });
+      let innerAnswered!: Promise<any>;
+      const probe = valueThatReenters(() => {
+        innerAnswered = answered(client.request({ ":path": "/inner" }));
+      });
+      const outer = client.request({ ":path": "/outer", "x-probe": probe });
+      const outerAnswered = answered(outer);
+      // Coercion happens on a copy: sentHeaders still holds the value as given, like node.
+      expect(outer.sentHeaders["x-probe"]).toBe(probe);
+      expect(await Promise.race([Promise.all([innerAnswered, outerAnswered]), sessionError])).toEqual([
+        { id: 1, path: "/inner", probe: undefined },
+        { id: 3, path: "/outer", probe: "outer" },
+      ]);
+    } finally {
+      client.destroy();
+      echoServer.close();
+    }
+  });
+
+  test("a pushStream() made while coercing another push's header value is reserved and announced first", async () => {
+    const pushServer = http2.createServer();
+    pushServer.on("sessionError", () => {});
+    const pushedIds = Promise.withResolvers<{ inner: number; outer: number }>();
+    pushServer.on("stream", (stream: any) => {
+      stream.on("error", () => {});
+      let innerId = 0;
+      const push = (headers: any, onPushed: (id: number) => void) =>
+        stream.pushStream(headers, (err: Error | null, pushed: any) => {
+          if (err) return pushedIds.reject(err);
+          pushed.on("error", () => {});
+          pushed.respond({ ":status": 200 });
+          pushed.end();
+          onPushed(pushed.id);
+        });
+      push(
+        {
+          ":path": "/outer",
+          "x-probe": valueThatReenters(() => push({ ":path": "/inner" }, id => (innerId = id))),
+        },
+        outerId => pushedIds.resolve({ inner: innerId, outer: outerId }),
+      );
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    pushServer.listen(0, "127.0.0.1");
+    await once(pushServer, "listening");
+    const c = await RawH2.connect((pushServer.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM | END_HEADERS */, 1, requestHeaderBlock("GET"));
+      // PUSH_PROMISE payload: 4-byte promised stream id, then the header block.
+      const promisedId = (f: Frame) => f.payload.readUInt32BE(0) & 0x7fffffff;
+      await Promise.all([
+        c.waitFor(f => f.type === FrameType.PUSH_PROMISE && promisedId(f) === 2),
+        c.waitFor(f => f.type === FrameType.PUSH_PROMISE && promisedId(f) === 4),
+      ]);
+      expect({
+        wireOrder: c.frames.filter(f => f.type === FrameType.PUSH_PROMISE).map(promisedId),
+        ids: await pushedIds.promise,
+      }).toEqual({ wireOrder: [2, 4], ids: { inner: 2, outer: 4 } });
+    } finally {
+      c.destroy();
+      pushServer.close();
+    }
+  });
+
+  // Since the values are coerced before anything is allocated or encoded, a throwing coercion
+  // surfaces where node surfaces it (synchronously, from the call itself) and the session is still
+  // usable: previously the half-encoded block desynced the HPACK table and the session died with
+  // COMPRESSION_ERROR.
+  test("a throwing header value coercion throws from request()/pushStream() and leaves the session usable", async () => {
+    const boom = () => ({
+      toString(): string {
+        throw new RangeError("boom");
+      },
+    });
+    const pushOutcome = Promise.withResolvers<string>();
+    const pushServer = http2.createServer();
+    pushServer.on("stream", (stream: any) => {
+      try {
+        stream.pushStream({ ":path": "/p", "x-a": boom() }, () => {});
+        pushOutcome.resolve("returned");
+      } catch (e: any) {
+        pushOutcome.resolve(`threw ${e.name}: ${e.message}`);
+      }
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    pushServer.listen(0, "127.0.0.1");
+    await once(pushServer, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(pushServer.address() as net.AddressInfo).port}`);
+    const sessionError = new Promise<never>((_, reject) => client.on("error", reject));
+    try {
+      // Still connecting: the request would be queued, but its values are coerced right away.
+      expect(() => client.request({ ":path": "/x", "x-a": boom() })).toThrow(new RangeError("boom"));
+      const req = client.request({ ":path": "/" });
+      const status = new Promise<number>((resolve, reject) => {
+        req.on("response", (h: any) => resolve(h[":status"]));
+        req.on("error", reject);
+        req.resume();
+        req.end();
+      });
+      expect(await Promise.race([Promise.all([status, pushOutcome.promise]), sessionError])).toEqual([
+        200,
+        "threw RangeError: boom",
+      ]);
+    } finally {
+      client.destroy();
+      pushServer.close();
+    }
+  });
+});
+
 describe("request header and body framing (RFC 9113 §8.1)", () => {
   let deferredServer: http2.Http2Server;
   let deferredPort: number;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1013,6 +1013,39 @@ describe("request()/pushStream() run no user code between taking a stream id and
     },
   );
 
+  // A queued request's sentHeaders object is reachable until the queue drains; the block that is
+  // eventually sent is the one request() was given (node sends a snapshot taken in request() too),
+  // so a value added to sentHeaders in the meantime is never coerced, let alone sent.
+  test("the block of a request queued before connect is fixed when request() is made", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const outer = client.request({ ":path": "/outer", "x-plain": "given to request()" });
+      outer.on("error", () => {});
+      outer.end();
+      let coercions = 0;
+      outer.sentHeaders["x-late"] = valueThatReenters(() => {
+        coercions++;
+        const inner = client.request({ ":path": "/inner" });
+        inner.on("error", () => {});
+        inner.end();
+      });
+      await raw.waitFor(f => f.type === FrameType.HEADERS);
+      // PING as a barrier: its ACK arrives after anything else the connect flush wrote.
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect({
+        headersStreamIds: raw.frames.filter(f => f.type === FrameType.HEADERS).map(f => f.streamId),
+        coercions,
+      }).toEqual({ headersStreamIds: [1], coercions: 0 });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
   // End to end against a real peer: with the blocks encoded in wire order, both requests are
   // answered and each one carries its own headers.
   test("both the nested and the outer request are answered by an http2 server", async () => {


### PR DESCRIPTION
## Repro

A header value whose `toString()` makes another request on the same session. The raw server below only records the stream id of each HEADERS frame it receives, in wire order:

```js
const http2 = require("node:http2"), net = require("node:net");
function frame(t, fl, sid, p = Buffer.alloc(0)) { const h = Buffer.alloc(9); h.writeUIntBE(p.length, 0, 3); h.writeUInt8(t, 3); h.writeUInt8(fl, 4); h.writeUInt32BE(sid, 5); return Buffer.concat([h, p]); }
const server = net.createServer(sock => {
  let buf = Buffer.alloc(0), preface = false; const ids = [];
  sock.on("data", d => {
    buf = Buffer.concat([buf, d]);
    if (!preface) { if (buf.length < 24) return; buf = buf.subarray(24); preface = true; sock.write(frame(4, 0, 0)); }
    while (buf.length >= 9) {
      const len = buf.readUIntBE(0, 3); if (buf.length < 9 + len) break;
      const type = buf.readUInt8(3), sid = buf.readUInt32BE(5) & 0x7fffffff; buf = buf.subarray(9 + len);
      if (type === 1) ids.push(sid);
      if (ids.length === 2) { console.log(JSON.stringify(ids)); process.exit(0); }
    }
  });
});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("connect", () => {
    let once = false;
    const value = { toString() { if (!once) { once = true; client.request({ ":path": "/inner" }).end(); } return "outer"; } };
    client.request({ ":path": "/outer", "x-probe": value }).end();
  });
});
```

| | node v26.3.0 | bun 1.4.0 / main |
| --- | --- | --- |
| HEADERS stream ids in wire order | `[1,3]` | `[3,1]` |
| same shape with `pushStream()`, PUSH_PROMISE promised ids | `[2,4]` | `[4,2]` |
| same shape against an `http2.createServer()` | both requests get a 200 | session dies: `Session closed with error code 9` (COMPRESSION_ERROR) |
| `request()` / `pushStream()` whose value `toString()` throws | throws synchronously | returned; the stream errors later and the session then dies with COMPRESSION_ERROR / error goes to the push callback |

RFC 9113 §5.1.1 requires every stream an endpoint opens or reserves to have a higher id than the ones before it, so nghttp2 (node's server, curl, ...) ignores the HEADERS on stream 1 and the outer request never gets a response. #37563 makes bun's server do the same for inbound HEADERS, after which this hangs against bun servers too.

## Cause

`ClientHttp2Session.request()` calls `parser.getNextStream()` and then passes the header object to the native `request()`, which coerces each value to a string while it encodes the block (`to_js_string` in `h2_frame_parser.rs`). Any user code that runs there, such as a `toString()`, runs after the outer request has taken its id but before its frame is written. A nested `request()` takes the next id and writes its HEADERS first. `ServerHttp2Stream.pushStream()` has the identical structure (`getNextStream()` for the promised id, then the native `pushPromise()` coerces).

The nested block is also encoded in the middle of the outer block's encoding, so the shared HPACK encoder table is updated in an order that differs from the order the blocks reach the peer; in the repro the nested block references the `:authority` entry the outer block inserted but has not sent yet, which is the COMPRESSION_ERROR in the table above. A throwing `toString()` leaves the same half-encoded state behind.

Node cannot hit any of this because `buildNgHeaderString` stringifies every value in JS inside `request()` / `pushStream()` itself, and nghttp2 only assigns the id when it serializes the frame. #31323 already moved `request()`'s *options* reads ahead of the encode for the same reason (a getter re-entering `request()` reordered the blocks); header values were one of the two remaining places user code could run between the id and the frame. The other is `diagnostics_channel`: `request()` published `http2.client.stream.created` and `pushStream()` published `http2.server.stream.created` / `.start` after taking the id but before the native call, so a subscriber making another request / push from its handler produced the same `[3,1]` / `[4,2]` wire order (only the id half; each block is encoded whole there, so HPACK stays consistent). Node publishes these after the frame is queued.

## Fix

`src/js/node/http2.ts`: `toWireHeaders()` builds the block handed to native with every object value (the only kind whose coercion runs user code) turned into a string up front, for the object form, array values (copied element-wise, in both forms, so they still reach the encoder as arrays; this is what lets #37796, which teaches the raw-form encoder about arrays, compose with this change in either merge order), and the raw `[name, value, ...]` form. `request()` calls it before the pending-queue check and `getNextStream()`, and the pending queue stores the coerced form, so a request made while still connecting is coerced when it is made too (node does the same). `pushStream()` calls it before reserving the promised id. A request that gets queued (made before connect, or behind `SETTINGS_MAX_CONCURRENT_STREAMS`) queues a copy of the block when nothing in it needed coercing, because in that case the block would otherwise be the very object the returned stream exposes as `sentHeaders` until the queue drains, and a value put there in the meantime would have been coerced by the encoder at flush time, after the id was taken. Node sends the list it built inside `request()` in that situation as well, so a later edit of `sentHeaders` has no effect on the wire in either runtime now.

The channel publishes move to after the frame is written: `http2.client.stream.created` is published at the end of `request()` on both branches (node's position as well: a connected `request()` now publishes `start` then `created` like node, and a request made by a subscriber while the session is still connecting is queued behind the one being published instead of ahead of it), and the server push `created` / `start` pair is published once `pushPromise()` has returned, still in that order (the ported `test-diagnostics-channel-http2-server-stream-created-start-timing.js` checks it). A push whose header block fails native validation still publishes `created` before its silent teardown, since that is the only handle user code can get on that stream (the existing `pushStream failure reports only via callback` test relies on it), but no longer publishes `start` for a stream that was never announced; node publishes neither.

Details that keep the rest of the behavior unchanged:

- Primitives are passed through untouched, so the native validator still produces the same errors for `undefined` / `null` / symbol values, and numbers still stringify natively.
- Arrays are always copied, so the native walk only ever reads a fresh array of primitives (nothing left for an accessor or a proxy to run from).
- The caller's object is never mutated: it still backs `sentHeaders` (node keeps the uncoerced values there as well; the test checks identity) and the diagnostics channel payloads.
- When nothing needs coercing (all values primitive, no arrays), the same object is passed through as before, so the common path adds one `Object.keys` walk over the block and does not copy it. Otherwise the block is copied before any coercion runs and the copy is what gets coerced, so the encoder never sees anything a coercion did to the object it was read from.
- A `toString()` that destroys the session instead of making a request now leaves `request()` returning a pending stream, which is what node returns there too (before, the stream had already taken an id); `pushStream()` behaves as before in that case.

A throwing coercion now propagates out of `request()` / `pushStream()` synchronously, which is what node does (verified against v26.3.0 for both); before, a pending `request()` reported it as a later stream `'error'` and `pushStream()` routed it to the callback, and in both cases the session was left with a desynced HPACK table. The existing `request() propagates a throwing header-value toString()` test in node-http2.test.js still passes.

The encode side of the same problem for `respond()` / `additionalHeaders()` / `sendTrailers()` (which have a fixed stream id, so only the HPACK half applies) is what #33470 addresses natively by collecting the block before encoding; this PR is the id-allocation half that a native change cannot cover, since the id is taken in JS before native is entered.

The other way to close this would be to stop taking the id in JS at all and have the native call allocate it as it writes the frame, the way nghttp2 does. That means creating the stream object without an id and attaching it afterwards (the push path creates the pushed stream from inside the id allocation today), and it would land in the middle of the native `request()` that #33470 is restructuring, for no gain over this once the only things left between `getNextStream()` and the write are the stream construction and bookkeeping in this module: header coercion, the channel publishes and the queued block were the inputs user code could reach, and all three are handled here.

## Verification

Twelve tests in `test/js/node/http2/h2-conformance.test.ts` (`request()/pushStream() run no user code between taking a stream id and writing its frame`): HEADERS wire order plus the ids each stream ends up with for the object, array-element, raw-array and raw-array-with-an-array-slot forms, the same for a `request()` made before the session connected, the same for a request made from a `http2.client.stream.created` subscriber on a connected and on a still-connecting session (it must come second both times: `[1,3]` with the outer request on 1) and for a push made from a `http2.server.stream.created` subscriber (`[2,4]` with the outer push on 2), a request queued before connect whose `sentHeaders` is given a re-entering value before the flush (it must never be coerced, and exactly one HEADERS frame goes out), an end-to-end run against an `http2.createServer()` checking that both requests are answered with their own headers (and that `sentHeaders` keeps the original value), PUSH_PROMISE promised-id order observed by a raw client, and the synchronous throw plus the session staying usable afterwards. The expected values were checked against node v26.3.0 with the same scenarios.

I also ran a script sending about 45 value shapes through `request()` (numbers, bigint, Date, Buffer and Uint8Array values and elements, boxed strings, `Symbol.toPrimitive` / `valueOf`-only objects, functions, nested / holey / empty arrays, Array subclasses, proxies, `undefined` / `null` / symbol values and elements, and the raw array form with numeric, object, `null` and symbol slots) against an `http2.createServer()` and compared what the server received or what was thrown on the unfixed and fixed builds. The only difference is a Proxy wrapping an array, which used to be sent as one joined field and is now sent as one field per element, which is what node does (`Array.isArray` sees through proxies).

All twelve fail on the unfixed build (`[3,1]` / `[4,2]` / `Session closed with error code 9` / `returned`) and pass with the fix. `bun bd test test/js/node/http2/` (476 tests), the 256 upstream `test-http2-*.js` files and the 18 `test-diagnostics-channel-http2-*.js` files all pass with the fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (f7554f227)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [385.60ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [108.46ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [84.93ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [42.89ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [38.18ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [38.84ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [40.23ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [6.98ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [1.77ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.58ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.85ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.76ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.69ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.76ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.66ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.63ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (f7554f227)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [388.97ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [102.44ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [77.83ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [42.27ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [36.09ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [32.43ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [40.08ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f7554f227c
  features     baseline

22 deps, 107 codegen, 1176 objects in 1050ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [15.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1238] gen bindgenv2
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [14.00ms]
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  87 +++++++--
 test/js/node/http2/h2-conformance.test.ts | 312 ++++++++++++++++++++++++++++++
 2 files changed, 382 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                          28     36      0
test/js/node/http2/h2-conformance.test.ts     11     11      0
```

</details>

<!-- robobun:evidence:end -->
