### PR TITLE
web_worker: own the worker env Loader as JsCell<Option<Box<Loader>>>

### DIFF
--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -100,7 +100,7 @@ pub struct WebWorker {
     arena: JsCell<Option<bun_alloc::Arena>>,
     /// Cloned env for the worker VM; boxed on the global heap because the arena
     /// does not run `Drop`. Reclaimed in `shutdown()`.
-    worker_env_loader: Cell<*mut bun_dotenv::Loader>,
+    worker_env_loader: JsCell<Option<Box<bun_dotenv::Loader>>>,
     /// `process.exit(code)` ran; later error paths must not overwrite its code.
     exit_called: AtomicBool,
     /// The parent asked this thread to stop (`worker.terminate()` or an exiting
@@ -356,7 +356,7 @@ impl WebWorker {
             join_handle: JsCell::new(None),
             status: Cell::new(Status::Start),
             arena: JsCell::new(None),
-            worker_env_loader: Cell::new(core::ptr::null_mut()),
+            worker_env_loader: JsCell::new(None),
             exit_called: AtomicBool::new(false),
             terminated_by_parent: AtomicBool::new(false),
         }));
@@ -640,8 +640,6 @@ impl WebWorker {
         // state.
         let mut temp_proxy_slots = jsc::rare_data::ProxyEnvSlots::default();
 
-        // Box the Loader on the global heap and hand ownership to the VM via
-        // `transpiler.env`; reclaimed in `vm.destroy()` in `shutdown()`.
         let mut map = {
             let parent_slots = parent.proxy_env_storage.lock();
             temp_proxy_slots.clone_from(&parent_slots);
@@ -652,12 +650,8 @@ impl WebWorker {
         // Ensure map entries point at the exact bytes we hold refs on.
         temp_proxy_slots.sync_into(&mut map);
 
-        // `heap::alloc`'d and stashed on `self` so `shutdown()` step 5 reclaims
-        // it on every path — including the early-terminate checkpoint below,
-        // which calls `shutdown()` before the VM exists.
-        let loader_ptr: *mut bun_dotenv::Loader =
-            bun_core::heap::into_raw(Box::new(bun_dotenv::Loader::init_with_map(map)));
-        self.worker_env_loader.set(loader_ptr);
+        self.worker_env_loader
+            .set(Some(Box::new(bun_dotenv::Loader::init_with_map(map))));
 
         // Checkpoint before the expensive part: initWorker builds a full JSC
         // VM. If a parent's request_termination() fired while we were cloning the env
@@ -673,7 +667,9 @@ impl WebWorker {
             self,
             virtual_machine::Options {
                 args: transform_options,
-                env_loader: NonNull::new(loader_ptr),
+                env_loader: self
+                    .worker_env_loader
+                    .with_mut(|l| l.as_deref_mut().map(NonNull::from)),
                 store_fd: self.store_fd,
                 graph: parent.standalone_module_graph,
                 ..Default::default()
@@ -987,7 +983,6 @@ impl WebWorker {
 
         // worker-thread only field; no other thread reads `arena`.
         let mut arena = self.arena.replace(None);
-        let env_loader = self.worker_env_loader.replace(core::ptr::null_mut());
 
         // ---- 1. Unpublish vm ------------------------------------------------
         self.vm_lock.lock();
@@ -1039,12 +1034,8 @@ impl WebWorker {
             "[{}] shutdown: VirtualMachine destroyed",
             self.execution_context_id
         );
-        // Reclaim the cloned env (`heap::alloc`'d in `start_vm()`; see field doc).
-        if !env_loader.is_null() {
-            // SAFETY: `heap::alloc`'d in `start_vm`; sole owner; the VM is
-            // gone so its raw `transpiler.env` borrow is dead.
-            drop(unsafe { bun_core::heap::take(env_loader) });
-        }
+        // After the VM: its `transpiler.env` pointed into this box.
+        self.worker_env_loader.set(None);
         // This thread's C++ thread_local destructors are not guaranteed to run
         // before the process exits, so free the HPACK scratch buffer that any
         // http2 session on this thread allocated.


### PR DESCRIPTION
## What

`WebWorker::worker_env_loader` (`src/jsc/web_worker.rs`) holds the env `Loader` cloned for a worker thread's VM. It was a `Cell<*mut bun_dotenv::Loader>`: `start_vm()` boxed the loader and stored `heap::into_raw` of it, the VM received `NonNull::new(loader_ptr)` as its borrowed `Options::env_loader`, and `shutdown()` took the pointer back out, null-checked it and freed it through an `unsafe { heap::take(..) }` after the VM had been torn down. The doc comment was the only place that said the worker owns the box.

The field is now `JsCell<Option<Box<bun_dotenv::Loader>>>`, the shape the neighbouring `arena: JsCell<Option<bun_alloc::Arena>>` field already uses for the same "owned by the worker thread, borrowed by its VM" relationship. `start_vm()` stores the `Box` and derives the VM's backref from it in place; `shutdown()` drops it with `set(None)` at the exact point the old free ran, after the VM (whose `transpiler.env` points into the box) is gone. The early-terminate paths that reach `shutdown()` with no loader (or no VM) need no special casing: the field is simply still `None`.

```rust
// before
let loader_ptr: *mut bun_dotenv::Loader =
    bun_core::heap::into_raw(Box::new(bun_dotenv::Loader::init_with_map(map)));
self.worker_env_loader.set(loader_ptr);
...
    env_loader: NonNull::new(loader_ptr),
...
if !env_loader.is_null() {
    // SAFETY: ...
    drop(unsafe { bun_core::heap::take(env_loader) });
}

// after
self.worker_env_loader
    .set(Some(Box::new(bun_dotenv::Loader::init_with_map(map))));
...
    env_loader: self
        .worker_env_loader
        .with_mut(|l| l.as_deref_mut().map(NonNull::from)),
...
self.worker_env_loader.set(None);
```

All 4 uses of the field are in this file; removes 1 `unsafe` block and its SAFETY comment, plus the `into_raw`/`take` pair. One file, +9/-18 lines.

## Why

Ownership of the cloned loader, and the fact that it may be absent (a worker terminated before or during startup), are now stated by the field type instead of by a raw pointer, a null sentinel and a comment; the VM's `Option<NonNull<Loader>>` is visibly a backref into storage the worker owns for longer than the VM. It is zero-cost: `JsCell` is `repr(transparent)` over `UnsafeCell` and `Option<Box<T>>` uses the null niche, so the field stays one pointer wide; the `Box` allocation existed before; and the explicit null test before the free is now the `Option` drop check at the same point, once per worker shutdown.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. test/js/web/workers/worker.test.ts + test/js/web/workers/worker-terminate-lifetime.test.ts + test/js/node/worker_threads/worker_threads.test.ts: 163 pass, 4 fail (worker_threads.test.ts fully green).
The 4 failures are pre-existing and reproduce identically on main (54d6d16cc9): "terminate() while dns.lookup() is in flight..." (LeakSanitizer leak of node_fs_binding::Binding), "a message flood from a worker does not starve the parent's event loop", "preload with an un-awaited import()..." (5s timeout), "terminate() while fs.readFile completions keep arriving" (5s timeout); the diff only touches env-loader ownership in src/jsc/web_worker.rs.
