### PR TITLE
redis: validate required command arguments by name and forward bitcount's range

### DIFF
--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -2537,6 +2537,29 @@ declare module "bun" {
     bitcount(key: RedisClient.KeyLike): Promise<number>;
 
     /**
+     * Count the number of set bits (population counting) in a range of a string
+     *
+     * `start` and `end` are inclusive and may be negative to count from the end
+     * of the string. They are byte offsets unless `unit` is `"BIT"`, in which
+     * case they are bit offsets (Redis 7.0+ / Valkey).
+     * @param key The key to count bits in
+     * @param start The first offset of the range
+     * @param end The last offset of the range
+     * @param unit Literal "BYTE" (the default) or "BIT" selecting what `start` and `end` are measured in
+     * @returns Promise that resolves with the number of bits set to 1 within the range
+     *
+     * @example
+     * ```ts
+     * await redis.set("mykey", "foobar");
+     * await redis.bitcount("mykey"); // 26
+     * await redis.bitcount("mykey", 0, 0); // 4
+     * await redis.bitcount("mykey", 1, 1); // 6
+     * await redis.bitcount("mykey", 5, 30, "BIT"); // 17
+     * ```
+     */
+    bitcount(key: RedisClient.KeyLike, start: number, end: number, unit?: "BYTE" | "BIT"): Promise<number>;
+
+    /**
      * Returns the bit value at offset in the string value stored at key
      * @param key The key containing the string value
      * @param offset The bit offset (zero-based)

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -76,6 +76,29 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
     JSArgument::from_js_maybe_file(global, value, FileBlobs::Allow)
 }
 
+/// Optional trailing arguments; `undefined`/`null` are skipped so an omitted option sends nothing.
+fn push_rest_args(
+    global: &JSGlobalObject,
+    function_name: &'static [u8],
+    args: &mut Vec<JSArgument>,
+    rest: &[JSValue],
+) -> JsResult<()> {
+    for arg in rest {
+        if arg.is_undefined_or_null() {
+            continue;
+        }
+        let Some(value) = from_js(global, *arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                bname(function_name),
+                "additional arguments",
+                "string or buffer",
+            ));
+        };
+        args.push(value);
+    }
+    Ok(())
+}
+
 /// Shim around `protocol::valkey_error_to_js` that:
 /// 1. accepts whatever error type `JSValkeyClient::send` currently returns
 ///    (presently `crate::Error`) and
@@ -101,7 +124,7 @@ fn promise_to_js(p: *mut JSPromise) -> JSValue {
 /// `this.send()` it, and convert the result to a `JsResult<JSValue>` —
 /// `Ok(promise.toJS())` on success, a JS-side Redis error value on failure.
 ///
-/// All 7 `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
+/// All 6 `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
 /// `set`, `incr`, `decr`, `exists`, `expire`, `ttl`, `srem`, `sadd`,
 /// `sismember`, `hmget`, `hincrby`, `hset`, `smove`, `publish`,
 /// `send_unsubscribe_request_and_cleanup`, …) duplicated this 15-line block
@@ -162,11 +185,10 @@ pub(crate) mod compile {
 // Note: each command-shape generator is a `macro_rules!` that emits a
 // `#[bun_jsc::host_fn(method)]` inside the `impl JSValkeyClient` block:
 // cmd_noargs! (), cmd_key! (key: RedisKey),
-// cmd_key_varargs! (key: RedisKey, ...args: RedisKey[]),
 // cmd_key_value! (key: RedisKey, value: RedisValue),
 // cmd_key_value_value2! (key: RedisKey, value: RedisValue, value2: RedisValue),
+// cmd_required_varargs! (required0: RedisValue, ..., requiredN: RedisValue, ...optional: RedisValue[]),
 // cmd_strings_varargs! (...strings: string[]),
-// cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue)
 
 macro_rules! cmd_noargs {
     ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
@@ -217,52 +239,6 @@ macro_rules! cmd_key {
                 frame.this(),
                 $command.as_bytes(),
                 CommandArgs::Args(&[key]),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
-    };
-}
-
-macro_rules! cmd_key_varargs {
-    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            if frame.argument(0).is_undefined_or_null() {
-                return Err(global.throw_missing_arguments_value(&[$arg0_name]));
-            }
-
-            let arguments = frame.arguments();
-            let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
-
-            for arg in arguments {
-                if arg.is_undefined_or_null() {
-                    continue;
-                }
-
-                let Some(another) = from_js(global, *arg)? else {
-                    return Err(global.throw_invalid_argument_type(
-                        bname($name),
-                        "additional arguments",
-                        "string or buffer",
-                    ));
-                };
-                args.push(another);
-            }
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&args),
                 CommandMeta::default(),
                 concat!("Failed to send ", $command),
             )
@@ -355,6 +331,53 @@ macro_rules! cmd_key_value_value2 {
     };
 }
 
+macro_rules! cmd_required_varargs {
+    ($fn_name:ident, $name:literal, $command:literal, $($required_name:literal,)+ $state:ident) => {
+        #[bun_jsc::host_fn(method)]
+        pub fn $fn_name(
+            this: &Self,
+            global: &JSGlobalObject,
+            frame: &CallFrame,
+        ) -> JsResult<JSValue> {
+            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
+                this, $name,
+            )?;
+
+            const REQUIRED: &[&str] = &[$($required_name),+];
+
+            let arguments = frame.arguments();
+            let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
+
+            for (index, required_name) in REQUIRED.iter().copied().enumerate() {
+                let Some(required) = from_js(global, frame.argument(index))? else {
+                    return Err(global.throw_invalid_argument_type(
+                        bname($name),
+                        required_name,
+                        "string or buffer",
+                    ));
+                };
+                args.push(required);
+            }
+
+            push_rest_args(
+                global,
+                $name,
+                &mut args,
+                arguments.get(REQUIRED.len()..).unwrap_or_default(),
+            )?;
+            send_cmd(
+                this,
+                global,
+                frame.this(),
+                $command.as_bytes(),
+                CommandArgs::Args(&args),
+                CommandMeta::default(),
+                concat!("Failed to send ", $command),
+            )
+        }
+    };
+}
+
 macro_rules! cmd_strings_varargs {
     ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
         cmd_strings_varargs!($fn_name, $name, $command, $state, CommandMeta::default());
@@ -389,47 +412,6 @@ macro_rules! cmd_strings_varargs {
                 $command.as_bytes(),
                 CommandArgs::Args(&args),
                 $meta,
-                concat!("Failed to send ", $command),
-            )
-        }
-    };
-}
-
-macro_rules! cmd_key_value_varargs {
-    ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
-
-            for arg in frame.arguments() {
-                if arg.is_undefined_or_null() {
-                    continue;
-                }
-
-                let Some(another) = from_js(global, *arg)? else {
-                    return Err(global.throw_invalid_argument_type(
-                        bname($name),
-                        "additional arguments",
-                        "string or buffer",
-                    ));
-                };
-                args.push(another);
-            }
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&args),
-                CommandMeta::default(),
                 concat!("Failed to send ", $command),
             )
         }
@@ -1200,15 +1182,15 @@ impl JSValkeyClient {
         Self::hset_impl(this, global, frame, b"HMSET")
     }
 
-    cmd_key_varargs!(hdel, b"hdel", "HDEL", "key", NotSubscriber);
-    cmd_key_varargs!(
+    cmd_required_varargs!(hdel, b"hdel", "HDEL", "key", "field", NotSubscriber);
+    cmd_required_varargs!(
         hrandfield,
         b"hrandfield",
         "HRANDFIELD",
         "key",
         NotSubscriber
     );
-    cmd_key_varargs!(hscan, b"hscan", "HSCAN", "key", NotSubscriber);
+    cmd_required_varargs!(hscan, b"hscan", "HSCAN", "key", "cursor", NotSubscriber);
     cmd_strings_varargs!(hgetdel, b"hgetdel", "HGETDEL", NotSubscriber);
     cmd_strings_varargs!(hgetex, b"hgetex", "HGETEX", NotSubscriber);
     cmd_strings_varargs!(hsetex, b"hsetex", "HSETEX", NotSubscriber);
@@ -1311,7 +1293,7 @@ impl JSValkeyClient {
         )
     }
 
-    cmd_key!(bitcount, b"bitcount", "BITCOUNT", "key", NotSubscriber);
+    cmd_required_varargs!(bitcount, b"bitcount", "BITCOUNT", "key", NotSubscriber);
     cmd_strings_varargs!(blmove, b"blmove", "BLMOVE", NotSubscriber);
     cmd_strings_varargs!(blmpop, b"blmpop", "BLMPOP", NotSubscriber);
     cmd_strings_varargs!(blpop, b"blpop", "BLPOP", NotSubscriber);
@@ -1381,7 +1363,7 @@ impl JSValkeyClient {
     cmd_key!(llen, b"llen", "LLEN", "key", NotSubscriber);
     cmd_strings_varargs!(lmove, b"lmove", "LMOVE", NotSubscriber);
     cmd_strings_varargs!(lmpop, b"lmpop", "LMPOP", NotSubscriber);
-    cmd_key_varargs!(lpop, b"lpop", "LPOP", "key", NotSubscriber);
+    cmd_required_varargs!(lpop, b"lpop", "LPOP", "key", NotSubscriber);
     cmd_strings_varargs!(lpos, b"lpos", "LPOS", NotSubscriber);
     cmd_key_value_value2!(
         lrange,
@@ -1445,7 +1427,7 @@ impl JSValkeyClient {
     );
     cmd_key!(pttl, b"pttl", "PTTL", "key", NotSubscriber);
     cmd_noargs!(randomkey, b"randomkey", "RANDOMKEY", NotSubscriber);
-    cmd_key_varargs!(rpop, b"rpop", "RPOP", "key", NotSubscriber);
+    cmd_required_varargs!(rpop, b"rpop", "RPOP", "key", NotSubscriber);
     cmd_key_value!(
         rpoplpush,
         b"rpoplpush",
@@ -1486,9 +1468,9 @@ impl JSValkeyClient {
         "max",
         NotSubscriber
     );
-    cmd_key_varargs!(zpopmax, b"zpopmax", "ZPOPMAX", "key", NotSubscriber);
-    cmd_key_varargs!(zpopmin, b"zpopmin", "ZPOPMIN", "key", NotSubscriber);
-    cmd_key_varargs!(
+    cmd_required_varargs!(zpopmax, b"zpopmax", "ZPOPMAX", "key", NotSubscriber);
+    cmd_required_varargs!(zpopmin, b"zpopmin", "ZPOPMIN", "key", NotSubscriber);
+    cmd_required_varargs!(
         zrandmember,
         b"zrandmember",
         "ZRANDMEMBER",
@@ -1509,18 +1491,22 @@ impl JSValkeyClient {
         "ZREVRANGEBYSCORE",
         NotSubscriber
     );
-    cmd_key_varargs!(
+    cmd_required_varargs!(
         zrangebylex,
         b"zrangebylex",
         "ZRANGEBYLEX",
         "key",
+        "min",
+        "max",
         NotSubscriber
     );
-    cmd_key_varargs!(
+    cmd_required_varargs!(
         zrevrangebylex,
         b"zrevrangebylex",
         "ZREVRANGEBYLEX",
         "key",
+        "max",
+        "min",
         NotSubscriber
     );
     cmd_key_value!(append, b"append", "APPEND", "key", "value", NotSubscriber);
@@ -1550,11 +1536,11 @@ impl JSValkeyClient {
         "decrement",
         NotSubscriber
     );
-    cmd_key_value_varargs!(lpush, b"lpush", "LPUSH", NotSubscriber);
-    cmd_key_value_varargs!(lpushx, b"lpushx", "LPUSHX", NotSubscriber);
+    cmd_required_varargs!(lpush, b"lpush", "LPUSH", "key", "value", NotSubscriber);
+    cmd_required_varargs!(lpushx, b"lpushx", "LPUSHX", "key", "value", NotSubscriber);
     cmd_key_value!(pfadd, b"pfadd", "PFADD", "key", "value", NotSubscriber);
-    cmd_key_value_varargs!(rpush, b"rpush", "RPUSH", NotSubscriber);
-    cmd_key_value_varargs!(rpushx, b"rpushx", "RPUSHX", NotSubscriber);
+    cmd_required_varargs!(rpush, b"rpush", "RPUSH", "key", "value", NotSubscriber);
+    cmd_required_varargs!(rpushx, b"rpushx", "RPUSHX", "key", "value", NotSubscriber);
     cmd_key_value!(setnx, b"setnx", "SETNX", "key", "value", NotSubscriber);
     cmd_key_value_value2!(
         setex,
@@ -1584,7 +1570,14 @@ impl JSValkeyClient {
         "member",
         NotSubscriber
     );
-    cmd_key_value_varargs!(zmscore, b"zmscore", "ZMSCORE", NotSubscriber);
+    cmd_required_varargs!(
+        zmscore,
+        b"zmscore",
+        "ZMSCORE",
+        "key",
+        "member",
+        NotSubscriber
+    );
     cmd_strings_varargs!(zadd, b"zadd", "ZADD", NotSubscriber);
     cmd_strings_varargs!(zscan, b"zscan", "ZSCAN", NotSubscriber);
     cmd_strings_varargs!(zdiff, b"zdiff", "ZDIFF", NotSubscriber);
@@ -1598,8 +1591,8 @@ impl JSValkeyClient {
     cmd_strings_varargs!(bzmpop, b"bzmpop", "BZMPOP", NotSubscriber);
     cmd_strings_varargs!(bzpopmin, b"bzpopmin", "BZPOPMIN", NotSubscriber);
     cmd_strings_varargs!(bzpopmax, b"bzpopmax", "BZPOPMAX", NotSubscriber);
-    cmd_key_varargs!(del, b"del", "DEL", "key", NotSubscriber);
-    cmd_key_varargs!(mget, b"mget", "MGET", "key", NotSubscriber);
+    cmd_required_varargs!(del, b"del", "DEL", "key", NotSubscriber);
+    cmd_required_varargs!(mget, b"mget", "MGET", "key", NotSubscriber);
     cmd_strings_varargs!(mset, b"mset", "MSET", NotSubscriber);
     cmd_strings_varargs!(msetnx, b"msetnx", "MSETNX", NotSubscriber);
     cmd_strings_varargs!(script, b"script", "SCRIPT", NotSubscriber);
@@ -1662,9 +1655,9 @@ impl JSValkeyClient {
         "field",
         NotSubscriber
     );
-    cmd_key_varargs!(zrank, b"zrank", "ZRANK", "key", NotSubscriber);
+    cmd_required_varargs!(zrank, b"zrank", "ZRANK", "key", "member", NotSubscriber);
     cmd_strings_varargs!(zrangestore, b"zrangestore", "ZRANGESTORE", NotSubscriber);
-    cmd_key_varargs!(zrem, b"zrem", "ZREM", "key", NotSubscriber);
+    cmd_required_varargs!(zrem, b"zrem", "ZREM", "key", "member", NotSubscriber);
     cmd_key_value_value2!(
         zremrangebylex,
         b"zremrangebylex",
@@ -1692,7 +1685,14 @@ impl JSValkeyClient {
         "max",
         NotSubscriber
     );
-    cmd_key_varargs!(zrevrank, b"zrevrank", "ZREVRANK", "key", NotSubscriber);
+    cmd_required_varargs!(
+        zrevrank,
+        b"zrevrank",
+        "ZREVRANK",
+        "key",
+        "member",
+        NotSubscriber
+    );
     cmd_strings_varargs!(
         psubscribe,
         b"psubscribe",
@@ -1709,8 +1709,8 @@ impl JSValkeyClient {
     );
     cmd_strings_varargs!(pubsub, b"pubsub", "PUBSUB", DontCare);
     cmd_strings_varargs!(copy, b"copy", "COPY", NotSubscriber);
-    cmd_key_varargs!(unlink, b"unlink", "UNLINK", "key", NotSubscriber);
-    cmd_key_varargs!(touch, b"touch", "TOUCH", "key", NotSubscriber);
+    cmd_required_varargs!(unlink, b"unlink", "UNLINK", "key", NotSubscriber);
+    cmd_required_varargs!(touch, b"touch", "TOUCH", "key", NotSubscriber);
     cmd_key_value!(rename, b"rename", "RENAME", "key", "newkey", NotSubscriber);
     cmd_key_value!(
         renamenx,

--- a/test/integration/bun-types/fixture/redis.ts
+++ b/test/integration/bun-types/fixture/redis.ts
@@ -34,6 +34,14 @@ const redis = Bun.redis;
 const buf = Buffer.from("key");
 
 // Bitmap
+expectType(redis.bitcount("key")).is<Promise<number>>();
+expectType(redis.bitcount("key", 0, -1)).is<Promise<number>>();
+expectType(redis.bitcount("key", 5, 30, "BIT")).is<Promise<number>>();
+expectType(redis.bitcount(buf, 1, 1, "BYTE")).is<Promise<number>>();
+// @ts-expect-error - BITCOUNT takes start and end together
+redis.bitcount("key", 0);
+// @ts-expect-error - the unit is BYTE or BIT
+redis.bitcount("key", 0, -1, "NIBBLE");
 expectType(redis.bitop("NOT", "dest", "k1")).is<Promise<number>>();
 expectType(redis.bitop("not", "dest", buf)).is<Promise<number>>();
 expectType(redis.bitop("AND", "dest", "k1")).is<Promise<number>>();

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -440,6 +440,25 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         expect(count).toBe(3);
       });
 
+      test("should count bits within a range with BITCOUNT", async () => {
+        const redis = ctx.redis;
+        const key = "bitcount-range";
+        // "foobar" has 26 set bits: 'f' = 4, 'o' = 6, 'o' = 6, 'b' = 3, 'a' = 3, 'r' = 4.
+        await redis.set(key, "foobar");
+
+        expect(
+          await Promise.all([
+            redis.bitcount(key),
+            redis.bitcount(key, 0, 0),
+            redis.bitcount(key, 1, 1),
+            redis.bitcount(key, 1, 1, "BYTE"),
+            redis.bitcount(key, -1, -1),
+            redis.bitcount(key, 5, 30, "BIT"),
+            redis.bitcount(key, 0, -1),
+          ]),
+        ).toEqual([26, 4, 6, 6, 4, 17, 26]);
+      });
+
       test("should get range of string", async () => {
         const redis = ctx.redis;
         const key = "rangetest";
@@ -990,7 +1009,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const redis = ctx.redis;
         expect(async () => {
           await redis.unlink({} as any);
-        }).toThrowErrorMatchingInlineSnapshot(`"Expected additional arguments to be a string or buffer for 'unlink'."`);
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'unlink'."`);
       });
 
       test("should reject invalid additional key in UNLINK", async () => {
@@ -1004,7 +1023,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const redis = ctx.redis;
         expect(async () => {
           await redis.touch(null as any);
-        }).toThrowErrorMatchingInlineSnapshot(`"The "key" argument must be specified"`);
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'touch'."`);
       });
 
       test("should reject invalid additional key in TOUCH", async () => {
@@ -3395,16 +3414,14 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const redis = ctx.redis;
         expect(async () => {
           await redis.zrem({} as any, "member");
-        }).toThrowErrorMatchingInlineSnapshot(`"Expected additional arguments to be a string or buffer for 'zrem'."`);
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'zrem'."`);
       });
 
       test("should reject invalid key in ZMSCORE", async () => {
         const redis = ctx.redis;
         expect(async () => {
           await redis.zmscore([] as any, "member");
-        }).toThrowErrorMatchingInlineSnapshot(
-          `"Expected additional arguments to be a string or buffer for 'zmscore'."`,
-        );
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'zmscore'."`);
       });
 
       test("should add members to sorted set with ZADD", async () => {
@@ -4279,7 +4296,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const redis = ctx.redis;
         expect(async () => {
           await redis.zrangebylex(null as any, "-", "+");
-        }).toThrowErrorMatchingInlineSnapshot(`"The "key" argument must be specified"`);
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'zrangebylex'."`);
       });
 
       test("should return members in reverse lexicographical order with ZREVRANGEBYLEX", async () => {
@@ -4381,9 +4398,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const redis = ctx.redis;
         expect(async () => {
           await redis.zrevrangebylex({} as any, "+", "-");
-        }).toThrowErrorMatchingInlineSnapshot(
-          `"Expected additional arguments to be a string or buffer for 'zrevrangebylex'."`,
-        );
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'zrevrangebylex'."`);
       });
 
       test("should reject invalid destination in ZRANGESTORE", async () => {
@@ -7518,6 +7533,94 @@ describe("RedisClient argument validation", () => {
       client.close();
     }
   });
+
+  test("hscan() rejects a missing cursor instead of sending `HSCAN key`", () => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    try {
+      const expected = {
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected cursor to be a string or buffer for 'hscan'.",
+      };
+      // @ts-expect-error: testing runtime behavior with a missing argument
+      expect(syncThrow(() => client.hscan("h"))).toMatchObject(expected);
+      // @ts-expect-error: testing runtime behavior with an explicit undefined
+      expect(syncThrow(() => client.hscan("h", undefined))).toMatchObject(expected);
+      // @ts-expect-error: testing runtime behavior with an explicit null
+      expect(syncThrow(() => client.hscan("h", null))).toMatchObject(expected);
+      // @ts-expect-error: testing runtime behavior with a non-stringifiable cursor
+      expect(syncThrow(() => client.hscan("h", {}))).toMatchObject(expected);
+      // @ts-expect-error: testing runtime behavior with a MATCH clause in the cursor's slot
+      expect(syncThrow(() => client.hscan("h", undefined, "MATCH", "f*"))).toMatchObject(expected);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("hscan() and bitcount() report a bad key by name", () => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    try {
+      // @ts-expect-error: testing runtime behavior with no arguments
+      expect(syncThrow(() => client.hscan())).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected key to be a string or buffer for 'hscan'.",
+      });
+      expect(syncThrow(() => client.hscan({} as any, 0))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected key to be a string or buffer for 'hscan'.",
+      });
+      // @ts-expect-error: testing runtime behavior with no arguments
+      expect(syncThrow(() => client.bitcount())).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected key to be a string or buffer for 'bitcount'.",
+      });
+      expect(syncThrow(() => client.bitcount({} as any, 0, -1))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected key to be a string or buffer for 'bitcount'.",
+      });
+      expect(syncThrow(() => client.bitcount("k", {} as any, -1))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected additional arguments to be a string or buffer for 'bitcount'.",
+      });
+    } finally {
+      client.close();
+    }
+  });
+
+  // Every required positional of these commands used to be skipped when it was
+  // undefined/null, which shifted the arguments after it into its slot (e.g.
+  // `zrank(key, undefined, "WITHSCORE")` looked up a member called WITHSCORE,
+  // `rpush(undefined, "a", "b")` pushed "b" onto a list called "a").
+  test.each<[call: string, invoke: (client: any) => unknown, missingArgument: string]>([
+    ['hdel("h")', c => c.hdel("h"), "field"],
+    ['hdel("h", null, "f2")', c => c.hdel("h", null, "f2"), "field"],
+    ['zrem("z", undefined, "b")', c => c.zrem("z", undefined, "b"), "member"],
+    ['zrank("z", undefined, "WITHSCORE")', c => c.zrank("z", undefined, "WITHSCORE"), "member"],
+    ['zrevrank("z", null, "WITHSCORE")', c => c.zrevrank("z", null, "WITHSCORE"), "member"],
+    ['zrangebylex("z", undefined, "+")', c => c.zrangebylex("z", undefined, "+"), "min"],
+    ['zrangebylex("z", "-")', c => c.zrangebylex("z", "-"), "max"],
+    ['zrevrangebylex("z", undefined, "-")', c => c.zrevrangebylex("z", undefined, "-"), "max"],
+    ['zrevrangebylex("z", "+")', c => c.zrevrangebylex("z", "+"), "min"],
+    ['zmscore("z")', c => c.zmscore("z"), "member"],
+    ['lpush("l")', c => c.lpush("l"), "value"],
+    ['lpushx("l", null, "b")', c => c.lpushx("l", null, "b"), "value"],
+    ['rpush(undefined, "a", "b")', c => c.rpush(undefined, "a", "b"), "key"],
+    ['rpushx("l", undefined, "b")', c => c.rpushx("l", undefined, "b"), "value"],
+    // Commands whose only required argument is the key use the same generator and report it by name too.
+    ["del()", c => c.del(), "key"],
+    ['mget(null, "b")', c => c.mget(null, "b"), "key"],
+    ["lpop({})", c => c.lpop({}), "key"],
+  ])("%s throws instead of shifting the later arguments into the empty slot", (call, invoke, missingArgument) => {
+    const client = new RedisClient("redis://127.0.0.1:1", { autoReconnect: false });
+    try {
+      const command = call.slice(0, call.indexOf("("));
+      expect(syncThrow(() => invoke(client))).toMatchObject({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `Expected ${missingArgument} to be a string or buffer for '${command}'.`,
+      });
+    } finally {
+      client.close();
+    }
+  });
 });
 
 describe("RedisClient command methods", () => {
@@ -7577,5 +7680,170 @@ describe("RedisClient command methods", () => {
     "xsetid",
   ] as const)("RedisClient.prototype.%s is a function", name => {
     expect(typeof RedisClient.prototype[name]).toBe("function");
+  });
+});
+
+describe("RedisClient command encoding", () => {
+  const CRLF = "\r\n";
+  const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
+  const HELLO_REPLY = `%2${CRLF}` + bulk("server") + bulk("redis") + bulk("proto") + `:3${CRLF}`;
+
+  /**
+   * Runs `body` against a fake server that answers HELLO, replies `:0` to
+   * everything else and records every command it received as an argv array.
+   */
+  async function recordCommands(body: (client: RedisClient) => Promise<unknown>): Promise<string[][]> {
+    const received: string[][] = [];
+    using server = Bun.listen<{ buf: Buffer }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { buf: Buffer.alloc(0) };
+        },
+        error() {},
+        close() {},
+        data(socket, chunk) {
+          let buf = (socket.data.buf = Buffer.concat([socket.data.buf, chunk]));
+          // Each client command is a RESP array of bulk strings:
+          // `*<argc>\r\n` followed by argc `$<len>\r\n<bytes>\r\n` frames.
+          for (;;) {
+            const headerEnd = buf.indexOf(CRLF);
+            if (headerEnd < 0 || buf[0] !== 0x2a /* '*' */) break;
+            const argc = parseInt(buf.subarray(1, headerEnd).toString("latin1"), 10);
+            const argv: string[] = [];
+            let pos = headerEnd + 2;
+            let complete = true;
+            for (let i = 0; i < argc; i++) {
+              const lenEnd = buf.indexOf(CRLF, pos);
+              if (lenEnd < 0 || buf[pos] !== 0x24 /* '$' */) {
+                complete = false;
+                break;
+              }
+              const len = parseInt(buf.subarray(pos + 1, lenEnd).toString("latin1"), 10);
+              const next = lenEnd + 2 + len + 2;
+              if (next > buf.length) {
+                complete = false;
+                break;
+              }
+              argv.push(buf.subarray(lenEnd + 2, lenEnd + 2 + len).toString("latin1"));
+              pos = next;
+            }
+            if (!complete) break;
+            buf = socket.data.buf = buf.subarray(pos);
+            if (argv[0] === "HELLO") {
+              socket.write(HELLO_REPLY);
+            } else {
+              received.push(argv);
+              socket.write(`:0${CRLF}`);
+            }
+          }
+        },
+      },
+    });
+
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { autoReconnect: false });
+    try {
+      await client.connect();
+      await body(client);
+    } finally {
+      client.close();
+    }
+    return received;
+  }
+
+  test("bitcount() forwards the start/end range and the BYTE|BIT unit", async () => {
+    const received = await recordCommands(async client => {
+      await client.bitcount("k");
+      await client.bitcount("k", 0, 10);
+      await client.bitcount("k", -2, -1);
+      await client.bitcount("k", 5, 30, "BIT");
+      await client.bitcount("k", 1, 1, "BYTE");
+      await client.bitcount(Buffer.from("binary-key"), 0, 0);
+    });
+    expect(received).toEqual([
+      ["BITCOUNT", "k"],
+      ["BITCOUNT", "k", "0", "10"],
+      ["BITCOUNT", "k", "-2", "-1"],
+      ["BITCOUNT", "k", "5", "30", "BIT"],
+      ["BITCOUNT", "k", "1", "1", "BYTE"],
+      ["BITCOUNT", "binary-key", "0", "0"],
+    ]);
+  });
+
+  test("bitcount() with an undefined range still sends a plain BITCOUNT", async () => {
+    const received = await recordCommands(async client => {
+      // @ts-expect-error: testing runtime behavior when optional arguments are passed as undefined
+      await client.bitcount("k", undefined, undefined);
+    });
+    expect(received).toEqual([["BITCOUNT", "k"]]);
+  });
+
+  test("hscan() forwards the cursor and its MATCH/COUNT/NOVALUES options", async () => {
+    const received = await recordCommands(async client => {
+      await client.hscan("h", 0);
+      await client.hscan("h", "42");
+      await client.hscan("h", 0, "MATCH", "field:*");
+      await client.hscan("h", 0, "COUNT", 25);
+      await client.hscan("h", 0, "MATCH", "field:*", "COUNT", 25);
+      // @ts-expect-error: NOVALUES is a Redis 7.4+ option not yet in the typings
+      await client.hscan("h", 0, "NOVALUES");
+      // @ts-expect-error: testing runtime behavior when an optional argument is passed as undefined
+      await client.hscan("h", 0, undefined);
+    });
+    expect(received).toEqual([
+      ["HSCAN", "h", "0"],
+      ["HSCAN", "h", "42"],
+      ["HSCAN", "h", "0", "MATCH", "field:*"],
+      ["HSCAN", "h", "0", "COUNT", "25"],
+      ["HSCAN", "h", "0", "MATCH", "field:*", "COUNT", "25"],
+      ["HSCAN", "h", "0", "NOVALUES"],
+      ["HSCAN", "h", "0"],
+    ]);
+  });
+
+  test("commands with required positionals still forward their variadic and option arguments", async () => {
+    const received = await recordCommands(async client => {
+      await client.hdel("h", "f1", "f2", Buffer.from("f3"));
+      await client.zrem("z", "a", "b");
+      await client.zrank("z", "a", "WITHSCORE");
+      await client.zrevrank("z", "a");
+      await client.zrangebylex("z", "-", "+", "LIMIT", 0, 10);
+      await client.zrevrangebylex("z", "+", "-", "LIMIT", "0", "10");
+      await client.zmscore("z", "a", "b", "c");
+      await client.lpush("l", "a", "b");
+      await client.lpushx("l", "a");
+      await client.rpush("l", "1", "2", "3");
+      await client.rpushx("l", "a");
+      await client.del("a", "b", "c");
+      await client.lpop("l", 2);
+      await client.hrandfield("h", 2, "WITHVALUES");
+      // An undefined option after the required arguments is still skipped.
+      // @ts-expect-error: testing runtime behavior when an optional argument is passed as undefined
+      await client.zrank("z", "a", undefined);
+      // @ts-expect-error: testing runtime behavior when a variadic argument is passed as undefined
+      await client.rpush("l", "a", undefined, "b");
+      // @ts-expect-error: testing runtime behavior when the optional count is passed as undefined
+      await client.lpop("l", undefined);
+    });
+    expect(received).toEqual([
+      ["HDEL", "h", "f1", "f2", "f3"],
+      ["ZREM", "z", "a", "b"],
+      ["ZRANK", "z", "a", "WITHSCORE"],
+      ["ZREVRANK", "z", "a"],
+      ["ZRANGEBYLEX", "z", "-", "+", "LIMIT", "0", "10"],
+      ["ZREVRANGEBYLEX", "z", "+", "-", "LIMIT", "0", "10"],
+      ["ZMSCORE", "z", "a", "b", "c"],
+      ["LPUSH", "l", "a", "b"],
+      ["LPUSHX", "l", "a"],
+      ["RPUSH", "l", "1", "2", "3"],
+      ["RPUSHX", "l", "a"],
+      ["DEL", "a", "b", "c"],
+      ["LPOP", "l", "2"],
+      ["HRANDFIELD", "h", "2", "WITHVALUES"],
+      ["ZRANK", "z", "a"],
+      ["RPUSH", "l", "a", "b"],
+      ["LPOP", "l"],
+    ]);
   });
 });


### PR DESCRIPTION
## Repro

Against any Redis/Valkey server (bun 1.4.0, redis-server 8.0.2):

```ts
import { RedisClient } from "bun";
const redis = new RedisClient("redis://127.0.0.1:6379");
await redis.set("bc", "foobar"); // 26 set bits in total
console.log(await redis.bitcount("bc", 0, 0));          // 26, server says 4
console.log(await redis.bitcount("bc", 5, 30, "BIT"));  // 26, server says 17
console.log(await redis.send("BITCOUNT", ["bc", "5", "30", "BIT"])); // 17

await redis.hscan("h", null);
// rejects after a round trip: ERR wrong number of arguments for 'hscan' command

await redis.zadd("z", 1, "WITHSCORE");
console.log(await redis.zrank("z", undefined, "WITHSCORE")); // 0: looked up the member "WITHSCORE"
await redis.rpush(undefined, "a", "b");                        // pushes "b" onto a list named "a"
```

## Cause

`bitcount` was registered with `cmd_key!`, which serializes argument 0 and ignores the rest, so `BITCOUNT key [start end [BYTE | BIT]]` always went out as `BITCOUNT key` and the caller got the whole-string count back as if the range had been applied.

`hscan` was registered with `cmd_key_varargs!`, which checks that the key is present and then forwards the remaining arguments, skipping `undefined`/`null` wherever they appear. That is fine for commands whose only required argument is the key, but for a command with further required positionals a missing one is skipped and everything after it shifts into its slot. `hscan` was one of seven such registrations (`hdel`, `zrem`, `zrank`, `zrevrank`, `zrangebylex`, `zrevrangebylex`), and `cmd_key_value_varargs!` (`lpush`, `lpushx`, `rpush`, `rpushx`, `zmscore`) did the same without checking even the key, which is how `rpush(undefined, "a", "b")` ends up writing to the list `a`.

## Fix

One generator, `cmd_required_varargs!`, replaces both `cmd_key_varargs!` and `cmd_key_value_varargs!`: it converts each listed argument under its own name (the same `Expected <name> to be a string or buffer for '<cmd>'.` error every fixed-arity command already raises) and forwards whatever follows through `push_rest_args`, which skips `undefined`/`null` exactly as the two old generators did for optional arguments. The 23 commands from the three old shapes are registered with it; the fixing lines are the registrations, e.g.

```rust
cmd_required_varargs!(bitcount, b"bitcount", "BITCOUNT", "key", NotSubscriber);
cmd_required_varargs!(hscan, b"hscan", "HSCAN", "key", "cursor", NotSubscriber);
cmd_required_varargs!(zrank, b"zrank", "ZRANK", "key", "member", NotSubscriber);
cmd_required_varargs!(rpush, b"rpush", "RPUSH", "key", "value", NotSubscriber);
```

Argument names come from the existing typings. `packages/bun-types/redis.d.ts` gains the ranged `bitcount` overload; the other commands' declarations already described the runtime and are unchanged.

`push_rest_args` and the generator are byte-identical to the ones in #37571 (which uses them for `pfadd` and the `expire` family); whichever PR lands second drops its copy during the rebase and keeps both sets of tests. The two branches were dry-run merged: the shared code merges onto one copy, the only source conflict is the adjacent `lpush`/`pfadd` registration lines.

First rebase: onto main after #29339 landed (squashed to one commit). The 45 commands it added are all on `cmd_strings_varargs!`, `cmd_noargs!`, `cmd_key!` or `cmd_key_value!`, so none of them is affected by removing the two generators and the Rust diff is the same as before the rebase; the conflicts were in the tests and the types fixture, where both branches appended to the same blocks. The `redis.d.ts` vs `valkey.classes.ts` lint from #39271 only compares member names, so the extra `bitcount` overload passes it.

Observable changes:

- `bitcount(key, start, end[, "BYTE" | "BIT"])` sends the range. `bitcount(key)` and `bitcount(key, undefined, undefined)` still send `BITCOUNT key`.
- A missing/null required positional of the 12 commands above now throws `ERR_INVALID_ARG_TYPE` naming the argument before anything is written, instead of sending a shifted command. Options and variadic tails (`WITHSCORE`, `LIMIT`, extra fields/members/values, `MATCH`/`COUNT`) are forwarded as before, and a trailing `undefined` is still skipped.
- A bad or missing key on any of these 23 commands now reports `Expected key to be a string or buffer for '<cmd>'.`; previously the key-only commands said `The "key" argument must be specified` (`ERR_MISSING_ARGS`) for `null`/`undefined` and `Expected additional arguments ...` for other bad values. Six inline snapshots in the docker suite pinned the old texts and are updated (`unlink`, `touch`, `zrem`, `zmscore`, `zrangebylex`, `zrevrangebylex`).
- Values themselves are still forwarded for the server to validate (`hscan(key, NaN)` rejects with the server's `ERR invalid cursor`, same as `sscan`/`zscan`/`scan` today). `sscan`/`zscan`/`scan` are registered through `cmd_strings_varargs!`, which already rejects a null cursor client-side, and are not touched.

Skipping `undefined`/`null` after the required arguments (rather than rejecting them) is deliberate: it is what these commands did before, so `lpop(key, undefined)` and `bitcount(key, undefined, undefined)` keep working, while a hole in the middle such as `bitcount(key, undefined, 5)` now produces a server-side syntax error instead of a silently different command.

## Depends on #39530 (landed)

The no-server encoding tests here close the client from the continuation of its last reply. On the tree this PR was first rebased onto, that tripped a pre-existing `panic: unreachable` in `subscription_callback_map` (a wrapper that a collection has found dead but that has not been swept yet, so `finalize()` has not run, while `update_poll_ref()` still runs at the end of `on_data`) on every Linux lane and on Windows, because CI runs the test process with `BUN_GARBAGE_COLLECTOR_LEVEL=1`. That fix was split out of this PR and landed as #39530, together with its fixture and `valkey-gc.test.ts` test. This branch is now rebased onto it and contains only the argument-validation change again (one commit, four files: the generator, the registrations, `redis.d.ts`, and the tests).

<details>
<summary>The crash as it was first described here, before it moved to #39530</summary>

After the rebase, `test/js/valkey/valkey.test.ts` died with SIGABRT on every Linux lane and on Windows, in the new no-server encoding tests:

```
panic: unreachable
  subscription_callback_map      src/runtime/valkey_jsc/js_valkey.rs:88
  channels_subscribed_to_count   js_valkey.rs:98
  has_subscriptions              js_valkey.rs:104
  update_poll_ref                js_valkey.rs:1659
  SocketHandler::on_data         js_valkey.rs:1928
```

- Cause (pre-existing, not introduced by the generator change): `subscription_callback_map()` did `this_value.try_get().expect("unreachable")`. `try_get()` on the weak `this_value` returns `None` as soon as a collection has found the JS wrapper dead, but `finalize()`, which sets the `flags.finalized` flag that `update_poll_ref()` short-circuited on, only runs when the cell is actually swept, some time later. The encoding tests close the client from the continuation of its last reply and drop it; CI runs the test process with `BUN_GARBAGE_COLLECTOR_LEVEL=1`, so the `expect()` that follows collects before the socket read that delivered the reply has returned, and the read's epilogue (`update_poll_ref()` at the end of `on_data`) then panicked. Any socket callback whose JS continuation closes and drops the client can hit this; the same pattern in user code needs a collection at the same moment, which is why it has only shown up under the test runner's GC setting.
- Fix (`js_valkey.rs`): the map lookup becomes `try_subscription_callback_map() -> Option`, and `channels_subscribed_to_count()` reports 0 when the wrapper is gone (the handlers live on the wrapper, so there is nothing left to deliver to). The subscribe/unsubscribe/message paths keep the strict accessor, since they run with the wrapper alive (it is the host fn's `this`, or held strongly because handlers are registered). The `finalized ||` short-circuit in `update_poll_ref()` goes away because `finalize()` clears `this_value`, so the same check covers it.
- Test: `RedisClient lifecycle` runs `test/js/valkey/valkey.close-from-reply.fixture.ts` in a child process. Reproducing the window on purpose needs three things, each of which the fixture comments explain: the client under test must not be one of the first 8 instances of the class, because JSC hands those out as "lower tier" precise cells and finalizes them at the end of every collection (this is why small repros never crashed and the suite did, once the argument-validation table had created enough clients); a few other async functions have to be resumed after the closing one returns, otherwise a stale stack slot still points at its frame and the collector keeps the client alive; and the collection has to be `fullGC()` from `bun:jsc`, i.e. synchronous without a sweep (`Bun.gc(true)` sweeps synchronously and closes the window itself).

</details>

## Verification

`test/js/valkey/valkey.test.ts`:

- `RedisClient argument validation` (no server): `hscan` cursor and key errors, `bitcount` key error, and a table of one shifted call per migrated command (`zrank("z", undefined, "WITHSCORE")`, `rpush(undefined, "a", "b")`, `del()`, ...) asserting the named error.
- `RedisClient command encoding` (in-process RESP server records the exact argv): `BITCOUNT` with/without range and unit, Buffer key, undefined range; `HSCAN` with `MATCH`/`COUNT`/`NOVALUES` and trailing `undefined`; and every migrated command with its variadic/option tail (`LIMIT`, `WITHSCORE`, `WITHVALUES`, multiple fields/members/values, skipped `undefined`).
- Docker suite: `bitcount` against a real server returns `[26, 4, 6, 6, 4, 17, 26]` for the documented `"foobar"` examples; the six updated snapshots.
- `test/integration/bun-types/fixture/redis.ts` exercises the new overload (`bun test test/integration/bun-types/bun-types.test.ts` passes, as does `test/internal/source-lints/redis-client-types.test.ts`).

On the current base (main at 891c1c7221, which includes #39530), building with main's `js_valkey_functions.rs` and `redis.d.ts` fails 20 of the file's 84 no-server tests (the hscan/bitcount validation tests, the shifted-call table and the `BITCOUNT` encoding test); all 84 pass with the change, also with `BUN_GARBAGE_COLLECTOR_LEVEL=1` set as in CI, and `valkey-gc.test.ts` reports its close-from-reply fixture reaching the window in 10 of 10 rounds alongside them. The same debug build against the local redis on this machine returns `[26, 4, 6, 6, 4, 17, 26]` for the `"foobar"` examples and throws the named errors for `hscan(h)`, `zrank(z, undefined, "WITHSCORE")` and `rpush(undefined, "a", "b")`, where the released build returns `26` seven times, rejects `hscan` server-side and sends the other two. Before the first rebase the docker half of the suite was also run against a local redis 8.0.2 over TCP (456 pass; the only failure, `high volume pub/sub`, pushes 1 GiB through a debug/ASAN build in a 5 s budget and passes with a release build), plus `test/js/valkey/unit` and `integration` (70 pass); the docker-suite lines in this diff (six snapshots and the `bitcount` range test) are unchanged by the rebases.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 20 failed, 994 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release without fix: 66 failed, 994 skipped
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME overwr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 994 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release with fix: 994 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     85363f22aa
  features     baseline

22 deps, 120 codegen, 1144 objects in 1050ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [5.00ms]
[2/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1206] gen bindgenv2
[4/1206] fetch tinycc
[tinycc] up to date
[5/1205] gen ErrorCode+*.h
[6/1205] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[7/1205] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1205] fetch zlib
[zlib] up to date
[9/1205] gen .bind.ts → GeneratedBindings.cpp
[10/1205] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/redis.d.ts                 |  23 ++
 src/runtime/valkey_jsc/js_valkey_functions.rs | 178 ++++++++--------
 test/integration/bun-types/fixture/redis.ts   |   8 +
 test/js/valkey/valkey.test.ts                 | 288 +++++++++++++++++++++++++-
 4 files changed, 398 insertions(+), 99 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-types/redis.d.ts                      0      0      0
src/runtime/valkey_jsc/js_valkey_functions.rs      0      0      0
test/integration/bun-types/fixture/redis.ts        1      2      0
test/js/valkey/valkey.test.ts                      5      7      0
```

</details>

<!-- robobun:evidence:end -->
