### PR TITLE
shell: replace EnvStr packed u128 with a niche enum over NonNull

### DIFF
--- a/src/runtime/shell/EnvStr.rs
+++ b/src/runtime/shell/EnvStr.rs
@@ -7,94 +7,50 @@
 //!
 //! So environment strings can be ref counted or borrowed slices
 
-use core::ffi::c_void;
+use core::mem::size_of;
+use core::ptr::NonNull;
 
 use super::ref_counted_str::RefCountedStr;
 
-/// Packed `u128` layout (LSB-first):
-/// - bits  0..48  : `ptr` (u48)
-/// - bits 48..64  : `tag` (u16)
-/// - bits 64..128 : `len` (usize)
-#[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct EnvStr(u128);
+pub enum EnvStr {
+    /// Memory is managed elsewhere so don't dealloc it: the `init_slice`
+    /// caller keeps the bytes alive for as long as the value is read.
+    Slice(NonNull<[u8]>),
 
-#[repr(u16)]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub enum Tag {
-    /// no value
-    Empty = 0,
-
-    /// Dealloced by reference counting
-    Refcounted = 1,
-
-    /// Memory is managed elsewhere so don't dealloc it
-    Slice = 2,
+    /// Dealloced by reference counting: the value stands for one of the
+    /// counted refs (taken by the constructors and `ref_`, released by
+    /// `deref`), so the target is live for as long as the value is used.
+    Refcounted(NonNull<RefCountedStr>),
 }
 
-const PTR_MASK: u128 = (1u128 << 48) - 1;
-const TAG_SHIFT: u32 = 48;
-const TAG_MASK: u128 = 0xFFFF;
-const LEN_SHIFT: u32 = 64;
+// `Refcounted` is encoded in the null niche of the `Slice` data pointer, so the
+// enum is exactly the fat pointer, with no discriminant word added.
+const _: () = assert!(size_of::<EnvStr>() == size_of::<NonNull<[u8]>>());
 
 impl EnvStr {
-    #[inline]
-    const fn pack(ptr: u64, tag: Tag, len: usize) -> EnvStr {
-        EnvStr(
-            (ptr as u128 & PTR_MASK)
-                | ((tag as u16 as u128) << TAG_SHIFT)
-                | ((len as u64 as u128) << LEN_SHIFT),
-        )
-    }
-
-    #[inline]
-    fn ptr(self) -> u64 {
-        (self.0 & PTR_MASK) as u64
-    }
-
-    #[inline]
-    fn tag(self) -> Tag {
-        // Only constructed via `pack` with a valid `Tag` discriminant (0..=2);
-        // any other value is corruption — trap rather than silently folding
-        // to `Empty`.
-        match ((self.0 >> TAG_SHIFT) & TAG_MASK) as u16 {
-            0 => Tag::Empty,
-            1 => Tag::Refcounted,
-            2 => Tag::Slice,
-            n => unreachable!("invalid EnvStr tag {n}"),
-        }
-    }
-
-    #[inline]
-    fn len(self) -> usize {
-        (self.0 >> LEN_SHIFT) as u64 as usize
-    }
+    /// What every constructor returns for an empty string.
+    const EMPTY: EnvStr = EnvStr::Slice(NonNull::from_ref(&[]));
 
     #[inline]
     pub(crate) fn init_slice(str: &[u8]) -> EnvStr {
         if str.is_empty() {
-            // Zero length strings may have invalid pointers, leading to a bad integer cast.
-            return Self::pack(0, Tag::Empty, 0);
+            return Self::EMPTY;
         }
 
-        Self::pack(to_ptr(str.as_ptr().cast::<c_void>()), Tag::Slice, str.len())
+        EnvStr::Slice(NonNull::from(str))
     }
 
     /// Same thing as `init_ref_counted` except it duplicates the passed string
     pub(crate) fn dupe_ref_counted(old_str: &[u8]) -> EnvStr {
         if old_str.is_empty() {
-            return Self::pack(0, Tag::Empty, 0);
+            return Self::EMPTY;
         }
 
         // Global mimalloc aborts on OOM; ownership of the duplicated bytes
         // transfers to RefCountedStr.
         let str: Box<[u8]> = Box::<[u8]>::from(old_str);
-        let len = str.len();
-        Self::pack(
-            to_ptr(RefCountedStr::init(str) as *const c_void),
-            Tag::Refcounted,
-            len,
-        )
+        EnvStr::Refcounted(RefCountedStr::init(str))
     }
 
     /// Takes ownership of the backing allocation (hands the slice to
@@ -102,106 +58,63 @@ impl EnvStr {
     /// copy a borrowed slice instead.
     pub(crate) fn init_ref_counted(str: Box<[u8]>) -> EnvStr {
         if str.is_empty() {
-            return Self::pack(0, Tag::Empty, 0);
+            return Self::EMPTY;
         }
 
-        // NOTE: `len` is left 0 here (only `ptr` + `tag` set); the slice
-        // length is recovered via RefCountedStr::byte_slice().
-        Self::pack(
-            to_ptr(RefCountedStr::init(str) as *const c_void),
-            Tag::Refcounted,
-            0,
-        )
+        EnvStr::Refcounted(RefCountedStr::init(str))
     }
 
     pub(crate) fn slice(&self) -> &[u8] {
-        // NOTE: the returned slice borrows either external memory (Tag::Slice) or the
+        // NOTE: the returned slice borrows either external memory (`Slice`) or the
         // RefCountedStr buffer. Tying the return lifetime to `&self` prevents the caller from
         // conjuring `&'static [u8]` (PORTING.md §Forbidden: lifetime-extension via raw-pointer
         // deref). `EnvStr` is still `Copy`, so this is a best-effort bound — the caller is
         // responsible for keeping the backing storage alive.
-        match self.tag() {
-            Tag::Empty => b"",
-            Tag::Slice => self.cast_slice(),
-            Tag::Refcounted => match self.as_ref_counted() {
-                Some(r) => r.byte_slice(),
-                // Unreachable: tag check above guarantees `Some`.
-                None => b"",
-            },
+        match self {
+            // SAFETY: `Slice` contract above; the borrow is tied to the value being read.
+            EnvStr::Slice(str) => unsafe { str.as_ref() },
+            EnvStr::Refcounted(refc) => ref_counted(refc).byte_slice(),
         }
     }
 
     pub(crate) fn memory_cost(self) -> usize {
-        let divisor: usize = 'brk: {
-            if let Some(refc) = self.as_ref_counted() {
-                break 'brk refc.refcount.get() as usize;
+        let (len, divisor) = match self {
+            EnvStr::Slice(str) => (str.len(), 1),
+            EnvStr::Refcounted(refc) => {
+                let refc = ref_counted(&refc);
+                (refc.byte_slice().len(), refc.refcount.get() as usize)
             }
-            break 'brk 1;
         };
         if divisor == 0 {
             bun_core::hint::cold();
             return 0;
         }
 
-        self.len() / divisor
+        len / divisor
     }
 
     pub fn ref_(self) {
-        if let Some(refc) = self.as_ref_counted() {
-            refc.ref_();
+        if let EnvStr::Refcounted(refc) = self {
+            ref_counted(&refc).ref_();
         }
     }
 
     pub fn deref(self) {
-        if self.tag() == Tag::Refcounted {
-            // SAFETY: tag == Refcounted guarantees a live *mut RefCountedStr;
-            // `deref` may free it, so this stays raw-ptr (not `as_ref_counted`).
-            unsafe { RefCountedStr::deref(self.cast_ref_counted()) };
+        if let EnvStr::Refcounted(refc) = self {
+            // SAFETY: `Refcounted` contract above; this releases the ref the value holds.
+            unsafe { RefCountedStr::deref(refc) };
         }
-    }
-
-    /// Shared-borrow accessor for the ref-counted backing — centralises the
-    /// `unsafe { &*self.cast_ref_counted() }` back-ref deref under the
-    /// `Tag::Refcounted ⇒ live heap RefCountedStr` invariant. Returns `None`
-    /// for `Slice`/`Empty`. The borrow is tied to `&self` (best-effort: `EnvStr`
-    /// is `Copy`, so the caller is still responsible for keeping the +1 alive).
-    #[inline]
-    fn as_ref_counted(&self) -> Option<&RefCountedStr> {
-        if self.tag() == Tag::Refcounted {
-            // SAFETY: tag == Refcounted guarantees `ptr` is a live
-            // *mut RefCountedStr (set by init_ref_counted/dupe_ref_counted)
-            // with refcount >= 1; read-only borrow here.
-            return Some(unsafe { &*self.cast_ref_counted() });
-        }
-        None
-    }
-
-    #[inline]
-    fn cast_slice(&self) -> &[u8] {
-        // SAFETY: tag == Slice guarantees `ptr` was derived from a valid `[*]const u8` of
-        // length `len` whose lifetime is managed elsewhere (caller contract of init_slice).
-        // The returned borrow is tied to `&self` so callers cannot pick `'static`.
-        // Provenance: the packed-tagged-value design round-trips the pointer
-        // through an integer by construction (exposed provenance), so this is
-        // not strict-provenance clean and cannot be without unpacking EnvStr.
-        unsafe { core::slice::from_raw_parts(self.ptr() as usize as *const u8, self.len()) }
-    }
-
-    #[inline]
-    fn cast_ref_counted(self) -> *mut RefCountedStr {
-        // SAFETY: tag == Refcounted guarantees `ptr` was derived from RefCountedStr::init.
-        self.ptr() as usize as *mut RefCountedStr
     }
 }
 
 impl Default for EnvStr {
     fn default() -> Self {
-        Self::pack(0, Tag::Empty, 0)
+        Self::EMPTY
     }
 }
 
 #[inline]
-fn to_ptr(ptr_val: *const c_void) -> u64 {
-    // Masks the low 48 bits of the address.
-    (ptr_val as usize as u64) & ((1u64 << 48) - 1)
+fn ref_counted(refc: &NonNull<RefCountedStr>) -> &RefCountedStr {
+    // SAFETY: `EnvStr::Refcounted` contract; the borrow is tied to the value holding the ref.
+    unsafe { refc.as_ref() }
 }

--- a/src/runtime/shell/RefCountedStr.rs
+++ b/src/runtime/shell/RefCountedStr.rs
@@ -1,4 +1,5 @@
 use core::cell::Cell;
+use core::ptr::NonNull;
 
 bun_core::declare_scope!(RefCountedEnvStr, hidden);
 
@@ -10,13 +11,13 @@ pub struct RefCountedStr {
 
 impl RefCountedStr {
     // Takes ownership of `slice` (global mimalloc) and stores it directly.
-    pub(crate) fn init(slice: Box<[u8]>) -> *mut RefCountedStr {
+    pub(crate) fn init(slice: Box<[u8]>) -> NonNull<RefCountedStr> {
         bun_core::scoped_log!(RefCountedEnvStr, "init: {}", bstr::BStr::new(&*slice));
         // bun.handleOom(bun.default_allocator.create(...)) → Box::new (aborts on OOM)
-        bun_core::heap::into_raw(Box::new(RefCountedStr {
+        bun_core::heap::alloc_nn(RefCountedStr {
             refcount: Cell::new(1),
             data: slice,
-        }))
+        })
     }
 
     pub(crate) fn byte_slice(&self) -> &[u8] {
@@ -27,13 +28,13 @@ impl RefCountedStr {
         self.refcount.set(self.refcount.get() + 1);
     }
 
-    // Takes `*mut Self` because reaching refcount==0 deallocates the
+    // Takes `NonNull<Self>` because reaching refcount==0 deallocates the
     // `Box<Self>` that backs `this`; a `&self` borrow would dangle across that drop.
-    pub unsafe fn deref(this: *mut RefCountedStr) {
+    pub unsafe fn deref(this: NonNull<RefCountedStr>) {
         // SAFETY: caller guarantees `this` was produced by `init` and is still
         // live; on hitting 0, `this` is uniquely owned and Box-allocated.
         unsafe {
-            let rc = &(*this).refcount;
+            let rc = &this.as_ref().refcount;
             rc.set(rc.get() - 1);
             if rc.get() == 0 {
                 Self::deinit(this);
@@ -43,16 +44,16 @@ impl RefCountedStr {
 
     // Not `impl Drop` — this is the intrusive-rc self-destroy path
     // (`bun.default_allocator.destroy(this)`), which must deallocate the Box backing `self`.
-    unsafe fn deinit(this: *mut RefCountedStr) {
+    unsafe fn deinit(mut this: NonNull<RefCountedStr>) {
         // SAFETY: refcount just reached 0; `this` is uniquely owned and was Box-allocated in `init`.
         unsafe {
             bun_core::scoped_log!(
                 RefCountedEnvStr,
                 "deinit: {}",
-                bstr::BStr::new((*this).byte_slice())
+                bstr::BStr::new(this.as_ref().byte_slice())
             );
-            (*this).free_str();
-            drop(bun_core::heap::take(this));
+            this.as_mut().free_str();
+            drop(bun_core::heap::take(this.as_ptr()));
         }
     }
 


### PR DESCRIPTION
## What

`EnvStr` (`src/runtime/shell/EnvStr.rs`), the key and value type of the shell's `EnvMap`s, was a `u128` hand-packed from a 48-bit address, a `u16` `Tag` (`Empty`, `Refcounted`, `Slice`) and a length. Every read went integer to pointer: `tag()` decoded the tag with an `unreachable!()` arm, `cast_slice()` rebuilt the slice with `from_raw_parts` from the masked address (and documented that this was not strict-provenance clean), `cast_ref_counted()` cast the same integer to `*mut RefCountedStr`, and `to_ptr()` truncated every stored pointer to 48 bits. `init_ref_counted` stored a length of 0 and relied on the `RefCountedStr` for the real one, so `memory_cost()` reported 0 for assigned variables and `.env()` entries.

```rust
// before
#[repr(transparent)]
pub struct EnvStr(u128);
pub enum Tag { Empty = 0, Refcounted = 1, Slice = 2 }
unsafe { core::slice::from_raw_parts(self.ptr() as usize as *const u8, self.len()) }
impl RefCountedStr { fn init(slice: Box<[u8]>) -> *mut RefCountedStr; unsafe fn deref(this: *mut RefCountedStr); }

// after
#[derive(Copy, Clone, Eq, PartialEq)]
pub enum EnvStr {
    Slice(NonNull<[u8]>),
    Refcounted(NonNull<RefCountedStr>),
}
const _: () = assert!(size_of::<EnvStr>() == size_of::<NonNull<[u8]>>());
impl RefCountedStr { fn init(slice: Box<[u8]>) -> NonNull<RefCountedStr>; unsafe fn deref(this: NonNull<RefCountedStr>); }
```

`Empty` folds into `EnvStr::EMPTY`, a `Slice` of the empty slice, which the three constructors and `Default` return for empty input exactly where they used to return the `Empty` tag (so empty strings still never allocate a `RefCountedStr`). `slice()`, `memory_cost()`, `ref_()` and `deref()` are now a `match` on the two variants; the one `RefCountedStr` borrow is in a private `ref_counted()` helper, and `memory_cost()` reads the length from whichever variant holds it, so it now counts `init_ref_counted` strings too (this only feeds the GC `estimatedSize` hint). `Tag`, `PTR_MASK`/`TAG_SHIFT`/`TAG_MASK`/`LEN_SHIFT`, `pack`, `ptr`, `tag`, `len`, `to_ptr`, `cast_slice`, `cast_ref_counted` and `as_ref_counted` are deleted. `RefCountedStr::init` uses `bun_core::heap::alloc_nn`, and `deref`/`deinit` take the `NonNull` it returns, with the one `.as_ptr()` at the `heap::take` that frees it. The public surface (`init_slice`, `dupe_ref_counted`, `init_ref_counted`, `slice`, `memory_cost`, `ref_`, `deref`, `Default`) is unchanged, so none of the 18 construction sites or the `EnvMap`/builtin readers in the rest of `src/runtime/shell` change. The file still has 3 `unsafe` blocks (borrow the `Slice` bytes, borrow the `RefCountedStr`, release a ref), but none of them manufactures a pointer from an integer any more; the only `as` cast left in the file is the `u32` to `usize` widening of the refcount in `memory_cost`.

## Why

The states an `EnvStr` can be in are now the two variants, and which pointer each one holds (and who frees it) is stated by the payload type instead of by a tag decode and two integer casts; a corrupt tag, a non-canonical address or a pointer above 48 bits are no longer representable, and the code is strict-provenance clean (the old reads required exposed provenance). It is zero-cost: `Refcounted` lives in the null niche of the `Slice` data pointer, so the enum is the same 16 bytes as the `u128` (asserted at compile time; `Option<EnvStr>`, the `EnvMap::get` return type, shrinks from 32 to 24 bytes), `Vec<EnvStr>` storage keeps its stride and its allocations (alignment 8 and 16 both take mimalloc's plain `mi_malloc` path), and the same `RefCountedStr` allocations are made. `slice()`, which `EnvMap` hashing and equality call on every probe and which builds every child's environment, is a null test plus a fat-pointer load instead of shift, mask, a tag range check and a panic path; the only thing that gets bigger is that by-value `EnvStr` arguments at non-inlined call boundaries are passed through memory like any two-word Rust aggregate rather than in two registers, which is a store pair at the caller against the decode work removed from every callee.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/js/bun/shell/bunshell.test.ts, leak.test.ts, assignments-in-pipeline.test.ts, commands/which.test.ts: 485 pass, 16 fail (bunshell 409/9, leak 35/7, assignments-in-pipeline 38/0, which 3/0).
The 16 failures are identical on main (pre-existing, environment-related): bunshell `condexprs > -c`, `-f character device` and the 7 `stdin redirect from a zero-length buffer` cases (/dev/null is a regular file in this sandbox), plus 7 leak.test.ts `memleak_*` tests hitting the 100s per-test timeout on the debug build.
