### PR TITLE
bundler: dedupe chunks whose hashed output paths collide with identical content

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -76,6 +76,12 @@ pub struct Chunk {
     pub intermediate_output: IntermediateOutput,
     pub(crate) isolated_hash: u64,
 
+    /// When an earlier chunk with identical content claimed the same output
+    /// path, this is that chunk's index and this chunk's output is not
+    /// emitted; importers resolve to the canonical chunk's path instead.
+    /// `u32::MAX` = not a duplicate. See `generate_chunks_in_parallel`.
+    pub(crate) duplicate_of_chunk_index: u32,
+
     // Set before use. The borrowed enum (`Renamer<'r,'src>`)
     // borrows from the symbol table and so can't live in this owning struct.
     // `ChunkRenamer` is the owning equivalent (see `crate::bun_renamer`).
@@ -209,6 +215,7 @@ impl Default for Chunk {
             output_source_map: source_map::SourceMapPieces::default(),
             intermediate_output: IntermediateOutput::default(),
             isolated_hash: u64::MAX,
+            duplicate_of_chunk_index: u32::MAX,
             renamer: bun_renamer::ChunkRenamer::default(),
             compile_results_for_chunk: CompileResultSlots::default(),
             metafile_chunk_json: Box::default(),
@@ -218,6 +225,11 @@ impl Default for Chunk {
 }
 
 impl Chunk {
+    #[inline]
+    pub(crate) fn is_duplicate_output(&self) -> bool {
+        self.duplicate_of_chunk_index != u32::MAX
+    }
+
     /// Write `result` into `compile_results_for_chunk[i]` through a raw
     /// `*mut Chunk`, for the `generate_compile_result_for_*_chunk` worker
     /// callbacks.

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -401,7 +401,9 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     // Write outputs by joining pre-built chunk JSON fragments
     let mut first_output = true;
     for chunk in chunks.iter() {
-        if chunk.final_rel_path.is_empty() {
+        // `metafile_chunk_json` stays empty for duplicate chunks (deduplicated
+        // output paths) and for chunks whose fragment failed to generate.
+        if chunk.final_rel_path.is_empty() || chunk.metafile_chunk_json.is_empty() {
             continue;
         }
 

--- a/src/bundler/linker_context/OutputFileListBuilder.rs
+++ b/src/bundler/linker_context/OutputFileListBuilder.rs
@@ -92,6 +92,10 @@ impl OutputFileList {
             'brk: {
                 let mut count: usize = 0;
                 for chunk in chunks {
+                    // Duplicate chunks emit no output of their own.
+                    if chunk.is_duplicate_output() {
+                        continue;
+                    }
                     if chunk
                         .content
                         .sourcemap(c.options.source_maps)
@@ -110,6 +114,9 @@ impl OutputFileList {
                 let mut bytecode_count: usize = 0;
                 let loaders = parse_graph.input_files.items_loader();
                 for chunk in chunks {
+                    if chunk.is_duplicate_output() {
+                        continue;
+                    }
                     let loader: Loader = if chunk.entry_point.is_entry_point() {
                         loaders[chunk.entry_point.source_index() as usize]
                     } else {

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -359,7 +359,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
     // TODO: enforceNoCyclicChunkImports()
     {
-        let mut path_names_map: StringHashMap<()> = StringHashMap::default();
+        // Maps output path -> index of the first chunk that claimed it.
+        let mut path_names_map: StringHashMap<u32> = StringHashMap::default();
 
         #[derive(Default)]
         struct DuplicateEntry {
@@ -386,31 +387,62 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 &mut chunk_visit_map,
             );
             chunk_visit_map.set_all(false);
-            let chunk = &mut chunks[index];
-            chunk.template.placeholder.hash = Some(hash.digest());
-
             let mut rel_path: Vec<u8> = Vec::new();
-            // Use the byte-writer (`PathTemplate::print`) directly —
-            // routing through `Display`/`write!` goes via `from_utf8_lossy`,
-            // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
-            // the output path.
-            // Disk output sanitizes leading `..`; `--compile` keeps it so
-            // runtime bunfs references to out-of-root entrypoints resolve.
-            chunk
-                .template
-                .print(&mut rel_path, !c.options.compile_mode.is_executable())
-                .expect("write to Vec<u8>");
+            {
+                let chunk = &mut chunks[index];
+                chunk.template.placeholder.hash = Some(hash.digest());
+
+                // Use the byte-writer (`PathTemplate::print`) directly —
+                // routing through `Display`/`write!` goes via `from_utf8_lossy`,
+                // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
+                // the output path.
+                // Disk output sanitizes leading `..`; `--compile` keeps it so
+                // runtime bunfs references to out-of-root entrypoints resolve.
+                chunk
+                    .template
+                    .print(&mut rel_path, !c.options.compile_mode.is_executable())
+                    .expect("write to Vec<u8>");
+            }
             path::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
 
-            if path_names_map.get_or_put(&rel_path)?.found_existing {
+            let entry = path_names_map.get_or_put(&rel_path)?;
+            if entry.found_existing {
+                let canonical_index = *entry.value_ptr as usize;
+
+                // Two shared split chunks can compile to identical content
+                // (e.g. two fully tree-shaken stubs that re-export the same
+                // chunk), in which case a `[hash]` naming template yields the
+                // same path for both. That collision is benign: equal digests
+                // imply byte-identical final output, because the digest covers
+                // the chunk's own pieces plus every transitively imported
+                // chunk's hash, and cross-chunk import specifiers are
+                // substituted from paths derived from those same hashes. Emit
+                // one file and alias the duplicate to it, matching esbuild.
+                // Entry-point chunks are excluded so every entry point keeps
+                // its own output file.
+                if !chunks[index].entry_point.is_entry_point()
+                    && !chunks[canonical_index].entry_point.is_entry_point()
+                    && chunks[index].template.placeholder.hash
+                        == chunks[canonical_index].template.placeholder.hash
+                {
+                    let canonical_path = chunks[canonical_index].final_rel_path.clone();
+                    chunks[index].final_rel_path = canonical_path;
+                    chunks[index].duplicate_of_chunk_index =
+                        u32::try_from(canonical_index).expect("int cast");
+                    continue;
+                }
+
                 // collect all duplicates in a list
                 let dup = duplicates_map.get_or_put(&rel_path)?;
                 if !dup.found_existing {
                     *dup.value_ptr = DuplicateEntry::default();
                 }
-                dup.value_ptr.sources.push(bun_ptr::BackRef::new(&*chunk));
+                dup.value_ptr
+                    .sources
+                    .push(bun_ptr::BackRef::new(&chunks[index]));
                 continue;
             }
+            *entry.value_ptr = u32::try_from(index).expect("int cast");
 
             // resolve any /./ and /../ occurrences
             // use resolvePosix since we asserted above all seps are '/'
@@ -420,11 +452,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 let rel_path_fixed: Box<[u8]> = Box::from(&*path::resolve_path::normalize_buf::<
                     path::platform::Posix,
                 >(&rel_path, &mut buf));
-                chunk.final_rel_path = rel_path_fixed;
+                chunks[index].final_rel_path = rel_path_fixed;
                 continue;
             }
 
-            chunk.final_rel_path = rel_path.into_boxed_slice();
+            chunks[index].final_rel_path = rel_path.into_boxed_slice();
         }
 
         if duplicates_map.count() > 0 {
@@ -433,7 +465,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             let mut entry_naming: Option<&[u8]> = None;
             let mut chunk_naming: Option<&[u8]> = None;
-            let mut asset_naming: Option<&[u8]> = None;
 
             writeln!(&mut msg, "Multiple files share the same output path")?;
 
@@ -455,7 +486,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             chunk_naming = Some(&chunk.template.data);
                         }
                     } else {
-                        asset_naming = Some(&chunk.template.data);
+                        // Shared split chunks are named by the chunk template.
+                        chunk_naming = Some(&chunk.template.data);
                     }
 
                     let source_index = chunk.entry_point.source_index();
@@ -471,11 +503,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             c.log_mut().add_error(None, bun_ast::Loc::EMPTY, msg);
 
-            for (name, template) in [
-                ("entry", entry_naming),
-                ("chunk", chunk_naming),
-                ("asset", asset_naming),
-            ] {
+            for (name, template) in [("entry", entry_naming), ("chunk", chunk_naming)] {
                 let Some(template) = template else { continue };
 
                 let mut text: Vec<u8> = Vec::new();
@@ -590,6 +618,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // Reshaped for borrowck — `generate_chunk_json` reads all chunks
         // immutably while we write one chunk's `metafile_chunk_json`; index split.
         for i in 0..chunks.len() {
+            // A duplicate chunk shares its canonical chunk's output path, so
+            // emitting a fragment for it would repeat that key in "outputs".
+            if chunks[i].is_duplicate_output() {
+                continue;
+            }
             let json =
                 metafile_builder::generate_chunk_json(c, &chunks[i], chunks).unwrap_or_default();
             chunks[i].metafile_chunk_json = json;
@@ -661,7 +694,13 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             if matches!(chunks[ci].content, crate::chunk::Content::Html) {
                 continue;
             }
-            let sourcemap_option = chunks[ci].content.sourcemap(c.options.source_maps);
+            // Duplicate chunks emit no .map file of their own (the canonical
+            // chunk's path is shared, so its .map covers both).
+            let sourcemap_option = if chunks[ci].is_duplicate_output() {
+                SourceMapOption::None
+            } else {
+                chunks[ci].content.sourcemap(c.options.source_maps)
+            };
             let mut ds: usize = 0;
             // Pass `scc` so that `.asset` pieces (e.g. `import logo from "./logo.svg"` with
             // the file loader) are resolved to data: URIs from `url_for_css` instead of
@@ -873,6 +912,24 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         entry_point_index: None,
                         referenced_css_chunks: Box::default(),
                         bake_extra: BakeExtra::default(),
+                        ..Default::default()
+                    },
+                ));
+                continue;
+            }
+
+            // A duplicate chunk's content is emitted by its canonical chunk.
+            // Insert a placeholder to keep chunk indices aligned; it is
+            // removed (with index remapping) before the list is returned.
+            if chunks[chunk_index_in_chunks_list].is_duplicate_output() {
+                let _ = output_files.insert_for_chunk(options::OutputFile::init(
+                    options::OutputFileInit {
+                        data: options::OutputFileData::Buffer {
+                            data: Box::default(),
+                        },
+                        loader: chunks[chunk_index_in_chunks_list].content.loader(),
+                        output_kind: options::OutputKind::Chunk,
+                        input_loader: Loader::Js,
                         ..Default::default()
                     },
                 ));
@@ -1343,7 +1400,54 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         return Ok(result);
     }
 
-    Ok(output_files.take())
+    let result = output_files.take();
+
+    // Drop the placeholder entries of duplicate chunks (identical content at
+    // the same output path as their canonical chunk) and remap every stored
+    // index into the list: `source_map_index`/`bytecode_index`/
+    // `module_info_index` shift with the removals, and `referenced_css_chunks`
+    // entries pointing at a duplicate redirect to its canonical chunk.
+    if chunks.iter().any(Chunk::is_duplicate_output) {
+        let is_removed = |i: usize| i < chunks.len() && chunks[i].is_duplicate_output();
+
+        let mut new_index: Vec<u32> = vec![u32::MAX; result.len()];
+        let mut kept: u32 = 0;
+        for (i, slot) in new_index.iter_mut().enumerate() {
+            if !is_removed(i) {
+                *slot = kept;
+                kept += 1;
+            }
+        }
+        for (i, chunk) in chunks.iter().enumerate() {
+            if chunk.is_duplicate_output() {
+                new_index[i] = new_index[chunk.duplicate_of_chunk_index as usize];
+            }
+        }
+
+        let mut compacted: Vec<options::OutputFile> = Vec::with_capacity(kept as usize);
+        for (i, mut file) in result.into_iter().enumerate() {
+            if is_removed(i) {
+                continue;
+            }
+            let remap = |index: u32| {
+                if index == u32::MAX {
+                    u32::MAX
+                } else {
+                    new_index[index as usize]
+                }
+            };
+            file.source_map_index = remap(file.source_map_index);
+            file.bytecode_index = remap(file.bytecode_index);
+            file.module_info_index = remap(file.module_info_index);
+            for chunk_ref in file.referenced_css_chunks.iter_mut() {
+                *chunk_ref = crate::output_file::Index::init(new_index[chunk_ref.get() as usize]);
+            }
+            compacted.push(file);
+        }
+        return Ok(compacted);
+    }
+
+    Ok(result)
 }
 
 use crate::EntryPoint;

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -194,6 +194,34 @@ pub(crate) fn write_output_files_to_disk(
             continue;
         }
 
+        // A duplicate chunk's content is identical to its canonical chunk,
+        // which already wrote the shared output path. Insert a placeholder to
+        // keep chunk indices aligned; it is removed (with index remapping)
+        // before the list is returned.
+        if chunk.is_duplicate_output() {
+            let _ = output_files.insert_for_chunk(OutputFile::init(OutputFileInit {
+                data: OutputFileData::Saved(0),
+                hash: None,
+                loader: chunk.content.loader(),
+                input_path: Box::default(),
+                display_size: 0,
+                output_kind: options::OutputKind::Chunk,
+                input_loader: Loader::Js,
+                output_path: Box::default(),
+                is_executable: false,
+                source_map_index: None,
+                bytecode_index: None,
+                module_info_index: None,
+                side: None,
+                entry_point_index: None,
+                referenced_css_chunks: Box::default(),
+                size: None,
+                source_index: IndexOptional::NONE,
+                bake_extra: BakeExtra::default(),
+            }));
+            continue;
+        }
+
         let _trace2 = bun_core::perf::trace("Bundler.writeChunkToDisk");
         // Reset the reusable
         // buffer after each chunk. `MaxHeapAllocator::scope()` returns an RAII

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync } from "node:fs";
 import { ESBUILD, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -215,6 +216,50 @@ describe("bundler", () => {
     },
     bundleErrors: {
       "<bun>": ['Multiple files share the same output path: "same-filename.txt"'],
+    },
+  });
+  // Two different shared chunks whose output is byte-identical (m12.js and
+  // m13.js are identical side-effect-only stubs shared by different entry
+  // pairs) hash to the same [hash] and thus the same output path. That must
+  // dedupe into one file instead of erroring; different-content collisions
+  // (see naming/EntryNamingCollission) must still error.
+  itBundled("naming/ChunkIdenticalContentSharesOutputPath", {
+    files: {
+      "/entry.js": /* js */ `
+        const [m1, m2, m3] = await Promise.all([import('./d1.js'), import('./d2.js'), import('./d3.js')]);
+        console.log(m1.d1, m2.d2, m3.d3, globalThis.core);
+      `,
+      "/d1.js": /* js */ `
+        import "./m12.js";
+        import "./m13.js";
+        export const d1 = 1;
+      `,
+      "/d2.js": /* js */ `
+        import "./m12.js";
+        export const d2 = 2;
+      `,
+      "/d3.js": /* js */ `
+        import "./m13.js";
+        export const d3 = 3;
+      `,
+      "/m12.js": `import "./core.js";`,
+      "/m13.js": `import "./core.js";`,
+      "/core.js": `globalThis.core = (globalThis.core ?? 0) + 1;`,
+    },
+    entryPoints: ["/entry.js"],
+    splitting: true,
+    outdir: "/out",
+    target: "bun",
+    format: "esm",
+    run: {
+      file: "/out/entry.js",
+      stdout: "1 2 3 1",
+    },
+    onAfterBundle(api) {
+      // entry + d1 + d2 + d3 + core chunk + the __require helper chunk +
+      // ONE deduped shared stub (8 would mean the stubs stopped colliding
+      // and this test no longer exercises the dedupe path)
+      expect(readdirSync(api.outdir)).toHaveLength(7);
     },
   });
   itBundled("naming/AssetFileLoaderPath1", {

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -402,4 +402,55 @@ describe("bundler", () => {
     }
     expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
   }, 60_000);
+
+  // https://github.com/oven-sh/bun/issues/37576
+  // m12 and m13 are shared by different entry-point pairs, so they become two
+  // separate chunks that compile to identical content and collide on the same
+  // `[hash]` output path. The collision must deduplicate into one emitted file
+  // (like esbuild) instead of failing with "Multiple files share the same
+  // output path". The on-disk variant of this shape is covered by
+  // naming/ChunkIdenticalContentSharesOutputPath.
+  const identicalSharedChunkFiles = {
+    "/entry.js": `
+      const [m1, m2, m3] = await Promise.all([import("./d1.js"), import("./d2.js"), import("./d3.js")]);
+      console.log(m1.d1, m2.d2, m3.d3);
+    `,
+    "/core.js": `globalThis.core = (globalThis.core ?? 0) + 1;`,
+    "/m12.js": `import "./core.js";`,
+    "/m13.js": `import "./core.js";`,
+    "/d1.js": `
+      import "./m12.js";
+      import "./m13.js";
+      export const d1 = 1;
+    `,
+    "/d2.js": `
+      import "./m12.js";
+      export const d2 = 2;
+    `,
+    "/d3.js": `
+      import "./m13.js";
+      export const d3 = 3;
+    `,
+  };
+
+  test.concurrent("identical shared chunks are deduplicated in in-memory builds", async () => {
+    using dir = tempDir(
+      "splitting-dedupe",
+      Object.fromEntries(Object.entries(identicalSharedChunkFiles).map(([name, contents]) => [name.slice(1), contents])),
+    );
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.js")],
+      target: "bun",
+      splitting: true,
+      throw: false,
+    });
+    expect(result.logs).toBeEmpty();
+    expect(result.success).toBe(true);
+
+    const paths = result.outputs.map(output => output.path);
+    expect(new Set(paths).size).toBe(paths.length);
+    const contents = await Promise.all(result.outputs.map(output => output.text()));
+    expect(new Set(contents).size).toBe(contents.length);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #37576. With splitting, two different shared chunks whose output is byte-identical hash to the same `[hash]`, and the build fails with "Multiple files share the same output path". This dedupes instead: on a path collision with equal isolated hashes, the later chunk is aliased to the first one's output file; differing hashes keep the existing error, and entry-point chunks are excluded so each entry keeps its own file. Duplicates skip codegen and are compacted out of the output list with source_map/bytecode/module_info/referenced_css_chunks indices remapped, so `result.outputs` contains each path once, matching esbuild. That also keeps `--compile` correct with no standalone-graph changes. The collision error's note no longer mislabels chunk naming as "asset naming".

The alias-and-compact mechanism follows robobun's `farm/8dce31c8/split-chunk-dedupe`. Equal digests imply byte-identical output: the aggregate hash is length-prefixed and covers each reached chunk's isolated hash and template.

### How did you verify your code works?

Two tests: a disk build of the colliding shape (runs, side effect executes once, deduped file emitted once) and an in-memory build asserting `result.outputs` paths and contents are unique. Ran bundler_naming, bundler_splitting, metafile, bundler_compile_splitting, bundler_compile via `bun bd test`; the one bundler_compile failure reproduces on unpatched main. Repro verified with external, inline and linked sourcemaps, identical-content entrypoints with and without maps, and `--compile` round-trip. cargo check, clippy, fmt clean.
