### PR TITLE
spawn: reject ArrayBuffer/TypedArray at stdio index >= 3 instead of silently dropping the bytes

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -563,10 +563,21 @@ impl Stdio {
                 return Ok(());
             }
 
-            if i == 1 || i == 2 {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "ArrayBufferView cannot be used for stdout/stderr yet"
-                )));
+            match i {
+                0 => {}
+                1 | 2 => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "ArrayBufferView cannot be used for stdout/stderr yet"
+                    )));
+                }
+                // Like Blob in `extract_blob`: only stdin has a writer for the
+                // bytes. `as_spawn_option` would map this to a bare pipe that
+                // nothing writes to, so a child reading the fd blocks forever.
+                _ => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "ArrayBufferView cannot be used for stdio[{i}] yet"
+                    )));
+                }
             }
 
             let copied_value =

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1049,6 +1049,64 @@ describe("close handling", () => {
       expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
     });
 
+    it.skipIf(isWindows)("empty ArrayBufferView at index >= 3 is treated as ignore", async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe", new Uint8Array(0)],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+    });
+
+    // Only stdin has a writer that delivers buffer contents to the child. An
+    // extra slot used to be accepted anyway and became a bare socketpair whose
+    // bytes were never written, so a child reading it blocked forever (and
+    // spawnSync blocked along with it).
+    const payload = () => new TextEncoder().encode("fd3-payload\n");
+    for (const [label, makeStdio, msg] of [
+      [
+        "Uint8Array at index 3",
+        () => ["ignore", "pipe", "pipe", payload()],
+        "ArrayBufferView cannot be used for stdio[3] yet",
+      ],
+      [
+        "ArrayBuffer at index 3",
+        () => ["ignore", "pipe", "pipe", payload().buffer],
+        "ArrayBufferView cannot be used for stdio[3] yet",
+      ],
+      [
+        "DataView at index 3",
+        () => ["ignore", "pipe", "pipe", new DataView(payload().buffer)],
+        "ArrayBufferView cannot be used for stdio[3] yet",
+      ],
+      [
+        "Uint8Array at index 4",
+        () => ["ignore", "pipe", "pipe", "ignore", payload()],
+        "ArrayBufferView cannot be used for stdio[4] yet",
+      ],
+    ] as const) {
+      it(`${label} throws`, () => {
+        expect(() =>
+          spawn({
+            cmd: [bunExe(), "-e", ""],
+            env: bunEnv,
+            stdio: makeStdio() as any,
+          }),
+        ).toThrow(msg);
+      });
+
+      it(`spawnSync ${label} throws`, () => {
+        expect(() =>
+          spawnSync({
+            cmd: [bunExe(), "-e", ""],
+            env: bunEnv,
+            stdio: makeStdio() as any,
+          }),
+        ).toThrow(msg);
+      });
+    }
+
     const pullStream = () =>
       new ReadableStream({
         pull(c) {


### PR DESCRIPTION
## Repro

```js
const d = new TextEncoder().encode("fd3-payload\n");

// Accepted, but the bytes never reach the child: cat blocks on fd 3 and
// spawnSync only returns because of the timeout.
Bun.spawnSync(["sh", "-c", "cat <&3"], { stdio: ["ignore", "pipe", "inherit", d], timeout: 2000 });
// -> { exitCode: null, signalCode: "SIGTERM", exitedDueToTimeout: true, stdout: "" }

// Same buffer at stdio[0] works.
Bun.spawnSync(["cat"], { stdio: [d, "pipe", "inherit"] }).stdout; // "fd3-payload\n"

// Blob / ReadableStream at stdio[3] already throw:
// "Blob cannot be used for stdio[3] yet"
```

Without a `timeout` the `spawnSync` call never returns. With `Bun.spawn`, `proc.stdio[3]` is the parent end of a socketpair that nothing writes to or closes, so a child reading it blocks until the `Subprocess` is collected.

## Cause

`Stdio::extract` in `src/runtime/api/bun/spawn/stdio.rs` only rejects an `ArrayBuffer`/`TypedArray` at indices 1 and 2. At index 3 and up it builds a `Stdio::ArrayBuffer`, which `as_spawn_option` maps to a plain `Buffer` (socketpair) exactly like `"pipe"`; the extra-slot loop in `js_bun_spawn_bindings.rs` then drops the `Stdio` value, and with it the bytes. The writer that pumps buffer contents into the child (`Writable::Buffer`, or a memfd on Linux) is only wired up for stdin.

#32363 fixed the same thing for `Blob`, `Request`, `Response` and `ReadableStream` at extra indices by throwing; buffers were missed.

## Fix

Throw `ArrayBufferView cannot be used for stdio[N] yet` for a non-empty buffer at index >= 3, matching the existing stdout/stderr and Blob/ReadableStream rejections. An empty buffer at an extra index still maps to ignore, as before. stdin is unchanged.

`node:child_process` is not affected: its stdio normalization already rejects buffers before reaching `Bun.spawn`.

## Verification

New tests in `test/js/bun/spawn/spawn.test.ts` under `stdio[N>=3] blob-like inputs`: `Uint8Array` / `ArrayBuffer` / `DataView` at index 3 and `Uint8Array` at index 4 throw for both `spawn` and `spawnSync` (8 tests, all fail on the released bun because the call succeeds), plus an empty view at index 3 still spawning normally.

The full `spawn.test.ts` (155 tests), `spawnSync.test.ts` and `spawn-empty-arrayBufferOrBlob.test.ts` pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->