### PR TITLE
http_jsc: park the WebSocket upgrade client refs as OwnedRef fields (and Cell handshake state)

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketProxy.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxy.rs
@@ -1,5 +1,7 @@
 use core::ptr::NonNull;
 
+use bun_ptr::OwnedRef;
+
 use super::WebSocketProxyTunnel;
 
 /// WebSocketProxy encapsulates proxy state for WebSocket connections through HTTP/HTTPS proxies.
@@ -13,9 +15,9 @@ pub(crate) struct WebSocketProxy {
     target_is_https: bool,
     /// WebSocket upgrade request to send after CONNECT succeeds
     websocket_request_buf: Box<[u8]>,
-    /// TLS tunnel for wss:// through HTTP proxy
-    // Holds one intrusive ref; Drop calls shutdown()+deref().
-    tunnel: Option<NonNull<WebSocketProxyTunnel>>,
+    /// TLS tunnel for wss:// through HTTP proxy; `Drop` shuts it down before
+    /// the ref is released.
+    tunnel: Option<OwnedRef<WebSocketProxyTunnel>>,
 }
 
 impl WebSocketProxy {
@@ -46,12 +48,13 @@ impl WebSocketProxy {
 
     /// Get the TLS tunnel for wss:// through HTTP proxy
     pub(crate) fn get_tunnel(&self) -> Option<NonNull<WebSocketProxyTunnel>> {
-        self.tunnel
+        self.tunnel.as_ref().map(OwnedRef::as_non_null)
     }
 
-    /// Set the TLS tunnel
-    pub(crate) fn set_tunnel(&mut self, new_tunnel: Option<NonNull<WebSocketProxyTunnel>>) {
-        self.tunnel = new_tunnel;
+    /// Store the TLS tunnel; the proxy now holds the ref until it is dropped.
+    pub(crate) fn set_tunnel(&mut self, new_tunnel: OwnedRef<WebSocketProxyTunnel>) {
+        debug_assert!(self.tunnel.is_none(), "a connection creates one tunnel");
+        self.tunnel = Some(new_tunnel);
     }
 
     /// Take ownership of the WebSocket request buffer, clearing the internal reference.
@@ -66,12 +69,9 @@ impl Drop for WebSocketProxy {
     fn drop(&mut self) {
         // target_host / websocket_request_buf: Box<[u8]> drops automatically.
         if let Some(tunnel) = self.tunnel.take() {
-            // SAFETY: tunnel is a live intrusive-refcounted pointer; we hold one ref
-            // until deref() below releases it.
-            unsafe {
-                WebSocketProxyTunnel::shutdown(tunnel.as_ptr());
-                WebSocketProxyTunnel::deref(tunnel.as_ptr());
-            }
+            // SAFETY: `tunnel` holds a ref, so the tunnel is live.
+            unsafe { WebSocketProxyTunnel::shutdown(tunnel.as_ptr()) };
+            // `tunnel` drops here and releases the ref.
         }
     }
 }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -36,6 +36,7 @@ use core::ptr::NonNull;
 
 use bun_boringssl as boringssl;
 use bun_io::StreamBuffer;
+use bun_ptr::OwnedRef;
 use bun_uws::ssl_wrapper::{Handlers as SslHandlers, SslWrapper};
 use bun_uws::{NewSocketHandler, us_bun_verify_error_t};
 
@@ -142,13 +143,14 @@ use bun_uws::MaybeAnySocket as SocketUnion;
 type SslWrapperType = SslWrapper<*mut WebSocketProxyTunnel>;
 
 impl WebSocketProxyTunnel {
-    /// Initialize a new proxy tunnel with all required parameters
+    /// Initialize a new proxy tunnel with all required parameters. The
+    /// returned value holds the tunnel's only ref.
     pub(crate) fn init<const SSL: bool>(
         upgrade_client: *mut NewHttpUpgradeClient<SSL>,
         socket: NewSocketHandler<SSL>,
         sni_hostname: &[u8],
         reject_unauthorized: bool,
-    ) -> Result<NonNull<WebSocketProxyTunnel>, bun_alloc::AllocError> {
+    ) -> Result<OwnedRef<WebSocketProxyTunnel>, bun_alloc::AllocError> {
         // const-generic bool → variant selection. The pointer cast is
         // identity when SSL matches the alias (HttpUpgradeClient = NewHttpUpgradeClient<false>,
         // etc); `assume_ssl`/`assume_tcp` rebuild the handler around the same
@@ -165,7 +167,7 @@ impl WebSocketProxyTunnel {
             )
         };
 
-        let boxed = Box::new(WebSocketProxyTunnel {
+        Ok(OwnedRef::new(WebSocketProxyTunnel {
             ref_count: Cell::new(1),
             upgrade_client,
             connected_websocket: ptr::null_mut(),
@@ -175,10 +177,7 @@ impl WebSocketProxyTunnel {
             ssl: None,
             sni_hostname: Some(Box::<[u8]>::from(sni_hostname)),
             reject_unauthorized,
-        });
-        // ref_count initialized to 1; caller owns the Box allocation via the
-        // returned raw pointer (paired with `heap::take` in `deref()`).
-        Ok(bun_core::heap::into_raw_nn(boxed))
+        }))
     }
 
     /// Start TLS handshake inside the tunnel

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -34,7 +34,7 @@ use bun_http::{HeaderValueIterator, Headers};
 use bun_io::KeepAlive;
 use bun_jsc::{JSGlobalObject, VirtualMachineRef};
 use bun_picohttp as picohttp;
-use bun_ptr::ThisPtr;
+use bun_ptr::{OwnedRef, ThisPtr};
 use bun_uws::{self as uws, SocketHandler, SocketKind, SslCtx};
 
 use super::cpp_websocket::CppWebSocket;
@@ -130,17 +130,36 @@ impl Drop for SslCtxOwned {
     }
 }
 
+/// What the C++ `WebSocket`'s `m_upgradeClient` pointer stands for: the
+/// `WebSocket` to report to, and the ref that pointer holds on the client.
+/// Dropping the pair, after the last call into `websocket`, releases the ref.
+struct CppOwner<const SSL: bool> {
+    websocket: NonNull<CppWebSocket>,
+    _client_ref: OwnedRef<HTTPClient<SSL>>,
+}
+
 /// WebSocket HTTP upgrade client, generic over `SSL`.
 ///
-/// Intrusive single-thread
-/// refcount; `ref_count` field below, `ref()`/`deref()` inherent methods, `deinit`
-/// runs when count hits 0.
+/// Intrusive single-thread refcount (`ref_count` below); `deinit` runs when it
+/// hits 0. Both refs other code holds on the client are parked inside it as
+/// `OwnedRef` values (`socket_ref`, `cpp_owner`), so the count can only reach
+/// 0 once both fields are `None`; re-entrancy brackets use `ThisPtr::ref_guard`.
 #[derive(bun_ptr::CellRefCounted)]
 #[ref_count(destroy = Self::deinit)]
 pub struct HTTPClient<const SSL: bool> {
     ref_count: Cell<u32>,
+    /// The ref the socket's userdata pointer holds on us (the count `connect`
+    /// allocates with). Parked here because uSockets cannot run `Drop`; taken
+    /// and dropped by whichever path retires the socket: `handle_close`,
+    /// `handle_connect_error`, `cancel`, or the non-tunnel hand-off in
+    /// `process_response` (in tunnel mode the socket stays ours until
+    /// `handle_close`).
+    socket_ref: Cell<Option<OwnedRef<Self>>>,
+    /// The C++ side, from the moment `connect` hands our pointer out until
+    /// `cancel`, `dispatch_abrupt_close` or either hand-off in
+    /// `process_response` takes it. `None` before that and afterwards.
+    cpp_owner: Cell<Option<CppOwner<SSL>>>,
     tcp: Cell<Socket<SSL>>,
-    outgoing_websocket: Cell<Option<NonNull<CppWebSocket>>>,
     /// Owned request bytes. Freed via `clear_input`.
     input_body_buf: Vec<u8>,
     // The unsent bytes are always a suffix of `input_body_buf`; stored here as
@@ -198,14 +217,17 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// Called by `RefCount` when the count hits zero.
     ///
     /// # Safety
-    /// `this` must be the unique remaining pointer to a `Self` allocated via
-    /// `heap::alloc` in `connect`.
+    /// `this` must be the unique remaining pointer to a `Self` allocated by
+    /// `OwnedRef::new` in `connect`.
     unsafe fn deinit(this: *mut Self) {
         // SAFETY: caller guarantees `this` is the unique remaining ref.
         unsafe {
             (*this).clear_data();
             debug_assert!((*this).tcp.get().is_detached());
-            // allocated via heap::alloc in `connect`.
+            // A parked ref would have kept the count above zero.
+            debug_assert!((*this).socket_ref.get_mut().is_none());
+            debug_assert!((*this).cpp_owner.get_mut().is_none());
+            // Reclaims the box `OwnedRef::new` allocated in `connect`.
             bun_core::scoped_log!(alloc, "destroy({}) = {:p}", Self::TYPE_NAME, this);
             drop(bun_core::heap::take(this));
         }
@@ -219,6 +241,28 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
     fn detach_tcp(&self) {
         self.tcp.set(Socket::<SSL>::detached());
+    }
+
+    /// The C++ `WebSocket`, while `cpp_owner` is still parked.
+    fn outgoing_websocket(&self) -> Option<NonNull<CppWebSocket>> {
+        let owner = self.cpp_owner.take();
+        let websocket = owner.as_ref().map(|owner| owner.websocket);
+        self.cpp_owner.set(owner);
+        websocket
+    }
+
+    /// Success exit of `connect`: the socket's userdata now points at the
+    /// client, so the ref `client` holds becomes `socket_ref`; C++ gets a
+    /// second ref, parked in `cpp_owner`, and the raw pointer it stores in
+    /// `m_upgradeClient`.
+    fn park_refs(client: OwnedRef<Self>, websocket: &CppWebSocket) -> *mut Self {
+        let this = client.this_ptr();
+        this.cpp_owner.set(Some(CppOwner {
+            websocket: NonNull::from(websocket),
+            _client_ref: client.clone(),
+        }));
+        this.socket_ref.set(Some(client));
+        this.as_ptr()
     }
 
     /// On error, this returns null.
@@ -448,10 +492,18 @@ impl<const SSL: bool> HTTPClient<SSL> {
             None
         };
 
-        let client: *mut Self = bun_core::heap::into_raw(Box::new(HTTPClient::<SSL> {
+        // Every failure exit below drops this and destroys the client; the
+        // success exit parks it in `socket_ref`.
+        let client: OwnedRef<Self> = OwnedRef::new(HTTPClient::<SSL> {
             ref_count: Cell::new(1),
+            socket_ref: Cell::new(None),
+            // Filled by `park_refs` together with the ref it carries. Nothing
+            // reads it before then: `connect_group` / `connect_unix_group`
+            // install the client as socket userdata only once the connect call
+            // has returned, so no callback can reach it, and the failure exits
+            // below destroy it.
+            cpp_owner: Cell::new(None),
             tcp: Cell::new(Socket::<SSL>::detached()),
-            outgoing_websocket: Cell::new(Some(NonNull::from(websocket))),
             input_body_buf,
             to_send_len: Cell::new(0),
             headers_buf: [picohttp::Header::ZERO; 128],
@@ -465,110 +517,78 @@ impl<const SSL: bool> HTTPClient<SSL> {
             expected_accept: request_result.expected_accept,
             offered_permessage_deflate: offer_permessage_deflate,
             subprotocols,
-        }));
-        bun_core::scoped_log!(alloc, "new({}) = {:p}", Self::TYPE_NAME, client);
+        });
+        bun_core::scoped_log!(alloc, "new({}) = {:p}", Self::TYPE_NAME, client.as_ptr());
 
         // Unix domain socket path (ws+unix:// / wss+unix://)
         if let Some(usp) = &unix_socket_path_slice {
-            match Socket::<SSL>::connect_unix_group(
+            let Ok(socket) = Socket::<SSL>::connect_unix_group(
                 group,
                 kind,
                 secure_ptr,
                 usp.slice(),
-                client,
+                client.as_ptr(),
                 false,
-            ) {
-                Ok(socket) => {
-                    // SAFETY: `client` is live (refcount 1, allocated above). It
-                    // is now also the socket's userdata, so it is only ever
-                    // accessed shared from here on.
-                    let client = unsafe { ThisPtr::new(client) };
-                    client.tcp.set(socket);
-                    if client.state.get() == State::Failed {
-                        // SAFETY: `client` from heap::alloc above.
-                        unsafe { Self::deref(client.as_ptr()) };
-                        return None;
-                    }
-                    bun_analytics::features::web_socket
-                        .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            ) else {
+                return None;
+            };
+            client.tcp.set(socket);
+            if client.state.get() == State::Failed {
+                return None;
+            }
+            bun_analytics::features::web_socket.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
-                    if SSL {
-                        // SNI uses the URL host (defaulted to "localhost" in
-                        // C++ when absent), mirroring the TCP path below. A
-                        // user-supplied Host header does NOT affect SNI; use
-                        // `tls: { checkServerIdentity }` or put the hostname
-                        // in the URL (wss+unix://name/path) to verify against
-                        // a specific certificate name.
-                        if !host_slice.slice().is_empty() {
-                            // SAFETY: scoped write.
-                            unsafe {
-                                (*client.as_ptr()).hostname = ZBox::from_bytes(host_slice.slice());
-                            }
-                        }
+            if SSL {
+                // SNI uses the URL host (defaulted to "localhost" in
+                // C++ when absent), mirroring the TCP path below. A
+                // user-supplied Host header does NOT affect SNI; use
+                // `tls: { checkServerIdentity }` or put the hostname
+                // in the URL (wss+unix://name/path) to verify against
+                // a specific certificate name.
+                if !host_slice.slice().is_empty() {
+                    // SAFETY: scoped write; no borrow of `*client` is live.
+                    unsafe {
+                        (*client.as_ptr()).hostname = ZBox::from_bytes(host_slice.slice());
                     }
-
-                    socket.set_timeout(handshake_timeout_seconds());
-                    client.state.set(State::Reading);
-                    // +1 for cpp_websocket
-                    client.ref_();
-                    return Some(client.as_ptr());
-                }
-                Err(_) => {
-                    // SAFETY: `client` from heap::alloc above; never
-                    // installed as userdata on the Err path.
-                    unsafe { Self::deref(client) };
                 }
             }
-            return None;
+
+            socket.set_timeout(handshake_timeout_seconds());
+            client.state.set(State::Reading);
+            return Some(Self::park_refs(client, websocket));
         }
 
-        match Socket::<SSL>::connect_group(
+        let Ok(sock) = Socket::<SSL>::connect_group(
             group,
             kind,
             secure_ptr,
             display_host,
             c_int::from(connect_port),
-            client,
+            client.as_ptr(),
             false,
-        ) {
-            Ok(sock) => {
-                // SAFETY: `client` is live (refcount 1, allocated above). It is
-                // now also the socket's userdata, so it is only ever accessed
-                // shared from here on.
-                let client = unsafe { ThisPtr::new(client) };
-                client.tcp.set(sock);
-                // I don't think this case gets reached.
-                if client.state.get() == State::Failed {
-                    // SAFETY: `client` from heap::alloc above.
-                    unsafe { Self::deref(client.as_ptr()) };
-                    return None;
-                }
-                bun_analytics::features::web_socket
-                    .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        ) else {
+            return None;
+        };
+        client.tcp.set(sock);
+        // I don't think this case gets reached.
+        if client.state.get() == State::Failed {
+            return None;
+        }
+        bun_analytics::features::web_socket.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
-                if SSL {
-                    // SNI for the outer TLS socket must use the host we actually
-                    // dialed. For HTTPS proxy connections, that's the proxy host,
-                    // not the wss:// target.
-                    if !display_host_.is_empty() {
-                        // SAFETY: scoped write.
-                        unsafe { (*client.as_ptr()).hostname = ZBox::from_bytes(display_host_) };
-                    }
-                }
-
-                sock.set_timeout(handshake_timeout_seconds());
-                client.state.set(State::Reading);
-                // +1 for cpp_websocket
-                client.ref_();
-                Some(client.as_ptr())
-            }
-            Err(_) => {
-                // SAFETY: `client` from heap::alloc above; never installed
-                // as userdata on the Err path.
-                unsafe { Self::deref(client) };
-                None
+        if SSL {
+            // SNI for the outer TLS socket must use the host we actually
+            // dialed. For HTTPS proxy connections, that's the proxy host,
+            // not the wss:// target.
+            if !display_host_.is_empty() {
+                // SAFETY: scoped write; no borrow of `*client` is live.
+                unsafe { (*client.as_ptr()).hostname = ZBox::from_bytes(display_host_) };
             }
         }
+
+        sock.set_timeout(handshake_timeout_seconds());
+        client.state.set(State::Reading);
+        Some(Self::park_refs(client, websocket))
     }
 
     pub(crate) fn clear_input(&mut self) {
@@ -610,8 +630,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// `this` must point to a live `Self`. Takes `*mut Self` (not `&mut self`)
     /// because `tcp.close()` synchronously dispatches `handle_close` from the
     /// socket userdata pointer, which would alias a `&mut self` argument; and
-    /// the trailing `deref` may free `this`, which would violate a `&mut self`
-    /// argument protector.
+    /// it releases the parked refs, so the guard drop at the end may free
+    /// `this`, which would violate a `&mut self` argument protector.
     pub(crate) unsafe fn cancel(this: *mut Self) {
         // SAFETY: caller (C++ / uWS) holds a live ref; `this` carries root
         // (userdata) provenance from `heap::alloc`.
@@ -619,30 +639,25 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: short-lived `&mut` for clear_data; ends before any reentrant call.
         unsafe { (*this.as_ptr()).clear_data() };
 
-        // Either of the below two operations - closing the TCP socket or clearing the C++ reference could trigger a deref
-        // Therefore, we need to make sure the `this` pointer is valid until the end of the function.
-        // Bumps the intrusive refcount and derefs on Drop (after `tcp.close`
-        // below), which may free `this` — no `&`/`&mut Self` is live at that
-        // point.
+        // The parked refs are released below, so the guard is what keeps `this`
+        // live until the end of the function; its drop may free `this`.
         let _guard = this.ref_guard();
 
-        // The C++ end of the socket is no longer holding a reference to this, so we must clear it.
-        if this.outgoing_websocket.take().is_some() {
-            // SAFETY: refcount > 1 here (the +1 from `_guard` above).
-            unsafe { Self::deref(this.as_ptr()) };
-        }
+        // C++ is dropping its `m_upgradeClient` pointer.
+        drop(this.cpp_owner.take());
 
         let tcp = this.tcp.get();
         // Clear the socket's ext slot before closing. `us_socket_close` on a
-        // SEMI_SOCKET (TCP connect still in flight — the common case when
+        // SEMI_SOCKET (TCP connect still in flight, the common case when
         // `ws.close()` is called synchronously after `new WebSocket()`) skips
-        // dispatch entirely, so we cannot rely on `handle_close` /
-        // `handle_connect_error` to release the socket-userdata ref taken in
-        // `connect()`. Take it back here and deref it ourselves; any callback
-        // that does fire sees `ext == None` and no-ops via the
-        // `RawPtrHandler` guard.
-        let had_socket_ref = tcp
-            .ext::<Option<core::ptr::NonNull<Self>>>()
+        // dispatch entirely, so neither `handle_close` nor
+        // `handle_connect_error` would run to retire `socket_ref`: emptying the
+        // slot makes that our job, and any callback that does fire sees
+        // `ext == None` and no-ops via the `RawPtrHandler` guard. A slot that
+        // is already empty (or a detached `tcp`) belongs to the close path that
+        // emptied it, which drops `socket_ref` itself.
+        let retire_socket = tcp
+            .ext::<Option<NonNull<Self>>>()
             // SAFETY: ext slot is the `Option<NonNull<Self>>` written in
             // `connect_group`; single-threaded (JS thread), no other `&mut`
             // to it is live.
@@ -653,12 +668,11 @@ impl<const SSL: bool> HTTPClient<SSL> {
         } else {
             tcp.close(uws::CloseCode::Failure);
         }
-        if had_socket_ref {
+        if retire_socket {
             this.detach_tcp();
-            // SAFETY: refcount > 1 (the +1 from `_guard` above).
-            unsafe { Self::deref(this.as_ptr()) };
+            drop(this.socket_ref.take());
         }
-        // `_guard` drops here, balancing the ref above. May free `this`.
+        // `_guard` drops here. May free `this`.
     }
 
     /// # Safety
@@ -674,8 +688,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // Copy `tcp` out before dispatch so nothing touches `*this` after the
         // FFI call (which may reenter and pop our tag).
         let tcp = this.tcp.get();
-        // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
-        unsafe { Self::dispatch_abrupt_close(this.as_ptr(), code) };
+        Self::dispatch_abrupt_close(this, code);
 
         // A failed upgrade (bad status line, mismatched subprotocol, invalid
         // headers, ...) is an application-level rejection of a healthy TCP
@@ -685,35 +698,29 @@ impl<const SSL: bool> HTTPClient<SSL> {
         tcp.close(uws::CloseCode::Normal);
     }
 
-    /// # Safety
-    /// `this` must point to a live `Self`. Takes `*mut Self` because
-    /// `did_abrupt_close` runs JS error handlers and may re-enter via C++
-    /// `cancel()`, which would alias a `&mut self` argument; and the trailing
-    /// `deref` may free `this`.
-    unsafe fn dispatch_abrupt_close(this: *mut Self, code: ErrorCode) {
-        // SAFETY: short-lived take; `this` is live per caller contract.
-        let ws = unsafe { (*this).outgoing_websocket.take() };
-        if let Some(ws) = ws {
-            CppWebSocket::opaque_ref(ws.as_ptr()).did_abrupt_close(code);
-            // SAFETY: `this` carries root provenance; may free `this`.
-            unsafe { Self::deref(this) };
-        }
+    /// Tells C++ the upgrade failed and releases its ref, which may free
+    /// `this` (hence `ThisPtr`, not `&self`). No-op once `cpp_owner` is gone.
+    fn dispatch_abrupt_close(this: ThisPtr<Self>, code: ErrorCode) {
+        let Some(owner) = this.cpp_owner.take() else {
+            return;
+        };
+        CppWebSocket::opaque_ref(owner.websocket.as_ptr()).did_abrupt_close(code);
+        // `owner` drops here, after the last call into C++.
     }
 
-    /// Takes `ThisPtr<Self>` because the trailing `deref` releases the socket
-    /// ref and on the normal path frees `this`; a `&mut self` argument would
-    /// carry a Stacked Borrows protector that makes deallocating it UB.
+    /// Takes `ThisPtr<Self>` because retiring `socket_ref` at the end frees
+    /// `this` on the normal path; a `&mut self` argument would carry a Stacked
+    /// Borrows protector that makes deallocating it UB.
     pub fn handle_close(this: ThisPtr<Self>, _: Socket<SSL>, _: c_int, _: *mut c_void) {
         log!("onClose");
         bun_jsc::mark_binding!();
         // SAFETY: short-lived `&mut` borrows; each ends before the next call.
         unsafe { (*this.as_ptr()).clear_data() };
         this.detach_tcp();
-        // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
-        unsafe { Self::dispatch_abrupt_close(this.as_ptr(), ErrorCode::Ended) };
+        Self::dispatch_abrupt_close(this, ErrorCode::Ended);
 
-        // SAFETY: may free `this`; no `&mut Self` is live.
-        unsafe { Self::deref(this.as_ptr()) };
+        // The socket that dispatched this is gone; its ref goes with it.
+        drop(this.socket_ref.take());
     }
 
     /// # Safety
@@ -739,7 +746,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         let handshake_success = success == 1;
         let mut reject_unauthorized = false;
-        if let Some(ws) = this.outgoing_websocket.get() {
+        if let Some(ws) = this.outgoing_websocket() {
             reject_unauthorized = CppWebSocket::opaque_ref(ws.as_ptr()).reject_unauthorized();
         }
 
@@ -911,7 +918,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
-        if this.outgoing_websocket.get().is_none() {
+        if this.outgoing_websocket().is_none() {
             this.state.set(State::Failed);
             // SAFETY: short-lived `&mut` for clear_data; ends before `socket.close` below.
             unsafe { (*this.as_ptr()).clear_data() };
@@ -995,9 +1002,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let _scope = is_101
             .then(|| bun_jsc::virtual_machine::VirtualMachine::get().enter_event_loop_scope());
 
-        if let Some(ws) = this.outgoing_websocket.get() {
+        if let Some(ws) = this.outgoing_websocket() {
             Self::dispatch_handshake(ws, &response, if is_101 { &[] } else { &full[head_len..] });
-            if this.outgoing_websocket.get().is_none() {
+            if this.outgoing_websocket().is_none() {
                 return;
             }
         }
@@ -1112,17 +1119,19 @@ impl<const SSL: bool> HTTPClient<SSL> {
         log!("startProxyTLSHandshake");
 
         // Get certificate verification setting
-        // SAFETY: `this` is live; scoped read of a `Copy` field.
-        let reject_unauthorized = match unsafe { (*this).outgoing_websocket.get() } {
+        // SAFETY: `this` is live; the shared borrow ends with the call.
+        let reject_unauthorized = match unsafe { (*this).outgoing_websocket() } {
             Some(ws) => CppWebSocket::opaque_ref(ws.as_ptr()).reject_unauthorized(),
             None => true,
         };
 
-        // Create proxy tunnel with all parameters.
+        // Create proxy tunnel with all parameters. `tunnel` owns the ref `init`
+        // returns until `set_tunnel` moves it into the proxy; on every failure
+        // exit below it is dropped, which destroys the tunnel.
         // Safely unwrap proxy state - it must exist if we're called from handle_proxy_response.
         // SAFETY: `this` is live; the borrow covers only `proxy` and is dead
         // before the re-entrant calls below (`init` only allocates).
-        let tunnel = match unsafe { (*this).proxy.as_ref() } {
+        let tunnel: OwnedRef<WebSocketProxyTunnel> = match unsafe { (*this).proxy.as_ref() } {
             Some(p) => match WebSocketProxyTunnel::init::<SSL>(
                 this,
                 socket,
@@ -1157,26 +1166,27 @@ impl<const SSL: bool> HTTPClient<SSL> {
         };
 
         // Start TLS handshake
-        // SAFETY: `tunnel` was just allocated by `init` (live, ref_count == 1).
+        // SAFETY: `tunnel` holds a ref, so the tunnel is live.
         if unsafe { WebSocketProxyTunnel::start(tunnel.as_ptr(), &ssl_options, initial_data) }
             .is_err()
         {
-            // SAFETY: release the ref taken by `init`.
-            unsafe { WebSocketProxyTunnel::deref(tunnel.as_ptr()) };
+            drop(tunnel);
             // SAFETY: no borrow of `*this` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::ProxyTunnelFailed) };
             return;
         }
 
         // Re-check proxy state: `start` dispatches SSLWrapper callbacks that
-        // can fail the client and take `proxy`.
+        // can fail the client and take `proxy`. Nothing else refs the tunnel
+        // yet, so dropping it here destroys it.
         // SAFETY: `this` is live; the borrow covers only `proxy`.
         let Some(p) = (unsafe { (*this).proxy.as_mut() }) else {
+            drop(tunnel);
             // SAFETY: no borrow of `*this` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::ProxyTunnelFailed) };
             return;
         };
-        p.set_tunnel(Some(tunnel));
+        p.set_tunnel(tunnel);
         // SAFETY: scoped write; `p` is dead.
         unsafe { (*this).state.set(State::ProxyTlsHandshake) };
     }
@@ -1281,8 +1291,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// # Safety
     /// `this` must point to a live `Self`. Takes `*mut Self` because
     /// `terminate`/`tcp.close()` may synchronously dispatch `handle_close`
-    /// (aliased `&mut`), and the success path's double `deref` may free
-    /// `this` (argument-protector UB on `&mut self`).
+    /// (aliased `&mut`), and the non-tunnel success path releases both parked
+    /// refs, freeing `this` (argument-protector UB on `&mut self`).
     pub(crate) unsafe fn process_response(
         this: *mut Self,
         response: picohttp::Response,
@@ -1380,8 +1390,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
                                 break 'brk false;
                             }
 
-                            // SAFETY: short-lived read of `outgoing_websocket`.
-                            if let Some(ws) = unsafe { (*this).outgoing_websocket.get() } {
+                            // SAFETY: `this` is live; the shared borrow ends with the call.
+                            if let Some(ws) = unsafe { (*this).outgoing_websocket() } {
                                 let mut protocol_str = BunString::clone_latin1(protocol);
                                 CppWebSocket::opaque_ref(ws.as_ptr())
                                     .set_protocol(&mut protocol_str);
@@ -1591,36 +1601,36 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 bun_jsc::mark_binding!();
                 // SAFETY: short-lived reads.
                 let tcp = unsafe { (*this).tcp.get() };
-                // SAFETY: short-lived read; `this` is live per caller contract.
-                let has_ws = unsafe { (*this).outgoing_websocket.get().is_some() };
+                // SAFETY: `this` is live per caller contract; the shared borrow
+                // ends with the call.
+                let has_ws = unsafe { (*this).outgoing_websocket().is_some() };
                 if !tcp.is_closed() && has_ws {
                     tcp.set_timeout(0);
                     log!("onDidConnect (tunnel mode)");
 
-                    // Release the ref that paired with C++'s m_upgradeClient: C++
-                    // nulls m_upgradeClient inside didConnectWithTunnel() so it will
-                    // never call cancel() to drop it. The TCP socket's ref (released
-                    // in handle_close) is what keeps this struct alive to forward
-                    // socket data to the tunnel after we switch to .done.
+                    // C++ nulls m_upgradeClient inside didConnectWithTunnel() and
+                    // so never calls cancel(): `owner` is dropped at the end of this
+                    // arm instead. `socket_ref` stays parked and keeps this struct
+                    // alive to forward socket data to the tunnel until handle_close.
                     // SAFETY: short-lived take; `this` is live per caller contract.
-                    let ws = unsafe { (*this).outgoing_websocket.take().unwrap() };
+                    let owner = unsafe { (*this).cpp_owner.take().unwrap() };
 
                     // Switch to forwarding before entering C++. did_connect_with_tunnel
                     // dispatches `open`, and an open handler that spins the event loop
                     // (expect().resolves, a debugger pause) delivers socket data to
                     // handle_data while this frame is on the stack; with the state
-                    // still `Reading` and `outgoing_websocket` taken, handle_data
-                    // would fail the client and close the socket. In `Done` it hands
-                    // the bytes to the tunnel, whose SSL engine is still inside the
-                    // pass that decrypted the 101 and so queues them until that pass
-                    // resumes, by which point C++ has attached the connected WebSocket.
-                    // Same order as the non-tunnel arm below, which detaches the socket
+                    // still `Reading` and `cpp_owner` taken, handle_data would fail
+                    // the client and close the socket. In `Done` it hands the bytes
+                    // to the tunnel, whose SSL engine is still inside the pass that
+                    // decrypted the 101 and so queues them until that pass resumes,
+                    // by which point C++ has attached the connected WebSocket. Same
+                    // order as the non-tunnel arm below, which detaches the socket
                     // before did_connect.
                     // SAFETY: short-lived write.
                     unsafe { (*this).state.set(State::Done) };
 
                     // Create the WebSocket client with the tunnel
-                    CppWebSocket::opaque_ref(ws.as_ptr()).did_connect_with_tunnel(
+                    CppWebSocket::opaque_ref(owner.websocket.as_ptr()).did_connect_with_tunnel(
                         tunnel.as_ptr().cast::<c_void>(),
                         overflow_ptr,
                         overflow_len,
@@ -1631,8 +1641,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         },
                     );
 
-                    // SAFETY: drops the outgoing_websocket ref; no `&mut Self` is live.
-                    unsafe { Self::deref(this) };
+                    drop(owner);
                 } else if tcp.is_closed() {
                     // SAFETY: no `&mut Self` is live across this call.
                     unsafe { Self::terminate(this, ErrorCode::Cancel) };
@@ -1657,14 +1666,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
         bun_jsc::mark_binding!();
         // SAFETY: short-lived reads.
         let tcp = unsafe { (*this).tcp.get() };
-        // SAFETY: short-lived read; `this` is live per caller contract.
-        let has_ws = unsafe { (*this).outgoing_websocket.get().is_some() };
+        // SAFETY: `this` is live per caller contract; the shared borrow ends
+        // with the call.
+        let has_ws = unsafe { (*this).outgoing_websocket().is_some() };
         if !tcp.is_closed() && has_ws {
             tcp.set_timeout(0);
             log!("onDidConnect");
 
             // SAFETY: short-lived take; `this` is live per caller contract.
-            let ws = unsafe { (*this).outgoing_websocket.take().unwrap() };
+            let owner = unsafe { (*this).cpp_owner.take().unwrap() };
             let socket = tcp;
 
             // Normal mode: pass socket directly to WebSocket client
@@ -1675,7 +1685,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 // SAFETY: `native_socket` is the open socket checked above, and
                 // `into_raw` yields the retained `SSL_CTX` being handed over.
                 unsafe {
-                    CppWebSocket::opaque_ref(ws.as_ptr()).did_connect(
+                    CppWebSocket::opaque_ref(owner.websocket.as_ptr()).did_connect(
                         &mut *native_socket,
                         overflow_ptr,
                         overflow_len,
@@ -1693,15 +1703,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 // SAFETY: no `&mut Self` is live across this call.
                 unsafe { Self::terminate(this, ErrorCode::FailedToConnect) };
             }
-            // SAFETY: two refs are released here (the outgoing_websocket ref
-            // then the TCP socket ref). The first call cannot reach zero
-            // because the second ref is still held. The second may free
-            // `this`; no `&mut Self` is live.
-            // Once for the outgoing_websocket.
-            unsafe { Self::deref(this) };
-            // Once again for the TCP socket.
-            // SAFETY: releases the TCP-socket ref; may free `this` — no `&mut Self` is live.
-            unsafe { Self::deref(this) };
+            // Both parked refs are retired: C++ nulled m_upgradeClient inside
+            // didConnect(), and the socket now belongs to the connected
+            // WebSocket, so handle_close will never run for us. The second
+            // drop frees `this`.
+            // SAFETY: short-lived take; `owner` still holds a ref, so `this`
+            // is live.
+            let socket_ref = unsafe { (*this).socket_ref.take() };
+            drop(owner);
+            drop(socket_ref);
         } else if tcp.is_closed() {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::Cancel) };
@@ -1785,16 +1795,16 @@ impl<const SSL: bool> HTTPClient<SSL> {
         unsafe { Self::terminate(this.as_ptr(), ErrorCode::Timeout) };
     }
 
-    /// In theory, this could be called immediately.
-    /// In that case, we set `state` to `failed` and return, expecting the parent to call `destroy`.
+    /// In theory, this could be called immediately. In that case we set `state`
+    /// to `Failed` and return: `socket_ref` is not parked yet, and `connect`
+    /// destroys the client by dropping the ref it still holds.
     ///
-    /// Takes `ThisPtr<Self>` because the trailing `deref` releases the socket
-    /// ref and may free `this`; a `&mut self` argument would carry a Stacked
-    /// Borrows protector that makes deallocating its referent UB.
+    /// Takes `ThisPtr<Self>` because retiring `socket_ref` at the end may free
+    /// `this`; a `&mut self` argument would carry a Stacked Borrows protector
+    /// that makes deallocating its referent UB.
     pub fn handle_connect_error(this: ThisPtr<Self>, _: Socket<SSL>, _: c_int) {
         this.detach_tcp();
 
-        // For the TCP socket.
         if this.state.get() == State::Reading {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this.as_ptr(), ErrorCode::FailedToConnect) };
@@ -1802,8 +1812,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
             this.state.set(State::Failed);
         }
 
-        // SAFETY: may free `this`; no `&mut Self` is live.
-        unsafe { Self::deref(this.as_ptr()) };
+        // The socket was closed before this was dispatched; its ref goes with it.
+        drop(this.socket_ref.take());
     }
 }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -21,7 +21,7 @@
 
 use core::cell::Cell;
 use core::ffi::{c_int, c_void};
-use core::ptr;
+use core::ptr::{self, NonNull};
 use std::io::Write as _;
 
 use bun_boringssl as boringssl;
@@ -139,19 +139,19 @@ impl Drop for SslCtxOwned {
 #[ref_count(destroy = Self::deinit)]
 pub struct HTTPClient<const SSL: bool> {
     ref_count: Cell<u32>,
-    tcp: Socket<SSL>,
-    outgoing_websocket: Option<*mut CppWebSocket>,
+    tcp: Cell<Socket<SSL>>,
+    outgoing_websocket: Cell<Option<NonNull<CppWebSocket>>>,
     /// Owned request bytes. Freed via `clear_input`.
     input_body_buf: Vec<u8>,
     // The unsent bytes are always a suffix of `input_body_buf`; stored here as
     // the suffix length so we don't hold a self-referential slice.
-    to_send_len: usize,
+    to_send_len: Cell<usize>,
     headers_buf: [picohttp::Header; 128],
     body: Vec<u8>,
     /// Owned NUL-terminated hostname for SNI; empty when unset.
     hostname: ZBox,
     poll_ref: KeepAlive,
-    state: State,
+    state: Cell<State>,
     subprotocols: StringSet,
 
     /// Proxy state (None when not using proxy)
@@ -204,7 +204,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: caller guarantees `this` is the unique remaining ref.
         unsafe {
             (*this).clear_data();
-            debug_assert!((*this).tcp.is_detached());
+            debug_assert!((*this).tcp.get().is_detached());
             // allocated via heap::alloc in `connect`.
             bun_core::scoped_log!(alloc, "destroy({}) = {:p}", Self::TYPE_NAME, this);
             drop(bun_core::heap::take(this));
@@ -214,7 +214,11 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// Suffix of `input_body_buf` still pending write.
     fn to_send(&self) -> &[u8] {
         let len = self.input_body_buf.len();
-        &self.input_body_buf[len - self.to_send_len..]
+        &self.input_body_buf[len - self.to_send_len.get()..]
+    }
+
+    fn detach_tcp(&self) {
+        self.tcp.set(Socket::<SSL>::detached());
     }
 
     /// On error, this returns null.
@@ -222,7 +226,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) unsafe fn connect(
         global: &JSGlobalObject,
-        websocket: *mut CppWebSocket,
+        websocket: &CppWebSocket,
         host: &BunString,
         port: u16,
         pathname: &BunString,
@@ -446,15 +450,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         let client: *mut Self = bun_core::heap::into_raw(Box::new(HTTPClient::<SSL> {
             ref_count: Cell::new(1),
-            tcp: Socket::<SSL>::detached(),
-            outgoing_websocket: Some(websocket),
+            tcp: Cell::new(Socket::<SSL>::detached()),
+            outgoing_websocket: Cell::new(Some(NonNull::from(websocket))),
             input_body_buf,
-            to_send_len: 0,
+            to_send_len: Cell::new(0),
             headers_buf: [picohttp::Header::ZERO; 128],
             body: Vec::new(),
             hostname: ZBox::default(),
             poll_ref,
-            state: State::Initializing,
+            state: Cell::new(State::Initializing),
             proxy: proxy_state,
             ssl_config,
             secure,
@@ -475,15 +479,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 false,
             ) {
                 Ok(socket) => {
-                    // `client` is live (refcount >= 1) but no longer solely
-                    // owned — it is also installed as socket userdata — so
-                    // use field-scoped accesses only.
-                    // SAFETY: scoped write; nothing re-enters here.
-                    unsafe { (*client).tcp = socket };
-                    // SAFETY: scoped read of a `Copy` field.
-                    if unsafe { (*client).state } == State::Failed {
+                    // SAFETY: `client` is live (refcount 1, allocated above). It
+                    // is now also the socket's userdata, so it is only ever
+                    // accessed shared from here on.
+                    let client = unsafe { ThisPtr::new(client) };
+                    client.tcp.set(socket);
+                    if client.state.get() == State::Failed {
                         // SAFETY: `client` from heap::alloc above.
-                        unsafe { Self::deref(client) };
+                        unsafe { Self::deref(client.as_ptr()) };
                         return None;
                     }
                     bun_analytics::features::web_socket
@@ -499,18 +502,16 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         if !host_slice.slice().is_empty() {
                             // SAFETY: scoped write.
                             unsafe {
-                                (*client).hostname = ZBox::from_bytes(host_slice.slice());
+                                (*client.as_ptr()).hostname = ZBox::from_bytes(host_slice.slice());
                             }
                         }
                     }
 
                     socket.set_timeout(handshake_timeout_seconds());
-                    // SAFETY: scoped write.
-                    unsafe { (*client).state = State::Reading };
+                    client.state.set(State::Reading);
                     // +1 for cpp_websocket
-                    // SAFETY: `client` is live; `ref_` needs only `&self`.
-                    unsafe { (*client).ref_() };
-                    return Some(client);
+                    client.ref_();
+                    return Some(client.as_ptr());
                 }
                 Err(_) => {
                     // SAFETY: `client` from heap::alloc above; never
@@ -531,16 +532,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
             false,
         ) {
             Ok(sock) => {
-                // `client` is live (refcount >= 1) but no longer solely owned
-                // — it is also socket userdata — so use field-scoped accesses
-                // only.
-                // SAFETY: scoped write; nothing re-enters here.
-                unsafe { (*client).tcp = sock };
+                // SAFETY: `client` is live (refcount 1, allocated above). It is
+                // now also the socket's userdata, so it is only ever accessed
+                // shared from here on.
+                let client = unsafe { ThisPtr::new(client) };
+                client.tcp.set(sock);
                 // I don't think this case gets reached.
-                // SAFETY: scoped read of a `Copy` field.
-                if unsafe { (*client).state } == State::Failed {
+                if client.state.get() == State::Failed {
                     // SAFETY: `client` from heap::alloc above.
-                    unsafe { Self::deref(client) };
+                    unsafe { Self::deref(client.as_ptr()) };
                     return None;
                 }
                 bun_analytics::features::web_socket
@@ -552,17 +552,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     // not the wss:// target.
                     if !display_host_.is_empty() {
                         // SAFETY: scoped write.
-                        unsafe { (*client).hostname = ZBox::from_bytes(display_host_) };
+                        unsafe { (*client.as_ptr()).hostname = ZBox::from_bytes(display_host_) };
                     }
                 }
 
                 sock.set_timeout(handshake_timeout_seconds());
-                // SAFETY: scoped write.
-                unsafe { (*client).state = State::Reading };
+                client.state.set(State::Reading);
                 // +1 for cpp_websocket
-                // SAFETY: `client` is live; `ref_` needs only `&self`.
-                unsafe { (*client).ref_() };
-                Some(client)
+                client.ref_();
+                Some(client.as_ptr())
             }
             Err(_) => {
                 // SAFETY: `client` from heap::alloc above; never installed
@@ -575,7 +573,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
     pub(crate) fn clear_input(&mut self) {
         self.input_body_buf = Vec::new();
-        self.to_send_len = 0;
+        self.to_send_len.set(0);
     }
 
     pub(crate) fn clear_data(&mut self) {
@@ -629,14 +627,12 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let _guard = this.ref_guard();
 
         // The C++ end of the socket is no longer holding a reference to this, so we must clear it.
-        // SAFETY: short-lived `&mut` for the field take; ends before any reentrant call.
-        if unsafe { (*this.as_ptr()).outgoing_websocket.take().is_some() } {
+        if this.outgoing_websocket.take().is_some() {
             // SAFETY: refcount > 1 here (the +1 from `_guard` above).
             unsafe { Self::deref(this.as_ptr()) };
         }
 
-        // Copy `tcp` out so no `&mut Self` spans the close.
-        let tcp = this.tcp;
+        let tcp = this.tcp.get();
         // Clear the socket's ext slot before closing. `us_socket_close` on a
         // SEMI_SOCKET (TCP connect still in flight — the common case when
         // `ws.close()` is called synchronously after `new WebSocket()`) skips
@@ -658,8 +654,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             tcp.close(uws::CloseCode::Failure);
         }
         if had_socket_ref {
-            // SAFETY: short-lived `&mut` for the field detach.
-            unsafe { (*this.as_ptr()).tcp.detach() };
+            this.detach_tcp();
             // SAFETY: refcount > 1 (the +1 from `_guard` above).
             unsafe { Self::deref(this.as_ptr()) };
         }
@@ -678,7 +673,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let this = unsafe { ThisPtr::new(this) };
         // Copy `tcp` out before dispatch so nothing touches `*this` after the
         // FFI call (which may reenter and pop our tag).
-        let tcp = this.tcp;
+        let tcp = this.tcp.get();
         // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
         unsafe { Self::dispatch_abrupt_close(this.as_ptr(), code) };
 
@@ -696,10 +691,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// `cancel()`, which would alias a `&mut self` argument; and the trailing
     /// `deref` may free `this`.
     unsafe fn dispatch_abrupt_close(this: *mut Self, code: ErrorCode) {
-        // SAFETY: short-lived `&mut` for the field take; ends before the FFI call.
+        // SAFETY: short-lived take; `this` is live per caller contract.
         let ws = unsafe { (*this).outgoing_websocket.take() };
         if let Some(ws) = ws {
-            CppWebSocket::opaque_ref(ws).did_abrupt_close(code);
+            CppWebSocket::opaque_ref(ws.as_ptr()).did_abrupt_close(code);
             // SAFETY: `this` carries root provenance; may free `this`.
             unsafe { Self::deref(this) };
         }
@@ -713,8 +708,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         bun_jsc::mark_binding!();
         // SAFETY: short-lived `&mut` borrows; each ends before the next call.
         unsafe { (*this.as_ptr()).clear_data() };
-        // SAFETY: short-lived `&mut` for the field detach; `this` is live.
-        unsafe { (*this.as_ptr()).tcp.detach() };
+        this.detach_tcp();
         // SAFETY: forwards `this` with root provenance; no `&mut Self` is live.
         unsafe { Self::dispatch_abrupt_close(this.as_ptr(), ErrorCode::Ended) };
 
@@ -745,8 +739,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         let handshake_success = success == 1;
         let mut reject_unauthorized = false;
-        if let Some(ws) = this.outgoing_websocket {
-            reject_unauthorized = CppWebSocket::opaque_ref(ws).reject_unauthorized();
+        if let Some(ws) = this.outgoing_websocket.get() {
+            reject_unauthorized = CppWebSocket::opaque_ref(ws.as_ptr()).reject_unauthorized();
         }
 
         if handshake_success {
@@ -808,15 +802,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// Takes `ThisPtr<Self>` because `terminate` may free `this`; see `fail`.
     pub fn handle_open(this: ThisPtr<Self>, socket: Socket<SSL>) {
         log!("onOpen");
-        // SAFETY: scoped write; nothing re-enters here.
-        unsafe { (*this.as_ptr()).tcp = socket };
+        this.tcp.set(socket);
         // `us_internal_socket_after_open` zeroes the socket timeout when the
         // SEMI_SOCKET opens, so the value `connect()` armed only covered the
         // TCP connect. Re-arm so an accept-but-never-answer peer times out.
         socket.set_timeout(handshake_timeout_seconds());
 
         debug_assert!(!this.input_body_buf.is_empty());
-        debug_assert!(this.to_send_len == 0);
+        debug_assert!(this.to_send_len.get() == 0);
 
         if SSL {
             if !this.hostname.is_empty() {
@@ -844,8 +837,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         // If using proxy, set state to proxy_handshake
         if this.proxy.is_some() {
-            // SAFETY: scoped write.
-            unsafe { (*this.as_ptr()).state = State::ProxyHandshake };
+            this.state.set(State::ProxyHandshake);
         }
 
         let wrote = socket.write(&this.input_body_buf);
@@ -856,13 +848,12 @@ impl<const SSL: bool> HTTPClient<SSL> {
         }
 
         let pending = this.input_body_buf.len() - usize::try_from(wrote).expect("int cast");
-        // SAFETY: scoped write.
-        unsafe { (*this.as_ptr()).to_send_len = pending };
+        this.to_send_len.set(pending);
     }
 
     pub(crate) fn is_same_socket(&self, socket: Socket<SSL>) -> bool {
         // `InternalSocket` has no `PartialEq`; compare native handles.
-        socket.get_native_handle() == self.tcp.get_native_handle()
+        socket.get_native_handle() == self.tcp.get().get_native_handle()
     }
 
     fn buffer_and_parse_head(&mut self, data: &[u8]) -> HeadParse {
@@ -904,7 +895,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         // For tunnel mode after successful upgrade, forward all data to the tunnel
         // The tunnel will decrypt and pass to the WebSocket client
-        if this.state == State::Done {
+        if this.state.get() == State::Done {
             // SAFETY: short-lived `&mut` for the proxy borrow; ends before return.
             if let Some(p) = unsafe { &mut (*this.as_ptr()).proxy } {
                 if let Some(tunnel) = p.get_tunnel() {
@@ -920,9 +911,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
 
-        if this.outgoing_websocket.is_none() {
-            // SAFETY: short-lived `&mut` writes; each ends before `socket.close`.
-            unsafe { (*this.as_ptr()).state = State::Failed };
+        if this.outgoing_websocket.get().is_none() {
+            this.state.set(State::Failed);
             // SAFETY: short-lived `&mut` for clear_data; ends before `socket.close` below.
             unsafe { (*this.as_ptr()).clear_data() };
             // No `&mut Self` is live across this call (handle_close reenters).
@@ -938,7 +928,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         debug_assert!(!socket.is_shutdown());
 
         // Handle proxy handshake response
-        if this.state == State::ProxyHandshake {
+        if this.state.get() == State::ProxyHandshake {
             Self::handle_proxy_response(this, socket, data);
             return;
         }
@@ -971,7 +961,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
     }
 
     /// Forward the handshake response to C++ as a `'handshake'` event.
-    fn dispatch_handshake(ws: *mut CppWebSocket, response: &picohttp::Response, body: &[u8]) {
+    fn dispatch_handshake(ws: NonNull<CppWebSocket>, response: &picohttp::Response, body: &[u8]) {
         let raw_headers: Vec<super::cpp_websocket::RawHeader> = response
             .headers
             .list
@@ -983,7 +973,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 value_len: h.value().len(),
             })
             .collect();
-        CppWebSocket::opaque_ref(ws).did_receive_handshake_response(
+        CppWebSocket::opaque_ref(ws.as_ptr()).did_receive_handshake_response(
             u16::try_from(response.status_code).unwrap_or(0),
             response.status,
             &raw_headers,
@@ -1005,9 +995,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let _scope = is_101
             .then(|| bun_jsc::virtual_machine::VirtualMachine::get().enter_event_loop_scope());
 
-        if let Some(ws) = this.outgoing_websocket {
+        if let Some(ws) = this.outgoing_websocket.get() {
             Self::dispatch_handshake(ws, &response, if is_101 { &[] } else { &full[head_len..] });
-            if this.outgoing_websocket.is_none() {
+            if this.outgoing_websocket.get().is_none() {
                 return;
             }
         }
@@ -1091,13 +1081,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let request_buf = p.take_websocket_request_buf().into_vec();
 
         // For ws:// through proxy, send the WebSocket upgrade request
-        // SAFETY: scoped writes; `p` is dead, nothing re-enters here.
-        unsafe {
-            let me = this.as_ptr();
-            (*me).state = State::Reading;
-            (*me).input_body_buf = request_buf;
-            (*me).to_send_len = 0;
-        }
+        this.state.set(State::Reading);
+        // SAFETY: scoped write; `p` is dead, nothing re-enters here.
+        unsafe { (*this.as_ptr()).input_body_buf = request_buf };
+        this.to_send_len.set(0);
 
         // Send the WebSocket upgrade request
         let wrote = socket.write(&this.input_body_buf);
@@ -1108,8 +1095,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         }
 
         let pending = this.input_body_buf.len() - usize::try_from(wrote).expect("int cast");
-        // SAFETY: scoped write.
-        unsafe { (*this.as_ptr()).to_send_len = pending };
+        this.to_send_len.set(pending);
 
         // If there's remaining data after the proxy response, process it
         if !remain_buf.is_empty() {
@@ -1127,8 +1113,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         // Get certificate verification setting
         // SAFETY: `this` is live; scoped read of a `Copy` field.
-        let reject_unauthorized = match unsafe { (*this).outgoing_websocket } {
-            Some(ws) => CppWebSocket::opaque_ref(ws).reject_unauthorized(),
+        let reject_unauthorized = match unsafe { (*this).outgoing_websocket.get() } {
+            Some(ws) => CppWebSocket::opaque_ref(ws.as_ptr()).reject_unauthorized(),
             None => true,
         };
 
@@ -1192,7 +1178,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         };
         p.set_tunnel(Some(tunnel));
         // SAFETY: scoped write; `p` is dead.
-        unsafe { (*this).state = State::ProxyTlsHandshake };
+        unsafe { (*this).state.set(State::ProxyTlsHandshake) };
     }
 
     /// Called by WebSocketProxyTunnel when TLS handshake completes successfully
@@ -1207,9 +1193,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: scoped writes; nothing re-enters here. The Vec::new()
         // assignment frees the CONNECT request buffer.
         unsafe {
-            (*this).state = State::Reading;
+            (*this).state.set(State::Reading);
             (*this).input_body_buf = Vec::new();
-            (*this).to_send_len = 0;
+            (*this).to_send_len.set(0);
         }
 
         // Take the WebSocket upgrade request from proxy state (transfers
@@ -1253,7 +1239,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
         };
         // SAFETY: scoped read + write; nothing re-enters here.
-        unsafe { (*this).to_send_len = (*this).input_body_buf.len() - wrote };
+        unsafe {
+            let pending = (*this).input_body_buf.len() - wrote;
+            (*this).to_send_len.set(pending);
+        }
     }
 
     /// Called by WebSocketProxyTunnel with decrypted data from the TLS tunnel
@@ -1392,9 +1381,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
                             }
 
                             // SAFETY: short-lived read of `outgoing_websocket`.
-                            if let Some(ws) = unsafe { (*this).outgoing_websocket } {
+                            if let Some(ws) = unsafe { (*this).outgoing_websocket.get() } {
                                 let mut protocol_str = BunString::clone_latin1(protocol);
-                                CppWebSocket::opaque_ref(ws).set_protocol(&mut protocol_str);
+                                CppWebSocket::opaque_ref(ws.as_ptr())
+                                    .set_protocol(&mut protocol_str);
                                 // `BunString` is `Copy`; explicitly drop the
                                 // ref taken by `clone_latin1`.
                                 protocol_str.deref();
@@ -1600,9 +1590,9 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 // The tunnel forwards decrypted data to the WebSocket client.
                 bun_jsc::mark_binding!();
                 // SAFETY: short-lived reads.
-                let tcp = unsafe { (*this).tcp };
+                let tcp = unsafe { (*this).tcp.get() };
                 // SAFETY: short-lived read; `this` is live per caller contract.
-                let has_ws = unsafe { (*this).outgoing_websocket.is_some() };
+                let has_ws = unsafe { (*this).outgoing_websocket.get().is_some() };
                 if !tcp.is_closed() && has_ws {
                     tcp.set_timeout(0);
                     log!("onDidConnect (tunnel mode)");
@@ -1612,7 +1602,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     // never call cancel() to drop it. The TCP socket's ref (released
                     // in handle_close) is what keeps this struct alive to forward
                     // socket data to the tunnel after we switch to .done.
-                    // SAFETY: short-lived `&mut` for the field take.
+                    // SAFETY: short-lived take; `this` is live per caller contract.
                     let ws = unsafe { (*this).outgoing_websocket.take().unwrap() };
 
                     // Switch to forwarding before entering C++. did_connect_with_tunnel
@@ -1627,22 +1617,19 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     // Same order as the non-tunnel arm below, which detaches the socket
                     // before did_connect.
                     // SAFETY: short-lived write.
-                    unsafe { (*this).state = State::Done };
+                    unsafe { (*this).state.set(State::Done) };
 
                     // Create the WebSocket client with the tunnel
-                    // SAFETY: live C++ back-reference.
-                    unsafe {
-                        (*ws).did_connect_with_tunnel(
-                            tunnel.as_ptr().cast::<c_void>(),
-                            overflow_ptr,
-                            overflow_len,
-                            if deflate_result.enabled {
-                                Some(&deflate_result.params)
-                            } else {
-                                None
-                            },
-                        )
-                    };
+                    CppWebSocket::opaque_ref(ws.as_ptr()).did_connect_with_tunnel(
+                        tunnel.as_ptr().cast::<c_void>(),
+                        overflow_ptr,
+                        overflow_len,
+                        if deflate_result.enabled {
+                            Some(&deflate_result.params)
+                        } else {
+                            None
+                        },
+                    );
 
                     // SAFETY: drops the outgoing_websocket ref; no `&mut Self` is live.
                     unsafe { Self::deref(this) };
@@ -1669,25 +1656,26 @@ impl<const SSL: bool> HTTPClient<SSL> {
         unsafe { (*this).clear_data() };
         bun_jsc::mark_binding!();
         // SAFETY: short-lived reads.
-        let tcp = unsafe { (*this).tcp };
+        let tcp = unsafe { (*this).tcp.get() };
         // SAFETY: short-lived read; `this` is live per caller contract.
-        let has_ws = unsafe { (*this).outgoing_websocket.is_some() };
+        let has_ws = unsafe { (*this).outgoing_websocket.get().is_some() };
         if !tcp.is_closed() && has_ws {
             tcp.set_timeout(0);
             log!("onDidConnect");
 
-            // SAFETY: short-lived `&mut` for the field take/detach; ends before
-            // the FFI call below.
+            // SAFETY: short-lived take; `this` is live per caller contract.
             let ws = unsafe { (*this).outgoing_websocket.take().unwrap() };
             let socket = tcp;
 
             // Normal mode: pass socket directly to WebSocket client
-            // SAFETY: short-lived `&mut` for the field detach; ends before the FFI call below.
-            unsafe { (*this).tcp.detach() };
+            // SAFETY: `this` is live per caller contract; the shared borrow ends
+            // before the FFI call below.
+            unsafe { (*this).detach_tcp() };
             if let uws::InternalSocket::Connected(native_socket) = socket.socket {
-                // SAFETY: live C++ back-reference.
+                // SAFETY: `native_socket` is the open socket checked above, and
+                // `into_raw` yields the retained `SSL_CTX` being handed over.
                 unsafe {
-                    (*ws).did_connect(
+                    CppWebSocket::opaque_ref(ws.as_ptr()).did_connect(
                         &mut *native_socket,
                         overflow_ptr,
                         overflow_len,
@@ -1729,7 +1717,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
     pub(crate) fn memory_cost(&self) -> usize {
         let mut cost: usize = core::mem::size_of::<Self>();
         cost += self.body.capacity();
-        cost += self.to_send_len;
+        cost += self.to_send_len.get();
         cost
     }
 
@@ -1745,12 +1733,12 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 // SAFETY: `p` holds a live ref on `tunnel`.
                 unsafe { WebSocketProxyTunnel::on_writable(tunnel.as_ptr()) };
                 // In .done state (after WebSocket upgrade), just handle tunnel writes
-                if this.state == State::Done {
+                if this.state.get() == State::Done {
                     return;
                 }
 
                 // Flush any unwritten upgrade request bytes through the tunnel
-                if this.to_send_len == 0 {
+                if this.to_send_len.get() == 0 {
                     return;
                 }
                 // Bumps the intrusive refcount and derefs on Drop at every
@@ -1766,16 +1754,13 @@ impl<const SSL: bool> HTTPClient<SSL> {
                             return;
                         }
                     };
-                // SAFETY: short-lived `&mut` write.
-                unsafe {
-                    let to_send_len = &mut (*this.as_ptr()).to_send_len;
-                    *to_send_len -= wrote.min(*to_send_len);
-                }
+                let pending = this.to_send_len.get();
+                this.to_send_len.set(pending.saturating_sub(wrote));
                 return;
             }
         }
 
-        if this.to_send_len == 0 {
+        if this.to_send_len.get() == 0 {
             return;
         }
 
@@ -1790,11 +1775,8 @@ impl<const SSL: bool> HTTPClient<SSL> {
             return;
         }
         let wrote = usize::try_from(wrote).expect("int cast");
-        // SAFETY: short-lived `&mut` write.
-        unsafe {
-            let to_send_len = &mut (*this.as_ptr()).to_send_len;
-            *to_send_len -= wrote.min(*to_send_len);
-        }
+        let pending = this.to_send_len.get();
+        this.to_send_len.set(pending.saturating_sub(wrote));
     }
 
     /// Takes `ThisPtr<Self>` because `terminate` may free `this`; see `fail`.
@@ -1810,16 +1792,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
     /// ref and may free `this`; a `&mut self` argument would carry a Stacked
     /// Borrows protector that makes deallocating its referent UB.
     pub fn handle_connect_error(this: ThisPtr<Self>, _: Socket<SSL>, _: c_int) {
-        // SAFETY: short-lived `&mut` for detach; ends before any reentrant call.
-        unsafe { (*this.as_ptr()).tcp.detach() };
+        this.detach_tcp();
 
         // For the TCP socket.
-        if this.state == State::Reading {
+        if this.state.get() == State::Reading {
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this.as_ptr(), ErrorCode::FailedToConnect) };
         } else {
-            // SAFETY: short-lived write.
-            unsafe { (*this.as_ptr()).state = State::Failed };
+            this.state.set(State::Failed);
         }
 
         // SAFETY: may free `this`; no `&mut Self` is live.
@@ -2190,7 +2170,7 @@ macro_rules! export_http_client {
             #[unsafe(no_mangle)]
             pub(crate) unsafe extern "C" fn $connect(
                 global: &JSGlobalObject,
-                websocket: *mut CppWebSocket,
+                websocket: &CppWebSocket,
                 host: &BunString,
                 port: u16,
                 pathname: &BunString,


### PR DESCRIPTION
Stacked on #37665 (the base of this PR is that branch). Two commits: the original `Cell` fields change, and, following review ("can we use RAII types instead of ref_ and unref()"), a second commit that turns the refs held on the client into `OwnedRef` values.

## What

### 1. Handshake state in `Cell`s (first commit)

`HTTPClient<SSL>` in `src/http_jsc/websocket_client/WebSocketUpgradeClient.rs` (the WebSocket upgrade client) stored its handshake state as plain fields, and every socket handler, which only has a `ThisPtr<Self>` (`&Self`), updated them through a separate `unsafe { (*this.as_ptr()).state = State::Failed }` with its own SAFETY comment. `tcp`, `to_send_len` and `state` are now `Cell`s, the shape the connected `WebSocket<SSL>` in `websocket_client.rs` already uses for the same fields, and every access goes through `get` / `set`; the `Bun__WebSocketHTTP(S)Client__connect` shims take the `WebCore::WebSocket` handle as `&CppWebSocket`, the mapping the same signature already uses for `JSGlobalObject*`; `dispatch_handshake` and the two `did_connect*` calls go through `CppWebSocket::opaque_ref` like the other dispatch sites in the file; the two `handle_writable` decrements become `saturating_sub`. That commit removes 21 `unsafe` blocks and adds 2.

### 2. The refs held on the client become values (second commit)

Two parties hold a ref on an `HTTPClient` while it exists, and both were implemented as hand-paired `ref_()` / `Self::deref()` calls:

- the count `connect()` allocated with stood for the uSockets userdata pointer, and was released by hand at the four failure exits of `connect()`, in `handle_close`, `handle_connect_error`, `cancel` (only when the ext slot still held the pointer) and the non-tunnel hand-off in `process_response`;
- the "+1 for cpp_websocket" taken at the two success exits of `connect()` stood for `WebCore::WebSocket`'s `m_upgradeClient`, and was released wherever `outgoing_websocket.take()` returned `Some` (`cancel`, `dispatch_abrupt_close`, both hand-offs).

Now:

```rust
struct CppOwner<const SSL: bool> {
    websocket: NonNull<CppWebSocket>,
    _client_ref: OwnedRef<HTTPClient<SSL>>,
}

pub struct HTTPClient<const SSL: bool> {
    ref_count: Cell<u32>,
    socket_ref: Cell<Option<OwnedRef<Self>>>,   // the socket userdata's ref, parked here
    cpp_owner: Cell<Option<CppOwner<SSL>>>,     // replaces outgoing_websocket
    ...
}
```

- `connect()` allocates with `OwnedRef::new`, so the local is the initial ref: each of the four failure exits is now a plain `return None` and the local's drop destroys the client. On success, `park_refs()` moves the local into `socket_ref` and parks a clone of it, paired with the `WebSocket` pointer, in `cpp_owner`; C++ receives and stores the same raw pointer as before. (The field is `None` until then; nothing can observe that window, because the socket functions install the client as userdata only after the connect call returns, and a failure before that destroys it.)
- Every release site takes the matching field and lets the value drop at the point where the `deref` used to be, after the last call into C++: `handle_close` and `handle_connect_error` end with `drop(this.socket_ref.take())`; `dispatch_abrupt_close` takes `cpp_owner`, calls `did_abrupt_close`, and drops it (it is a safe fn now); the tunnel hand-off takes `cpp_owner` and drops it after `did_connect_with_tunnel` while `socket_ref` stays parked, since the client keeps forwarding socket data until `handle_close`; the non-tunnel hand-off drops `cpp_owner` and then `socket_ref`, the order of the two derefs it replaces. `cancel()` keeps its `ref_guard` bracket and still retires the socket only when the ext slot held the pointer (a close callback further up the stack otherwise releases `socket_ref` itself), so its behaviour is unchanged too. Reads of the C++ handle go through a small `outgoing_websocket()` accessor.
- `deinit` asserts both fields are empty: a parked ref would have kept the count above zero, so destruction can only happen once both holders have let go. `clear_data()` does not touch either field; the release points are exactly the sites above. No `ref_()` or `deref()` on `HTTPClient` remains.
- The same treatment for the proxy tunnel: `WebSocketProxyTunnel::init` returns `OwnedRef<WebSocketProxyTunnel>` (built with `OwnedRef::new`), `WebSocketProxy.tunnel` is `Option<OwnedRef<..>>`, and the proxy's `Drop` calls `shutdown()` and lets the field release the ref, in the order it used by hand. `start_proxy_tls_handshake` drops the local on its failure exits. One of those exits (the proxy was taken while `start()` ran) used to drop a bare `NonNull` and leak the tunnel, SSL state included; it now destroys it. That is the one behaviour change, and it is a leak fix: nothing else references the tunnel at that point and the client it points back to is still live while it is destroyed.

The second commit removes 18 `unsafe` blocks and adds 1 in the upgrade client (153 on main, 117 now across both commits), and `dispatch_abrupt_close` stops being an `unsafe fn`. The struct grows by two words (the two parked refs), which is what `memoryCost` reports for it.

## Why

Who holds a ref on the client, and where each one is released, is now stated by two fields and readable from their types: a retirement path cannot forget to release (the field is taken), cannot release twice (it is `None` the second time) and cannot release the wrong one, and `deinit` checks the invariant. The `Cell`s say which state the handlers update through a shared self-pointer. It is zero-cost: an `OwnedRef` is one pointer, a parked ref is the same increment the `ref_()` call was, and each `take()` + drop is the same decrement the removed `deref` was; `Cell` accessors on these `Copy` fields compile to the same loads and stores as the raw projections did.

Related to #30777: `connect()` is still an `unsafe fn` taking raw header pointers, so that issue stays open for a follow-up.

Part of a series of small type-system hardening changes.

## Verification

`cargo check` and `cargo clippy` are clean for `bun_http_jsc`. Debug build succeeds. `bun bd test` on the six files that exercise this code (websocket-client.test.ts, websocket-proxy.test.ts, websocket-close-connecting.test.ts, websocket-proxy-tunnel-upgrade-leak.test.ts, websocket-proxy-tunnel-client-leak.test.ts, websocket-proxy-close-reentrancy.test.ts): 78 pass, 4 skip (Docker-only Squid proxy cases), 0 fail; the two tunnel leak tests are the ones that count `new` / `destroy` of these objects. websocket.test.js also passes apart from `should connect many times over https`, which times out identically on main in this container (300 TLS connections on a debug ASAN build on a loaded machine); run alone it passes here too, with the WebSocket instance count returning to its baseline.


`cargo check --target x86_64-pc-windows-msvc` also passes for `bun_http_jsc` on this branch, so no platform-gated caller of the removed hand-written ref/deref entry points remains.
