### PR TITLE
test(require-cache): measure allocator-live bytes instead of RSS in the source code leak fixtures

### DIFF
--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -11,9 +11,9 @@ import { join } from "path";
 // CodeBlock metadata table that is reported to the GC while collection is
 // deferred, so whether a collection actually runs between loads depends on
 // concurrent JIT timing, and mimalloc keeps pages mapped for a while after the
-// blocks in them are freed. Together those moved RSS by 60-180 MB between two
-// gc(true) calls with nothing retained (the alpine x64 and macOS CI failures of
-// this file), while liveBytes() stayed within 4 MB.
+// blocks in them are freed. Together those moved RSS by 60-500 MB between two
+// gc(true) calls with nothing retained (the alpine and macOS CI failures of this
+// file), while liveBytes() stayed within 7 MB.
 //
 // ASAN builds allocate through the system allocator, which the heap walk does
 // not see, so they keep the RSS bound.
@@ -36,15 +36,17 @@ const leakFixturePrelude = `
 
 // Leaking one copy of index.js's output per load adds at least ~44 MB in the
 // smallest fixture (100 KB x 400 loads; the long-export-name fixtures add
-// hundreds of MB). The noise floor is the most recently loaded module's
-// unlinked bytecode occasionally surviving gc(true): ~3 MB.
+// hundreds of MB). The noise floor is one load's worth of compilation state
+// that the concurrent JIT thread has not let go of yet when the second
+// measurement is taken (it never shows up with BUN_JSC_useConcurrentJIT=0):
+// ~3.5 MB on x64 and up to ~6.5 MB on aarch64 in CI.
 function leakFixtureCheck(asanRssMB: number) {
   return `
           const after = measure();
           const liveDiff = after.live - baseline.live;
           const rssDiff = after.rss - baseline.rss;
           console.log("live diff", (liveDiff / 1024 / 1024).toFixed(1), "MB,", "RSS diff", (rssDiff / 1024 / 1024) | 0, "MB");
-          if (${isASAN} ? rssDiff > ${asanRssMB} * 1024 * 1024 : liveDiff > 16 * 1024 * 1024) {
+          if (${isASAN} ? rssDiff > ${asanRssMB} * 1024 * 1024 : liveDiff > 24 * 1024 * 1024) {
             throw new Error("Memory leak detected");
           }
 `;

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -1,18 +1,54 @@
 import { describe, expect, test } from "bun:test";
-import {
-  bunEnv,
-  bunExe,
-  isArm64,
-  isASAN,
-  isBroken,
-  isCI,
-  isIntelMacOS,
-  isMacOS,
-  isMusl,
-  isWindows,
-  tempDir,
-} from "harness";
+import { bunEnv, bunExe, isArm64, isASAN, isBroken, isIntelMacOS, isWindows, tempDir } from "harness";
 import { join } from "path";
+
+// Shared by the "don't leak the output source code" fixtures below.
+//
+// The leak they guard against (the transpiled source, or the whole module, kept
+// alive once per load) is measured as the bytes mimalloc currently has handed
+// out, summed over every heap; JSC allocates through mimalloc as well. RSS is
+// not a usable signal for these loops: each load of index.js creates a ~2 MB
+// CodeBlock metadata table that is reported to the GC while collection is
+// deferred, so whether a collection actually runs between loads depends on
+// concurrent JIT timing, and mimalloc keeps pages mapped for a while after the
+// blocks in them are freed. Together those moved RSS by 60-180 MB between two
+// gc(true) calls with nothing retained (the alpine x64 and macOS CI failures of
+// this file), while liveBytes() stayed within 4 MB.
+//
+// ASAN builds allocate through the system allocator, which the heap walk does
+// not see, so they keep the RSS bound.
+const leakFixturePrelude = `
+          const { heapStats } = require("bun:jsc");
+          const gc = global.gc || globalThis?.Bun?.gc || (() => {});
+          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          function liveBytes() {
+            let bytes = 0;
+            for (const heap of heapStats({ dump: true }).mimallocDump.heaps) {
+              for (const page of heap.pages) bytes += page.block_size * page.used;
+            }
+            return bytes;
+          }
+          function measure() {
+            gc(true);
+            return { live: liveBytes(), rss: rss() };
+          }
+`;
+
+// Leaking one copy of index.js's output per load adds at least ~44 MB in the
+// smallest fixture (100 KB x 400 loads; the long-export-name fixtures add
+// hundreds of MB). The noise floor is the most recently loaded module's
+// unlinked bytecode occasionally surviving gc(true): ~3 MB.
+function leakFixtureCheck(asanRssMB: number) {
+  return `
+          const after = measure();
+          const liveDiff = after.live - baseline.live;
+          const rssDiff = after.rss - baseline.rss;
+          console.log("live diff", (liveDiff / 1024 / 1024).toFixed(1), "MB,", "RSS diff", (rssDiff / 1024 / 1024) | 0, "MB");
+          if (${isASAN} ? rssDiff > ${asanRssMB} * 1024 * 1024 : liveDiff > 16 * 1024 * 1024) {
+            throw new Error("Memory leak detected");
+          }
+`;
+}
 
 describe.concurrent("require.cache", () => {
   test("require.cache is not an empty object literal when inspected", () => {
@@ -62,9 +98,8 @@ describe.concurrent("require.cache", () => {
       await using dir = tempDir("require-cache-bug-leak-1", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
+          ${leakFixturePrelude}
           const path = require.resolve("./index.js");
-          const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
           const noChildren = module.children = { indexOf() { return 0; } }; // disable children tracking
           function bust() {
             const mod = require.cache[path];
@@ -79,22 +114,12 @@ describe.concurrent("require.cache", () => {
             require(path);
             bust();
           }
-          gc(true);
-          const baseline = rss();
+          const baseline = measure();
           for (let i = 0; i < 500; i++) {
             require(path);
             bust(path);
           }
-          gc(true);
-          const after = rss();
-          const diff = after - baseline;
-          console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
-          console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
-          if (diff > ${isASAN ? 400 : 100} * 1024 * 1024) {
-            // Bun v1.1.21 reported 844 MB here on macOS arm64.
-            throw new Error("Memory leak detected");
-          }
-
+          ${leakFixtureCheck(400)}
           exports.abc = 123;
         `,
       });
@@ -121,9 +146,8 @@ describe.concurrent("require.cache", () => {
       await using dir = tempDir("require-cache-bug-leak-3", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
+          ${leakFixturePrelude}
           const path = require.resolve("./index.js");
-          const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
           function bust() {
             delete require.cache[path];
           }
@@ -132,23 +156,12 @@ describe.concurrent("require.cache", () => {
             await import(path);
             bust();
           }
-          gc(true);
-          const baseline = rss();
+          const baseline = measure();
           for (let i = 0; i < 400; i++) {
             await import(path);
             bust(path);
           }
-          gc(true);
-          const after = rss();
-          const diff = after - baseline;
-          console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
-          console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
-          if (diff > ${isASAN ? 320 : 64} * 1024 * 1024) {
-            // Bun v1.1.22 reported 1 MB here on macoS arm64.
-            // Bun v1.1.21 reported 257 MB here on macoS arm64.
-            throw new Error("Memory leak detected");
-          }
-
+          ${leakFixtureCheck(320)}
           export default 123;
         `,
       });
@@ -171,9 +184,8 @@ describe.concurrent("require.cache", () => {
       await using dir = tempDir("require-cache-bug-leak-4", {
         "index.js": text,
         "require-cache-bug-leak-fixture.js": `
+          ${leakFixturePrelude}
           const path = require.resolve("./index.js");
-          const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
           function bust() {
             delete require.cache[path];
           }
@@ -182,23 +194,12 @@ describe.concurrent("require.cache", () => {
             await import(path);
             bust();
           }
-          gc(true);
-          const baseline = rss();
+          const baseline = measure();
           for (let i = 0; i < 250; i++) {
             await import(path);
             bust(path);
           }
-          gc(true);
-          const after = rss();
-          const diff = after - baseline;
-          console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
-          console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
-          if (diff > ${isASAN ? 320 : 64} * 1024 * 1024) {
-            // Bun v1.1.21 reported 423 MB here on macoS arm64.
-            // Bun v1.1.22 reported 4 MB here on macoS arm64.
-            throw new Error("Memory leak detected");
-          }
-
+          ${leakFixtureCheck(320)}
           export default 124;
         `,
       });
@@ -213,28 +214,20 @@ describe.concurrent("require.cache", () => {
       expect(exitCode).toBe(0);
     }, 60000);
 
-    test.todoIf(
-      // Flaky specifically on macOS CI, and on musl-aarch64 under ThinLTO +
-      // -Zshare-generics where RSS reports ~280 MB for the same workload
-      // that measures under 64 MB elsewhere (intermittent).
-      isBroken && isCI && (isMacOS || (isMusl && isArm64)),
-    )(
-      "via require() with a lot of function calls",
-      async () => {
-        let text = "function i() { return 1; }\n";
-        for (let i = 0; i < 20000; i++) {
-          text += `i();\n`;
-        }
-        text += "exports.forceCommonJS = true;\n";
+    test("via require() with a lot of function calls", async () => {
+      let text = "function i() { return 1; }\n";
+      for (let i = 0; i < 20000; i++) {
+        text += `i();\n`;
+      }
+      text += "exports.forceCommonJS = true;\n";
 
-        console.log("Text length:", text.length);
+      console.log("Text length:", text.length);
 
-        await using dir = tempDir("require-cache-bug-leak-2", {
-          "index.js": text,
-          "require-cache-bug-leak-fixture.js": `
+      await using dir = tempDir("require-cache-bug-leak-2", {
+        "index.js": text,
+        "require-cache-bug-leak-fixture.js": `
+          ${leakFixturePrelude}
           const path = require.resolve("./index.js");
-          const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
           function bust() {
             const mod = require.cache[path];
             if (mod) {
@@ -248,37 +241,24 @@ describe.concurrent("require.cache", () => {
             require(path);
             bust();
           }
-          gc(true);
-          const baseline = rss();
+          const baseline = measure();
           for (let i = 0; i < 400; i++) {
             require(path);
             bust(path);
           }
-          gc(true);
-          const after = rss();
-          const diff = after - baseline;
-          console.log("RSS diff", (diff / 1024 / 1024) | 0, "MB");
-          console.log("RSS", (diff / 1024 / 1024) | 0, "MB");
-          if (diff > ${isASAN ? 320 : 64} * 1024 * 1024) {
-            // Bun v1.1.22 reported 4 MB here on macoS arm64.
-            // Bun v1.1.21 reported 248 MB here on macoS arm64.
-            throw new Error("Memory leak detected");
-          }
-
+          ${leakFixtureCheck(320)}
           exports.abc = 123;
         `,
-        });
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
-          env: bunEnv,
-          stdio: ["inherit", "inherit", "inherit"],
-        });
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+        env: bunEnv,
+        stdio: ["inherit", "inherit", "inherit"],
+      });
 
-        const exitCode = await proc.exited;
-        expect(exitCode).toBe(0);
-      },
-      60000,
-    ); // takes 4s on an M1 in release build
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0);
+    }, 60000); // takes 4s on an M1 in release build
   });
 
   describe("files transpiled and loaded don't leak the AST", () => {

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -42,6 +42,8 @@ const leakFixturePrelude = `
             return bytes;
           }
           const liveBeforeProbe = liveBytes();
+          // Not Buffer#toString(): that string does not register in the walk even where a source
+          // would. A single-character repeat is a flat WTF string and a memset, also in debug builds.
           let probe = "a".repeat(32 * MB);
           const walkSeesJSC = liveBytes() - liveBeforeProbe >= maxLiveGrowth;
           probe = undefined;

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -1,26 +1,39 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isArm64, isASAN, isBroken, isIntelMacOS, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isArm64, isBroken, isIntelMacOS, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Shared by the "don't leak the output source code" fixtures below.
 //
 // The leak they guard against (the transpiled source, or the whole module, kept
 // alive once per load) is measured as the bytes mimalloc currently has handed
-// out, summed over every heap; JSC allocates through mimalloc as well. RSS is
-// not a usable signal for these loops: each load of index.js creates a ~2 MB
-// CodeBlock metadata table that is reported to the GC while collection is
-// deferred, so whether a collection actually runs between loads depends on
-// concurrent JIT timing, and mimalloc keeps pages mapped for a while after the
-// blocks in them are freed. Together those moved RSS by 60-500 MB between two
-// gc(true) calls with nothing retained (the alpine and macOS CI failures of this
-// file), while liveBytes() stayed within 7 MB.
+// out, summed over every heap; in release builds JSC allocates through mimalloc
+// as well. RSS is not a usable signal for these loops: each load of index.js
+// creates a ~2 MB CodeBlock metadata table that is reported to the GC while
+// collection is deferred, so whether a collection actually runs between loads
+// depends on concurrent JIT timing, and mimalloc keeps pages mapped for a while
+// after the blocks in them are freed. Together those moved RSS by 60-500 MB
+// between two gc(true) calls with nothing retained (the alpine and macOS CI
+// failures of this file), while liveBytes() stayed within 7 MB.
 //
-// ASAN builds allocate through the system allocator, which the heap walk does
-// not see, so they keep the RSS bound.
+// Leaking one copy of index.js's output per load adds at least ~44 MB in the
+// smallest fixture (100 KB x 400 loads; the long-export-name fixtures add
+// hundreds of MB). The noise floor is one load's worth of compilation state
+// that the concurrent JIT thread has not let go of yet when the second
+// measurement is taken (it never shows up with BUN_JSC_useConcurrentJIT=0):
+// ~3.5 MB on x64 and up to ~6.5 MB on aarch64 in CI.
+//
+// Whether JSC's allocations are in the heaps the walk sees is a property of the
+// WebKit build (ASAN builds and WebKit built without USE_MIMALLOC, e.g. the
+// debug prebuilts, use another allocator), so the prelude checks it with a flat
+// JS string of 32 MB, the same kind of allocation as a retained source. Where
+// that string is invisible the fixture falls back to comparing RSS, at the
+// looser bound those builds were already using.
 const leakFixturePrelude = `
           const { heapStats } = require("bun:jsc");
           const gc = global.gc || globalThis?.Bun?.gc || (() => {});
           const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const MB = 1024 * 1024;
+          const maxLiveGrowth = 24 * MB;
           function liveBytes() {
             let bytes = 0;
             for (const heap of heapStats({ dump: true }).mimallocDump.heaps) {
@@ -28,25 +41,27 @@ const leakFixturePrelude = `
             }
             return bytes;
           }
+          const liveBeforeProbe = liveBytes();
+          let probe = "a".repeat(32 * MB);
+          const walkSeesJSC = liveBytes() - liveBeforeProbe >= maxLiveGrowth;
+          probe = undefined;
           function measure() {
             gc(true);
             return { live: liveBytes(), rss: rss() };
           }
 `;
 
-// Leaking one copy of index.js's output per load adds at least ~44 MB in the
-// smallest fixture (100 KB x 400 loads; the long-export-name fixtures add
-// hundreds of MB). The noise floor is one load's worth of compilation state
-// that the concurrent JIT thread has not let go of yet when the second
-// measurement is taken (it never shows up with BUN_JSC_useConcurrentJIT=0):
-// ~3.5 MB on x64 and up to ~6.5 MB on aarch64 in CI.
-function leakFixtureCheck(asanRssMB: number) {
+function leakFixtureCheck(fallbackRssMB: number) {
   return `
           const after = measure();
           const liveDiff = after.live - baseline.live;
           const rssDiff = after.rss - baseline.rss;
-          console.log("live diff", (liveDiff / 1024 / 1024).toFixed(1), "MB,", "RSS diff", (rssDiff / 1024 / 1024) | 0, "MB");
-          if (${isASAN} ? rssDiff > ${asanRssMB} * 1024 * 1024 : liveDiff > 24 * 1024 * 1024) {
+          console.log(
+            "live", (baseline.live / MB).toFixed(1), "->", (after.live / MB).toFixed(1), "MB (diff", (liveDiff / MB).toFixed(1), "MB),",
+            "RSS diff", (rssDiff / MB) | 0, "MB,",
+            walkSeesJSC ? "checking live bytes" : "allocator walk does not see JSC allocations in this build, checking RSS",
+          );
+          if (walkSeesJSC ? liveDiff > maxLiveGrowth : rssDiff > ${fallbackRssMB} * MB) {
             throw new Error("Memory leak detected");
           }
 `;


### PR DESCRIPTION
`test/cli/run/require-cache.test.ts` > "files transpiled and loaded don't leak the output source code" > "via require() with a lot of function calls" intermittently fails on the alpine 3.23 x64 lane and passes on retry (main builds 84503, 85969, 87643, 88433):

```
RSS diff 177 MB
error: Memory leak detected
      at <anonymous> (.../require-cache-bug-leak-2_eoBlgm/require-cache-bug-leak-fixture.js:31:23)
```

The other builds reported 94, 104 and 112 MB against the fixture's 64 MB bound. This is the same failure the fixture's `todoIf` already excused on macOS and musl-aarch64 ("RSS reports ~280 MB"), and the same one #34159 saw on macOS for the import() long-export-names sibling.

### Cause

Nothing is retained; RSS is the wrong signal for these loops. It reproduces on glibc x64 with a release build whenever the machine is busy (3 of 20 and 4 of 10 runs in two batches here, 8 of 15 with a build running in the background).

Every load of the 20k-call `index.js` creates a CodeBlock whose metadata table is ~1.9 MB. `CodeBlock::finishCreation` reports it with `reportExtraMemoryAllocated` while `ScriptExecutable::prepareForExecutionImpl` holds a `DeferGCForAWhile`, so the request is only recorded, and almost nothing else in the loop allocates through a path that re-checks it. In practice the collection gets kicked off when a concurrent JIT plan for `i` is installed on the main thread. When the JIT thread lags, no GC runs for 30 to 60 loads and the dead CodeBlocks pile up at ~2.3 MB per load; `BUN_JSC_logGC=1` shows stretches with no collection ending in `bytes allocated this cycle: 119104488 exceed bytes allowed: 9147120`. `gc(true)` then frees all of it, but the pages stay mapped past the RSS read (mimalloc purges them ~100 ms later), so `RSS diff` is whatever the ramp happened to be. With `BUN_JSC_useConcurrentJIT=0` the diff is 1 to 5 MB in 20 of 20 runs. The `await import()` siblings yield to the event loop between loads, which is why they rarely hit this.

This is not a Bun-side regression to fix in `src/` instead: the `DeferGCForAWhile` and the deferral branch of `Heap::collectIfNecessaryOrDefer` are unmodified upstream JSC code, and Bun's own GC scheduling (`src/jsc/GarbageCollectionController.rs`, both before and after #35356) is driven by event-loop timers, which a synchronous `require()` loop never reaches; nothing in the module loading path ever prompted the GC. The first of the alpine failures (build 84503, 2026-07-29) also predates #35356. What changed recently is only how much of the freed memory stays resident long enough to be read (#34009), which the macOS `todo` from 2025 shows was already enough to make RSS flaky before that.

Through all of this, the bytes mimalloc actually has handed out (JSC allocates through it too since #34009) stay flat: `heapStats()` shows the same object counts after each `gc(true)`, and the mimalloc heap walk moves by 0 to 3.6 MB on x64. The residue is quantized: in about a quarter of the measurements one load's worth of compilation state (a 2.25 MB block plus a 512 KB and a 320 KB one on x64) is still allocated after `gc(true)`, with identical JS cell counts either way; it never occurs with `BUN_JSC_useConcurrentJIT=0` (0 of 24 runs vs 10 of 24 with the default), so it is something the JIT worker thread has not released yet when the measurement is taken. On the aarch64 CI lanes that residue is larger, up to 6.4 MB (see the CI numbers below).

### Fix

Test only. The four fixtures in that describe block share one prelude and one check: `liveBytes()` sums `block_size * used` over every page of every heap in `heapStats({ dump: true }).mimallocDump`, and the fixture fails if that grows by more than 24 MB over the measured loop (3.7x the largest residue seen in CI). The smallest leak these fixtures exist to catch, one copy of the transpiled output kept per load, adds 44 MB in the 20k-call fixtures (100 KB x 400 loads) and hundreds of MB in the long-export-name ones; the old RSS check reported 59 and 50 MB for that same leak in the 20k-call fixtures, under its 64 MB bound.

Whether JSC's allocations are in the heaps this walk sees is a property of the WebKit build: the release prebuilts are built with `USE_MIMALLOC`, while ASAN builds and WebKit built without it (the debug prebuilts, local WebKit builds) use another allocator, and there the walk reads 0.0 MB whatever is retained. So rather than keying on `isASAN`, the prelude allocates a flat 32 MB JS string (the same kind of allocation as a retained source) and checks that `liveBytes()` saw it; where it did not, the fixture compares RSS instead, at the 400 / 320 MB bounds the ASAN lane was already using, and says which check it applied in its output. On ASAN lanes this is the same comparison as before this PR; on non-ASAN builds with a non-mimalloc WebKit it is the RSS check instead of a vacuous pass. The output line also prints the absolute live figures, so a blind walk is visible in CI logs (`live 0.0 -> 0.0 MB`) and the live baselines per lane can be compared.

The other two describe blocks in this file ("don't leak the AST", "don't leak file paths") still compare RSS in their own fixture files. They load many small modules rather than one large one, so they do not build up 2 MB per load, they have not failed on main in the last 60 builds, and one of their fixtures is being changed by #37562, so they are left alone here.

The `todoIf` on the require() function-calls test is removed since the readings it excused were this. The per-version RSS figures in the removed comments described the RSS check and are summarized in the shared comment instead. This supersedes #34159, which converts only the import() long-export-names fixture and is based on the file before #36194 and #36429.

### Verification

Release build on this (busy) machine:

- Unchanged fixture, 20 runs: RSS diff within 6 MB in 16, 47 MB in one, and 65, 67 and 130 MB in the remaining three (3 failures). An earlier batch of 10 failed 4 times (67-121 MB).
- New fixtures, 15 rounds of all four running concurrently (60 runs): live diff between -5.6 and 3.6 MB, no failures. In those same runs the require() function-calls fixture's RSS diff exceeded 64 MB 8 times (83-128 MB).
- `bun test test/cli/run/require-cache.test.ts` with the release build: 7 of 7 runs, 11 tests passing each time.
- Simulated leaks against the new check: keeping one `readFileSync` copy of index.js per load fails with 44.2 MB (require) / 46.7 MB (import); keeping `module.exports` per load fails with 303 MB (long names, require) / 900 MB (long names, import); keeping `i` per load fails with 935 MB.
- Probe: `"a".repeat(32 MB)` registers as +36.0 MB in the walk on the release build and +0.0 MB on the debug ASAN build (`Buffer#toString("latin1")` would not have worked as a probe: it registers 0.0 even on release).
- The exact prelude/check text, extracted from the test file into tiny CommonJS and ESM fixtures: on the release build both pass reporting "checking live bytes", and a variant retaining 42 MB of strings fails with `live 3.2 -> 48.2 MB`; on the debug ASAN build all three report "allocator walk does not see JSC allocations in this build, checking RSS" and apply the RSS bound.
- Full file with the release build after the probe commit: 11 tests pass, fixtures report live baselines of 7.8 / 8.1 / 8.2 / 17.3 MB with diffs of 0.0 / 3.4 / 0.4 / 0.2 MB.

First CI run of this branch (build 92405, every test lane green), live diff per fixture as printed by the four fixtures:

| lane | live diff (MB) | RSS diff (MB) |
|---|---|---|
| alpine 3.23 x64 | 0.4, 0.1, -0.4, 0.3 | 3, 11, -4, 21 |
| alpine 3.23 aarch64 (previously `todo`) | 0.2, 6.4, 4.6, 0.2 | 5, 505, -2, 14 |
| debian 13 aarch64 | 0.2, 5.7, -0.8, -1.3 | 6, -1, 0, 0 |
| ubuntu 25.04 aarch64 | 5.0, 0.4, 1.2, 0.2 | 10, -9, -13, 10 |
| debian 13 x64 | 0.3, 0.1, 0.2, 0.2 | 2, 5, 39, 51 |
| ubuntu 25.04 x64 | 0.1, 2.3, 2.6, 0.1 | 4, 8, 6, 14 |
| windows 2019 x64 | 0.0, 3.4, 0.2, 0.0 | -13, 6, 5, 15 |
| debian 13 x64 ASAN (RSS fallback, same comparison as before) | n/a | 50, 219, 120, 557 on the first attempt, passed on retry |

Second run, with the 24 MB bound (build 92426, also green everywhere): largest live diffs were 5.6 MB (ubuntu aarch64), 5.1 MB (windows 11 aarch64) and 2.6 MB (windows x64); everything else was within 0.5 MB. The ~5-6 MB residue shows up on every aarch64 lane regardless of OS, so it is an architecture difference in the size of the per-load compilation state, not a musl one.

The 505 MB RSS reading on alpine aarch64 next to a 6.4 MB live diff is the failure mode this PR is about; that run is what moved the bound from the 16 MB in the first commit to 24 MB. The pipeline currently has no macOS test lanes, so the macOS half of the removed `todoIf` is covered only by the mechanism argument.

The 557 MB reading on the ASAN lane is the same mechanism on the RSS fallback, which this PR leaves as it was: under ASAN the heap walk sees nothing, so those fixtures still compare RSS (same loops, same 400 / 320 MB bounds as before). It has not failed on main's ASAN lane in the last 60 main builds, so it is not changed here; a live-bytes counterpart for ASAN would need `__sanitizer_get_current_allocated_bytes` exposed to the fixture, which is a separate change.

The fail-before/pass-after proof does not apply to this change mechanically: there is no `src/` change, so the same tree runs both times; the numbers above are the before/after evidence. The file as a whole is too slow to finish under a debug build with these workloads regardless of this change (each load of the 20k-line file takes over a second there), which is pre-existing.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->