### PR TITLE
node:http2: put the peer-initiated stream mark in every GOAWAY we send (RFC 9113 6.8)

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -116,9 +116,9 @@ const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 /// ownership cycle.
 pub trait Sink {
     fn write(&self, bytes: &[u8]) -> WriteResult;
-    /// A locally-detected connection error: the GOAWAY (when one applies) is already on the wire.
-    /// `lib_error_code` is the negative nghttp2-style library error code (`wire::lib_error`) the
-    /// embedder maps to node's NghttpError.
+    /// A locally-detected connection error: the GOAWAY (when one applies) is already on the wire,
+    /// carrying `last_stream_id`. `lib_error_code` is the negative nghttp2-style library error
+    /// code (`wire::lib_error`) the embedder maps to node's NghttpError.
     fn on_error(&self, lib_error_code: i32, last_stream_id: u32, debug: &[u8]);
     fn on_local_settings(&self, settings: &Settings);
     fn on_remote_settings(&self, settings: &Settings);
@@ -170,6 +170,12 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
+    /// `Connection::last_peer_stream_id` advanced to `stream_id`. Same contract as
+    /// on_frame_counters: called while the connection is mutably borrowed, so the embedder must
+    /// only store the value. It needs its own copy because the GOAWAYs it writes itself
+    /// (session.close()/destroy()/goaway(), its rejection budgets) can be triggered from JS
+    /// dispatched inside receive(), while the connection is still borrowed.
+    fn on_last_peer_stream_id(&self, _stream_id: u32) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
     /// inbound frames for it are not treated as frames on an idle stream.
@@ -282,7 +288,16 @@ pub struct Connection {
     evict_buf: Vec<u32>,
 
     preface_received: usize,
+    /// Highest stream id seen in either direction; only meaningful for the §5.1 "has this id
+    /// ever existed" checks. It also counts locally-initiated streams (a client's own requests,
+    /// once their response arrives), so it must never go into a GOAWAY: see `last_peer_stream_id`.
     pub last_stream_id: u32,
+    /// Highest peer-initiated stream id processed: request ids on a server (refused ones
+    /// included), promised ids on a client. nghttp2's last_proc_stream_id. RFC 9113 §6.8 defines
+    /// a GOAWAY's last-stream-id in terms of streams its receiver initiated, and nghttp2 fails
+    /// the connection with PROTOCOL_ERROR on a GOAWAY naming one of the sender's own ids, so this
+    /// is the only mark a GOAWAY written here may carry.
+    pub last_peer_stream_id: u32,
     pub going_away: bool,
 }
 
@@ -323,6 +338,7 @@ impl Connection {
             evict_buf: Vec::new(),
             preface_received: 0,
             last_stream_id: 0,
+            last_peer_stream_id: 0,
             going_away: false,
         }
     }
@@ -373,13 +389,26 @@ impl Connection {
     ) {
         self.going_away = true;
         self.terminated = true;
+        let last = self.last_peer_stream_id;
         let mut payload = Vec::with_capacity(8 + debug.len());
-        payload.extend_from_slice(&self.last_stream_id.to_be_bytes());
+        payload.extend_from_slice(&last.to_be_bytes());
         payload.extend_from_slice(&code.as_u32().to_be_bytes());
         payload.extend_from_slice(debug);
         self.write_frame(sink, FrameType::GoAway, 0, 0, &payload);
-        let last = self.last_stream_id;
         sink.on_error(lib_code, last, debug);
+    }
+
+    /// A peer-initiated stream was opened or reserved: advance the mark every GOAWAY we send
+    /// carries (see `last_peer_stream_id`) before the stream is surfaced to the embedder, so a
+    /// GOAWAY written from inside its callbacks already covers this stream.
+    fn note_peer_stream(&mut self, sink: &impl Sink, stream_id: u32) {
+        if stream_id > self.last_stream_id {
+            self.last_stream_id = stream_id;
+        }
+        if stream_id > self.last_peer_stream_id {
+            self.last_peer_stream_id = stream_id;
+            sink.on_last_peer_stream_id(stream_id);
+        }
     }
 
     /// Connection error with the generic NGHTTP2_ERR_PROTO library code — the same thing node
@@ -988,8 +1017,15 @@ impl Connection {
         if is_new {
             // Must advance even for refused streams: §5.1 treats anything at or below the
             // high-water mark as having existed, so frames a client pipelined behind the
-            // refused HEADERS (RST_STREAM especially) are tolerated instead of GOAWAY'd.
-            if hdr.stream_id > self.last_stream_id {
+            // refused HEADERS (RST_STREAM especially) are tolerated instead of GOAWAY'd. The peer
+            // mark counts them as well: nghttp2 advances last_proc_stream_id before the
+            // on_begin_headers callback in which node refuses a stream for maxSessionMemory.
+            if self.is_server {
+                self.note_peer_stream(sink, hdr.stream_id);
+            } else if hdr.stream_id > self.last_stream_id {
+                // On a client a "new" HEADERS is the response to one of its own requests (the
+                // legacy outbound path opened the stream without telling this engine): it was
+                // initiated locally and must never end up in a GOAWAY we send.
                 self.last_stream_id = hdr.stream_id;
             }
             if !refused {
@@ -1694,9 +1730,7 @@ impl Connection {
             .entry(promised)
             .or_insert_with(|| Stream::new(send_init, recv_init));
         entry.state = State::ReservedRemote;
-        if promised > self.last_stream_id {
-            self.last_stream_id = promised;
-        }
+        self.note_peer_stream(sink, promised);
 
         let end_headers = wire::flags::has(hdr.flags, wire::flags::END_HEADERS);
         self.header_block.clear();
@@ -1977,6 +2011,13 @@ mod tests {
         goaway: Cell<Option<(u32, u32)>>,
         /// nghttp2-style lib error code from on_error (locally-detected connection errors).
         local_error: Cell<Option<i32>>,
+        /// last_stream_id reported by on_error (what the GOAWAY it announces carried).
+        local_error_last_stream_id: Cell<Option<u32>>,
+        /// Every value pushed through on_last_peer_stream_id, in order.
+        peer_marks: RefCell<Vec<u32>>,
+        /// When set, can_open_stream refuses every new peer stream (the embedder's
+        /// maxSessionMemory budget is exhausted).
+        refuse_streams: Cell<bool>,
         opens: RefCell<Vec<u32>>,
         headers: RefCell<Vec<(u32, Vec<u8>, Vec<u8>)>>,
         headers_done: RefCell<Vec<(u32, bool)>>,
@@ -1992,9 +2033,16 @@ mod tests {
             self.out.borrow_mut().extend_from_slice(bytes);
             WriteResult::Sent
         }
-        fn on_error(&self, lib_code: i32, _l: u32, _d: &[u8]) {
+        fn on_error(&self, lib_code: i32, last_stream_id: u32, _d: &[u8]) {
             // send_go_away() reports through on_error; record it so the _is_goaway tests can assert.
             self.local_error.set(Some(lib_code));
+            self.local_error_last_stream_id.set(Some(last_stream_id));
+        }
+        fn on_last_peer_stream_id(&self, stream_id: u32) {
+            self.peer_marks.borrow_mut().push(stream_id);
+        }
+        fn can_open_stream(&self) -> bool {
+            !self.refuse_streams.get()
         }
         fn on_local_settings(&self, _s: &Settings) {}
         fn on_remote_settings(&self, _s: &Settings) {
@@ -2065,6 +2113,41 @@ mod tests {
         v.copy_from_slice(&hb);
         v.extend_from_slice(payload);
         v
+    }
+
+    /// (last-stream-id, error code) of the GOAWAY the engine wrote to `sink`, if any.
+    fn goaway_sent(sink: &CaptureSink) -> Option<(u32, u32)> {
+        let out = sink.out.borrow();
+        let mut off = 0usize;
+        let mut found = None;
+        while out.len() - off >= wire::FRAME_HEADER_SIZE {
+            let hdr = FrameHeader::parse(&out[off..]);
+            let payload = &out[off + wire::FRAME_HEADER_SIZE
+                ..off + wire::FRAME_HEADER_SIZE + hdr.length as usize];
+            if hdr.frame_type == FrameType::GoAway as u8 {
+                let last = u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]])
+                    & 0x7fff_ffff;
+                let code = u32::from_be_bytes([payload[4], payload[5], payload[6], payload[7]]);
+                found = Some((last, code));
+            }
+            off += wire::FRAME_HEADER_SIZE + hdr.length as usize;
+        }
+        found
+    }
+
+    fn request_block() -> Vec<u8> {
+        encode_block(&[
+            (b":method", b"GET"),
+            (b":scheme", b"http"),
+            (b":path", b"/"),
+            (b":authority", b"localhost"),
+        ])
+    }
+
+    /// A frame every endpoint must answer with a connection PROTOCOL_ERROR (§6.9: a
+    /// connection-level WINDOW_UPDATE with a zero increment).
+    fn connection_error_frame() -> Vec<u8> {
+        frame(FrameType::WindowUpdate, 0, 0, &[0, 0, 0, 0])
     }
 
     #[test]
@@ -2303,5 +2386,112 @@ mod tests {
         // Only 4 of 10 bytes fit in the window.
         let sent = c.send_data(&sink, 1, b"0123456789", true);
         assert_eq!(sent, 4);
+    }
+
+    #[test]
+    fn server_goaway_names_the_last_client_stream_not_its_own_push() {
+        let sink = CaptureSink::default();
+        let mut c = Connection::new(true, Settings::default());
+        c.preface_received = wire::CONNECTION_PREFACE.len();
+        let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
+        c.receive(
+            &sink,
+            &frame(FrameType::Headers, flags, 1, &request_block()),
+        );
+        c.receive(
+            &sink,
+            &frame(FrameType::Headers, flags, 3, &request_block()),
+        );
+        // Our own push reserves stream 4, numerically above everything the client opened.
+        c.begin_header_block();
+        assert!(c.encode_header(b":method", b"GET", false));
+        c.send_push_promise(&sink, 1, 4);
+        assert_eq!(c.last_stream_id, 4);
+
+        let fed = c.receive(&sink, &connection_error_frame());
+        assert!(fed.fatal);
+        assert_eq!(
+            goaway_sent(&sink),
+            Some((3, ErrorCode::ProtocolError.as_u32()))
+        );
+        assert_eq!(sink.local_error_last_stream_id.get(), Some(3));
+        assert_eq!(*sink.peer_marks.borrow(), vec![1, 3]);
+    }
+
+    #[test]
+    fn server_goaway_counts_a_stream_it_refused() {
+        let sink = CaptureSink::default();
+        sink.refuse_streams.set(true);
+        let mut c = Connection::new(true, Settings::default());
+        c.preface_received = wire::CONNECTION_PREFACE.len();
+        let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
+        c.receive(
+            &sink,
+            &frame(FrameType::Headers, flags, 1, &request_block()),
+        );
+        assert!(sink.opens.borrow().is_empty());
+
+        let fed = c.receive(&sink, &connection_error_frame());
+        assert!(fed.fatal);
+        assert_eq!(
+            goaway_sent(&sink),
+            Some((1, ErrorCode::ProtocolError.as_u32()))
+        );
+        assert_eq!(*sink.peer_marks.borrow(), vec![1]);
+    }
+
+    #[test]
+    fn client_goaway_does_not_name_its_own_requests() {
+        let sink = CaptureSink::default();
+        let mut c = Connection::new(false, Settings::default());
+        // Responses to the client's own requests on 1 and 3 (opened by the outbound path, so
+        // they look new to the engine).
+        let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
+        let response = encode_block(&[(b":status", b"200")]);
+        c.receive(&sink, &frame(FrameType::Headers, flags, 1, &response));
+        c.receive(&sink, &frame(FrameType::Headers, flags, 3, &response));
+        assert_eq!(*sink.headers_done.borrow(), vec![(1, true), (3, true)]);
+        // They still count for the §5.1 "has this id existed" mark...
+        assert_eq!(c.last_stream_id, 3);
+
+        // ...but the GOAWAY may only name streams the server initiated, of which there are none.
+        let fed = c.receive(&sink, &connection_error_frame());
+        assert!(fed.fatal);
+        assert_eq!(
+            goaway_sent(&sink),
+            Some((0, ErrorCode::ProtocolError.as_u32()))
+        );
+        assert_eq!(sink.local_error_last_stream_id.get(), Some(0));
+        assert!(sink.peer_marks.borrow().is_empty());
+    }
+
+    #[test]
+    fn client_goaway_names_the_last_promised_stream() {
+        let sink = CaptureSink::default();
+        let mut c = Connection::new(false, Settings::default());
+        // The server reserves stream 2 on the client's request stream 1 (which, as in
+        // production, this engine has no entry for), then answers the requests on 1 and 3.
+        let mut push = vec![0, 0, 0, 2];
+        push.extend_from_slice(&request_block());
+        c.receive(
+            &sink,
+            &frame(FrameType::PushPromise, wire::flags::END_HEADERS, 1, &push),
+        );
+        assert_eq!(*sink.pushes.borrow(), vec![(1, 2)]);
+        let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
+        let response = encode_block(&[(b":status", b"200")]);
+        c.receive(&sink, &frame(FrameType::Headers, flags, 1, &response));
+        // The client's own stream 3 is numerically above the promised stream and must not
+        // displace it.
+        c.receive(&sink, &frame(FrameType::Headers, flags, 3, &response));
+        assert_eq!(c.last_stream_id, 3);
+
+        let fed = c.receive(&sink, &connection_error_frame());
+        assert!(fed.fatal);
+        assert_eq!(
+            goaway_sent(&sink),
+            Some((2, ErrorCode::ProtocolError.as_u32()))
+        );
+        assert_eq!(*sink.peer_marks.borrow(), vec![2]);
     }
 }

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -2398,14 +2398,16 @@ mod tests {
             &sink,
             &frame(FrameType::Headers, flags, 1, &request_block()),
         );
+        // Our own push reserves stream 4; the client's next request on 3 then arrives below
+        // that high-water mark and must still become the peer mark.
+        c.begin_header_block();
+        assert!(c.encode_header(b":method", b"GET", false));
+        c.send_push_promise(&sink, 1, 4);
+        assert_eq!(c.last_stream_id, 4);
         c.receive(
             &sink,
             &frame(FrameType::Headers, flags, 3, &request_block()),
         );
-        // Our own push reserves stream 4, numerically above everything the client opened.
-        c.begin_header_block();
-        assert!(c.encode_header(b":method", b"GET", false));
-        c.send_push_promise(&sink, 1, 4);
         assert_eq!(c.last_stream_id, 4);
 
         let fed = c.receive(&sink, &connection_error_frame());
@@ -2469,8 +2471,17 @@ mod tests {
     fn client_goaway_names_the_last_promised_stream() {
         let sink = CaptureSink::default();
         let mut c = Connection::new(false, Settings::default());
-        // The server reserves stream 2 on the client's request stream 1 (which, as in
-        // production, this engine has no entry for), then answers the requests on 1 and 3.
+        // The server answers the client's requests on 1 (left open) and 3 first, so the
+        // client's own stream 3 is the highest id seen when the numerically lower promise of
+        // stream 2 arrives on stream 1. The promise must still become the peer mark.
+        let response = encode_block(&[(b":status", b"200")]);
+        c.receive(
+            &sink,
+            &frame(FrameType::Headers, wire::flags::END_HEADERS, 1, &response),
+        );
+        let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
+        c.receive(&sink, &frame(FrameType::Headers, flags, 3, &response));
+        assert_eq!(c.last_stream_id, 3);
         let mut push = vec![0, 0, 0, 2];
         push.extend_from_slice(&request_block());
         c.receive(
@@ -2478,12 +2489,6 @@ mod tests {
             &frame(FrameType::PushPromise, wire::flags::END_HEADERS, 1, &push),
         );
         assert_eq!(*sink.pushes.borrow(), vec![(1, 2)]);
-        let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
-        let response = encode_block(&[(b":status", b"200")]);
-        c.receive(&sink, &frame(FrameType::Headers, flags, 1, &response));
-        // The client's own stream 3 is numerically above the promised stream and must not
-        // displace it.
-        c.receive(&sink, &frame(FrameType::Headers, flags, 3, &response));
         assert_eq!(c.last_stream_id, 3);
 
         let fed = c.receive(&sink, &connection_error_frame());

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -116,9 +116,9 @@ const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 /// ownership cycle.
 pub trait Sink {
     fn write(&self, bytes: &[u8]) -> WriteResult;
-    /// A locally-detected connection error: the GOAWAY (when one applies) is already on the wire,
-    /// carrying `last_stream_id`. `lib_error_code` is the negative nghttp2-style library error
-    /// code (`wire::lib_error`) the embedder maps to node's NghttpError.
+    /// A locally-detected connection error: the GOAWAY (when one applies) is already on the wire.
+    /// `lib_error_code` is the negative nghttp2-style library error code (`wire::lib_error`) the
+    /// embedder maps to node's NghttpError.
     fn on_error(&self, lib_error_code: i32, last_stream_id: u32, debug: &[u8]);
     fn on_local_settings(&self, settings: &Settings);
     fn on_remote_settings(&self, settings: &Settings);
@@ -170,11 +170,8 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
-    /// `Connection::last_peer_stream_id` advanced to `stream_id`. Same contract as
-    /// on_frame_counters: called while the connection is mutably borrowed, so the embedder must
-    /// only store the value. It needs its own copy because the GOAWAYs it writes itself
-    /// (session.close()/destroy()/goaway(), its rejection budgets) can be triggered from JS
-    /// dispatched inside receive(), while the connection is still borrowed.
+    /// `last_peer_stream_id` advanced. Same store-only contract as on_frame_counters; the
+    /// embedder's GOAWAYs can be written from JS dispatched inside receive(), so it needs a copy.
     fn on_last_peer_stream_id(&self, _stream_id: u32) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
@@ -288,15 +285,11 @@ pub struct Connection {
     evict_buf: Vec<u32>,
 
     preface_received: usize,
-    /// Highest stream id seen in either direction; only meaningful for the §5.1 "has this id
-    /// ever existed" checks. It also counts locally-initiated streams (a client's own requests,
-    /// once their response arrives), so it must never go into a GOAWAY: see `last_peer_stream_id`.
+    /// Highest stream id seen in either direction (§5.1 "has this id existed" checks). Counts
+    /// locally-initiated streams too, so a GOAWAY must carry `last_peer_stream_id` instead.
     pub last_stream_id: u32,
-    /// Highest peer-initiated stream id processed: request ids on a server (refused ones
-    /// included), promised ids on a client. nghttp2's last_proc_stream_id. RFC 9113 §6.8 defines
-    /// a GOAWAY's last-stream-id in terms of streams its receiver initiated, and nghttp2 fails
-    /// the connection with PROTOCOL_ERROR on a GOAWAY naming one of the sender's own ids, so this
-    /// is the only mark a GOAWAY written here may carry.
+    /// Highest peer-initiated stream id (request ids on a server, refused included; promised ids
+    /// on a client): nghttp2's last_proc_stream_id, the only value a GOAWAY may carry (§6.8).
     pub last_peer_stream_id: u32,
     pub going_away: bool,
 }
@@ -398,9 +391,8 @@ impl Connection {
         sink.on_error(lib_code, last, debug);
     }
 
-    /// A peer-initiated stream was opened or reserved: advance the mark every GOAWAY we send
-    /// carries (see `last_peer_stream_id`) before the stream is surfaced to the embedder, so a
-    /// GOAWAY written from inside its callbacks already covers this stream.
+    /// Call before surfacing the stream to the embedder, so a GOAWAY written from inside its
+    /// callbacks already covers it.
     fn note_peer_stream(&mut self, sink: &impl Sink, stream_id: u32) {
         if stream_id > self.last_stream_id {
             self.last_stream_id = stream_id;
@@ -1017,15 +1009,12 @@ impl Connection {
         if is_new {
             // Must advance even for refused streams: §5.1 treats anything at or below the
             // high-water mark as having existed, so frames a client pipelined behind the
-            // refused HEADERS (RST_STREAM especially) are tolerated instead of GOAWAY'd. The peer
-            // mark counts them as well: nghttp2 advances last_proc_stream_id before the
-            // on_begin_headers callback in which node refuses a stream for maxSessionMemory.
+            // refused HEADERS (RST_STREAM especially) are tolerated instead of GOAWAY'd.
+            // (nghttp2 counts refused streams in last_proc_stream_id as well.)
             if self.is_server {
                 self.note_peer_stream(sink, hdr.stream_id);
             } else if hdr.stream_id > self.last_stream_id {
-                // On a client a "new" HEADERS is the response to one of its own requests (the
-                // legacy outbound path opened the stream without telling this engine): it was
-                // initiated locally and must never end up in a GOAWAY we send.
+                // A client's "new" HEADERS is the response to its own request: not a peer stream.
                 self.last_stream_id = hdr.stream_id;
             }
             if !refused {
@@ -2011,12 +2000,10 @@ mod tests {
         goaway: Cell<Option<(u32, u32)>>,
         /// nghttp2-style lib error code from on_error (locally-detected connection errors).
         local_error: Cell<Option<i32>>,
-        /// last_stream_id reported by on_error (what the GOAWAY it announces carried).
         local_error_last_stream_id: Cell<Option<u32>>,
-        /// Every value pushed through on_last_peer_stream_id, in order.
+        /// Values received through on_last_peer_stream_id, in order.
         peer_marks: RefCell<Vec<u32>>,
-        /// When set, can_open_stream refuses every new peer stream (the embedder's
-        /// maxSessionMemory budget is exhausted).
+        /// Makes can_open_stream refuse every new peer stream (maxSessionMemory exhausted).
         refuse_streams: Cell<bool>,
         opens: RefCell<Vec<u32>>,
         headers: RefCell<Vec<(u32, Vec<u8>, Vec<u8>)>>,
@@ -2144,8 +2131,7 @@ mod tests {
         ])
     }
 
-    /// A frame every endpoint must answer with a connection PROTOCOL_ERROR (§6.9: a
-    /// connection-level WINDOW_UPDATE with a zero increment).
+    /// §6.9: a zero-increment WINDOW_UPDATE on stream 0 is a connection PROTOCOL_ERROR.
     fn connection_error_frame() -> Vec<u8> {
         frame(FrameType::WindowUpdate, 0, 0, &[0, 0, 0, 0])
     }
@@ -2398,8 +2384,7 @@ mod tests {
             &sink,
             &frame(FrameType::Headers, flags, 1, &request_block()),
         );
-        // Our own push reserves stream 4; the client's next request on 3 then arrives below
-        // that high-water mark and must still become the peer mark.
+        // The client's request on 3 arrives below our own push of 4.
         c.begin_header_block();
         assert!(c.encode_header(b":method", b"GET", false));
         c.send_push_promise(&sink, 1, 4);
@@ -2446,17 +2431,14 @@ mod tests {
     fn client_goaway_does_not_name_its_own_requests() {
         let sink = CaptureSink::default();
         let mut c = Connection::new(false, Settings::default());
-        // Responses to the client's own requests on 1 and 3 (opened by the outbound path, so
-        // they look new to the engine).
+        // Responses to the client's own requests on 1 and 3.
         let flags = wire::flags::END_HEADERS | wire::flags::END_STREAM;
         let response = encode_block(&[(b":status", b"200")]);
         c.receive(&sink, &frame(FrameType::Headers, flags, 1, &response));
         c.receive(&sink, &frame(FrameType::Headers, flags, 3, &response));
         assert_eq!(*sink.headers_done.borrow(), vec![(1, true), (3, true)]);
-        // They still count for the §5.1 "has this id existed" mark...
         assert_eq!(c.last_stream_id, 3);
 
-        // ...but the GOAWAY may only name streams the server initiated, of which there are none.
         let fed = c.receive(&sink, &connection_error_frame());
         assert!(fed.fatal);
         assert_eq!(
@@ -2471,9 +2453,7 @@ mod tests {
     fn client_goaway_names_the_last_promised_stream() {
         let sink = CaptureSink::default();
         let mut c = Connection::new(false, Settings::default());
-        // The server answers the client's requests on 1 (left open) and 3 first, so the
-        // client's own stream 3 is the highest id seen when the numerically lower promise of
-        // stream 2 arrives on stream 1. The promise must still become the peer mark.
+        // The promise of 2 arrives after the client's own stream 3 has been answered.
         let response = encode_block(&[(b":status", b"200")]);
         c.receive(
             &sink,

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -170,8 +170,7 @@ pub trait Sink {
     /// counter moves, while the connection is mutably borrowed — the embedder must only
     /// store the values.
     fn on_frame_counters(&self, _received: u64, _sent: u64) {}
-    /// `last_peer_stream_id` advanced. Same store-only contract as on_frame_counters; the
-    /// embedder's GOAWAYs can be written from JS dispatched inside receive(), so it needs a copy.
+    /// `last_peer_stream_id` advanced. Store-only, like on_frame_counters.
     fn on_last_peer_stream_id(&self, _stream_id: u32) {}
     /// Transition shim while the outbound path still flows through the embedder's legacy encoder:
     /// returns true if `stream_id` was initiated locally (HEADERS already sent by the embedder), so
@@ -285,11 +284,9 @@ pub struct Connection {
     evict_buf: Vec<u32>,
 
     preface_received: usize,
-    /// Highest stream id seen in either direction (§5.1 "has this id existed" checks). Counts
-    /// locally-initiated streams too, so a GOAWAY must carry `last_peer_stream_id` instead.
+    /// Highest stream id in either direction, for the §5.1 idle checks; never sent in a GOAWAY.
     pub last_stream_id: u32,
-    /// Highest peer-initiated stream id (request ids on a server, refused included; promised ids
-    /// on a client): nghttp2's last_proc_stream_id, the only value a GOAWAY may carry (§6.8).
+    /// Highest peer-initiated id (nghttp2's last_proc_stream_id): what a GOAWAY carries (§6.8).
     pub last_peer_stream_id: u32,
     pub going_away: bool,
 }
@@ -391,8 +388,7 @@ impl Connection {
         sink.on_error(lib_code, last, debug);
     }
 
-    /// Call before surfacing the stream to the embedder, so a GOAWAY written from inside its
-    /// callbacks already covers it.
+    /// Must run before the stream is surfaced to the embedder.
     fn note_peer_stream(&mut self, sink: &impl Sink, stream_id: u32) {
         if stream_id > self.last_stream_id {
             self.last_stream_id = stream_id;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1330,12 +1330,10 @@ pub struct H2FrameParser {
     /// node strictSingleValueFields session option (default true): when false, duplicate
     /// single-value headers and array values for them are encoded as-is instead of rejected.
     strict_single_value_fields: Cell<bool>,
-    /// Highest stream id registered in either direction (see highest_started_stream_id). Not
-    /// what a GOAWAY carries: that is `last_peer_stream_id`.
+    /// Highest stream id registered in either direction; a GOAWAY carries `last_peer_stream_id`.
     last_stream_id: Cell<u32>,
-    /// Mirror of `Connection::last_peer_stream_id`, kept current by the engine's
-    /// on_last_peer_stream_id callback: the last-stream-id every GOAWAY filled in on this side
-    /// must carry, and node's state.lastProcStreamID. The engine's own GOAWAYs read its field.
+    /// Copy of `Connection::last_peer_stream_id` (fed by on_last_peer_stream_id): what every
+    /// GOAWAY written on this side carries, and node's state.lastProcStreamID.
     last_peer_stream_id: Cell<u32>,
     // Stream id whose header block is awaiting CONTINUATION frames
     // (RFC 9113 §4.3); 0 when none.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2593,13 +2593,13 @@ impl H2FrameParser {
                 self.dispatch_with_2_extra(
                     JSH2FrameParser::Gc::onError,
                     JSValue::js_number(rst_code.0 as f64),
-                    JSValue::js_number(self.last_stream_id.get() as f64),
+                    JSValue::js_number(last_stream_id as f64),
                     chunk,
                 );
             }
             self.dispatch_with_extra(
                 JSH2FrameParser::Gc::onEnd,
-                JSValue::js_number(self.last_stream_id.get() as f64),
+                JSValue::js_number(last_stream_id as f64),
                 chunk,
             );
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1330,12 +1330,12 @@ pub struct H2FrameParser {
     /// node strictSingleValueFields session option (default true): when false, duplicate
     /// single-value headers and array values for them are encoded as-is instead of rejected.
     strict_single_value_fields: Cell<bool>,
+    /// Highest stream id registered in either direction (see highest_started_stream_id). Not
+    /// what a GOAWAY carries: that is `last_peer_stream_id`.
     last_stream_id: Cell<u32>,
-    /// Highest PEER-initiated stream id processed (odd ids for a server, even for a
-    /// client). This — not `last_stream_id` — is what an auto-filled GOAWAY must carry:
-    /// RFC 9113 §6.8 last_stream_id refers to streams the RECEIVER initiated, and
-    /// nghttp2 servers reject a GOAWAY naming a client-initiated id with a connection
-    /// PROTOCOL_ERROR (node's last_proc_stream_id semantics).
+    /// Mirror of `Connection::last_peer_stream_id`, kept current by the engine's
+    /// on_last_peer_stream_id callback: the last-stream-id every GOAWAY filled in on this side
+    /// must carry, and node's state.lastProcStreamID. The engine's own GOAWAYs read its field.
     last_peer_stream_id: Cell<u32>,
     // Stream id whose header block is awaiting CONTINUATION frames
     // (RFC 9113 §4.3); 0 when none.
@@ -2421,7 +2421,7 @@ impl H2FrameParser {
                 0,
                 ErrorCode::MAX_PENDING_SETTINGS_ACK,
                 b"Maximum number of pending settings acknowledgements",
-                self.last_stream_id.get(),
+                self.last_peer_stream_id.get(),
                 true,
             );
             return false;
@@ -5312,12 +5312,6 @@ impl H2FrameParser {
         if stream_identifier > self.last_stream_id.get() {
             self.last_stream_id.set(stream_identifier);
         }
-        let peer_parity: u32 = if self.is_server.get() { 1 } else { 0 };
-        if stream_identifier % 2 == peer_parity
-            && stream_identifier > self.last_peer_stream_id.get()
-        {
-            self.last_peer_stream_id.set(stream_identifier);
-        }
 
         // new stream open
         let local_window_size = if self.outstanding_settings.get() > 0 {
@@ -5893,6 +5887,10 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.engine_frames_sent.set(sent);
     }
 
+    fn on_last_peer_stream_id(&self, stream_id: u32) {
+        self.last_peer_stream_id.set(stream_id);
+    }
+
     fn write(&self, bytes: &[u8]) -> crate::api::h2::connection::WriteResult {
         if self.write(bytes) {
             crate::api::h2::connection::WriteResult::Sent
@@ -5901,7 +5899,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         }
     }
 
-    fn on_error(&self, lib_error_code: i32, _last: u32, debug: &[u8]) {
+    fn on_error(&self, lib_error_code: i32, last_stream_id: u32, debug: &[u8]) {
         // The engine detected a connection error and already wrote the GOAWAY: surface it to JS
         // as the negative nghttp2-style library error code (the JS handler builds node's
         // NghttpError from it: code ERR_HTTP2_ERROR, message nghttp2_strerror), then the end
@@ -5917,13 +5915,13 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
             self.dispatch_with_2_extra(
                 JSH2FrameParser::Gc::onError,
                 JSValue::js_number(lib_error_code as f64),
-                JSValue::js_number(self.last_stream_id.get() as f64),
+                JSValue::js_number(last_stream_id as f64),
                 chunk,
             );
         }
         self.dispatch_with_extra(
             JSH2FrameParser::Gc::onEnd,
-            JSValue::js_number(self.last_stream_id.get() as f64),
+            JSValue::js_number(last_stream_id as f64),
             chunk,
         );
     }
@@ -6332,7 +6330,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 stream_id,
                 ErrorCode::ENHANCE_YOUR_CALM,
                 b"ENHANCE_YOUR_CALM",
-                self.last_stream_id.get(),
+                self.last_peer_stream_id.get(),
                 true,
             );
         }
@@ -6819,7 +6817,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"lastProcStreamID",
-            JSValue::js_number(this.last_stream_id.get() as f64),
+            JSValue::js_number(this.last_peer_stream_id.get() as f64),
         );
 
         let settings = this.remote_settings.get().unwrap_or_default();
@@ -7296,7 +7294,7 @@ impl H2FrameParser {
                 stream.id,
                 ErrorCode::PROTOCOL_ERROR,
                 b"Stream with self dependency",
-                this.last_stream_id.get(),
+                this.last_peer_stream_id.get(),
                 true,
             );
             return Ok(JSValue::FALSE);
@@ -7366,7 +7364,7 @@ impl H2FrameParser {
                     stream_id,
                     ErrorCode::ENHANCE_YOUR_CALM,
                     b"ENHANCE_YOUR_CALM",
-                    this.last_stream_id.get(),
+                    this.last_peer_stream_id.get(),
                     true,
                 );
                 return Ok(JSValue::UNDEFINED);
@@ -7996,7 +7994,7 @@ impl H2FrameParser {
                             triggering_id,
                             ErrorCode::NO_ERROR,
                             b"",
-                            this.last_stream_id.get(),
+                            this.last_peer_stream_id.get(),
                             true,
                         );
                         Ok(Some(JSValue::UNDEFINED))

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1332,8 +1332,7 @@ pub struct H2FrameParser {
     strict_single_value_fields: Cell<bool>,
     /// Highest stream id registered in either direction; a GOAWAY carries `last_peer_stream_id`.
     last_stream_id: Cell<u32>,
-    /// Copy of `Connection::last_peer_stream_id` (fed by on_last_peer_stream_id): what every
-    /// GOAWAY written on this side carries, and node's state.lastProcStreamID.
+    /// Copy of `Connection::last_peer_stream_id` (GOAWAY last-stream-id, state.lastProcStreamID).
     last_peer_stream_id: Cell<u32>,
     // Stream id whose header block is awaiting CONTINUATION frames
     // (RFC 9113 §4.3); 0 when none.

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1656,7 +1656,10 @@ describe("inbound stream lifecycle", () => {
 // ids in a client's GOAWAY, 0 when there are none. nghttp2 (node's peer implementation) fails the
 // connection with PROTOCOL_ERROR when a GOAWAY names a stream its sender initiated, so a client
 // naming one of its own requests turns a clean shutdown into a protocol error at a node server.
-// Every expected value below was checked against node v26.3.0.
+// The last-stream-id values asserted below are what node v26.3.0 puts on the wire in the same
+// situations. The frames carrying them are not all node behaviour: the two maxSessionRejectedStreams
+// tests drive GOAWAYs that only bun writes (node has no GOAWAY for an oversized response header
+// list or a user-refused stream); their error code is only asserted to identify that GOAWAY.
 describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
   const STATUS_200 = Buffer.from([0x88]); // HPACK static index 8
   const BAD_PING = Buffer.alloc(6); // a PING must be 8 octets: connection FRAME_SIZE_ERROR
@@ -1710,10 +1713,16 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
     try {
       const { client, requests } = await connectClient(raw, 2);
       expect(requests.map(r => r.id)).toEqual([1, 3]);
-      raw.sendFrame(FrameType.PUSH_PROMISE, 0x4 /* END_HEADERS */, 1, pushPromise(2));
-      raw.sendFrame(FrameType.HEADERS, 0x5, 1, STATUS_200);
-      raw.sendFrame(FrameType.HEADERS, 0x5, 3, STATUS_200);
+      // Both responses arrive first, so the client's own stream 3 is already the highest id it
+      // has seen when the (numerically lower) promise of stream 2 comes in on the still-open
+      // stream 1. The promise must still become the mark.
+      raw.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, STATUS_200);
+      raw.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM | END_HEADERS */, 3, STATUS_200);
       await Promise.all(requests.map(req => once(req, "response")));
+      expect(client.state.lastProcStreamID).toBe(0);
+      const pushed = once(client, "stream");
+      raw.sendFrame(FrameType.PUSH_PROMISE, 0x4, 1, pushPromise(2));
+      expect((await pushed)[0].id).toBe(2);
       expect(client.state.lastProcStreamID).toBe(2);
       raw.sendFrame(FrameType.PING, 0, 0, BAD_PING);
       const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
@@ -1752,13 +1761,40 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
       });
       // Three :status fields are 3 * (7 + 3 + 32) = 126 octets of header list (§10.5.1), over
       // the 100 the client advertised: the response is refused and the rejection budget of 1
-      // is used up, so the session itself writes a GOAWAY.
+      // is used up, so the session itself writes its ENHANCE_YOUR_CALM GOAWAY (a bun-only
+      // frame, see the describe comment) ahead of the teardown GOAWAY.
       raw.sendFrame(FrameType.HEADERS, 0x5, 1, Buffer.concat([STATUS_200, STATUS_200, STATUS_200]));
-      const rst = await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
-      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+      await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
       const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
       expect(goawayFields(goaway)).toEqual({ lastStreamId: 0, errorCode: ErrorCode.ENHANCE_YOUR_CALM });
       client.destroy();
+    } finally {
+      raw.close();
+    }
+  });
+
+  test("a client's GOAWAY after an unencodable trailer block does not name its own request", async () => {
+    const raw = await RawH2Server.listen();
+    try {
+      const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+      client.on("error", () => {});
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      const frameError = once(req, "frameError");
+      req.on("wantTrailers", () => {
+        // A single field above the HPACK encoder's 64 KiB limit cannot be put on the wire; the
+        // stream is reset and the session shuts down with a graceful GOAWAY (node also ends up
+        // writing GOAWAY(NO_ERROR, 0) here).
+        req.sendTrailers({ "x-big": Buffer.alloc(64 * 1024 + 1, 0x58).toString() });
+      });
+      req.end();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      const [type, code] = await frameError;
+      expect([type, code]).toEqual([FrameType.HEADERS, ErrorCode.FRAME_SIZE_ERROR]);
+      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 0, errorCode: ErrorCode.NO_ERROR });
     } finally {
       raw.close();
     }
@@ -1786,7 +1822,9 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
     server.on("stream", (stream: any) => {
       stream.on("error", () => {});
       // Reserve stream 2 (numerically above the request on 1), then refuse the request: the
-      // refusal uses up the budget of 1 and the session writes a GOAWAY.
+      // refusal uses up the budget of 1 and the session writes its ENHANCE_YOUR_CALM GOAWAY
+      // (bun counts user refusals against maxSessionRejectedStreams; node does not, but a node
+      // server's GOAWAY in this position names 1 as well).
       stream.pushStream({ ":path": "/pushed" }, (err: Error | null, pushed: any) => {
         pushError.resolve(err);
         if (!pushed) return;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -155,6 +155,10 @@ function goawayErrorCode(f: Frame): number {
   return f.payload.readUInt32BE(4);
 }
 
+function goawayFields(f: Frame) {
+  return { lastStreamId: f.payload.readUInt32BE(0) & 0x7fffffff, errorCode: goawayErrorCode(f) };
+}
+
 let server: http2.Http2Server;
 let port: number;
 
@@ -1508,7 +1512,9 @@ describe("inbound stream lifecycle", () => {
   async function exhaustedSession() {
     const seen: { path: string; sync?: string }[] = [];
     let first = true;
+    let session!: http2.ServerHttp2Session;
     const server = http2.createServer({ maxSessionMemory: 1 });
+    server.on("session", s => (session = s));
     server.on("stream", (stream: any, headers: any) => {
       seen.push({ path: headers[":path"], sync: headers["x-bun-sync"] });
       stream.on("error", () => {});
@@ -1527,7 +1533,7 @@ describe("inbound stream lifecycle", () => {
     c.sendEmptySettings();
     c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
     await c.waitFor(f => f.type === FrameType.DATA && f.streamId === 1);
-    return { server, c, seen };
+    return { server, session, c, seen };
   }
 
   /** Open the connection and stream-1 windows so the queued response drains, bringing the
@@ -1617,6 +1623,191 @@ describe("inbound stream lifecycle", () => {
       expect(resp.type).toBe(FrameType.HEADERS);
       expect(c.frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
       expect(seen).toEqual([{ path: "/" }, { path: "/", sync: "1" }]);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  // A refused stream was still acted on (it got the RST_STREAM), so it is the highest stream the
+  // server "might have taken action on" (§6.8) and a later GOAWAY names it. node does the same:
+  // nghttp2 advances last_proc_stream_id before the callback in which node refuses the stream.
+  // (The rest of the last-stream-id coverage is in the §6.8 describe below.)
+  test("a graceful GOAWAY names a stream that was refused for maxSessionMemory", async () => {
+    const { server, session, c, seen } = await exhaustedSession();
+    try {
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, requestHeaderBlock("GET"));
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 3);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+      expect(seen).toEqual([{ path: "/" }]);
+      expect(session.state.lastProcStreamID).toBe(3);
+      session.close();
+      const goaway = await c.waitForGoaway();
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 3, errorCode: ErrorCode.NO_ERROR });
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+});
+
+// §6.8: a GOAWAY's last-stream-id names the highest stream *initiated by the GOAWAY's receiver*
+// that the sender may have acted on: client request ids in a server's GOAWAY, pushed (promised)
+// ids in a client's GOAWAY, 0 when there are none. nghttp2 (node's peer implementation) fails the
+// connection with PROTOCOL_ERROR when a GOAWAY names a stream its sender initiated, so a client
+// naming one of its own requests turns a clean shutdown into a protocol error at a node server.
+// Every expected value below was checked against node v26.3.0.
+describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
+  const STATUS_200 = Buffer.from([0x88]); // HPACK static index 8
+  const BAD_PING = Buffer.alloc(6); // a PING must be 8 octets: connection FRAME_SIZE_ERROR
+
+  /** http2.connect() against `raw` with `count` requests in flight; resolves once the server
+   *  has seen every request HEADERS and completed the SETTINGS exchange. */
+  async function connectClient(raw: RawH2Server, count: number, options: http2.ClientSessionOptions = {}) {
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`, options);
+    client.on("error", () => {});
+    client.on("stream", pushed => pushed.on("error", () => {}));
+    const requests: http2.ClientHttp2Stream[] = [];
+    for (let i = 0; i < count; i++) {
+      const req = client.request({ ":path": `/${i}` });
+      req.on("error", () => {});
+      requests.push(req);
+    }
+    for (const req of requests) {
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === req.id);
+    }
+    raw.sendFrame(FrameType.SETTINGS, 0, 0);
+    raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+    return { client, requests };
+  }
+
+  function pushPromise(promisedId: number): Buffer {
+    const promised = Buffer.alloc(4);
+    promised.writeUInt32BE(promisedId, 0);
+    return Buffer.concat([promised, requestHeaderBlock("GET")]);
+  }
+
+  test("a client's connection-error GOAWAY does not name its own request stream", async () => {
+    const raw = await RawH2Server.listen();
+    try {
+      const { client, requests } = await connectClient(raw, 1);
+      const [req] = requests;
+      expect(req.id).toBe(1);
+      raw.sendFrame(FrameType.HEADERS, 0x5 /* END_STREAM | END_HEADERS */, 1, STATUS_200);
+      await once(req, "response");
+      expect(client.state.lastProcStreamID).toBe(0);
+      raw.sendFrame(FrameType.PING, 0, 0, BAD_PING);
+      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 0, errorCode: ErrorCode.FRAME_SIZE_ERROR });
+      client.destroy();
+    } finally {
+      raw.close();
+    }
+  });
+
+  test("a client's connection-error GOAWAY names the last pushed stream, not its own higher request", async () => {
+    const raw = await RawH2Server.listen();
+    try {
+      const { client, requests } = await connectClient(raw, 2);
+      expect(requests.map(r => r.id)).toEqual([1, 3]);
+      raw.sendFrame(FrameType.PUSH_PROMISE, 0x4 /* END_HEADERS */, 1, pushPromise(2));
+      raw.sendFrame(FrameType.HEADERS, 0x5, 1, STATUS_200);
+      raw.sendFrame(FrameType.HEADERS, 0x5, 3, STATUS_200);
+      await Promise.all(requests.map(req => once(req, "response")));
+      expect(client.state.lastProcStreamID).toBe(2);
+      raw.sendFrame(FrameType.PING, 0, 0, BAD_PING);
+      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 2, errorCode: ErrorCode.FRAME_SIZE_ERROR });
+      client.destroy();
+    } finally {
+      raw.close();
+    }
+  });
+
+  test("a client's close() after a push names the pushed stream", async () => {
+    const raw = await RawH2Server.listen();
+    try {
+      const { client, requests } = await connectClient(raw, 1);
+      const pushed = once(client, "stream");
+      raw.sendFrame(FrameType.PUSH_PROMISE, 0x4, 1, pushPromise(2));
+      raw.sendFrame(FrameType.HEADERS, 0x5, 2, STATUS_200);
+      raw.sendFrame(FrameType.HEADERS, 0x5, 1, STATUS_200);
+      const [pushedStream] = await pushed;
+      expect(pushedStream.id).toBe(2);
+      await once(requests[0], "response");
+      client.close();
+      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 2, errorCode: ErrorCode.NO_ERROR });
+    } finally {
+      raw.close();
+    }
+  });
+
+  test("a client's rejected-streams GOAWAY (maxSessionRejectedStreams) does not name its own request", async () => {
+    const raw = await RawH2Server.listen();
+    try {
+      const { client } = await connectClient(raw, 1, {
+        maxSessionRejectedStreams: 1,
+        settings: { maxHeaderListSize: 100 },
+      });
+      // Three :status fields are 3 * (7 + 3 + 32) = 126 octets of header list (§10.5.1), over
+      // the 100 the client advertised: the response is refused and the rejection budget of 1
+      // is used up, so the session itself writes a GOAWAY.
+      raw.sendFrame(FrameType.HEADERS, 0x5, 1, Buffer.concat([STATUS_200, STATUS_200, STATUS_200]));
+      const rst = await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 0, errorCode: ErrorCode.ENHANCE_YOUR_CALM });
+      client.destroy();
+    } finally {
+      raw.close();
+    }
+  });
+
+  test("a server's connection-error GOAWAY names the last request stream", async () => {
+    const c = await RawH2.connect(port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, requestHeaderBlock("GET"));
+      await c.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+      c.sendFrame(FrameType.PING, 0, 0, BAD_PING);
+      const goaway = await c.waitForGoaway();
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 3, errorCode: ErrorCode.FRAME_SIZE_ERROR });
+    } finally {
+      c.destroy();
+    }
+  });
+
+  test("a server's rejected-streams GOAWAY names the request stream, not the stream it pushed", async () => {
+    const server = http2.createServer({ maxSessionRejectedStreams: 1 });
+    const pushError = Promise.withResolvers<Error | null>();
+    server.on("stream", (stream: any) => {
+      stream.on("error", () => {});
+      // Reserve stream 2 (numerically above the request on 1), then refuse the request: the
+      // refusal uses up the budget of 1 and the session writes a GOAWAY.
+      stream.pushStream({ ":path": "/pushed" }, (err: Error | null, pushed: any) => {
+        pushError.resolve(err);
+        if (!pushed) return;
+        pushed.on("error", () => {});
+        pushed.respond({ ":status": 200 });
+        pushed.end();
+      });
+      stream.close(http2.constants.NGHTTP2_REFUSED_STREAM);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      const promise = await c.waitFor(f => f.type === FrameType.PUSH_PROMISE);
+      expect(promise.payload.readUInt32BE(0) & 0x7fffffff).toBe(2);
+      expect(await pushError.promise).toBeNull();
+      const goaway = await c.waitForGoaway();
+      expect(goawayFields(goaway)).toEqual({ lastStreamId: 1, errorCode: ErrorCode.ENHANCE_YOUR_CALM });
     } finally {
       c.destroy();
       server.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -159,6 +159,11 @@ function goawayFields(f: Frame) {
   return { lastStreamId: f.payload.readUInt32BE(0) & 0x7fffffff, errorCode: goawayErrorCode(f) };
 }
 
+/** The last-stream-id of every GOAWAY in `frames`, in arrival order. */
+function goawayLastStreamIds(frames: Frame[]): number[] {
+  return frames.filter(f => f.type === FrameType.GOAWAY).map(f => f.payload.readUInt32BE(0) & 0x7fffffff);
+}
+
 let server: http2.Http2Server;
 let port: number;
 
@@ -645,6 +650,7 @@ class RawH2Server {
   private buf: Buffer = Buffer.alloc(0);
   private sawPreface = false;
   frames: Frame[] = [];
+  closed = false;
   private waiters: Array<{ pred: (f: Frame) => boolean; resolve: (f: Frame) => void }> = [];
 
   private constructor(server: net.Server) {
@@ -657,6 +663,7 @@ class RawH2Server {
     server.on("connection", socket => {
       s.socket = socket;
       socket.on("data", d => s.onData(d));
+      socket.on("close", () => (s.closed = true));
       socket.on("error", () => {});
     });
     server.listen(0, "127.0.0.1");
@@ -712,6 +719,18 @@ class RawH2Server {
         clearTimeout(t);
         orig(f);
       };
+    });
+  }
+
+  /** Wait until the connection is closed by the peer. */
+  waitClosed(timeoutMs = 10_000): Promise<void> {
+    if (this.closed) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error("connection did not close")), timeoutMs);
+      this.socket!.once("close", () => {
+        clearTimeout(t);
+        resolve();
+      });
     });
   }
 
@@ -1656,10 +1675,11 @@ describe("inbound stream lifecycle", () => {
 // ids in a client's GOAWAY, 0 when there are none. nghttp2 (node's peer implementation) fails the
 // connection with PROTOCOL_ERROR when a GOAWAY names a stream its sender initiated, so a client
 // naming one of its own requests turns a clean shutdown into a protocol error at a node server.
-// The last-stream-id values asserted below are what node v26.3.0 puts on the wire in the same
-// situations. The frames carrying them are not all node behaviour: the two maxSessionRejectedStreams
-// tests drive GOAWAYs that only bun writes (node has no GOAWAY for an oversized response header
-// list or a user-refused stream); their error code is only asserted to identify that GOAWAY.
+// Every test below passes on node v26.3.0 as well: the asserted last-stream-id values are what
+// node puts on the wire in the same situations. The two maxSessionRejectedStreams tests are the
+// ones where the two runtimes write a different set of GOAWAYs (node has no GOAWAY for an
+// oversized response header list or a user-refused stream), so they assert the last-stream-id of
+// every GOAWAY the session writes and not the frame count or the error code.
 describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
   const STATUS_200 = Buffer.from([0x88]); // HPACK static index 8
   const BAD_PING = Buffer.alloc(6); // a PING must be 8 octets: connection FRAME_SIZE_ERROR
@@ -1752,7 +1772,7 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
     }
   });
 
-  test("a client's rejected-streams GOAWAY (maxSessionRejectedStreams) does not name its own request", async () => {
+  test("no GOAWAY a client sends after a refused response names its own request", async () => {
     const raw = await RawH2Server.listen();
     try {
       const { client } = await connectClient(raw, 1, {
@@ -1760,13 +1780,17 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
         settings: { maxHeaderListSize: 100 },
       });
       // Three :status fields are 3 * (7 + 3 + 32) = 126 octets of header list (§10.5.1), over
-      // the 100 the client advertised: the response is refused and the rejection budget of 1
-      // is used up, so the session itself writes its ENHANCE_YOUR_CALM GOAWAY (a bun-only
-      // frame, see the describe comment) ahead of the teardown GOAWAY.
+      // the 100 the client advertised, so the response is refused. On bun that also uses up
+      // the rejection budget of 1 and the session writes an ENHANCE_YOUR_CALM GOAWAY of its
+      // own; node only resets the stream. The run asserts every GOAWAY that reaches the wire,
+      // so both shutdowns are covered: the client received no push, so each one names 0.
       raw.sendFrame(FrameType.HEADERS, 0x5, 1, Buffer.concat([STATUS_200, STATUS_200, STATUS_200]));
       await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
-      const goaway = await raw.waitFor(f => f.type === FrameType.GOAWAY);
-      expect(goawayFields(goaway)).toEqual({ lastStreamId: 0, errorCode: ErrorCode.ENHANCE_YOUR_CALM });
+      client.close();
+      await raw.waitClosed();
+      const lastStreamIds = goawayLastStreamIds(raw.frames);
+      expect(lastStreamIds.length).toBeGreaterThan(0);
+      expect(lastStreamIds.filter(id => id !== 0)).toEqual([]);
       client.destroy();
     } finally {
       raw.close();
@@ -1816,15 +1840,19 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
     }
   });
 
-  test("a server's rejected-streams GOAWAY names the request stream, not the stream it pushed", async () => {
+  test("no GOAWAY a server sends after a refused request names the stream it pushed", async () => {
     const server = http2.createServer({ maxSessionRejectedStreams: 1 });
     const pushError = Promise.withResolvers<Error | null>();
+    let session!: http2.ServerHttp2Session;
+    server.on("session", s => {
+      session = s;
+      s.on("error", () => {});
+    });
     server.on("stream", (stream: any) => {
       stream.on("error", () => {});
-      // Reserve stream 2 (numerically above the request on 1), then refuse the request: the
-      // refusal uses up the budget of 1 and the session writes its ENHANCE_YOUR_CALM GOAWAY
-      // (bun counts user refusals against maxSessionRejectedStreams; node does not, but a node
-      // server's GOAWAY in this position names 1 as well).
+      // Reserve stream 2 (numerically above the request on 1), then refuse the request. On bun
+      // the refusal uses up the budget of 1 and the session writes an ENHANCE_YOUR_CALM GOAWAY
+      // of its own (bun counts user refusals against maxSessionRejectedStreams, node does not).
       stream.pushStream({ ":path": "/pushed" }, (err: Error | null, pushed: any) => {
         pushError.resolve(err);
         if (!pushed) return;
@@ -1844,8 +1872,14 @@ describe("GOAWAY last-stream-id (RFC 9113 §6.8)", () => {
       const promise = await c.waitFor(f => f.type === FrameType.PUSH_PROMISE);
       expect(promise.payload.readUInt32BE(0) & 0x7fffffff).toBe(2);
       expect(await pushError.promise).toBeNull();
-      const goaway = await c.waitForGoaway();
-      expect(goawayFields(goaway)).toEqual({ lastStreamId: 1, errorCode: ErrorCode.ENHANCE_YOUR_CALM });
+      // close() is the GOAWAY node writes here. On bun the budget GOAWAY is already on the
+      // wire and the session is gone, so close() is a no-op. The run asserts every GOAWAY:
+      // each one names the request on 1, never the even id the server itself pushed.
+      session.close();
+      await c.waitClosed();
+      const lastStreamIds = goawayLastStreamIds(c.frames);
+      expect(lastStreamIds.length).toBeGreaterThan(0);
+      expect(lastStreamIds.filter(id => id !== 1)).toEqual([]);
     } finally {
       c.destroy();
       server.close();


### PR DESCRIPTION
### Problem

When the HTTP/2 engine detects a connection error itself, the GOAWAY it writes carries `Connection::last_stream_id`. On a client that mark is advanced by the client's own request ids (every response HEADERS opens a "new" entry in the inbound engine), so the GOAWAY can name one of the client's own odd streams. RFC 9113 section 6.8 defines the field in terms of streams the GOAWAY's receiver initiated, and nghttp2 (node's server) treats a GOAWAY naming one of the sender's own ids as a connection `PROTOCOL_ERROR` ("GOAWAY: invalid last_stream_id"); node's own `test-http2-invalid-last-stream-id.js` asserts exactly that a client GOAWAY with last-stream-id 1 produces a `sessionError` on the server. Bun's server applies the same rule to GOAWAYs it receives (`handle_go_away`, and that node test passes here), so a bun client talking to a bun server trips it too: a clean client-side protocol error report turns into a spurious `sessionError` at the server.

Raw server that answers the request on stream 1 and then sends a PING with a 6 byte payload; the client's GOAWAY on the wire:

```
node v26.3.0 client:  last_stream_id=0  error_code=6 (FRAME_SIZE_ERROR)
bun 1.4.0 client:     last_stream_id=1  error_code=6
```

With a server push of stream 2 and requests on 1 and 3, node names 2 and bun names 3.

The embedder has the same concept (`H2FrameParser.last_peer_stream_id`, used by `session.goaway()`/`close()`/`destroy()`) but it was maintained separately and had two gaps of its own, both also checked against node:

* it was only advanced from `handle_received_stream_id`, which pushed streams never go through on the live client path, so a client's `close()` after receiving a push sent `last_stream_id=0` (node: the promised id), and a server's GOAWAY did not count a stream it had refused for `maxSessionMemory` (node counts it: nghttp2 advances `last_proc_stream_id` before the callback node refuses in);
* the GOAWAYs the embedder fills in for its own budgets (`maxSessionRejectedStreams` in `on_stream_rejected` and in `rstStream`, plus the settings/priority/trailers host fns) passed the mixed `last_stream_id`, so a client hitting its rejection budget named its own request, and a server that had pushed named its own even push id. `state.lastProcStreamID` reported the mixed mark as well (node: 0 on a client that received no pushes; bun: 1).

### Fix

`Connection` gets `last_peer_stream_id`: advanced for request ids a server receives (refused ones included, matching nghttp2's `last_proc_stream_id`) and for promised ids a client receives, never for locally initiated streams. `local_connection_error` writes it into the GOAWAY (and reports it through `Sink::on_error`). `last_stream_id` keeps its only remaining job, the section 5.1 "has this id existed" checks, which still need the locally initiated ids.

The engine pushes each advance to the embedder through a new `Sink::on_last_peer_stream_id` callback (same store-only contract as `on_frame_counters`; the embedder needs its own copy because its GOAWAYs can be written from JS running inside `receive()`, while the engine is borrowed). That callback is now what keeps `H2FrameParser.last_peer_stream_id` current, so the host fn GOAWAYs, the budget GOAWAYs (switched from `last_stream_id` to `last_peer_stream_id`) and `state.lastProcStreamID` all carry the same value as the engine's own GOAWAYs. The `onError`/`onEnd` dispatches that announce a GOAWAY to JS (engine `Sink::on_error` impl and the embedder's `send_go_away`) now pass the value that went on the wire too; the JS handlers ignore that argument today, this just keeps the two in step. The many `send_go_away(.., self.last_stream_id.get(), ..)` calls left untouched are in the legacy inbound parser, which the file header marks as dead code pending removal.

Why this is the right value rather than just "0 on a client": the mark follows nghttp2's `last_proc_stream_id` exactly (request ids incl. refused on a server, promised ids on a client). Every one of the eight tests below runs green on node v26.3.0 as well, so each asserted last-stream-id is node's value in the same situation. The two `maxSessionRejectedStreams` tests are where the two runtimes write a different set of GOAWAYs (node has no GOAWAY for an oversized response header list or a user-refused stream, and when its own budget trips it tears down with `INTERNAL_ERROR`): each of those asserts the last-stream-id of every GOAWAY the session puts on the wire, not the frame count or the error code. That pre-existing budget divergence is out of scope here.

Of the five embedder sites switched to `last_peer_stream_id`, three are exercised by tests (`on_stream_rejected`, the `rstStream` refusal budget, `sendTrailers`). The other two cannot be reached through `node:http2`: `setStreamPriority` has no JS caller (`Http2Stream#priority()` is the DEP0194 no-op) and the native `MAX_PENDING_SETTINGS_ACK` check is pre-empted by the JS `maxOutstandingSettings` guard; they are switched so the file has one rule rather than two.

Overlap note: #37563 and #36343 each add an engine-side `last_peer_stream_id` with the same definition for their own section 5.1 checks but do not touch the GOAWAY payload; whichever lands second only has to keep one copy of the field.

### Tests

`test/js/node/http2/h2-conformance.test.ts`, raw sockets on both sides:

* client connection error after a request: GOAWAY names 0 (was 1), `state.lastProcStreamID` is 0
* client connection error after requests 1 and 3 were answered and stream 2 was then pushed (the promise arrives below the client's own highest id, which is the case the mixed mark gets wrong): names 2 (was 3), `lastProcStreamID` goes 0 then 2
* client `close()` after a push: names 2 (was 0)
* client with a `maxSessionRejectedStreams` budget, after a refused response: every GOAWAY names 0 (the budget one named 1)
* client GOAWAY after a trailer block the HPACK encoder cannot emit (the `sendTrailers` site): names 0 (was 1; node also writes `NO_ERROR`/0 here)
* server `close()` after refusing stream 3 for `maxSessionMemory`: names 3 (was 1), `lastProcStreamID` is 3
* server with a `maxSessionRejectedStreams` budget, after pushing stream 2 and refusing the request: every GOAWAY names 1 (the budget one named 2)
* server connection error after requests 1 and 3: names 3 (unchanged; guards the server side, which was already correct)

Seven of the eight fail on bun 1.4.3 (`USE_SYSTEM_BUN=1`). All eight pass on node v26.3.0 (run through a shim that maps `bun:test` onto `node:test`). The file (69 tests), `node-http2.test.js` (347 pass), the other `test/js/node/http2/` files and the ported node tests around GOAWAY, push, session state and the memory/rejection budgets (`test-http2-invalid-last-stream-id`, `-goaway-*`, `-graceful-close`, `-session-stream-state`, `-server-push-stream*`, `-respond-file-push`, `-misbehaving-multiplex`, `-server-sessionerror`, `sequential/test-http2-max-session-memory`, 21 in all) pass on the debug build.

Four engine-level `#[test]`s in `connection.rs` cover the same situations against a bare `Connection` (client with own requests only, client whose push arrives below its own highest id, server with a refused stream, and a server whose request on 3 arrives after it pushed 4 through `send_push_promise`, a path production does not route through the engine yet). The workspace has no wiring to run `bun_runtime`'s unit tests (the test binary needs the C side linked in); linking it by hand against lshpack plus abort stubs for the 15 other C symbols it references (none of which these tests reach), all 28 `h2::` tests pass, the three that assert the GOAWAY payload fail when `local_connection_error` is switched back to `last_stream_id`, and the two push tests fail if the peer mark is only advanced when the id is also a new overall high-water mark.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 7 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [10.06ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.80ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [2.44ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.24ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.98ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.00ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.05ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.89ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.94ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (52c6fec78)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [399.56ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [106.11ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [82.22ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [43.70ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [39.07ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [33.93ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [40.34ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 668ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/170] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 107 installs across 153 packages (no changes) [10.00ms]
[2/170] gen ErrorCode+*.h
[3/170] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[4/170] gen string-map defines_table
[5/170] gen bindgenv2
[6/170] esbuild runtime.out.js

  build/release/codegen/runtime.out.js  5.3kb

⚡ Done in 6ms
[7/170] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       42.1kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 33ms
[8/170] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[9/170] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[10/170] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      | 185 ++++++++++++++++++++-
 src/runtime/api/bun/h2_frame_parser.rs    |  39 ++---
 test/js/node/http2/h2-conformance.test.ts | 265 +++++++++++++++++++++++++++++-
 3 files changed, 459 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs           0      0     14
src/runtime/api/bun/h2_frame_parser.rs         0      0     14
test/js/node/http2/h2-conformance.test.ts      2      6     14
```

</details>

<!-- robobun:evidence:end -->

