### PR TITLE
tls: read the pfx option through ArrayBuffer::byte_slice()

### DIFF
--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -113,14 +113,17 @@ impl SecureContext {
         // The pfx arrives as a Buffer/TypedArray (binary DER) or a string;
         // a string-conversion would mangle the DER bytes, so read the raw
         // view when one exists.
+        let pfx_view;
         let pfx_string;
-        let pfx_bytes: &[u8] = if let Some(ab) = args[0].as_array_buffer(global) {
-            // SAFETY: the ArrayBuffer view is alive for the duration of the
-            // call (the argument is rooted by the call frame).
-            unsafe { core::slice::from_raw_parts(ab.ptr, ab.len) }
-        } else {
-            pfx_string = args[0].to_slice(global)?;
-            pfx_string.slice()
+        let pfx_bytes: &[u8] = match args[0].as_array_buffer(global) {
+            Some(view) => {
+                pfx_view = view;
+                pfx_view.byte_slice()
+            }
+            None => {
+                pfx_string = args[0].to_slice(global)?;
+                pfx_string.slice()
+            }
         };
         if pfx_bytes.is_empty() {
             return Err(global.throw(format_args!("PFX certificate argument is mandatory")));

--- a/test/js/node/tls/node-tls-create-secure-context-args.test.ts
+++ b/test/js/node/tls/node-tls-create-secure-context-args.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import * as tls from "node:tls";
 
 describe("tls.createSecureContext extra arguments test", () => {
@@ -66,5 +69,59 @@ describe("tls.createSecureContext extra arguments test", () => {
     expect(() => tls.createSecureContext({ privateKeyIdentifier: {} })).toThrow(
       "The property 'options.privateKeyEngine' is invalid. Received undefined",
     );
+  });
+});
+
+describe("tls.createSecureContext pfx argument", () => {
+  it("throws instead of crashing when the pfx buffer is detached", async () => {
+    // A detached view reaches the native PKCS#12 parser as a null pointer. Run
+    // in a child so a regression aborts that process, not the test runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import tls from "node:tls";
+          const report = (label, fn) => {
+            try {
+              fn();
+              console.log(label + ": no error");
+            } catch (e) {
+              console.log(label + ": " + e.message);
+            }
+          };
+          const view = new Uint8Array(64);
+          structuredClone(view.buffer, { transfer: [view.buffer] });
+          report("detached view", () => tls.createSecureContext({ pfx: view }));
+          const arrayBuffer = new ArrayBuffer(64);
+          structuredClone(arrayBuffer, { transfer: [arrayBuffer] });
+          report("detached ArrayBuffer", () => tls.createSecureContext({ pfx: arrayBuffer }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      [
+        "detached view: PFX certificate argument is mandatory",
+        "detached ArrayBuffer: PFX certificate argument is mandatory",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("reads the whole byte range of a non-Uint8Array view", () => {
+    // agent10.pfx is 4736 bytes, so it can be viewed exactly as 8-byte elements.
+    const pfx = readFileSync(join(import.meta.dir, "../test/fixtures/keys/agent10.pfx"));
+    const bytes = new Uint8Array(pfx).buffer;
+    expect(bytes.byteLength % 8).toBe(0);
+    for (const view of [new Uint16Array(bytes), new Float64Array(bytes)]) {
+      // @ts-expect-error the types only admit Buffer, the runtime accepts any view
+      expect(() => tls.createSecureContext({ pfx: view, passphrase: "sample" })).not.toThrow();
+    }
   });
 });


### PR DESCRIPTION
### What does this PR do?

`tls.createSecureContext({ pfx })` hands the pfx bytes to the native PKCS#12 parser (`SecureContext::parse_pkcs12`), which built its input slice with `from_raw_parts(ab.ptr, ab.len)` on the raw `ArrayBuffer` view. Two problems with that line:

1. A detached Buffer / ArrayBuffer arrives with `ptr == NULL`, which violates the `from_raw_parts` precondition. Debug builds abort; release builds construct a null slice and only happen to reject it at the following `is_empty()` check.

   ```
   panic: unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
     <bun_runtime::api::bun_secure_context::SecureContext>::parse_pkcs12
       src/runtime/api/bun/SecureContext.rs:120
   ```

2. `ab.len` is the view's element count, not its byte length. A `Uint16Array` or `Float64Array` over a PKCS#12 blob was truncated to 1/2 or 1/8 of the data and rejected with `PFX MAC verification failed - is the passphrase correct?`. This one reproduces on release builds too (bun 1.4.0); Node accepts any ArrayBufferView here.

Repro:

```js
import tls from "node:tls";
const u = new Uint8Array(64);
structuredClone(u.buffer, { transfer: [u.buffer] }); // detach
tls.createSecureContext({ pfx: u });                 // debug build: abort at SecureContext.rs:120
```

Fix: read the view through `ArrayBuffer::byte_slice()`, which returns an empty slice for detached buffers and uses `byte_len`. This is how `SSLConfig` already reads the key/cert/ca buffers; `parse_pkcs12` was the only caller building the slice by hand. A detached pfx now throws `PFX certificate argument is mandatory` (the same error an empty buffer gets), and wider typed array views parse.

### How did you verify your code works?

Added two tests to `test/js/node/tls/node-tls-create-secure-context-args.test.ts`:

- detached `Uint8Array` and detached `ArrayBuffer` pfx, run in a child process: aborted on the unfixed debug build, throws cleanly with the fix.
- `Uint16Array` / `Float64Array` views over `agent10.pfx`: fails with the MAC verification error on the unfixed build (and on release 1.4.0), passes with the fix.

Also ran the existing pfx coverage against the fixed debug build: the pfx test in `node-tls-server.test.ts` plus `test-tls-multi-pfx.js`, `test-tls-pfx-authorizationerror.js`, `test-tls-multi-key.js`, `test-tls-env-extra-ca-with-options.js`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-create-secure-context-args.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/node/tls/node-tls-create-secure-context-args.test.ts:
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyEngine is not a string [27.61ms]
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyIdentifier is not a string [8.73ms]
(pass) tls.createSecureContext extra arguments test > should throw with a valid privateKeyIdentifier but missing privateKeyEngine [3.42ms]
(pass) tls.createSecureContext extra arguments test > should not throw for invalid privateKeyEngine when privateKeyIdentifier is not provided [97.55ms]
(pass) tls.createSecureContext extra arguments test > should throw for invalid privateKeyIdentifier [8.30ms]
101 |       env: bunEnv,
102 |       stdout: "pipe",
103 |       stderr: "pipe",
104 |     });
105 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
106 |     expect(stdout).toBe(
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/node/tls/node-tls-create-secure-context-args.test.ts:
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyEngine is not a string [0.45ms]
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyIdentifier is not a string [0.06ms]
(pass) tls.createSecureContext extra arguments test > should throw with a valid privateKeyIdentifier but missing privateKeyEngine [0.02ms]
(pass) tls.createSecureContext extra arguments test > should not throw for invalid privateKeyEngine when privateKeyIdentifier is not provided [9.44ms]
(pass) tls.createSecureContext extra arguments test > should throw for invalid privateKeyIdentifier [0.10ms]
(pass) tls.createSecureContext pfx argument > throws instead of crashing when the pfx buffer is detached [23.89ms]
119 |     const pfx = readFileSync(join(import.meta.dir, "../test/fixtures/keys/agent10.pfx"));
120 |     const bytes = new Uint8Array(pfx).buffer;
121 |     expect(bytes.byteLength % 8).toBe(0);
122 |     for (const view of [new Uint16Array(bytes), new Float64Array(bytes)]) {
123 |       // @ts-expect-error the ty
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-create-secure-context-args.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/node/tls/node-tls-create-secure-context-args.test.ts:
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyEngine is not a string [40.09ms]
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyIdentifier is not a string [8.74ms]
(pass) tls.createSecureContext extra arguments test > should throw with a valid privateKeyIdentifier but missing privateKeyEngine [4.19ms]
(pass) tls.createSecureContext extra arguments test > should not throw for invalid privateKeyEngine when privateKeyIdentifier is not provided [114.00ms]
(pass) tls.createSecureContext extra arguments test > should throw for invalid privateKeyIdentifier [9.73ms]
(pass) tls.createSecureContext pfx argument > throws instead of crashing when the pfx buffer is detached [1366.29ms]
(pass) tls.createSecureContext pfx argument > reads the whole byte range of a non-Uint8Array view [60.10ms]

 7 pass
 0 fail
 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 671ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 33s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.0-canary.1+2f2ca2bd6
[build] done
bun test v1.4.0-canary.1 (2f2ca2bd6)

test/js/node/tls/node-tls-create-secure-context-args.test.ts:
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyEngine is not a string [0.47ms]
(pass) tls.createSecureContext extra arguments test > should throw an error if the privateKeyIdentifier is not a string [0.06ms]
(pass) tls
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/SecureContext.rs               | 17 ++++---
 .../node-tls-create-secure-context-args.test.ts    | 57 ++++++++++++++++++++++
 2 files changed, 67 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/api/bun/SecureContext.rs                          2      1      0
…js/node/tls/node-tls-create-secure-context-args.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->