### PR TITLE
Bun.serve: close the connection after responding to a CONNECT request

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -452,6 +452,17 @@ private:
                     httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
                 }
 
+                /* After a CONNECT request-line the parser no longer parses this
+                 * connection as HTTP (isConnectRequest). node:http hands it to its
+                 * 'connect' listener as a tunnel; Bun.serve has no tunnel handler, so
+                 * the response to a CONNECT is the connection's last one: close after
+                 * it rather than keep a connection whose further input is discarded. */
+                if constexpr (!IsNodeHttp) {
+                    if (httpResponseData->isConnectRequest) [[unlikely]] {
+                        httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+                    }
+                }
+
                 /* Per-response trailer fields must not leak into the next response
                  * on this keep-alive connection (the flag itself was cleared above). */
                 if constexpr (IsNodeHttp) {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -2625,6 +2625,121 @@ describe.concurrent("HEAD requests #15355", () => {
   });
 });
 
+describe.concurrent("CONNECT requests", () => {
+  // Bun.serve has nothing to hand a CONNECT tunnel to, and once the parser has
+  // seen a CONNECT request-line it stops parsing the connection as HTTP. So the
+  // response to a CONNECT has to be the connection's last one: the server must
+  // close after sending it, rather than keep the connection open and silently
+  // discard everything the client sends next. Every test below waits for the
+  // server to end the connection; idleTimeout is raised so that a close can
+  // only come from the response itself.
+  const CONNECT_HEAD = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n";
+  // What a client sends once it believes the tunnel is up (or, pipelining, its
+  // next request). It must neither be answered nor keep the connection alive.
+  const AFTER_HEAD = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+
+  async function connectExchange(server: Server, chunks: readonly string[]) {
+    let received = "";
+    const ended = Promise.withResolvers<void>();
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        data(_socket, data) {
+          received += data.toString("latin1");
+        },
+        end: () => ended.resolve(),
+        close: () => ended.resolve(),
+        error: () => ended.resolve(),
+      },
+    });
+    try {
+      for (const [i, chunk] of chunks.entries()) {
+        if (i > 0) {
+          // Let the server read the previous chunk before the next one is
+          // written, so the head really does arrive in separate reads.
+          await new Promise(resolve => setImmediate(resolve));
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        socket.write(chunk);
+        socket.flush();
+      }
+      // Resolves only once the server ends the connection.
+      await ended.promise;
+    } finally {
+      socket.end();
+    }
+    const headersEnd = received.indexOf("\r\n\r\n");
+    return {
+      statusLine: received.slice(0, received.indexOf("\r\n")),
+      // Everything after the response head. Only the declared body may be
+      // here: a second response would mean the bytes after the CONNECT head
+      // were parsed as a request.
+      body: received.slice(headersEnd + 4),
+    };
+  }
+
+  test.each([
+    ["in one read", [CONNECT_HEAD + AFTER_HEAD]],
+    ["split inside the Host header", [CONNECT_HEAD.slice(0, 40), CONNECT_HEAD.slice(40) + AFTER_HEAD]],
+  ] as const)("the fetch handler's response is sent and the connection is closed (head %s)", async (_name, chunks) => {
+    const methods: string[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 255,
+      fetch(req) {
+        methods.push(req.method);
+        return new Response("not a proxy", { status: 405 });
+      },
+    });
+
+    expect(await connectExchange(server, chunks)).toEqual({
+      statusLine: "HTTP/1.1 405 Method Not Allowed",
+      body: "not a proxy",
+    });
+    expect(methods).toEqual(["CONNECT"]);
+  });
+
+  test("a response produced after the handler returned still closes the connection", async () => {
+    const methods: string[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 255,
+      async fetch(req) {
+        methods.push(req.method);
+        // Respond from a later event loop turn, after the read that carried
+        // the CONNECT has been fully processed.
+        await new Promise(resolve => setImmediate(resolve));
+        return new Response("not a proxy", { status: 405 });
+      },
+    });
+
+    expect(await connectExchange(server, [CONNECT_HEAD + AFTER_HEAD])).toEqual({
+      statusLine: "HTTP/1.1 405 Method Not Allowed",
+      body: "not a proxy",
+    });
+    expect(methods).toEqual(["CONNECT"]);
+  });
+
+  test("a server without a fetch handler answers 404 and closes the connection", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 255,
+      routes: {
+        "/": () => new Response("root"),
+      },
+    });
+
+    expect(await connectExchange(server, [CONNECT_HEAD + AFTER_HEAD])).toEqual({
+      statusLine: "HTTP/1.1 404 Not Found",
+      body: "",
+    });
+  });
+});
+
 describe.concurrent("websocket and routes test", () => {
   const serverConfigurations = [
     {


### PR DESCRIPTION
## Repro

```js
const server = Bun.serve({ port: 0, fetch: () => new Response("nope", { status: 404 }) });
const sock = await Bun.connect({
  hostname: "127.0.0.1", port: server.port,
  socket: {
    data(_, d) { console.log(JSON.stringify(d.toString().split("\r\n")[0])); },
    close() { console.log("closed"); },
  },
});
sock.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
// before: "HTTP/1.1 404 Not Found", then nothing: the connection stays open and
//         anything written to it afterwards (a pipelined GET, tunnel bytes) is
//         discarded without a response
// after:  "HTTP/1.1 404 Not Found", "closed"
```

## Cause

`HttpParser.h` sets the per-connection `isConnectRequest` flag when it parses a `CONNECT` request-line and from then on stops parsing the connection as HTTP: after the dispatch it marks the rest of the buffer consumed, and every later read goes straight to the data handler (`consumePostPadded`), which on a Bun.serve connection has no `inStream` to deliver to. node:http relies on this to hand the connection to its `'connect'` listener as a tunnel. Bun.serve has nothing to hand a tunnel to: the request went through the normal handler (`fetch`, routes, or the 404 fallback), the response was written, and the connection was then kept alive in tunnel mode as a sink.

## Fix

In the uWS request dispatch (`HttpContext.h`), when a CONNECT is dispatched on a Bun.serve context (`!IsNodeHttp`), set `HTTP_CONNECTION_CLOSE` on the connection, the same state an HTTP/1.0 or `Connection: close` request sets a few lines above. The handler still answers however it likes, and the existing close gates (post-parse in `onData`, `internalEnd`, `onWritable`) close the socket once that response has been flushed. Every Bun.serve response path already feeds this state into its `end()` call, so this covers `fetch`, `routes`, static/file routes and the no-handler 404 alike. The node:http instantiation is unchanged (its CONNECT handling lives in `_http_server.ts`: `'connect'` listener, or close when there is none).

As with the other close-marked requests on Bun.serve, no `Connection: close` header is added; the response is complete and the socket is closed behind it.

#34261 addresses the same report differently, by dropping CONNECT before dispatch with no response written. This PR keeps the response and closes afterwards.

## Verification

`test/js/bun/http/bun-server.test.ts`, new `CONNECT requests` block. Each case sends a CONNECT head followed by a pipelined `GET` on a server with a long idle timeout and waits for the server to end the connection, then checks that exactly one response (the handler's) came back:

- head in one read, and head split across two reads (exercises the fallback buffer path)
- handler that responds from a later event loop turn (close happens outside the parse window)
- routes-only server with no `fetch` (404 fallback)

Without the change all four time out waiting for the close (the 404/405 arrives, the connection stays open); with it they pass. `test/js/node/http/node-http-connect.test.ts` and the node CONNECT regression tests (`25862`, `32734`) still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->