### PR TITLE
bun_jsc: return OwnedString from JSValue::get_name

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3972,7 +3972,7 @@ pub mod formatter {
             // `Function.prototype.constructor === Function`, returning
             // "Function". The `.name` property is set to the real class name
             // on the constructor itself. See #29225.
-            let printable = OwnedString::new(value.get_name(self.global_this)?);
+            let printable = value.get_name(self.global_this)?;
             writer.add_for_new_line(printable.length());
 
             // Only report `extends` when the parent is itself a class
@@ -3983,11 +3983,11 @@ pub mod formatter {
             let proto_is_class = !proto.is_empty_or_undefined_or_null()
                 && proto.is_cell()
                 && proto.is_class(self.global_this);
-            let printable_proto = OwnedString::new(if proto_is_class {
+            let printable_proto = if proto_is_class {
                 proto.get_name(self.global_this)?
             } else {
-                BunString::empty()
-            });
+                OwnedString::new(BunString::empty())
+            };
             writer.add_for_new_line(printable_proto.length());
 
             if printable.is_empty() {
@@ -4043,11 +4043,11 @@ pub mod formatter {
                     pfmt!($s, C)
                 };
             }
-            let printable = OwnedString::new(value.get_name(self.global_this)?);
+            let printable = value.get_name(self.global_this)?;
 
             let proto = value.get_prototype(self.global_this);
             // "Function" | "AsyncFunction" | "GeneratorFunction" | "AsyncGeneratorFunction"
-            let func_name = OwnedString::new(proto.get_name(self.global_this)?);
+            let func_name = proto.get_name(self.global_this)?;
 
             if printable.is_empty() || func_name.eql(&printable) {
                 if func_name.is_empty() {
@@ -5502,7 +5502,7 @@ pub mod formatter {
 
             let mut display_name = value.get_name(self.global_this)?;
             if display_name.is_empty() {
-                display_name = BunString::static_("Object");
+                display_name = OwnedString::new(BunString::static_("Object"));
             }
             let _ = write!(
                 writer_,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2306,8 +2306,8 @@ impl JSValue {
 
     // ── Reflection / naming. ───────────────
     /// `JSValue.getName` — function/class display name.
-    pub fn get_name(self, global: &JSGlobalObject) -> JsResult<bun_core::String> {
-        let mut ret = bun_core::String::default();
+    pub fn get_name(self, global: &JSGlobalObject) -> JsResult<bun_core::OwnedString> {
+        let mut ret = bun_core::OwnedString::default();
         host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__getName(self, global, &mut ret)
         })?;

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -574,7 +574,6 @@ fn get_description(
         }
 
         let description_name = description.get_name(global)?;
-        // `description_name.deref()` handled by Drop on bun_core::String
         return Ok(description_name.to_owned_slice());
     }
 

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1620,7 +1620,7 @@ impl Expect {
             expect.flags.get(),
             global_this,
             value,
-            matcher_name,
+            matcher_name.get(),
             &matcher_params,
             false,
         )?;
@@ -1638,7 +1638,7 @@ impl Expect {
             matcher_args.push(*arg);
         }
 
-        let _ = Self::execute_custom_matcher(global_this, matcher_name, matcher_fn, &matcher_args, expect.flags.get(), false)?;
+        let _ = Self::execute_custom_matcher(global_this, matcher_name.get(), matcher_fn, &matcher_args, expect.flags.get(), false)?;
 
         Ok(this_value)
     }
@@ -2635,7 +2635,7 @@ impl ExpectCustomAsymmetricMatcher {
             matcher_args.push(captured_args.get_index(global_this, i as u32)?);
         }
 
-        Expect::execute_custom_matcher(global_this, matcher_name, matcher_fn, &matcher_args, this.flags, true)
+        Expect::execute_custom_matcher(global_this, matcher_name.get(), matcher_fn, &matcher_args, this.flags, true)
     }
 
     /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -24,3 +24,31 @@ test("Printing errors does not leak", () => {
   // retention inflate RSS even when nothing is leaking.
   expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 10);
 }, 10_000);
+
+test("Printing a depth-exceeded object's name does not leak its string", () => {
+  // Each iteration hands the formatter a distinct 64 KiB Symbol.toStringTag, so a
+  // leaked reference to the name retains 64 KiB: ~640 MB over the run, above both
+  // bounds below, while a correct build frees all of it.
+  const tagPerBatch = 500;
+  const tagRepeat = 20;
+  const padding = Buffer.alloc(64 * 1024, "x").toString();
+  let n = 0;
+  function batch() {
+    for (let i = 0; i < tagPerBatch; i++) {
+      Bun.inspect({ a: { [Symbol.toStringTag]: `Tag${n++}${padding}` } }, { depth: 0 });
+    }
+    Bun.gc(true);
+  }
+
+  batch();
+  const baseline = Math.floor(rss() / 1024);
+  for (let i = 0; i < tagRepeat; i++) {
+    batch();
+  }
+
+  const after = Math.floor(rss() / 1024);
+  const diff = ((after - baseline) / 1024) | 0;
+  console.log(`RSS increased by ${diff} MB`);
+  // Same ASAN allowance as above: the quarantine (256 MB by default) holds the freed tags for a while.
+  expect(diff, `RSS grew by ${diff} MB after ${tagPerBatch * tagRepeat} iterations`).toBeLessThan(isASAN ? 400 : 32);
+}, 20_000);


### PR DESCRIPTION
## What

`JSValue::get_name` wraps `JSC__JSValue__getName`, whose C++ body ends in `*arg2 = Bun::toStringRef(displayName)`, so the caller receives a +1 `WTF::StringImpl` ref. The Rust wrapper returned that ref as a bare `bun_core::String`, which is `Copy` and has no `Drop`, so releasing it was up to each caller. Of the 10 call sites, 4 (`ConsoleObject.rs` `print_class` and `print_function`) wrapped the result in `OwnedString::new(..)` by hand and 6 did not: `describe(SomeClass)` and `describe(someFn)` in `test_runner/ScopeFunctions.rs` (the comment there claimed `bun_core::String` had a `Drop`), the symmetric and asymmetric custom matcher paths in `test_runner/expect.rs`, asymmetric matcher printing in `test_runner/pretty_format.rs`, and depth-exceeded object printing in `ConsoleObject.rs`. Each of those leaked one `StringImpl` ref per call.

```rust
// before
pub fn get_name(self, global: &JSGlobalObject) -> JsResult<bun_core::String>

let printable = OwnedString::new(value.get_name(self.global_this)?);   // ConsoleObject.rs, 3 sites
let matcher_name = matcher_fn.get_name(global_this)?;                  // expect.rs, leaked
Self::execute_custom_matcher(global_this, matcher_name, ..)

// after
pub fn get_name(self, global: &JSGlobalObject) -> JsResult<bun_core::OwnedString>

let printable = value.get_name(self.global_this)?;
let matcher_name = matcher_fn.get_name(global_this)?;                  // released at scope exit
Self::execute_custom_matcher(global_this, matcher_name.get(), ..)
```

The wrapper now fills an `OwnedString` directly (the out-param goes through `DerefMut`), so the ref is also released on the early return taken when the C++ side throws after writing the name. In `ConsoleObject.rs` three `OwnedString::new(..)` wrappers are deleted and the fourth, which wrapped an `if` over `get_name` and an empty fallback, now wraps only the fallback branch; the depth-exceeded site assigns its `"Object"` fallback as `OwnedString::new(BunString::static_("Object"))`. The three `expect.rs` uses that pass the name on to `process_promise` and `execute_custom_matcher` (both of which only format it) pass `matcher_name.get()`, the non-owning `Copy` view. The `ScopeFunctions.rs` and `pretty_format.rs` call sites compile unchanged through `Deref` and `Display`; only the incorrect comment in `ScopeFunctions.rs` is removed. The `extern "C"` declaration and the C++ side are untouched. 4 files, 12 insertions, 13 deletions, no `unsafe` involved.

## Why

Who releases the name is now stated by the return type: every caller gets an `OwnedString` that derefs the `StringImpl` exactly once when it goes out of scope, on every return path, and forgetting to release it is no longer expressible. It is zero-cost: `OwnedString` is `#[repr(transparent)]` over `bun_core::String`, so the value handed back across the FFI out-param and returned from `get_name` has the same layout as before, the four previously correct callers execute exactly the same scope-exit `deref()` they already did, and the only new instructions are that same `deref()` at the six sites that were missing it.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/test/describe.test.ts test/js/bun/test/expect-extend.test.js test/js/bun/util/inspect.test.js test/js/web/console/console-log.test.ts: 119 pass, 0 fail across 4 files.

Since this also stops six call sites from leaking, `test/js/bun/util/inspect-error-leak.test.js` gains a regression test for the one of them reachable from JS in a tight loop: printing a depth-exceeded object whose `Symbol.toStringTag` is a fresh 64 KiB string, 10000 times, so a leaked name retains about 640 MB over the run. That is above the test's bound on every build flavour: the bound is 32 MB normally and 400 MB under ASAN (the allowance the neighbouring test already uses for the quarantine), and the test fails against the current release binary. With the fix the debug ASAN build retained 137 MB (quarantine) and a release build frees everything.

