### PR TITLE
node:http2: send array-valued pushStream() headers as one field per element

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3425,8 +3425,7 @@ class ServerHttp2Stream extends Http2Stream {
     }
     headers = { ...headers };
     assertNoConnectionHeaders(headers);
-    // node throws these synchronously from pushStream() (buildNgHeaderString), before a stream id
-    // is reserved; same rule respond() applies.
+    // Thrown synchronously like node, before a promised stream id is reserved.
     if (session[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
     const sensitives = headers[sensitiveHeaders];
     // Note: the sensitiveHeaders symbol stays on the object — the native header walk skips

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3425,6 +3425,9 @@ class ServerHttp2Stream extends Http2Stream {
     }
     headers = { ...headers };
     assertNoConnectionHeaders(headers);
+    // node throws these synchronously from pushStream() (buildNgHeaderString), before a stream id
+    // is reserved; same rule respond() applies.
+    if (session[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
     const sensitives = headers[sensitiveHeaders];
     // Note: the sensitiveHeaders symbol stays on the object — the native header walk skips
     // symbol keys, and deleting it here would flip the object into dictionary mode,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8486,7 +8486,6 @@ impl H2FrameParser {
                     }
                     Ok(None)
                 };
-                // Like request() and send_trailers(): an array value is one field per element.
                 if js_value.js_type().is_array() {
                     let mut value_iter = js_value.array_iterator(global_object)?;
                     if let Some(idx) = this.single_value_index_checked(validated_name) {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8381,6 +8381,7 @@ impl H2FrameParser {
 
         let mut name_buffer = [0u8; 4096];
         let mut encoded_headers: Vec<u8> = Vec::new();
+        let mut single_value_headers = [false; SINGLE_VALUE_HEADERS_LEN];
 
         // A PUSH_PROMISE carries a REQUEST, so request pseudo-headers are valid even on the server.
         // Pseudo-headers must be encoded first, so iterate twice.
@@ -8438,7 +8439,6 @@ impl H2FrameParser {
                 if js_value.is_empty_or_undefined_or_null() {
                     continue;
                 }
-                let value_str = js_value.to_js_string(global_object)?;
                 // All-digit names can't be passed to get_truthy (integer-index-like names trip
                 // a debug assert in getIfPropertyExistsImpl) and can never be sensitive.
                 let never_index = if Self::is_index_like_name(validated_name) {
@@ -8449,32 +8449,94 @@ impl H2FrameParser {
                         None => sensitive_arg.get_truthy(global_object, name)?.is_some(),
                     }
                 };
-                let value_slice = value_str.to_slice(global_object);
-                let value = value_slice.slice();
-                if !is_valid_header_value(value) {
-                    return Err(global_object
-                        .err(
-                            JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                            format_args!(
-                                "Invalid value for header \"{}\"",
-                                BStr::new(validated_name)
-                            ),
+                let mut encode_value = |item: JSValue| -> JsResult<Option<JSValue>> {
+                    let value_str = item.to_js_string(global_object)?;
+                    let value_slice = value_str.to_slice(global_object);
+                    let value = value_slice.slice();
+                    if !is_valid_header_value(value) {
+                        return Err(global_object
+                            .err(
+                                JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
+                                format_args!(
+                                    "Invalid value for header \"{}\"",
+                                    BStr::new(validated_name)
+                                ),
+                            )
+                            .throw());
+                    }
+                    bun_output::scoped_log!(
+                        H2FrameParser,
+                        "encode header {} {}",
+                        BStr::new(validated_name),
+                        BStr::new(value)
+                    );
+                    if this
+                        .encode_header_into_list(
+                            &mut encoded_headers,
+                            validated_name,
+                            value,
+                            never_index,
                         )
-                        .throw());
-                }
-                if this
-                    .encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    )
-                    .is_err()
-                {
-                    // Same as the request/respond encode failures: nghttp2 fails the whole
-                    // session, and node never surfaces this through the pushStream callback.
-                    this.schedule_header_compression_session_error();
-                    return Ok(JSValue::js_number(-1.0));
+                        .is_err()
+                    {
+                        // Same as the request/respond encode failures: nghttp2 fails the whole
+                        // session, and node never surfaces this through the pushStream callback.
+                        this.schedule_header_compression_session_error();
+                        return Ok(Some(JSValue::js_number(-1.0)));
+                    }
+                    Ok(None)
+                };
+                // Like request() and send_trailers(): an array value is one field per element.
+                if js_value.js_type().is_array() {
+                    let mut value_iter = js_value.array_iterator(global_object)?;
+                    if let Some(idx) = this.single_value_index_checked(validated_name) {
+                        if value_iter.len > 1 || single_value_headers[idx] {
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_HEADER_SINGLE_VALUE,
+                                    format_args!(
+                                        "Header field \"{}\" must only have a single value",
+                                        BStr::new(validated_name)
+                                    ),
+                                )
+                                .throw());
+                        }
+                        single_value_headers[idx] = true;
+                    }
+                    while let Some(item) = value_iter.next()? {
+                        if item.is_empty_or_undefined_or_null() {
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
+                                    format_args!(
+                                        "Invalid value for header \"{}\"",
+                                        BStr::new(validated_name)
+                                    ),
+                                )
+                                .throw());
+                        }
+                        if let Some(ret) = encode_value(item)? {
+                            return Ok(ret);
+                        }
+                    }
+                } else {
+                    if let Some(idx) = this.single_value_index_checked(validated_name) {
+                        if single_value_headers[idx] {
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_HEADER_SINGLE_VALUE,
+                                    format_args!(
+                                        "Header field \"{}\" must only have a single value",
+                                        BStr::new(validated_name)
+                                    ),
+                                )
+                                .throw());
+                        }
+                        single_value_headers[idx] = true;
+                    }
+                    if let Some(ret) = encode_value(js_value)? {
+                        return Ok(ret);
+                    }
                 }
             }
         }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3592,10 +3592,15 @@ it("http2 pushStream failure reports only via callback, never via stream 'error'
 async function pushedHeaderBlocks(onStream, serverOptions) {
   const server = http2.createServer(serverOptions);
   server.on("stream", onStream);
-  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  await new Promise((listening, failed) => {
+    server.once("error", failed);
+    server.listen(0, "127.0.0.1", listening);
+  });
+  let client;
   try {
-    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
     const { promise, resolve, reject } = Promise.withResolvers();
+    server.on("sessionError", reject);
+    client = http2.connect(`http://127.0.0.1:${server.address().port}`);
     client.on("error", reject);
     const blocks = [];
     client.on("stream", (pushed, headers, _flags, rawHeaders) => {
@@ -3618,9 +3623,9 @@ async function pushedHeaderBlocks(onStream, serverOptions) {
     req.on("end", resolve);
     req.resume();
     await promise;
-    client.close();
     return blocks;
   } finally {
+    client?.close();
     server.close();
   }
 }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3584,6 +3584,210 @@ it("http2 pushStream failure reports only via callback, never via stream 'error'
   }
 });
 
+// Serves a single request with `onStream` (which must push synchronously and then respond) and
+// resolves with the PUSH_PROMISE header blocks the client received, in wire order: `fields` is the
+// flat [name, value, ...] list as decoded from the wire, `headers` the object form, both without
+// pseudo-headers. Every PUSH_PROMISE precedes the parent's response on the wire, so once the parent
+// response has ended every push has been observed.
+async function pushedHeaderBlocks(onStream, serverOptions) {
+  const server = http2.createServer(serverOptions);
+  server.on("stream", onStream);
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    const { promise, resolve, reject } = Promise.withResolvers();
+    client.on("error", reject);
+    const blocks = [];
+    client.on("stream", (pushed, headers, _flags, rawHeaders) => {
+      pushed.on("error", reject);
+      pushed.resume();
+      const fields = [];
+      for (let i = 0; i < rawHeaders.length; i += 2) {
+        if (!rawHeaders[i].startsWith(":")) fields.push(rawHeaders[i], rawHeaders[i + 1]);
+      }
+      blocks.push({
+        id: pushed.id,
+        path: headers[":path"],
+        sensitive: headers[http2.sensitiveHeaders],
+        headers: Object.fromEntries(Object.entries(headers).filter(([name]) => !name.startsWith(":"))),
+        fields,
+      });
+    });
+    const req = client.request({ ":path": "/" });
+    req.on("error", reject);
+    req.on("end", resolve);
+    req.resume();
+    await promise;
+    client.close();
+    return blocks;
+  } finally {
+    server.close();
+  }
+}
+
+it("http2 pushStream sends an array-valued header as one field per element", async () => {
+  const blocks = await pushedHeaderBlocks(stream => {
+    stream.pushStream(
+      {
+        ":path": ["/pushed"],
+        "set-cookie": ["c1=1", "c2=2"],
+        "x-multi": ["a", "b"],
+        "x-number": [1, 2],
+        "x-one": ["only"],
+        "x-none": [],
+        "x-plain": "p",
+      },
+      (err, push) => {
+        if (err) {
+          stream.destroy(err);
+          return;
+        }
+        push.respond({ ":status": 200 });
+        push.end();
+      },
+    );
+    stream.respond({ ":status": 200 });
+    stream.end();
+  });
+
+  expect(blocks.length).toBe(1);
+  const [block] = blocks;
+  expect(block.path).toBe("/pushed");
+  expect(block.fields).toEqual([
+    ...["set-cookie", "c1=1", "set-cookie", "c2=2"],
+    ...["x-multi", "a", "x-multi", "b"],
+    ...["x-number", "1", "x-number", "2"],
+    ...["x-one", "only"],
+    ...["x-plain", "p"],
+  ]);
+  // The object form a receiver builds from those fields: set-cookie stays a list, other repeated
+  // fields are joined with ", ", and an empty array sends nothing at all.
+  expect(block.headers).toEqual({
+    "set-cookie": ["c1=1", "c2=2"],
+    "x-multi": "a, b",
+    "x-number": "1, 2",
+    "x-one": "only",
+    "x-plain": "p",
+  });
+});
+
+it("http2 pushStream never-indexes every element of a sensitive array-valued header", async () => {
+  const blocks = await pushedHeaderBlocks(stream => {
+    stream.pushStream(
+      { ":path": "/pushed", "x-secret": ["s1", "s2"], [http2.sensitiveHeaders]: ["x-secret"] },
+      (err, push) => {
+        if (err) {
+          stream.destroy(err);
+          return;
+        }
+        push.respond({ ":status": 200 });
+        push.end();
+      },
+    );
+    stream.respond({ ":status": 200 });
+    stream.end();
+  });
+
+  // The receiver lists a name once per field that arrived with the never-index flag.
+  expect(blocks.map(({ headers, sensitive }) => ({ secret: headers["x-secret"], sensitive }))).toEqual([
+    { secret: "s1, s2", sensitive: ["x-secret", "x-secret"] },
+  ]);
+});
+
+it("http2 pushStream throws ERR_HTTP2_HEADER_SINGLE_VALUE synchronously without reserving a stream", async () => {
+  const attempts = [
+    { ":path": "/pushed", "content-type": ["text/plain", "text/html"] },
+    { ":path": ["/a", "/b"] },
+    { ":path": "/pushed", "content-type": "text/plain", "Content-Type": "text/html" },
+  ];
+  const thrown = [];
+  let rejectedCallbackCalls = 0;
+  const blocks = await pushedHeaderBlocks(stream => {
+    for (const headers of attempts) {
+      try {
+        stream.pushStream(headers, () => rejectedCallbackCalls++);
+        thrown.push(null);
+      } catch (err) {
+        thrown.push({ name: err.constructor.name, code: err.code, message: err.message });
+      }
+    }
+    stream.pushStream({ ":path": "/after" }, (err, push) => {
+      if (err) {
+        stream.destroy(err);
+        return;
+      }
+      push.respond({ ":status": 200 });
+      push.end();
+    });
+    stream.respond({ ":status": 200 });
+    stream.end();
+  });
+
+  const singleValue = name => ({
+    name: "TypeError",
+    code: "ERR_HTTP2_HEADER_SINGLE_VALUE",
+    message: `Header field "${name}" must only have a single value`,
+  });
+  expect(thrown).toEqual([singleValue("content-type"), singleValue(":path"), singleValue("content-type")]);
+  expect(rejectedCallbackCalls).toBe(0);
+  // The rejected attempts reserved nothing: the push that followed them got the first even id.
+  expect(blocks.map(({ id, path }) => ({ id, path }))).toEqual([{ id: 2, path: "/after" }]);
+});
+
+it("http2 pushStream sends each element of a single-value header when strictSingleValueFields is off", async () => {
+  const blocks = await pushedHeaderBlocks(
+    stream => {
+      stream.pushStream({ ":path": "/pushed", "content-type": ["text/plain", "text/html"] }, (err, push) => {
+        if (err) {
+          stream.destroy(err);
+          return;
+        }
+        push.respond({ ":status": 200 });
+        push.end();
+      });
+      stream.respond({ ":status": 200 });
+      stream.end();
+    },
+    { strictSingleValueFields: false },
+  );
+
+  expect(blocks.map(({ path, fields }) => ({ path, fields }))).toEqual([
+    { path: "/pushed", fields: ["content-type", "text/plain", "content-type", "text/html"] },
+  ]);
+});
+
+it("http2 pushStream reports an unsendable array element through the callback", async () => {
+  const results = [];
+  const blocks = await pushedHeaderBlocks(stream => {
+    const values = [
+      ["ok", "a\nb"],
+      ["ok", null],
+    ];
+    let pending = values.length;
+    for (const value of values) {
+      stream.pushStream({ ":path": "/pushed", "x-custom": value }, (err, push) => {
+        results.push(err ? { name: err.constructor.name, code: err.code, message: err.message } : "pushed");
+        if (push) {
+          push.respond({ ":status": 200 });
+          push.end();
+        }
+        if (--pending === 0) {
+          stream.respond({ ":status": 200 });
+          stream.end();
+        }
+      });
+    }
+  });
+
+  const invalidValue = {
+    name: "TypeError",
+    code: "ERR_HTTP2_INVALID_HEADER_VALUE",
+    message: 'Invalid value for header "x-custom"',
+  };
+  expect(results).toEqual([invalidValue, invalidValue]);
+  expect(blocks).toEqual([]);
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3590,16 +3590,15 @@ it("http2 pushStream failure reports only via callback, never via stream 'error'
 // pseudo-headers. Every PUSH_PROMISE precedes the parent's response on the wire, so once the parent
 // response has ended every push has been observed.
 async function pushedHeaderBlocks(onStream, serverOptions) {
+  // Every failure on either side, from listen() onwards, rejects this one promise.
+  const { promise, resolve, reject } = Promise.withResolvers();
   const server = http2.createServer(serverOptions);
+  server.on("error", reject);
+  server.on("sessionError", reject);
   server.on("stream", onStream);
-  await new Promise((listening, failed) => {
-    server.once("error", failed);
-    server.listen(0, "127.0.0.1", listening);
-  });
   let client;
   try {
-    const { promise, resolve, reject } = Promise.withResolvers();
-    server.on("sessionError", reject);
+    await Promise.race([promise, new Promise(listening => server.listen(0, "127.0.0.1", listening))]);
     client = http2.connect(`http://127.0.0.1:${server.address().port}`);
     client.on("error", reject);
     const blocks = [];
@@ -3640,6 +3639,7 @@ it("http2 pushStream sends an array-valued header as one field per element", asy
         "x-number": [1, 2],
         "x-one": ["only"],
         "x-none": [],
+        "content-type": [],
         "x-plain": "p",
       },
       (err, push) => {
@@ -3666,7 +3666,7 @@ it("http2 pushStream sends an array-valued header as one field per element", asy
     ...["x-plain", "p"],
   ]);
   // The object form a receiver builds from those fields: set-cookie stays a list, other repeated
-  // fields are joined with ", ", and an empty array sends nothing at all.
+  // fields are joined with ", ", and an empty array (single-value field or not) sends nothing.
   expect(block.headers).toEqual({
     "set-cookie": ["c1=1", "c2=2"],
     "x-multi": "a, b",


### PR DESCRIPTION
## Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("stream", stream => {
  stream.pushStream({ ":path": "/p", "x-multi": ["a", "b"], "set-cookie": ["c1=1", "c2=2"] }, (err, push) => {
    if (err) throw err;
    push.respond({ ":status": 200 }); push.end();
  });
  stream.respond({ ":status": 200 }); stream.end();
});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect("http://127.0.0.1:" + server.address().port);
  client.on("stream", (pushed, headers) => {
    console.log(JSON.stringify({ "x-multi": headers["x-multi"], "set-cookie": headers["set-cookie"] }));
    pushed.resume(); client.close(); server.close();
  });
  client.request({ ":path": "/" }).resume();
});
```

| | output |
| --- | --- |
| node v26.3.0 | `{"x-multi":"a, b","set-cookie":["c1=1","c2=2"]}` |
| bun 1.4.0 / main | `{"x-multi":"a,b","set-cookie":["c1=1,c2=2"]}` |
| this PR | `{"x-multi":"a, b","set-cookie":["c1=1","c2=2"]}` |

(A receiver joins repeated fields with `", "`, so the missing space in `x-multi` shows a single field was sent; `set-cookie` shows it directly: two cookies collapsed into one invalid cookie.)

## Cause

Every outbound header block in bun goes through a native encoder in `h2_frame_parser.rs`. `request()` (used by `session.request()`, `respond()`, `additionalHeaders()`) and `send_trailers()` have an array branch that encodes one field per element. `push_promise()`, which backs `pushStream()`, did not: it called `to_js_string()` on the value, so an array went through `Array.prototype.toString` and was sent as a single field joined with `","`. Node's `buildNgHeaderString` emits one field per element for every block, `pushStream()` included.

The same missing branch meant `pushStream()` had no single-value enforcement at all: `{"content-type": ["a", "b"]}` was sent as `content-type: a,b`, `{":path": ["/a", "/b"]}` as `:path: /a,/b`, and `{"content-type": "a", "Content-Type": "b"}` as two fields. Node throws `ERR_HTTP2_HEADER_SINGLE_VALUE` synchronously from `pushStream()` for all three (verified against v26.3.0).

## Fix

- `src/runtime/api/bun/h2_frame_parser.rs`: `push_promise()` gets the same value handling as `request()` and `send_trailers()`: an array encodes one field per element (each element validated like a single value, so an element with CR/LF/NUL or a null element is rejected with `ERR_HTTP2_INVALID_HEADER_VALUE` exactly as it is for `respond()`), and single-value fields are tracked with the same `strictSingleValueFields`-gated bitset the other encoders use. The never-index lookup is done once per header name and applied to every element.
- `src/js/node/http2.ts`: `pushStream()` runs `assertSingleValueHeaders()` (the check `respond()` / `additionalHeaders()` / `request()` already run) before a promised stream id is reserved, so the violation throws synchronously from `pushStream()` like node, reserves no stream, and never reaches the encoder.

Behavior checked against node v26.3.0 with a per-case probe:

| `pushStream()` headers | node | main | this PR |
| --- | --- | --- | --- |
| `"x-multi": ["a", "b"]` | two fields | one field `a,b` | two fields |
| `"set-cookie": ["c1=1", "c2=2"]` | two fields | one field `c1=1,c2=2` | two fields |
| `"x-none": []` | nothing sent | `x-none: ` (empty value) | nothing sent |
| `"x-num": [1, 2]` | `1`, `2` | `1,2` | `1`, `2` |
| `"content-type": ["a", "b"]` | throws `ERR_HTTP2_HEADER_SINGLE_VALUE` | sent as `a,b` | throws |
| `":path": ["/a", "/b"]` | throws | sent as `/a,/b` | throws |
| `"content-type": "a", "Content-Type": "b"` | throws | both sent | throws |
| same with `strictSingleValueFields: false` | two fields | one field | two fields |
| `"x": ["ok", null]` | sends `null` (stringified) | one field `ok,` | callback `ERR_HTTP2_INVALID_HEADER_VALUE` |

The last row is the one deliberate difference from node: rejecting a null element is what bun's `request()` / `respond()` already do for array elements, so `pushStream()` now matches the rest of bun rather than node's `String(null)`.

Not changed here: a block that fails validation after some of its fields were already fed to the HPACK encoder still desyncs the encoder table from the peer. That is pre-existing (the same `{"x-a": "fine", "x-bad": "a\nb"}` push kills the session with COMPRESSION_ERROR before and after this change, and it applies to every encoder) and is what #33470 fixes by collecting the block before encoding; this change keeps `push_promise()`'s loop shape so that PR rebases mechanically either way. #37568 (coerce values in JS before taking the id) passes arrays through to the native encoder and is complementary.

## Verification

Five tests added to `test/js/node/http2/node-http2.test.js`, asserting on the flat header list the client decodes from the wire (one name/value pair per field):

- array value sends one field per element; empty array sends nothing; `[x]` sends one field (also for a pseudo-header)
- every element of a `[http2.sensitiveHeaders]` header arrives never-indexed
- the three single-value violations throw `ERR_HTTP2_HEADER_SINGLE_VALUE` synchronously, the callback is never invoked, and the next push still gets stream id 2
- `strictSingleValueFields: false` sends each element of a single-value header
- an element containing LF, or a null element, is reported through the callback as `ERR_HTTP2_INVALID_HEADER_VALUE` and nothing is pushed

All five fail on the current release (`USE_SYSTEM_BUN=1`) and pass with this change. The rest of `node-http2.test.js` (352 tests), `h2-conformance.test.ts`, `h2-push-refusal-staged.test.ts`, and the ported node push tests (`test-http2-server-push-stream*.js`, `test-http2-compat-serverresponse-createpushresponse.js`, `test-http2-respond-file-push.js`, `test-http2-server-push-disabled.js`, `test-http2-single-headers-validation-disabled.js`) pass with the debug build.
