### PR TITLE
ptr: make cargo test -p bun_ptr link natively and run the Miri crate set natively in CI

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -116,16 +116,17 @@ export LLVM_VERSION_MAJOR=19
 
 ## rust-lints.yml Workflow
 
-Four independent jobs that each run one cargo command over the Rust workspace. They share `.github/actions/rust-lint-setup`, a composite action that installs LLVM from apt.llvm.org (configure resolves a clang even though nothing here compiles C++), Bun, optionally a pinned Rust toolchain plus components, runs `bun install`, then `bun scripts/build.ts --configure-only` and the ninja targets a job asks for: `clone-lolhtml` (cargo cannot resolve the workspace until the vendored `lol_html` path dependency exists) and, for jobs that check `bun_runtime`/`bun_jsc`/`bun_core`, `codegen` (their `include!()`d sources under `build/debug/codegen`).
+Four independent jobs that each run cargo over the Rust workspace. They share `.github/actions/rust-lint-setup`, a composite action that installs LLVM from apt.llvm.org (configure resolves a clang even though nothing here compiles C++), Bun, optionally a pinned Rust toolchain plus components, runs `bun install`, then `bun scripts/build.ts --configure-only` and the ninja targets a job asks for: `clone-lolhtml` (cargo cannot resolve the workspace until the vendored `lol_html` path dependency exists) and, for jobs that check `bun_runtime`/`bun_jsc`/`bun_core`, `codegen` (their `include!()`d sources under `build/debug/codegen`).
 
-| Job       | Check name            | Runs                                         | Blocking                       |
-| --------- | --------------------- | -------------------------------------------- | ------------------------------ |
-| `clippy`  | `cargo clippy`        | `bun run rust:clippy`                        | yes                            |
-| `miri`    | `cargo miri test`     | `bun run rust:miri` (`scripts/rust-miri.ts`) | yes                            |
-| `lolhtml` | `lol-html cargo test` | `cargo test` in `vendor/lolhtml`             | yes                            |
-| `mordant` | `mordant`             | `cargo dylint --all --workspace`             | advisory (`continue-on-error`) |
+| Job       | Check name            | Runs                                          | Blocking                       |
+| --------- | --------------------- | --------------------------------------------- | ------------------------------ |
+| `clippy`  | `cargo clippy`        | `bun run rust:clippy`                         | yes                            |
+| `miri`    | `cargo miri test`     | `bun run rust:test`, then `bun run rust:miri` | yes                            |
+| `lolhtml` | `lol-html cargo test` | `cargo test` in `vendor/lolhtml`              | yes                            |
+| `mordant` | `mordant`             | `cargo dylint --all --workspace`              | advisory (`continue-on-error`) |
 
 - `clippy`, `miri` and `lolhtml` pin `RUSTUP_TOOLCHAIN` at the workflow level (kept in sync with `channel` in `rust-toolchain.toml`) so rustup does not install that file's cross-target list; the action installs the toolchain with `--profile minimal` plus the components the job names (`clippy`, `miri rust-src`, none).
+- `miri` runs the crate set in `scripts/rust-workspace.ts` twice: `scripts/rust-test.ts` links and runs each crate's tests as an ordinary host binary (Miri never links, so it is what notices a test reaching a symbol that only the full bun binary defines; a crate either carries a `#[cfg(test)]` shim module for what its tests reach, as `src/ptr/native_test_shims.rs` does, or sits in that script's `NATIVE_LINK_PENDING` list, which re-links it and fails once it links so the entry has to come out), then `scripts/rust-miri.ts` interprets them under Miri. The Miri step runs even when the native one fails so both verdicts land in one run.
 - `lolhtml` exists because the vendored lol-html is a fork (oven-sh/lol-html, `bun` branch) whose own test suite is the only thing guarding the fork's invariants. It used to trigger only on `scripts/build/deps/lolhtml.ts`; it now shares the workflow's wider path filter.
 - `mordant` runs the [mordant](https://github.com/scarletindustries/mordant) dylint pack. It sets `RUSTUP_TOOLCHAIN: stable` instead: mordant is built with, and lints us using, the nightly named in its own rust-toolchain file, which dylint fetches on demand, so the outer cargo only needs to exist. Because that nightly is older than ours, the job passes `-A unknown_lints` through `DYLINT_RUSTFLAGS`. Two caches cover the slow parts: `~/.cargo/bin/{cargo-dylint,dylint-link}` keyed on `DYLINT_VERSION`, and `~/.dylint_drivers` + `target/dylint/libraries` keyed on `DYLINT_VERSION` plus the pinned mordant rev read out of `Cargo.toml`. It is skipped on `merge_group`.
 

--- a/.github/workflows/rust-lints.yml
+++ b/.github/workflows/rust-lints.yml
@@ -14,6 +14,8 @@ on:
       - "scripts/build/**"
       - "scripts/build.ts"
       - "scripts/rust-miri.ts"
+      - "scripts/rust-test.ts"
+      - "scripts/rust-workspace.ts"
       - "package.json"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -80,7 +82,18 @@ jobs:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           components: miri rust-src
 
+      - name: cargo test
+        # The same crates as ordinary host test binaries, linked by the clang
+        # and lld the setup installed. Miri never links, so this is what
+        # catches a test reaching a symbol only the full bun binary defines
+        # (scripts/rust-test.ts). It is the quick step, so it goes first; Miri
+        # below still reports when it fails.
+        env:
+          BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
+        run: bun run rust:test
+
       - name: cargo miri test
+        if: ${{ !cancelled() }}
         env:
           BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
         run: bun run rust:miri

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "rust:mordant": "DYLINT_RUSTFLAGS='-A unknown_lints' cargo dylint --all --workspace -- --keep-going",
     "rust:mordant:baseline": "DYLINT_RUSTFLAGS='-A unknown_lints' MORDANT_BASELINE_WRITE=1 cargo dylint --all --workspace",
     "rust:miri": "bun scripts/rust-miri.ts",
+    "rust:test": "bun scripts/rust-test.ts",
     "rust:timings": "bun scripts/rust-timings.ts",
     "codegen:string-maps": "for f in src/**/*.string-map.ts; do bun src/codegen/generate-string-map.ts \"$f\" \"${f%.string-map.ts}.generated.rs\"; done",
     "codegen:verify": "bun run codegen:string-maps && git diff --exit-code 'src/**/*.generated.rs' || (echo '\\n*.generated.rs is stale — run `bun run codegen:string-maps` and commit the result.' >&2; exit 1)",

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -16,72 +16,20 @@
  * is the candidate replacement spec, allows that pattern, and still catches
  * the bugs we care about.
  *
+ * Miri never links, so it cannot tell when a crate's tests start reaching a
+ * symbol only the full bun binary defines; rust-test.ts (`bun run rust:test`)
+ * runs the same crate set (MIRI_CRATES in rust-workspace.ts) natively for that.
+ *
  * Usage:
  *   bun run rust:miri              # default crate set, crates run concurrently
  *   bun run rust:miri -p bun_foo   # extra args go straight to one `cargo miri test`
  */
 
-import { spawn, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { availableParallelism } from "node:os";
-import { resolve } from "node:path";
+import { MIRI_CRATES, ensureConfigured, repo, run } from "./rust-workspace.ts";
 
-const repo = resolve(import.meta.dirname, "..");
-
-// Crates that pass `cargo miri test` under Tree Borrows. To add one it must
-// (a) have at least one `#[test]`, (b) compile under `--cfg test`, (c) at test
-// runtime only call `extern "C"` functions Miri has shims for (libc's futex and
-// thread APIs are; vendored C is not) — otherwise Miri reports
-// `unsupported operation: can't call foreign function`.
-//
-// Ordered longest-running-under-Miri first so the concurrent run below starts
-// the long poles immediately; everything after bun_hash takes seconds.
-const MIRI_CRATES = [
-  "bun_collections",
-  "bun_ast",
-  "bun_paths",
-  "bun_hash",
-  "bun_base64",
-  "bun_clap",
-  "bun_dispatch",
-  "bun_errno",
-  "bun_http_types",
-  "bun_md",
-  "bun_ptr",
-  "bun_resolve_builtins",
-  "bun_shell_parser",
-  "bun_threading",
-  "bun_wyhash",
-];
-
-function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] = {}) {
-  return spawnSync(cmd, args, { stdio: "inherit", cwd: repo, ...opts });
-}
-
-// `bun_core/build.rs` needs `build_options.rs`; cargo can't resolve the
-// workspace until `vendor/lolhtml/` (a path dep) exists. Both come from the
-// configure step, which is a no-op when already done.
-const buildOptionsRs = resolve(repo, "build/debug/codegen/build_options.rs");
-const lolhtmlCargo = resolve(repo, "vendor/lolhtml/Cargo.toml");
-if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
-  console.log("\x1b[36m[setup]\x1b[0m bun run build --configure-only");
-  if (run("bun", ["run", "build", "--configure-only"]).status !== 0) process.exit(1);
-  if (!existsSync(lolhtmlCargo) && run("ninja", ["-C", "build/debug", "clone-lolhtml"]).status !== 0) {
-    process.exit(1);
-  }
-  // Re-check: configure can succeed without producing these (e.g. partial
-  // checkout, ninja target rename) — fail fast instead of letting cargo
-  // produce a confusing workspace-resolution error.
-  for (const [path, hint] of [
-    [buildOptionsRs, "bun run build --configure-only"],
-    [lolhtmlCargo, "ninja -C build/debug clone-lolhtml"],
-  ] as const) {
-    if (!existsSync(path)) {
-      console.error(`\x1b[31m[error]\x1b[0m ${path} still missing after setup — try: ${hint}`);
-      process.exit(1);
-    }
-  }
-}
+ensureConfigured();
 
 const env = {
   ...process.env,

--- a/scripts/rust-test.ts
+++ b/scripts/rust-test.ts
@@ -68,12 +68,19 @@ for (const crate of crates) {
   if (run("cargo", ["test", "--locked", ...args, "-p", crate]).status !== 0) failed.push(crate);
 }
 
+// The only failure a pending crate is allowed is the linker's (lld, or
+// link.exe's spelling); a compile error or a cargo failure stays loud.
+const LINK_FAILURE = /undefined symbol|unresolved external|error: linking with/;
 for (const crate of NATIVE_LINK_PENDING) {
   console.log(`\x1b[36m[test]\x1b[0m cargo test --locked --no-run -p ${crate} (pending: expected not to link)`);
-  if (run("cargo", ["test", "--locked", "--no-run", "-p", crate], { stdio: "pipe" }).status === 0) {
+  const result = run("cargo", ["test", "--locked", "--no-run", "-p", crate], { stdio: "pipe" });
+  if (result.status === 0) {
     console.error(
       `\x1b[31m[test]\x1b[0m ${crate} links natively now; remove it from NATIVE_LINK_PENDING in scripts/rust-test.ts`,
     );
+    failed.push(crate);
+  } else if (!LINK_FAILURE.test(String(result.stderr ?? ""))) {
+    console.error(`\x1b[31m[test]\x1b[0m ${crate} failed for a reason other than linking:\n${result.stderr}`);
     failed.push(crate);
   }
 }

--- a/scripts/rust-test.ts
+++ b/scripts/rust-test.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+/**
+ * Plain `cargo test` for the Miri crate set (MIRI_CRATES in rust-workspace.ts).
+ *
+ * A crate's test binary links the crate's Rust dependencies and nothing else.
+ * Everything the full bun binary gets from C/C++ (the highway kernels behind
+ * `bun_core::strings`, mimalloc, ...) or from a higher-tier crate (the
+ * `bun_sys` arm of `bun_core`'s `OutputSink`) is missing, so a test that
+ * reaches one either gets it from the crate's own `#[cfg(test)]` shim module
+ * (src/ptr/native_test_shims.rs) or fails to link, naming the symbol. Miri
+ * never links, and `bun_highway` takes scalar paths under `cfg(miri)`, so
+ * `rust:miri` stays green either way; this is the lane that notices.
+ *
+ * Usage:
+ *   bun run rust:test              # the crate set (per the lists below), then the pending check
+ *   bun run rust:test -p bun_foo   # extra args go straight to one `cargo test`
+ */
+
+import { MIRI_CRATES, ensureConfigured, run } from "./rust-workspace.ts";
+
+// Miri crates whose test binaries do not link natively yet, with the live
+// reference that stops them. Each entry is re-linked below and fails this
+// script once the crate links, so the list can only shrink.
+const NATIVE_LINK_PENDING = [
+  // `TapeAlloc::Arena` keeps `MimallocArena` live: mi_heap_malloc, mi_free_size, ...
+  "bun_ast",
+  // `StreamingClap::normal` reaches highway_index_of_char.
+  "bun_clap",
+];
+
+// Crates whose test binary is built and linked here but not run: linking is
+// what this lane checks, and running these is known to be unreliable natively.
+const LINK_ONLY = [
+  // pool.rs's tests race libtest's parallel threads against the thread-local
+  // pool's teardown (3 of 40 runs fail on main); #37793 joins the thread.
+  // Remove once it lands.
+  "bun_collections",
+];
+
+for (const [list, name] of [
+  [NATIVE_LINK_PENDING, "NATIVE_LINK_PENDING"],
+  [LINK_ONLY, "LINK_ONLY"],
+] as const) {
+  for (const crate of list) {
+    if (!MIRI_CRATES.includes(crate)) {
+      console.error(`\x1b[31m[test]\x1b[0m ${crate} is in ${name} but not in MIRI_CRATES`);
+      process.exit(1);
+    }
+  }
+}
+
+ensureConfigured();
+
+const extraArgs = process.argv.slice(2);
+if (extraArgs.length > 0) {
+  console.log(`\x1b[36m[test]\x1b[0m cargo test --locked ${extraArgs.join(" ")}`);
+  process.exit(run("cargo", ["test", "--locked", ...extraArgs]).status ?? 1);
+}
+
+// One `cargo test` per crate, so that every crate's own link result is
+// reported rather than only the first failure's; the build artifacts are
+// shared, so only the first invocation compiles anything substantial.
+const failed: string[] = [];
+const crates = MIRI_CRATES.filter(crate => !NATIVE_LINK_PENDING.includes(crate));
+for (const crate of crates) {
+  const args = LINK_ONLY.includes(crate) ? ["--no-run"] : [];
+  console.log(`\x1b[36m[test]\x1b[0m cargo test --locked ${[...args, "-p", crate].join(" ")}`);
+  if (run("cargo", ["test", "--locked", ...args, "-p", crate]).status !== 0) failed.push(crate);
+}
+
+for (const crate of NATIVE_LINK_PENDING) {
+  console.log(`\x1b[36m[test]\x1b[0m cargo test --locked --no-run -p ${crate} (pending: expected not to link)`);
+  if (run("cargo", ["test", "--locked", "--no-run", "-p", crate], { stdio: "pipe" }).status === 0) {
+    console.error(
+      `\x1b[31m[test]\x1b[0m ${crate} links natively now; remove it from NATIVE_LINK_PENDING in scripts/rust-test.ts`,
+    );
+    failed.push(crate);
+  }
+}
+
+if (failed.length) {
+  console.error(`\x1b[31m[test]\x1b[0m failed: ${failed.join(", ")}`);
+  process.exit(1);
+}
+console.log(
+  `\x1b[36m[test]\x1b[0m ${crates.length} crates link, ${crates.length - LINK_ONLY.length} of them ran and passed, ` +
+    `${NATIVE_LINK_PENDING.length} still pending`,
+);

--- a/scripts/rust-workspace.ts
+++ b/scripts/rust-workspace.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared by rust-miri.ts (`bun run rust:miri`) and rust-test.ts
+ * (`bun run rust:test`): the crate set both run, and the configure step
+ * cargo needs before it can resolve the workspace.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const repo = resolve(import.meta.dirname, "..");
+
+// Crates that pass `cargo miri test` under Tree Borrows. To add one it must
+// (a) have at least one `#[test]`, (b) compile under `--cfg test`, (c) at test
+// runtime only call `extern "C"` functions Miri has shims for (libc's futex and
+// thread APIs are; vendored C is not) — otherwise Miri reports
+// `unsupported operation: can't call foreign function` — and (d) link and pass
+// as a plain `cargo test` binary too (rust-test.ts), or be listed as pending
+// there.
+//
+// Ordered longest-running-under-Miri first so rust-miri.ts's concurrent run
+// starts the long poles immediately; everything after bun_hash takes seconds.
+export const MIRI_CRATES = [
+  "bun_collections",
+  "bun_ast",
+  "bun_paths",
+  "bun_hash",
+  "bun_base64",
+  "bun_clap",
+  "bun_dispatch",
+  "bun_errno",
+  "bun_http_types",
+  "bun_md",
+  "bun_ptr",
+  "bun_resolve_builtins",
+  "bun_shell_parser",
+  "bun_threading",
+  "bun_wyhash",
+];
+
+export function run(cmd: string, args: string[], opts: Parameters<typeof spawnSync>[2] = {}) {
+  return spawnSync(cmd, args, { stdio: "inherit", cwd: repo, ...opts });
+}
+
+// `bun_core/build.rs` needs `build_options.rs`; cargo can't resolve the
+// workspace until `vendor/lolhtml/` (a path dep) exists. Both come from the
+// configure step, which is a no-op when already done.
+export function ensureConfigured() {
+  const buildOptionsRs = resolve(repo, "build/debug/codegen/build_options.rs");
+  const lolhtmlCargo = resolve(repo, "vendor/lolhtml/Cargo.toml");
+  if (existsSync(buildOptionsRs) && existsSync(lolhtmlCargo)) return;
+  console.log("\x1b[36m[setup]\x1b[0m bun run build --configure-only");
+  if (run("bun", ["run", "build", "--configure-only"]).status !== 0) process.exit(1);
+  if (!existsSync(lolhtmlCargo) && run("ninja", ["-C", "build/debug", "clone-lolhtml"]).status !== 0) {
+    process.exit(1);
+  }
+  // Re-check: configure can succeed without producing these (e.g. partial
+  // checkout, ninja target rename) — fail fast instead of letting cargo
+  // produce a confusing workspace-resolution error.
+  for (const [path, hint] of [
+    [buildOptionsRs, "bun run build --configure-only"],
+    [lolhtmlCargo, "ninja -C build/debug clone-lolhtml"],
+  ] as const) {
+    if (!existsSync(path)) {
+      console.error(`\x1b[31m[error]\x1b[0m ${path} still missing after setup — try: ${hint}`);
+      process.exit(1);
+    }
+  }
+}

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -31,6 +31,9 @@ pub use bun_core::{ExternalShared, ExternalSharedDescriptor, ExternalSharedOptio
 // `cast_fn_ptr` and `RawSlice` likewise moved to `bun_core`; re-export.
 pub use bun_core::{RawSlice, cast_fn_ptr};
 
+#[cfg(test)]
+mod native_test_shims;
+
 pub mod raw_ref_count;
 pub mod weak_ptr;
 

--- a/src/ptr/native_test_shims.rs
+++ b/src/ptr/native_test_shims.rs
@@ -1,0 +1,64 @@
+//! The symbols this crate's tests reach that only the full bun binary defines, for `cargo test`.
+
+use bun_core::Fd;
+use bun_core::output::{File, QuietWriter};
+
+/// Returns `haystack_len` when `needle` is absent, like the kernel.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn highway_index_of_char(
+    haystack: *const u8,
+    haystack_len: usize,
+    needle: u8,
+) -> usize {
+    // SAFETY: `bun_highway::index_of_char` passes a live slice's (ptr, len).
+    let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+    haystack
+        .iter()
+        .position(|&b| b == needle)
+        .unwrap_or(haystack_len)
+}
+
+/// Returns `usize::MAX` for no match and `haystack_len` for an empty needle, like the kernel.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn highway_memrmem(
+    haystack: *const u8,
+    haystack_len: usize,
+    needle: *const u8,
+    needle_len: usize,
+) -> usize {
+    // SAFETY: `bun_highway::memrmem` passes two live slices' (ptr, len) pairs.
+    let (haystack, needle) = unsafe {
+        (
+            core::slice::from_raw_parts(haystack, haystack_len),
+            core::slice::from_raw_parts(needle, needle_len),
+        )
+    };
+    let Some(last_start) = haystack_len.checked_sub(needle_len) else {
+        return usize::MAX;
+    };
+    (0..=last_start)
+        .rev()
+        .find(|&i| haystack[i..].starts_with(needle))
+        .unwrap_or(usize::MAX)
+}
+
+// Reached via `RefCount`'s `ThreadLock` -> `bun_core::dump_stack_trace`; everything goes to stderr.
+bun_core::link_impl_OutputSink! {
+    Sys for () => |_this| {
+        stderr() => File(Fd::stderr()),
+        make_path(_cwd, _dir) => Err(bun_core::Error::Unexpected),
+        create_file(_cwd, _path) => Err(bun_core::Error::Unexpected),
+        quiet_writer_from_fd(_fd) => QuietWriter::ZEROED,
+        quiet_writer_adapt(_qw, _buf, _len) => {
+            unreachable!("bun_ptr tests never initialize a bun_core::output::Source")
+        },
+        quiet_writer_flush(_qw) => (),
+        quiet_writer_write_all(_qw, bytes) => {
+            std::io::Write::write_all(&mut std::io::stderr(), bytes).is_ok()
+        },
+        quiet_writer_fd(_qw) => Fd::stderr(),
+        tty_winsize(_fd) => None,
+        is_terminal(_fd) => false,
+        read(_fd, _buf) => Err(bun_core::Error::Unexpected),
+    }
+}

--- a/test/internal/rust-ptr-cargo-test.test.ts
+++ b/test/internal/rust-ptr-cargo-test.test.ts
@@ -1,0 +1,52 @@
+// bun_ptr's tests reach two things a plain `cargo test` binary does not get
+// from the Rust dependency graph: `type_base_name` (src/ptr/ref_count.rs) goes
+// through bun_core::strings, i.e. the highway C++ kernels, and `RefCount`'s
+// ThreadLock pulls in bun_core's OutputSink interface, whose only arm is in
+// bun_sys. src/ptr/native_test_shims.rs defines both for the test binary;
+// without it the link fails with
+//   ld.lld: error: undefined symbol: highway_memrmem
+//   ld.lld: error: undefined symbol: __bun_dispatch__OutputSink__Sys__stderr
+// and a COFF link forced through instead crashes in
+// type_base_name_strips_module_path, so this runs the tests rather than
+// stopping at --no-run. Miri (scripts/rust-miri.ts) never links and so cannot
+// notice either; the CI guard for the whole crate set is scripts/rust-test.ts
+// in rust-lints.yml's miri job, and this is the bun_ptr slice of it.
+//
+// Same prerequisites as rust-windows-sys-link.test.ts: cargo on PATH and a
+// configured checkout (cargo needs vendor/lolhtml to resolve the workspace,
+// bun_core/build.rs needs build_options.rs). The test-only CI lanes have
+// neither and skip.
+import { which } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const cargo = which("cargo");
+const repoRoot = join(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+
+test.skipIf(!cargo || !workspaceResolvable)(
+  "cargo test -p bun_ptr links and passes as a plain host binary",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "scripts/rust-test.ts", "-p", "bun_ptr"],
+      cwd: repoRoot,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("undefined symbol");
+    // The test that reaches the shimmed kernels must have actually run.
+    expect(stdout).toContain("test ref_count::tests::type_base_name_strips_module_path ... ok");
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+  },
+  // `bun bd` builds into build/<profile>/rust-target, so on a fresh checkout
+  // this compiles bun_core's closure first (about 10s on 16 cores); the 5s
+  // default cannot hold that. Same ceiling as the miri test in linear-fifo.test.ts.
+  120_000,
+);


### PR DESCRIPTION
### Repro

On a configured checkout (`bun run build --configure-only`), on main:

```
$ cargo test --locked -p bun_ptr
ld.lld: error: undefined symbol: highway_memrmem
>>> referenced by src/highway/lib.rs:323 (bun_core::string::immutable::last_index_of)
ld.lld: error: undefined symbol: highway_index_of_char
>>> referenced by src/highway/lib.rs:232 (bun_core::string::immutable::index_of_char_usize)
ld.lld: error: undefined symbol: __bun_dispatch__OutputSink__Sys__quiet_writer_from_fd
ld.lld: error: undefined symbol: __bun_dispatch__OutputSink__Sys__quiet_writer_write_all
ld.lld: error: undefined symbol: __bun_dispatch__OutputSink__Sys__stderr
>>> referenced by src/bun_core/lib.rs:563 (<bun_core::OutputSink>::stderr) ...
error: could not compile `bun_ptr` (lib test)
```

Still the case on current main (8c5296ac45). `bun run rust:miri -p bun_ptr` passes on the same tree, and nothing in CI runs any workspace crate's tests as a host binary, so the crate's place in the Miri set did not catch this: Miri never links, and `bun_highway` takes its `cfg(miri)` scalar paths (#37078). The break landed in #37052 with CI green.

### Cause

lld only reports undefined symbols referenced from sections that survive `--gc-sections`, so all five are reached by this crate's own tests (`ld.lld --why-live`):

* `type_base_name` (ref_count.rs, exercised by `type_base_name_strips_module_path` and the `debug_name()` defaults) searches through `bun_core::strings`, i.e. the highway C++ kernels, which only exist in the full bun link. `"a::b::Foo<c::Bar>"` is past the 16-byte scalar cutoff and `memrmem` has no scalar path at all, so these are called, not just referenced: with the link forced through on Windows (#37575) this test dies with `STATUS_ACCESS_VIOLATION`.
* `RefCount::init_exact_refs` locks a `bun_core::ThreadLock`, whose contention path calls `bun_core::dump_stack_trace`, which writes via `output::File::stderr()`, i.e. the `OutputSink` link interface. Its only arm is `bun_sys`'s `link_impl_OutputSink!`, and `bun_ptr` sits below `bun_sys`.

### Fix

**`src/ptr/native_test_shims.rs`**, mounted `#[cfg(test)]` from lib.rs, defines exactly the symbols the test binary reaches: scalar `highway_index_of_char` / `highway_memrmem` with the kernels' return conventions, and an `OutputSink` arm through `bun_core::link_impl_OutputSink!` whose writers go to the process's stderr (double-locking a `ThreadLock` in this binary prints the trace lines and then panics as in the real binary; checked by hand) and whose file, tty and stdin entry points, which nothing here reaches, fail or return the inert value.

This is the workspace's existing answer (`src/paths/string_paths.rs` stubs the two simdutf functions its tests reach; `src/parsers/native_test_shims.rs` plus `scripts/bench-json-rust.sh` do the same at a larger scale): a crate's test binary defines what its tests reach and everything else stays a link error naming the symbol. Going through `link_impl_OutputSink!` means the arm is checked against the interface's signatures, including in the Miri lane, which compiles the crate under `cfg(test)`. Nothing here is compiled into the real build, and `type_base_name` itself is unchanged.

#37599 (the bun_clap case) has since been reworked into a `bun_highway` `scalar` cargo feature enabled from dev-dependencies, plus its own version of the CI lane below. The two compose: the feature would let this crate drop its two kernel stubs later, but the `OutputSink` arm (and #37611's mimalloc case) still need a per-crate definition, and the lane here runs one `cargo test` per crate, so a dev-dependency feature on one crate cannot mask a missing one elsewhere. The two PRs do overlap on `scripts/rust-test.ts`, `scripts/rust-workspace.ts` and `package.json`; whichever lands second rebases onto the other.

### CI

* `scripts/rust-test.ts` (`bun run rust:test`) runs `cargo test --locked -p <crate>` once per crate in the Miri set, reports every crate's result, links `bun_collections` without running it (its pool tests race natively, 3 of 40 runs on current main; #37793 is the fix and the entry says to remove it once that lands), then re-links each crate in `NATIVE_LINK_PENDING` (`bun_ast`, #37611; `bun_clap`, #37599) and fails as soon as one links, so that list can only shrink. On current main the other 13 crates, including the newly added `bun_threading`, link and pass.
* The crate list and the configure step move from `rust-miri.ts` into `scripts/rust-workspace.ts` so both scripts share them; `rust-miri.ts` is otherwise unchanged (its default concurrent run and `-p` passthrough both re-verified). The list's comment gains criterion (d): link natively or be listed as pending.
* `rust-lints.yml`'s `miri` job runs the native step before `cargo miri test`; its setup already installs the clang and lld the generated `.cargo/config.toml` points at and clones lolhtml. The Miri step keeps running when the native one fails so both verdicts land in one run; the two scripts are added to the path filter, and `.github/workflows/CLAUDE.md` describes the step.
* `test/internal/rust-ptr-cargo-test.test.ts` runs `rust-test.ts -p bun_ptr` on a configured checkout: the proof for the `src/ptr` change, while the whole set is the workflow step's job. Like `rust-windows-sys-link.test.ts` it skips on the test-only CI lanes, and it keeps the 120s ceiling `linear-fifo.test.ts` uses: `bun bd` builds into `build/<profile>/rust-target`, so a fresh checkout compiles bun_core's closure first (9s cold here, 5s even warm), which the 5s default cannot hold, and one crate's test binary is already the smallest workload.

### Verification (on the rebase onto 8c5296ac45)

* `cargo test --locked -p bun_ptr`: links, 22 passed; with lib.rs as on main it fails with the five errors above. `bun run rust:miri -p bun_ptr`: 22 passed; the full `bun run rust:miri` through the slimmed script: all 15 crates pass.
* `bun run rust:test`: 13 crates link, 12 run and pass, both pending crates still fail to link; exit 0. Listing a linking crate as pending makes it exit 1 asking for the entry to be removed; `rust:test -p bun_ptr` runs just that crate.
* `bun bd test test/internal/rust-ptr-cargo-test.test.ts` passes; `cargo fmt --check`, prettier and `bun test test/internal/source-lints/` are clean.
* The earlier revision's workflow step ran in 37s on a GitHub runner (12 crates plus the pending re-links); this revision's run is the rust-lints `cargo miri test` check on this PR.

<!-- robobun:evidence:begin -->

---

**[decide:dep]** gate passed · iteration 3 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-ptr-cargo-test.test.ts
bun test v1.4.0 (0361ed49c)

test/internal/rust-ptr-cargo-test.test.ts:
38 |       stdout: "pipe",
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 | 
43 |     expect(stderr).not.toContain("undefined symbol");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "undefined symbol"
Received: "   Compiling bun_ptr v0.0.0 (/workspace/bun/src/ptr)\nerror: linking with `/usr/lib/llvm-21/bin/clang++` failed: exit status: 1\n  |\n  = note:  \"/usr/lib/llvm-21/bin/clang++\" \"-m64\" \"/workspace/bun/target/debug/deps/rustcKaiQ7F/symbols.o\" \"<4 object files omitted>\" \"-Wl,--as-needed\" \"-Wl,-Bstatic\" \"<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libtest-*,libgetopts-*,librustc_std_workspace_std-*}.rlib\" \"/workspace/bun/target/debug/deps/{libbun_core-f391aa709dcb75cd,libthiserror-dc5bf0719b7079ba,libbun_output_tags-54cdcf0ec5c68
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/internal/rust-ptr-cargo-test.test.ts:
38 |       stdout: "pipe",
39 |       stderr: "pipe",
40 |     });
41 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
42 | 
43 |     expect(stderr).not.toContain("undefined symbol");
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "undefined symbol"
Received: "   Compiling bun_ptr v0.0.0 (/workspace/bun/src/ptr)\nerror: linking with `/usr/lib/llvm-21/bin/clang++` failed: exit status: 1\n  |\n  = note:  \"/usr/lib/llvm-21/bin/clang++\" \"-m64\" \"/workspace/bun/target/debug/deps/rustcHlai2F/symbols.o\" \"<4 object files omitted>\" \"-Wl,--as-needed\" \"-Wl,-Bstatic\" \"<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libtest-*,libgetopts-*,librustc_std_workspace_std-*}.rlib\" \"/workspace/bun/target/debug/deps/{libbun_core-f391aa709dcb75cd,libthiserror-dc5bf0719b7079ba,libbun_output_tags-54cdcf0ec5c6886e,libitoa-8d0ab51d268956b3,libstrum-8b09883ff8f1e3c8,libbun_simdutf_sys-bf8bf121a9fddbab,libbun_hash-ab0dfcfa57edd519,libbun_highway-5b5809b1107fb1e5,libbytemuck-a9
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/rust-ptr-cargo-test.test.ts
bun test v1.4.0 (0361ed49c)

test/internal/rust-ptr-cargo-test.test.ts:
(pass) cargo test -p bun_ptr links and passes as a plain host binary [1992.36ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [4.38s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3c6a2101cc
  features     baseline

22 deps, 120 codegen, 1175 objects in 700ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [10.00ms]
[2/1236] gen ErrorCode+*.h
[3/1236] gen bindgenv2
[4/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [6.00ms]
[5/1236] fetch tinycc
[tinycc] up to date
[6/1235] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (eabb96de7)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[7/1235] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1235] fetch zlib
[zlib] up to date
[9/1235] gen .bind.ts → GeneratedBindings.cpp
[10/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.github/workflows/CLAUDE.md               | 15 +++---
 .github/workflows/rust-lints.yml          | 13 +++++
 package.json                              |  1 +
 scripts/rust-miri.ts                      | 66 +++--------------------
 scripts/rust-test.ts                      | 88 +++++++++++++++++++++++++++++++
 scripts/rust-workspace.ts                 | 69 ++++++++++++++++++++++++
 src/ptr/lib.rs                            |  3 ++
 src/ptr/native_test_shims.rs              | 64 ++++++++++++++++++++++
 test/internal/rust-ptr-cargo-test.test.ts | 52 ++++++++++++++++++
 9 files changed, 305 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
.github/workflows/CLAUDE.md                    1      3      0
.github/workflows/rust-lints.yml               1      2      0
package.json                                   2      3      0
scripts/rust-miri.ts                           3      4      0
scripts/rust-test.ts                           2      8      0
scripts/rust-workspace.ts                      0      1      0
src/ptr/lib.rs                                 1      1      0
src/ptr/native_test_shims.rs                   3      8      0
test/internal/rust-ptr-cargo-test.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->