### PR TITLE
sys/exe_format: LoadCommand borrows its bytes; patch commands by offset

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2483,20 +2483,19 @@ mod draft {
 
                     // SAFETY: header points to a valid mach_header_64
                     let header_ref = unsafe { &*header };
-                    // SAFETY: load commands follow the mach header in memory; the
-                    // dyld-mapped image stays live for the process lifetime, so the
-                    // iterator's no-realloc/no-free contract is trivially upheld.
-                    let mut it =
-                        bun_sys::macho::LoadCommandIterator::new(header_ref.ncmds, unsafe {
-                            core::slice::from_raw_parts(
-                                header
-                                    .cast::<u8>()
-                                    .add(core::mem::size_of::<bun_sys::macho::mach_header_64>()),
-                                header_ref.sizeofcmds as usize,
-                            )
-                        });
+                    // SAFETY: `sizeofcmds` bytes of load commands follow the mach header in
+                    // the dyld-mapped image, which stays mapped for the process lifetime.
+                    let cmds: &[u8] = unsafe {
+                        core::slice::from_raw_parts(
+                            header
+                                .cast::<u8>()
+                                .add(core::mem::size_of::<bun_sys::macho::mach_header_64>()),
+                            header_ref.sizeofcmds as usize,
+                        )
+                    };
+                    let mut it = bun_sys::macho::LoadCommandIterator::new(header_ref.ncmds);
 
-                    while let Some(cmd) = it.next() {
+                    while let Some(cmd) = it.next(cmds) {
                         match cmd.cmd() {
                             bun_sys::macho::LC_SEGMENT_64 => {
                                 let segment_cmd =

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -91,9 +91,9 @@ impl MachoFile {
         let mut found_bun = false;
 
         let lc_base = size_of::<macho::mach_header_64>();
-        let mut iter = self.iterator();
+        let mut iter = macho::LoadCommandIterator::new(self.header.ncmds);
 
-        while let Some(entry) = iter.next() {
+        while let Some(entry) = iter.next(self.load_commands()) {
             let cmd = entry.hdr;
             match cmd.cmd {
                 macho::LC::SEGMENT_64 => {
@@ -350,7 +350,8 @@ impl MachoFile {
         let aligned_previous = align_size(previous_fileoff, PAGE_SIZE);
         let aligned_linkedit = align_size(new_linkedit_fileoff, PAGE_SIZE);
 
-        let mut iter = self.iterator();
+        let lc_base = size_of::<macho::mach_header_64>();
+        let mut iter = macho::LoadCommandIterator::new(self.header.ncmds);
 
         // Create shifter with validated parameters
         let shifter = Shifter {
@@ -360,40 +361,21 @@ impl MachoFile {
             linkedit_filesize: new_linkedit_filesize,
         };
 
-        while let Some(entry) = iter.next() {
+        while let Some(entry) = iter.next(self.load_commands()) {
             let cmd = entry.hdr;
-            let cmd_ptr: *mut u8 = entry.data.as_ptr().cast_mut();
-
-            // `cmdsize` (= `entry.data.len()`) is untrusted; reject commands too
-            // small for the typed struct we're about to read/write so the
-            // unaligned access stays within this command's bytes.
-            let require = |sz: usize| -> Result<(), MachoError> {
-                if entry.data.len() < sz {
-                    return Err(MachoError::InvalidObject);
-                }
-                Ok(())
-            };
+            let cmd_off = lc_base + entry.offset;
+            let cmd_len = entry.data.len();
+            let bytes = &mut self.data[cmd_off..][..cmd_len];
 
             match cmd.cmd {
                 macho::LC::SYMTAB => {
-                    require(size_of::<macho::symtab_command>())?;
-                    // SAFETY: cmd_ptr points into self.data's load-command region with at least
-                    // size_of::<symtab_command>() bytes (checked above); symtab_command is
-                    // #[repr(C)] POD. read/write_unaligned tolerate the Vec<u8>'s arbitrary
-                    // alignment.
-                    unsafe {
-                        let mut symtab: macho::symtab_command =
-                            core::ptr::read_unaligned(cmd_ptr.cast::<macho::symtab_command>());
+                    patch(bytes, |symtab: &mut macho::symtab_command| {
                         shift_fields!(shifter, symtab, symoff, stroff);
-                        core::ptr::write_unaligned(cmd_ptr.cast::<macho::symtab_command>(), symtab);
-                    }
+                        Ok(())
+                    })?;
                 }
                 macho::LC::DYSYMTAB => {
-                    require(size_of::<macho::dysymtab_command>())?;
-                    // SAFETY: as above; dysymtab_command is #[repr(C)] POD.
-                    unsafe {
-                        let mut dysymtab: macho::dysymtab_command =
-                            core::ptr::read_unaligned(cmd_ptr.cast::<macho::dysymtab_command>());
+                    patch(bytes, |dysymtab: &mut macho::dysymtab_command| {
                         shift_fields!(
                             shifter,
                             dysymtab,
@@ -404,11 +386,8 @@ impl MachoFile {
                             extreloff,
                             locreloff
                         );
-                        core::ptr::write_unaligned(
-                            cmd_ptr.cast::<macho::dysymtab_command>(),
-                            dysymtab,
-                        );
-                    }
+                        Ok(())
+                    })?;
                 }
                 macho::LC::DYLD_CHAINED_FIXUPS
                 | macho::LC::CODE_SIGNATURE
@@ -417,13 +396,7 @@ impl MachoFile {
                 | macho::LC::DYLIB_CODE_SIGN_DRS
                 | macho::LC::LINKER_OPTIMIZATION_HINT
                 | macho::LC::DYLD_EXPORTS_TRIE => {
-                    require(size_of::<macho::linkedit_data_command>())?;
-                    // SAFETY: as above; linkedit_data_command is #[repr(C)] POD.
-                    unsafe {
-                        let mut linkedit_cmd: macho::linkedit_data_command =
-                            core::ptr::read_unaligned(
-                                cmd_ptr.cast::<macho::linkedit_data_command>(),
-                            );
+                    patch(bytes, |linkedit_cmd: &mut macho::linkedit_data_command| {
                         shift_fields!(shifter, linkedit_cmd, dataoff);
 
                         // Special handling for code signature
@@ -431,18 +404,11 @@ impl MachoFile {
                             // Update the size of the code signature to the newer signature size
                             linkedit_cmd.datasize = u32::try_from(sig_size).expect("int cast");
                         }
-                        core::ptr::write_unaligned(
-                            cmd_ptr.cast::<macho::linkedit_data_command>(),
-                            linkedit_cmd,
-                        );
-                    }
+                        Ok(())
+                    })?;
                 }
                 macho::LC::DYLD_INFO | macho::LC::DYLD_INFO_ONLY => {
-                    require(size_of::<macho::dyld_info_command>())?;
-                    // SAFETY: as above; dyld_info_command is #[repr(C)] POD.
-                    unsafe {
-                        let mut dyld_info: macho::dyld_info_command =
-                            core::ptr::read_unaligned(cmd_ptr.cast::<macho::dyld_info_command>());
+                    patch(bytes, |dyld_info: &mut macho::dyld_info_command| {
                         shift_fields!(
                             shifter,
                             dyld_info,
@@ -452,11 +418,8 @@ impl MachoFile {
                             lazy_bind_off,
                             export_off
                         );
-                        core::ptr::write_unaligned(
-                            cmd_ptr.cast::<macho::dyld_info_command>(),
-                            dyld_info,
-                        );
-                    }
+                        Ok(())
+                    })?;
                 }
                 _ => {}
             }
@@ -464,11 +427,9 @@ impl MachoFile {
         Ok(())
     }
 
-    pub(crate) fn iterator(&self) -> macho::LoadCommandIterator {
-        macho::LoadCommandIterator::new(
-            self.header.ncmds,
-            &self.data[size_of::<macho::mach_header_64>()..][..self.header.sizeofcmds as usize],
-        )
+    /// The `sizeofcmds` bytes of load commands following the header.
+    fn load_commands(&self) -> &[u8] {
+        &self.data[size_of::<macho::mach_header_64>()..][..self.header.sizeofcmds as usize]
     }
 
     pub(crate) fn build(&self, writer: &mut impl std::io::Write) -> crate::Result<()> {
@@ -477,10 +438,10 @@ impl MachoFile {
     }
 
     fn validate_segments(&self) -> Result<(), MachoError> {
-        let mut iter = self.iterator();
+        let mut iter = macho::LoadCommandIterator::new(self.header.ncmds);
         let mut prev_end: u64 = 0;
 
-        while let Some(entry) = iter.next() {
+        while let Some(entry) = iter.next(self.load_commands()) {
             let cmd = entry.hdr;
             if cmd.cmd == macho::LC::SEGMENT_64 {
                 let seg = entry
@@ -550,6 +511,20 @@ impl Shifter {
     }
 }
 
+/// Read-modify-write of the `T` heading a load command; a command shorter than `T` is rejected.
+fn patch<T: Copy>(
+    bytes: &mut [u8],
+    f: impl FnOnce(&mut T) -> Result<(), MachoError>,
+) -> Result<(), MachoError> {
+    let bytes = bytes
+        .get_mut(..size_of::<T>())
+        .ok_or(MachoError::InvalidObject)?;
+    let mut value: T = read_struct(bytes);
+    f(&mut value)?;
+    write_struct(bytes, &value);
+    Ok(())
+}
+
 struct MachoSigner {
     data: Vec<u8>,
     sig_off: usize,
@@ -573,13 +548,11 @@ impl MachoSigner {
         let mut linkedit_seg: macho::segment_command_64 =
             unsafe { bun_core::ffi::zeroed_unchecked() };
 
-        let mut it = macho::LoadCommandIterator::new(
-            header.ncmds,
-            &obj[header_size..][..header.sizeofcmds as usize],
-        );
+        let cmds = &obj[header_size..][..header.sizeofcmds as usize];
+        let mut it = macho::LoadCommandIterator::new(header.ncmds);
 
         // First pass: find segments to establish bounds
-        while let Some(cmd) = it.next() {
+        while let Some(cmd) = it.next(cmds) {
             if cmd.cmd() == macho::LC::SEGMENT_64 {
                 let seg = cmd
                     .cast::<macho::segment_command_64>()
@@ -601,13 +574,10 @@ impl MachoSigner {
         }
 
         // Reset iterator
-        it = macho::LoadCommandIterator::new(
-            header.ncmds,
-            &obj[header_size..][..header.sizeofcmds as usize],
-        );
+        it = macho::LoadCommandIterator::new(header.ncmds);
 
         // Second pass: find code signature
-        while let Some(cmd) = it.next() {
+        while let Some(cmd) = it.next(cmds) {
             match cmd.cmd() {
                 macho::LC::CODE_SIGNATURE => {
                     let cs = cmd

--- a/src/exe_format/macho_types.rs
+++ b/src/exe_format/macho_types.rs
@@ -1,13 +1,6 @@
 //! Mach-O type definitions needed by `macho.rs`. All structs are `#[repr(C)]`
 //! POD matching the on-disk Mach-O format so they can be read/written via
 //! unaligned `ptr::{read,write}_unaligned`.
-//!
-//! `LoadCommandIterator` deliberately stores a raw `*const u8` rather than a
-//! borrowed `&'a [u8]`: macho.rs interleaves iterator reads with in-place
-//! mutation of the same backing `Vec<u8>`. Holding a Rust borrow across that
-//! mutation would force a structural rewrite; raw pointers avoid that.
-//! SAFETY contract: callers must not reallocate or shrink the backing buffer
-//! while a `LoadCommandIterator` derived from it is live.
 
 #![allow(non_camel_case_types, non_snake_case)]
 
@@ -15,7 +8,8 @@
 // crate, also consumed by `crash_handler`). Re-export so `exe_format::macho`
 // keeps its existing `macho::segment_command_64` etc. paths.
 pub use bun_sys::macho::{
-    cpu_subtype_t, cpu_type_t, load_command, mach_header_64, segment_command_64, vm_prot_t,
+    LoadCommandIterator, cpu_subtype_t, cpu_type_t, load_command, mach_header_64,
+    segment_command_64, vm_prot_t,
 };
 
 pub(crate) const CPU_TYPE_ARM64: cpu_type_t = 0x0100_000C;
@@ -82,6 +76,10 @@ pub(crate) struct linkedit_data_command {
     pub dataoff: u32,
     pub datasize: u32,
 }
+// SAFETY: `#[repr(C)]` 4×u32: no padding, every bit pattern is valid.
+unsafe impl bytemuck::Zeroable for linkedit_data_command {}
+// SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
+unsafe impl bytemuck::Pod for linkedit_data_command {}
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -189,11 +187,6 @@ unsafe impl bytemuck::NoUninit for CodeDirectory {}
 unsafe impl bytemuck::NoUninit for BlobIndex {}
 // SAFETY: `#[repr(C)]` 3×u32 → size 12, align 4, no padding. `Copy + 'static`.
 unsafe impl bytemuck::NoUninit for SuperBlob {}
-
-// ── load-command iterator ─────────────────────────────────────────────────
-// Canonical impl lives in `bun_sys::macho` (raw-ptr storage; see module-level
-// SAFETY note above for why a borrowed `&[u8]` does not work for `macho.rs`).
-pub use bun_sys::macho::{LoadCommand, LoadCommandIterator, RawSlice};
 
 #[inline]
 fn parse_name(name: &[u8; 16]) -> &[u8] {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6075,7 +6075,17 @@ pub mod macho {
             if self.index >= self.ncmds {
                 return None;
             }
-            let rest = cmds.get(self.offset..)?;
+            let Some(lc) = Self::parse_at(cmds, self.offset) else {
+                self.index = self.ncmds;
+                return None;
+            };
+            self.offset += lc.data.len();
+            self.index += 1;
+            Some(lc)
+        }
+
+        fn parse_at(cmds: &[u8], offset: usize) -> Option<LoadCommand<'_>> {
+            let rest = cmds.get(offset..)?;
             let hdr: load_command = rest
                 .get(..size_of::<load_command>())
                 .map(bytemuck::pod_read_unaligned)?;
@@ -6083,14 +6093,11 @@ pub mod macho {
             if cmdsize < size_of::<load_command>() {
                 return None;
             }
-            let lc = LoadCommand {
+            Some(LoadCommand {
                 hdr,
                 data: rest.get(..cmdsize)?,
-                offset: self.offset,
-            };
-            self.offset += cmdsize;
-            self.index += 1;
-            Some(lc)
+                offset,
+            })
         }
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5965,6 +5965,8 @@ pub mod darwin {}
 // Mach-O `--compile` target from a Linux/Windows build machine.
 #[allow(non_camel_case_types, non_snake_case)]
 pub mod macho {
+    use core::mem::size_of;
+
     pub type cpu_type_t = i32;
     pub type cpu_subtype_t = i32;
     pub type vm_prot_t = i32;
@@ -5995,6 +5997,10 @@ pub mod macho {
         pub cmd: u32,
         pub(crate) cmdsize: u32,
     }
+    // SAFETY: `#[repr(C)]` 2×u32: no padding, every bit pattern is valid.
+    unsafe impl bytemuck::Zeroable for load_command {}
+    // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
+    unsafe impl bytemuck::Pod for load_command {}
 
     /// `<mach-o/loader.h> segment_command_64`.
     #[repr(C)]
@@ -6012,6 +6018,11 @@ pub mod macho {
         pub nsects: u32,
         pub flags: u32,
     }
+    // SAFETY: `#[repr(C)]` 2×u32, [u8; 16], 4×u64, 2×i32, 2×u32: 72 bytes with no padding,
+    // every bit pattern is a valid value.
+    unsafe impl bytemuck::Zeroable for segment_command_64 {}
+    // SAFETY: see `Zeroable` impl above; additionally `Copy + 'static`.
+    unsafe impl bytemuck::Pod for segment_command_64 {}
     impl segment_command_64 {
         /// Segment name with trailing NULs trimmed.
         #[inline]
@@ -6020,112 +6031,63 @@ pub mod macho {
         }
     }
 
-    /// Raw `(*const u8, len)` pair so [`LoadCommandIterator`] does not hold a
-    /// Rust borrow of its backing buffer. `bun_exe_format::macho` interleaves
-    /// iterator reads with in-place mutation of the same `Vec<u8>`;
-    /// a `&'a [u8]` here would
-    /// force a structural rewrite of that consumer.
-    #[derive(Clone, Copy)]
-    pub struct RawSlice {
-        ptr: *const u8,
-        len: usize,
-    }
-    impl RawSlice {
-        #[inline]
-        pub fn as_ptr(&self) -> *const u8 {
-            self.ptr
-        }
-        #[inline]
-        pub fn len(&self) -> usize {
-            self.len
-        }
-    }
-
     /// One parsed load command: header + raw bytes (header included).
     #[derive(Clone, Copy)]
-    pub struct LoadCommand {
+    pub struct LoadCommand<'a> {
         pub hdr: load_command,
-        pub data: RawSlice,
-        /// Byte offset of this command within the buffer passed to
-        /// `LoadCommandIterator::new`.
+        pub data: &'a [u8],
+        /// Byte offset of this command within the region passed to `LoadCommandIterator::next`.
         pub offset: usize,
     }
-    impl LoadCommand {
+    impl LoadCommand<'_> {
         #[inline]
         pub fn cmd(&self) -> u32 {
             self.hdr.cmd
         }
-        /// Reinterpret the command bytes
-        /// as `T` if large enough. Returns an owned `Copy` value (via
-        /// `read_unaligned`) rather than `&T`: the backing buffer may be a
-        /// heap `Vec<u8>` with arbitrary alignment, so materialising a typed
-        /// reference would be UB.
-        pub fn cast<T: Copy>(&self) -> Option<T> {
-            if self.data.len < core::mem::size_of::<T>() {
-                return None;
-            }
-            // SAFETY: `data.ptr` points into a live Mach-O image buffer with
-            // at least `size_of::<T>()` bytes (checked above); `T` is
-            // `#[repr(C)]` POD per all callers. `read_unaligned` tolerates any
-            // alignment.
-            Some(unsafe { core::ptr::read_unaligned(self.data.ptr.cast::<T>()) })
+        /// The command as a `T` if `cmdsize` covers one; by value, as the buffer is byte-aligned.
+        pub fn cast<T: bytemuck::AnyBitPattern>(&self) -> Option<T> {
+            self.data
+                .get(..size_of::<T>())
+                .map(bytemuck::pod_read_unaligned)
         }
     }
 
-    /// Walks the load-command region
-    /// that immediately follows a `mach_header_64`.
-    ///
-    /// SAFETY contract: callers must not reallocate, shrink, or free the
-    /// backing buffer while a `LoadCommandIterator` derived from it (or any
-    /// `LoadCommand` it yielded) is live.
+    /// Cursor over the load commands following a `mach_header_64`. It holds no borrow of the
+    /// region: that is passed to each [`Self::next`] call, so callers may patch it in between.
     pub struct LoadCommandIterator {
         ncmds: u32,
         index: u32,
-        buf_ptr: *const u8,
-        buf_len: usize,
         offset: usize,
     }
     impl LoadCommandIterator {
-        /// `buffer` must remain live (no realloc/free) for the lifetime of the
-        /// returned iterator and any `LoadCommand` it yields.
         #[inline]
-        pub fn new(ncmds: u32, buffer: &[u8]) -> Self {
+        pub fn new(ncmds: u32) -> Self {
             Self {
                 ncmds,
                 index: 0,
-                buf_ptr: buffer.as_ptr(),
-                buf_len: buffer.len(),
                 offset: 0,
             }
         }
 
-        pub fn next(&mut self) -> Option<LoadCommand> {
-            if self.index >= self.ncmds || self.buf_len < core::mem::size_of::<load_command>() {
-                self.index = self.ncmds;
+        /// `cmds` must be the same `sizeofcmds`-byte region on every call.
+        /// Stops (and stays stopped) at the first malformed header.
+        pub fn next<'a>(&mut self, cmds: &'a [u8]) -> Option<LoadCommand<'a>> {
+            if self.index >= self.ncmds {
                 return None;
             }
-            // SAFETY: `buf_ptr` was derived from a slice of `buf_len` bytes
-            // which the caller promised stays live, and at least
-            // `size_of::<load_command>()` bytes remain (checked above).
-            let hdr: load_command =
-                unsafe { core::ptr::read_unaligned(self.buf_ptr.cast::<load_command>()) };
+            let rest = cmds.get(self.offset..)?;
+            let hdr: load_command = rest
+                .get(..size_of::<load_command>())
+                .map(bytemuck::pod_read_unaligned)?;
             let cmdsize = hdr.cmdsize as usize;
-            if cmdsize < core::mem::size_of::<load_command>() || cmdsize > self.buf_len {
-                // Malformed header — stop iteration rather than UB.
-                self.index = self.ncmds;
+            if cmdsize < size_of::<load_command>() {
                 return None;
             }
             let lc = LoadCommand {
                 hdr,
-                data: RawSlice {
-                    ptr: self.buf_ptr,
-                    len: cmdsize,
-                },
+                data: rest.get(..cmdsize)?,
                 offset: self.offset,
             };
-            // SAFETY: advancing within the original buffer; bounds checked above.
-            self.buf_ptr = unsafe { self.buf_ptr.add(cmdsize) };
-            self.buf_len -= cmdsize;
             self.offset += cmdsize;
             self.index += 1;
             Some(lc)


### PR DESCRIPTION
## What

`bun_sys::macho::LoadCommand` stored the bytes of a load command as `RawSlice { ptr: *const u8, len }`, and `LoadCommandIterator::new(ncmds, buffer: &[u8])` copied the slice into a `*const u8` plus length, so "the buffer must stay live while the iterator or any command is in use" was a doc-comment contract, and the safe `cast<T: Copy>()` was a `read_unaligned` of whatever `T` the caller named. Its one writing consumer, `MachoFile::update_load_command_offsets` in `src/exe_format/macho.rs`, took `entry.data.as_ptr().cast_mut()` on a pointer obtained through a shared borrow of `self.data` and wrote through it in four arms, each with its own `read_unaligned`/`write_unaligned` block.

The command now borrows its bytes and the cursor borrows nothing: the region is passed to each `next` call, so a yielded command only borrows the file for as long as the caller uses it.

```rust
// before
pub struct LoadCommand { pub hdr: load_command, pub data: RawSlice, pub offset: usize }
impl LoadCommand { pub fn cast<T: Copy>(&self) -> Option<T> }            // unsafe read_unaligned
pub struct LoadCommandIterator { ncmds, index, buf_ptr: *const u8, buf_len, offset }
impl LoadCommandIterator { pub fn new(ncmds: u32, buffer: &[u8]) -> Self; pub fn next(&mut self) -> Option<LoadCommand> }

// after
pub struct LoadCommand<'a> { pub hdr: load_command, pub data: &'a [u8], pub offset: usize }
impl LoadCommand<'_> { pub fn cast<T: bytemuck::AnyBitPattern>(&self) -> Option<T> }   // pod_read_unaligned
pub struct LoadCommandIterator { ncmds, index, offset }
impl LoadCommandIterator { pub fn new(ncmds: u32) -> Self; pub fn next<'a>(&mut self, cmds: &'a [u8]) -> Option<LoadCommand<'a>> }
```

`load_command` and `segment_command_64` (in `bun_sys`) and `linkedit_data_command` (in `macho_types.rs`) get `bytemuck::Zeroable + Pod` impls; they are the three types `cast` is instantiated with, all `#[repr(C)]` integer structs without padding. `RawSlice` and the `macho_types.rs` re-export of it are deleted along with the module comment that explained the raw-pointer design.

Call sites: `MachoFile::iterator()` becomes `load_commands()` (the `sizeofcmds` slice after the header), and the three loops in `write_section`, `update_load_command_offsets` and `validate_segments` plus the two passes in `MachoSigner::init` call `iter.next(region)`; the crash handler (`src/crash_handler/lib.rs`, macOS only) keeps its one `from_raw_parts` over the dyld image and passes the resulting slice to `next`. In `update_load_command_offsets` each iteration copies `hdr`, `offset` and `data.len()` out of the yielded command, takes `&mut self.data[lc_base + offset..][..len]`, and the four arms go through one `patch::<T>(bytes, |cmd| ..)` helper built on the crate's existing `read_struct`/`write_struct`, which also replaces the per-arm `require(size)` closure (a command shorter than `T` is still `MachoError::InvalidObject`, and a failed shift still leaves the command unwritten). Seven `unsafe` blocks are removed (three in `bun_sys`, four in `macho.rs`); the six added lines are the `unsafe impl` markers.

## Why

The lifetime of the bytes a `LoadCommand` points at is now checked by the compiler instead of stated in comments, and the write in `update_load_command_offsets` goes through a real `&mut` into the `Vec` rather than through a pointer derived from a shared borrow. `cast` can no longer be instantiated with a type for which arbitrary bytes are not a valid value. `&[u8]` is the same pointer and length pair `RawSlice` held, the cursor shrinks from 32 to 16 bytes, `pod_read_unaligned` on an exactly sized subslice is the same unaligned copy as before, and the per-command work is the same header checks plus the slice bounds checks the surrounding `read_struct`/`write_struct` call sites already use, on a loop that runs once per load command while writing a compiled single-file executable or formatting a crash report.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/bundler/bundler_compile.test.ts (60 pass, 1 fail), test/regression/issue/29120.test.ts (2 skipped, darwin-only), test/cli/run/run-crash-handler.test.ts (14 pass, 9 skipped platform-gated): 74 pass, 11 skip, 1 fail total.

The single failure, compile/HelloWorldWithProcessVersionsBun, fails identically on main (debug build reports process.versions.bun as "1.4.0-debug" while the test compares against the version with "-debug" stripped); pre-existing and unrelated to the Mach-O load-command changes.
