### PR TITLE
Bun.serve HTTP/3: validate :path and :authority before building req.url

### DIFF
--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -35,12 +35,10 @@ struct Http3Context {
             rd->reset();
 
             Http3Request req(s);
-            /* RFC 9114 §4.3.1: :path is the path and query of the target URI
-             * (origin-form), or "*" for OPTIONS; anything else is malformed
-             * (§4.1.2). HttpParser rejects asterisk-form too for HTTP/1, and
-             * HttpRouter assumes a leading '/', so only origin-form is routed:
-             * it would otherwise route on whatever follows the first byte of an
-             * absolute URL, "*", "xfoo", ... while req.url carried it verbatim. */
+            /* RFC 9114 §4.3.1: :path is the path and query of the target URI, or "*"
+             * for OPTIONS; anything else is malformed (§4.1.2). HttpRouter assumes a
+             * leading '/', and HttpParser rejects asterisk-form for HTTP/1 as well,
+             * so only origin-form is routed. */
             std::string_view fullUrl = req.getFullUrl();
             if (fullUrl.empty() || fullUrl[0] != '/') {
                 res->writeStatus("400 Bad Request")->end();

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -35,11 +35,12 @@ struct Http3Context {
             rd->reset();
 
             Http3Request req(s);
-            /* RFC 9114 §4.3.1: :path is the path and query of the target URI, so
-             * anything but origin-form is malformed (§4.1.2). HttpParser rejects
-             * the HTTP/1 equivalents before routing; HttpRouter assumes a leading
-             * '/' and would otherwise route on whatever follows the first byte of
-             * an absolute URL, "*", "xfoo", ... while req.url carried it verbatim. */
+            /* RFC 9114 §4.3.1: :path is the path and query of the target URI
+             * (origin-form), or "*" for OPTIONS; anything else is malformed
+             * (§4.1.2). HttpParser rejects asterisk-form too for HTTP/1, and
+             * HttpRouter assumes a leading '/', so only origin-form is routed:
+             * it would otherwise route on whatever follows the first byte of an
+             * absolute URL, "*", "xfoo", ... while req.url carried it verbatim. */
             std::string_view fullUrl = req.getFullUrl();
             if (fullUrl.empty() || fullUrl[0] != '/') {
                 res->writeStatus("400 Bad Request")->end();

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -35,6 +35,16 @@ struct Http3Context {
             rd->reset();
 
             Http3Request req(s);
+            /* RFC 9114 §4.3.1: :path is the path and query of the target URI, so
+             * anything but origin-form is malformed (§4.1.2). HttpParser rejects
+             * the HTTP/1 equivalents before routing; HttpRouter assumes a leading
+             * '/' and would otherwise route on whatever follows the first byte of
+             * an absolute URL, "*", "xfoo", ... while req.url carried it verbatim. */
+            std::string_view fullUrl = req.getFullUrl();
+            if (fullUrl.empty() || fullUrl[0] != '/') {
+                res->writeStatus("400 Bad Request")->end();
+                return;
+            }
             if (req.getHeader("expect") == "100-continue") res->writeContinue();
             cd->router.getUserData() = {res, &req};
             if (!cd->router.route(req.getMethod(), req.getUrl())) {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3270,9 +3270,7 @@ where
                     std::ptr::from_mut(req).cast::<c_void>(),
                 ))
             }));
-            // `:authority` surfaces as the `host` header. Same synthesis as the
-            // HTTP/1 lazy path, so a value that cannot form a URL authority is
-            // left out of `req.url` here too.
+            // uWS surfaces `:authority` as the `host` header.
             request_object
                 .set_url_from_request_target(ReqLike::header(req, b"host"), ReqLike::url(req));
             ctx.clear_req();

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -280,14 +280,14 @@ where
 // touching `bun_uws_sys`. Only the surface `prepare_js_request_context_for`
 // actually needs is exposed.
 trait ReqLike {
-    fn header(&mut self, name: &[u8]) -> Option<&[u8]>;
+    fn header(&self, name: &[u8]) -> Option<&[u8]>;
     fn method(&mut self) -> &[u8];
-    fn url(&mut self) -> &[u8];
+    fn url(&self) -> &[u8];
     fn set_yield(&mut self, y: bool);
 }
 impl ReqLike for uws_sys::Request {
     #[inline]
-    fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
+    fn header(&self, name: &[u8]) -> Option<&[u8]> {
         uws_sys::Request::header(self, name)
     }
     #[inline]
@@ -295,7 +295,7 @@ impl ReqLike for uws_sys::Request {
         uws_sys::Request::method(self)
     }
     #[inline]
-    fn url(&mut self) -> &[u8] {
+    fn url(&self) -> &[u8] {
         uws_sys::Request::url(self)
     }
     #[inline]
@@ -305,7 +305,7 @@ impl ReqLike for uws_sys::Request {
 }
 impl ReqLike for uws_sys::h3::Request {
     #[inline]
-    fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
+    fn header(&self, name: &[u8]) -> Option<&[u8]> {
         uws_sys::h3::Request::header(self, name)
     }
     #[inline]
@@ -313,7 +313,7 @@ impl ReqLike for uws_sys::h3::Request {
         uws_sys::h3::Request::method(self)
     }
     #[inline]
-    fn url(&mut self) -> &[u8] {
+    fn url(&self) -> &[u8] {
         uws_sys::h3::Request::url(self)
     }
     #[inline]
@@ -3270,31 +3270,11 @@ where
                     std::ptr::from_mut(req).cast::<c_void>(),
                 ))
             }));
-            // NOTE: `ReqLike::{url,header}` both borrow `&mut req`; the
-            // returned slices alias the same uWS-owned header buffer. Format
-            // the `https://{host}` prefix while `host` is borrowed so the
-            // second `&mut req` borrow for `url` is unconflicted.
-            let prefix: Option<Vec<u8>> = ReqLike::header(req, b"host").map(|host| {
-                let fmt = bun_fmt::HostFormatter {
-                    is_https: true,
-                    host,
-                    port: None,
-                };
-                let mut s = Vec::new();
-                write!(&mut s, "https://{}", fmt).ok();
-                s
-            });
-            let path = ReqLike::url(req);
-            if !path.is_empty() && path[0] == b'/' {
-                if let Some(mut s) = prefix {
-                    s.extend_from_slice(path);
-                    request_object.url.set(BunString::clone_utf8(&s));
-                } else {
-                    request_object.url.set(BunString::clone_utf8(path));
-                }
-            } else {
-                request_object.url.set(BunString::clone_utf8(path));
-            }
+            // `:authority` surfaces as the `host` header. Same synthesis as the
+            // HTTP/1 lazy path, so a value that cannot form a URL authority is
+            // left out of `req.url` here too.
+            request_object
+                .set_url_from_request_target(ReqLike::header(req, b"host"), ReqLike::url(req));
             ctx.clear_req();
         }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -860,9 +860,7 @@ impl Request {
         }
     }
 
-    /// RFC 3986 3.2.2 `uri-host [ ":" port ]` byte set. A Host value outside it, or an empty
-    /// one, cannot form a URL authority, so `request.url` synthesis falls back to the bare
-    /// request target instead of pasting the client bytes into the URL.
+    /// RFC 3986 3.2.2 `uri-host [ ":" port ]` byte set; anything else cannot be a URL authority.
     fn is_valid_host_header(host: &[u8]) -> bool {
         !host.is_empty()
             && host.iter().all(|&c| {
@@ -891,9 +889,7 @@ impl Request {
             })
     }
 
-    /// The authority `request.url` is synthesized with: the client's `Host` (HTTP/1) or
-    /// `:authority` (HTTP/3) value, but only for an origin-form target and only when the
-    /// value can form a URL authority. `None` means `request.url` is the bare target.
+    /// `Some(host)` when `request.url` gets an authority; `None` leaves it as the bare target.
     fn url_authority<'a>(host: Option<&'a [u8]>, path: &[u8]) -> Option<&'a [u8]> {
         if !path.is_empty() && path[0] == b'/' {
             host.filter(|host| Self::is_valid_host_header(host))
@@ -915,11 +911,8 @@ impl Request {
         Ok(())
     }
 
-    /// Synthesizes `request.url` from the raw request target and the client-supplied
-    /// authority (`Host` for HTTP/1, `:authority` for HTTP/3). HTTP/1 gets here lazily via
-    /// [`Self::ensure_url`]; HTTP/3 eagerly from the server, since its uWS request does not
-    /// outlive the dispatch. Both transports share this so the authority filter and the URL
-    /// normalization cannot drift between them.
+    /// Shared by HTTP/1 (`ensure_url`, lazily) and HTTP/3 (the server, eagerly: its uWS
+    /// request dies with the dispatch) so `request.url` is built by one set of rules.
     pub(crate) fn set_url_from_request_target(&self, host: Option<&[u8]>, target: &[u8]) {
         let req_url = Self::request_target_path(target);
         let Some(host) = Self::url_authority(host, &req_url) else {
@@ -927,10 +920,8 @@ impl Request {
             return;
         };
 
-        // Assemble the URL with straight slice copies instead of going through
-        // `core::fmt::write` (which is not monomorphized and shows up in per-request
-        // profiles). When the WHATWG parser rejects the result (e.g. a port out of
-        // range), the raw concatenation is kept.
+        // Slice copies, not `core::fmt::write` (not monomorphized; shows up in per-request
+        // profiles). An href the URL parser rejects keeps the raw concatenation.
         let protocol = self.get_protocol();
         let url_bytelength = protocol.len() + host.len() + req_url.len();
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -911,8 +911,7 @@ impl Request {
         Ok(())
     }
 
-    /// Shared by HTTP/1 (`ensure_url`, lazily) and HTTP/3 (the server, eagerly: its uWS
-    /// request dies with the dispatch) so `request.url` is built by one set of rules.
+    /// Used by both HTTP/1 (lazily, via `ensure_url`) and HTTP/3 (eagerly, by the server).
     pub(crate) fn set_url_from_request_target(&self, host: Option<&[u8]>, target: &[u8]) {
         let req_url = Self::request_target_path(target);
         let Some(host) = Self::url_authority(host, &req_url) else {
@@ -920,8 +919,7 @@ impl Request {
             return;
         };
 
-        // Slice copies, not `core::fmt::write` (not monomorphized; shows up in per-request
-        // profiles). An href the URL parser rejects keeps the raw concatenation.
+        // Hand-assembled: `core::fmt::write` is not monomorphized and shows up in profiles.
         let protocol = self.get_protocol();
         let url_bytelength = protocol.len() + host.len() + req_url.len();
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -817,19 +817,10 @@ impl Request {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
             let req_url = Self::request_target_path(req.url());
-            if !req_url.is_empty() && req_url[0] == b'/' {
-                if let Some(host) = req
-                    .header(b"host")
-                    .filter(|host| Self::is_valid_host_header(host))
-                {
-                    // With `port: None`, HostFormatter always emits exactly `host`, so the
-                    // formatted byte-count is just `host.len()`. Avoid the `core::fmt::write`
-                    // vtable dispatch that `bun_fmt::count(format_args!(...))` incurs — this
-                    // runs once per request via JSC extra-memory accounting.
-                    return self.get_protocol().len() + host.len() + req_url.len();
-                }
-            }
-            return req_url.len();
+            return match Self::url_authority(req.header(b"host"), &req_url) {
+                Some(host) => self.get_protocol().len() + host.len() + req_url.len(),
+                None => req_url.len(),
+            };
         }
 
         0
@@ -870,8 +861,8 @@ impl Request {
     }
 
     /// RFC 3986 3.2.2 `uri-host [ ":" port ]` byte set. A Host value outside it, or an empty
-    /// one, cannot form a URL authority, so `request.url` synthesis falls back to the
-    /// configured host instead of pasting the client bytes into the URL.
+    /// one, cannot form a URL authority, so `request.url` synthesis falls back to the bare
+    /// request target instead of pasting the client bytes into the URL.
     fn is_valid_host_header(host: &[u8]) -> bool {
         !host.is_empty()
             && host.iter().all(|&c| {
@@ -900,6 +891,17 @@ impl Request {
             })
     }
 
+    /// The authority `request.url` is synthesized with: the client's `Host` (HTTP/1) or
+    /// `:authority` (HTTP/3) value, but only for an origin-form target and only when the
+    /// value can form a URL authority. `None` means `request.url` is the bare target.
+    fn url_authority<'a>(host: Option<&'a [u8]>, path: &[u8]) -> Option<&'a [u8]> {
+        if !path.is_empty() && path[0] == b'/' {
+            host.filter(|host| Self::is_valid_host_header(host))
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn ensure_url(&self) -> Result<(), AllocError> {
         if !self.url.get().is_empty() {
             return Ok(());
@@ -908,86 +910,78 @@ impl Request {
         if let Some(req) = self.request_context.get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             let req = bun_opaque::opaque_deref(req);
-            let req_url = Self::request_target_path(req.url());
-            if !req_url.is_empty() && req_url[0] == b'/' {
-                if let Some(host) = req
-                    .header(b"host")
-                    .filter(|host| Self::is_valid_host_header(host))
-                {
-                    // With `port: None`, HostFormatter always emits exactly `host`. Compute the
-                    // length and assemble the URL with straight slice copies instead of going
-                    // through `core::fmt::write` (which is not monomorphized and shows up in
-                    // per-request profiles).
-                    let protocol = self.get_protocol();
-                    let url_bytelength = protocol.len() + host.len() + req_url.len();
-
-                    debug_assert!(self.size_of_url() == url_bytelength);
-
-                    if url_bytelength < 128 {
-                        let mut buffer = [0u8; 128];
-                        let url = {
-                            let mut at = 0;
-                            buffer[at..at + protocol.len()].copy_from_slice(protocol);
-                            at += protocol.len();
-                            buffer[at..at + host.len()].copy_from_slice(host);
-                            at += host.len();
-                            buffer[at..at + req_url.len()].copy_from_slice(&req_url);
-                            at += req_url.len();
-                            &buffer[..at]
-                        };
-
-                        debug_assert!(self.size_of_url() == url.len());
-
-                        let href = bun_url::href_from_string(&BunString::from_bytes(url));
-                        if !href.is_empty() {
-                            if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
-                                self.url.set(BunString::clone_latin1(&url[..href.length()]));
-                                href.deref();
-                            } else {
-                                self.url.set(href);
-                            }
-                        } else {
-                            // TODO: what is the right thing to do for invalid URLS?
-                            self.url.set(BunString::clone_utf8(url));
-                        }
-
-                        return Ok(());
-                    }
-
-                    if strings::is_all_ascii(host) && strings::is_all_ascii(&req_url) {
-                        let (new_url, bytes) =
-                            BunString::create_uninitialized_latin1(url_bytelength);
-                        self.url.set(new_url);
-                        // exact space was counted above
-                        let (a, rest) = bytes.split_at_mut(protocol.len());
-                        let (b, c) = rest.split_at_mut(host.len());
-                        a.copy_from_slice(protocol);
-                        b.copy_from_slice(host);
-                        c.copy_from_slice(&req_url);
-                    } else {
-                        // slow path
-                        let mut temp_url: Vec<u8> = Vec::with_capacity(url_bytelength);
-                        temp_url.extend_from_slice(protocol);
-                        temp_url.extend_from_slice(host);
-                        temp_url.extend_from_slice(&req_url);
-                        // `defer bun.default_allocator.free(temp_url)` → Vec drops at scope end
-                        self.url.set(BunString::clone_utf8(&temp_url));
-                    }
-
-                    let href = bun_url::href_from_string(&self.url.get());
-                    // TODO: what is the right thing to do for invalid URLS?
-                    if !href.is_empty() {
-                        self.url.set(href);
-                    }
-
-                    return Ok(());
-                }
-            }
-
-            debug_assert!(self.size_of_url() == req_url.len());
-            self.url.set(BunString::clone_utf8(&req_url));
+            self.set_url_from_request_target(req.header(b"host"), req.url());
         }
         Ok(())
+    }
+
+    /// Synthesizes `request.url` from the raw request target and the client-supplied
+    /// authority (`Host` for HTTP/1, `:authority` for HTTP/3). HTTP/1 gets here lazily via
+    /// [`Self::ensure_url`]; HTTP/3 eagerly from the server, since its uWS request does not
+    /// outlive the dispatch. Both transports share this so the authority filter and the URL
+    /// normalization cannot drift between them.
+    pub(crate) fn set_url_from_request_target(&self, host: Option<&[u8]>, target: &[u8]) {
+        let req_url = Self::request_target_path(target);
+        let Some(host) = Self::url_authority(host, &req_url) else {
+            self.url.set(BunString::clone_utf8(&req_url));
+            return;
+        };
+
+        // Assemble the URL with straight slice copies instead of going through
+        // `core::fmt::write` (which is not monomorphized and shows up in per-request
+        // profiles). When the WHATWG parser rejects the result (e.g. a port out of
+        // range), the raw concatenation is kept.
+        let protocol = self.get_protocol();
+        let url_bytelength = protocol.len() + host.len() + req_url.len();
+
+        if url_bytelength < 128 {
+            let mut buffer = [0u8; 128];
+            let url = {
+                let mut at = 0;
+                buffer[at..at + protocol.len()].copy_from_slice(protocol);
+                at += protocol.len();
+                buffer[at..at + host.len()].copy_from_slice(host);
+                at += host.len();
+                buffer[at..at + req_url.len()].copy_from_slice(&req_url);
+                at += req_url.len();
+                &buffer[..at]
+            };
+
+            let href = bun_url::href_from_string(&BunString::from_bytes(url));
+            if !href.is_empty() {
+                if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
+                    self.url.set(BunString::clone_latin1(&url[..href.length()]));
+                    href.deref();
+                } else {
+                    self.url.set(href);
+                }
+            } else {
+                self.url.set(BunString::clone_utf8(url));
+            }
+            return;
+        }
+
+        if strings::is_all_ascii(host) && strings::is_all_ascii(&req_url) {
+            let (new_url, bytes) = BunString::create_uninitialized_latin1(url_bytelength);
+            self.url.set(new_url);
+            // exact space was counted above
+            let (a, rest) = bytes.split_at_mut(protocol.len());
+            let (b, c) = rest.split_at_mut(host.len());
+            a.copy_from_slice(protocol);
+            b.copy_from_slice(host);
+            c.copy_from_slice(&req_url);
+        } else {
+            let mut temp_url: Vec<u8> = Vec::with_capacity(url_bytelength);
+            temp_url.extend_from_slice(protocol);
+            temp_url.extend_from_slice(host);
+            temp_url.extend_from_slice(&req_url);
+            self.url.set(BunString::clone_utf8(&temp_url));
+        }
+
+        let href = bun_url::href_from_string(&self.url.get());
+        if !href.is_empty() {
+            self.url.set(href);
+        }
     }
 }
 

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -49,7 +49,7 @@ impl Request {
     pub fn set_yield(&mut self, y: bool) {
         c::uws_h3_req_set_yield(self, y)
     }
-    pub fn url(&mut self) -> &[u8] {
+    pub fn url(&self) -> &[u8] {
         let mut p: *const u8 = ptr::null();
         let n = c::uws_h3_req_get_url(self, &mut p);
         // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
@@ -61,7 +61,7 @@ impl Request {
         // SAFETY: uws returns a pointer+len pair valid for the lifetime of the request
         unsafe { bun_core::ffi::slice(p, n) }
     }
-    pub fn header(&mut self, name: &[u8]) -> Option<&[u8]> {
+    pub fn header(&self, name: &[u8]) -> Option<&[u8]> {
         let mut p: *const u8 = ptr::null();
         // SAFETY: self is a live FFI handle; name ptr/len valid for read; out-ptr is a valid local
         let n = unsafe { c::uws_h3_req_get_header(self, name.as_ptr(), name.len(), &raw mut p) };
@@ -733,10 +733,10 @@ mod c {
         // Out-param `out` is `&mut *const u8` (non-null, valid for write); the C
         // shim only stores a pointer into request-owned storage and returns its
         // length — no read-through precondition, so `safe fn`.
-        pub(super) safe fn uws_h3_req_get_url(req: &mut Request, out: &mut *const u8) -> usize;
+        pub(super) safe fn uws_h3_req_get_url(req: &Request, out: &mut *const u8) -> usize;
         pub(super) safe fn uws_h3_req_get_method(req: &mut Request, out: &mut *const u8) -> usize;
         pub(super) fn uws_h3_req_get_header(
-            req: *mut Request,
+            req: *const Request,
             name: *const u8,
             len: usize,
             out: *mut *const u8,

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash, randomBytes } from "crypto";
 import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
+import { connect } from "node:quic";
 import { join } from "path";
 
 // Native HTTP/3 fetch wrapper. Every request in this file forces
@@ -1300,4 +1301,98 @@ describe("Bun.serve HTTP/3 production", () => {
   // Expect: 100-continue is handled at the uWS layer for both transports
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
+});
+
+// The native client always derives :path / :authority from a parsed URL, so
+// these use node:quic to put arbitrary bytes in the pseudo-headers, the way a
+// hostile peer would.
+describe("Bun.serve HTTP/3 request target and authority", () => {
+  function serveRecordingHits(hits: string[]) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls,
+      http3: true,
+      routes: {
+        "/declared": () => {
+          hits.push("route");
+          return new Response("route");
+        },
+      },
+      fetch(req) {
+        hits.push("fetch");
+        return Response.json({ url: req.url, host: req.headers.get("host") });
+      },
+    });
+  }
+
+  async function rawH3(port: number, headers: Record<string, string>) {
+    const client = await connect(
+      { address: "127.0.0.1", port, family: "ipv4" },
+      { servername: "localhost", verifyPeer: "manual" },
+    );
+    try {
+      await client.opened;
+      const status = Promise.withResolvers<string | undefined>();
+      const stream = await client.createBidirectionalStream({
+        headers: { ":method": "GET", ":scheme": "https", ...headers },
+        onheaders(received: Record<string, string>) {
+          status.resolve(received[":status"]);
+        },
+      });
+      const chunks: Uint8Array[] = [];
+      for await (const batch of stream) chunks.push(...batch);
+      // FIN arrived, so the response headers (if any) were delivered already.
+      stream.closed.then(
+        () => status.resolve(undefined),
+        () => status.resolve(undefined),
+      );
+      return { status: await status.promise, body: Buffer.concat(chunks).toString() };
+    } finally {
+      await client.close();
+    }
+  }
+
+  // Same rule as HTTP/1 (serve.test.ts, "not a valid authority"): the request
+  // is still served, but an :authority that cannot be a URL authority stays out
+  // of req.url, so new URL(req.url) cannot disagree with the router about the
+  // host or the path.
+  test.each(["good.com@evil", "a/b", "a?b", "a b"])(
+    "req.url is the request target when :authority is %j",
+    async authority => {
+      const hits: string[] = [];
+      using server = serveRecordingHits(hits);
+      const res = await rawH3(server.port, { ":path": "/x", ":authority": authority });
+      expect(res.status).toBe("200");
+      expect(JSON.parse(res.body)).toEqual({ url: "/x", host: authority });
+      expect(hits).toEqual(["fetch"]);
+    },
+  );
+
+  test("a valid :authority becomes req.url, normalized like an HTTP/1 Host header", async () => {
+    const hits: string[] = [];
+    using server = serveRecordingHits(hits);
+    const res = await rawH3(server.port, { ":path": "/x/./y/../z?q=1", ":authority": `LOCALHOST:${server.port}` });
+    expect(res.status).toBe("200");
+    expect(JSON.parse(res.body)).toEqual({
+      url: `https://localhost:${server.port}/x/z?q=1`,
+      host: `LOCALHOST:${server.port}`,
+    });
+    expect(hits).toEqual(["fetch"]);
+  });
+
+  // RFC 9114 4.3.1: :path is the path and query of the target URI. The router
+  // assumes that shape, so anything else used to be routed on what followed
+  // the first byte ("xdeclared" hit the /declared route, an absolute URL fell
+  // through to fetch()) and reached the handler verbatim as req.url.
+  test.each(["https://other-tenant/declared", "xdeclared", "*", ""])(
+    "a :path of %j is rejected with 400 before routing",
+    async path => {
+      const hits: string[] = [];
+      using server = serveRecordingHits(hits);
+      const res = await rawH3(server.port, { ":path": path, ":authority": `127.0.0.1:${server.port}` });
+      expect(res).toEqual({ status: "400", body: "" });
+      expect(hits).toEqual([]);
+    },
+  );
 });

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1384,7 +1384,8 @@ describe("Bun.serve HTTP/3 request target and authority", () => {
   // RFC 9114 4.3.1: :path is the path and query of the target URI. The router
   // assumes that shape, so anything else used to be routed on what followed
   // the first byte ("xdeclared" hit the /declared route, an absolute URL fell
-  // through to fetch()) and reached the handler verbatim as req.url.
+  // through to fetch()) and reached the handler verbatim as req.url. "*" is
+  // the asterisk-form the RFC allows for OPTIONS; HTTP/1 rejects it too.
   test.each(["https://other-tenant/declared", "xdeclared", "*", ""])(
     "a :path of %j is rejected with 400 before routing",
     async path => {

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1369,6 +1369,15 @@ describe("Bun.serve HTTP/3 request target and authority", () => {
     },
   );
 
+  test("req.url is the request target when :authority is absent", async () => {
+    const hits: string[] = [];
+    using server = serveRecordingHits(hits);
+    const res = await rawH3(server.port, { ":path": "/x" });
+    expect(res.status).toBe("200");
+    expect(JSON.parse(res.body)).toEqual({ url: "/x", host: null });
+    expect(hits).toEqual(["fetch"]);
+  });
+
   test("a valid :authority becomes req.url, normalized like an HTTP/1 Host header", async () => {
     const hits: string[] = [];
     using server = serveRecordingHits(hits);


### PR DESCRIPTION
### Problem

`Bun.serve({ http3: true })` built `req.url` as `"https://" + :authority + :path` without looking at either value (`server_body.rs`, the `Ctx::IS_H3` block in `prepare_js_request_context_for`). The HTTP/1 path (`Request::ensure_url`) only uses a `Host` that passes `is_valid_host_header`, reduces an absolute-form target to its path, and runs the result through the URL parser. HTTP/3 clients got none of that.

Observed with a `node:quic` client against a server with `routes: { "/declared": ... }` plus a `fetch` fallback, on the current release:

```
:path /x                            :authority good.com@evil  -> 200, req.url = https://good.com@evil/x   (new URL().hostname is "evil")
:path /x                            :authority a/b            -> 200, req.url = https://a/b/x            (pathname is /b/x, router matched /x)
:path https://other-tenant/declared                           -> 200 from fetch(), req.url = https://other-tenant/declared
:path xdeclared                                               -> 200 from the /declared route, req.url = "xdeclared"
:path *                                                       -> 200, req.url = "*"
```

The same requests over HTTP/1 give `req.url = /x` for the first two and `400` for the last two, because `HttpParser` rejects request-targets that are neither origin-form nor absolute-form. `HttpRouter` assumes a leading `/` and strips the first byte unconditionally, which is why `xdeclared` reached the `/declared` route.

### Fix

- `packages/bun-uws/src/Http3Context.h`: a `:path` that does not start with `/` (absolute URL, `*`, empty, anything else) gets a `400` before routing. RFC 9114 4.3.1 defines `:path` as the path and query of the target URI (plus `*` for OPTIONS), so apart from asterisk-form these are malformed requests (4.1.2); this is the same layer where HTTP/1 rejects its equivalents. Side effects: `OPTIONS *` gets `400` over HTTP/3 as it already does over HTTP/1 (`HttpParser` only accepts origin-form, absolute-form and CONNECT; previously it reached the handler with `req.url === "*"`), and a request with no `:path` at all (CONNECT) now gets `400` instead of the router's `404`.
- `src/runtime/webcore/Request.rs`: the body of `ensure_url` moves into `Request::set_url_from_request_target(host, target)`, and `size_of_url` shares the host selection through `url_authority`, which replaces the two `debug_assert`s that were keeping the two copies in sync. HTTP/1 behavior is unchanged.
- `src/runtime/server/server_body.rs`: the HTTP/3 eager path calls the same function, so an `:authority` that cannot be a URL authority is left out of `req.url` (it becomes the bare path, exactly as HTTP/1 does) and a valid one is normalized the same way. This also drops the per-request `Vec` + `core::fmt` formatting that #31055 set out to remove; the shared code uses the stack buffer / direct latin1 paths.
- `src/uws_sys/h3.rs`: `Request::url` and `Request::header` take `&self` (the C++ side only reads), so host and path can be borrowed at the same time instead of copying one of them.

#33721 also routes HTTP/3 through a shared helper as part of changing the HTTP/1 fallback to the server's configured authority; this PR keeps the current fallback and only closes the HTTP/3 gaps, including the `:path` one that #33721 does not cover.

### Tests

`test/js/bun/http/serve-http3.test.ts`, new `describe` using a `node:quic` client so the pseudo-headers can carry arbitrary bytes (the native client always derives them from a parsed URL):

- `:authority` of `good.com@evil`, `a/b`, `a?b`, `a b`: served with `req.url === "/x"`, raw value still visible in `req.headers.get("host")`
- valid `:authority` `LOCALHOST:<port>` with `/x/./y/../z?q=1`: `req.url === "https://localhost:<port>/x/z?q=1"`
- `:path` of `https://other-tenant/declared`, `xdeclared`, `*`, `""`: `400`, no handler invoked

All 9 fail on the unpatched build (verbatim URLs / 200s as in the table above) and pass with the fix. Also ran `serve-http3.test.ts` (57 pass), `serve.test.ts` (the 4 failures there are IPv6 / root-port environment failures that fail identically without this change), `request-smuggling.test.ts`, `bun-serve-routes.test.ts`, `websocket-server.test.ts`, `serve-protocols.test.ts`, `fetch-http3-client.test.ts` and `fetch-http3-adversarial.test.ts`. A 2048-request run with a 15 KB request-target on the debug build measured the same per-request time before and after the `ensure_url` refactor (about 23.2 ms vs 23.5 ms, within run-to-run noise).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.0 (d26419272)

test/js/bun/http/serve-http3.test.ts:
(node:99080) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [1785.78ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1754.52ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1717.66ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1657.04ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1672.64ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1661.78ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1672.77ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1701.09ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2575.68ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Co
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (99d8bf983)

test/js/bun/http/serve-http3.test.ts:
(node:99759) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [145.09ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [144.03ms]
(pass) Bun.serve HTTP/3 > 204 with no body [141.86ms]
(pass) Bun.serve HTTP/3 > query string is preserved [143.81ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [142.95ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [141.00ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [141.06ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [142.41ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1039.75ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [137.10ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [144.57ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [143.39ms]
(pass) Bun.serve HTTP/3 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.0 (d26419272)

test/js/bun/http/serve-http3.test.ts:
(node:105382) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [1636.20ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1570.56ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1563.21ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1585.81ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1563.22ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1596.68ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1575.59ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1599.74ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2493.49ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without C
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 937ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/Http3Context.h  |   9 ++
 src/runtime/server/server_body.rs    |  40 ++-------
 src/runtime/webcore/Request.rs       | 161 ++++++++++++++++-------------------
 src/uws_sys/h3.rs                    |   8 +-
 test/js/bun/http/serve-http3.test.ts | 105 +++++++++++++++++++++++
 5 files changed, 199 insertions(+), 124 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-uws/src/Http3Context.h       3      4      0
src/runtime/server/server_body.rs         4      4      0
src/runtime/webcore/Request.rs            8      8      0
src/uws_sys/h3.rs                         2      3      0
test/js/bun/http/serve-http3.test.ts      8      3      0
```

</details>

<!-- robobun:evidence:end -->
