### PR TITLE
install: pass every resolved dependency to the configured security scanner

### DIFF
--- a/docs/pm/security-scanner-api.mdx
+++ b/docs/pm/security-scanner-api.mdx
@@ -87,6 +87,46 @@ Consult your scanner's documentation for which environment variables to set and 
 For a complete example with tests and CI setup, see the official template:
 [github.com/oven-sh/security-scanner-template](https://github.com/oven-sh/security-scanner-template)
 
+A scanner is a module that exports a `scanner` object implementing `Bun.Security.Scanner`. Bun calls its `scan()` hook
+with every package it is about to install, including transitive dependencies, and cancels the install if any returned
+advisory is `fatal`:
+
+```ts scanner.ts icon="/icons/typescript.svg"
+export const scanner: Bun.Security.Scanner = {
+  version: "1",
+  async scan({ packages }) {
+    const advisories: Bun.Security.Advisory[] = [];
+
+    for (const pkg of packages) {
+      if (pkg.name === "event-stream" && Bun.semver.satisfies(pkg.version, ">=3.3.6 <4.0.0")) {
+        advisories.push({
+          level: "fatal",
+          package: pkg.name,
+          url: "https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident",
+          description: "event-stream 3.3.6 shipped a compromised dependency",
+        });
+      }
+    }
+
+    return advisories;
+  },
+};
+```
+
+Each entry in `packages` describes one resolved package:
+
+| Field            | Description                                                                                                                                                                                                                                                                                                                                   |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | The package name.                                                                                                                                                                                                                                                                                                                             |
+| `version`        | What Bun resolved the dependency to. For registry packages this is the exact semver version (`4.1.2`). For other sources it is the resolved specifier as written to `bun.lock`, e.g. `github:user/repo#<commit>`, `git+https://host/repo.git#<commit>`, `https://example.com/pkg.tgz`, `./vendor/pkg.tgz`, `file:packages/pkg` or `link:pkg`. |
+| `requestedRange` | The range that was requested in `package.json` or on the command line, e.g. `^4.0.0`, `latest`, `github:user/repo` or `file:./pkg`.                                                                                                                                                                                                           |
+| `tarball`        | The URL of the tarball Bun downloads (or the path of a local tarball). For `github:` dependencies this is the GitHub API tarball URL for the resolved commit. Empty for packages that are not installed from a tarball, such as `git+` dependencies and local `file:` / `link:` directories.                                                  |
+
+Packages from every source are included — registry, git, GitHub, remote and local tarballs, and local directories — so a
+scanner can apply policy to dependencies that do not come from a registry. For those packages `version` is not a semver
+version, so compare it with `Bun.semver.satisfies()` (which returns `false` for such specifiers) rather than assuming it
+parses. Workspace packages are part of the project itself and are not included.
+
 ## Related
 
 - [Configuration (bunfig.toml)](/runtime/bunfig#install-security-scanner)

--- a/packages/bun-types/security.d.ts
+++ b/packages/bun-types/security.d.ts
@@ -10,19 +10,34 @@ declare module "bun" {
       name: string;
 
       /**
-       * The exact version Bun resolved from the requested range, **not** a
-       * range itself.
+       * What Bun resolved the requested range to, **not** a range itself.
+       *
+       * For packages from a registry this is the exact semver version, like
+       * `4.1.2`. For packages from other sources this is the resolved
+       * specifier as it appears in `bun.lock`, for example
+       * `github:user/repo#<commit>`, `git+https://host/repo.git#<commit>`,
+       * `https://example.com/pkg.tgz`, `./vendor/pkg.tgz`, `file:packages/pkg`
+       * or `link:pkg`. Compare it with {@link Bun.semver.satisfies}, which
+       * returns `false` for such specifiers, rather than assuming it parses
+       * as semver.
        */
       version: string;
 
       /**
-       * The URL of the package tarball (`.tgz`) Bun downloads
+       * The URL of the package tarball (`.tgz`) Bun downloads, or the path of
+       * a local tarball.
+       *
+       * For `github:` dependencies this is the GitHub API tarball URL for the
+       * resolved commit (honoring `GITHUB_API_URL`). Empty for packages that
+       * are not installed from a tarball, such as `git+` dependencies and
+       * local `file:` / `link:` directories.
        */
       tarball: string;
 
       /**
-       * The range the command requested: a tag like `beta` or a semver
-       * range like `>=4.0.0`
+       * The range the command requested, as written in `package.json` or on
+       * the command line: a tag like `beta`, a semver range like `>=4.0.0`, or
+       * a non-registry specifier like `github:user/repo` or `file:./pkg`
        */
       requestedRange: string;
     }
@@ -81,7 +96,9 @@ declare module "bun" {
        *
        * @param info An object whose `packages` array contains every
        * proposed dependency, including transitive dependencies of the
-       * packages the user asked for
+       * packages the user asked for, whether it resolves to a registry
+       * version, a git repository, a tarball, or a local directory. Workspace
+       * packages are part of the project itself and are not included.
        *
        * @returns A list of advisories
        */

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1689,6 +1689,15 @@ pub fn get_network_task(this: &mut PackageManager) -> *mut NetworkTask {
 }
 
 pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
+    let committish = this.lockfile.str(&repository.committish);
+    alloc_github_url_for_ref(this, repository, committish)
+}
+
+pub(crate) fn alloc_github_url_for_ref(
+    this: &PackageManager,
+    repository: &Repository,
+    committish: &[u8],
+) -> Vec<u8> {
     let mut github_api_url: &[u8] = b"https://api.github.com";
     if let Some(url) = this.env().get(b"GITHUB_API_URL") {
         if !url.is_empty() {
@@ -1698,7 +1707,6 @@ pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u
 
     let owner = this.lockfile.str(&repository.owner);
     let repo = this.lockfile.str(&repository.repo);
-    let committish = this.lockfile.str(&repository.committish);
 
     let mut out = Vec::new();
     write!(

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -13,10 +13,12 @@ use crate::Error;
 use crate::bun_fs::FileSystem;
 use crate::bun_json::{Expr, ExprData};
 use crate::package_manager_real::Command::Context as CommandContext;
+use crate::repository_real::RepositoryExt as _;
 use bun_collections::ArrayHashMap;
 use bun_core::strings;
 use bun_core::{self, Output};
 use bun_event_loop::EventLoopHandle;
+use bun_install::resolution::Tag as ResolutionTag;
 use bun_install::{
     DependencyID, PackageID, PackageManager, invalid_dependency_id, invalid_package_id,
 };
@@ -459,6 +461,13 @@ pub(crate) fn prompt_for_warnings() -> bool {
     true
 }
 
+fn is_scannable_resolution(tag: ResolutionTag) -> bool {
+    !matches!(
+        tag,
+        ResolutionTag::Uninitialized | ResolutionTag::Root | ResolutionTag::Workspace
+    )
+}
+
 struct PackageCollector<'a> {
     manager: &'a PackageManager,
     dedupe: ArrayHashMap<PackageID, ()>,
@@ -491,7 +500,7 @@ impl<'a> PackageCollector<'a> {
         let root_pkg_id: PackageID = 0;
         let root_deps = pkg_dependencies[root_pkg_id as usize];
 
-        // collect all npm deps from the root package
+        // collect all deps from the root package
         for _dep_id in root_deps.begin()..root_deps.end() {
             let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
             let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id as usize];
@@ -516,7 +525,7 @@ impl<'a> PackageCollector<'a> {
             });
         }
 
-        // and collect npm deps from workspace packages
+        // and collect deps from workspace packages
         for pkg_idx in 0..pkgs.len() {
             let pkg_id: PackageID = PackageID::try_from(pkg_idx).expect("int cast");
             if pkg_resolutions[pkg_id as usize].tag != bun_install::resolution::Tag::Workspace {
@@ -633,7 +642,7 @@ impl<'a> PackageCollector<'a> {
             let pkg_id = item.pkg_id;
             let _ = item.dep_id; // Could be useful in the future for dependency-specific processing
 
-            if pkg_resolutions[pkg_id as usize].tag == bun_install::resolution::Tag::Npm {
+            if is_scannable_resolution(pkg_resolutions[pkg_id as usize].tag) {
                 let pkg_path_copy: Box<[PackageID]> = item.pkg_path.clone().into_boxed_slice();
                 let dep_path_copy: Box<[DependencyID]> = item.dep_path.clone().into_boxed_slice();
 
@@ -699,6 +708,8 @@ impl<'a> JSONBuilder<'a> {
         json_buf.extend_from_slice(b"[\n");
 
         let mut first = true;
+        let mut version_buf: Vec<u8> = Vec::new();
+        let mut tarball_buf: Vec<u8> = Vec::new();
         // `ArrayHashMap::iterator()` takes `&mut self`, but we only
         // need shared access. Iterate by index over the parallel key/value
         // slices instead (insertion-ordered).
@@ -721,34 +732,58 @@ impl<'a> JSONBuilder<'a> {
                 json_buf.extend_from_slice(b",\n");
             }
 
-            // SAFETY: `PackageCollector::process_queue` only inserts packages
-            // whose resolution tag is `Tag::Npm` into `package_paths`, so the
-            // `npm` union variant is the active field here.
-            let npm = pkg_res.npm();
-            if dep_id == invalid_dependency_id {
-                write!(
-                    &mut json_buf,
-                    "  {{\n    \"name\": {},\n    \"version\": \"{}\",\n    \"requestedRange\": \"{}\",\n    \"tarball\": {}\n  }}",
-                    bun_core::fmt::format_json_string_utf8(pkg_name.slice(string_buf), json_opts),
-                    npm.version.fmt(string_buf),
-                    npm.version.fmt(string_buf),
-                    bun_core::fmt::format_json_string_utf8(npm.url.slice(string_buf), json_opts),
-                )?;
-            } else {
-                let dep_version =
-                    &self.manager.lockfile.buffers.dependencies[dep_id as usize].version;
-                write!(
-                    &mut json_buf,
-                    "  {{\n    \"name\": {},\n    \"version\": \"{}\",\n    \"requestedRange\": {},\n    \"tarball\": {}\n  }}",
-                    bun_core::fmt::format_json_string_utf8(pkg_name.slice(string_buf), json_opts),
-                    npm.version.fmt(string_buf),
-                    bun_core::fmt::format_json_string_utf8(
-                        dep_version.literal.slice(string_buf),
-                        json_opts
-                    ),
-                    bun_core::fmt::format_json_string_utf8(npm.url.slice(string_buf), json_opts),
-                )?;
+            version_buf.clear();
+            tarball_buf.clear();
+            match pkg_res.tag {
+                ResolutionTag::Npm => {
+                    let npm = pkg_res.npm();
+                    write!(&mut version_buf, "{}", npm.version.fmt(string_buf))?;
+                    tarball_buf.extend_from_slice(npm.url.slice(string_buf));
+                }
+                ResolutionTag::Github => {
+                    let repository = pkg_res.github();
+                    write!(&mut version_buf, "{}", pkg_res.fmt_url(string_buf))?;
+                    let commit = if repository.resolved.is_empty() {
+                        repository.committish.slice(string_buf)
+                    } else {
+                        repository.resolved_commit(string_buf)
+                    };
+                    tarball_buf = crate::package_manager_real::run_tasks::alloc_github_url_for_ref(
+                        self.manager,
+                        repository,
+                        commit,
+                    );
+                }
+                ResolutionTag::LocalTarball | ResolutionTag::RemoteTarball => {
+                    write!(&mut version_buf, "{}", pkg_res.fmt_url(string_buf))?;
+                    tarball_buf.extend_from_slice(&version_buf);
+                }
+                ResolutionTag::Folder => {
+                    version_buf.extend_from_slice(b"file:");
+                    write!(&mut version_buf, "{}", pkg_res.fmt_url(string_buf))?;
+                }
+                _ => {
+                    write!(&mut version_buf, "{}", pkg_res.fmt_url(string_buf))?;
+                }
             }
+
+            let requested_range: &[u8] = if dep_id == invalid_dependency_id {
+                &version_buf
+            } else {
+                self.manager.lockfile.buffers.dependencies[dep_id as usize]
+                    .version
+                    .literal
+                    .slice(string_buf)
+            };
+
+            write!(
+                &mut json_buf,
+                "  {{\n    \"name\": {},\n    \"version\": {},\n    \"requestedRange\": {},\n    \"tarball\": {}\n  }}",
+                bun_core::fmt::format_json_string_utf8(pkg_name.slice(string_buf), json_opts),
+                bun_core::fmt::format_json_string_utf8(&version_buf, json_opts),
+                bun_core::fmt::format_json_string_utf8(requested_range, json_opts),
+                bun_core::fmt::format_json_string_utf8(&tarball_buf, json_opts),
+            )?;
 
             first = false;
         }

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -330,6 +330,7 @@ pub trait RepositoryExt: Sized {
     fn fmt_store_path<'a>(&'a self, label: &'a str, string_buf: &'a [u8])
     -> StorePathFormatter<'a>;
     fn fmt<'a>(&'a self, label: &'a str, buf: &'a [u8]) -> Formatter<'a>;
+    fn resolved_commit<'a>(&'a self, buf: &'a [u8]) -> &'a [u8];
     fn try_ssh(url: &[u8]) -> Option<&[u8]>;
     fn try_https(url: &[u8]) -> Option<&[u8]>;
     fn download(
@@ -537,6 +538,14 @@ impl RepositoryExt for Repository {
             repository: self,
             buf,
             label,
+        }
+    }
+
+    fn resolved_commit<'a>(&'a self, buf: &'a [u8]) -> &'a [u8] {
+        let resolved = self.resolved.slice(buf);
+        match strings::last_index_of_char(resolved, b'-') {
+            Some(i) => &resolved[i + 1..],
+            None => resolved,
         }
     }
 
@@ -1058,10 +1067,7 @@ impl<'a> fmt::Display for StorePathFormatter<'a> {
 
         if !self.repo.resolved.is_empty() {
             writer.write_str("+")?; // this would be '#' but it's not valid on windows
-            let mut resolved = self.repo.resolved.slice(self.string_buf);
-            if let Some(i) = strings::last_index_of_char(resolved, b'-') {
-                resolved = &resolved[i + 1..];
-            }
+            let resolved = self.repo.resolved_commit(self.string_buf);
             write!(writer, "{}", Install::fmt_store_path(resolved))?;
         } else if !self.repo.committish.is_empty() {
             writer.write_str("+")?; // this would be '#' but it's not valid on windows
@@ -1101,10 +1107,7 @@ impl<'a> fmt::Display for Formatter<'a> {
 
         if !self.repository.resolved.is_empty() {
             writer.write_str("#")?;
-            let mut resolved = self.repository.resolved.slice(self.buf);
-            if let Some(i) = strings::last_index_of_char(resolved, b'-') {
-                resolved = &resolved[i + 1..];
-            }
+            let resolved = self.repository.resolved_commit(self.buf);
             write!(writer, "{}", BStr::new(resolved))?;
         } else if !self.repository.committish.is_empty() {
             writer.write_str("#")?;

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, runBunInstall } from "harness";
+import { bunEnv, bunExe, runBunInstall, tempDir } from "harness";
 import { join } from "node:path";
 import {
   createTestContext,
@@ -24,7 +24,8 @@ function test(
     bunfigScanner?: string | false;
     packages?: string[];
     scannerFile?: string;
-    packageJson?: object;
+    packageJson?: object | ((ctx: TestContext) => object);
+    files?: Record<string, string | Blob>;
     customRegistry?: (urls: string[], ctx: TestContext) => any;
     concurrent?: boolean;
   },
@@ -41,8 +42,15 @@ function test(
           options.customRegistry ? options.customRegistry(urls, ctx) : dummyRegistryForContext(ctx, urls),
         );
 
-        const write = (path: string, content: string | object) =>
-          Bun.write(join(ctx.package_dir, path), typeof content === "string" ? content : JSON.stringify(content));
+        const write = (path: string, content: string | Blob | object) =>
+          Bun.write(
+            join(ctx.package_dir, path),
+            typeof content === "string" || content instanceof Blob ? content : JSON.stringify(content),
+          );
+
+        for (const [path, content] of Object.entries(options.files ?? {})) {
+          await write(path, content);
+        }
 
         const scannerPath = options.scannerFile || "./scanner.ts";
         if (typeof options.scanner === "string") {
@@ -63,7 +71,7 @@ function test(
 
         await write(
           "package.json",
-          options.packageJson ?? {
+          (typeof options.packageJson === "function" ? options.packageJson(ctx) : options.packageJson) ?? {
             name: "my-app",
             version: "1.0.0",
             dependencies: {},
@@ -703,6 +711,162 @@ describe("Package Resolution", () => {
     expect: ({ out }) => {
       expect(out).toContain("Latest tag:");
     },
+  });
+
+  test("scanner receives packages resolved from folders and tarballs", {
+    scanner: async ({ packages }) => {
+      const sorted = [...packages].sort((a, b) => a.name.localeCompare(b.name));
+      console.log("PACKAGES:" + JSON.stringify(sorted));
+      return [];
+    },
+    files: {
+      "mypkg/package.json": JSON.stringify({ name: "mypkg", version: "1.2.3" }),
+      "bar-0.0.2.tgz": Bun.file(join(import.meta.dir, "bar-0.0.2.tgz")),
+    },
+    packageJson: ctx => ({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        bar: "./bar-0.0.2.tgz",
+        baz: `${ctx.registry_url}baz-0.0.3.tgz`,
+        mypkg: "file:./mypkg",
+      },
+    }),
+    packages: [],
+    expectedExitCode: 0,
+    expect: ({ out, ctx }) => {
+      const line = out.split("\n").find(l => l.startsWith("PACKAGES:"));
+      expect(line).toBeDefined();
+      expect(JSON.parse(line!.slice("PACKAGES:".length))).toEqual([
+        {
+          name: "bar",
+          version: "./bar-0.0.2.tgz",
+          requestedRange: "./bar-0.0.2.tgz",
+          tarball: "./bar-0.0.2.tgz",
+        },
+        {
+          name: "baz",
+          version: `${ctx.registry_url}baz-0.0.3.tgz`,
+          requestedRange: `${ctx.registry_url}baz-0.0.3.tgz`,
+          tarball: `${ctx.registry_url}baz-0.0.3.tgz`,
+        },
+        {
+          name: "mypkg",
+          version: "file:mypkg",
+          requestedRange: "file:./mypkg",
+          tarball: "",
+        },
+      ]);
+    },
+  });
+
+  test("scanner receives a local tarball added on the command line", {
+    scanner: async ({ packages }) => {
+      console.log("PACKAGES:" + JSON.stringify(packages));
+      return [];
+    },
+    files: {
+      "bar-0.0.2.tgz": Bun.file(join(import.meta.dir, "bar-0.0.2.tgz")),
+    },
+    packages: ["./bar-0.0.2.tgz"],
+    expectedExitCode: 0,
+    expect: ({ out }) => {
+      const line = out.split("\n").find(l => l.startsWith("PACKAGES:"));
+      expect(line).toBeDefined();
+      expect(JSON.parse(line!.slice("PACKAGES:".length))).toEqual([
+        {
+          name: "bar",
+          version: "./bar-0.0.2.tgz",
+          requestedRange: "./bar-0.0.2.tgz",
+          tarball: "./bar-0.0.2.tgz",
+        },
+      ]);
+    },
+  });
+
+  test("fatal advisory for a folder dependency stops the install", {
+    scanner: async ({ packages }) =>
+      packages
+        .filter(pkg => pkg.version.startsWith("file:"))
+        .map(pkg => ({
+          package: pkg.name,
+          description: `Folder dependency ${pkg.name} is not allowed`,
+          level: "fatal",
+          url: null,
+        })),
+    files: {
+      "mypkg/package.json": JSON.stringify({ name: "mypkg", version: "1.2.3" }),
+    },
+    packageJson: {
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        mypkg: "file:./mypkg",
+      },
+    },
+    packages: [],
+    fails: true,
+    expect: ({ out }) => {
+      expect(out).toContain("Folder dependency mypkg is not allowed");
+    },
+  });
+
+  it.concurrent("scanner receives GitHub packages with a tarball URL for the resolved commit", async () => {
+    const tarball = await new Bun.Archive(
+      {
+        "user-repo-abc1234/": "",
+        "user-repo-abc1234/package.json": JSON.stringify({ name: "gh-pkg", version: "1.0.0" }),
+      },
+      { compress: "gzip" },
+    ).bytes();
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname.includes("/tarball/")) {
+          return new Response(tarball, { headers: { "Content-Type": "application/gzip" } });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+    const githubApiUrl = `http://localhost:${server.port}`;
+
+    using dir = tempDir("scanner-github", {
+      "package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: { "gh-pkg": "github:user/repo#main" },
+      }),
+      "bunfig.toml": `[install]\ncache = false\n\n[install.security]\nscanner = "./scanner.ts"\n`,
+      "scanner.ts": `export const scanner = {
+  version: "1",
+  scan: async ({ packages }) => {
+    console.log("PACKAGES:" + JSON.stringify(packages));
+    return [];
+  },
+};`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...bunEnv, GITHUB_API_URL: githubApiUrl },
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const line = out.split("\n").find(l => l.startsWith("PACKAGES:"));
+    expect(line, err).toBeDefined();
+    expect(JSON.parse(line!.slice("PACKAGES:".length))).toEqual([
+      {
+        name: "gh-pkg",
+        version: "github:user/repo#abc1234",
+        requestedRange: "github:user/repo#main",
+        tarball: `${githubApiUrl}/repos/user/repo/tarball/abc1234`,
+      },
+    ]);
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

When `install.security.scanner` is configured, `bun install` / `bun add` / `bun pm scan` previously only passed packages that resolved to a registry version to the scanner's `scan()` hook. Dependencies resolved from other sources — `file:` folders, local and remote tarballs, `git+…` and `github:` — were traversed for their own dependencies but were not themselves included in the `packages` array.

With this change every resolved dependency is submitted, regardless of where it resolves from. Registry entries are unchanged (same fields, same values). Entries for other sources use the same four fields:

- `name` — package name
- `version` — the resolved specifier exactly as it appears in `bun.lock` (`github:user/repo#<commit>`, `https://…/pkg.tgz`, `./pkg.tgz`, `file:pkg`, `link:pkg`, …)
- `requestedRange` — the specifier from `package.json` / the command line
- `tarball` — the tarball URL Bun downloads (GitHub API tarball URL for the resolved commit, remote tarball URL, or local tarball path); empty for git clones and local directories

For non-registry packages `version` is a specifier rather than a semver version, so scanners should compare it with `Bun.semver.satisfies()` (which returns `false` for such values) rather than assume it parses as semver. The types and docs call this out.

Workspace packages are still not submitted — they are the project itself, and the existing workspace scanner tests keep asserting that.

`packages/bun-types/security.d.ts` and `docs/pm/security-scanner-api.mdx` are updated to describe the fields for non-registry packages.

Nothing changes when no scanner is configured.

### How did you verify your code works?

New tests in `test/cli/install/bun-install-security-provider.test.ts`:

- `scanner receives packages resolved from folders and tarballs` — a project with a `file:` folder, a local `.tgz` and a remote tarball URL; asserts the exact payload the scanner receives
- `scanner receives a local tarball added on the command line` — the `bun add ./pkg.tgz` path
- `fatal advisory for a folder dependency stops the install` — a `fatal` advisory returned for a `file:` dependency cancels the install
- `scanner receives GitHub packages with a tarball URL for the resolved commit` — a `github:user/repo#main` dependency served from a local `Bun.serve` via `GITHUB_API_URL`; asserts `version` is `github:user/repo#<commit>` and `tarball` points at `/repos/user/repo/tarball/<commit>`

All four fail on the current release and pass with this branch. The existing scanner test files (`bun-install-security-provider`, `bun-pm-scan`, `bun-security-scanner-workspaces`, `bun-update-security-*`) pass unchanged.

Also checked by hand with a `github:` and a `git+https://github.com/…` dependency:

```json
{
  "name": "is-number",
  "version": "github:jonschlinkert/is-number#98e8ff1",
  "requestedRange": "github:jonschlinkert/is-number#98e8ff1",
  "tarball": "https://api.github.com/repos/jonschlinkert/is-number/tarball/98e8ff1"
}
```
