### PR TITLE
install: replace Bin tag+union literals with named constructors

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -39,25 +39,61 @@ bun_output::declare_scope!(BinLinker, hidden);
 #[derive(Clone, Copy)]
 pub struct Bin {
     pub tag: Tag,
-    pub(crate) _padding_tag: [u8; 3],
+    _padding_tag: [u8; 3],
 
     // Largest member must be zero initialized
-    pub(crate) value: Value,
+    value: Value,
 }
 
 impl Default for Bin {
     fn default() -> Self {
-        Bin {
-            tag: Tag::None,
-            _padding_tag: [0; 3],
-            value: Value {
-                map: ExternalStringList::default(),
-            },
-        }
+        Self::NONE
     }
 }
 
 impl Bin {
+    pub(crate) const NONE: Bin = Bin {
+        tag: Tag::None,
+        _padding_tag: [0; 3],
+        value: Value::NONE,
+    };
+
+    #[inline]
+    pub(crate) fn init_file(file: String) -> Bin {
+        Bin {
+            tag: Tag::File,
+            _padding_tag: [0; 3],
+            value: Value::init_file(file),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn init_named_file(named_file: [String; 2]) -> Bin {
+        Bin {
+            tag: Tag::NamedFile,
+            _padding_tag: [0; 3],
+            value: Value::init_named_file(named_file),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn init_dir(dir: String) -> Bin {
+        Bin {
+            tag: Tag::Dir,
+            _padding_tag: [0; 3],
+            value: Value::init_dir(dir),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn init_map(map: ExternalStringList) -> Bin {
+        Bin {
+            tag: Tag::Map,
+            _padding_tag: [0; 3],
+            value: Value::init_map(map),
+        }
+    }
+
     pub(crate) fn count<B: StringBuilder>(
         &self,
         buf: &[u8],
@@ -158,29 +194,13 @@ impl Bin {
         // SAFETY: tag determines the active union field
         unsafe {
             match self.tag {
-                Tag::None => Bin {
-                    tag: Tag::None,
-                    _padding_tag: [0; 3],
-                    value: Value::init_none(),
-                },
-                Tag::File => Bin {
-                    tag: Tag::File,
-                    _padding_tag: [0; 3],
-                    value: Value::init_file(builder.append_string(self.value.file.slice(buf))),
-                },
-                Tag::NamedFile => Bin {
-                    tag: Tag::NamedFile,
-                    _padding_tag: [0; 3],
-                    value: Value::init_named_file([
-                        builder.append_string(self.value.named_file[0].slice(buf)),
-                        builder.append_string(self.value.named_file[1].slice(buf)),
-                    ]),
-                },
-                Tag::Dir => Bin {
-                    tag: Tag::Dir,
-                    _padding_tag: [0; 3],
-                    value: Value::init_dir(builder.append_string(self.value.dir.slice(buf))),
-                },
+                Tag::None => Bin::NONE,
+                Tag::File => Bin::init_file(builder.append_string(self.value.file.slice(buf))),
+                Tag::NamedFile => Bin::init_named_file([
+                    builder.append_string(self.value.named_file[0].slice(buf)),
+                    builder.append_string(self.value.named_file[1].slice(buf)),
+                ]),
+                Tag::Dir => Bin::init_dir(builder.append_string(self.value.dir.slice(buf))),
                 Tag::Map => {
                     for (i, extern_string) in
                         self.value.map.get(prev_external_strings).iter().enumerate()
@@ -189,14 +209,10 @@ impl Bin {
                             builder.append_external_string(extern_string.slice(buf));
                     }
 
-                    Bin {
-                        tag: Tag::Map,
-                        _padding_tag: [0; 3],
-                        value: Value::init_map(ExternalStringList::new(
-                            extern_strings_slice_off,
-                            extern_strings_slice.len() as u32,
-                        )),
-                    }
+                    Bin::init_map(ExternalStringList::new(
+                        extern_strings_slice_off,
+                        extern_strings_slice.len() as u32,
+                    ))
                 }
             }
         }
@@ -237,13 +253,7 @@ impl Bin {
         }
         if let Some(str_) = bin_expr.as_utf8_string_literal() {
             if !str_.is_empty() {
-                return Ok(Bin {
-                    tag: Tag::File,
-                    _padding_tag: [0; 3],
-                    value: Value {
-                        file: buf.append(str_)?,
-                    },
-                });
+                return Ok(Bin::init_file(buf.append(str_)?));
             }
         }
         Ok(Bin::default())
@@ -261,13 +271,10 @@ impl Bin {
                 let Some((Some(bin_name), Some(value))) = pairs.next() else {
                     return Ok(Bin::default());
                 };
-                return Ok(Bin {
-                    tag: Tag::NamedFile,
-                    _padding_tag: [0; 3],
-                    value: Value {
-                        named_file: [buf.append(bin_name)?, buf.append(value)?],
-                    },
-                });
+                return Ok(Bin::init_named_file([
+                    buf.append(bin_name)?,
+                    buf.append(value)?,
+                ]));
             }
             _ => {
                 let current_len = extern_strings.len();
@@ -289,13 +296,10 @@ impl Bin {
                 }
                 debug_assert!(i == num_props);
                 let new = &extern_strings[current_len..current_len + num_props];
-                return Ok(Bin {
-                    tag: Tag::Map,
-                    _padding_tag: [0; 3],
-                    value: Value {
-                        map: ExternalStringList::init(extern_strings.as_slice(), new),
-                    },
-                });
+                return Ok(Bin::init_map(ExternalStringList::init(
+                    extern_strings.as_slice(),
+                    new,
+                )));
             }
         }
         Ok(Bin::default())
@@ -306,13 +310,7 @@ impl Bin {
         buf: &mut bun_semver::string::Buf,
     ) -> Result<Bin, AllocError> {
         if let Some(bin_str) = bin_expr.as_utf8_string_literal() {
-            return Ok(Bin {
-                tag: Tag::Dir,
-                _padding_tag: [0; 3],
-                value: Value {
-                    dir: buf.append(bin_str)?,
-                },
-            });
+            return Ok(Bin::init_dir(buf.append(bin_str)?));
         }
         Ok(Bin::default())
     }
@@ -448,17 +446,9 @@ impl Bin {
         Ok(())
     }
 
-    pub(crate) fn init() -> Bin {
-        Bin {
-            tag: Tag::None,
-            _padding_tag: [0; 3],
-            value: Value::init_none(),
-        }
-    }
-
     // ── Tag-checked union accessors ────────────────────────────────────────
-    // `Value` is a `Copy` POD union (largest member `ExternalStringList` is two
-    // `u32`s); reading the wrong variant is well-defined garbage.
+    // `Value` is a `Copy` POD union whose every byte is initialized (see
+    // `Value::NONE`); reading the wrong variant is well-defined garbage.
     bun_core::extern_union_accessors! {
         tag: tag as Tag, value: value;
         File      => file: String;
@@ -482,15 +472,15 @@ pub use bun_semver::StringBuilder;
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub union Value {
+pub(crate) union Value {
     /// no "bin", or empty "bin"
-    pub none: (),
+    none: (),
 
     /// "bin" is a string
     /// ```json
     /// "bin": "./bin/foo",
     /// ```
-    pub(crate) file: String,
+    file: String,
 
     // Single-entry map
     ///```json
@@ -498,7 +488,7 @@ pub union Value {
     ///     "babel": "./cli.js",
     /// }
     ///```
-    pub(crate) named_file: [String; 2],
+    named_file: [String; 2],
 
     /// "bin" is a directory
     ///```json
@@ -506,7 +496,7 @@ pub union Value {
     ///     "bin": "./bin",
     /// }
     ///```
-    pub(crate) dir: String,
+    dir: String,
     // "bin" is a map
     ///```json
     /// "bin": {
@@ -514,37 +504,41 @@ pub union Value {
     ///     "babel-cli": "./cli.js",
     /// }
     ///```
-    pub(crate) map: ExternalStringList,
+    map: ExternalStringList,
 }
+
+const _: () = assert!(
+    core::mem::size_of::<[String; 2]>() == core::mem::size_of::<Value>(),
+    "Value::NONE zeroes the union through `named_file`, which must be its largest member",
+);
 
 impl Value {
     /// To avoid undefined memory between union values, we must zero initialize the union first.
+    const NONE: Value = Value {
+        named_file: [String::EMPTY; 2],
+    };
+
     #[inline]
-    pub(crate) fn init_none() -> Value {
-        // SAFETY: all-zero is a valid Value (largest member ExternalStringList is POD)
-        unsafe { bun_core::ffi::zeroed_unchecked() }
-    }
-    #[inline]
-    pub(crate) fn init_file(file: String) -> Value {
-        let mut v = Self::init_none();
+    fn init_file(file: String) -> Value {
+        let mut v = Self::NONE;
         v.file = file;
         v
     }
     #[inline]
-    pub(crate) fn init_named_file(named_file: [String; 2]) -> Value {
-        let mut v = Self::init_none();
+    fn init_named_file(named_file: [String; 2]) -> Value {
+        let mut v = Self::NONE;
         v.named_file = named_file;
         v
     }
     #[inline]
-    pub(crate) fn init_dir(dir: String) -> Value {
-        let mut v = Self::init_none();
+    fn init_dir(dir: String) -> Value {
+        let mut v = Self::NONE;
         v.dir = dir;
         v
     }
     #[inline]
-    pub(crate) fn init_map(map: ExternalStringList) -> Value {
-        let mut v = Self::init_none();
+    fn init_map(map: ExternalStringList) -> Value {
+        let mut v = Self::NONE;
         v.map = map;
         v
     }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -16,8 +16,7 @@ use crate::repository::RepositoryExt as _;
 use crate::{
     self as install, Aligner, Bin, Dependency, ExternalStringList, ExternalStringMap, Features,
     Npm, PackageID, PackageManager, PackageNameHash, Repository, TruncatedPackageNameHash,
-    UpdateRequest, bin, default_trusted_dependencies, dependency, initialize_store,
-    invalid_package_id,
+    UpdateRequest, default_trusted_dependencies, dependency, initialize_store, invalid_package_id,
 };
 // `Package.rs` is mounted as `crate::lockfile_real::package`; the parent module
 // (`super`) is the real `lockfile.rs`, distinct from the `crate::lockfile`
@@ -2470,14 +2469,10 @@ impl Package<u64> {
                                 break 'bin;
                             };
 
-                            self.bin = Bin {
-                                tag: bin::Tag::NamedFile,
-                                value: bin::Value::init_named_file([
-                                    string_builder.append::<String>(bin_name),
-                                    string_builder.append::<String>(value),
-                                ]),
-                                ..Default::default()
-                            };
+                            self.bin = Bin::init_named_file([
+                                string_builder.append::<String>(bin_name),
+                                string_builder.append::<String>(value),
+                            ]);
                         }
                         n => {
                             let current_len = lockfile.buffers.extern_strings.len();
@@ -2499,16 +2494,10 @@ impl Package<u64> {
                                 i += 1;
                             }
                             debug_assert!(i == extern_strings.len());
-                            self.bin = Bin {
-                                tag: bin::Tag::Map,
-                                value: bin::Value {
-                                    map: ExternalStringList::new(
-                                        current_len as u32,
-                                        extern_strings.len() as u32,
-                                    ),
-                                },
-                                ..Default::default()
-                            };
+                            self.bin = Bin::init_map(ExternalStringList::new(
+                                current_len as u32,
+                                extern_strings.len() as u32,
+                            ));
                         }
                     }
 
@@ -2516,13 +2505,7 @@ impl Package<u64> {
                 }
                 if let ExprData::EString(stri) = &bin.expr.data {
                     if !stri.data.is_empty() {
-                        self.bin = Bin {
-                            tag: bin::Tag::File,
-                            value: bin::Value {
-                                file: string_builder.append::<String>(&stri.data),
-                            },
-                            ..Default::default()
-                        };
+                        self.bin = Bin::init_file(string_builder.append::<String>(&stri.data));
                         break 'bin;
                     }
                 }
@@ -2539,13 +2522,7 @@ impl Package<u64> {
                 if let Some(bin_prop) = dirs.expr.as_property(b"bin") {
                     if let Some(str_) = bin_prop.expr.as_utf8(&bump) {
                         if !str_.is_empty() {
-                            self.bin = Bin {
-                                tag: bin::Tag::Dir,
-                                value: bin::Value {
-                                    dir: string_builder.append::<String>(str_),
-                                },
-                                ..Default::default()
-                            };
+                            self.bin = Bin::init_dir(string_builder.append::<String>(str_));
                             break 'bin;
                         }
                     }

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -8,7 +8,7 @@ use bun_semver::query::token::Wildcard;
 use bun_semver::{self as Semver, SlicedString, String as SemverString};
 use bun_sys::{self, Fd, File, O};
 
-use crate::bin::{self, Bin};
+use crate::bin::Bin;
 use crate::dependency::{
     self, Behavior, Dependency, DependencyExt as _, Tag as DepTag, TagExt as _, Value as DepValue,
     Version as DepVersion,
@@ -643,21 +643,10 @@ fn migrate_npm_lockfile<'a>(
                         .ok_or(crate::Error::InvalidNPMLockfile)?;
 
                     if strings::eql(key, pkg_name) {
-                        break 'bin Bin {
-                            tag: bin::Tag::File,
-                            _padding_tag: [0; 3],
-                            value: bin::Value::init_file(sb.append(script_value)?),
-                        };
+                        break 'bin Bin::init_file(sb.append(script_value)?);
                     }
 
-                    break 'bin Bin {
-                        tag: bin::Tag::NamedFile,
-                        _padding_tag: [0; 3],
-                        value: bin::Value::init_named_file([
-                            sb.append(key)?,
-                            sb.append(script_value)?,
-                        ]),
-                    };
+                    break 'bin Bin::init_named_file([sb.append(key)?, sb.append(script_value)?]);
                 }
 
                 let off = this.buffers.extern_strings.len() as u32;
@@ -683,14 +672,10 @@ fn migrate_npm_lockfile<'a>(
                     );
                 }
 
-                break 'bin Bin {
-                    tag: bin::Tag::Map,
-                    _padding_tag: [0; 3],
-                    value: bin::Value::init_map(ExternalStringList::new(off, len)),
-                };
+                break 'bin Bin::init_map(ExternalStringList::new(off, len));
             }
         } else {
-            Bin::init()
+            Bin::NONE
         };
 
         let meta_value = lockfile::Meta {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -16,7 +16,7 @@ use bun_sys::{self, Fd, File};
 use bun_url::{OwnedURL, URL};
 use bun_wyhash::Wyhash11;
 
-use crate::bin::{self, Bin};
+use crate::bin::Bin;
 use crate::external_slice::ExternalPackageNameHashList;
 use crate::integrity::Integrity;
 use crate::{
@@ -2324,7 +2324,7 @@ impl PackageManifest {
             // so names go last because we are better able to dedupe at the end
             let mut prev_extern_bin_group: Option<core::ops::Range<usize>> = None;
             let empty_version = PackageVersion {
-                bin: Bin::init(),
+                bin: Bin::NONE,
                 ..PackageVersion::default()
             };
             // PackageVersion's explicit `_padding_*` fields are zeroed by
@@ -2431,14 +2431,10 @@ impl PackageManifest {
                                             break 'bin;
                                         };
 
-                                        package_version.bin = Bin {
-                                            tag: bin::Tag::NamedFile,
-                                            _padding_tag: [0; 3],
-                                            value: bin::Value::init_named_file([
-                                                string_builder.append::<SemverString>(bin_name),
-                                                string_builder.append::<SemverString>(value),
-                                            ]),
-                                        };
+                                        package_version.bin = Bin::init_named_file([
+                                            string_builder.append::<SemverString>(bin_name),
+                                            string_builder.append::<SemverString>(value),
+                                        ]);
                                     }
                                     _ => {
                                         let group_start = extern_strings_bin_entries_cursor;
@@ -2519,14 +2515,11 @@ impl PackageManifest {
                                             r
                                         };
 
-                                        package_version.bin = Bin {
-                                            tag: bin::Tag::Map,
-                                            _padding_tag: [0; 3],
-                                            value: bin::Value::init_map(ExternalStringList::init(
+                                        package_version.bin =
+                                            Bin::init_map(ExternalStringList::init(
                                                 &all_extern_strings_bin_entries,
                                                 &all_extern_strings_bin_entries[final_range],
-                                            )),
-                                        };
+                                            ));
                                     }
                                 }
 
@@ -2535,13 +2528,8 @@ impl PackageManifest {
                             JSON::E::JsonValue::String(stri) => {
                                 let stri = stri.slice();
                                 if !stri.is_empty() {
-                                    package_version.bin = Bin {
-                                        tag: bin::Tag::File,
-                                        _padding_tag: [0; 3],
-                                        value: bin::Value::init_file(
-                                            string_builder.append::<SemverString>(stri),
-                                        ),
-                                    };
+                                    package_version.bin =
+                                        Bin::init_file(string_builder.append::<SemverString>(stri));
                                     break 'bin;
                                 }
                             }
@@ -2563,13 +2551,8 @@ impl PackageManifest {
                         .and_then(|bin| bin.as_str())
                     {
                         if !str_.is_empty() {
-                            package_version.bin = Bin {
-                                tag: bin::Tag::Dir,
-                                _padding_tag: [0; 3],
-                                value: bin::Value::init_dir(
-                                    string_builder.append::<SemverString>(str_),
-                                ),
-                            };
+                            package_version.bin =
+                                Bin::init_dir(string_builder.append::<SemverString>(str_));
                             break 'bin;
                         }
                     }

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -800,7 +800,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 integrity: Integrity::default(),
                 ..Default::default()
             },
-            bin: Bin::init(),
+            bin: Bin::NONE,
             scripts: Default::default(),
         })?;
 
@@ -1148,7 +1148,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 },
                 ..Default::default()
             },
-            bin: Bin::init(),
+            bin: Bin::NONE,
             scripts: Default::default(),
         })?;
     }


### PR DESCRIPTION
## What

`Bin` (`src/install/bin.rs`) is a `#[repr(C)]` tag plus a 16-byte POD union that is copied byte for byte into `bun.lockb` and the `.npm` manifest cache, so every construction has to zero the whole union before setting a member (`Value::init_*` existed for exactly that). Construction was nevertheless open-coded at 22 sites in three styles: full literals spelling out `_padding_tag: [0; 3]` (bin.rs, npm.rs, migration.rs), `..Default::default()` literals (lockfile/Package.rs), and, at seven of those sites (three in `Bin::parse_append*`, three in `Package::parse`, plus `impl Default`), a raw `Value { file: .. }` / `dir: ..` / `map: ..` literal that set an 8-byte member and left the other 8 bytes of the union uninitialized. `Bin::init()` and `impl Default for Bin` were two separate none constructors that did not even agree on that point.

`Bin` now has one constructor per tag, and they are the only way to build one:

```rust
impl Bin {
    pub(crate) const NONE: Bin = Bin { tag: Tag::None, _padding_tag: [0; 3], value: Value::NONE };
    pub(crate) fn init_file(file: String) -> Bin { .. }
    pub(crate) fn init_named_file(named_file: [String; 2]) -> Bin { .. }
    pub(crate) fn init_dir(dir: String) -> Bin { .. }
    pub(crate) fn init_map(map: ExternalStringList) -> Bin { .. }
}
```

`Default` delegates to `NONE`; `Bin::init()` is removed and its 4 callers (npm.rs, yarn.rs x2, migration.rs) use `Bin::NONE`. The 22 literal sites become one-line calls, for example in `Package::parse`:

```rust
// before
self.bin = Bin {
    tag: bin::Tag::Dir,
    value: bin::Value { dir: string_builder.append::<String>(str_) },
    ..Default::default()
};
// after
self.bin = Bin::init_dir(string_builder.append::<String>(str_));
```

`Bin::_padding_tag` and `Bin::value` are now private, `Value` is `pub(crate)` (the padding checker still pins its size) with private fields and private `init_*` helpers, and the now unused `bin` module imports in npm.rs, migration.rs and Package.rs are dropped. `Value::init_none()`, an `unsafe { zeroed_unchecked() }` block, becomes the safe `const NONE: Value = Value { named_file: [String::EMPTY; 2] }`, with a `const` assertion that `[String; 2]` spans the whole union. Removes 1 unsafe block.

## Why

A `Bin` whose tag disagrees with its payload, or whose union carries uninitialized bytes into the lockfile, is no longer expressible outside bin.rs: the fields needed to write a `Bin` literal are private, so each tag can only be paired with its own member through the zeroing path. It is zero-cost: the `#[repr(C)]` layout, `Tag` discriminants and on-disk format are untouched, the constructors are `#[inline]` wrappers producing the same 20-byte value the literals did, and the seven formerly partial sites now perform the same full-union store the other sites already performed.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/cli/install/bun-lock.test.ts test/cli/install/bun-install-native-binlink.test.ts test/cli/install/migration/migrate.test.ts test/cli/install/migration/pnpm-migration.test.ts: 56 pass, 0 fail, 12 todo (68 tests across 4 files).
