### PR TITLE
errno: fix errno_mapping on Windows and run the crate's Windows test arms under miri

### DIFF
--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -95,7 +95,11 @@ const passes: string[][] = [];
 if (extraArgs.length > 0) {
   passes.push(extraArgs);
   const hasTarget = extraArgs.some(a => a === "--target" || a.startsWith("--target="));
-  if (!hasTarget && MIRI_WINDOWS_CRATES.some(c => extraArgs.includes(c))) {
+  // `-p X` / `--package X` leave X as its own token; cargo also accepts `-pX` and `--package=X`.
+  const selectsWindowsCrate = MIRI_WINDOWS_CRATES.some(c =>
+    extraArgs.some(a => a === c || a === `-p${c}` || a === `--package=${c}`),
+  );
+  if (!hasTarget && selectsWindowsCrate) {
     passes.push(["--target", WINDOWS_TARGET, ...extraArgs]);
   }
 } else {

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -15,9 +15,16 @@
  * is the candidate replacement spec, allows that pattern, and still catches
  * the bugs we care about.
  *
+ * Crates in MIRI_WINDOWS_CRATES get a second pass with
+ * `--target x86_64-pc-windows-msvc`. Miri builds the sysroot for a foreign
+ * target from rust-src and interprets it on the host, so this is the one lane
+ * that compiles and runs those crates' `#[cfg(windows)]` test arms: no CI host
+ * has a cargo workspace on Windows.
+ *
  * Usage:
- *   bun run rust:miri              # default safe crate set
- *   bun run rust:miri -p bun_foo   # extra args go straight to cargo miri test
+ *   bun run rust:miri              # default safe crate set (both passes)
+ *   bun run rust:miri -p bun_foo   # extra args go straight to cargo miri test;
+ *                                  # crates in MIRI_WINDOWS_CRATES get both passes
  */
 
 import { spawnSync } from "node:child_process";
@@ -46,6 +53,12 @@ const MIRI_CRATES = [
   "bun_shell_parser",
   "bun_wyhash",
 ];
+
+// Subset of MIRI_CRATES whose unit tests have `#[cfg(windows)]` arms (the
+// Windows errno tables and `SystemErrno::init` dispatch in bun_errno). Same
+// three requirements as above, evaluated with the Windows cfg.
+const MIRI_WINDOWS_CRATES = ["bun_errno"];
+const WINDOWS_TARGET = "x86_64-pc-windows-msvc";
 
 function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] = {}) {
   return spawnSync(cmd, args, { stdio: "inherit", cwd: repo, ...opts });
@@ -77,13 +90,27 @@ if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
 }
 
 const extraArgs = process.argv.slice(2);
-const crateArgs = extraArgs.length > 0 ? extraArgs : MIRI_CRATES.flatMap(c => ["-p", c]);
 
-console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${crateArgs.join(" ")}`);
-const r = run("cargo", ["miri", "test", ...crateArgs], {
-  env: {
-    ...process.env,
-    MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
-  },
-});
-process.exit(r.status ?? 1);
+const passes: string[][] = [];
+if (extraArgs.length > 0) {
+  passes.push(extraArgs);
+  if (!extraArgs.some(a => a.startsWith("--target")) && MIRI_WINDOWS_CRATES.some(c => extraArgs.includes(c))) {
+    passes.push(["--target", WINDOWS_TARGET, ...extraArgs]);
+  }
+} else {
+  passes.push(MIRI_CRATES.flatMap(c => ["-p", c]));
+  passes.push(["--target", WINDOWS_TARGET, ...MIRI_WINDOWS_CRATES.flatMap(c => ["-p", c])]);
+}
+
+const env = {
+  ...process.env,
+  MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
+};
+
+let status = 0;
+for (const args of passes) {
+  console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${args.join(" ")}`);
+  const r = run("cargo", ["miri", "test", ...args], { env });
+  if (r.status !== 0) status = r.status ?? 1;
+}
+process.exit(status);

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -94,7 +94,8 @@ const extraArgs = process.argv.slice(2);
 const passes: string[][] = [];
 if (extraArgs.length > 0) {
   passes.push(extraArgs);
-  if (!extraArgs.some(a => a.startsWith("--target")) && MIRI_WINDOWS_CRATES.some(c => extraArgs.includes(c))) {
+  const hasTarget = extraArgs.some(a => a === "--target" || a.startsWith("--target="));
+  if (!hasTarget && MIRI_WINDOWS_CRATES.some(c => extraArgs.includes(c))) {
     passes.push(["--target", WINDOWS_TARGET, ...extraArgs]);
   }
 } else {

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -449,8 +449,8 @@ mod errno_name_tests {
         }
     }
 
-    /// On Windows `init` dispatches on the argument type. `i64` (the shared
-    /// `from_errno` / `bun_sys::Error` paths) is a discriminant lookup that only
+    /// On Windows `init` dispatches on the argument type. `i64` (`from_errno`
+    /// and the shared socket error paths) is a discriminant lookup that only
     /// falls back to the Win32/WSA table for values that are not discriminants;
     /// `c_int` (`Bun__errnoName`, libuv results) and `u32` (`GetLastError()`)
     /// are always mapped. The same number means different things on each path.
@@ -466,8 +466,10 @@ mod errno_name_tests {
         assert_eq!(SystemErrno::init(12_i64), Some(SystemErrno::ENOMEM));
         assert_eq!(SystemErrno::init(12_i32), None);
         assert_eq!(SystemErrno::init(12_u32), None);
-        // WSAEADDRINUSE is not a discriminant, so the i64 path reaches the WSA table.
+        // WSAEADDRINUSE is not a discriminant, so the i64 path reaches the WSA
+        // table, in either sign (udp bind widens usockets' negated getaddrinfo code).
         assert_eq!(SystemErrno::init(10048_i64), Some(SystemErrno::EADDRINUSE));
+        assert_eq!(SystemErrno::init(-10048_i64), Some(SystemErrno::EADDRINUSE));
         assert_eq!(SystemErrno::init(10048_i32), Some(SystemErrno::EADDRINUSE));
         // Negated libuv codes are what the c_int path exists for.
         assert_eq!(

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -418,8 +418,7 @@ mod errno_name_tests {
     use super::*;
     use bun_core::coreutils_error_map;
 
-    /// `i64` is the discriminant entry point on every target; on Windows an
-    /// unsuffixed literal would pick the Win32-code `c_int` impl instead.
+    // `_i64` matters: on Windows a bare literal selects the Win32-code `c_int` impl of `init`.
     #[test]
     fn errno_mapping() {
         assert_eq!(system_errno_name(2), Some("ENOENT"));
@@ -447,8 +446,6 @@ mod errno_name_tests {
         }
     }
 
-    /// Windows `init` dispatches on the argument type: `i64` is a discriminant
-    /// lookup (WSA table as fallback), `c_int` and `u32` are always mapped.
     #[cfg(windows)]
     #[test]
     fn init_dispatches_on_argument_type() {

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -418,11 +418,16 @@ mod errno_name_tests {
     use super::*;
     use bun_core::coreutils_error_map;
 
+    /// `init` is called with `i64` on purpose: that is the discriminant entry
+    /// point on every target. On Windows `init` is generic and an unsuffixed
+    /// literal picks the `c_int` impl, which maps Win32/libuv codes instead
+    /// (`init_dispatches_on_argument_type` below).
     #[test]
     fn errno_mapping() {
         assert_eq!(system_errno_name(2), Some("ENOENT"));
-        assert_eq!(SystemErrno::init(2), Some(SystemErrno::ENOENT));
-        assert_eq!(SystemErrno::init(12), Some(SystemErrno::ENOMEM));
+        assert_eq!(SystemErrno::init(2_i64), Some(SystemErrno::ENOENT));
+        assert_eq!(SystemErrno::init(12_i64), Some(SystemErrno::ENOMEM));
+        assert_eq!(from_errno(12), SystemErrno::ENOMEM);
         assert_eq!(system_errno_name(0), None);
         assert_eq!(system_errno_name(9999), None);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
@@ -433,15 +438,42 @@ mod errno_name_tests {
             target_family = "wasm"
         ))]
         {
-            assert_eq!(SystemErrno::init(11), Some(SystemErrno::EAGAIN));
-            assert_eq!(SystemErrno::init(104), Some(SystemErrno::ECONNRESET));
+            assert_eq!(SystemErrno::init(11_i64), Some(SystemErrno::EAGAIN));
+            assert_eq!(SystemErrno::init(104_i64), Some(SystemErrno::ECONNRESET));
         }
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         {
-            assert_eq!(SystemErrno::init(11), Some(SystemErrno::EDEADLK));
-            assert_eq!(SystemErrno::init(35), Some(SystemErrno::EAGAIN));
-            assert_eq!(SystemErrno::init(54), Some(SystemErrno::ECONNRESET));
+            assert_eq!(SystemErrno::init(11_i64), Some(SystemErrno::EDEADLK));
+            assert_eq!(SystemErrno::init(35_i64), Some(SystemErrno::EAGAIN));
+            assert_eq!(SystemErrno::init(54_i64), Some(SystemErrno::ECONNRESET));
         }
+    }
+
+    /// On Windows `init` dispatches on the argument type. `i64` (the shared
+    /// `from_errno` / `bun_sys::Error` paths) is a discriminant lookup that only
+    /// falls back to the Win32/WSA table for values that are not discriminants;
+    /// `c_int` (`Bun__errnoName`, libuv results) and `u32` (`GetLastError()`)
+    /// are always mapped. The same number means different things on each path.
+    #[cfg(windows)]
+    #[test]
+    fn init_dispatches_on_argument_type() {
+        // 13 is the EACCES discriminant; Win32 ERROR_INVALID_DATA (13) maps to EINVAL.
+        assert_eq!(SystemErrno::init(13_i64), Some(SystemErrno::EACCES));
+        assert_eq!(from_errno(13), SystemErrno::EACCES);
+        assert_eq!(SystemErrno::init(13_i32), Some(SystemErrno::EINVAL));
+        assert_eq!(SystemErrno::init(13_u32), Some(SystemErrno::EINVAL));
+        // 12 is the ENOMEM discriminant; Win32 ERROR_INVALID_ACCESS (12) has no mapping.
+        assert_eq!(SystemErrno::init(12_i64), Some(SystemErrno::ENOMEM));
+        assert_eq!(SystemErrno::init(12_i32), None);
+        assert_eq!(SystemErrno::init(12_u32), None);
+        // WSAEADDRINUSE is not a discriminant, so the i64 path reaches the WSA table.
+        assert_eq!(SystemErrno::init(10048_i64), Some(SystemErrno::EADDRINUSE));
+        assert_eq!(SystemErrno::init(10048_i32), Some(SystemErrno::EADDRINUSE));
+        // Negated libuv codes are what the c_int path exists for.
+        assert_eq!(
+            SystemErrno::init(bun_libuv_sys::UV_ENOENT),
+            Some(SystemErrno::ENOENT)
+        );
     }
 
     /// Exhaustive: every dense slot in the per-platform enum round-trips through

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -418,10 +418,8 @@ mod errno_name_tests {
     use super::*;
     use bun_core::coreutils_error_map;
 
-    /// `init` is called with `i64` on purpose: that is the discriminant entry
-    /// point on every target. On Windows `init` is generic and an unsuffixed
-    /// literal picks the `c_int` impl, which maps Win32/libuv codes instead
-    /// (`init_dispatches_on_argument_type` below).
+    /// `i64` is the discriminant entry point on every target; on Windows an
+    /// unsuffixed literal would pick the Win32-code `c_int` impl instead.
     #[test]
     fn errno_mapping() {
         assert_eq!(system_errno_name(2), Some("ENOENT"));
@@ -449,11 +447,8 @@ mod errno_name_tests {
         }
     }
 
-    /// On Windows `init` dispatches on the argument type. `i64` (`from_errno`
-    /// and the shared socket error paths) is a discriminant lookup that only
-    /// falls back to the Win32/WSA table for values that are not discriminants;
-    /// `c_int` (`Bun__errnoName`, libuv results) and `u32` (`GetLastError()`)
-    /// are always mapped. The same number means different things on each path.
+    /// Windows `init` dispatches on the argument type: `i64` is a discriminant
+    /// lookup (WSA table as fallback), `c_int` and `u32` are always mapped.
     #[cfg(windows)]
     #[test]
     fn init_dispatches_on_argument_type() {
@@ -466,8 +461,7 @@ mod errno_name_tests {
         assert_eq!(SystemErrno::init(12_i64), Some(SystemErrno::ENOMEM));
         assert_eq!(SystemErrno::init(12_i32), None);
         assert_eq!(SystemErrno::init(12_u32), None);
-        // WSAEADDRINUSE is not a discriminant, so the i64 path reaches the WSA
-        // table, in either sign (udp bind widens usockets' negated getaddrinfo code).
+        // WSAEADDRINUSE is not a discriminant: i64 falls through to the WSA table, either sign.
         assert_eq!(SystemErrno::init(10048_i64), Some(SystemErrno::EADDRINUSE));
         assert_eq!(SystemErrno::init(-10048_i64), Some(SystemErrno::EADDRINUSE));
         assert_eq!(SystemErrno::init(10048_i32), Some(SystemErrno::EADDRINUSE));

--- a/test/internal/rust-miri-windows-target.test.ts
+++ b/test/internal/rust-miri-windows-target.test.ts
@@ -1,0 +1,52 @@
+// No CI host compiles the `#[cfg(windows)]` arms of bun_errno's unit tests
+// natively (no Windows host has a cargo workspace), so scripts/rust-miri.ts
+// runs the crate a second time with `--target x86_64-pc-windows-msvc`, which
+// miri interprets on any host. This drives the script the way
+// `bun run rust:miri -p bun_errno` does and checks that the Windows pass ran:
+// it is what catches a bun_errno test that only holds on POSIX (errno_mapping
+// used to pick the Win32-code overload of `SystemErrno::init` on Windows).
+//
+// Skipped where miri is not installed or the cargo workspace is not
+// resolvable (same prerequisite check as linear-fifo.test.ts and the script).
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const cargoBin = Bun.which("cargo");
+const repoRoot = path.resolve(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(path.join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(path.join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+const miriAvailable =
+  !!cargoBin &&
+  workspaceResolvable &&
+  Bun.spawnSync({
+    cmd: [cargoBin, "miri", "--version"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  }).exitCode === 0;
+
+test.skipIf(!miriAvailable)(
+  "bun_errno unit tests pass under miri for the Windows target",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(repoRoot, "scripts", "rust-miri.ts"), "-p", "bun_errno"],
+      cwd: repoRoot,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("cargo miri test --target x86_64-pc-windows-msvc -p bun_errno");
+    // Only defined under cfg(windows): proves the second pass compiled the Windows arms.
+    expect(stdout).toContain("init_dispatches_on_argument_type ... ok");
+    // The failing assertion (stdout) or miri diagnostic (stderr) ends up in the failure message.
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+  },
+  // Cold miri sysroot for the target plus the crate's dependencies, twice.
+  240_000,
+);


### PR DESCRIPTION
### Repro

`cargo test -p bun_errno` compiled for Windows fails on main. Natively on a Windows host (needs #37575, or `RUSTFLAGS="-C link-arg=/FORCE:UNRESOLVED"`, to link), and equally from Linux, since miri interprets a foreign target:

```
$ cargo miri test -p bun_errno --target x86_64-pc-windows-msvc
test errno_name_tests::errno_mapping ... FAILED

thread 'errno_name_tests::errno_mapping' panicked at src/errno/lib.rs:425:9:
assertion `left == right` failed
  left: None
 right: Some(ENOMEM)

test result: FAILED. 3 passed; 1 failed
```

Nothing in CI ran either form: the miri lane runs the crate for the host only, clippy does not build `#[cfg(test)]` code, and no CI host has a cargo workspace on Windows, so the `#[cfg(windows)]` arms of this crate's tests had never been compiled since they were written.

### Cause

`errno_mapping` calls `SystemErrno::init(2)`, `init(12)`, `init(11)`, `init(104)` with unsuffixed literals and expects errno discriminants. On POSIX targets `init` is `fn init(code: i64)`, so that is what it gets. On Windows `init` is generic over `SystemErrnoInit`, so an unsuffixed literal falls back to `i32`, and the `i32` impl is `init_c_int`, the Win32/WSA/libuv code mapper: `2` is `ERROR_FILE_NOT_FOUND` and happens to map to `ENOENT`; `12` is `ERROR_INVALID_ACCESS`, which has no mapping, hence `None`. The `i64` impl is the discriminant path the test describes (its `windows` cfg arm expects the Linux-numbered `11 == EAGAIN`, `104 == ECONNRESET`).

The overload behaviour is intended, not the bug: the `c_int` entry point is what `Bun__errnoName` (libuv codes from `createSystemError` on Windows) and `wsa_get_last_error()` rely on, the `u32` one is `GetLastError()`, and `bun_sys::Error::get_errno` / `resolve_system_errno` already document that the `u16`/`i32` entry points must not be handed discriminants on Windows. Production callers holding a discriminant go through `i64` (`from_errno`, `Listener.rs`, `udp_socket.rs`, `us_socket_t.rs`), so only the test was affected.

### Fix

* `src/errno/lib.rs`: `errno_mapping` passes `i64` literals, so it exercises the discriminant entry point on every target, and also checks `from_errno`, the `i32` helper the rest of the tree uses for this. New Windows-only test `init_dispatches_on_argument_type` pins what made this easy to get wrong: the same number resolves differently through `i64`, `c_int` and `u32` (`13`: `EACCES` vs `ERROR_INVALID_DATA -> EINVAL`; `12`: `ENOMEM` vs unmapped `-> None`), the `i64` path falls through to the WSA table for non-discriminants in either sign (`+-10048 -> EADDRINUSE`; udp bind feeds it a negated getaddrinfo code), `UV_ENOENT` resolves through the `c_int` path, and `from_errno(13)` is `EACCES` on Windows too. Rerouting `from_errno` or the `i64` impl through the mapper would fail here.
* `scripts/rust-miri.ts`: after the host pass, run the crates in `MIRI_WINDOWS_CRATES` (currently just `bun_errno`, the only miri crate with `#[cfg(windows)]` test arms) again with `--target x86_64-pc-windows-msvc`. Miri builds that sysroot from `rust-src`, which `miri.yml` already installs, and the workflow already triggers on `src/errno/**` and on the script, so the workflow itself is unchanged. `bun run rust:miri -p bun_errno` gets the same second pass; an explicit `--target` is passed through as-is. The extra pass is about a second of interpretation plus a one-time sysroot build.
* `test/internal/rust-miri-windows-target.test.ts`: drives the script for `bun_errno` and checks that the Windows pass ran (`init_dispatches_on_argument_type` only exists under `cfg(windows)`). Same skip conditions as `linear-fifo.test.ts` (no miri, or no resolvable workspace), so it is a local / source-build check rather than a Buildkite one; the enforcing lane is miri.yml via the script change.

### Verification

* linux-x64: with main's `lib.rs` and this branch's script, `bun run rust:miri -p bun_errno` fails in the Windows pass with the assertion above and `bun bd test test/internal/rust-miri-windows-target.test.ts` fails; with the branch both pass (host 4, Windows target 5). Full default `bun run rust:miri` (what miri.yml runs) passes end to end. `cargo test -p bun_errno`, `cargo clippy -p bun_errno --tests`, `cargo fmt --check` clean.
* CI: the `cargo miri test` job on this PR (plain ubuntu runner, `rust-src` + `miri` only, no rustup Windows target) ran the second pass and executed both Windows-cfg tests (`errno_mapping`, `init_dispatches_on_argument_type ... ok`), so the sysroot-from-rust-src path works in the real lane.
* windows-x64 (native, `RUSTFLAGS="-C link-arg=/FORCE:UNRESOLVED"`): `cargo test -p bun_errno` fails as above on main at 97e21e5405, `5 passed` at e120521.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-miri-windows-target.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/64] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/64] gen cpp.rs (cppbind)
[3/64] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[4/64] gen JS modules (bundle-modules)
Preprocess modules (10320ms)
Bundle modules (70ms)
Postprocesss modules (294ms)
Bundle Functions (959ms)
Generate Code (13ms)

[11.68s] Bundled "src/js" for development
  2803 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/51] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[33/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-12.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings-12.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g3 -gz=zstd -glldb 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/internal/rust-miri-windows-target.test.ts:
41 |     });
42 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
43 | 
44 |     expect(stdout).toContain("cargo miri test --target x86_64-pc-windows-msvc -p bun_errno");
45 |     // Only defined under cfg(windows): proves the second pass compiled the Windows arms.
46 |     expect(stdout).toContain("init_dispatches_on_argument_type ... ok");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "init_dispatches_on_argument_type ... ok"
Received: "\^[[36m[miri]\^[[0m cargo miri test -p bun_errno\n\nrunning 4 tests\ntest errno_name_tests::coreutils_map ... ok\ntest errno_name_tests::errno_mapping ... ok\ntest errno_name_tests::errno_table_full_range ... ok\ntest errno_name_tests::win32_errno_names ... ok\n\ntest result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.53s\n\n\nrunning 0 tests\n\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n\n\^[[36m[miri]\^[[0m cargo miri test --target x86_64-p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-miri-windows-target.test.ts
bun test v1.4.0 (1b77e732f)

test/internal/rust-miri-windows-target.test.ts:
(pass) bun_errno unit tests pass under miri for the Windows target [10111.10ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [12.53s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1b77e732fa
  features     baseline

22 deps, 107 codegen, 1176 objects in 951ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [26.00ms]
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch picohttpparser
[picohttpparser] up to date
[7/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] fetch zlib
[zlib] up to date
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/binding
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/rust-miri.ts                           | 54 ++++++++++++++++++++------
 src/errno/lib.rs                               | 39 +++++++++++++++----
 test/internal/rust-miri-windows-target.test.ts | 52 +++++++++++++++++++++++++
 3 files changed, 127 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
scripts/rust-miri.ts                                3      5      0
src/errno/lib.rs                                    5     13      0
test/internal/rust-miri-windows-target.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->
