### PR TITLE
shell_parser: back SmolList heap with &'a Bump, drop SmolListAlloc

### DIFF
--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -144,12 +144,14 @@ pub use bun_shell_parser::{escape_8bit, needs_escape_utf8_ascii_latin1};
 // lifetime-widening slice cast (`Script<'a>` → `Script<'static>`, identical
 // layout) at the arena/state-machine boundary.
 pub mod ast {
-    pub use bun_shell_parser::parse::SmolList;
+    use bun_shell_parser::parse::SmolList;
     use bun_shell_parser::parse::ast as p;
     pub use p::{BinaryOp, CondExprOp, IoKind, RedirectFlags};
 
     pub type Script = p::Script<'static>;
     pub type Stmt = p::Stmt<'static>;
+    /// `If::cond`, `If::then`, and each `If::else_parts` entry.
+    pub(crate) type StmtList = SmolList<'static, Stmt, 1>;
     pub type Expr = p::Expr<'static>;
     pub(crate) type Binary = p::Binary<'static>;
     pub type Pipeline = p::Pipeline<'static>;

--- a/src/runtime/shell/states/If.rs
+++ b/src/runtime/shell/states/If.rs
@@ -24,22 +24,22 @@ pub enum IfState {
 
 pub struct Exec {
     pub(crate) state: ExecBranch,
-    /// Back-reference to the current `SmolList<ast::Stmt, 1>` being walked.
+    /// Back-reference to the current `ast::StmtList` being walked.
     /// Points into the AST arena, which the interpreter holds for its entire
     /// lifetime — it outlives every state node.
-    pub(crate) stmts: bun_ptr::BackRef<ast::SmolList<ast::Stmt, 1>>,
+    pub(crate) stmts: bun_ptr::BackRef<ast::StmtList>,
     pub(crate) stmt_idx: u32,
     pub(crate) last_exit_code: ExitCode,
 }
 
 impl Exec {
-    /// Borrow the current `SmolList<Stmt, 1>` being walked.
+    /// Borrow the current `ast::StmtList` being walked.
     ///
     /// `stmts` always points into the AST arena (`ShellArgs::__arena`), which
     /// the interpreter holds for its entire lifetime — it outlives every state
     /// node (BackRef invariant).
     #[inline]
-    fn stmts(&self) -> &ast::SmolList<ast::Stmt, 1> {
+    fn stmts(&self) -> &ast::StmtList {
         self.stmts.get()
     }
 

--- a/src/shell_parser/json_fmt.rs
+++ b/src/shell_parser/json_fmt.rs
@@ -77,7 +77,10 @@ fn write_stmt(w: &mut impl Write, s: &Stmt<'_>) -> fmt::Result {
     w.write_char('}')
 }
 
-fn write_stmt_smol<const N: usize>(w: &mut impl Write, s: &SmolList<Stmt<'_>, N>) -> fmt::Result {
+fn write_stmt_smol<const N: usize>(
+    w: &mut impl Write,
+    s: &SmolList<'_, Stmt<'_>, N>,
+) -> fmt::Result {
     write_array(w, s.slice(), write_stmt)
 }
 

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -123,7 +123,7 @@ pub mod ast {
         pub args: CondExprArgList<'arena>,
     }
 
-    pub(crate) type CondExprArgList<'arena> = SmolList<Atom<'arena>, 2>;
+    pub(crate) type CondExprArgList<'arena> = SmolList<'arena, Atom<'arena>, 2>;
 
     impl<'arena> CondExpr<'arena> {
         pub(crate) fn to_expr(
@@ -327,8 +327,8 @@ pub mod ast {
 
     /// TODO: If we know cond/then/elif/else is just a single command we don't need to store the stmt
     pub struct If<'arena> {
-        pub cond: SmolList<Stmt<'arena>, 1>,
-        pub then: SmolList<Stmt<'arena>, 1>,
+        pub cond: SmolList<'arena, Stmt<'arena>, 1>,
+        pub then: SmolList<'arena, Stmt<'arena>, 1>,
         /// From the spec:
         ///
         /// else_part        : Elif compound_list Then else_part
@@ -339,7 +339,7 @@ pub mod ast {
         /// - 1                                   => just else
         /// - 2n (n is # of elif/then branches)   => n elif/then branches
         /// - 2n + 1                              => n elif/then branches and an else branch
-        pub else_parts: SmolList<SmolList<Stmt<'arena>, 1>, 1>,
+        pub else_parts: SmolList<'arena, SmolList<'arena, Stmt<'arena>, 1>, 1>,
     }
 
     impl<'arena> Default for If<'arena> {
@@ -1176,8 +1176,8 @@ impl<'bump> Parser<'bump> {
     fn parse_if_body(
         &mut self,
         until: &[IfClauseTok],
-    ) -> ParseResult<SmolList<ast::Stmt<'bump>, 1>> {
-        let mut ret: SmolList<ast::Stmt<'bump>, 1> = SmolList::zeroes();
+    ) -> ParseResult<SmolList<'bump, ast::Stmt<'bump>, 1>> {
+        let mut ret: SmolList<'bump, ast::Stmt<'bump>, 1> = SmolList::zeroes();
         while if self.inside_subshell.is_none() {
             !self.peek_any_comptime_ifclausetok(until) && !self.peek_any_comptime(&[TokenTag::Eof])
         } else {
@@ -1213,7 +1213,8 @@ impl<'bump> Parser<'bump> {
 
         let then = self.parse_if_body(&[IfClauseTok::Else, IfClauseTok::Elif, IfClauseTok::Fi])?;
 
-        let mut else_parts: SmolList<SmolList<ast::Stmt<'bump>, 1>, 1> = SmolList::zeroes();
+        let mut else_parts: SmolList<'bump, SmolList<'bump, ast::Stmt<'bump>, 1>, 1> =
+            SmolList::zeroes();
 
         let if_clause_tok = match IfClauseTok::from_tok(self, self.peek()) {
             Some(t) => t,
@@ -4131,71 +4132,13 @@ pub fn is_if_clause_keyword_bunstr(bunstr: BunString) -> bool {
 
 // ───────────────────────────── SmolList ─────────────────────────────
 
-/// `Allocator` routing `SmolList::Heap` through the parser arena. Must not outlive the arena.
-#[derive(Clone, Copy)]
-pub struct SmolListAlloc(core::ptr::NonNull<Bump>);
-
-// SAFETY: just a pointer to a `Send + Sync` `MimallocArena`.
-unsafe impl Send for SmolListAlloc {}
-// SAFETY: just a pointer to a `Send + Sync` `MimallocArena`.
-unsafe impl Sync for SmolListAlloc {}
-
-impl SmolListAlloc {
-    #[inline]
-    fn new(bump: &Bump) -> Self {
-        Self(core::ptr::NonNull::from(bump))
-    }
-    #[inline]
-    fn arena(&self) -> &Bump {
-        // SAFETY: the arena outlives `self`.
-        unsafe { self.0.as_ref() }
-    }
-}
-
-// SAFETY: forwards every method to `&Bump`'s `Allocator` impl; clones hold the
-// same arena pointer, so blocks stay valid across clones until the arena drops.
-unsafe impl core::alloc::Allocator for SmolListAlloc {
-    #[inline]
-    fn allocate(
-        &self,
-        layout: core::alloc::Layout,
-    ) -> Result<core::ptr::NonNull<[u8]>, core::alloc::AllocError> {
-        core::alloc::Allocator::allocate(&self.arena(), layout)
-    }
-    #[inline]
-    unsafe fn deallocate(&self, ptr: core::ptr::NonNull<u8>, layout: core::alloc::Layout) {
-        // SAFETY: caller upholds `deallocate`'s contract; `ptr`/`layout` came from this arena.
-        unsafe { core::alloc::Allocator::deallocate(&self.arena(), ptr, layout) }
-    }
-    #[inline]
-    unsafe fn grow(
-        &self,
-        ptr: core::ptr::NonNull<u8>,
-        old: core::alloc::Layout,
-        new: core::alloc::Layout,
-    ) -> Result<core::ptr::NonNull<[u8]>, core::alloc::AllocError> {
-        // SAFETY: caller upholds `grow`'s contract; `ptr`/`old` came from this arena.
-        unsafe { core::alloc::Allocator::grow(&self.arena(), ptr, old, new) }
-    }
-    #[inline]
-    unsafe fn shrink(
-        &self,
-        ptr: core::ptr::NonNull<u8>,
-        old: core::alloc::Layout,
-        new: core::alloc::Layout,
-    ) -> Result<core::ptr::NonNull<[u8]>, core::alloc::AllocError> {
-        // SAFETY: caller upholds `shrink`'s contract; `ptr`/`old` came from this arena.
-        unsafe { core::alloc::Allocator::shrink(&self.arena(), ptr, old, new) }
-    }
-}
-
-pub(crate) type SmolListHeap<T> = Vec<T, SmolListAlloc>;
+pub(crate) type SmolListHeap<'a, T> = Vec<T, &'a Bump>;
 
 /// A list that can store its items inlined, and promote itself to an
 /// arena-backed heap list.
-pub enum SmolList<T, const INLINED_MAX: usize> {
+pub enum SmolList<'a, T, const INLINED_MAX: usize> {
     Inlined(SmolListInlined<T, INLINED_MAX>),
-    Heap(SmolListHeap<T>),
+    Heap(SmolListHeap<'a, T>),
 }
 
 pub struct SmolListInlined<T, const INLINED_MAX: usize> {
@@ -4227,8 +4170,8 @@ impl<T, const INLINED_MAX: usize> SmolListInlined<T, INLINED_MAX> {
         }
     }
 
-    fn promote(&mut self, n: usize, new: T, bump: &Bump) -> SmolListHeap<T> {
-        let mut list = Vec::with_capacity_in(n + 1, SmolListAlloc::new(bump));
+    fn promote<'a>(&mut self, n: usize, new: T, bump: &'a Bump) -> SmolListHeap<'a, T> {
+        let mut list = Vec::with_capacity_in(n + 1, bump);
         for i in 0..INLINED_MAX {
             // SAFETY: all INLINED_MAX slots are initialized when promote is called (len == INLINED_MAX)
             let v = unsafe { self.items[i].assume_init_read() };
@@ -4240,7 +4183,7 @@ impl<T, const INLINED_MAX: usize> SmolListInlined<T, INLINED_MAX> {
     }
 }
 
-impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
+impl<'a, T, const INLINED_MAX: usize> SmolList<'a, T, INLINED_MAX> {
     pub(crate) fn zeroes() -> Self {
         SmolList::Inlined(SmolListInlined::default())
     }
@@ -4252,7 +4195,7 @@ impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
         SmolList::Inlined(inlined)
     }
 
-    pub(crate) fn init_with_slice(vals: &[T], bump: &Bump) -> Self
+    pub(crate) fn init_with_slice(vals: &[T], bump: &'a Bump) -> Self
     where
         T: Clone,
     {
@@ -4265,7 +4208,7 @@ impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
             inlined.len = u32::try_from(vals.len()).expect("int cast");
             return SmolList::Inlined(inlined);
         }
-        let mut heap = Vec::with_capacity_in(vals.len(), SmolListAlloc::new(bump));
+        let mut heap = Vec::with_capacity_in(vals.len(), bump);
         heap.extend_from_slice(vals);
         SmolList::Heap(heap)
     }
@@ -4304,7 +4247,7 @@ impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
         &self.slice()[idx]
     }
 
-    pub(crate) fn append(&mut self, new: T, bump: &Bump) {
+    pub(crate) fn append(&mut self, new: T, bump: &'a Bump) {
         match self {
             SmolList::Inlined(inlined) => {
                 if inlined.len as usize == INLINED_MAX {
@@ -4322,7 +4265,7 @@ impl<T, const INLINED_MAX: usize> SmolList<T, INLINED_MAX> {
     }
 }
 
-impl<T, const N: usize> core::ops::Index<usize> for SmolList<T, N> {
+impl<'a, T, const N: usize> core::ops::Index<usize> for SmolList<'a, T, N> {
     type Output = T;
     #[inline]
     fn index(&self, idx: usize) -> &T {
@@ -4330,7 +4273,7 @@ impl<T, const N: usize> core::ops::Index<usize> for SmolList<T, N> {
     }
 }
 
-impl<T, const N: usize> Drop for SmolList<T, N> {
+impl<'a, T, const N: usize> Drop for SmolList<'a, T, N> {
     fn drop(&mut self) {
         // Heap: the Vec drops itself.
         // Inlined: drop the initialized prefix so `T: Drop` elements are not
@@ -4345,7 +4288,7 @@ impl<T, const N: usize> Drop for SmolList<T, N> {
     }
 }
 
-impl<T: fmt::Debug, const N: usize> fmt::Display for SmolList<T, N> {
+impl<'a, T: fmt::Debug, const N: usize> fmt::Display for SmolList<'a, T, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.slice())
     }


### PR DESCRIPTION
## What

`SmolList<T, N>` (the inline-or-arena list behind `ast::If::{cond, then, else_parts}` and `ast::CondExprArgList` in `src/shell_parser/parse.rs`) stored its heap variant as `Vec<T, SmolListAlloc>`, where `SmolListAlloc` was a `NonNull<Bump>` newtype documented as "must not outlive the arena". Keeping that newtype usable as a `Vec` allocator took two `unsafe impl Send`/`Sync`, an `unsafe` deref in `arena()`, and a 35 line `unsafe impl Allocator` whose four methods only forwarded to the `unsafe impl Allocator for &MimallocArena` that `bun_alloc` already provides. The list now names the arena lifetime and the heap variant holds the arena reference itself:

```rust
// before
pub(crate) type SmolListHeap<T> = Vec<T, SmolListAlloc>;
pub enum SmolList<T, const N: usize> { Inlined(..), Heap(SmolListHeap<T>) }
fn promote(&mut self, n: usize, new: T, bump: &Bump) -> SmolListHeap<T>
pub(crate) fn init_with_slice(vals: &[T], bump: &Bump) -> Self
pub(crate) fn append(&mut self, new: T, bump: &Bump)

// after
pub(crate) type SmolListHeap<'a, T> = Vec<T, &'a Bump>;
pub enum SmolList<'a, T, const N: usize> { Inlined(..), Heap(SmolListHeap<'a, T>) }
fn promote<'a>(&mut self, n: usize, new: T, bump: &'a Bump) -> SmolListHeap<'a, T>
pub(crate) fn init_with_slice(vals: &[T], bump: &'a Bump) -> Self
pub(crate) fn append(&mut self, new: T, bump: &'a Bump)
```

`SmolListAlloc` and its four impls are deleted, removing 7 `unsafe` items (2 auto-trait impls, 1 trait impl, 4 blocks). Every embedding already carried the arena lifetime, so the type-level changes are spelling it: `CondExprArgList<'arena>`, the three `If<'arena>` fields, the two locals and one return type in `parse_if_body`/`parse_if_clause`, and `write_stmt_smol` in `json_fmt.rs`. The `append`/`init_with_slice` call sites (6) already pass `Parser::alloc: &'bump Bump` and are unchanged. The interpreter, which erases the AST to `'static` in `src/runtime/shell/mod.rs`, gains `ast::StmtList = SmolList<'static, Stmt, 1>` next to the other erased aliases, and the two spellings in `states/If.rs` use it; the `SmolList` re-export that alias replaces is dropped. Four files, +31/-83 lines.

## Why

The lifetime that the deleted doc comment and `SAFETY` comments asserted ("the arena outlives `self`") is now carried by the type: a `SmolList<'a, ..>` cannot be built from, or appended with, an arena that does not live for `'a`, and `Send`/`Sync` follow from `&MimallocArena` instead of two hand-written unsafe impls. It is zero-cost: `&'a MimallocArena` is one non-null pointer exactly like `NonNull<Bump>`, so `Vec<T, &'a Bump>` has the same size, alignment and niche as `Vec<T, SmolListAlloc>` (and `SmolList` the same layout, which the interpreter's `Script<'a>` to `Script<'static>` widening relies on), and every allocator call was already forwarded to the `&MimallocArena` impl through `#[inline]` wrappers, so the generated code is the same.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/bun/shell/parse.test.ts test/js/bun/shell/bunshell.test.ts test/js/bun/shell/shell-seq-condexpr.test.ts: 432 pass, 2 skip, 87 todo, 9 fail. The 9 failures (all in bunshell.test.ts: condexprs "-f character device", condexprs "-c", and the 7 "stdin redirect from a zero-length buffer" cases) fail identically on main (409 pass / 9 fail) and are pre-existing, caused by /dev/null being a regular file in this environment rather than a character device; parse.test.ts and shell-seq-condexpr.test.ts pass fully.
