### PR TITLE
sourcemap: replace SourceContentPtr's u64 pointer pun with an enum

### DIFF
--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -7,6 +7,7 @@ use bun_core::{self, ZigStringSlice};
 use bun_core::{declare_scope, scoped_log};
 use bun_semver::String as SemverString;
 
+use crate::parsed_source_map::SourceContent;
 use crate::vlq::decode as decode_vlq;
 use crate::{LineColumnOffset, Ordinal, ParseResult, ParseResultFail, ParsedSourceMap};
 
@@ -335,7 +336,7 @@ impl Lookup {
 
         let name: &[u8] = &source_map.external_source_names[source_idx];
 
-        if source_map.is_standalone_module_graph {
+        if source_map.is_standalone_module_graph() {
             return Some(bun_core::String::clone_utf8(name));
         }
 
@@ -365,26 +366,23 @@ impl Lookup {
             let source_map = self.source_map.as_deref()?;
             debug_assert!(source_map.is_external());
 
-            let provider = source_map.underlying_provider.provider()?;
-
             let index = usize::try_from(self.mapping.source_index).ok()?;
 
-            // Standalone module graph source maps are stored (in memory) compressed.
-            // They are decompressed on demand.
-            if source_map.is_standalone_module_graph {
-                let serialized = source_map.standalone_module_graph_data();
-                if index >= source_map.external_source_names.len() {
-                    return None;
+            let provider = match source_map.underlying_provider.content() {
+                SourceContent::None => return None,
+                // Standalone module graph source maps are stored (in memory) compressed.
+                // They are decompressed on demand.
+                SourceContent::Standalone(serialized) => {
+                    if index >= source_map.external_source_names.len() {
+                        return None;
+                    }
+
+                    let code = serialized.source_file_contents(index)?;
+
+                    return Some(ZigStringSlice::from_utf8_never_free(code));
                 }
-
-                // SAFETY: `standalone_module_graph_data` returns a pointer
-                // owned by the standalone module graph trailer; lifetime is
-                // process-static (mmapped). `source_file_contents` fills the
-                // per-index decompression cache through a `OnceLock`.
-                let code = unsafe { (*serialized).source_file_contents(index) };
-
-                return Some(ZigStringSlice::from_utf8_never_free(code?));
-            }
+                SourceContent::Provider(provider) => provider,
+            };
 
             if let Some(parsed) = provider.get_source_map(
                 base_filename,

--- a/src/sourcemap/ParsedSourceMap.rs
+++ b/src/sourcemap/ParsedSourceMap.rs
@@ -7,7 +7,6 @@ use crate::mapping;
 use crate::vlq::VLQ;
 use crate::{
     InternalSourceMap, Mapping, ParseUrl, ParseUrlResultHint, SourceMapLoadHint, SourceProvider,
-    SourceProviderMap,
 };
 
 /// ParsedSourceMap can be acquired by different threads via the thread-safe
@@ -36,8 +35,6 @@ pub struct ParsedSourceMap {
     /// are emitted (specifically with Bun.inspect / unhandled; the ones that
     /// rely on source contents)
     pub underlying_provider: SourceContentPtr,
-
-    pub is_standalone_module_graph: bool,
 }
 
 impl Drop for ParsedSourceMap {
@@ -53,7 +50,7 @@ impl Drop for ParsedSourceMap {
         //
         // `mappings`/`external_source_names` free via their own `Drop`.
         if let Some(ism) = self.internal.take() {
-            if !self.is_standalone_module_graph {
+            if !self.is_standalone_module_graph() {
                 ism.free_owned();
             }
         }
@@ -68,7 +65,6 @@ impl Default for ParsedSourceMap {
             internal: None,
             external_source_names: Vec::new(),
             underlying_provider: SourceContentPtr::NONE,
-            is_standalone_module_graph: false,
         }
     }
 }
@@ -85,25 +81,25 @@ type ErasedGetSourceMap = unsafe fn(
 ) -> Option<ParseUrl>;
 
 /// # Safety
-/// `provider` must be the pointer packed by
-/// [`SourceContentPtr::from_source_provider`] for the same `P`, still live.
+/// `provider` must be the pointer packed by [`AnySourceProvider::new`] for
+/// the same `P`, still live.
 unsafe fn erased_get_source_map<P: SourceProvider>(
     provider: *mut c_void,
     source_filename: &[u8],
     load_hint: SourceMapLoadHint,
     result: ParseUrlResultHint,
 ) -> Option<ParseUrl> {
-    // SAFETY: caller contract — `provider` originates from
-    // `SourceContentPtr::from_source_provider::<P>`, so it is a live
-    // `*const P` for the duration of this call.
+    // SAFETY: caller contract: `provider` originates from
+    // `AnySourceProvider::new::<P>`, so it is a live `*const P` for the
+    // duration of this call.
     let provider = unsafe { &*provider.cast::<P>() };
     crate::get_source_map_impl(provider, source_filename, load_hint, result)
 }
 
 /// An erased source provider: the raw FFI handle plus the `get_source_map`
-/// dispatch monomorphized for its concrete type. Recovered from a
-/// [`SourceContentPtr`], or stored whole (boxed) where the pair must travel
-/// together (`bun_jsc::SavedSourceMap`'s provider entries).
+/// dispatch monomorphized for its concrete type. Stored in a
+/// [`SourceContentPtr`], or boxed on its own (`bun_jsc::SavedSourceMap`'s
+/// provider entries).
 #[derive(Clone, Copy)]
 pub struct AnySourceProvider {
     ptr: *mut c_void,
@@ -111,9 +107,8 @@ pub struct AnySourceProvider {
 }
 
 impl AnySourceProvider {
-    /// Erases a provider handle. Like [`SourceContentPtr::from_source_provider`],
-    /// `p` must stay live for as long as the returned value (or any copy of
-    /// it) is dispatched through.
+    /// Erases a provider handle. `p` must stay live for as long as the
+    /// returned value (or any copy of it) is dispatched through.
     pub fn new<P: SourceProvider>(p: *const P) -> AnySourceProvider {
         AnySourceProvider {
             ptr: p.cast_mut().cast::<c_void>(),
@@ -132,28 +127,39 @@ impl AnySourceProvider {
         result: ParseUrlResultHint,
     ) -> Option<ParseUrl> {
         // SAFETY: `ptr` and `get_source_map` were packed together by
-        // `SourceContentPtr::from_source_provider`; the provider FFI handle
-        // outlives any `ParsedSourceMap` that stores it, so it is valid for
-        // the duration of this call.
+        // `Self::new`; the provider FFI handle outlives any `ParsedSourceMap`
+        // that stores it, so it is valid for the duration of this call.
         unsafe { (self.get_source_map)(self.ptr, source_filename, load_hint, result) }
     }
 }
 
-/// A provider handle (stored as a raw address in `data`), the erased
-/// `get_source_map` dispatch for its concrete type, and a load hint.
+/// Where a [`ParsedSourceMap`] fetches source contents from after the fact.
+#[derive(Copy, Clone)]
+pub(crate) enum SourceContent {
+    None,
+    Provider(AnySourceProvider),
+    /// Embedded `bun build --compile` section. The map's `InternalSourceMap`
+    /// blob is borrowed from that same section, so `Drop` must not free it.
+    Standalone(&'static crate::SerializedSourceMap::Loaded),
+}
+
+/// A `SourceContent` plus the load hint to reuse when re-loading through it.
 #[derive(Copy, Clone)]
 pub struct SourceContentPtr {
-    data: u64,
+    content: SourceContent,
     load_hint: SourceMapLoadHint,
-    get_source_map: Option<ErasedGetSourceMap>,
 }
 
 impl SourceContentPtr {
     pub(crate) const NONE: SourceContentPtr = SourceContentPtr {
-        data: 0,
+        content: SourceContent::None,
         load_hint: SourceMapLoadHint::None,
-        get_source_map: None,
     };
+
+    #[inline]
+    pub(crate) fn content(self) -> SourceContent {
+        self.content
+    }
 
     #[inline]
     pub(crate) fn load_hint(self) -> SourceMapLoadHint {
@@ -165,34 +171,18 @@ impl SourceContentPtr {
         self.load_hint = hint;
     }
 
-    #[inline]
-    pub(crate) fn data(self) -> u64 {
-        self.data
-    }
-
-    /// Pack a provider handle. [`Self::provider`] recovers it together with
-    /// the `get_source_map` dispatch for `P`.
     pub fn from_source_provider<P: SourceProvider>(p: *const P) -> SourceContentPtr {
         SourceContentPtr {
-            data: u64::try_from(p as usize).expect("int cast"),
+            content: SourceContent::Provider(AnySourceProvider::new(p)),
             load_hint: SourceMapLoadHint::None,
-            get_source_map: Some(erased_get_source_map::<P>),
         }
     }
 
-    /// `SourceProviderMap` packing helper. Also used by the standalone module
-    /// graph, which stores a `*mut SerializedSourceMap::Loaded` here (guarded
-    /// by [`ParsedSourceMap::is_standalone_module_graph`], so the provider
-    /// dispatch is never invoked for it).
-    pub fn from_provider(p: *const SourceProviderMap) -> SourceContentPtr {
-        Self::from_source_provider(p)
-    }
-
     pub fn provider(self) -> Option<AnySourceProvider> {
-        Some(AnySourceProvider {
-            ptr: self.data as usize as *mut c_void,
-            get_source_map: self.get_source_map?,
-        })
+        match self.content {
+            SourceContent::Provider(provider) => Some(provider),
+            SourceContent::None | SourceContent::Standalone(_) => None,
+        }
     }
 }
 
@@ -220,11 +210,8 @@ impl ParsedSourceMap {
     }
 
     /// Construct a `ParsedSourceMap` whose mappings are backed by an
-    /// `InternalSourceMap` blob (e.g. one embedded in a `bun build --compile`
-    /// executable's standalone module graph) instead of a materialized
-    /// `mapping::List`. Ownership of the blob transfers to the returned value
-    /// (freed in `Drop`) unless the caller subsequently sets
-    /// [`Self::is_standalone_module_graph`].
+    /// `InternalSourceMap` blob instead of a materialized `mapping::List`.
+    /// Ownership of the blob transfers to the returned value (freed in `Drop`).
     pub fn from_internal(internal: InternalSourceMap) -> Self {
         Self {
             input_line_count: internal.input_line_count(),
@@ -232,8 +219,33 @@ impl ParsedSourceMap {
             internal: Some(internal),
             external_source_names: Vec::new(),
             underlying_provider: SourceContentPtr::NONE,
-            is_standalone_module_graph: false,
         }
+    }
+
+    /// Unlike [`Self::from_internal`], `internal` is borrowed from the
+    /// executable and `Drop` does not free it.
+    pub fn from_standalone(
+        internal: InternalSourceMap,
+        loaded: &'static crate::SerializedSourceMap::Loaded,
+        external_source_names: Vec<Box<[u8]>>,
+    ) -> Self {
+        Self {
+            input_line_count: internal.input_line_count(),
+            mappings: mapping::List::default(),
+            internal: Some(internal),
+            external_source_names,
+            underlying_provider: SourceContentPtr {
+                content: SourceContent::Standalone(loaded),
+                load_hint: SourceMapLoadHint::None,
+            },
+        }
+    }
+
+    pub(crate) fn is_standalone_module_graph(&self) -> bool {
+        matches!(
+            self.underlying_provider.content,
+            SourceContent::Standalone(_)
+        )
     }
 
     pub fn is_external(&self) -> bool {
@@ -249,11 +261,6 @@ impl ParsedSourceMap {
 
     pub fn internal_cursor(&self) -> Option<crate::internal_source_map::Cursor> {
         self.internal.as_ref().map(|ism| ism.cursor())
-    }
-
-    pub(crate) fn standalone_module_graph_data(&self) -> *mut crate::SerializedSourceMap::Loaded {
-        debug_assert!(self.is_standalone_module_graph);
-        self.underlying_provider.data() as usize as *mut crate::SerializedSourceMap::Loaded
     }
 
     pub fn memory_cost(&self) -> usize {

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -33,8 +33,8 @@ pub use parsed_source_map::{ParsedSourceMap, SourceContentPtr};
 // `SavedSourceMap` store (its `ref_count` is an `AtomicU32`). The auto-trait
 // inference fails only because `InternalSourceMap` holds the blob's raw data
 // pointer (owned by this map, or borrowed from the embedded standalone
-// section); `SourceContentPtr`'s provider handles are packed as plain
-// integers and never dereferenced off the JS thread.
+// section) and `SourceContentPtr` holds the raw provider handle, which is
+// never dereferenced off the JS thread.
 unsafe impl Send for ParsedSourceMap {}
 // SAFETY: see the `Send` rationale above — refcount is atomic and the raw
 // provider pointers are opaque, never dereferenced off the JS thread.
@@ -363,7 +363,7 @@ impl SourceProviderMap {
     }
 
     pub(crate) fn to_source_content_ptr(&self) -> SourceContentPtr {
-        SourceContentPtr::from_provider(self)
+        SourceContentPtr::from_source_provider::<Self>(self)
     }
 }
 
@@ -684,9 +684,9 @@ pub mod SerializedSourceMap {
     }
 
     /// Once loaded, this map stores additional data for keeping track of
-    /// source code. Held behind `ParsedSourceMap.underlying_provider` as a raw
-    /// pointer (see `ParsedSourceMap::standalone_module_graph_data`).
-    pub(crate) struct Loaded {
+    /// source code. Held by `ParsedSourceMap.underlying_provider` (see
+    /// `ParsedSourceMap::from_standalone`).
+    pub struct Loaded {
         pub(crate) map: SerializedSourceMap,
         /// Only decompress source code once! Once a file is decompressed,
         /// it is stored here. Decompression failure is recorded as an empty
@@ -695,6 +695,17 @@ pub mod SerializedSourceMap {
     }
 
     impl Loaded {
+        /// `bytes` is the whole serialized map, starting at its [`Header`];
+        /// `source_files_count` is that header's file count.
+        pub fn new(bytes: &'static [u8], source_files_count: usize) -> Loaded {
+            Loaded {
+                map: SerializedSourceMap { bytes },
+                decompressed_files: std::iter::repeat_with(std::sync::OnceLock::new)
+                    .take(source_files_count)
+                    .collect(),
+            }
+        }
+
         pub(crate) fn source_file_contents(&self, index: usize) -> Option<&[u8]> {
             let decompressed = self.decompressed_files[index].get_or_init(|| {
                 let sp = self.map.compressed_source_file_at(index);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -548,19 +548,12 @@ impl LazySourceMap {
                 let ism = SourceMap::InternalSourceMap {
                     data: blob.as_ptr(),
                 };
-                // Note: `from_internal` fills `internal = Some(ism)` +
-                // `input_line_count = ism.input_line_count()` and defaults the rest.
-                let mut stored = SourceMap::ParsedSourceMap::from_internal(ism);
 
                 let source_files_count = serialized.source_files_count();
                 // PERF: `external_source_names` is `Vec<Box<[u8]>>` so we
                 // copy the section bytes. Could switch
                 // the field to `Vec<&'static [u8]>` for the standalone path.
                 let mut file_names: Vec<Box<[u8]>> = Vec::with_capacity(source_files_count);
-                let decompressed_contents_slice: Vec<std::sync::OnceLock<Vec<u8>>> =
-                    std::iter::repeat_with(std::sync::OnceLock::new)
-                        .take(source_files_count)
-                        .collect();
                 for i in 0..source_files_count {
                     // SAFETY: `serialized.bytes` is a 'static read-only sourcemap subrange
                     // (disjoint from bytecode); StringPointer offsets were serialized by
@@ -574,24 +567,15 @@ impl LazySourceMap {
                     }));
                 }
 
-                let data = Box::new(SerializedSourceMapLoaded {
-                    map: SerializedSourceMap {
-                        bytes: serialized.bytes,
-                    },
-                    decompressed_files: decompressed_contents_slice.into_boxed_slice(),
-                });
+                let loaded: &'static SourceMap::SerializedSourceMap::Loaded =
+                    Box::leak(Box::new(SourceMap::SerializedSourceMap::Loaded::new(
+                        serialized.bytes,
+                        source_files_count,
+                    )));
 
-                stored.external_source_names = file_names;
-                // `from_provider` stores the pointer as a raw address in
-                // `SourceContentPtr.data`; the provider dispatch is never
-                // invoked for this type-punned pointer (guarded by
-                // `is_standalone_module_graph`).
-                stored.underlying_provider = SourceMap::SourceContentPtr::from_provider(
-                    bun_core::heap::into_raw(data).cast::<SourceMap::SourceProviderMap>(),
-                );
-                stored.is_standalone_module_graph = true;
-
-                let parsed = Arc::new(stored);
+                let parsed = Arc::new(SourceMap::ParsedSourceMap::from_standalone(
+                    ism, loaded, file_names,
+                ));
                 // The Arc clone held in self keeps the parsed map alive.
                 *self = LazySourceMap::Parsed(Arc::clone(&parsed));
                 Some(parsed)
@@ -2339,16 +2323,6 @@ impl SerializedSourceMap {
         // SAFETY: index bounds-checked; layout per Header doc; pointer may be misaligned.
         unsafe { core::ptr::read_unaligned(self.string_pointers_base().add(index)) }
     }
-}
-
-/// Once loaded, this map stores additional data for keeping track of source code.
-pub struct SerializedSourceMapLoaded {
-    pub map: SerializedSourceMap,
-
-    /// Only decompress source code once! Once a file is decompressed,
-    /// it is stored here. Decompression failures are stored as an empty
-    /// string, which will be treated as "no contents".
-    pub decompressed_files: Box<[std::sync::OnceLock<Vec<u8>>]>,
 }
 
 pub(crate) fn serialize_json_source_map_for_standalone(


### PR DESCRIPTION
## What

`SourceContentPtr` (`src/sourcemap/ParsedSourceMap.rs`) kept a provider handle as a `u64` next to an `Option` of its type-erased `get_source_map` fn, and `provider()` re-paired the two into an `AnySourceProvider` (the struct defined directly above it with the same two fields). The `bun build --compile` path reused the same slot for something else: `LazySourceMap::load` (`src/standalone_graph/StandaloneModuleGraph.rs`) packed a `*mut SerializedSourceMapLoaded` cast to `*const SourceProviderMap` through `from_provider`, then set a separate `ParsedSourceMap.is_standalone_module_graph: bool` after construction. That bool was the only thing keeping the bogus dispatch fn from being called, drove the `u64 -> *mut SerializedSourceMap::Loaded` cast in `standalone_module_graph_data()` (dereferenced in an `unsafe` block in `Lookup::get_source_code`), and decided in `Drop` whether the `InternalSourceMap` blob is owned or borrowed. The struct written (`bun_standalone_graph::SerializedSourceMapLoaded`) and the struct read (`bun_sourcemap::SerializedSourceMap::Loaded`) were two distinct `repr(Rust)` definitions that merely had the same fields.

```rust
// before
pub struct SourceContentPtr {
    data: u64,
    load_hint: SourceMapLoadHint,
    get_source_map: Option<ErasedGetSourceMap>,
}
pub struct ParsedSourceMap { /* .. */ pub underlying_provider: SourceContentPtr, pub is_standalone_module_graph: bool }

// after
pub(crate) enum SourceContent {
    None,
    Provider(AnySourceProvider),
    Standalone(&'static SerializedSourceMap::Loaded),
}
pub struct SourceContentPtr {
    content: SourceContent,
    load_hint: SourceMapLoadHint,
}
```

`from_source_provider` now builds `Provider(AnySourceProvider::new(p))`, so `AnySourceProvider::new` is the single packing site and `provider()` is a `match`. `SerializedSourceMap::Loaded` becomes `pub` with a `new(bytes, source_files_count)` constructor; the standalone graph builds it, `Box::leak`s it and passes it to the new `ParsedSourceMap::from_standalone(internal, loaded, external_source_names)`, which sets the borrowed-blob state in the constructor. `is_standalone_module_graph` becomes a `pub(crate)` method over the variant, used by `Drop` and `display_source_url_if_needed`; `get_source_code` (the other former reader of the bool) matches on the 3 variants, with the standalone arm reading through the reference. Deleted: `from_provider` (2 callers), `data()`, `standalone_module_graph_data()`, the bool field, and the duplicate `SerializedSourceMapLoaded` struct. The SAFETY comments on `erased_get_source_map`, `AnySourceProvider::get_source_map` and the `Send`/`Sync` impls are updated to describe the new fields. Removes 1 `unsafe` block. External users (`SourceContentPtr::from_source_provider` in bake, `provider()` in `bun_jsc::SavedSourceMap`, `AnySourceProvider::new`) are unchanged.

## Why

The three states a map can be in (no source, a provider, an embedded standalone section) are now one enum instead of a `u64` plus an `Option<fn>` plus a `bool` that had to agree with each other, a `ParsedSourceMap` whose blob is borrowed cannot exist without its `Standalone` reference, the dispatch fn can no longer be paired with a pointer of the wrong type, and the decompression cache is built as the type that reads it. It is zero-cost: `SourceContentPtr` grows from 24 to 32 bytes while the bool and its 7 bytes of padding leave `ParsedSourceMap`, so `size_of::<ParsedSourceMap>()` (which `memory_cost` reports) is unchanged; `provider()` tests a discriminant instead of an `Option`; `Box::leak` is the same leak `heap::into_raw` performed before; the `Loaded` allocation is the same `Box` plus the same `OnceLock` slice. Everything else is compile-time only.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds; test/bundler/compile-sourcemap-internal.test.ts, test/bundler/bundler_compile.test.ts, test/bundler/bundler_bun.test.ts, test/js/bun/sourcemap/internal-sourcemap.test.ts: 77 pass, 1 fail across 78 tests.
The single failure, bundler_compile.test.ts `compile/HelloWorldWithProcessVersionsBun` (process.versions.bun version-string check, no sourcemaps involved), fails identically on main (60 pass, 1 fail) and is pre-existing/unrelated to this change.
