### PR TITLE
bun_url: make freeing a whatwg::URL an unsafe raw-pointer operation

### DIFF
--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -334,7 +334,7 @@ impl HostedGitInfo {
 // ──────────────────────────────────────────────────────────────────────────
 
 /// RAII handle over a heap-allocated `WTF::URL` (C++). The allocation comes from
-/// `URL__fromString` (C++ `new`), so it MUST be freed via `URL__deinit` — wrapping
+/// `URL__fromString` (C++ `new`), so it MUST be freed via `JscUrl::destroy` — wrapping
 /// the pointer in `Box` is allocator-mismatch UB and never runs the C++ destructor.
 pub struct OwnedJscUrl(NonNull<JscUrl>);
 impl core::ops::Deref for OwnedJscUrl {
@@ -346,9 +346,9 @@ impl core::ops::Deref for OwnedJscUrl {
 }
 impl Drop for OwnedJscUrl {
     fn drop(&mut self) {
-        // SAFETY: pointer is the unique owner of a `new WTF::URL` from C++; `deinit`
-        // calls `URL__deinit` which `delete`s it.
-        unsafe { self.0.as_mut() }.deinit();
+        // SAFETY: `self.0` came from `JscUrl::from_utf8` (`concat_parts_to_url`) and this
+        // private newtype is its only owner, so this is the one and only destroy.
+        unsafe { JscUrl::destroy(self.0.as_ptr()) };
     }
 }
 

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -143,8 +143,7 @@ pub mod whatwg {
         }
         /// # Safety
         /// `this` must be a live handle from `from_string`/`from_utf8`; it is `delete`d here
-        /// and must not be used afterwards. (A `&mut URL` to this ZST would prove neither,
-        /// hence the pointer.)
+        /// and must not be used afterwards.
         pub unsafe fn destroy(this: *mut Self) {
             // SAFETY: fn contract.
             unsafe { URL__deinit(this) }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -52,9 +52,7 @@ pub mod whatwg {
         _opaque: [u8; 0],
     }
 
-    // Getters are `safe fn` over `&URL`: C++ (BunString.cpp) only reads, and `URL` is a ZST,
-    // so any non-null pointer is a valid `&URL`. `URL__deinit` (`delete`) and
-    // `URL__originLength` (raw slice pair) stay `unsafe fn`.
+    // Getters are `safe fn`: C++ only reads, and `&URL` (a ZST) is valid for any non-null pointer.
     unsafe extern "C" {
         // `URL__fromJS` / `URL__getHrefFromJS` intentionally omitted — tier-6 (bun_jsc).
         safe fn URL__fromString(str: &mut String) -> Option<core::ptr::NonNull<URL>>;
@@ -143,12 +141,10 @@ pub mod whatwg {
         pub fn pathname(&self) -> String {
             URL__pathname(self)
         }
-        /// `delete`s the WTF::URL. Takes a pointer, not `&mut self`: a reference to this ZST
-        /// proves neither ownership nor liveness.
-        ///
         /// # Safety
-        /// `this` came from `from_string`/`from_utf8`, has not been destroyed, and is not
-        /// used afterwards.
+        /// `this` must be a live handle from `from_string`/`from_utf8`; it is `delete`d here
+        /// and must not be used afterwards. (A `&mut URL` to this ZST would prove neither,
+        /// hence the pointer.)
         pub unsafe fn destroy(this: *mut Self) {
             // SAFETY: fn contract.
             unsafe { URL__deinit(this) }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -52,12 +52,9 @@ pub mod whatwg {
         _opaque: [u8; 0],
     }
 
-    // Getters are `safe fn` taking `&URL`: the C++ side (BunString.cpp) never mutates the
-    // WTF::URL on read, and `URL` is an opaque ZST, so any non-null pointer reborrows to a
-    // valid `&URL`. `URL__deinit` `delete`s the allocation, so it takes a raw pointer and
-    // stays `unsafe fn` (see `URL::destroy`). `BunString*` inputs are `&mut String` to match
-    // the C ABI; callers pass a mutable local copy (see below).
-    // `URL__originLength` keeps a raw `(*const u8, usize)` slice pair → stays `unsafe fn`.
+    // Getters are `safe fn` over `&URL`: C++ (BunString.cpp) only reads, and `URL` is a ZST,
+    // so any non-null pointer is a valid `&URL`. `URL__deinit` (`delete`) and
+    // `URL__originLength` (raw slice pair) stay `unsafe fn`.
     unsafe extern "C" {
         // `URL__fromJS` / `URL__getHrefFromJS` intentionally omitted — tier-6 (bun_jsc).
         safe fn URL__fromString(str: &mut String) -> Option<core::ptr::NonNull<URL>>;
@@ -113,14 +110,12 @@ pub mod whatwg {
     }
 
     impl URL {
-        /// `None` if `str` does not parse. Otherwise the returned pointer owns a fresh C++
-        /// allocation that the caller must pass to [`destroy`](Self::destroy) exactly once.
+        /// Owned by the caller; free with [`destroy`](Self::destroy). `None` if invalid.
         pub(crate) fn from_string(str: &String) -> Option<core::ptr::NonNull<URL>> {
             let mut input = *str;
             URL__fromString(&mut input)
         }
-        /// `None` if `input` does not parse. Otherwise the returned pointer owns a fresh C++
-        /// allocation that the caller must pass to [`destroy`](Self::destroy) exactly once.
+        /// Owned by the caller; free with [`destroy`](Self::destroy). `None` if invalid.
         pub fn from_utf8(input: &[u8]) -> Option<core::ptr::NonNull<URL>> {
             Self::from_string(&String::borrow_utf8(input))
         }
@@ -148,15 +143,14 @@ pub mod whatwg {
         pub fn pathname(&self) -> String {
             URL__pathname(self)
         }
-        /// `delete`s the WTF::URL returned by `from_string`/`from_utf8`. Not a `Drop` and
-        /// not a `&mut self` method: `URL` is a ZST token for the C++ allocation, so a
-        /// reference to it does not prove the caller owns (or still has) the allocation.
+        /// `delete`s the WTF::URL. Takes a pointer, not `&mut self`: a reference to this ZST
+        /// proves neither ownership nor liveness.
         ///
         /// # Safety
-        /// `this` must have come from `from_string`/`from_utf8`, must not have been
-        /// destroyed already, and must not be used afterwards.
+        /// `this` came from `from_string`/`from_utf8`, has not been destroyed, and is not
+        /// used afterwards.
         pub unsafe fn destroy(this: *mut Self) {
-            // SAFETY: fn contract; C++ `delete`s the allocation exactly once.
+            // SAFETY: fn contract.
             unsafe { URL__deinit(this) }
         }
     }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -46,18 +46,17 @@ pub mod whatwg {
     use super::strings;
 
     /// Opaque handle to a heap-allocated WTF::URL (C++). Always behind `*mut URL`.
-    /// Construct via `from_string`/`from_utf8`; free via `deinit`.
+    /// Construct via `from_string`/`from_utf8`; free exactly once via `destroy`.
     #[repr(C)]
     pub struct URL {
         _opaque: [u8; 0],
     }
 
-    // Getters take `*const URL` — the C++ side (BunString.cpp) never mutates the
-    // WTF::URL on read. `URL__deinit` keeps `*mut` (it `delete`s). `BunString*` inputs stay
-    // `*mut` to match the C ABI; callers pass a mutable local copy (see below).
-    // SAFETY (safe fn): `URL` is an opaque ZST handle (never null when behind `&`);
-    // `String` is a `#[repr(C)]` Copy POD that C++ reads (`BunString::toWTFString() const`).
-    // Getters take `&URL` (C++ never mutates on read); `deinit` takes `&mut URL` (consumes).
+    // Getters are `safe fn` taking `&URL`: the C++ side (BunString.cpp) never mutates the
+    // WTF::URL on read, and `URL` is an opaque ZST, so any non-null pointer reborrows to a
+    // valid `&URL`. `URL__deinit` `delete`s the allocation, so it takes a raw pointer and
+    // stays `unsafe fn` (see `URL::destroy`). `BunString*` inputs are `&mut String` to match
+    // the C ABI; callers pass a mutable local copy (see below).
     // `URL__originLength` keeps a raw `(*const u8, usize)` slice pair → stays `unsafe fn`.
     unsafe extern "C" {
         // `URL__fromJS` / `URL__getHrefFromJS` intentionally omitted — tier-6 (bun_jsc).
@@ -65,7 +64,7 @@ pub mod whatwg {
         safe fn URL__protocol(url: &URL) -> String;
         safe fn URL__href(url: &URL) -> String;
         safe fn URL__hostname(url: &URL) -> String;
-        safe fn URL__deinit(url: &mut URL);
+        fn URL__deinit(url: *mut URL);
         safe fn URL__pathname(url: &URL) -> String;
         safe fn URL__getHref(input: &mut String) -> String;
         safe fn URL__getFileURLString(input: &mut String) -> String;
@@ -114,10 +113,14 @@ pub mod whatwg {
     }
 
     impl URL {
+        /// `None` if `str` does not parse. Otherwise the returned pointer owns a fresh C++
+        /// allocation that the caller must pass to [`destroy`](Self::destroy) exactly once.
         pub(crate) fn from_string(str: &String) -> Option<core::ptr::NonNull<URL>> {
             let mut input = *str;
             URL__fromString(&mut input)
         }
+        /// `None` if `input` does not parse. Otherwise the returned pointer owns a fresh C++
+        /// allocation that the caller must pass to [`destroy`](Self::destroy) exactly once.
         pub fn from_utf8(input: &[u8]) -> Option<core::ptr::NonNull<URL>> {
             Self::from_string(&String::borrow_utf8(input))
         }
@@ -145,8 +148,16 @@ pub mod whatwg {
         pub fn pathname(&self) -> String {
             URL__pathname(self)
         }
-        pub fn deinit(&mut self) {
-            URL__deinit(self)
+        /// `delete`s the WTF::URL returned by `from_string`/`from_utf8`. Not a `Drop` and
+        /// not a `&mut self` method: `URL` is a ZST token for the C++ allocation, so a
+        /// reference to it does not prove the caller owns (or still has) the allocation.
+        ///
+        /// # Safety
+        /// `this` must have come from `from_string`/`from_utf8`, must not have been
+        /// destroyed already, and must not be used afterwards.
+        pub unsafe fn destroy(this: *mut Self) {
+            // SAFETY: fn contract; C++ `delete`s the allocation exactly once.
+            unsafe { URL__deinit(this) }
         }
     }
 }

--- a/test/internal/source-lints/safe-ffi-release-method.test.ts
+++ b/test/internal/source-lints/safe-ffi-release-method.test.ts
@@ -1,0 +1,176 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A C/C++ object that Rust only ever sees through an opaque handle (`opaque_ffi!`,
+// or a hand-rolled `[u8; 0]` struct) must not expose the call that frees it, or
+// gives back its refcount, as a safe method on the handle:
+//
+//     pub fn deinit(&mut self) {
+//         URL__deinit(self)          // C++: `delete url;`
+//     }
+//
+// The handle is a ZST, so a `&Handle` / `&mut Handle` reborrowed from any non-null
+// pointer is a valid reference (`opaque_ffi!` even offers safe `opaque_ref` /
+// `opaque_mut` for it) and proves neither that the caller owns the allocation nor
+// that it is still alive. A `&self` / `&mut self` receiver is also not consumed by
+// the call, so fully safe code can call the method twice (double free) or keep
+// using the handle afterwards (use after free). `bun_url::whatwg::URL::deinit` had
+// exactly this shape.
+//
+// Either of these shapes is fine:
+//
+//   * `pub unsafe fn destroy(this: *mut Self)` with a `# Safety` contract
+//     (`bun_url::whatwg::URL`, `bun_jsc::URL`, `RegularExpression`, ...).
+//   * A private shim reached only from `Drop` of an owning wrapper
+//     (`CookieMapRef` in runtime/webcore/CookieMap.rs, `OwnedJscUrl` in
+//     install/hosted_git_info.rs).
+//
+// Sibling guards: unsound-erased-box.test.ts, frozen-nonnull-reborrow.test.ts.
+
+// `pub` (any visibility) method, not `unsafe` (`pub unsafe fn` does not match because
+// `unsafe` sits between `pub` and `fn`), taking `&self` / `&mut self`, whose body
+// starts by handing `self` (or a projection of it) to a shim whose name ends in a
+// free or refcount-release verb. The shim must be a bare identifier: extern shims
+// are declared in the file that wraps them and called unqualified, whereas a
+// path-qualified call (`bun_opaque::opaque_deref(self.ptr)`, `Async::actually_deinit(self, id)`)
+// is a Rust helper that merely takes `self` as context. Sockets' `close` shims are a
+// different lifecycle (the library frees the socket later, from its event loop) and
+// are deliberately not matched either.
+const RELEASE_FORWARDER =
+  /\bpub(?:\([^)]*\))?\s+fn\s+(\w+)\s*\(\s*(&(?:mut\s+)?self)\b[^)]*\)[^{;]*\{\s*(\w+_(?:deinit|destroy|delete|free|dealloc|deref|unref|release))\s*\(\s*self\b/g;
+
+// Instances that predate this lint and are being removed separately (FetchHeaders
+// and SourceProvider become Drop-owned handles in #33820; AbortSignal is tracked on
+// its own). Ratchet: delete the entry together with the method (the test below
+// fails on a stale entry). Prefer converting a new instance over adding one here.
+const ALLOW = new Set([
+  "src/jsc/AbortSignal.rs: unref -> WebCore__AbortSignal__unref",
+  "src/jsc/FetchHeaders.rs: deref -> WebCore__FetchHeaders__deref",
+  "src/jsc/SourceProvider.rs: deref -> JSC__SourceProvider__deref",
+]);
+
+// Strip `//` comments without disturbing line numbers (`[ \t]*`, not `\s*`, so the
+// preceding newlines survive), so prose like the example above does not count.
+function stripLineComments(content: string): string {
+  return content.replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+function scan(source: string, content: string): { key: string; display: string }[] {
+  const stripped = stripLineComments(content);
+  const found: { key: string; display: string }[] = [];
+  for (const m of stripped.matchAll(RELEASE_FORWARDER)) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    found.push({
+      key: `${source}: ${m[1]} -> ${m[3]}`,
+      display: `${source}:${line}: pub fn ${m[1]}(${m[2]}, ..) forwards self to ${m[3]}`,
+    });
+  }
+  return found;
+}
+
+test("matches the unsound shape and not the sound ones", () => {
+  const unsound = `
+    impl URL {
+        pub fn deinit(&mut self) {
+            URL__deinit(self)
+        }
+    }
+    impl Headers {
+        pub(crate) fn deref(&self) -> u32 { WebCore__Headers__deref(self.0) }
+    }
+    impl Archive {
+        pub fn free(&self, mode: Mode) {
+            archive_read_free(self.as_mut_ptr(), mode)
+        }
+    }
+  `;
+  expect(scan("x.rs", unsound).map(o => o.key)).toEqual([
+    "x.rs: deinit -> URL__deinit",
+    "x.rs: deref -> WebCore__Headers__deref",
+    "x.rs: free -> archive_read_free",
+  ]);
+
+  const sound = `
+    impl URL {
+        /// pub fn deinit(&mut self) { URL__deinit(self) }
+        pub unsafe fn destroy(this: *mut Self) {
+            unsafe { URL__deinit(this) }
+        }
+        pub fn protocol(&self) -> String {
+            URL__protocol(self)
+        }
+        pub fn release_weak_refs(&self) {
+            JSC__VM__releaseWeakRefs(self)
+        }
+        pub fn into_raw(self) {
+            Foo__deinit(self)
+        }
+        pub fn global(&self) -> &JSGlobalObject {
+            bun_opaque::opaque_deref(self.global)
+        }
+        pub(crate) fn async_cmd_done(&self, id: NodeId) {
+            Async::actually_deinit(self, id);
+        }
+    }
+    impl Drop for CookieMapRef {
+        fn drop(&mut self) {
+            CookieMap__deref(self)
+        }
+    }
+    trait Release {
+        fn release(&self);
+    }
+    impl Owned {
+        pub fn unref(&self) {
+            self.0.take().map(|p| unsafe { Foo__unref(p) });
+        }
+    }
+  `;
+  expect(scan("x.rs", sound)).toEqual([]);
+});
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const offenders: { key: string; display: string }[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  offenders.push(...scan(source, await file(abs).text()));
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the bans below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("no safe &self method frees or releases an FFI handle", () => {
+  expect(offenders.filter(o => !ALLOW.has(o.key)).map(o => o.display)).toEqual([]);
+});
+
+test("every ALLOW entry is still present (delete the entry along with the method)", () => {
+  const seen = new Set(offenders.map(o => o.key));
+  expect([...ALLOW].filter(key => !seen.has(key))).toEqual([]);
+});

--- a/test/internal/source-lints/safe-ffi-release-method.test.ts
+++ b/test/internal/source-lints/safe-ffi-release-method.test.ts
@@ -31,25 +31,38 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // Sibling guards: unsound-erased-box.test.ts, frozen-nonnull-reborrow.test.ts.
 
 // `pub` (any visibility) method, not `unsafe` (`pub unsafe fn` does not match because
-// `unsafe` sits between `pub` and `fn`), taking `&self` / `&mut self`, whose body
-// starts by handing `self` (or a projection of it) to a shim whose name ends in a
-// free or refcount-release verb. The shim must be a bare identifier: extern shims
-// are declared in the file that wraps them and called unqualified, whereas a
-// path-qualified call (`bun_opaque::opaque_deref(self.ptr)`, `Async::actually_deinit(self, id)`)
-// is a Rust helper that merely takes `self` as context. Sockets' `close` shims are a
-// different lifecycle (the library frees the socket later, from its event loop) and
-// are deliberately not matched either.
+// `unsafe` sits between `pub` and `fn`), taking `&self` / `&mut self`, whose first
+// statement hands `self` (or a projection of it) to a shim whose name ends in a free
+// or refcount-release verb. The statement may be wrapped in `unsafe { .. }`: that is
+// what the body looks like once the shim itself is declared the recommended way
+// (`fn X__deinit(*mut X)` in the extern block), so a lint that skipped it would only
+// ever see shims still declared `safe fn`. Full-line comments (`// SAFETY: ..`) are
+// stripped first, so they may sit anywhere in between.
+//
+// Deliberately not matched, so a new instance in one of these shapes is a review
+// matter rather than a lint failure: path-qualified calls
+// (`bun_opaque::opaque_deref(self.ptr)`, `Async::actually_deinit(self, id)` are Rust
+// helpers that merely take `self` as context; extern shims are declared in the file
+// that wraps them and called bare), release calls after a first statement that does
+// something else, non-`pub` fns (a private forwarder is the Drop-only pattern), and
+// sockets' `close` shims (a different lifecycle: the library frees the socket later,
+// from its event loop).
 const RELEASE_FORWARDER =
-  /\bpub(?:\([^)]*\))?\s+fn\s+(\w+)\s*\(\s*(&(?:mut\s+)?self)\b[^)]*\)[^{;]*\{\s*(\w+_(?:deinit|destroy|delete|free|dealloc|deref|unref|release))\s*\(\s*self\b/g;
+  /\bpub(?:\([^)]*\))?\s+fn\s+(\w+)\s*\(\s*(&(?:mut\s+)?self)\b[^)]*\)[^{;]*\{\s*(?:unsafe\s*\{\s*)?(\w+_(?:deinit|destroy|delete|free|dealloc|deref|unref|release))\s*\(\s*self\b/g;
 
-// Instances that predate this lint and are being removed separately (FetchHeaders
-// and SourceProvider become Drop-owned handles in #33820; AbortSignal is tracked on
-// its own). Ratchet: delete the entry together with the method (the test below
+// Instances that predate this lint and are tracked separately: FetchHeaders and
+// SourceProvider become Drop-owned handles in #33820; AbortSignal and the three
+// libarchive methods (each has a Drop-owning wrapper that derefs to the handle, so
+// `owner.read_free()` followed by the owner's drop is a double free) have their own
+// fixes pending. Ratchet: delete the entry together with the method (the test below
 // fails on a stale entry). Prefer converting a new instance over adding one here.
 const ALLOW = new Set([
   "src/jsc/AbortSignal.rs: unref -> WebCore__AbortSignal__unref",
   "src/jsc/FetchHeaders.rs: deref -> WebCore__FetchHeaders__deref",
   "src/jsc/SourceProvider.rs: deref -> JSC__SourceProvider__deref",
+  "src/libarchive/lib.rs: read_free -> archive_read_free",
+  "src/libarchive/lib.rs: write_free -> archive_write_free",
+  "src/libarchive/lib.rs: free -> archive_entry_free",
 ]);
 
 // Strip `//` comments without disturbing line numbers (`[ \t]*`, not `\s*`, so the
@@ -77,20 +90,26 @@ test("matches the unsound shape and not the sound ones", () => {
         pub fn deinit(&mut self) {
             URL__deinit(self)
         }
+        pub fn deinit_via_unsafe_shim(&mut self) {
+            // SAFETY: (a claim the signature cannot back up)
+            unsafe { URL__deinit(self) }
+        }
     }
     impl Headers {
         pub(crate) fn deref(&self) -> u32 { WebCore__Headers__deref(self.0) }
     }
     impl Archive {
-        pub fn free(&self, mode: Mode) {
-            archive_read_free(self.as_mut_ptr(), mode)
+        pub fn read_free(&self) -> Result {
+            // SAFETY: self came from archive_read_new(); not used after this.
+            unsafe { archive_read_free(self.as_mut_ptr()) }
         }
     }
   `;
-  expect(scan("x.rs", unsound).map(o => o.key)).toEqual([
-    "x.rs: deinit -> URL__deinit",
-    "x.rs: deref -> WebCore__Headers__deref",
-    "x.rs: free -> archive_read_free",
+  expect(scan("x.rs", unsound).map(o => o.display)).toEqual([
+    "x.rs:3: pub fn deinit(&mut self, ..) forwards self to URL__deinit",
+    "x.rs:6: pub fn deinit_via_unsafe_shim(&mut self, ..) forwards self to URL__deinit",
+    "x.rs:12: pub fn deref(&self, ..) forwards self to WebCore__Headers__deref",
+    "x.rs:15: pub fn read_free(&self, ..) forwards self to archive_read_free",
   ]);
 
   const sound = `
@@ -101,6 +120,10 @@ test("matches the unsound shape and not the sound ones", () => {
         }
         pub fn protocol(&self) -> String {
             URL__protocol(self)
+        }
+        pub fn read_close(&self) -> Result {
+            // SAFETY: self came from archive_read_new().
+            unsafe { archive_read_close(self.as_mut_ptr()) }
         }
         pub fn release_weak_refs(&self) {
             JSC__VM__releaseWeakRefs(self)


### PR DESCRIPTION
### What

`bun_url::whatwg::URL` (src/url/lib.rs) is an opaque zero-sized handle to a C++ heap `WTF::URL` (`URL__fromString` does `new`, `URL__deinit` does `delete`). The extern was declared `safe fn URL__deinit(url: &mut URL)` and wrapped as a safe `pub fn deinit(&mut self)`, so this compiles with no `unsafe` anywhere and is a double delete, and the commented-out line is a use after free:

```rust
let p = bun_url::whatwg::URL::from_utf8(b"https://example.com/").unwrap();
let url = unsafe { &mut *p.as_ptr() };   // a valid &mut to a ZST; proves nothing about ownership
url.deinit();
// url.href();
url.deinit();
```

Nothing in tree does this today. The one caller, `OwnedJscUrl::drop` in src/install/hosted_git_info.rs, is correct, but the `unsafe` block it did have only covered `as_mut()`, not the free. Surfaced by review on #32023, which re-exports this type as `bun_jsc::URL` and deliberately left the signature alone (zero behavior change PR).

### Cause

The comment above the extern block argued "`deinit` takes `&mut URL` (consumes)". `&mut self` does not consume, and for a zero-sized handle a `&mut` is obtainable from any non-null pointer, so it also does not prove the allocation is owned or still alive. The `safe fn` declaration was claiming a contract the signature cannot enforce. The `bun_jsc::URL` copy of the same binding (src/jsc/URL.rs) already had the right shape: `fn URL__deinit(*mut URL)` plus `pub unsafe fn destroy(this: *mut Self)`.

### Fix

* `URL__deinit` is declared as an unsafe fn taking `*mut URL`.
* `deinit(&mut self)` is replaced by `pub unsafe fn destroy(this: *mut Self)` with a Safety contract; `from_string` / `from_utf8` say the result is owned and freed with it. Same name and signature as `bun_jsc::URL::destroy`.
* `OwnedJscUrl::drop` calls `JscUrl::destroy` and says why it is the single free.

Why this layer and not a `Drop` on `URL`: the type is a ZST token, not the allocation, so Rust never holds a `URL` by value and `Drop` cannot apply. Ownership lives in whoever holds the pointer (`OwnedJscUrl` here), and `unsafe fn destroy(*mut Self)` is the shape the other 18 FFI-handle destructors in the workspace use for this situation. No runtime behavior changes.

Interaction with #32023, checked with a three-way merge of src/url/lib.rs: three small conflicts (struct docs, the `URL__deinit` line, the constructor docs), the merge drops `deinit` by itself, and #32023 then has to delete its own `destroy` (whose body calls `deinit`) and two doc references to it. Its `opaque_ffi!` conversion and by-value `from_string` are its own dedup scope and are intentionally not pulled in here.

### Test

`test/internal/source-lints/safe-ffi-release-method.test.ts` flags any safe `pub fn` taking `&self` / `&mut self` whose first statement, optionally inside `unsafe { .. }`, forwards `self` to a `*_deinit` / `*_destroy` / `*_delete` / `*_free` / `*_dealloc` / `*_deref` / `*_unref` / `*_release` shim. The `unsafe { .. }` form matters: once a shim is declared the recommended way (unsafe fn over a raw pointer), that is the only form the unsound wrapper can take, so without it the lint would only ever see shims still declared `safe fn` and would not catch `deinit` being re-added on top of this fix. The regex is checked against inline fixtures in both directions (`pub unsafe fn destroy(*mut Self)`, Drop-only private shims, `opaque_deref`, `releaseWeakRefs`, by-value receivers and non-release calls inside `unsafe` blocks must not match). Against main's `src/` it reports exactly `src/url/lib.rs:148: pub fn deinit(&mut self, ..) forwards self to URL__deinit`; with this branch it passes.

The same scan finds six pre-existing instances of the shape, which are allowlisted with a ratchet (a stale entry fails the test) rather than fixed here: `FetchHeaders::deref` and `SourceProvider::deref` are removed by #33820, which turns both into Drop-owned handles; `AbortSignal::unref` / `detach` and libarchive's `Archive::read_free` / `write_free` / `Entry::free` (each has a Drop-owning wrapper that derefs to the handle, so `owner.read_free()` plus the owner's drop is a double free; their callers sit in files #33820 and #37549 are changing) are tracked as their own fixes.

### Verification

* `cargo check`, `cargo clippy` and `cargo fmt --check` on `bun_url` and `bun_install`; debug (ASAN) build links.
* `bun bd test test/cli/install/hosted-git-info/` (655 pass) creates and drops a `WTF::URL` through `OwnedJscUrl` on every parse, so the new `destroy` path runs under ASAN.
* The new lint fails with main's two source files checked out in place of this branch's and passes with them restored (above).
