### PR TITLE
spawn: honor timeouts of 2**31 ms or more instead of truncating them to 31 bits

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -438,11 +438,13 @@ static const struct timespec *us_internal_clamp_to_sweep(struct us_loop_t *loop,
 }
 
 /* XNU rejects a kevent timeout with tv_sec > INT32_MAX as EINVAL
- * (bsd/kern/kern_time.c, timespec_is_valid), so while a deadline that far out
- * (a spawn `timeout` or AbortSignal.timeout of centuries) is the soonest timer,
- * every tick would return at once and the loop would spin. The epoll_pwait
- * fallback's nanosecond arithmetic overflows on such values too. Callers
- * recompute the remaining time after every wake, so waking early is harmless. */
+ * (bsd/kern/kern_time.c, timespec_is_valid). A spawn `timeout` or
+ * AbortSignal.timeout may be as large as 2^53 ms, and Bun.spawnSync's isolated
+ * loop waits on exactly that deadline, so without this every one of its ticks
+ * would return at once, never collecting the child's exit. The epoll_pwait
+ * fallback's nanosecond arithmetic overflows on such values too. Same bound as
+ * WTFTimer applies to JSC's timers; callers recompute the remaining time after
+ * every wake, so waking early is harmless. */
 static const struct timespec *us_internal_clamp_to_kernel_max(const struct timespec *timeout, struct timespec *storage) {
     if (!timeout || timeout->tv_sec <= INT32_MAX) {
         return timeout;

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -437,6 +437,21 @@ static const struct timespec *us_internal_clamp_to_sweep(struct us_loop_t *loop,
     return storage;
 }
 
+/* XNU rejects a kevent timeout with tv_sec > INT32_MAX as EINVAL
+ * (bsd/kern/kern_time.c, timespec_is_valid), so while a deadline that far out
+ * (a spawn `timeout` or AbortSignal.timeout of centuries) is the soonest timer,
+ * every tick would return at once and the loop would spin. The epoll_pwait
+ * fallback's nanosecond arithmetic overflows on such values too. Callers
+ * recompute the remaining time after every wake, so waking early is harmless. */
+static const struct timespec *us_internal_clamp_to_kernel_max(const struct timespec *timeout, struct timespec *storage) {
+    if (!timeout || timeout->tv_sec <= INT32_MAX) {
+        return timeout;
+    }
+    storage->tv_sec = INT32_MAX;
+    storage->tv_nsec = 0;
+    return storage;
+}
+
 void us_loop_run(struct us_loop_t *loop) {
     /* While we have non-fallthrough polls we shouldn't fall through */
     while (loop->num_polls) {
@@ -471,6 +486,9 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
         return;
 
     loop->data.tick_depth++;
+
+    struct timespec kernel_max_ts;
+    timeout = us_internal_clamp_to_kernel_max(timeout, &kernel_max_ts);
 
     /* Emit pre callback */
     us_internal_loop_pre(loop);

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -381,7 +381,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut socket_fd_indices: Vec<usize> = Vec::new();
     let mut argv0: Option<*const c_char> = None;
     let mut ipc_channel: i32 = -1;
-    let mut timeout: Option<i32> = None;
+    let mut timeout: Option<i64> = None;
     let mut uid: Option<u32> = None;
     let mut gid: Option<u32> = None;
     let mut kill_signal: SignalCode = SignalCode::DEFAULT;
@@ -764,7 +764,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                             }
                         }
 
-                        let timeout_int = global_this.validate_integer_range::<u64>(
+                        let timeout_int = global_this.validate_integer_range::<i64>(
                             timeout_value,
                             0,
                             bun_sql_jsc::jsc::IntegerRange {
@@ -774,10 +774,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                             },
                         )?;
                         if timeout_int > 0 {
-                            timeout = Some(
-                                i32::try_from((timeout_int as u32) & 0x7FFF_FFFF)
-                                    .expect("int cast"),
-                            );
+                            timeout = Some(timeout_int);
                         }
                     }
                 }
@@ -1683,7 +1680,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
         // This must go before other things happen so that the exit handler is
         // registered before onProcessExit can potentially be called.
         if let Some(timeout_val) = timeout {
-            let ts = Timespec::ms_from_now(TimespecMockMode::ForceRealTime, i64::from(timeout_val));
+            let ts = Timespec::ms_from_now(TimespecMockMode::ForceRealTime, timeout_val);
             // Note: `EventLoopTimer.next` is a local-stub Timespec until
             // `bun_event_loop` switches to `bun_core::Timespec`; copy fieldwise.
             subprocess.event_loop_timer.with_mut(|t| {
@@ -1902,7 +1899,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
         let mut absolute_timespec = Timespec::EPOCH;
         let mut now = Timespec::now(TimespecMockMode::ForceRealTime);
         let mut user_timespec: Timespec = if let Some(timeout_ms) = timeout {
-            now.add_ms(i64::from(timeout_ms))
+            now.add_ms(timeout_ms)
         } else {
             absolute_timespec
         };

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -285,3 +285,48 @@ describe("timeout Infinity does not kill the process", () => {
     expect(stderr).toBe("");
   });
 });
+
+describe("timeout of 2**31 ms or more does not kill the process", () => {
+  // The timeout used to be truncated to its low 31 bits: 2**31 became 0 (killed on the first
+  // tick of the event loop) and 2**32 + 1 became 1 ms. Number.MAX_SAFE_INTEGER is the largest
+  // value the option accepts; a deadline that far out exceeds the largest wait kevent accepts.
+  const timeouts = [2 ** 31, 2 ** 32 + 1, Number.MAX_SAFE_INTEGER];
+
+  test.concurrent.each(timeouts)("Bun.spawn timeout: %d", async timeout => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log('ran to completion')"],
+      env: bunEnv,
+      timeout,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "ran to completion\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.each(timeouts)("Bun.spawnSync timeout: %d", timeout => {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.log('ran to completion')"],
+      env: bunEnv,
+      timeout,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect({
+      stdout: proc.stdout.toString("utf-8"),
+      stderr: proc.stderr.toString("utf-8"),
+      exitCode: proc.exitCode,
+      signalCode: proc.signalCode,
+      exitedDueToTimeout: proc.exitedDueToTimeout,
+    }).toEqual({
+      stdout: "ran to completion\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: undefined,
+      exitedDueToTimeout: false,
+    });
+  });
+});

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -289,7 +289,7 @@ describe("timeout Infinity does not kill the process", () => {
 describe("timeout of 2**31 ms or more does not kill the process", () => {
   // The timeout used to be truncated to its low 31 bits: 2**31 became 0 (killed on the first
   // tick of the event loop) and 2**32 + 1 became 1 ms. Number.MAX_SAFE_INTEGER is the largest
-  // value the option accepts; a deadline that far out exceeds the largest wait kevent accepts.
+  // value the option accepts.
   const timeouts = [2 ** 31, 2 ** 32 + 1, Number.MAX_SAFE_INTEGER];
 
   test.concurrent.each(timeouts)("Bun.spawn timeout: %d", async timeout => {
@@ -327,6 +327,34 @@ describe("timeout of 2**31 ms or more does not kill the process", () => {
       exitCode: 0,
       signalCode: undefined,
       exitedDueToTimeout: false,
+    });
+  });
+
+  // Inside `bun test`, spawnSync bounds its wait by the per-test deadline, so the cases above
+  // never hand the spawn deadline itself to the kernel. In a plain script, spawnSync's isolated
+  // event loop waits on exactly that deadline, and kevent rejects a wait of more than INT32_MAX
+  // seconds: unless us_loop_run_bun_tick clamps it, this child never observes the grandchild
+  // exiting and spins until the test times out.
+  test.concurrent("Bun.spawnSync timeout: Number.MAX_SAFE_INTEGER outside the test runner", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const proc = Bun.spawnSync({
+           cmd: [process.execPath, "-e", "console.log('ran to completion')"],
+           timeout: Number.MAX_SAFE_INTEGER,
+           stdio: ["ignore", "pipe", "inherit"],
+         });
+         console.log(JSON.stringify({ stdout: proc.stdout.toString(), exitCode: proc.exitCode, exitedDueToTimeout: proc.exitedDueToTimeout }));`,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ stdout: "ran to completion\n", exitCode: 0, exitedDueToTimeout: false }) + "\n",
+      stderr: "",
+      exitCode: 0,
     });
   });
 });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -716,14 +716,17 @@ describe("spawnSync()", () => {
 
   // Node passes the timeout to a uint64 libuv timer, so unlike spawn() (which goes through
   // setTimeout and its 2**31 - 1 clamp) a timeout of 2**31 ms or more is honored as written.
-  it.each([2 ** 31, 2 ** 32 + 1])("timeout: %d is honored instead of firing immediately", timeout => {
-    const { stdout, status, signal, error } = spawnSync(bunExe(), ["-e", "console.log('ok')"], {
-      timeout,
-      encoding: "utf8",
-      env: bunEnv,
-    });
-    expect({ stdout, status, signal, error }).toEqual({ stdout: "ok\n", status: 0, signal: null, error: undefined });
-  });
+  it.each([2 ** 31, 2 ** 32 + 1, Number.MAX_SAFE_INTEGER])(
+    "timeout: %d is honored instead of firing immediately",
+    timeout => {
+      const { stdout, status, signal, error } = spawnSync(bunExe(), ["-e", "console.log('ok')"], {
+        timeout,
+        encoding: "utf8",
+        env: bunEnv,
+      });
+      expect({ stdout, status, signal, error }).toEqual({ stdout: "ok\n", status: 0, signal: null, error: undefined });
+    },
+  );
 });
 
 describe("execFileSync()", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -713,6 +713,17 @@ describe("spawnSync()", () => {
       signal: null,
     });
   });
+
+  // Node passes the timeout to a uint64 libuv timer, so unlike spawn() (which goes through
+  // setTimeout and its 2**31 - 1 clamp) a timeout of 2**31 ms or more is honored as written.
+  it.each([2 ** 31, 2 ** 32 + 1])("timeout: %d is honored instead of firing immediately", timeout => {
+    const { stdout, status, signal, error } = spawnSync(bunExe(), ["-e", "console.log('ok')"], {
+      timeout,
+      encoding: "utf8",
+      env: bunEnv,
+    });
+    expect({ stdout, status, signal, error }).toEqual({ stdout: "ok\n", status: 0, signal: null, error: undefined });
+  });
 });
 
 describe("execFileSync()", () => {


### PR DESCRIPTION
### What does this PR do?

`Bun.spawn` / `Bun.spawnSync` accept `timeout` as an integer in `0..2**53`, then keep only its low 31 bits. Any timeout of 2**31 ms (24.8 days) or more silently wraps: `2**31` and `2**32` kill the child on the first tick, `2**32 + 400` kills it after 400 ms. `child_process.spawnSync` passes its `timeout` straight through, so it is affected as well (Node honors these values there; the async `spawn()` goes through `setTimeout` and is unaffected).

```js
for (const t of [2 ** 31, 2 ** 32 + 400, 2 ** 31 - 1]) {
  const t0 = Date.now();
  const p = Bun.spawn([process.execPath, "-e", "await Bun.sleep(2000)"], { timeout: t });
  console.log(t, await Promise.race([
    p.exited.then(() => `KILLED ${p.signalCode} after ${Date.now() - t0} ms`),
    Bun.sleep(800).then(() => { p.kill(9); return "alive at 800 ms"; }),
  ]));
}
```

bun 1.4.0:

```
2147483648 KILLED SIGTERM after 1 ms
4294967696 KILLED SIGTERM after 402 ms
2147483647 alive at 800 ms
```

`Bun.spawnSync` reports the same thing as `exitedDueToTimeout: true` after 1 ms / 402 ms. With this change every value stays alive at 800 ms, and `child_process.spawnSync(..., { timeout: 2 ** 31 })` returns `status: 0` like Node v26 does instead of `ETIMEDOUT`.

**Cause:** `js_bun_spawn_bindings.rs` stored the validated `u64` as `Some(((timeout_int as u32) & 0x7FFF_FFFF) as i32)`.

**Fix:**

- `js_bun_spawn_bindings.rs`: `timeout` is an `Option<i64>` holding the validated value as is. Both consumers (`Timespec::ms_from_now` for `Bun.spawn`, `add_ms` for `Bun.spawnSync`) already took an `i64`, so the value is simply honored. The accepted range and the `ERR_OUT_OF_RANGE` message (`>= 0 and <= 9007199254740991`) are unchanged.
- `epoll_kqueue.c`: once such values are honored, a deadline centuries out can reach `us_loop_run_bun_tick` as a wait whose `tv_sec` exceeds `INT32_MAX`. XNU rejects that with `EINVAL` ([`timespec_is_valid`](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_time.c)). `Bun.spawnSync` is the case that actually gets there: its isolated loop waits on exactly the user deadline, so on macOS `Bun.spawnSync(..., { timeout: Number.MAX_SAFE_INTEGER })` would return from every tick without collecting anything and spin until the process is killed. (The main event loop nearly always has a sooner timer, JSC's GC timers or the GC controller's repeating timer, so `Bun.spawn` and `AbortSignal.timeout` only reach this when nothing else is scheduled.) The `epoll_pwait` fallback for pre-5.11 kernels overflows its nanosecond arithmetic on the same input. The wait handed to epoll/kevent is now clamped to `INT32_MAX` seconds, the same bound `WTFTimer::update` already applies to JSC's timers; every caller recomputes the remaining time after a wake, so this is not observable. Windows is unaffected: the timers there go through `uv_timer_start`, which takes a `uint64_t` ms value and clamps its own poll timeout.

### How did you verify your code works?

- `test/js/bun/spawn/spawn-maxbuf.test.ts` (next to the existing `timeout` tests): `Bun.spawn` and `Bun.spawnSync` with `timeout` of `2**31`, `2**32 + 1` and `Number.MAX_SAFE_INTEGER` must let a child run to completion. The first two values fail on the unfixed build (`signalCode: "SIGTERM"`, `exitedDueToTimeout: true`).
- Same file: `Bun.spawnSync` with `Number.MAX_SAFE_INTEGER` run inside a plain child process. Under `bun test` itself the per-test deadline is always the sooner wait, so the in-runner cases never reach the clamp; in a plain script spawnSync's isolated loop waits on the spawn deadline itself. Verified with a temporary print in `us_internal_clamp_to_kernel_max` that this case reaches the clamp (three ticks with `tv_sec=9007199254740`) and the in-runner cases do not. Without the clamp this test hangs on macOS; on Linux `epoll_pwait2` accepts the value, so it passes either way there.
- `test/js/node/child_process/child_process.test.ts`: `spawnSync` with `timeout: 2**31` / `2**32 + 1` / `Number.MAX_SAFE_INTEGER` returns `status: 0`, matching Node v26.3.0 (the first two fail on the unfixed build with `ETIMEDOUT`).
- The existing `spawn-maxbuf`, `spawnSync`, `spawn-signal`, `spawnsync-isolated-event-loop` and `child_process` test files pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-maxbuf.test.ts test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->