### PR TITLE
redis: forward PFADD elements and the NX|XX|GT|LT condition of the EXPIRE family

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -280,25 +280,37 @@ declare module "bun" {
      * Set a key's time to live in seconds
      * @param key The key to set the expiration for
      * @param seconds The number of seconds until expiration
+     * @param condition Only set the expiration when the condition holds (Redis 7.0+ / Valkey):
+     * `NX` the key has no expiration, `XX` the key already has one,
+     * `GT` the new expiration is later than the current one, `LT` it is earlier.
      * @returns Promise that resolves with 1 if the timeout was set, 0 if not
+     * (the key does not exist or the condition was not met)
      */
-    expire(key: RedisClient.KeyLike, seconds: number): Promise<number>;
+    expire(key: RedisClient.KeyLike, seconds: number, condition?: "NX" | "XX" | "GT" | "LT"): Promise<number>;
 
     /**
      * Set the expiration for a key as a Unix timestamp (in seconds)
      * @param key The key to set expiration on
      * @param timestamp Unix timestamp in seconds when the key should expire
-     * @returns Promise that resolves with 1 if timeout was set, 0 if key does not exist
+     * @param condition Only set the expiration when the condition holds (Redis 7.0+ / Valkey):
+     * `NX` the key has no expiration, `XX` the key already has one,
+     * `GT` the new expiration is later than the current one, `LT` it is earlier.
+     * @returns Promise that resolves with 1 if timeout was set, 0 if not
+     * (the key does not exist or the condition was not met)
      */
-    expireat(key: RedisClient.KeyLike, timestamp: number): Promise<number>;
+    expireat(key: RedisClient.KeyLike, timestamp: number, condition?: "NX" | "XX" | "GT" | "LT"): Promise<number>;
 
     /**
      * Set a key's time to live in milliseconds
      * @param key The key to set the expiration for
      * @param milliseconds The number of milliseconds until expiration
-     * @returns Promise that resolves with 1 if the timeout was set, 0 if the key does not exist
+     * @param condition Only set the expiration when the condition holds (Redis 7.0+ / Valkey):
+     * `NX` the key has no expiration, `XX` the key already has one,
+     * `GT` the new expiration is later than the current one, `LT` it is earlier.
+     * @returns Promise that resolves with 1 if the timeout was set, 0 if not
+     * (the key does not exist or the condition was not met)
      */
-    pexpire(key: RedisClient.KeyLike, milliseconds: number): Promise<number>;
+    pexpire(key: RedisClient.KeyLike, milliseconds: number, condition?: "NX" | "XX" | "GT" | "LT"): Promise<number>;
 
     /**
      * Get the time to live for a key in seconds
@@ -1223,9 +1235,17 @@ declare module "bun" {
      * Set the expiration for a key as a Unix timestamp in milliseconds
      * @param key The key to set expiration on
      * @param millisecondsTimestamp Unix timestamp in milliseconds when the key should expire
-     * @returns Promise that resolves with 1 if timeout was set, 0 if key does not exist
+     * @param condition Only set the expiration when the condition holds (Redis 7.0+ / Valkey):
+     * `NX` the key has no expiration, `XX` the key already has one,
+     * `GT` the new expiration is later than the current one, `LT` it is earlier.
+     * @returns Promise that resolves with 1 if timeout was set, 0 if not
+     * (the key does not exist or the condition was not met)
      */
-    pexpireat(key: RedisClient.KeyLike, millisecondsTimestamp: number): Promise<number>;
+    pexpireat(
+      key: RedisClient.KeyLike,
+      millisecondsTimestamp: number,
+      condition?: "NX" | "XX" | "GT" | "LT",
+    ): Promise<number>;
 
     /**
      * Get the expiration time of a key as a UNIX timestamp in milliseconds
@@ -1864,13 +1884,14 @@ declare module "bun" {
     ltrim(key: RedisClient.KeyLike, start: number, stop: number): Promise<string>;
 
     /**
-     * Add an element to a HyperLogLog
+     * Add elements to a HyperLogLog. Called with only a key, creates an empty
+     * HyperLogLog if the key does not exist.
      * @param key The HyperLogLog key
-     * @param element The element to add
-     * @returns Promise that resolves with 1 if the HyperLogLog was altered, 0
-     * otherwise
+     * @param elements The elements to add
+     * @returns Promise that resolves with 1 if the HyperLogLog was altered
+     * (its estimated cardinality changed, or it was created), 0 otherwise
      */
-    pfadd(key: RedisClient.KeyLike, element: string): Promise<number>;
+    pfadd(key: RedisClient.KeyLike, ...elements: RedisClient.KeyLike[]): Promise<number>;
 
     /**
      * Append one or multiple values to a list

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -76,6 +76,33 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
     JSArgument::from_js_maybe_file(global, value, false)
 }
 
+/// Appends the arguments a caller passed after a command's named ones, for
+/// commands whose Redis syntax ends in optional arguments (`PFADD key
+/// [element ...]`, `EXPIRE key seconds [NX | XX | GT | LT]`, ...). The values
+/// are forwarded verbatim for the server to validate; `undefined`/`null` are
+/// skipped so an optional argument can be passed through as `undefined`.
+fn push_rest_args(
+    global: &JSGlobalObject,
+    function_name: &'static [u8],
+    args: &mut Vec<JSArgument>,
+    rest: &[JSValue],
+) -> JsResult<()> {
+    for arg in rest {
+        if arg.is_undefined_or_null() {
+            continue;
+        }
+        let Some(value) = from_js(global, *arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                bname(function_name),
+                "additional arguments",
+                "string or buffer",
+            ));
+        };
+        args.push(value);
+    }
+    Ok(())
+}
+
 /// Shim around `protocol::valkey_error_to_js` that:
 /// 1. accepts whatever error type `JSValkeyClient::send` currently returns
 ///    (presently `crate::Error`) and
@@ -101,7 +128,7 @@ fn promise_to_js(p: *mut JSPromise) -> JSValue {
 /// `this.send()` it, and convert the result to a `JsResult<JSValue>` —
 /// `Ok(promise.toJS())` on success, a JS-side Redis error value on failure.
 ///
-/// All 7 `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
+/// All the `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
 /// `set`, `incr`, `decr`, `exists`, `expire`, `ttl`, `srem`, `sadd`,
 /// `sismember`, `hmget`, `hincrby`, `hset`, `smove`, `publish`,
 /// `send_unsubscribe_request_and_cleanup`, …) duplicated this 15-line block
@@ -166,7 +193,9 @@ pub(crate) mod compile {
 // cmd_key_value! (key: RedisKey, value: RedisValue),
 // cmd_key_value_value2! (key: RedisKey, value: RedisValue, value2: RedisValue),
 // cmd_strings_varargs! (...strings: string[]),
-// cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue)
+// cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue),
+// cmd_required_then_rest! (each listed required arg, validated under its own
+//   name, then ...rest: RedisValue[] forwarded via `push_rest_args`)
 
 macro_rules! cmd_noargs {
     ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
@@ -436,6 +465,51 @@ macro_rules! cmd_key_value_varargs {
     };
 }
 
+macro_rules! cmd_required_then_rest {
+    ($fn_name:ident, $name:literal, $command:literal, [$($arg_name:literal),+ $(,)?], $state:ident) => {
+        #[bun_jsc::host_fn(method)]
+        pub fn $fn_name(
+            this: &Self,
+            global: &JSGlobalObject,
+            frame: &CallFrame,
+        ) -> JsResult<JSValue> {
+            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
+                this, $name,
+            )?;
+
+            let arguments = frame.arguments();
+            let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
+            let mut required = 0usize;
+            $(
+                let Some(arg) = from_js(global, frame.argument(required))? else {
+                    return Err(global.throw_invalid_argument_type(
+                        bname($name),
+                        $arg_name,
+                        "string or buffer",
+                    ));
+                };
+                args.push(arg);
+                required += 1;
+            )+
+            push_rest_args(
+                global,
+                $name,
+                &mut args,
+                arguments.get(required..).unwrap_or_default(),
+            )?;
+            send_cmd(
+                this,
+                global,
+                frame.this(),
+                $command.as_bytes(),
+                CommandArgs::Args(&args),
+                CommandMeta::default(),
+                concat!("Failed to send ", $command),
+            )
+        }
+    };
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // JSValkeyClient prototype methods
 // ──────────────────────────────────────────────────────────────────────────
@@ -684,15 +758,28 @@ impl JSValkeyClient {
             },
         )?;
 
+        // Optional trailing condition: EXPIRE key seconds [NX | XX | GT | LT]
+        let mut rest: Vec<JSArgument> = Vec::new();
+        push_rest_args(
+            global,
+            b"expire",
+            &mut rest,
+            frame.arguments().get(2..).unwrap_or_default(),
+        )?;
+
         // Convert seconds to a string
         let mut int_buf = bun_core::fmt::ItoaBuf::new();
         let seconds_slice = bun_core::fmt::itoa(&mut int_buf, seconds);
+        let mut args: Vec<&[u8]> = Vec::with_capacity(2 + rest.len());
+        args.push(key.slice());
+        args.push(seconds_slice);
+        args.extend(rest.iter().map(JSArgument::slice));
         send_cmd(
             this,
             global,
             frame.this(),
             b"EXPIRE",
-            CommandArgs::Raw(&[key.slice(), seconds_slice]),
+            CommandArgs::Raw(&args),
             CommandMeta::default(),
             "Failed to send EXPIRE command",
         )
@@ -1354,12 +1441,11 @@ impl JSValkeyClient {
         NotSubscriber
     );
     cmd_key!(dump, b"dump", "DUMP", "key", NotSubscriber);
-    cmd_key_value!(
+    cmd_required_then_rest!(
         expireat,
         b"expireat",
         "EXPIREAT",
-        "key",
-        "timestamp",
+        ["key", "timestamp"],
         NotSubscriber
     );
     cmd_key!(
@@ -1420,20 +1506,18 @@ impl JSValkeyClient {
         NotSubscriber
     );
     cmd_key!(persist, b"persist", "PERSIST", "key", NotSubscriber);
-    cmd_key_value!(
+    cmd_required_then_rest!(
         pexpire,
         b"pexpire",
         "PEXPIRE",
-        "key",
-        "milliseconds",
+        ["key", "milliseconds"],
         NotSubscriber
     );
-    cmd_key_value!(
+    cmd_required_then_rest!(
         pexpireat,
         b"pexpireat",
         "PEXPIREAT",
-        "key",
-        "milliseconds-timestamp",
+        ["key", "milliseconds-timestamp"],
         NotSubscriber
     );
     cmd_key!(
@@ -1552,7 +1636,7 @@ impl JSValkeyClient {
     );
     cmd_key_value_varargs!(lpush, b"lpush", "LPUSH", NotSubscriber);
     cmd_key_value_varargs!(lpushx, b"lpushx", "LPUSHX", NotSubscriber);
-    cmd_key_value!(pfadd, b"pfadd", "PFADD", "key", "value", NotSubscriber);
+    cmd_required_then_rest!(pfadd, b"pfadd", "PFADD", ["key"], NotSubscriber);
     cmd_key_value_varargs!(rpush, b"rpush", "RPUSH", NotSubscriber);
     cmd_key_value_varargs!(rpushx, b"rpushx", "RPUSHX", NotSubscriber);
     cmd_key_value!(setnx, b"setnx", "SETNX", "key", "value", NotSubscriber);

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -76,11 +76,8 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
     JSArgument::from_js_maybe_file(global, value, false)
 }
 
-/// Appends the arguments a caller passed after a command's named ones, for
-/// commands whose Redis syntax ends in optional arguments (`PFADD key
-/// [element ...]`, `EXPIRE key seconds [NX | XX | GT | LT]`, ...). The values
-/// are forwarded verbatim for the server to validate; `undefined`/`null` are
-/// skipped so an optional argument can be passed through as `undefined`.
+/// Forwards the arguments after a command's named ones (the `[NX | XX | GT | LT]` of
+/// `EXPIRE`), skipping `undefined`/`null` so an omitted optional argument sends nothing.
 fn push_rest_args(
     global: &JSGlobalObject,
     function_name: &'static [u8],
@@ -192,9 +189,7 @@ pub(crate) mod compile {
 // cmd_key_varargs! (key: RedisKey, ...args: RedisKey[]),
 // cmd_key_value! (key: RedisKey, value: RedisValue),
 // cmd_key_value_value2! (key: RedisKey, value: RedisValue, value2: RedisValue),
-// cmd_required_varargs! (required0: RedisValue, ..., requiredN: RedisValue, ...optional: RedisValue[])
-//   (each named argument is validated and reported by name; whatever follows
-//   is forwarded as-is, skipping undefined/null),
+// cmd_required_varargs! (required0: RedisValue, ..., requiredN: RedisValue, ...optional: RedisValue[]),
 // cmd_strings_varargs! (...strings: string[]),
 // cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue)
 

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -128,7 +128,7 @@ fn promise_to_js(p: *mut JSPromise) -> JSValue {
 /// `this.send()` it, and convert the result to a `JsResult<JSValue>` —
 /// `Ok(promise.toJS())` on success, a JS-side Redis error value on failure.
 ///
-/// All the `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
+/// All 8 `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
 /// `set`, `incr`, `decr`, `exists`, `expire`, `ttl`, `srem`, `sadd`,
 /// `sismember`, `hmget`, `hincrby`, `hset`, `smove`, `publish`,
 /// `send_unsubscribe_request_and_cleanup`, …) duplicated this 15-line block
@@ -192,10 +192,11 @@ pub(crate) mod compile {
 // cmd_key_varargs! (key: RedisKey, ...args: RedisKey[]),
 // cmd_key_value! (key: RedisKey, value: RedisValue),
 // cmd_key_value_value2! (key: RedisKey, value: RedisValue, value2: RedisValue),
+// cmd_required_varargs! (required0: RedisValue, ..., requiredN: RedisValue, ...optional: RedisValue[])
+//   (each named argument is validated and reported by name; whatever follows
+//   is forwarded as-is, skipping undefined/null),
 // cmd_strings_varargs! (...strings: string[]),
-// cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue),
-// cmd_required_then_rest! (each listed required arg, validated under its own
-//   name, then ...rest: RedisValue[] forwarded via `push_rest_args`)
+// cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue)
 
 macro_rules! cmd_noargs {
     ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
@@ -384,6 +385,53 @@ macro_rules! cmd_key_value_value2 {
     };
 }
 
+macro_rules! cmd_required_varargs {
+    ($fn_name:ident, $name:literal, $command:literal, $($required_name:literal,)+ $state:ident) => {
+        #[bun_jsc::host_fn(method)]
+        pub fn $fn_name(
+            this: &Self,
+            global: &JSGlobalObject,
+            frame: &CallFrame,
+        ) -> JsResult<JSValue> {
+            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
+                this, $name,
+            )?;
+
+            const REQUIRED: &[&str] = &[$($required_name),+];
+
+            let arguments = frame.arguments();
+            let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
+
+            for (index, required_name) in REQUIRED.iter().copied().enumerate() {
+                let Some(required) = from_js(global, frame.argument(index))? else {
+                    return Err(global.throw_invalid_argument_type(
+                        bname($name),
+                        required_name,
+                        "string or buffer",
+                    ));
+                };
+                args.push(required);
+            }
+
+            push_rest_args(
+                global,
+                $name,
+                &mut args,
+                arguments.get(REQUIRED.len()..).unwrap_or_default(),
+            )?;
+            send_cmd(
+                this,
+                global,
+                frame.this(),
+                $command.as_bytes(),
+                CommandArgs::Args(&args),
+                CommandMeta::default(),
+                concat!("Failed to send ", $command),
+            )
+        }
+    };
+}
+
 macro_rules! cmd_strings_varargs {
     ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
         cmd_strings_varargs!($fn_name, $name, $command, $state, CommandMeta::default());
@@ -452,51 +500,6 @@ macro_rules! cmd_key_value_varargs {
                 };
                 args.push(another);
             }
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&args),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
-    };
-}
-
-macro_rules! cmd_required_then_rest {
-    ($fn_name:ident, $name:literal, $command:literal, [$($arg_name:literal),+ $(,)?], $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let arguments = frame.arguments();
-            let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
-            let mut required = 0usize;
-            $(
-                let Some(arg) = from_js(global, frame.argument(required))? else {
-                    return Err(global.throw_invalid_argument_type(
-                        bname($name),
-                        $arg_name,
-                        "string or buffer",
-                    ));
-                };
-                args.push(arg);
-                required += 1;
-            )+
-            push_rest_args(
-                global,
-                $name,
-                &mut args,
-                arguments.get(required..).unwrap_or_default(),
-            )?;
             send_cmd(
                 this,
                 global,
@@ -1441,11 +1444,12 @@ impl JSValkeyClient {
         NotSubscriber
     );
     cmd_key!(dump, b"dump", "DUMP", "key", NotSubscriber);
-    cmd_required_then_rest!(
+    cmd_required_varargs!(
         expireat,
         b"expireat",
         "EXPIREAT",
-        ["key", "timestamp"],
+        "key",
+        "timestamp",
         NotSubscriber
     );
     cmd_key!(
@@ -1506,18 +1510,20 @@ impl JSValkeyClient {
         NotSubscriber
     );
     cmd_key!(persist, b"persist", "PERSIST", "key", NotSubscriber);
-    cmd_required_then_rest!(
+    cmd_required_varargs!(
         pexpire,
         b"pexpire",
         "PEXPIRE",
-        ["key", "milliseconds"],
+        "key",
+        "milliseconds",
         NotSubscriber
     );
-    cmd_required_then_rest!(
+    cmd_required_varargs!(
         pexpireat,
         b"pexpireat",
         "PEXPIREAT",
-        ["key", "milliseconds-timestamp"],
+        "key",
+        "milliseconds-timestamp",
         NotSubscriber
     );
     cmd_key!(
@@ -1636,7 +1642,7 @@ impl JSValkeyClient {
     );
     cmd_key_value_varargs!(lpush, b"lpush", "LPUSH", NotSubscriber);
     cmd_key_value_varargs!(lpushx, b"lpushx", "LPUSHX", NotSubscriber);
-    cmd_required_then_rest!(pfadd, b"pfadd", "PFADD", ["key"], NotSubscriber);
+    cmd_required_varargs!(pfadd, b"pfadd", "PFADD", "key", NotSubscriber);
     cmd_key_value_varargs!(rpush, b"rpush", "RPUSH", NotSubscriber);
     cmd_key_value_varargs!(rpushx, b"rpushx", "RPUSHX", NotSubscriber);
     cmd_key_value!(setnx, b"setnx", "SETNX", "key", "value", NotSubscriber);

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -76,8 +76,7 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
     JSArgument::from_js_maybe_file(global, value, false)
 }
 
-/// Forwards the arguments after a command's named ones (the `[NX | XX | GT | LT]` of
-/// `EXPIRE`), skipping `undefined`/`null` so an omitted optional argument sends nothing.
+/// Optional trailing arguments; `undefined`/`null` are skipped so an omitted option sends nothing.
 fn push_rest_args(
     global: &JSGlobalObject,
     function_name: &'static [u8],

--- a/test/integration/bun-types/fixture/redis.ts
+++ b/test/integration/bun-types/fixture/redis.ts
@@ -29,3 +29,17 @@ await copy.unsubscribe();
 await copy.unsubscribe("hello");
 
 expectType(copy.unsubscribe("hello", () => {})).is<Promise<void>>();
+
+expectType(Bun.redis.expire("key", 10)).is<Promise<number>>();
+expectType(Bun.redis.expire("key", 10, "NX")).is<Promise<number>>();
+expectType(Bun.redis.pexpire("key", 10_000, "XX")).is<Promise<number>>();
+expectType(Bun.redis.expireat("key", 1_700_000_000, "GT")).is<Promise<number>>();
+expectType(Bun.redis.pexpireat("key", 1_700_000_000_000, "LT")).is<Promise<number>>();
+// @ts-expect-error - the condition must be one of NX, XX, GT, LT
+Bun.redis.expire("key", 10, "EX");
+// @ts-expect-error - EXPIRE takes a single condition
+Bun.redis.expire("key", 10, "NX", "GT");
+
+expectType(Bun.redis.pfadd("hll")).is<Promise<number>>();
+expectType(Bun.redis.pfadd("hll", "a")).is<Promise<number>>();
+expectType(Bun.redis.pfadd("hll", "a", Buffer.from("b"), new Blob(["c"]))).is<Promise<number>>();

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,5 +1,5 @@
-import { randomUUIDv7, RedisClient, spawn, type TCPSocketListener } from "bun";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUIDv7, RedisClient, spawn } from "bun";
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { bunExe, bunRun } from "harness";
 import { join } from "node:path";
 import {
@@ -7110,120 +7110,178 @@ describe("RedisClient argument validation", () => {
       client.close();
     }
   });
+
+  test("pfadd() and the expire family still report a bad required argument by name", () => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    const badKey = (name: string) => ({
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `Expected key to be a string or buffer for '${name}'.`,
+    });
+    try {
+      // @ts-expect-error: testing runtime behavior with no arguments
+      expect(syncThrow(() => client.pfadd())).toMatchObject(badKey("pfadd"));
+      expect(syncThrow(() => client.pfadd({} as any, "a"))).toMatchObject(badKey("pfadd"));
+      expect(syncThrow(() => client.expireat({} as any, 1, "NX"))).toMatchObject(badKey("expireat"));
+      expect(syncThrow(() => client.pexpire({} as any, 1, "NX"))).toMatchObject(badKey("pexpire"));
+      expect(syncThrow(() => client.pexpireat({} as any, 1, "NX"))).toMatchObject(badKey("pexpireat"));
+      // @ts-expect-error: testing runtime behavior with a missing argument
+      expect(syncThrow(() => client.pexpire("k"))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected milliseconds to be a string or buffer for 'pexpire'.",
+      });
+      // The condition is not promoted into the slot of a missing required argument.
+      // @ts-expect-error: testing runtime behavior with an undefined timestamp
+      expect(syncThrow(() => client.expireat("k", undefined, "NX"))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected timestamp to be a string or buffer for 'expireat'.",
+      });
+      expect(syncThrow(() => client.expire("k", NaN, "NX"))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('"seconds"'),
+      });
+    } finally {
+      client.close();
+    }
+  });
+
+  test("pfadd() and the expire family reject a non-string trailing argument", () => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    const badRest = (name: string) => ({
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `Expected additional arguments to be a string or buffer for '${name}'.`,
+    });
+    try {
+      expect(syncThrow(() => client.pfadd("hll", "a", {} as any))).toMatchObject(badRest("pfadd"));
+      expect(syncThrow(() => client.expire("k", 5, {} as any))).toMatchObject(badRest("expire"));
+      expect(syncThrow(() => client.pexpire("k", 5, {} as any))).toMatchObject(badRest("pexpire"));
+      expect(syncThrow(() => client.expireat("k", 5, {} as any))).toMatchObject(badRest("expireat"));
+      expect(syncThrow(() => client.pexpireat("k", 5, {} as any))).toMatchObject(badRest("pexpireat"));
+    } finally {
+      client.close();
+    }
+  });
 });
 
-// Wire-level coverage for commands whose Redis syntax ends in optional
-// arguments. An in-process stand-in for the server records each command frame
-// exactly as it was sent, so these run without docker.
-describe("RedisClient forwards optional trailing arguments", () => {
+describe("RedisClient command encoding", () => {
   const CRLF = "\r\n";
   const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
-  const HELLO_REPLY =
-    `%3${CRLF}` + bulk("server") + bulk("redis") + bulk("proto") + `:3${CRLF}` + bulk("version") + bulk("8.0.0");
+  const HELLO_REPLY = `%2${CRLF}` + bulk("server") + bulk("redis") + bulk("proto") + `:3${CRLF}`;
 
-  /** Splits the complete `*N\r\n($len\r\n<bytes>\r\n){N}` frames off the front of `buf`. */
-  function takeFrames(buf: Buffer): { frames: string[][]; rest: Buffer } {
-    const frames: string[][] = [];
-    let offset = 0;
-    while (offset < buf.length && buf[offset] === 0x2a /* '*' */) {
-      const headerEnd = buf.indexOf(CRLF, offset);
-      if (headerEnd < 0) break;
-      const argc = parseInt(buf.subarray(offset + 1, headerEnd).toString("latin1"), 10);
-      const fields: string[] = [];
-      let pos = headerEnd + 2;
-      for (let i = 0; i < argc; i++) {
-        const lenEnd = buf.indexOf(CRLF, pos);
-        if (lenEnd < 0 || buf[pos] !== 0x24 /* '$' */) return { frames, rest: buf.subarray(offset) };
-        const len = parseInt(buf.subarray(pos + 1, lenEnd).toString("latin1"), 10);
-        const end = lenEnd + 2 + len;
-        if (end + 2 > buf.length) return { frames, rest: buf.subarray(offset) };
-        fields.push(buf.subarray(lenEnd + 2, end).toString());
-        pos = end + 2;
-      }
-      frames.push(fields);
-      offset = pos;
-    }
-    return { frames, rest: buf.subarray(offset) };
-  }
-
-  const received: string[][] = [];
-  let server: TCPSocketListener<Buffer>;
-  let client: RedisClient;
-
-  beforeAll(async () => {
-    server = Bun.listen<Buffer>({
+  /**
+   * Runs `body` against a fake server that answers HELLO, replies `:0` to
+   * everything else and records every command it received as an argv array.
+   */
+  async function recordCommands(body: (client: RedisClient) => Promise<unknown>): Promise<string[][]> {
+    const received: string[][] = [];
+    using server = Bun.listen<{ buf: Buffer }>({
       hostname: "127.0.0.1",
       port: 0,
       socket: {
         open(socket) {
-          socket.data = Buffer.alloc(0);
+          socket.data = { buf: Buffer.alloc(0) };
         },
+        error() {},
+        close() {},
         data(socket, chunk) {
-          const { frames, rest } = takeFrames(Buffer.concat([socket.data, chunk]));
-          socket.data = rest;
-          for (const frame of frames) {
-            if (frame[0] === "HELLO") {
+          let buf = (socket.data.buf = Buffer.concat([socket.data.buf, chunk]));
+          // Each client command is a RESP array of bulk strings:
+          // `*<argc>\r\n` followed by argc `$<len>\r\n<bytes>\r\n` frames.
+          for (;;) {
+            const headerEnd = buf.indexOf(CRLF);
+            if (headerEnd < 0 || buf[0] !== 0x2a /* '*' */) break;
+            const argc = parseInt(buf.subarray(1, headerEnd).toString("latin1"), 10);
+            const argv: string[] = [];
+            let pos = headerEnd + 2;
+            let complete = true;
+            for (let i = 0; i < argc; i++) {
+              const lenEnd = buf.indexOf(CRLF, pos);
+              if (lenEnd < 0 || buf[pos] !== 0x24 /* '$' */) {
+                complete = false;
+                break;
+              }
+              const len = parseInt(buf.subarray(pos + 1, lenEnd).toString("latin1"), 10);
+              const next = lenEnd + 2 + len + 2;
+              if (next > buf.length) {
+                complete = false;
+                break;
+              }
+              argv.push(buf.subarray(lenEnd + 2, lenEnd + 2 + len).toString("latin1"));
+              pos = next;
+            }
+            if (!complete) break;
+            buf = socket.data.buf = buf.subarray(pos);
+            if (argv[0] === "HELLO") {
               socket.write(HELLO_REPLY);
             } else {
-              received.push(frame);
-              socket.write(`:1${CRLF}`);
+              received.push(argv);
+              socket.write(`:0${CRLF}`);
             }
           }
         },
-        error() {},
       },
     });
-    client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
-    await client.connect();
-  });
 
-  afterAll(() => {
-    client?.close();
-    server?.stop(true);
-  });
-
-  /** Runs `call` against the recording server and returns the command frames it produced. */
-  async function sent(call: (redis: RedisClient) => Promise<unknown>): Promise<string[][]> {
-    const start = received.length;
-    await call(client);
-    return received.slice(start);
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    try {
+      await client.connect();
+      await body(client);
+    } finally {
+      client.close();
+    }
+    return received;
   }
 
-  test.each<[string, (redis: RedisClient) => Promise<unknown>, string[]]>([
-    ['pfadd(key, "a", "b", "c")', r => r.pfadd("hll", "a", "b", "c"), ["PFADD", "hll", "a", "b", "c"]],
-    ['pfadd(key, "a", Buffer("b"))', r => r.pfadd("hll", "a", Buffer.from("b")), ["PFADD", "hll", "a", "b"]],
-    ["pfadd(key)", r => r.pfadd("hll"), ["PFADD", "hll"]],
-    ['expire(key, 5, "NX")', r => r.expire("k", 5, "NX"), ["EXPIRE", "k", "5", "NX"]],
-    ['pexpire(key, 5000, "XX")', r => r.pexpire("k", 5000, "XX"), ["PEXPIRE", "k", "5000", "XX"]],
-    ['expireat(key, ts, "GT")', r => r.expireat("k", 1700000000, "GT"), ["EXPIREAT", "k", "1700000000", "GT"]],
-    ['pexpireat(key, ms, "LT")', r => r.pexpireat("k", 1700000000000, "LT"), ["PEXPIREAT", "k", "1700000000000", "LT"]],
-    // Without a condition (or with an explicit undefined) the frame is unchanged.
-    ["expire(key, 5)", r => r.expire("k", 5), ["EXPIRE", "k", "5"]],
-    ["expire(key, 5, undefined)", r => r.expire("k", 5, undefined), ["EXPIRE", "k", "5"]],
-    ["pexpire(key, 5000)", r => r.pexpire("k", 5000), ["PEXPIRE", "k", "5000"]],
-    ["expireat(key, ts, undefined)", r => r.expireat("k", 1700000000, undefined), ["EXPIREAT", "k", "1700000000"]],
-    ["pexpireat(key, ms)", r => r.pexpireat("k", 1700000000000), ["PEXPIREAT", "k", "1700000000000"]],
-  ])("%s sends exactly the arguments it was given", async (_name, call, frame) => {
-    expect(await sent(call)).toEqual([frame]);
+  test("pfadd() forwards every element", async () => {
+    const received = await recordCommands(async client => {
+      await client.pfadd("hll", "a", "b", "c");
+      await client.pfadd("hll", "a", Buffer.from("b"));
+      // PFADD key on its own is valid: it creates an empty HyperLogLog.
+      await client.pfadd("hll");
+    });
+    expect(received).toEqual([
+      ["PFADD", "hll", "a", "b", "c"],
+      ["PFADD", "hll", "a", "b"],
+      ["PFADD", "hll"],
+    ]);
   });
 
-  test("the required arguments are still validated by name", () => {
-    expect(() => client.pfadd({} as any, "a")).toThrow("Expected key to be a string or buffer for 'pfadd'.");
-    expect(() => client.expireat({} as any, 1, "NX")).toThrow("Expected key to be a string or buffer for 'expireat'.");
-    expect(() => client.pexpire({} as any, 1, "NX")).toThrow("Expected key to be a string or buffer for 'pexpire'.");
-    expect(() => client.pexpireat({} as any, 1, "NX")).toThrow(
-      "Expected key to be a string or buffer for 'pexpireat'.",
-    );
-    expect(() => (client as any).pexpire("k")).toThrow("Expected milliseconds to be a string or buffer for 'pexpire'.");
-    expect(() => client.expire("k", NaN, "NX")).toThrow('The "seconds" property must be of type integer.');
-    expect(() => client.expire("k", 5, {} as any)).toThrow(
-      "Expected additional arguments to be a string or buffer for 'expire'.",
-    );
-    expect(() => client.pfadd("hll", "a", {} as any)).toThrow(
-      "Expected additional arguments to be a string or buffer for 'pfadd'.",
-    );
-    expect(() => client.pexpireat("k", 1, {} as any)).toThrow(
-      "Expected additional arguments to be a string or buffer for 'pexpireat'.",
-    );
+  test("expire(), pexpire(), expireat() and pexpireat() forward the NX|XX|GT|LT condition", async () => {
+    const received = await recordCommands(async client => {
+      await client.expire("k", 5, "NX");
+      await client.expire(Buffer.from("binary-key"), 5, "XX");
+      await client.pexpire("k", 5000, "XX");
+      await client.expireat("k", 1700000000, "GT");
+      await client.pexpireat("k", 1700000000000, "LT");
+    });
+    expect(received).toEqual([
+      ["EXPIRE", "k", "5", "NX"],
+      ["EXPIRE", "binary-key", "5", "XX"],
+      ["PEXPIRE", "k", "5000", "XX"],
+      ["EXPIREAT", "k", "1700000000", "GT"],
+      ["PEXPIREAT", "k", "1700000000000", "LT"],
+    ]);
+  });
+
+  test("the expire family without a condition (or with an undefined one) sends the two-argument form", async () => {
+    const received = await recordCommands(async client => {
+      await client.expire("k", 5);
+      await client.expire("k", 5, undefined);
+      await client.pexpire("k", 5000);
+      await client.pexpire("k", 5000, undefined);
+      await client.expireat("k", 1700000000);
+      await client.expireat("k", 1700000000, undefined);
+      await client.pexpireat("k", 1700000000000);
+      await client.pexpireat("k", 1700000000000, undefined);
+    });
+    expect(received).toEqual([
+      ["EXPIRE", "k", "5"],
+      ["EXPIRE", "k", "5"],
+      ["PEXPIRE", "k", "5000"],
+      ["PEXPIRE", "k", "5000"],
+      ["EXPIREAT", "k", "1700000000"],
+      ["EXPIREAT", "k", "1700000000"],
+      ["PEXPIREAT", "k", "1700000000000"],
+      ["PEXPIREAT", "k", "1700000000000"],
+    ]);
   });
 });

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,5 +1,5 @@
-import { randomUUIDv7, RedisClient, spawn } from "bun";
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUIDv7, RedisClient, spawn, type TCPSocketListener } from "bun";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { bunExe, bunRun } from "harness";
 import { join } from "node:path";
 import {
@@ -358,6 +358,40 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const futureTimestampMs = Date.now() + 5000;
         const result = await redis.pexpireat("nonexistent-pexpireat-key", futureTimestampMs);
         expect(result).toBe(0);
+      });
+
+      test("EXPIRE/PEXPIRE/EXPIREAT/PEXPIREAT forward the NX/XX/GT/LT condition", async () => {
+        const redis = ctx.redis;
+        const key = "expire-condition-test-key";
+        const nxCalls = {
+          expire: () => redis.expire(key, 10, "NX"),
+          pexpire: () => redis.pexpire(key, 10_000, "NX"),
+          expireat: () => redis.expireat(key, Math.floor(Date.now() / 1000) + 10, "NX"),
+          pexpireat: () => redis.pexpireat(key, Date.now() + 10_000, "NX"),
+        };
+
+        // NX only sets a TTL when the key has none, so on a key that already
+        // has one every call must be a no-op that leaves the long TTL in place.
+        for (const [name, call] of Object.entries(nxCalls)) {
+          await redis.set(key, "value");
+          expect(await redis.expire(key, 1000)).toBe(1);
+          expect([name, await call()]).toEqual([name, 0]);
+          expect(await redis.ttl(key)).toBeGreaterThan(900);
+        }
+
+        // XX requires an existing TTL; GT/LT compare against it.
+        await redis.set(key, "value");
+        expect(await redis.expire(key, 1000, "XX")).toBe(0);
+        expect(await redis.ttl(key)).toBe(-1);
+        expect(await redis.expire(key, 1000, "NX")).toBe(1);
+        expect(await redis.pexpire(key, 500_000, "GT")).toBe(0);
+        expect(await redis.pexpire(key, 500_000, "LT")).toBe(1);
+        expect(await redis.expireat(key, Math.floor(Date.now() / 1000) + 2000, "LT")).toBe(0);
+        expect(await redis.pexpireat(key, Date.now() + 2_000_000, "GT")).toBe(1);
+        expect(await redis.ttl(key)).toBeGreaterThan(1900);
+
+        // The condition is forwarded as-is; the server validates it.
+        await expect(redis.expire(key, 10, "BOGUS" as any)).rejects.toThrow("ERR Unsupported option BOGUS");
       });
 
       test("should determine the type of a key with TYPE", async () => {
@@ -727,6 +761,23 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
 
         const result3 = await redis.pfadd(key, "element1");
         expect(result3).toBe(0);
+      });
+
+      test("PFADD sends every element, and accepts the key-only form", async () => {
+        const redis = ctx.redis;
+        const key = "pfadd-multi-test";
+
+        expect(await redis.pfadd(key, "a", "b", "c")).toBe(1);
+        expect(await redis.send("PFCOUNT", [key])).toBe(3);
+        expect(await redis.pfadd(key, "a", "b", "c")).toBe(0);
+        expect(await redis.pfadd(key, "c", Buffer.from("d"))).toBe(1);
+        expect(await redis.send("PFCOUNT", [key])).toBe(4);
+
+        // PFADD key (no elements) creates an empty HyperLogLog.
+        const emptyKey = "pfadd-empty-test";
+        expect(await redis.pfadd(emptyKey)).toBe(1);
+        expect(await redis.pfadd(emptyKey)).toBe(0);
+        expect(await redis.send("PFCOUNT", [emptyKey])).toBe(0);
       });
 
       test("should implement TTL command correctly for different cases", async () => {
@@ -7058,5 +7109,121 @@ describe("RedisClient argument validation", () => {
     } finally {
       client.close();
     }
+  });
+});
+
+// Wire-level coverage for commands whose Redis syntax ends in optional
+// arguments. An in-process stand-in for the server records each command frame
+// exactly as it was sent, so these run without docker.
+describe("RedisClient forwards optional trailing arguments", () => {
+  const CRLF = "\r\n";
+  const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
+  const HELLO_REPLY =
+    `%3${CRLF}` + bulk("server") + bulk("redis") + bulk("proto") + `:3${CRLF}` + bulk("version") + bulk("8.0.0");
+
+  /** Splits the complete `*N\r\n($len\r\n<bytes>\r\n){N}` frames off the front of `buf`. */
+  function takeFrames(buf: Buffer): { frames: string[][]; rest: Buffer } {
+    const frames: string[][] = [];
+    let offset = 0;
+    while (offset < buf.length && buf[offset] === 0x2a /* '*' */) {
+      const headerEnd = buf.indexOf(CRLF, offset);
+      if (headerEnd < 0) break;
+      const argc = parseInt(buf.subarray(offset + 1, headerEnd).toString("latin1"), 10);
+      const fields: string[] = [];
+      let pos = headerEnd + 2;
+      for (let i = 0; i < argc; i++) {
+        const lenEnd = buf.indexOf(CRLF, pos);
+        if (lenEnd < 0 || buf[pos] !== 0x24 /* '$' */) return { frames, rest: buf.subarray(offset) };
+        const len = parseInt(buf.subarray(pos + 1, lenEnd).toString("latin1"), 10);
+        const end = lenEnd + 2 + len;
+        if (end + 2 > buf.length) return { frames, rest: buf.subarray(offset) };
+        fields.push(buf.subarray(lenEnd + 2, end).toString());
+        pos = end + 2;
+      }
+      frames.push(fields);
+      offset = pos;
+    }
+    return { frames, rest: buf.subarray(offset) };
+  }
+
+  const received: string[][] = [];
+  let server: TCPSocketListener<Buffer>;
+  let client: RedisClient;
+
+  beforeAll(async () => {
+    server = Bun.listen<Buffer>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = Buffer.alloc(0);
+        },
+        data(socket, chunk) {
+          const { frames, rest } = takeFrames(Buffer.concat([socket.data, chunk]));
+          socket.data = rest;
+          for (const frame of frames) {
+            if (frame[0] === "HELLO") {
+              socket.write(HELLO_REPLY);
+            } else {
+              received.push(frame);
+              socket.write(`:1${CRLF}`);
+            }
+          }
+        },
+        error() {},
+      },
+    });
+    client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    await client.connect();
+  });
+
+  afterAll(() => {
+    client?.close();
+    server?.stop(true);
+  });
+
+  /** Runs `call` against the recording server and returns the command frames it produced. */
+  async function sent(call: (redis: RedisClient) => Promise<unknown>): Promise<string[][]> {
+    const start = received.length;
+    await call(client);
+    return received.slice(start);
+  }
+
+  test.each<[string, (redis: RedisClient) => Promise<unknown>, string[]]>([
+    ['pfadd(key, "a", "b", "c")', r => r.pfadd("hll", "a", "b", "c"), ["PFADD", "hll", "a", "b", "c"]],
+    ['pfadd(key, "a", Buffer("b"))', r => r.pfadd("hll", "a", Buffer.from("b")), ["PFADD", "hll", "a", "b"]],
+    ["pfadd(key)", r => r.pfadd("hll"), ["PFADD", "hll"]],
+    ['expire(key, 5, "NX")', r => r.expire("k", 5, "NX"), ["EXPIRE", "k", "5", "NX"]],
+    ['pexpire(key, 5000, "XX")', r => r.pexpire("k", 5000, "XX"), ["PEXPIRE", "k", "5000", "XX"]],
+    ['expireat(key, ts, "GT")', r => r.expireat("k", 1700000000, "GT"), ["EXPIREAT", "k", "1700000000", "GT"]],
+    ['pexpireat(key, ms, "LT")', r => r.pexpireat("k", 1700000000000, "LT"), ["PEXPIREAT", "k", "1700000000000", "LT"]],
+    // Without a condition (or with an explicit undefined) the frame is unchanged.
+    ["expire(key, 5)", r => r.expire("k", 5), ["EXPIRE", "k", "5"]],
+    ["expire(key, 5, undefined)", r => r.expire("k", 5, undefined), ["EXPIRE", "k", "5"]],
+    ["pexpire(key, 5000)", r => r.pexpire("k", 5000), ["PEXPIRE", "k", "5000"]],
+    ["expireat(key, ts, undefined)", r => r.expireat("k", 1700000000, undefined), ["EXPIREAT", "k", "1700000000"]],
+    ["pexpireat(key, ms)", r => r.pexpireat("k", 1700000000000), ["PEXPIREAT", "k", "1700000000000"]],
+  ])("%s sends exactly the arguments it was given", async (_name, call, frame) => {
+    expect(await sent(call)).toEqual([frame]);
+  });
+
+  test("the required arguments are still validated by name", () => {
+    expect(() => client.pfadd({} as any, "a")).toThrow("Expected key to be a string or buffer for 'pfadd'.");
+    expect(() => client.expireat({} as any, 1, "NX")).toThrow("Expected key to be a string or buffer for 'expireat'.");
+    expect(() => client.pexpire({} as any, 1, "NX")).toThrow("Expected key to be a string or buffer for 'pexpire'.");
+    expect(() => client.pexpireat({} as any, 1, "NX")).toThrow(
+      "Expected key to be a string or buffer for 'pexpireat'.",
+    );
+    expect(() => (client as any).pexpire("k")).toThrow("Expected milliseconds to be a string or buffer for 'pexpire'.");
+    expect(() => client.expire("k", NaN, "NX")).toThrow('The "seconds" property must be of type integer.');
+    expect(() => client.expire("k", 5, {} as any)).toThrow(
+      "Expected additional arguments to be a string or buffer for 'expire'.",
+    );
+    expect(() => client.pfadd("hll", "a", {} as any)).toThrow(
+      "Expected additional arguments to be a string or buffer for 'pfadd'.",
+    );
+    expect(() => client.pexpireat("k", 1, {} as any)).toThrow(
+      "Expected additional arguments to be a string or buffer for 'pexpireat'.",
+    );
   });
 });


### PR DESCRIPTION
### What

`RedisClient` silently dropped the optional trailing arguments of five commands, so the server executed a different command than the caller asked for and returned a plausible-looking result:

- `pfadd(key, ...elements)` only sent the first element (`PFADD key [element ...]`)
- `expire`, `pexpire`, `expireat`, `pexpireat` dropped the `NX | XX | GT | LT` condition (Redis 7.0+ / Valkey)

Repro against a local redis-server 8.0.2 with bun 1.4.0:

```ts
import { RedisClient } from "bun";
const redis = new RedisClient("redis://127.0.0.1:6379");
await redis.send("FLUSHDB", []);

console.log(await redis.pfadd("hll", "a", "b", "c"));   // 1
console.log(await redis.send("PFCOUNT", ["hll"]));      // 1   (expected 3)

await redis.set("e", "v");
await redis.expire("e", 1000);
console.log(await redis.expire("e", 5, "NX"));          // 1   (expected 0: key already has a TTL)
console.log(await redis.ttl("e"));                      // 5   (expected ~1000, NX was dropped)
// pexpire / expireat / pexpireat behave the same way
console.log(await redis.send("EXPIRE", ["e", "5", "NX"])); // 0 (what the server does when NX arrives)
```

### Cause

`pfadd`, `expireat`, `pexpire` and `pexpireat` were registered with the fixed-arity `cmd_key_value!` generator in `src/runtime/valkey_jsc/js_valkey_functions.rs`, which reads `argument(0)` and `argument(1)` and serializes exactly those two. The hand-written `expire()` likewise built `EXPIRE key seconds` from its first two arguments and never looked at `argument(2)`.

### Fix

The fix itself is the four re-registrations plus the tail of `expire()`:

```rust
cmd_required_varargs!(pfadd, b"pfadd", "PFADD", "key", NotSubscriber);
cmd_required_varargs!(expireat, b"expireat", "EXPIREAT", "key", "timestamp", NotSubscriber);
cmd_required_varargs!(pexpire, b"pexpire", "PEXPIRE", "key", "milliseconds", NotSubscriber);
cmd_required_varargs!(pexpireat, b"pexpireat", "PEXPIREAT", "key", "milliseconds-timestamp", NotSubscriber);
```

- `cmd_required_varargs!` validates each named argument under its own name (so the existing `Expected key to be a string or buffer for 'pexpire'.` style messages, which tests snapshot, are unchanged) and forwards everything after them through a small `push_rest_args` helper.
- `expire()` keeps its integer validation of `seconds` (#36835) and forwards its tail through the same helper.
- `push_rest_args` skips `undefined`/`null` like the existing varargs generators do, so `expire(key, 10, opts.condition)` with an unset condition still sends plain `EXPIRE key 10`. The values themselves are forwarded as-is and validated by the server (`expire(k, 1, "BOGUS")` rejects with the server's `ERR Unsupported option BOGUS`), matching how `set`, `hexpire`, `zadd` etc. already treat their option arguments.
- `packages/bun-types/redis.d.ts`: `condition?: "NX" | "XX" | "GT" | "LT"` on the four expire methods (the union the `hexpire` family already declares) and `pfadd(key, ...elements: KeyLike[])`.

Why forwarding is the right layer: the client's job for these commands is to put the caller's arguments on the wire; the server owns the option grammar and already reports bad options precisely, and every other command with options in this file works that way. Duplicating the option table client-side would only add a second place to keep in sync with Redis/Valkey.

Observable changes beyond the bug itself:

- `pfadd(key)` with no elements is now sent (`PFADD key` creates an empty HyperLogLog, which is valid Redis syntax) instead of throwing.
- A non-string/buffer value after the required arguments (for example `expire(k, 5, {})`) now throws `Expected additional arguments to be a string or buffer ...`, the same error the other varargs commands raise; previously it was silently ignored.

### Relationship to #37574

#37574 fixes the last two sites with this shape (`bitcount`'s range, `hscan`'s cursor) and adds the same generator. The two branches deliberately use the same macro name, invocation syntax, generator-list entry and `RedisClient command encoding` test harness, so a dry-run merge of the two leaves exactly one generator and one harness; the only non-trivial conflict is the generator's tail (this branch routes it through `push_rest_args` because `expire()` needs the same loop; #37574 inlines it), and the remaining conflicts are the tests and fixture lines each branch appends. Whichever lands second resolves those by keeping `push_rest_args` and both sets of tests; no registration on either side needs to change.

### Verification

`test/js/valkey/valkey.test.ts`:

- `RedisClient command encoding` (no docker): a small in-process RESP server records what the client writes. Asserts the exact argv for `pfadd` with several elements, with a `Buffer` element and with only a key; for all four expire methods with a condition (including a `Buffer` key); and for all four without a condition or with an explicit `undefined`. On the unfixed build the first two tests fail (the trailing arguments are missing from the frames and `pfadd(key)` throws); the third pins the unchanged two-argument form.
- `RedisClient argument validation` (no docker): the required-argument messages are unchanged for all five methods, a condition is not promoted into a missing time argument's slot, `expire()`'s seconds validation still runs, and a non-string trailing argument is rejected by name for all five (the last of these fails on the unfixed build, where the argument was ignored).
- Docker-backed suite (runs for TCP and TLS in CI; passed against the redis 8 container in build 92389 and against a local redis-server 8.0.2 here, failing on the unfixed build in both cases): `NX` on a key that already has a TTL returns 0 and leaves the TTL alone for all four methods, `XX`/`GT`/`LT` behave as documented, an unknown option is rejected by the server, and a three-element `pfadd` gives `PFCOUNT` 3.

`test/integration/bun-types/fixture/redis.ts` exercises the new declarations, including that an invalid condition and a second condition are rejected by the type checker (`bun test test/integration/bun-types/bun-types.test.ts` passes with and without lib.dom).

`cargo fmt --check` and `cargo clippy -p bun_runtime` are clean.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 920 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (f97fe2ed0)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release without fix: 3 failed, 920 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME overwr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 920 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (f97fe2ed0)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release with fix: 920 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1278ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/37] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/37] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/37] gen cpp.rs (cppbind)
[4/37] gen JS modules (bundle-modules)
Preprocess modules (14022ms)
Bundle modules (252ms)
Postprocesss modules (443ms)
Bundle Functions (1359ms)
Generate Code (40ms)

[16.14s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/30] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/redis.d.ts                 |  45 ++++--
 src/runtime/valkey_jsc/js_valkey_functions.rs |  96 ++++++++++-
 test/integration/bun-types/fixture/redis.ts   |  14 ++
 test/js/valkey/valkey.test.ts                 | 225 ++++++++++++++++++++++++++
 4 files changed, 362 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-types/redis.d.ts                      3      6      0
src/runtime/valkey_jsc/js_valkey_functions.rs      9     18      0
test/integration/bun-types/fixture/redis.ts        1      1      0
test/js/valkey/valkey.test.ts                      7      9      0
```

</details>

<!-- robobun:evidence:end -->