### PR TITLE
crypto: remove pwhash Encoding and silently_truncate_password options

### DIFF
--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -279,27 +279,14 @@ impl PasswordObject {
     // This is purposely simple because nobody asked to make it more complicated
     pub(crate) fn hash(password: &[u8], algorithm: AlgorithmValue) -> Result<Box<[u8]>, HashError> {
         match algorithm {
-            AlgorithmValue::Argon2i(argon)
-            | AlgorithmValue::Argon2d(argon)
-            | AlgorithmValue::Argon2id(argon) => {
-                let mut outbuf = [0u8; 4096];
-                let hash_options = pwhash::argon2::HashOptions {
-                    params: argon.to_params(),
-                    // allocator dropped — global mimalloc
-                    mode: match algorithm {
-                        AlgorithmValue::Argon2i(_) => pwhash::argon2::Mode::Argon2i,
-                        AlgorithmValue::Argon2d(_) => pwhash::argon2::Mode::Argon2d,
-                        AlgorithmValue::Argon2id(_) => pwhash::argon2::Mode::Argon2id,
-                        _ => unreachable!(),
-                    },
-                    encoding: pwhash::Encoding::Phc,
-                };
-                // warning: argon2's code may spin up threads if paralellism is set to > 0
-                // we don't expose this option
-                // but since it parses from phc format, it's possible that it will be set
-                // eventually we should do something that about that.
-                let out_bytes = pwhash::argon2::str_hash(password, hash_options, &mut outbuf)?;
-                Ok(Box::<[u8]>::from(out_bytes))
+            AlgorithmValue::Argon2i(argon) => {
+                Self::hash_argon2(password, argon, pwhash::argon2::Mode::Argon2i)
+            }
+            AlgorithmValue::Argon2d(argon) => {
+                Self::hash_argon2(password, argon, pwhash::argon2::Mode::Argon2d)
+            }
+            AlgorithmValue::Argon2id(argon) => {
+                Self::hash_argon2(password, argon, pwhash::argon2::Mode::Argon2id)
             }
             AlgorithmValue::Bcrypt(cost) => {
                 let mut outbuf = [0u8; 4096];
@@ -320,19 +307,29 @@ impl PasswordObject {
                     outbuf_slice = &mut outbuf[..];
                 }
 
-                let hash_options = pwhash::bcrypt::HashOptions {
-                    params: pwhash::bcrypt::Params {
-                        rounds_log: cost,
-                        silently_truncate_password: true,
-                    },
-                    // allocator dropped
-                    encoding: pwhash::Encoding::Crypt,
-                };
-                let out_bytes =
-                    pwhash::bcrypt::str_hash(password_to_use, hash_options, outbuf_slice)?;
+                let params = pwhash::bcrypt::Params { rounds_log: cost };
+                let out_bytes = pwhash::bcrypt::str_hash(password_to_use, params, outbuf_slice)?;
                 Ok(Box::<[u8]>::from(out_bytes))
             }
         }
+    }
+
+    fn hash_argon2(
+        password: &[u8],
+        argon: Argon2Params,
+        mode: pwhash::argon2::Mode,
+    ) -> Result<Box<[u8]>, HashError> {
+        let mut outbuf = [0u8; 4096];
+        let hash_options = pwhash::argon2::HashOptions {
+            params: argon.to_params(),
+            mode,
+        };
+        // warning: argon2's code may spin up threads if paralellism is set to > 0
+        // we don't expose this option
+        // but since it parses from phc format, it's possible that it will be set
+        // eventually we should do something that about that.
+        let out_bytes = pwhash::argon2::str_hash(password, hash_options, &mut outbuf)?;
+        Ok(Box::<[u8]>::from(out_bytes))
     }
 
     pub(crate) fn verify(
@@ -359,7 +356,7 @@ impl PasswordObject {
     ) -> Result<bool, HashError> {
         match algorithm {
             Algorithm::Argon2id | Algorithm::Argon2d | Algorithm::Argon2i => {
-                match pwhash::argon2::str_verify(previous_hash, password, Default::default()) {
+                match pwhash::argon2::str_verify(previous_hash, password) {
                     Ok(()) => Ok(true),
                     Err(crate::Error::PasswordVerificationFailed) => Ok(false),
                     Err(err) => Err(err),
@@ -377,13 +374,7 @@ impl PasswordObject {
                     sha_512.r#final(&mut outbuf);
                     password_to_use = &outbuf;
                 }
-                match pwhash::bcrypt::str_verify(
-                    previous_hash,
-                    password_to_use,
-                    pwhash::bcrypt::VerifyOptions {
-                        silently_truncate_password: true,
-                    },
-                ) {
+                match pwhash::bcrypt::str_verify(previous_hash, password_to_use) {
                     Ok(()) => Ok(true),
                     Err(crate::Error::PasswordVerificationFailed) => Ok(false),
                     Err(err) => Err(err),

--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -1,15 +1,16 @@
 //! Password hashing for `Bun.password` (argon2 / bcrypt). Neither algorithm is
 //! provided by BoringSSL, so this module implements the API surface that
-//! `PasswordObject` consumes (`str_hash` / `str_verify` / `Params` / `Mode` /
-//! `Encoding`) and routes to the pure-Rust `rust-argon2` and `bcrypt` crates
-//! from crates.io.
+//! `PasswordObject` consumes (`str_hash` / `str_verify` / `Params` / `Mode`)
+//! and routes to the pure-Rust `rust-argon2` and `bcrypt` crates from
+//! crates.io.
 //!
-//!   * argon2: PHC string format only (`str_hash` rejects `.crypt`), 32-byte
-//!     random salt, 32-byte tag, version 0x13.
-//!   * bcrypt: modular-crypt `$2b$…` 60-byte string for hashing; verification
-//!     additionally accepts the PHC `$bcrypt$…` form (decoded locally — the
-//!     Rust `bcrypt` crate has no PHC codec). `silently_truncate_password` is
-//!     asserted `true` (Bun's only caller never sets `false`).
+//!   * argon2: always emits the PHC string format, 32-byte random salt,
+//!     32-byte tag, version 0x13.
+//!   * bcrypt: always emits the modular-crypt `$2b$…` 60-byte string and, like
+//!     crypt(3), silently truncates passwords to 72 bytes (`PasswordObject`
+//!     pre-hashes longer ones); verification additionally accepts the PHC
+//!     `$bcrypt$…` form (decoded locally, the Rust `bcrypt` crate has no PHC
+//!     codec).
 
 use crate::Error;
 
@@ -25,17 +26,8 @@ fn phc_ascii_str(s: &[u8]) -> Result<&str, Error> {
     Ok(unsafe { core::str::from_utf8_unchecked(s) })
 }
 
-/// Output string encoding.
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub enum Encoding {
-    /// PHC string format (`$argon2id$v=19$...`).
-    Phc,
-    /// Traditional crypt(3) format (`$2b$...`).
-    Crypt,
-}
-
 pub mod argon2 {
-    use super::{Encoding, Error};
+    use super::Error;
     use bun_core::strings;
 
     // The `rust-argon2` package exports its lib as crate name `argon2`; refer to
@@ -89,12 +81,7 @@ pub mod argon2 {
     pub(crate) struct HashOptions {
         pub params: Params,
         pub mode: Mode,
-        pub encoding: Encoding,
     }
-
-    /// Options for `str_verify`.
-    #[derive(Copy, Clone, Default)]
-    pub(crate) struct VerifyOptions;
 
     fn map_err(e: &vendor::Error) -> Error {
         use vendor::Error as E;
@@ -130,10 +117,6 @@ pub mod argon2 {
         options: HashOptions,
         out: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
-        if options.encoding != Encoding::Phc {
-            return Err(crate::Error::InvalidEncoding);
-        }
-
         let mut salt = [0u8; DEFAULT_SALT_LEN];
         getrandom::fill(&mut salt).map_err(|_| crate::Error::Unexpected)?;
 
@@ -164,11 +147,7 @@ pub mod argon2 {
     }
 
     /// Verify a PHC-encoded argon2 hash.
-    pub(crate) fn str_verify(
-        encoded_hash: &[u8],
-        password: &[u8],
-        _options: VerifyOptions,
-    ) -> Result<(), Error> {
+    pub(crate) fn str_verify(encoded_hash: &[u8], password: &[u8]) -> Result<(), Error> {
         // PHC strings are 7-bit ASCII; reject non-ASCII input as a decode
         // failure.
         let encoded = super::phc_ascii_str(encoded_hash)?;
@@ -259,7 +238,7 @@ pub mod argon2 {
 }
 
 pub mod bcrypt {
-    use super::{Encoding, Error};
+    use super::Error;
     use bun_core::strings;
 
     use ::bcrypt as vendor;
@@ -274,20 +253,6 @@ pub mod bcrypt {
     pub struct Params {
         /// log2 rounds (clamped 4..=31 by caller).
         pub(crate) rounds_log: u8,
-        pub(crate) silently_truncate_password: bool,
-    }
-
-    /// Options for `str_hash`.
-    #[derive(Copy, Clone)]
-    pub(crate) struct HashOptions {
-        pub params: Params,
-        pub encoding: Encoding,
-    }
-
-    /// Options for `str_verify`.
-    #[derive(Copy, Clone)]
-    pub(crate) struct VerifyOptions {
-        pub silently_truncate_password: bool,
     }
 
     fn map_err(e: &vendor::BcryptError) -> Error {
@@ -305,33 +270,14 @@ pub mod bcrypt {
     /// subslice.
     pub(crate) fn str_hash<'a>(
         password: &[u8],
-        options: HashOptions,
+        params: Params,
         out: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
         if out.len() < HASH_LENGTH {
             return Err(crate::Error::Sys(bun_errno::SystemErrno::ENOSPC));
         }
-        // Bun only ever requests `.crypt`. A `.phc` request would need the
-        // `$bcrypt$…` PHC serializer, which the Rust `bcrypt` crate does not
-        // implement; surface that as an encoding error rather than silently
-        // returning the wrong format.
-        if options.encoding != Encoding::Crypt {
-            return Err(crate::Error::InvalidEncoding);
-        }
 
-        let cost = u32::from(options.params.rounds_log);
-
-        // A `silently_truncate_password == false` implementation would need to
-        // pre-hash >72-byte passwords via HMAC-SHA512 keyed by the salt without
-        // erroring; the `bcrypt` crate's `non_truncating_*` instead returns
-        // `Err(Truncation)` (and trips at `>=72`, not `>72`). Bun's only caller
-        // (`PasswordObject`) always passes `true` and pre-hashes long passwords
-        // itself, so hard-assert here rather than ship a divergent codepath.
-        debug_assert!(
-            options.params.silently_truncate_password,
-            "bcrypt: silently_truncate_password=false is unreachable from Bun \
-             and not implemented in this shim",
-        );
+        let cost = u32::from(params.rounds_log);
 
         // `hash_with_result` → `_hash_password(.., err_on_truncation = false)`:
         // null-terminates then clamps to 72 bytes.
@@ -348,23 +294,10 @@ pub mod bcrypt {
     }
 
     /// Verify a bcrypt hash (modular-crypt or PHC form).
-    pub(crate) fn str_verify(
-        encoded_hash: &[u8],
-        password: &[u8],
-        options: VerifyOptions,
-    ) -> Result<(), Error> {
+    pub(crate) fn str_verify(encoded_hash: &[u8], password: &[u8]) -> Result<(), Error> {
         // Both the modular-crypt and PHC alphabets are pure ASCII; non-ASCII
         // input is a decode failure either way.
         let encoded = super::phc_ascii_str(encoded_hash)?;
-
-        // See `str_hash`: the `false` path's HMAC-SHA512 pre-hash is not
-        // implemented in this shim and is unreachable from Bun.
-        debug_assert!(
-            options.silently_truncate_password,
-            "bcrypt: silently_truncate_password=false is unreachable from Bun \
-             and not implemented in this shim",
-        );
-        let _ = options;
 
         // Dispatch on prefix:
         //   `$2…`      → modular-crypt verify


### PR DESCRIPTION
## What

`crypto::pwhash` (the argon2 / bcrypt shim behind `Bun.password`) carried two options that only existed to be rejected. `pwhash::Encoding { Phc, Crypt }` sat in both `argon2::HashOptions` and `bcrypt::HashOptions` so that `argon2::str_hash` could return `InvalidEncoding` for `Crypt` and `bcrypt::str_hash` could return it for `Phc`; `bcrypt::Params.silently_truncate_password` and `bcrypt::VerifyOptions.silently_truncate_password` existed only to be `debug_assert!`ed `true`. `PasswordObject`, the only caller, always passed the single accepted value at all 4 sites (`Encoding::Phc`, `Encoding::Crypt`, `silently_truncate_password: true` twice), and `argon2::VerifyOptions` was already an empty unit struct.

```rust
// before
pub enum Encoding { Phc, Crypt }
argon2::HashOptions { params, mode, encoding }        argon2::str_verify(hash, pw, VerifyOptions)
bcrypt::HashOptions { params: Params { rounds_log, silently_truncate_password }, encoding }
bcrypt::str_verify(hash, pw, VerifyOptions { silently_truncate_password })

// after
argon2::HashOptions { params, mode }                  argon2::str_verify(hash, pw)
bcrypt::str_hash(pw, Params { rounds_log }, out)      bcrypt::str_verify(hash, pw)
```

`Encoding`, `argon2::VerifyOptions`, `bcrypt::HashOptions` and `bcrypt::VerifyOptions` are deleted along with the two `InvalidEncoding` early returns and the two `debug_assert!`s; the module doc now states that argon2 emits PHC and bcrypt emits `$2b$` modular-crypt by construction. `crate::Error::InvalidEncoding` is unchanged and still used for genuine decode failures. In the caller, `PasswordObject::hash` previously matched all three argon2 variants in one arm and then re-matched `algorithm` inside it to recover the `Mode`, with a `_ => unreachable!()` arm; it now has one arm per variant, each calling a small `hash_argon2(password, params, mode)` helper, so the nested match and the `unreachable!()` are gone. 4 call sites in `PasswordObject.rs` updated; 2 files changed, 46 insertions, 122 deletions.

## Why

The output encoding and the truncation policy are properties of the implementation, not inputs, so representing them as parameters only created states that were rejected at runtime; after this change they cannot be expressed at all, and the argon2 `Mode` is bound by the pattern match instead of a second match with an unreachable arm. This is zero-cost: it removes two comparisons and two debug assertions on paths the only caller never took, the option values are stack-only `Copy` structs that simply lose fields, and no behaviour reachable from JS changes.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/util/password.test.ts`: 71 pass, 8 skip, 0 fail (79 tests).
