### PR TITLE
bun_alloc: give MutexGuard a real lifetime, drop the 'static transmute

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -541,13 +541,6 @@ pub fn buf_print_len(
 }
 
 // ── RAII Mutex ────────────────────────────────────────────────────────────
-// The BSS containers below need to hold the lock across `&mut self` method calls, so
-// the returned [`MutexGuard`] deliberately erases its borrow of `self` — it
-// stores the `std::sync::MutexGuard` lifetime-extended to `'static` (lifetimes
-// are erased at codegen, so this is a layout no-op). This is sound because
-// every `Mutex` here lives inside a `'static` BSS singleton (see `instance()`
-// below), so the pointee always outlives the guard.
-//
 // LAYERING: `bun_alloc` is below `bun_threading` in the crate graph, so the
 // futex-backed `bun_threading::Mutex` is unavailable here; `std::sync` (itself
 // futex-backed since Rust 1.62) is the dependency-free stand-in.
@@ -557,29 +550,20 @@ impl Mutex {
         Self(std::sync::Mutex::new(()))
     }
     #[inline]
-    pub(crate) fn lock(&self) -> MutexGuard {
-        let g = self
-            .0
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // SAFETY: lifetime extension only — `std::sync::MutexGuard<'a, ()>` and
-        // `<'static, ()>` have identical layout. Every `bun_alloc::Mutex` lives
-        // in a `'static` BSS singleton, so the inner `&Mutex` the guard holds
-        // is in fact valid for `'static`.
-        let _guard = unsafe {
-            core::mem::transmute::<std::sync::MutexGuard<'_, ()>, std::sync::MutexGuard<'static, ()>>(
-                g,
-            )
-        };
-        MutexGuard { _guard }
+    pub(crate) fn lock(&self) -> MutexGuard<'_> {
+        MutexGuard {
+            _guard: self
+                .0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        }
     }
 }
 
-/// Unlocks the paired [`Mutex`] on drop. See the type-level comment on
-/// [`Mutex`] for why this erases the guard lifetime rather than borrowing.
+/// Unlocks the borrowed [`Mutex`] on drop.
 #[must_use = "if unused the Mutex will immediately unlock"]
-pub(crate) struct MutexGuard {
-    _guard: std::sync::MutexGuard<'static, ()>,
+pub(crate) struct MutexGuard<'a> {
+    _guard: std::sync::MutexGuard<'a, ()>,
 }
 impl Default for Mutex {
     fn default() -> Self {
@@ -2128,8 +2112,8 @@ impl<ValueType, const COUNT: usize> BSSList<ValueType, COUNT> {
         this: *mut Self,
     ) -> core::result::Result<*mut MaybeUninit<ValueType>, AllocError> {
         // SAFETY: `this` is live; `Mutex: Sync` so concurrent `&Mutex` formation
-        // is sound. `MutexGuard` stores a raw pointer (see its doc), so the
-        // `&mut *this` formed below does not alias a live guard borrow.
+        // is sound. The guard borrows only `(*this).mutex`, which the `&mut *this`
+        // formed below never touches.
         let _guard = unsafe { (*this).mutex.lock() };
         // SAFETY: the inner mutex is held, so this call has exclusive access
         // to `*this` (the receiver is raw precisely so nothing exclusive is
@@ -2308,8 +2292,8 @@ impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LEN
         value: &A,
     ) -> core::result::Result<&'a mut [u8], AllocError> {
         // SAFETY: `this` is live; `Mutex: Sync` so concurrent `&Mutex` formation
-        // is sound. `MutexGuard` stores a raw pointer (see its doc), so the
-        // `&mut *this` formed below does not alias a live guard borrow.
+        // is sound. The guard borrows only `(*this).mutex`, which the `&mut *this`
+        // formed below never touches.
         let _guard = unsafe { (*this).mutex.lock() };
         // SAFETY: inner mutex held ⇒ this thread has exclusive access.
         let (ptr, len) = unsafe { (*this).do_append(value)? };
@@ -2387,8 +2371,8 @@ impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LEN
         value: &A,
     ) -> core::result::Result<&'a [u8], AllocError> {
         // SAFETY: `this` is live; `Mutex: Sync` so concurrent `&Mutex` formation
-        // is sound. `MutexGuard` stores a raw pointer (see its doc), so the
-        // `&mut *this` formed below does not alias a live guard borrow.
+        // is sound. The guard borrows only `(*this).mutex`, which the `&mut *this`
+        // formed below never touches.
         let _guard = unsafe { (*this).mutex.lock() };
         // SAFETY: inner mutex held ⇒ this thread has exclusive access.
         let (ptr, len) = unsafe { (*this).do_append(value)? };
@@ -2632,13 +2616,11 @@ impl<ValueType, const COUNT: usize, const REMOVE_TRAILING_SLASHES: bool>
 
     pub fn get(&mut self, denormalized_key: &[u8]) -> Option<&mut ValueType> {
         let _key = Self::key_hash(denormalized_key);
-        // Hold the lock across `at_index` —
-        // a concurrent `put()` could otherwise mutate `overflow_list`/`backing_buf` while
-        // we dereference `index`. `MutexGuard` holds a raw pointer (see [`Mutex`] docs),
-        // so it does not conflict with the `&mut self` borrow in `at_index`.
+        // Hold the lock across the slot lookup: a concurrent `put()` could otherwise
+        // mutate `overflow_list`/`backing_buf` while we dereference `index`.
         let _guard = self.mutex.lock();
         let index = self.index.get(&_key).copied()?;
-        self.at_index(index)
+        Self::slot_mut(&mut self.overflow_list, &mut self.backing_buf, index)
     }
 
     pub fn mark_not_found(&mut self, result: Result) {
@@ -2647,16 +2629,26 @@ impl<ValueType, const COUNT: usize, const REMOVE_TRAILING_SLASHES: bool>
     }
 
     pub fn at_index(&mut self, index: IndexType) -> Option<&mut ValueType> {
+        Self::slot_mut(&mut self.overflow_list, &mut self.backing_buf, index)
+    }
+
+    /// Takes fields, not `&mut self`, so `get` can call it while its guard borrows `self.mutex`.
+    #[inline(always)]
+    fn slot_mut<'a>(
+        overflow_list: &'a mut OverflowList<ValueType, BSS_OVERFLOW_BLOCK_SIZE>,
+        backing_buf: &'a mut [MaybeUninit<ValueType>; COUNT],
+        index: IndexType,
+    ) -> Option<&'a mut ValueType> {
         if index.index() == NOT_FOUND.index() || index.index() == UNASSIGNED.index() {
             return None;
         }
 
         if index.is_overflow() {
-            Some(self.overflow_list.at_index_mut(index))
+            Some(overflow_list.at_index_mut(index))
         } else {
             // SAFETY: a non-sentinel, non-overflow index was assigned by `put`, which
             // initialized this slot via `.write()`.
-            Some(unsafe { self.backing_buf[index.index() as usize].assume_init_mut() })
+            Some(unsafe { backing_buf[index.index() as usize].assume_init_mut() })
         }
     }
 

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -2112,8 +2112,8 @@ impl<ValueType, const COUNT: usize> BSSList<ValueType, COUNT> {
         this: *mut Self,
     ) -> core::result::Result<*mut MaybeUninit<ValueType>, AllocError> {
         // SAFETY: `this` is live; `Mutex: Sync` so concurrent `&Mutex` formation
-        // is sound. The guard borrows only `(*this).mutex`, which the `&mut *this`
-        // formed below never touches.
+        // is sound. The guard borrows only `(*this).mutex`; the `&mut *this` formed
+        // below covers it, but `append_overflow_uninit` never accesses `self.mutex`.
         let _guard = unsafe { (*this).mutex.lock() };
         // SAFETY: the inner mutex is held, so this call has exclusive access
         // to `*this` (the receiver is raw precisely so nothing exclusive is
@@ -2292,8 +2292,8 @@ impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LEN
         value: &A,
     ) -> core::result::Result<&'a mut [u8], AllocError> {
         // SAFETY: `this` is live; `Mutex: Sync` so concurrent `&Mutex` formation
-        // is sound. The guard borrows only `(*this).mutex`, which the `&mut *this`
-        // formed below never touches.
+        // is sound. The guard borrows only `(*this).mutex`; the `&mut *this` formed
+        // below covers it, but `do_append` never accesses `self.mutex`.
         let _guard = unsafe { (*this).mutex.lock() };
         // SAFETY: inner mutex held ⇒ this thread has exclusive access.
         let (ptr, len) = unsafe { (*this).do_append(value)? };
@@ -2371,8 +2371,8 @@ impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LEN
         value: &A,
     ) -> core::result::Result<&'a [u8], AllocError> {
         // SAFETY: `this` is live; `Mutex: Sync` so concurrent `&Mutex` formation
-        // is sound. The guard borrows only `(*this).mutex`, which the `&mut *this`
-        // formed below never touches.
+        // is sound. The guard borrows only `(*this).mutex`; the `&mut *this` formed
+        // below covers it, but `do_append` never accesses `self.mutex`.
         let _guard = unsafe { (*this).mutex.lock() };
         // SAFETY: inner mutex held ⇒ this thread has exclusive access.
         let (ptr, len) = unsafe { (*this).do_append(value)? };


### PR DESCRIPTION
## What

`bun_alloc::Mutex::lock()` (the lock guarding the `BSSList`, `BSSStringList` and `BSSMapInner` containers in `src/bun_alloc/lib.rs`) returned a `MutexGuard` holding a `std::sync::MutexGuard<'static, ()>`, produced by `mem::transmute`-ing the real guard's lifetime to `'static`. The accompanying comments justified this by every `Mutex` living in a never-freed singleton, and four SAFETY comments at the lock sites still described an older guard that "stores a raw pointer". The guard now borrows the mutex it unlocks:

```rust
// before
pub(crate) fn lock(&self) -> MutexGuard           // MutexGuard { _guard: std::sync::MutexGuard<'static, ()> }, via transmute

// after
pub(crate) fn lock(&self) -> MutexGuard<'_>       // MutexGuard<'a> { _guard: std::sync::MutexGuard<'a, ()> }
```

Of the 9 lock sites (all inside `bun_alloc`; `lock` is `pub(crate)`), 8 compile unchanged: the four `*mut Self` append paths (`BSSList::append_uninit`, `BSSStringList::{append_mutable, append, append_lower_case}`) lock through the raw pointer, and `BSSMapInner::{get_or_put, mark_not_found, put, remove}` only touch fields disjoint from `mutex` while the guard is live. `BSSMapInner::get` called the whole-`&mut self` method `at_index` under the guard, which the borrow checker now rejects, so `at_index`'s body moves into a field-wise `slot_mut(&mut overflow_list, &mut backing_buf, index)` that both `get` and `at_index` call; `at_index`'s public signature (used by `bun_resolver`) is unchanged. The three identical stale SAFETY comments at the raw-pointer lock sites and the stale comment in `get` are rewritten to describe what the guard actually borrows. Removes 1 `unsafe` block (the only lifetime transmute in the crate); one file, +31/-39 lines.

## Why

The guard's type now states that it borrows a specific mutex for the critical section, so the soundness of unlocking is checked by the compiler instead of resting on a comment-level claim that every container holding a `Mutex` is a never-freed singleton (true today, but nothing enforced it on new users of the type). It is zero-cost: lifetimes are erased before codegen, so `std::sync::MutexGuard<'a, ()>` and `<'static, ()>` are the same runtime type and `lock()`/`Drop` compile to the same code; `slot_mut` is `#[inline(always)]` with `at_index`'s previous body, and `get` takes the same lock over the same lookup as before. No layout, locking or behavior change.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/resolve/resolve.test.ts test/js/bun/resolve/import-meta.test.js test/cli/run/require-cache.test.ts`: 109 pass, 2 skip, 7 fail (resolve.test.ts 73 pass/2 skip, import-meta.test.js 32 pass, require-cache.test.ts 4 pass/7 fail).
The 7 require-cache.test.ts failures are the RSS leak-threshold/timeout tests ("don't leak the AST/file paths/output source code") and fail identically on main in this debug build (4 pass/7 fail, ~169 MB/71 MB reported on main vs ~159 MB/72 MB on the branch), so they are pre-existing and unrelated to the src/bun_alloc/lib.rs lifetime-only change.
