### PR TITLE
bun_jsc: URL constructors return OwnedURL, port() returns Option<u16>

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -162,14 +162,12 @@ WHATWG-compliant, backed by WebKit's URL parser. Returns `None` for invalid inpu
 ```rust
 use bun_jsc::URL;
 
-let url = URL::from_utf8(href)?;                  // Option<NonNull<URL>>
-// caller owns the C++ object — destroy it when done:
-// unsafe { URL::destroy(url.as_ptr()) }
+let url = URL::from_utf8(href)?;                  // Option<OwnedURL>: derefs to URL, deletes the WTF::URL on drop
 
 url.protocol()   // bun_core::String
 url.pathname()   // bun_core::String
 url.host()       // bun_core::String — the hostname WITHOUT the port (opposite of JS `host`!)
-url.port()       // u32 (u32::MAX = unset; otherwise u16 range)
+url.port()       // Option<u16> (None = unset)
 ```
 
 `URL::href_from_js`, `URL::file_url_from_string`, `URL::path_from_file_url`

--- a/src/jsc/URL.rs
+++ b/src/jsc/URL.rs
@@ -13,8 +13,8 @@ bun_opaque::opaque_ffi! {
 // ABI-identical to non-null `*mut String`. `URL__deinit` consumes the C++
 // allocation, so it keeps a raw pointer and stays `unsafe fn`.
 unsafe extern "C" {
-    safe fn URL__fromJS(value: JSValue, global: &JSGlobalObject) -> *mut URL;
-    safe fn URL__fromString(input: &mut String) -> *mut URL;
+    safe fn URL__fromJS(value: JSValue, global: &JSGlobalObject) -> Option<NonNull<URL>>;
+    safe fn URL__fromString(input: &mut String) -> Option<NonNull<URL>>;
     safe fn URL__protocol(url: &URL) -> String;
     safe fn URL__username(url: &URL) -> String;
     safe fn URL__password(url: &URL) -> String;
@@ -25,6 +25,28 @@ unsafe extern "C" {
     safe fn URL__getHrefFromJS(value: JSValue, global: &JSGlobalObject) -> String;
     safe fn URL__getFileURLString(input: &mut String) -> String;
     safe fn URL__pathFromFileURL(input: &mut String) -> String;
+}
+
+/// Owns the `new WTF::URL` handed back by `URL__fromJS` / `URL__fromString` and deletes it on drop.
+#[repr(transparent)]
+pub struct OwnedURL(NonNull<URL>);
+
+impl core::ops::Deref for OwnedURL {
+    type Target = URL;
+
+    #[inline]
+    fn deref(&self) -> &URL {
+        // SAFETY: `self.0` is the live heap `WTF::URL` this handle owns until `drop`.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl Drop for OwnedURL {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is a C++ `new WTF::URL` and this handle is its only owner.
+        unsafe { URL__deinit(self.0.as_ptr()) }
+    }
 }
 
 impl URL {
@@ -46,20 +68,18 @@ impl URL {
     }
 
     #[track_caller]
-    pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<NonNull<URL>>> {
-        crate::call_check_slow(global, || URL__fromJS(value, global)).map(NonNull::new)
+    pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<OwnedURL>> {
+        crate::call_check_slow(global, || URL__fromJS(value, global).map(OwnedURL))
     }
 
-    pub fn from_utf8(input: &[u8]) -> Option<NonNull<URL>> {
+    pub fn from_utf8(input: &[u8]) -> Option<OwnedURL> {
         Self::from_string(String::borrow_utf8(input))
     }
 
-    pub fn from_string(str: String) -> Option<NonNull<URL>> {
+    pub fn from_string(str: String) -> Option<OwnedURL> {
         let mut input = str;
-        NonNull::new(URL__fromString(&mut input))
+        URL__fromString(&mut input).map(OwnedURL)
     }
-    // from_js/from_string/from_utf8 return an owned C++ heap pointer that the
-    // caller must destroy().
 
     pub fn protocol(&self) -> String {
         URL__protocol(self)
@@ -85,17 +105,9 @@ impl URL {
         URL__host(self)
     }
 
-    /// Returns `u32::MAX` if the port is not set. Otherwise, `port`
-    /// is guaranteed to be within the `u16` range.
-    pub fn port(&self) -> u32 {
-        URL__port(self)
-    }
-
-    // Kept as explicit destroy (not Drop) — URL is an opaque #[repr(C)] FFI
-    // handle constructed/destroyed across the C++ boundary.
-    pub unsafe fn destroy(this: *mut Self) {
-        // SAFETY: `this` is a valid *URL from C++; freed exactly once
-        unsafe { URL__deinit(this) }
+    /// `None` when the URL has no port, which `URL__port` encodes as `u32::MAX`.
+    pub fn port(&self) -> Option<u16> {
+        u16::try_from(URL__port(self)).ok()
     }
 
     pub fn pathname(&self) -> String {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -833,7 +833,7 @@ mod __macro_smoke {
 // newtypes; the real opaque-FFI structs now live in their own files and are
 // surfaced here at the crate root.
 pub use self::dom_form_data::DOMFormData;
-pub use self::url::URL;
+pub use self::url::{OwnedURL, URL};
 pub use self::zig_stack_frame::ZigStackFrame;
 pub use self::zig_stack_trace::ZigStackTrace;
 pub use abort_signal::{AbortSignal, AbortSignalRef};

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -209,24 +209,11 @@ impl SocketAddress {
             OwnedString::new(str)
         };
 
-        let Some(url_ptr) = URL::from_string(url_str.get()) else {
+        let Some(url) = URL::from_string(url_str.get()) else {
             return Ok(JSValue::UNDEFINED);
         };
-        // SAFETY: URL::from_string returns an owned C++ heap pointer; freed exactly once via destroy().
-        let _url_guard = scopeguard::guard(url_ptr, |p| unsafe { URL::destroy(p.as_ptr()) });
-        // `_url_guard` keeps the C++ allocation live for this scope, so the
-        // `BackRef` liveness invariant holds; `Deref` encapsulates the single
-        // `NonNull::as_ref` site.
-        let url = bun_ptr::BackRef::from(url_ptr);
         let host: BunString = url.host();
-        let port_: u16 = {
-            let port32 = url.port();
-            if port32 > u32::from(u16::MAX) {
-                0
-            } else {
-                u16::try_from(port32).expect("int cast")
-            }
-        };
+        let port_: u16 = url.port().unwrap_or(0);
         debug_assert!(host.tag() != bun_core::Tag::Dead);
         debug_assert!(host.length() >= 2);
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1,6 +1,5 @@
 use core::cell::Cell;
 use core::ffi::c_void;
-use core::ptr::NonNull;
 
 use crate::socket::{SSLConfig, SSLConfigFromJs};
 use bun_boringssl as boringssl;
@@ -19,7 +18,7 @@ use super::protocol_jsc;
 use super::valkey;
 use super::valkey_command_body as command;
 use super::valkey_command_body::Command;
-use bun_jsc::url::URL;
+use bun_jsc::url::{OwnedURL, URL};
 use bun_valkey::valkey_protocol as protocol;
 
 /// `bun.JSTerminated!T`
@@ -587,7 +586,7 @@ impl JSValkeyClient {
         // the case right now and I do not understand why. It will take some work in JSC to
         // understand why this is happening, but since I need to uncork valkey, I'm adding this as
         // a stop-gap.
-        let parsed_url: NonNull<URL> = 'get_url: {
+        let parsed_url: OwnedURL = 'get_url: {
             let url_slice = url_str.to_utf8();
             let url_byte_slice = url_slice.slice();
 
@@ -632,13 +631,6 @@ impl JSValkeyClient {
                 }
             }
         };
-        // SAFETY: `from_utf8` heap-allocates; release on scope exit.
-        let _parsed_url_drop =
-            scopeguard::guard(parsed_url, |p| unsafe { URL::destroy(p.as_ptr()) });
-        // `_parsed_url_drop` keeps the heap `URL` live for this scope, so the
-        // `BackRef` liveness invariant holds; `Deref` encapsulates the single
-        // `NonNull::as_ref` site.
-        let parsed_url = bun_ptr::BackRef::from(parsed_url);
 
         // Extract protocol string
         let protocol_str = parsed_url.protocol();
@@ -691,28 +683,15 @@ impl JSValkeyClient {
 
         let port: u16 = match uri {
             valkey::Protocol::StandaloneUnix | valkey::Protocol::StandaloneTlsUnix => 0,
-            _ => 'brk: {
-                let port_value = parsed_url.port();
-                // URL.port() returns u32::MAX if port is not set
-                if port_value == u32::MAX {
-                    // No port specified, use default
-                    break 'brk 6379;
-                } else {
-                    // Port was explicitly specified
-                    if port_value == 0 {
-                        // Port 0 is invalid for TCP connections (though it's allowed for unix sockets)
-                        return Err(global_object.throw_invalid_arguments(format_args!(
-                            "Port 0 is not valid for TCP connections",
-                        )));
-                    }
-                    if port_value > 65535 {
-                        return Err(global_object.throw_invalid_arguments(format_args!(
-                            "Invalid port number in URL. Port must be a number between 0 and 65535",
-                        )));
-                    }
-                    break 'brk u16::try_from(port_value).expect("int cast");
+            _ => match parsed_url.port() {
+                None => 6379,
+                Some(0) => {
+                    return Err(global_object.throw_invalid_arguments(format_args!(
+                        "Port 0 is not valid for TCP connections",
+                    )));
                 }
-            }
+                Some(port) => port,
+            },
         };
 
         let options = if arguments.len() >= 2


### PR DESCRIPTION
## What

`bun_jsc::URL::from_js`, `from_utf8` and `from_string` returned `Option<NonNull<URL>>` pointing at a C++ `new WTF::URL`, and every caller was responsible for calling `pub unsafe fn URL::destroy`. `URL::port()` returned `u32` with `u32::MAX` standing in for "no port". The two users (`runtime/valkey_jsc/js_valkey.rs` and `runtime/socket/SocketAddress.rs`) each rebuilt the same RAII by hand: a `scopeguard` closure calling `URL::destroy` plus a `bun_ptr::BackRef` to dereference, and each decoded the port sentinel itself.

`URL.rs` now has an owning handle, and the constructors return it:

```rust
#[repr(transparent)]
pub struct OwnedURL(NonNull<URL>);          // Deref<Target = URL>; Drop calls URL__deinit

pub fn from_string(str: String) -> Option<OwnedURL>
pub fn from_utf8(input: &[u8]) -> Option<OwnedURL>
pub fn from_js(..) -> JsResult<Option<OwnedURL>>   // no in-tree callers, converted for consistency
pub fn port(&self) -> Option<u16>                   // was u32 with a u32::MAX sentinel
```

`URL::destroy` is deleted. The `URL__fromJS` / `URL__fromString` declarations return `Option<NonNull<URL>>` (the same shape `bun_url::whatwg` already uses for these symbols); the C++ side is untouched. At the two call sites the guard and `BackRef` lines go away: `js_valkey.rs` binds `let parsed_url: OwnedURL = ...` and its port handling becomes a three-arm match (`None` defaults to 6379, `Some(0)` throws, `Some(p)` is the port), which also deletes an unreachable `> 65535` error branch and an `expect`; `SocketAddress::parse` becomes `let Some(url) = URL::from_string(..) else { .. }` and `url.port().unwrap_or(0)`. Removes 3 `unsafe` blocks (the `destroy` body and the two guard closures) and adds the 2 audited ones inside `OwnedURL` (`Deref`, `Drop`), so `bun_runtime` has no `unsafe` left for URL handling. The `URL` snippet in `src/CLAUDE.md` is updated to match. `OwnedURL` is also re-exported at the crate root next to `URL`.

## Why

Who frees the `WTF::URL`, and when, is now stated by the type: an `OwnedURL` value deletes it exactly once when it goes out of scope on every return path, and a `None` port is no longer a magic `u32` value each caller has to know about. It is zero-cost: `Option<OwnedURL>` is `#[repr(transparent)]` over `NonNull<URL>` and therefore the same single nullable pointer as before, `Drop` emits the same `URL__deinit` call the scopeguards emitted at the same scope exit, and `port()` performs the one comparison both callers already performed (`WTF::URL::port()` is `std::optional<uint16_t>`, so `u16::try_from(..).ok()` decodes the shim's `u32::MAX` sentinel exactly).

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/regression/issue/23621.test.ts test/js/node/net/socketaddress.spec.ts test/js/valkey/valkey-tls-verify.test.ts test/js/valkey/reliability/connection-failures.test.ts: 87 pass, 14 skip, 0 fail across 4 files (23621: 13 pass; socketaddress: 66 pass, 1 skip; valkey-tls-verify: 7 pass; connection-failures: 1 pass, 13 skipped because no local Valkey server is available).
