### PR TITLE
jsc: remove AbortSignal::unref/detach; add abort_signal::PendingActivityRef as the owned hold on a signal

### DIFF
--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -48,8 +48,7 @@ unsafe extern "C" {
     safe fn WebCore__AbortSignal__fromJS(value0: JSValue) -> *mut AbortSignal;
     safe fn WebCore__AbortSignal__ref(arg0: &AbortSignal) -> *mut AbortSignal;
     safe fn WebCore__AbortSignal__toJS(arg0: &AbortSignal, arg1: &JSGlobalObject) -> JSValue;
-    // Frees the signal at count zero. Only `ext_deref` (the `Drop` of
-    // `AbortSignalRef`) may call this; see the note on `ref_`.
+    // Only called from `ext_deref`; see `ref_`.
     safe fn WebCore__AbortSignal__unref(arg0: &AbortSignal);
     // `*mut Timeout` is round-tripped opaquely through C++ (stored from
     // `AbortSignal__Timeout__create`, never dereferenced on the C++ side), so
@@ -162,12 +161,10 @@ impl AbortSignal {
         ))
     }
 
-    /// Takes a ref and returns the same pointer carrying it. The caller owns
-    /// that `+1`; the only way to release it is to adopt it into an
-    /// [`AbortSignalRef`] and drop that. There is deliberately no inherent
-    /// `unref(&self)`: `&AbortSignal` is reachable from every `AbortSignalRef`
-    /// (and, being an opaque ZST handle, from any pointer), so a safe release on
-    /// the pointee would let safe code drop a ref it does not own.
+    /// Takes a ref; release it by adopting it into an [`AbortSignalRef`]. There
+    /// is no `unref(&self)` on purpose: `&AbortSignal` does not prove ownership
+    /// of a ref (every `AbortSignalRef` derefs to one), so a safe release here
+    /// would let safe code double-release.
     pub fn ref_(&self) -> *mut AbortSignal {
         WebCore__AbortSignal__ref(self)
     }
@@ -188,11 +185,10 @@ impl AbortSignal {
         WebCore__AbortSignal__create(global)
     }
 
-    /// Creates a signal with no JS wrapper yet (`to_js` makes one on demand).
     pub fn new(global: &JSGlobalObject) -> AbortSignalRef {
         crate::mark_binding!();
-        // SAFETY: `WebCore__AbortSignal__new` is `RefPtr::leakRef()` of a fresh
-        // signal: a live, non-null pointer carrying the `+1` adopted here.
+        // SAFETY: C++ returns `leakRef()` of a fresh signal, i.e. the `+1`
+        // adopted here.
         unsafe { AbortSignalRef::adopt(WebCore__AbortSignal__new(global)) }
     }
 
@@ -259,15 +255,13 @@ impl AbortSignal {
     }
 }
 
-/// What a native operation holds on a signal while it is in flight: a ref
-/// (keeps the C++ object alive), a pending-activity count (keeps the JS
-/// wrapper and the `abort` listeners on it alive, and marks the signal as
-/// observed for `AbortSignal.timeout`), and optionally the one native listener
-/// the operation registered. Dropping it gives all three back, so holders keep
-/// an `Option<PendingActivityRef>` and release by taking it out.
+/// What a native operation holds on a signal while it is in flight: a ref, a
+/// pending-activity count (keeps the JS wrapper and its `abort` listeners
+/// alive), and at most one native listener. `Drop` gives all three back, so
+/// holders keep an `Option<PendingActivityRef>` and release by taking it out.
 pub struct PendingActivityRef {
     signal: AbortSignalRef,
-    /// The `ctx` passed to [`Self::add_listener`], or null if none was.
+    /// Null until [`Self::add_listener`].
     listener_ctx: Cell<*mut c_void>,
 }
 
@@ -280,11 +274,8 @@ impl PendingActivityRef {
         }
     }
 
-    /// Registers `callback(ctx, reason)` to run when the signal aborts (at once
-    /// if it already has, like [`AbortSignal::add_listener`]); it is removed
-    /// when `self` drops. One listener per hold. Takes `&self` so that this
-    /// shadows the `Deref`'d `AbortSignal::add_listener`, whose registration
-    /// nothing would remove.
+    /// [`AbortSignal::add_listener`], but removed again when `self` drops.
+    /// Takes `&self` so it shadows the `Deref`'d original for every receiver.
     pub fn add_listener(
         &self,
         ctx: *mut c_void,
@@ -298,7 +289,6 @@ impl PendingActivityRef {
         self.signal.add_listener(ctx, callback);
     }
 
-    /// A plain ref to the same signal, for an owner that outlives this hold.
     pub fn signal_ref(&self) -> AbortSignalRef {
         self.signal.clone()
     }
@@ -318,13 +308,10 @@ impl Drop for PendingActivityRef {
         if !ctx.is_null() {
             self.signal.clean_native_bindings(ctx);
         }
-        // Listener first: `cleanNativeBindings` is the one of the two that
-        // cancels an `AbortSignal.timeout` timer if it finds the signal
-        // unobserved, so it must run while the pending-activity count still
-        // counts as an observer, or a timeout signal JS is still holding would
-        // never fire.
+        // Second on purpose: `cleanNativeBindings` cancels an `AbortSignal.timeout`
+        // timer once nothing observes the signal, and pending activity counts
+        // as observing it. The ref itself goes when `self.signal` drops.
         self.signal.pending_activity_unref();
-        // `self.signal` drops last and releases the ref.
     }
 }
 

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -47,6 +47,8 @@ unsafe extern "C" {
     safe fn WebCore__AbortSignal__fromJS(value0: JSValue) -> *mut AbortSignal;
     safe fn WebCore__AbortSignal__ref(arg0: &AbortSignal) -> *mut AbortSignal;
     safe fn WebCore__AbortSignal__toJS(arg0: &AbortSignal, arg1: &JSGlobalObject) -> JSValue;
+    // Frees the signal at count zero. Only `ext_deref` (the `Drop` of
+    // `AbortSignalRef`) may call this; see the note on `ref_`.
     safe fn WebCore__AbortSignal__unref(arg0: &AbortSignal);
     // `*mut Timeout` is round-tripped opaquely through C++ (stored from
     // `AbortSignal__Timeout__create`, never dereferenced on the C++ side), so
@@ -159,17 +161,14 @@ impl AbortSignal {
         ))
     }
 
+    /// Takes a ref and returns the same pointer carrying it. The caller owns
+    /// that `+1`; the only way to release it is to adopt it into an
+    /// [`AbortSignalRef`] and drop that. There is deliberately no inherent
+    /// `unref(&self)`: `&AbortSignal` is reachable from every `AbortSignalRef`
+    /// (and, being an opaque ZST handle, from any pointer), so a safe release on
+    /// the pointee would let safe code drop a ref it does not own.
     pub fn ref_(&self) -> *mut AbortSignal {
         WebCore__AbortSignal__ref(self)
-    }
-
-    pub fn unref(&self) {
-        WebCore__AbortSignal__unref(self)
-    }
-
-    pub fn detach(&self, ctx: *mut c_void) {
-        self.clean_native_bindings(ctx);
-        self.unref();
     }
 
     /// Lifetime: the returned pointer is borrowed from the JS wrapper and is
@@ -188,6 +187,8 @@ impl AbortSignal {
         WebCore__AbortSignal__create(global)
     }
 
+    /// Creates a signal and returns it carrying a `+1` the caller owns; same
+    /// release rule as [`AbortSignal::ref_`].
     pub fn new(global: &JSGlobalObject) -> *mut AbortSignal {
         crate::mark_binding!();
         WebCore__AbortSignal__new(global)
@@ -199,9 +200,9 @@ impl AbortSignal {
     ///
     /// Thread-safety: not thread-safe; call only on the owning thread/loop.
     ///
-    /// Usage: if you need to operate on the Timeout (run/cancel/deinit), hold a ref
-    /// to `this` for the duration (e.g., `this.ref_(); defer this.unref();`) and avoid
-    /// caching the pointer across turns.
+    /// Usage: if you need to operate on the Timeout (run/cancel/deinit), hold an
+    /// [`AbortSignalRef`] to `self` for the duration and avoid caching the
+    /// pointer across turns.
     pub fn get_timeout(&self) -> Option<&Timeout> {
         let ptr = WebCore__AbortSignal__getTimeout(self);
         // SAFETY: returned Timeout is owned by `self` and valid while `self` is held

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
@@ -187,11 +188,12 @@ impl AbortSignal {
         WebCore__AbortSignal__create(global)
     }
 
-    /// Creates a signal and returns it carrying a `+1` the caller owns; same
-    /// release rule as [`AbortSignal::ref_`].
-    pub fn new(global: &JSGlobalObject) -> *mut AbortSignal {
+    /// Creates a signal with no JS wrapper yet (`to_js` makes one on demand).
+    pub fn new(global: &JSGlobalObject) -> AbortSignalRef {
         crate::mark_binding!();
-        WebCore__AbortSignal__new(global)
+        // SAFETY: `WebCore__AbortSignal__new` is `RefPtr::leakRef()` of a fresh
+        // signal: a live, non-null pointer carrying the `+1` adopted here.
+        unsafe { AbortSignalRef::adopt(WebCore__AbortSignal__new(global)) }
     }
 
     /// Returns a borrowed handle to the internal Timeout, or null.
@@ -254,6 +256,75 @@ impl AbortSignal {
             // same non-null pointer with +1 ownership.
             unsafe { AbortSignalRef::adopt((*p).ref_()) }
         })
+    }
+}
+
+/// What a native operation holds on a signal while it is in flight: a ref
+/// (keeps the C++ object alive), a pending-activity count (keeps the JS
+/// wrapper and the `abort` listeners on it alive, and marks the signal as
+/// observed for `AbortSignal.timeout`), and optionally the one native listener
+/// the operation registered. Dropping it gives all three back, so holders keep
+/// an `Option<PendingActivityRef>` and release by taking it out.
+pub struct PendingActivityRef {
+    signal: AbortSignalRef,
+    /// The `ctx` passed to [`Self::add_listener`], or null if none was.
+    listener_ctx: Cell<*mut c_void>,
+}
+
+impl PendingActivityRef {
+    pub fn new(signal: AbortSignalRef) -> Self {
+        signal.pending_activity_ref();
+        Self {
+            signal,
+            listener_ctx: Cell::new(core::ptr::null_mut()),
+        }
+    }
+
+    /// Registers `callback(ctx, reason)` to run when the signal aborts (at once
+    /// if it already has, like [`AbortSignal::add_listener`]); it is removed
+    /// when `self` drops. One listener per hold. Takes `&self` so that this
+    /// shadows the `Deref`'d `AbortSignal::add_listener`, whose registration
+    /// nothing would remove.
+    pub fn add_listener(
+        &self,
+        ctx: *mut c_void,
+        callback: unsafe extern "C" fn(*mut c_void, JSValue),
+    ) {
+        debug_assert!(
+            self.listener_ctx.get().is_null(),
+            "PendingActivityRef already has a listener"
+        );
+        self.listener_ctx.set(ctx);
+        self.signal.add_listener(ctx, callback);
+    }
+
+    /// A plain ref to the same signal, for an owner that outlives this hold.
+    pub fn signal_ref(&self) -> AbortSignalRef {
+        self.signal.clone()
+    }
+}
+
+impl core::ops::Deref for PendingActivityRef {
+    type Target = AbortSignal;
+    #[inline]
+    fn deref(&self) -> &AbortSignal {
+        &self.signal
+    }
+}
+
+impl Drop for PendingActivityRef {
+    fn drop(&mut self) {
+        let ctx = self.listener_ctx.get();
+        if !ctx.is_null() {
+            self.signal.clean_native_bindings(ctx);
+        }
+        // Listener first: `cleanNativeBindings` is the one of the two that
+        // cancels an `AbortSignal.timeout` timer if it finds the signal
+        // unobserved, so it must run while the pending-activity count still
+        // counts as an observer, or a timeout signal JS is still holding would
+        // never fire.
+        self.signal.pending_activity_unref();
+        // `self.signal` drops last and releases the ref.
     }
 }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -32,7 +32,8 @@ use bun_jsc::abort_signal::AbortListener;
 use bun_jsc::array_buffer::BinaryType;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
-    CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsClass, JsRef, JsResult, StrongOptional,
+    AbortSignalRef, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsClass, JsRef,
+    JsResult, StrongOptional,
 };
 use bun_ptr::IntrusiveRc;
 
@@ -1549,14 +1550,9 @@ pub struct Stream {
 }
 
 pub(crate) struct SignalRef {
-    // LIFETIMES.tsv: SHARED — AbortSignal is intrusively refcounted across FFI/codegen.
-    // `AbortSignal` is an opaque C++ type whose ref/unref go through
-    // `WebCore__AbortSignal__ref/unref`; it does not (and cannot) implement
-    // `bun_ptr::RefCounted`, so balance refs by hand in `attach_signal` /
-    // `Drop`. `BackRef` captures the backref invariant
-    // (signal is `ref_()`'d in `attach_signal` and outlives this struct until
-    // `Drop` calls `detach()`/`unref()`), so reads go through safe `Deref`.
-    signal: bun_ptr::BackRef<AbortSignal>,
+    /// Owns a ref on the signal for as long as our listener is registered on
+    /// it; `Drop` removes the listener, then the field's drop releases the ref.
+    signal: AbortSignalRef,
     // LIFETIMES.tsv: SHARED — H2FrameParser carries an intrusive RefCount and is
     // recovered via `from_field_ptr!` from the auto-flusher. It uses a hand-rolled
     // `Cell<u32>` ref count (not `bun_ptr::RefCount<Self>`), so `IntrusiveRc`'s
@@ -1570,7 +1566,6 @@ pub(crate) struct SignalRef {
 
 impl SignalRef {
     pub(crate) fn is_aborted(&self) -> bool {
-        // BackRef invariant: signal kept alive via .ref_() in attach_signal.
         self.signal.aborted()
     }
 
@@ -1594,12 +1589,10 @@ impl SignalRef {
 
 impl Drop for SignalRef {
     fn drop(&mut self) {
-        // BackRef invariant: `signal` is the C++-refcounted AbortSignal we
-        // ref_()'d in `attach_signal`; valid until this `detach` releases our
-        // listener and unrefs. Copy the `BackRef` out first so the `&mut self`
-        // taken by `from_mut` doesn't overlap the receiver borrow.
-        let signal = self.signal;
-        signal.detach(std::ptr::from_mut(self).cast::<c_void>());
+        // The listener was registered with `self`'s address as its ctx
+        // (`attach_signal`); remove it before `self.signal` drops our ref.
+        let ctx = std::ptr::from_mut(self).cast::<c_void>();
+        self.signal.clean_native_bindings(ctx);
         // ParentRef backref — parser outlives every SignalRef (ref()'d in
         // `attach_signal`); release that ref now via the inherent `deref()`.
         H2FrameParser::deref(self.parser.get());
@@ -2120,20 +2113,19 @@ impl Stream {
             .unwrap_or_else(|| JSValue::js_number(self.id as f64))
     }
 
-    pub fn attach_signal(&mut self, parser: &H2FrameParser, signal: &mut AbortSignal) {
-        // `ref_()` bumps the C++ intrusive refcount and returns the same live
-        // `self` pointer with FFI (wildcard) provenance — store *that* in the
-        // `BackRef` so its validity is tied to the refcount, not to the
-        // borrowed `&mut AbortSignal` parameter's lifetime.
-        let refed = core::ptr::NonNull::new(signal.ref_()).expect("AbortSignal::ref_");
+    pub fn attach_signal(&mut self, parser: &H2FrameParser, signal: &AbortSignal) {
+        // SAFETY: `signal` is live (borrowed from the JS wrapper the caller is
+        // holding); `ref_()` returns the same pointer carrying a `+1`, which
+        // the `AbortSignalRef` now owns.
+        let owned = unsafe { AbortSignalRef::adopt(signal.ref_()) };
         // we need a stable pointer to know what signal points to what stream_id + parser
         let mut signal_ref = Box::new(SignalRef {
-            signal: bun_ptr::BackRef::from(refed),
+            signal: owned,
             parser: bun_ptr::ParentRef::new(parser),
             stream_id: self.id,
         });
         // `signal_ref` is heap-allocated and outlives the listener registration
-        // (cleared via `detach` in `Drop for SignalRef`).
+        // (removed in `Drop for SignalRef`).
         signal.listen(&raw mut *signal_ref);
         // TODO: We should not need this ref counting here, since Parser owns Stream
         parser.ref_();
@@ -9360,8 +9352,9 @@ impl H2FrameParser {
 
             if let Some(signal_arg) = options.get(global_object, "signal")? {
                 if let Some(signal_ptr) = AbortSignal::from_js(signal_arg) {
-                    // SAFETY: `from_js` returns a live *mut AbortSignal owned by JSC; rooted via `signal_arg` on the stack.
-                    let signal_ = unsafe { &mut *signal_ptr };
+                    // `from_js` returns the signal owned by the JS wrapper, which
+                    // `signal_arg` keeps alive for the rest of this call.
+                    let signal_ = AbortSignal::opaque_ref(signal_ptr);
                     if signal_.aborted() {
                         stream.state = StreamState::IDLE;
                         let wrapped =

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1550,8 +1550,6 @@ pub struct Stream {
 }
 
 pub(crate) struct SignalRef {
-    /// Owns a ref on the signal for as long as our listener is registered on
-    /// it; `Drop` removes the listener, then the field's drop releases the ref.
     signal: AbortSignalRef,
     // LIFETIMES.tsv: SHARED — H2FrameParser carries an intrusive RefCount and is
     // recovered via `from_field_ptr!` from the auto-flusher. It uses a hand-rolled
@@ -1589,8 +1587,7 @@ impl SignalRef {
 
 impl Drop for SignalRef {
     fn drop(&mut self) {
-        // The listener was registered with `self`'s address as its ctx
-        // (`attach_signal`); remove it before `self.signal` drops our ref.
+        // `attach_signal` registered the listener with `self`'s address as ctx.
         let ctx = std::ptr::from_mut(self).cast::<c_void>();
         self.signal.clean_native_bindings(ctx);
         // ParentRef backref — parser outlives every SignalRef (ref()'d in
@@ -9352,8 +9349,6 @@ impl H2FrameParser {
 
             if let Some(signal_arg) = options.get(global_object, "signal")? {
                 if let Some(signal_ptr) = AbortSignal::from_js(signal_arg) {
-                    // `from_js` returns the signal owned by the JS wrapper, which
-                    // `signal_arg` keeps alive for the rest of this call.
                     let signal_ = AbortSignal::opaque_ref(signal_ptr);
                     if signal_.aborted() {
                         stream.state = StreamState::IDLE;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1790,13 +1790,13 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
     // Therefore, we must do this at the very end.
     if let Some(signal) = abort_signal.take() {
-        signal.pending_activity_ref();
+        let signal = jsc::abort_signal::PendingActivityRef::new(signal);
         // `add_listener` may synchronously fire `on_abort_signal` (already
         // aborted), which re-enters via `subprocess_ptr`, so the store below
         // goes through the raw pointer rather than a `&mut Subprocess`.
-        let _ = signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
+        signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
         // SAFETY: `subprocess_ptr` is the live Subprocess allocated above;
-        // `clear_abort_signal` releases the ref and the pending-activity count.
+        // `clear_abort_signal` drops the hold.
         unsafe { (*subprocess_ptr).abort_signal.set(Some(signal)) };
     }
 
@@ -1834,8 +1834,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
             // Therefore, we must do this at the very end.
             if let Some(signal) = abort_signal.take() {
-                signal.pending_activity_ref();
-                let _ = signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
+                let signal = jsc::abort_signal::PendingActivityRef::new(signal);
+                signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
                 // SAFETY: see the matching block above.
                 unsafe { (*subprocess_ptr).abort_signal.set(Some(signal)) };
             }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1826,21 +1826,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
         // watchOrReap will handle the already exited case for us.
     }
 
-    match subprocess.process_mut().watch_or_reap() {
-        sys::Result::Ok(_) => {
-            // Once everything is set up, we can add the abort listener
-            // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
-            // Therefore, we must do this at the very end.
-            if let Some(signal) = abort_signal.take() {
-                let signal = jsc::abort_signal::PendingActivityRef::new(signal);
-                signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-                // SAFETY: see the matching block above.
-                unsafe { (*subprocess_ptr).abort_signal.set(Some(signal)) };
-            }
-        }
-        sys::Result::Err(_) => {
-            subprocess.process_mut().wait(true);
-        }
+    if subprocess.process_mut().watch_or_reap().is_err() {
+        subprocess.process_mut().wait(true);
     }
 
     if !subprocess.has_exited() {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -367,8 +367,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut windows_hide: bool = false;
     #[cfg(windows)]
     let mut windows_verbatim_arguments: bool = false;
-    // Owned here until it moves into the Subprocess at the very end; every
-    // earlier return releases it by dropping it.
     let mut abort_signal: Option<jsc::AbortSignalRef> = None;
     let mut terminal_info: Option<TerminalCreateResult> = None;
     let mut existing_terminal: Option<bun_ptr::BackRef<Terminal, bun_ptr::Mut>> = None; // Existing terminal passed by user

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -367,22 +367,15 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     let mut windows_hide: bool = false;
     #[cfg(windows)]
     let mut windows_verbatim_arguments: bool = false;
-    let mut abort_signal: Option<*mut WebCore::AbortSignal> = None;
+    // Owned here until it moves into the Subprocess at the very end; every
+    // earlier return releases it by dropping it.
+    let mut abort_signal: Option<jsc::AbortSignalRef> = None;
     let mut terminal_info: Option<TerminalCreateResult> = None;
     let mut existing_terminal: Option<bun_ptr::BackRef<Terminal, bun_ptr::Mut>> = None; // Existing terminal passed by user
     let mut terminal_js_value: JSValue = JSValue::ZERO;
     let mut defer_guard = scopeguard::guard(
-        (&mut abort_signal, &mut terminal_info),
-        |(abort_signal, terminal_info): (
-            &mut Option<*mut WebCore::AbortSignal>,
-            &mut Option<TerminalCreateResult>,
-        )| {
-            if let Some(signal) = abort_signal.take() {
-                // signal was ref()'d when stored; unref releases that ref.
-                // `AbortSignal` is an `opaque_ffi!` ZST handle; `opaque_ref` is
-                // the centralised non-null deref proof.
-                WebCore::AbortSignal::opaque_ref(signal).unref();
-            }
+        &mut terminal_info,
+        |terminal_info: &mut Option<TerminalCreateResult>| {
             // If we created a new terminal but spawn failed, close it. The
             // writer/reader/finalize deref paths release the remaining refs.
             // Downgrade the JSRef so the wrapper is GC-eligible, and mark
@@ -395,8 +388,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             }
         },
     );
-    // Note: reshaped for borrowck — re-borrow through the guard tuple.
-    let (abort_signal, terminal_info) = &mut *defer_guard;
+    // Note: reshaped for borrowck — re-borrow through the guard.
+    let terminal_info = &mut *defer_guard;
 
     // Owned ZBox for `cwd` held here so the `&[u8]` borrow stays valid until
     // `spawn_process` returns.
@@ -511,15 +504,11 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             }
 
             if let Some(signal_val) = args.get_truthy(global_this, "signal")? {
-                if let Some(signal) = WebCore::AbortSignal::from_js(signal_val) {
-                    // `from_js` returns a live FFI handle owned by JS.
-                    // `AbortSignal` is an `opaque_ffi!` ZST handle; `opaque_ref`
-                    // is the centralised non-null deref proof.
-                    let sig = WebCore::AbortSignal::opaque_ref(signal);
-                    if let Some(abort_error) = sig.node_abort_error_if_aborted(global_this) {
+                if let Some(signal) = WebCore::AbortSignal::ref_from_js(signal_val) {
+                    if let Some(abort_error) = signal.node_abort_error_if_aborted(global_this) {
                         return Err(global_this.throw_value(abort_error));
                     }
-                    **abort_signal = Some(sig.ref_());
+                    abort_signal = Some(signal);
                 } else {
                     return Err(global_this.throw_invalid_argument_type_value(
                         b"signal",
@@ -1336,7 +1325,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
         closed: Default::default(),
         this_value: Default::default(),
         weak_file_sink_stdin_ptr: Cell::new(None),
-        abort_signal: Cell::new(None),
+        abort_signal: JsCell::new(None),
         event_loop_timer_refd: Cell::new(false),
         event_loop_timer: JsCell::new(crate::timer::EventLoopTimer::init_paused(
             crate::timer::EventLoopTimerTag::SubprocessTimeout,
@@ -1801,16 +1790,14 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
     // Therefore, we must do this at the very end.
     if let Some(signal) = abort_signal.take() {
-        // SAFETY: `signal` is a live *mut AbortSignal carrying the +1 ref taken
-        // above; ownership of that ref transfers to `subprocess.abort_signal`.
+        signal.pending_activity_ref();
         // `add_listener` may synchronously fire `on_abort_signal` (already
-        // aborted), which re-enters via `subprocess_ptr` — write through the
-        // raw pointer so no `&mut Subprocess` is held across the call.
-        unsafe {
-            (*signal).pending_activity_ref();
-            let _ = (*signal).add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-            (*subprocess_ptr).abort_signal.set(NonNull::new(signal));
-        }
+        // aborted), which re-enters via `subprocess_ptr`, so the store below
+        // goes through the raw pointer rather than a `&mut Subprocess`.
+        let _ = signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
+        // SAFETY: `subprocess_ptr` is the live Subprocess allocated above;
+        // `clear_abort_signal` releases the ref and the pending-activity count.
+        unsafe { (*subprocess_ptr).abort_signal.set(Some(signal)) };
     }
 
     if !IS_SYNC {
@@ -1847,13 +1834,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             // Adding the abort listener may call the onAbortSignal callback immediately if it was already aborted
             // Therefore, we must do this at the very end.
             if let Some(signal) = abort_signal.take() {
+                signal.pending_activity_ref();
+                let _ = signal.add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
                 // SAFETY: see the matching block above.
-                unsafe {
-                    (*signal).pending_activity_ref();
-                    let _ =
-                        (*signal).add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-                    (*subprocess_ptr).abort_signal.set(NonNull::new(signal));
-                }
+                unsafe { (*subprocess_ptr).abort_signal.set(Some(signal)) };
             }
         }
         sys::Result::Err(_) => {

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -361,8 +361,7 @@ bun_spawn::link_impl_ProcessExit! {
 }
 
 impl Subprocess<'_> {
-    /// The attached `AbortSignal`, if any; the returned ref outlives a
-    /// concurrent `clear_abort_signal`.
+    /// Owned, so it stays valid if `clear_abort_signal` runs meanwhile.
     #[inline]
     pub(crate) fn abort_signal_ref(&self) -> Option<jsc::AbortSignalRef> {
         self.abort_signal.get().as_ref().map(|s| s.signal_ref())

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -29,7 +29,7 @@ use crate::api::bun_process::{Process, Rusage, Status};
 use crate::ipc as IPC;
 use crate::node::node_cluster_binding;
 use crate::timer::{EventLoopTimer, EventLoopTimerState};
-use crate::webcore::{self, AbortSignal, FileSink};
+use crate::webcore::{self, FileSink};
 #[cfg(windows)]
 use bun_libuv_sys::UvHandle as _;
 
@@ -361,10 +361,11 @@ bun_spawn::link_impl_ProcessExit! {
 }
 
 impl Subprocess<'_> {
-    /// Shared borrow of the attached `AbortSignal`, if any.
+    /// The attached `AbortSignal`, if any; the returned ref outlives a
+    /// concurrent `clear_abort_signal`.
     #[inline]
-    pub(crate) fn abort_signal_ref(&self) -> Option<&AbortSignal> {
-        self.abort_signal.get().as_deref()
+    pub(crate) fn abort_signal_ref(&self) -> Option<jsc::AbortSignalRef> {
+        self.abort_signal.get().as_ref().map(|s| s.signal_ref())
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -8,8 +8,8 @@ use core::ptr::NonNull;
 use bun_ptr::RefCount;
 
 use bun_jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsRef, JsResult,
-    VirtualMachine,
+    self as jsc, AbortSignalRef, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsRef,
+    JsResult, VirtualMachine,
 };
 use bun_jsc::{JsClass, SysErrorJsc};
 #[cfg(not(windows))]
@@ -147,10 +147,9 @@ pub struct Subprocess<'a> {
     /// Weak observer of the stdin `FileSink` — holds no ownership/ref. `onStdinDestroyed`
     /// nulls this before the sink is freed, so it is never dereferenced after the sink dies.
     pub(crate) weak_file_sink_stdin_ptr: Cell<Option<NonNull<FileSink>>>,
-    /// +1 C++-intrusive ref held; released in `clear_abort_signal` via
-    /// `AbortSignal::unref()`. Not `Arc` — `AbortSignal` is an opaque FFI
-    /// handle whose refcount lives on the C++ side.
-    pub(crate) abort_signal: Cell<Option<NonNull<AbortSignal>>>,
+    /// The `signal` spawn option, held (with a pending-activity count on it)
+    /// while our abort listener is registered; `clear_abort_signal` drops both.
+    pub(crate) abort_signal: JsCell<Option<AbortSignalRef>>,
 
     pub(crate) event_loop_timer_refd: Cell<bool>,
     /// Intrusive timer node. `JsCell` so `&self` can hand `*mut EventLoopTimer`
@@ -364,15 +363,9 @@ bun_spawn::link_impl_ProcessExit! {
 
 impl Subprocess<'_> {
     /// Shared borrow of the attached `AbortSignal`, if any.
-    ///
-    /// `abort_signal` holds a +1 C++-intrusive ref taken in
-    /// `spawn_maybe_sync`; the pointee is therefore live for as long as the
-    /// cell is `Some` (it is `take`n *before* `unref()` in
-    /// [`clear_abort_signal`](Self::clear_abort_signal)) — i.e. the
-    /// owner-outlives-holder `BackRef` invariant holds.
     #[inline]
-    pub(crate) fn abort_signal_ref(&self) -> Option<bun_ptr::BackRef<AbortSignal>> {
-        self.abort_signal.get().map(bun_ptr::BackRef::from)
+    pub(crate) fn abort_signal_ref(&self) -> Option<&AbortSignal> {
+        self.abort_signal.get().as_deref()
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1279,13 +1272,10 @@ impl Subprocess<'_> {
     }
 
     fn clear_abort_signal(&self) {
-        if let Some(signal) = self.abort_signal.replace(None).map(bun_ptr::BackRef::from) {
-            // `signal` was stored with a +1 C++ intrusive ref (taken in
-            // `spawn_maybe_sync`); it stays live until `unref()` below, so the
-            // `BackRef` invariant (pointee outlives holder) holds for this scope.
+        if let Some(signal) = self.abort_signal.replace(None) {
             signal.pending_activity_unref();
             signal.clean_native_bindings(self.as_ctx_ptr().cast::<c_void>());
-            signal.unref();
+            // Dropping `signal` releases the ref taken in `spawn_maybe_sync`.
         }
     }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -8,8 +8,8 @@ use core::ptr::NonNull;
 use bun_ptr::RefCount;
 
 use bun_jsc::{
-    self as jsc, AbortSignalRef, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsRef,
-    JsResult, VirtualMachine,
+    self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsRef, JsResult,
+    VirtualMachine,
 };
 use bun_jsc::{JsClass, SysErrorJsc};
 #[cfg(not(windows))]
@@ -147,9 +147,8 @@ pub struct Subprocess<'a> {
     /// Weak observer of the stdin `FileSink` — holds no ownership/ref. `onStdinDestroyed`
     /// nulls this before the sink is freed, so it is never dereferenced after the sink dies.
     pub(crate) weak_file_sink_stdin_ptr: Cell<Option<NonNull<FileSink>>>,
-    /// The `signal` spawn option, held (with a pending-activity count on it)
-    /// while our abort listener is registered; `clear_abort_signal` drops both.
-    pub(crate) abort_signal: JsCell<Option<AbortSignalRef>>,
+    /// The `signal` spawn option, with our abort listener registered on it.
+    pub(crate) abort_signal: JsCell<Option<jsc::abort_signal::PendingActivityRef>>,
 
     pub(crate) event_loop_timer_refd: Cell<bool>,
     /// Intrusive timer node. `JsCell` so `&self` can hand `*mut EventLoopTimer`
@@ -1272,11 +1271,7 @@ impl Subprocess<'_> {
     }
 
     fn clear_abort_signal(&self) {
-        if let Some(signal) = self.abort_signal.replace(None) {
-            signal.pending_activity_unref();
-            signal.clean_native_bindings(self.as_ctx_ptr().cast::<c_void>());
-            // Dropping `signal` releases the ref taken in `spawn_maybe_sync`.
-        }
+        drop(self.abort_signal.replace(None));
     }
 
     pub fn finalize(self: Box<Self>) {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -385,18 +385,18 @@ mod shim {
         // See `signal_aborted` — counted ref keeps pointee live.
         bun_ptr::BackRef::from(s).signal(g, r)
     }
-    /// Release BOTH refcounts the request holds on its AbortSignal.
-    /// `pending_activity_unref()` drops the GC-visibility count and `unref()`
-    /// drops the intrusive C++ `RefPtr` count taken at creation. `s` must not
-    /// be dereferenced after this call.
+    /// Release BOTH refcounts the request holds on its AbortSignal:
+    /// `pending_activity_unref()` drops the GC-visibility count and dropping
+    /// the adopted `AbortSignalRef` releases the intrusive C++ count taken at
+    /// creation (which may free the signal). `s` must not be dereferenced
+    /// after this call.
     #[inline]
     pub(super) fn signal_release(s: NonNull<AbortSignal>) {
-        // See `signal_aborted`. Order: pending-activity first,
-        // then the owning intrusive ref (which may free). `BackRef` is dropped
-        // before `unref()` returns, so no dangling deref.
-        let signal = bun_ptr::BackRef::from(s);
+        // SAFETY: `s` was just `take()`n out of `ctx.signal`, which held the
+        // `+1` from `AbortSignal::new()` since the request was created, so
+        // this adopt is the only release of that ref.
+        let signal = unsafe { jsc::AbortSignalRef::adopt(s.as_ptr()) };
         signal.pending_activity_unref();
-        signal.unref();
     }
     #[inline]
     pub(super) fn iec_trigger(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -117,11 +117,9 @@ pub struct RequestContext<
     pub(crate) resp: Cell<Option<uws::AnyResponse>>,
     pub(crate) req: Cell<Option<*mut Req<SSL_ENABLED, HTTP3>>>,
     pub(crate) request_weakref: JsCell<request::WeakRef>,
-    /// `request.signal`, fired with `ConnectionClosed` when the client goes
-    /// away. The `Request` holds its own `AbortSignalRef` to the same signal;
-    /// this hold is taken out (and released) in `on_abort` /
-    /// `finalize_without_deinit`, or moved into the `ServerWebSocket` on
-    /// upgrade.
+    /// `request.signal` (the `Request` holds its own ref to it). Taken out in
+    /// `on_abort` / `finalize_without_deinit`, or moved to the `ServerWebSocket`
+    /// on upgrade.
     pub(crate) signal: JsCell<Option<jsc::abort_signal::PendingActivityRef>>,
     pub method: Method,
     /// Owned `+1` ref on a C++ `CookieMap` (taken in `set_cookies`, released
@@ -622,9 +620,8 @@ where
     }
 
     pub(crate) fn set_signal_aborted(&self, reason: jsc::CommonAbortReason) {
-        // Abort listeners may end this request and take the hold out of
-        // `self.signal`, so fire through a ref of our own rather than a borrow
-        // of the cell.
+        // Own ref, not a borrow of the cell: abort listeners may end the request
+        // and empty it.
         let Some(signal) = self.signal.get().as_ref().map(|s| s.signal_ref()) else {
             return;
         };
@@ -1420,7 +1417,6 @@ where
                 signal.signal(global_this, jsc::CommonAbortReason::ConnectionClosed);
                 any_js_calls.set(true);
             }
-            // Dropping the hold releases the signal.
         }
 
         // if have sink, call onAborted on sink
@@ -1507,7 +1503,6 @@ where
             if self.flags.aborted() && !signal.aborted() {
                 signal.signal(global_this, jsc::CommonAbortReason::ConnectionClosed);
             }
-            // Dropping the hold releases the signal.
         }
 
         // Case 1:

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -12,8 +12,8 @@ use bun_uws::{self as uws, WebSocketUpgradeContext};
 use crate::server::jsc::{self, JSGlobalObject, JSValue, JsResult, VirtualMachine};
 use crate::server::{RangeRequest, ServerLike};
 use crate::webcore::{
-    self as WebCore, AbortSignal, AnyBlob, ByteStream, CookieMap, CookieMapRef, FetchHeaders,
-    Request, Response, blob::SizeType as BlobSizeType, body, readable_stream, request, response,
+    self as WebCore, AnyBlob, ByteStream, CookieMap, CookieMapRef, FetchHeaders, Request, Response,
+    blob::SizeType as BlobSizeType, body, readable_stream, request, response,
 };
 
 /// Q: Why is this needed?
@@ -117,13 +117,12 @@ pub struct RequestContext<
     pub(crate) resp: Cell<Option<uws::AnyResponse>>,
     pub(crate) req: Cell<Option<*mut Req<SSL_ENABLED, HTTP3>>>,
     pub(crate) request_weakref: JsCell<request::WeakRef>,
-    // NOTE: `Arc<AbortSignal>` was wrong —
-    // `AbortSignal` is an opaque ZST FFI handle; an `Arc` of a ZST never owns
-    // the C++ allocation. Store the raw pointer. The request holds TWO counts:
-    // the intrusive C++ `RefPtr` (+1 from `AbortSignal::new()`/`ref_()`) and a
-    // pending-activity count for GC visibility. Both are released together via
-    // `shim::signal_release` in `on_abort`/`finalize_without_deinit`.
-    pub(crate) signal: Cell<Option<NonNull<AbortSignal>>>,
+    /// `request.signal`, fired with `ConnectionClosed` when the client goes
+    /// away. The `Request` holds its own `AbortSignalRef` to the same signal;
+    /// this hold is taken out (and released) in `on_abort` /
+    /// `finalize_without_deinit`, or moved into the `ServerWebSocket` on
+    /// upgrade.
+    pub(crate) signal: JsCell<Option<jsc::abort_signal::PendingActivityRef>>,
     pub method: Method,
     /// Owned `+1` ref on a C++ `CookieMap` (taken in `set_cookies`, released
     /// when the field is dropped/replaced — `CookieMapRef` handles the unref).
@@ -367,36 +366,6 @@ mod shim {
     #[inline]
     pub(super) fn response_detach_stream(r: &mut Response, g: &JSGlobalObject) {
         r.detach_readable_stream(g)
-    }
-    #[inline]
-    pub(super) fn signal_aborted(s: NonNull<AbortSignal>) -> bool {
-        // `signal` is kept alive by the intrusive C++ refcount (+1 from
-        // `AbortSignal::new()` / `ref_()`) plus `pending_activity_ref()` until
-        // `signal_release` drops both — satisfies the `BackRef` outlives-holder
-        // invariant for the duration of this call.
-        bun_ptr::BackRef::from(s).aborted()
-    }
-    #[inline]
-    pub(super) fn signal_fire(
-        s: NonNull<AbortSignal>,
-        g: &JSGlobalObject,
-        r: jsc::CommonAbortReason,
-    ) {
-        // See `signal_aborted` — counted ref keeps pointee live.
-        bun_ptr::BackRef::from(s).signal(g, r)
-    }
-    /// Release BOTH refcounts the request holds on its AbortSignal:
-    /// `pending_activity_unref()` drops the GC-visibility count and dropping
-    /// the adopted `AbortSignalRef` releases the intrusive C++ count taken at
-    /// creation (which may free the signal). `s` must not be dereferenced
-    /// after this call.
-    #[inline]
-    pub(super) fn signal_release(s: NonNull<AbortSignal>) {
-        // SAFETY: `s` was just `take()`n out of `ctx.signal`, which held the
-        // `+1` from `AbortSignal::new()` since the request was created, so
-        // this adopt is the only release of that ref.
-        let signal = unsafe { jsc::AbortSignalRef::adopt(s.as_ptr()) };
-        signal.pending_activity_unref();
     }
     #[inline]
     pub(super) fn iec_trigger(
@@ -653,12 +622,16 @@ where
     }
 
     pub(crate) fn set_signal_aborted(&self, reason: jsc::CommonAbortReason) {
-        if let Some(signal) = self.signal.get() {
-            if let Some(server) = self.server.get() {
-                // server is a BACKREF — valid while this RequestContext is alive
-                let global = server.global_this();
-                shim::signal_fire(signal, global, reason);
-            }
+        // Abort listeners may end this request and take the hold out of
+        // `self.signal`, so fire through a ref of our own rather than a borrow
+        // of the cell.
+        let Some(signal) = self.signal.get().as_ref().map(|s| s.signal_ref()) else {
+            return;
+        };
+        if let Some(server) = self.server.get() {
+            // server is a BACKREF — valid while this RequestContext is alive
+            let global = server.global_this();
+            signal.signal(global, reason);
         }
     }
 
@@ -1331,7 +1304,7 @@ where
                 defer_deinit_until_callback_completes: Cell::new(should_deinit_context),
                 range: RangeRequest::raw_from_request(&Self::any_request(req)),
                 request_weakref: JsCell::new(request::WeakRef::EMPTY),
-                signal: Cell::new(None),
+                signal: JsCell::new(None),
                 cookies: JsCell::new(None),
                 flags: Flags::<DEBUG_MODE>::default(),
                 upgrade_context: Cell::new(UpgradeState::None),
@@ -1442,16 +1415,12 @@ where
             this.request_weakref.with_mut(|w| w.deref());
         }
         // if signal is not aborted, abort the signal
-        if let Some(signal) = this.signal.take() {
-            if !shim::signal_aborted(signal) {
-                shim::signal_fire(
-                    signal,
-                    global_this,
-                    jsc::CommonAbortReason::ConnectionClosed,
-                );
+        if let Some(signal) = this.signal.replace(None) {
+            if !signal.aborted() {
+                signal.signal(global_this, jsc::CommonAbortReason::ConnectionClosed);
                 any_js_calls.set(true);
             }
-            shim::signal_release(signal);
+            // Dropping the hold releases the signal.
         }
 
         // if have sink, call onAborted on sink
@@ -1534,15 +1503,11 @@ where
         }
 
         // if signal is not aborted, abort the signal
-        if let Some(signal) = self.signal.take() {
-            if self.flags.aborted() && !shim::signal_aborted(signal) {
-                shim::signal_fire(
-                    signal,
-                    global_this,
-                    jsc::CommonAbortReason::ConnectionClosed,
-                );
+        if let Some(signal) = self.signal.replace(None) {
+            if self.flags.aborted() && !signal.aborted() {
+                signal.signal(global_this, jsc::CommonAbortReason::ConnectionClosed);
             }
-            shim::signal_release(signal);
+            // Dropping the hold releases the signal.
         }
 
         // Case 1:

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -25,16 +25,14 @@ bun_output::declare_scope!(WebSocketServer, visible);
 // — `on_open` → `ws.cork(JS)` → `ws.close()` → `on_close` mutates `flags` /
 // `this_value` on the SAME `m_ctx`. A `&mut Self` receiver would alias under
 // Stacked Borrows. Receivers therefore take `&self`; per-field interior
-// mutability (`Cell` for the `Copy` flags and the only-ever-`take()`n signal,
-// `JsCell` for the non-`Copy` `JsRef`) carries the writes.
+// mutability (`Cell`, `JsCell` for the non-`Copy` `JsRef`) carries the writes.
 #[bun_jsc::JsClass]
 pub struct ServerWebSocket {
     handler: bun_ptr::BackRef<WebSocketServerHandler>,
     this_value: JsCell<JsRef>,
     flags: Cell<Flags>,
-    /// The upgraded request's signal, taken over from its `RequestContext`;
-    /// `on_close` takes it out to fire it, and whatever is left is released
-    /// with the socket.
+    /// The upgraded request's signal, moved here from its `RequestContext`;
+    /// `on_close` takes it out and fires it.
     signal: Cell<Option<abort_signal::PendingActivityRef>>,
 }
 
@@ -349,9 +347,7 @@ impl ServerWebSocket {
     // pub const js = jsc.Codegen.JSServerWebSocket; — provided by #[bun_jsc::JsClass]
     // toJS / fromJS / fromJSDirect — provided by codegen (see `to_js_ptr` / `JsClass` impl)
 
-    /// Initialize a ServerWebSocket with the given handler, data value, and the
-    /// upgraded request's signal, which is fired and released when the socket
-    /// closes.
+    /// `signal` is the upgraded request's; it is fired when the socket closes.
     pub(crate) fn init(
         handler: &WebSocketServerHandler,
         data_value: JSValue,
@@ -699,8 +695,6 @@ impl ServerWebSocket {
             .try_get()
             .unwrap_or(JSValue::UNDEFINED);
         let this_value_cell: &JsCell<JsRef> = &self.this_value;
-        // The guard owns the signal until fn exit; the abort below borrows it
-        // through the guard.
         let cleanup = scopeguard::guard(signal, move |signal| {
             drop(signal);
             if was_not_empty {

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -9,8 +9,8 @@ use bun_uws_sys::{Opcode, SendStatus};
 
 use crate::server::WebSocketServerHandler;
 use crate::server::jsc::{
-    self, AbortSignalRef, ArrayBuffer, BinaryType, CallFrame, CommonAbortReason, JSGlobalObject,
-    JSType, JSValue, JsError, JsRef, JsResult, ZigStringSlice,
+    self, ArrayBuffer, BinaryType, CallFrame, CommonAbortReason, JSGlobalObject, JSType, JSValue,
+    JsError, JsRef, JsResult, ZigStringSlice, abort_signal,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
 use crate::webcore::Blob;
@@ -32,10 +32,10 @@ pub struct ServerWebSocket {
     handler: bun_ptr::BackRef<WebSocketServerHandler>,
     this_value: JsCell<JsRef>,
     flags: Cell<Flags>,
-    /// The request's signal, handed over by the upgrade caller together with
-    /// its pending-activity count; whichever of `on_close`/`finalize` runs
-    /// first takes it, drops the pending-activity count, and releases it.
-    signal: Cell<Option<AbortSignalRef>>,
+    /// The upgraded request's signal, taken over from its `RequestContext`;
+    /// `on_close` takes it out to fire it, and whatever is left is released
+    /// with the socket.
+    signal: Cell<Option<abort_signal::PendingActivityRef>>,
 }
 
 // We pack the per-socket data into this struct below:
@@ -349,14 +349,13 @@ impl ServerWebSocket {
     // pub const js = jsc.Codegen.JSServerWebSocket; — provided by #[bun_jsc::JsClass]
     // toJS / fromJS / fromJSDirect — provided by codegen (see `to_js_ptr` / `JsClass` impl)
 
-    /// Initialize a ServerWebSocket with the given handler, data value, and signal.
-    /// The socket takes over `signal` (and the pending-activity count the
-    /// request context put on it) and releases both when it closes or is
-    /// finalized.
+    /// Initialize a ServerWebSocket with the given handler, data value, and the
+    /// upgraded request's signal, which is fired and released when the socket
+    /// closes.
     pub(crate) fn init(
         handler: &WebSocketServerHandler,
         data_value: JSValue,
-        signal: Option<AbortSignalRef>,
+        signal: Option<abort_signal::PendingActivityRef>,
     ) -> *mut ServerWebSocket {
         let global_object = handler.global_object();
         let this = bun_core::heap::into_raw(Box::new(ServerWebSocket {
@@ -702,11 +701,8 @@ impl ServerWebSocket {
         let this_value_cell: &JsCell<JsRef> = &self.this_value;
         // The guard owns the signal until fn exit; the abort below borrows it
         // through the guard.
-        let cleanup = scopeguard::guard(signal, move |sig| {
-            if let Some(sig) = sig {
-                sig.pending_activity_unref();
-                // Dropping `sig` releases the ref the upgrade caller handed over.
-            }
+        let cleanup = scopeguard::guard(signal, move |signal| {
+            drop(signal);
             if was_not_empty {
                 // The `server` traced edge set in `init` must outlive this
                 // wrapper: `self.handler` points into the server's allocation
@@ -797,10 +793,7 @@ impl ServerWebSocket {
     pub fn finalize(self: Box<Self>) {
         bun_output::scoped_log!(WebSocketServer, "finalize");
         self.this_value.with_mut(|v| v.finalize());
-        if let Some(signal) = self.signal.take() {
-            signal.pending_activity_unref();
-            // Dropping `signal` releases the ref the upgrade caller handed over.
-        }
+        // Dropping the box releases `signal` if `on_close` never ran.
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -1,7 +1,6 @@
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::mem;
-use core::ptr::NonNull;
 
 use bun_jsc::JsCell;
 use bun_uws::{self as uws, AnyWebSocket, WebSocketBehavior};
@@ -10,7 +9,7 @@ use bun_uws_sys::{Opcode, SendStatus};
 
 use crate::server::WebSocketServerHandler;
 use crate::server::jsc::{
-    self, AbortSignal, ArrayBuffer, BinaryType, CallFrame, CommonAbortReason, JSGlobalObject,
+    self, AbortSignalRef, ArrayBuffer, BinaryType, CallFrame, CommonAbortReason, JSGlobalObject,
     JSType, JSValue, JsError, JsRef, JsResult, ZigStringSlice,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
@@ -26,17 +25,17 @@ bun_output::declare_scope!(WebSocketServer, visible);
 // — `on_open` → `ws.cork(JS)` → `ws.close()` → `on_close` mutates `flags` /
 // `this_value` on the SAME `m_ctx`. A `&mut Self` receiver would alias under
 // Stacked Borrows. Receivers therefore take `&self`; per-field interior
-// mutability (`Cell` for `Copy` flags/signal, `JsCell` for the non-`Copy`
-// `JsRef`) carries the writes.
+// mutability (`Cell` for the `Copy` flags and the only-ever-`take()`n signal,
+// `JsCell` for the non-`Copy` `JsRef`) carries the writes.
 #[bun_jsc::JsClass]
 pub struct ServerWebSocket {
     handler: bun_ptr::BackRef<WebSocketServerHandler>,
     this_value: JsCell<JsRef>,
     flags: Cell<Flags>,
-    // `AbortSignal` is an opaque C++ type
-    // with intrusive WebCore ref-counting (ref/unref) — never `Arc`. The init
-    // caller transfers a +1 ref; `finalize`/`on_close` unref it.
-    signal: Cell<Option<NonNull<AbortSignal>>>,
+    /// The request's signal, handed over by the upgrade caller together with
+    /// its pending-activity count; whichever of `on_close`/`finalize` runs
+    /// first takes it, drops the pending-activity count, and releases it.
+    signal: Cell<Option<AbortSignalRef>>,
 }
 
 // We pack the per-socket data into this struct below:
@@ -351,11 +350,13 @@ impl ServerWebSocket {
     // toJS / fromJS / fromJSDirect — provided by codegen (see `to_js_ptr` / `JsClass` impl)
 
     /// Initialize a ServerWebSocket with the given handler, data value, and signal.
-    /// The signal will not be ref'd inside the ServerWebSocket init function, but will unref itself when the ServerWebSocket is destroyed.
+    /// The socket takes over `signal` (and the pending-activity count the
+    /// request context put on it) and releases both when it closes or is
+    /// finalized.
     pub(crate) fn init(
         handler: &WebSocketServerHandler,
         data_value: JSValue,
-        signal: Option<NonNull<AbortSignal>>,
+        signal: Option<AbortSignalRef>,
     ) -> *mut ServerWebSocket {
         let global_object = handler.global_object();
         let this = bun_core::heap::into_raw(Box::new(ServerWebSocket {
@@ -699,14 +700,12 @@ impl ServerWebSocket {
             .try_get()
             .unwrap_or(JSValue::UNDEFINED);
         let this_value_cell: &JsCell<JsRef> = &self.this_value;
-        let _cleanup = scopeguard::guard(signal, move |sig| {
+        // The guard owns the signal until fn exit; the abort below borrows it
+        // through the guard.
+        let cleanup = scopeguard::guard(signal, move |sig| {
             if let Some(sig) = sig {
-                // `sig` was stored with a +1 ref by the upgrade caller; it
-                // stays live until this paired `unref()`, so the transient
-                // `BackRef` (pointee-outlives-holder) is sound for both calls.
-                let sig = bun_ptr::BackRef::from(sig);
                 sig.pending_activity_unref();
-                sig.unref();
+                // Dropping `sig` releases the ref the upgrade caller handed over.
             }
             if was_not_empty {
                 // The `server` traced edge set in `init` must outlive this
@@ -736,10 +735,7 @@ impl ServerWebSocket {
 
             let _loop_guard = vm.enter_event_loop_scope();
 
-            if let Some(sig) = signal {
-                // `sig` is held alive by the +1 ref released in `_cleanup`;
-                // BackRef invariant (pointee outlives the temporary) holds.
-                let sig = bun_ptr::BackRef::from(sig);
+            if let Some(sig) = cleanup.as_deref() {
                 if !sig.aborted() {
                     sig.signal(handler.global_object(), CommonAbortReason::ConnectionClosed);
                 }
@@ -766,12 +762,9 @@ impl ServerWebSocket {
                 handler.run_error_callback(on_error, global_object, err);
                 return;
             }
-        } else if let Some(sig) = signal {
+        } else if let Some(sig) = cleanup.as_deref() {
             let _loop_guard = vm.enter_event_loop_scope();
 
-            // `sig` is held alive by the +1 ref released in `_cleanup`;
-            // BackRef invariant (pointee outlives the temporary) holds.
-            let sig = bun_ptr::BackRef::from(sig);
             if !sig.aborted() {
                 sig.signal(handler.global_object(), CommonAbortReason::ConnectionClosed);
             }
@@ -805,13 +798,8 @@ impl ServerWebSocket {
         bun_output::scoped_log!(WebSocketServer, "finalize");
         self.this_value.with_mut(|v| v.finalize());
         if let Some(signal) = self.signal.take() {
-            // `signal` was stored with a +1 ref by the upgrade caller; it
-            // stays live until this paired `unref()`, so the transient
-            // `BackRef` (pointee-outlives-holder) is sound for both calls —
-            // same pattern as `on_close()`'s `_cleanup` guard.
-            let sig = bun_ptr::BackRef::from(signal);
-            sig.pending_activity_unref();
-            sig.unref();
+            signal.pending_activity_unref();
+            // Dropping `signal` releases the ref the upgrade caller handed over.
         }
     }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -806,14 +806,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         ctx_ref.request_body.set(Some(body_hive.clone()));
 
         let global = server.global_this();
-        let signal = jsc::AbortSignal::new(global);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        ctx_ref.signal.set(core::ptr::NonNull::new(signal));
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-
-        // SAFETY: `signal.ref_()` bumps the intrusive count and returns +1.
-        let signal_ref =
-            unsafe { jsc::AbortSignalRef::adopt(bun_opaque::opaque_deref_mut(signal).ref_()) };
+        let signal = jsc::abort_signal::PendingActivityRef::new(jsc::AbortSignal::new(global));
+        let signal_ref = signal.signal_ref();
+        ctx_ref.signal.set(Some(signal));
         // ownership: `Request::new` is `bun.TrivialNew` — the heap
         // allocation is handed to the JS GC via `to_js`/`to_js_for_bake` (C++
         // wrapper finalizer frees it), or, for `CreateJsRequest::No`, retained

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2179,8 +2179,6 @@ where
         // --- After this point, do not throw an exception
         // See https://github.com/oven-sh/bun/issues/1339
         upgrader.upgrade_context.set(UpgradeState::Upgraded);
-        // The socket takes over the request's signal (fired when the socket
-        // closes instead of when the request ends).
         let signal = upgrader.signal.replace(None);
         upgrader.resp.set(None);
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2183,7 +2183,14 @@ where
         // --- After this point, do not throw an exception
         // See https://github.com/oven-sh/bun/issues/1339
         upgrader.upgrade_context.set(UpgradeState::Upgraded);
-        let signal = upgrader.signal.take();
+        // SAFETY: `upgrader.signal` held the `+1` from `AbortSignal::new()` (and
+        // the pending-activity count) since the request was created. Taking it
+        // out of the context means `signal_release` will never run for it; the
+        // `ServerWebSocket` below releases both in `on_close`/`finalize`.
+        let signal = upgrader
+            .signal
+            .take()
+            .map(|signal| unsafe { jsc::AbortSignalRef::adopt(signal.as_ptr()) });
         upgrader.resp.set(None);
 
         // Snapshot lazy url/headers before detaching (mirrors to_async_without_abort_handler).

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -120,7 +120,7 @@ trait RequestCtxOps: RequestCtx {
         reason = "the body slot is a separate pooled allocation, not a field of *self (R-2)"
     )]
     fn request_body_mut(&self) -> Option<&mut BodyValue>;
-    fn set_signal(&self, sig: *mut AbortSignal);
+    fn set_signal(&self, sig: jsc::abort_signal::PendingActivityRef);
     fn set_request_weakref(&self, req: *mut Request);
     fn clear_req(&self);
     fn set_is_web_browser_navigation(&self, v: bool);
@@ -209,12 +209,8 @@ where
             .map(|h| unsafe { &mut (*h.as_ptr()).value })
     }
     #[inline]
-    fn set_signal(&self, sig: *mut AbortSignal) {
-        // `AbortSignal::new` returns a raw +1 ref to a C++-refcounted opaque;
-        // `RequestContext.signal` stores it as `Option<NonNull<AbortSignal>>`
-        // and pairs the unref in RequestContext cleanup (`shim::signal_release`,
-        // which drops both the pending-activity count and the intrusive ref).
-        self.signal.set(NonNull::new(sig));
+    fn set_signal(&self, sig: jsc::abort_signal::PendingActivityRef) {
+        self.signal.set(Some(sig));
     }
     #[inline]
     fn set_request_weakref(&self, req: *mut Request) {
@@ -2183,14 +2179,9 @@ where
         // --- After this point, do not throw an exception
         // See https://github.com/oven-sh/bun/issues/1339
         upgrader.upgrade_context.set(UpgradeState::Upgraded);
-        // SAFETY: `upgrader.signal` held the `+1` from `AbortSignal::new()` (and
-        // the pending-activity count) since the request was created. Taking it
-        // out of the context means `signal_release` will never run for it; the
-        // `ServerWebSocket` below releases both in `on_close`/`finalize`.
-        let signal = upgrader
-            .signal
-            .take()
-            .map(|signal| unsafe { jsc::AbortSignalRef::adopt(signal.as_ptr()) });
+        // The socket takes over the request's signal (fired when the socket
+        // closes instead of when the request ends).
+        let signal = upgrader.signal.replace(None);
         upgrader.resp.set(None);
 
         // Snapshot lazy url/headers before detaching (mirrors to_async_without_abort_handler).
@@ -3236,15 +3227,9 @@ where
         // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
         ctx.set_request_body(Some(body_hive.clone()));
 
-        let signal = AbortSignal::new(&server.global());
+        let signal = jsc::abort_signal::PendingActivityRef::new(AbortSignal::new(&server.global()));
+        let signal_for_req = signal.signal_ref();
         ctx.set_signal(signal);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-
-        // Bump once for the Request's owned
-        // copy and adopt into RAII so it pairs with `Request::Drop`'s unref.
-        // SAFETY: `signal` is live; `ref_()` returns the same non-null ptr +1.
-        let signal_for_req = unsafe { jsc::AbortSignalRef::adopt((*signal).ref_()) };
         let request_object_box = Request::new(Request::init(
             ctx.ctx_method(),
             AnyRequestContext::init(std::ptr::from_ref::<Ctx>(ctx)),
@@ -3504,17 +3489,11 @@ where
         // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
         ctx.request_body.set(Some(body_hive.clone()));
 
-        let signal = AbortSignal::new(&this.global());
-        // The
-        // RequestContext owns one ref so aborts during the WS-upgrade fallback
-        // fetch path propagate.
-        ctx.signal.set(NonNull::new(signal));
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-        // Bump once for the Request's copy and
-        // adopt into RAII so it pairs with `Request::Drop`'s unref.
-        // SAFETY: `signal` is live; `ref_()` returns the same non-null ptr +1.
-        let signal_for_req = unsafe { jsc::AbortSignalRef::adopt((*signal).ref_()) };
+        // The RequestContext holds the signal too, so aborts during the
+        // WS-upgrade fallback fetch path propagate.
+        let signal = jsc::abort_signal::PendingActivityRef::new(AbortSignal::new(&this.global()));
+        let signal_for_req = signal.signal_ref();
+        ctx.signal.set(Some(signal));
         let request_object_box = Request::new(Request::init(
             ctx.method,
             AnyRequestContext::init(std::ptr::from_ref(ctx)),

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -115,7 +115,9 @@ impl Drop for HeadersRef {
 
 /// Errors the owning fetch `Response`'s body on abort (Fetch spec "abort a fetch" step 4).
 pub(crate) struct BodyAbortListener {
-    signal: AbortSignalRef,
+    /// Registered with this box's address as the listener ctx; dropping it
+    /// unregisters `on_abort` before the box goes away.
+    signal: bun_jsc::abort_signal::PendingActivityRef,
     /// `Response` owns `Box<Self>`, so a ref-counted pointer here would cycle.
     response: bun_ptr::ParentRef<Response, bun_ptr::Mut>,
     global: GlobalRef,
@@ -152,14 +154,6 @@ impl BodyAbortListener {
             // R-2: re-derive after `error()` ran JS.
             let _ = response.get_body_value().to_error_instance(err, &global);
         }
-    }
-}
-
-impl Drop for BodyAbortListener {
-    fn drop(&mut self) {
-        let ctx = core::ptr::from_mut(self).cast::<c_void>();
-        self.signal.clean_native_bindings(ctx);
-        self.signal.pending_activity_unref();
     }
 }
 
@@ -519,19 +513,19 @@ impl Response {
         global: &JSGlobalObject,
         signal: &AbortSignal,
     ) {
-        // SAFETY: `signal` is live; `ref_()` bumps the intrusive refcount.
+        // SAFETY: `signal` is live; `ref_()` returns it carrying the `+1`
+        // adopted here.
         let signal_ref = unsafe { AbortSignalRef::adopt(signal.ref_()) };
-        signal.pending_activity_ref();
         let mut listener = Box::new(BodyAbortListener {
-            signal: signal_ref,
+            signal: bun_jsc::abort_signal::PendingActivityRef::new(signal_ref),
             // SAFETY: caller contract; `this` is live and owns the box.
             response: unsafe { bun_ptr::ParentRef::from_raw_mut(this) },
             global: GlobalRef::new(global),
         });
-        signal.add_listener(
-            core::ptr::from_mut(&mut *listener).cast::<c_void>(),
-            BodyAbortListener::on_abort,
-        );
+        let ctx = core::ptr::from_mut(&mut *listener).cast::<c_void>();
+        listener
+            .signal
+            .add_listener(ctx, BodyAbortListener::on_abort);
         // SAFETY: caller contract; `this` is live.
         unsafe { (*this).abort_listener.set(Some(listener)) };
     }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -115,8 +115,7 @@ impl Drop for HeadersRef {
 
 /// Errors the owning fetch `Response`'s body on abort (Fetch spec "abort a fetch" step 4).
 pub(crate) struct BodyAbortListener {
-    /// Registered with this box's address as the listener ctx; dropping it
-    /// unregisters `on_abort` before the box goes away.
+    /// `on_abort` is registered on it with this box's address as ctx.
     signal: bun_jsc::abort_signal::PendingActivityRef,
     /// `Response` owns `Box<Self>`, so a ref-counted pointer here would cycle.
     response: bun_ptr::ParentRef<Response, bun_ptr::Mut>,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -55,7 +55,7 @@ use bun_core::{String as BunString, Tag as BunStringTag, ZigStringSlice};
 use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
-use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
+use bun_jsc::{AbortSignalRef, HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
 use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
@@ -129,10 +129,10 @@ impl SignalRef {
 impl Drop for SignalRef {
     fn drop(&mut self) {
         if let Some(sig) = self.0.take() {
-            // `sig` was obtained from `AbortSignal::ref_()` which bumped the
-            // C++ intrusive refcount; the pointee outlives this `BackRef`
-            // until `unref()` releases that +1.
-            bun_ptr::BackRef::from(sig).unref();
+            // SAFETY: `sig` is the `+1` taken by `ref_()` in `extract_signal`
+            // and was not handed to `FetchOptions` (`take()` would have cleared
+            // it), so adopting it here releases that ref exactly once.
+            drop(unsafe { AbortSignalRef::adopt(sig.as_ptr()) });
         }
     }
 }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -19,7 +19,8 @@ use bun_io::KeepAlive;
 use bun_jsc::debugger::AsyncTaskTracker;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
-    self as jsc, GlobalRef, JSGlobalObject, JSValue, JsResult, StringJsc, StrongOptional,
+    self as jsc, AbortSignalRef, GlobalRef, JSGlobalObject, JSValue, JsResult, StringJsc,
+    StrongOptional,
 };
 use bun_sys::FdExt;
 use bun_threading::Mutex;
@@ -1303,14 +1304,13 @@ impl FetchTasklet {
         let Some(signal) = self.signal.take() else {
             return;
         };
-        // `signal` is a live C++-owned WebCore::AbortSignal*; we hold one ref
-        // (taken in `fetch.rs` before populating FetchOptions). Order matters:
-        // cleanNativeBindings first, then unref + pending_activity_unref.
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe `*const → &`.
-        let signal = bun_opaque::opaque_deref(signal);
+        // SAFETY: `signal` carries the `+1` taken in `fetch.rs` before it was
+        // moved into `FetchOptions`; it was just taken out of `self.signal`, so
+        // dropping the adopted ref below is the only release of that `+1`.
+        let signal = unsafe { AbortSignalRef::adopt(signal) };
+        // Unregister our listener while we still hold the ref.
         signal.clean_native_bindings(std::ptr::from_mut(self).cast::<c_void>());
         signal.pending_activity_unref();
-        signal.unref();
     }
 
     fn on_reject(&mut self) -> BodyValueError {

--- a/test/internal/source-lints/refcount-release-owner.test.ts
+++ b/test/internal/source-lints/refcount-release-owner.test.ts
@@ -1,0 +1,114 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// Intrusively refcounted foreign objects (`WTF::RefCounted` on the C++ side,
+// `napi_env`, ...) are owned from Rust through an RAII handle: `Clone` takes a
+// ref, `Drop` releases one, and adopting a raw `+1` into the handle is an
+// `unsafe fn` that states the ownership transfer. The FFI shim that releases a
+// ref frees the object when the count hits zero, so it may only be called from
+// that handle's release hook. Wrapping it in a safe method on the pointee
+// (`AbortSignal::unref(&self)`, `AbortSignal::detach(&self, ..)`) let safe code
+// release a ref it did not own: the pointee is an `opaque_ffi!` ZST, so
+// `&AbortSignal` is obtainable from any pointer (and from `AbortSignalRef`'s
+// `Deref`), and `AbortSignal::ref_from_js(v)?.unref()` followed by the
+// `AbortSignalRef`'s own `Drop` was a double release without any `unsafe`.
+//
+// Each entry below is a release shim, the file that declares it, and the one
+// function allowed to call it. Every other mention in `src/**/*.rs` is an
+// escape hatch that needs to become an owned handle (or an `unsafe` adopt of
+// the raw ref into one). Counts are asserted exactly so a renamed shim shows
+// up here instead of silently dropping out of the lint.
+const RELEASE_SHIMS: Record<string, { file: string; owner: string }> = {
+  // `WebCore::AbortSignal`; the owner is `AbortSignalRef` (`ExternalShared<AbortSignal>`).
+  WebCore__AbortSignal__unref: { file: "src/jsc/AbortSignal.rs", owner: "ext_deref" },
+  // `JSC::ArrayBuffer`; the owner is `ExternalShared<JSCArrayBuffer>`.
+  JSC__ArrayBuffer__deref: { file: "src/jsc/array_buffer.rs", owner: "ext_deref" },
+  // `napi_env`; the owner is `NapiEnvRef` (`ExternalShared<NapiEnv>`).
+  NapiEnv__deref: { file: "src/runtime/napi/napi_body.rs", owner: "ext_deref" },
+  // `WebCore::CookieMap`; the owner is the hand-rolled `CookieMapRef`.
+  CookieMap__deref: { file: "src/runtime/webcore/CookieMap.rs", owner: "drop" },
+};
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+interface Usage {
+  declarations: number;
+  ownerCalls: number;
+  other: string[];
+}
+
+const usage = new Map<string, Usage>();
+for (const shim of Object.keys(RELEASE_SHIMS)) {
+  usage.set(shim, { declarations: 0, ownerCalls: 0, other: [] });
+}
+
+const FN_HEADER = /\bfn\s+([A-Za-z_][A-Za-z0-9_]*)\s*[(<]/;
+
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Every shim name is a `__`-joined identifier that never appears in normal
+  // prose, so a whole-file substring check skips almost everything.
+  if (!Object.keys(RELEASE_SHIMS).some(shim => content.includes(shim))) continue;
+
+  // Strip `//` comments (full-line and trailing) so prose mentions don't count.
+  const lines = content.split("\n").map(line => line.replace(/\/\/.*$/, ""));
+  for (const [shim, { file: declFile, owner }] of Object.entries(RELEASE_SHIMS)) {
+    const ident = new RegExp(`\\b${shim}\\b`);
+    const record = usage.get(shim)!;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!ident.test(line)) continue;
+      const declared = new RegExp(`\\bfn\\s+${shim}\\s*\\(`).test(line);
+      // The enclosing function is the nearest `fn` header above the call.
+      let enclosing: string | undefined;
+      for (let j = i - 1; j >= 0 && enclosing === undefined; j--) {
+        enclosing = FN_HEADER.exec(lines[j])?.[1];
+      }
+      if (source === declFile && declared) {
+        record.declarations++;
+      } else if (source === declFile && enclosing === owner) {
+        record.ownerCalls++;
+      } else {
+        record.other.push(`${source}:${i + 1} (in fn ${enclosing ?? "<none>"}): ${line.trim()}`);
+      }
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing (e.g. a
+  // symlinked checkout root) and leaving nothing to scan, so a failure below
+  // is attributable to the sources rather than to the scan. Same guard as
+  // unsound-erased-box.test.ts.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+for (const [shim, { owner }] of Object.entries(RELEASE_SHIMS)) {
+  test(`${shim} is declared once and called only from ${owner}`, () => {
+    expect(usage.get(shim)).toEqual({ declarations: 1, ownerCalls: 1, other: [] });
+  });
+}

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 test("spawn AbortSignal works after spawning", async () => {
   const controller = new AbortController();
@@ -136,7 +136,13 @@ test("spawnSync AbortSignal works as timeout", async () => {
 
 // The subprocess lets go of the signal when the child exits. The caller still
 // holds it, so its timer has to keep running.
-describe("AbortSignal.timeout() still fires after the child has exited", () => {
+describe.concurrent("AbortSignal.timeout() still fires after the child has exited", () => {
+  // The child must exit before the timer fires, so it skips booting a JS VM
+  // (`--version`) and slow builds get a wider window (the passing path waits
+  // it out, so it has to stay inside the per-test ceiling).
+  const timeoutMs = isDebug || isASAN ? 3000 : 1000;
+  const cmd = [bunExe(), "--version"];
+
   async function expectTimeoutAfterExit(signal: AbortSignal, exitCode: number | null) {
     // Proves nothing unless the child was gone before the timer fired.
     expect(exitCode).toBe(0);
@@ -147,24 +153,14 @@ describe("AbortSignal.timeout() still fires after the child has exited", () => {
   }
 
   test("Bun.spawn", async () => {
-    const signal = AbortSignal.timeout(1000);
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "0"],
-      env: bunEnv,
-      stdio: ["ignore", "ignore", "ignore"],
-      signal,
-    });
+    const signal = AbortSignal.timeout(timeoutMs);
+    await using proc = Bun.spawn({ cmd, env: bunEnv, stdio: ["ignore", "ignore", "ignore"], signal });
     await expectTimeoutAfterExit(signal, await proc.exited);
   });
 
   test("Bun.spawnSync", async () => {
-    const signal = AbortSignal.timeout(1000);
-    const { exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), "-e", "0"],
-      env: bunEnv,
-      stdio: ["ignore", "ignore", "ignore"],
-      signal,
-    });
+    const signal = AbortSignal.timeout(timeoutMs);
+    const { exitCode } = Bun.spawnSync({ cmd, env: bunEnv, stdio: ["ignore", "ignore", "ignore"], signal });
     await expectTimeoutAfterExit(signal, exitCode);
   });
 });

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -134,6 +134,24 @@ test("spawnSync AbortSignal works as timeout", async () => {
   expect(end - start).toBeLessThan(100);
 });
 
+test("AbortSignal.timeout() passed to spawn still fires after the child has exited", async () => {
+  // The subprocess lets go of the signal when the child exits. The caller
+  // still holds it, so its timer has to keep running.
+  const signal = AbortSignal.timeout(1000);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "0"],
+    env: bunEnv,
+    stdio: ["ignore", "ignore", "ignore"],
+    signal,
+  });
+  await proc.exited;
+  if (!signal.aborted) {
+    await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+  }
+  expect(signal.reason).toBeInstanceOf(DOMException);
+  expect(signal.reason.name).toBe("TimeoutError");
+});
+
 describe("Bun.spawn option validation", () => {
   const spawners = [
     ["Bun.spawn", (opts: any) => Bun.spawn(opts)],

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -145,9 +145,9 @@ test("AbortSignal.timeout() passed to spawn still fires after the child has exit
     signal,
   });
   await proc.exited;
-  if (!signal.aborted) {
-    await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
-  }
+  // Proves nothing unless the child was gone before the timer fired.
+  expect(signal.aborted).toBe(false);
+  await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
   expect(signal.reason).toBeInstanceOf(DOMException);
   expect(signal.reason.name).toBe("TimeoutError");
 });

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -134,22 +134,39 @@ test("spawnSync AbortSignal works as timeout", async () => {
   expect(end - start).toBeLessThan(100);
 });
 
-test("AbortSignal.timeout() passed to spawn still fires after the child has exited", async () => {
-  // The subprocess lets go of the signal when the child exits. The caller
-  // still holds it, so its timer has to keep running.
-  const signal = AbortSignal.timeout(1000);
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", "0"],
-    env: bunEnv,
-    stdio: ["ignore", "ignore", "ignore"],
-    signal,
+// The subprocess lets go of the signal when the child exits. The caller still
+// holds it, so its timer has to keep running.
+describe("AbortSignal.timeout() still fires after the child has exited", () => {
+  async function expectTimeoutAfterExit(signal: AbortSignal, exitCode: number | null) {
+    // Proves nothing unless the child was gone before the timer fired.
+    expect(exitCode).toBe(0);
+    expect(signal.aborted).toBe(false);
+    await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+    expect(signal.reason).toBeInstanceOf(DOMException);
+    expect(signal.reason.name).toBe("TimeoutError");
+  }
+
+  test("Bun.spawn", async () => {
+    const signal = AbortSignal.timeout(1000);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "0"],
+      env: bunEnv,
+      stdio: ["ignore", "ignore", "ignore"],
+      signal,
+    });
+    await expectTimeoutAfterExit(signal, await proc.exited);
   });
-  await proc.exited;
-  // Proves nothing unless the child was gone before the timer fired.
-  expect(signal.aborted).toBe(false);
-  await new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
-  expect(signal.reason).toBeInstanceOf(DOMException);
-  expect(signal.reason.name).toBe("TimeoutError");
+
+  test("Bun.spawnSync", async () => {
+    const signal = AbortSignal.timeout(1000);
+    const { exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "0"],
+      env: bunEnv,
+      stdio: ["ignore", "ignore", "ignore"],
+      signal,
+    });
+    await expectTimeoutAfterExit(signal, exitCode);
+  });
 });
 
 describe("Bun.spawn option validation", () => {


### PR DESCRIPTION
### What

`bun_jsc::AbortSignal` (src/jsc/AbortSignal.rs) is an `opaque_ffi!` zero-sized handle to a `WebCore::AbortSignal`, which is `WTF::RefCounted`; `WebCore__AbortSignal__unref` is `deref()` and frees the object at count zero. The handle exposed that as two safe `&self` methods:

```rust
pub fn unref(&self) { WebCore__AbortSignal__unref(self) }
pub fn detach(&self, ctx: *mut c_void) { self.clean_native_bindings(ctx); self.unref(); }
```

A `&AbortSignal` proves nothing about owning a ref: it is what `AbortSignalRef` (`ExternalShared<AbortSignal>`) hands out through `Deref`, and for a ZST handle it is also obtainable from any non-null pointer via the safe `AbortSignal::opaque_ref`. So this compiles with no `unsafe` anywhere and is a double release (the `AbortSignalRef` releases the same ref again when it drops):

```rust
let signal = AbortSignal::ref_from_js(value).unwrap();
signal.unref();
```

Nothing in tree did this; every caller released a ref it had taken with `ref_()` / `new()`. But none of those sites had to say so, because the API did not ask. The same was true of the two things the callers release alongside the ref: the pending-activity count and the native abort listener were balanced by hand at every site.

### Fix

`unref` and `detach` are deleted. The release shim is now reached only from `ExternalSharedDescriptor::ext_deref`, i.e. from `AbortSignalRef`'s `Drop`, the shape `JSCArrayBuffer`, `NapiEnv` and `CookieMapRef` already use: taking a ref is safe, releasing one means dropping the owner, and turning a raw `+1` into an owner (`AbortSignalRef::adopt`) is the one `unsafe` step. `ref_` documents this so the method does not grow back; `AbortSignal::new()` returns an `AbortSignalRef` since every caller wrapped it.

Per @Jarred-Sumner's suggestion, what the native holders keep is modelled as one owned value, `abort_signal::PendingActivityRef` (the Rust spelling of `AbortSignal::PendingActivityRef`): it owns an `AbortSignalRef`, takes the pending-activity count in `new`, records the ctx of the one native listener registered through its `add_listener`, derefs to `&AbortSignal`, and its `Drop` removes the listener, drops the pending-activity count and releases the ref. Holders store `Option<PendingActivityRef>` and release by taking it out. Converted:

* `Subprocess.abort_signal`; the spawn code parses the option into an `AbortSignalRef` (`ref_from_js`; its own `Drop` covers the early returns, replacing a scopeguard branch) and wraps it when the listener is attached. `clear_abort_signal` is a `drop`. The second attach block in the spawnSync tail was unreachable (the first one runs unconditionally and empties the option) and is deleted.
* `RequestContext.signal`, created from `AbortSignal::new()` with `signal_ref()` giving the `Request` its copy; `on_abort` / `finalize_without_deinit` take it out, fire it, and drop it, and the WebSocket upgrade moves it into `ServerWebSocket.signal`, which `on_close` fires and drops (whatever is left goes with the box in `finalize`). The three `NonNull` shims in RequestContext.rs go away. `set_signal_aborted` fires through a `signal_ref()` of its own because the listeners it runs can end the request and empty the cell.
* `Response`'s `BodyAbortListener`, which was this struct written out by hand.

Holders left as they are, each with a one-line reason: `FetchTasklet` / fetch's `SignalRef` guard adopt the `+1` they already own at the release point, because #37549 is replacing those fields (on top of this PR its `unref()` deletion is a no-op conflict) and they become `Option<PendingActivityRef>` in one line once it lands; the two `node:fs` holders are the same story with #37420; the http2 `SignalRef` and `fs.watch`'s `FSWatcher` (untouched by this PR, it never used `unref()`) hold an `AbortSignalRef` plus a listener but take no pending activity today (a native listener already counts as a timeout observer), so giving them a `PendingActivityRef` would be a GC-behavior change and is left for a follow-up. Once those are converted, `pending_activity_ref`/`unref` and `clean_native_bindings` can stop being public.

### Behavior

Everything releases at the same program points as before. The one observable change is the unified `Drop` order. `cleanNativeBindings` runs `eventListenersDidChange`, which cancels an `AbortSignal.timeout()` timer if the signal has no observers left at that moment; `Subprocess` dropped its pending-activity count first and removed its listener second, so on main this never aborts:

```js
const signal = AbortSignal.timeout(1000);
await Bun.spawn({ cmd: [bunExe(), "--version"], signal }).exited;
// signal.aborted stays false forever; fetch() with the same signal aborts at 1s
```

`PendingActivityRef::drop` removes the listener while the pending-activity count still counts as an observer (the order `FetchTasklet` and `Response` already used), so spawn and spawnSync now match fetch; `spawn-signal.test.ts` gets a case for each, both of which time out on main (fetch's own order is unchanged, so a fetch case would pass on both sides; it is worth adding when `FetchTasklet` converts). The eager cancel itself also hits a held timeout signal whose last JS listener is removed, and is being fixed separately on the C++ side. The http2 `SignalRef` now releases its parser ref before the signal ref rather than after; neither release can observe the other.

### Tests

* `test/internal/source-lints/refcount-release-owner.test.ts` lists the release shims whose pointee has an RAII owner (`WebCore__AbortSignal__unref`, `JSC__ArrayBuffer__deref`, `NapiEnv__deref`, `CookieMap__deref`) and asserts each is declared once and called only from that owner's release hook, with exact counts so a renamed shim surfaces instead of dropping out. On main it fails with `src/jsc/AbortSignal.rs:167 (in fn unref): WebCore__AbortSignal__unref(self)` and the other three entries pass; with this change all pass. Complementary to #37577's lint, which allowlists this instance; whichever lands second drops that line.
* `test/js/bun/spawn/spawn-signal.test.ts`: the two timeout cases above, run concurrently. Each asserts the child exited before the timer fired (the child is `bun --version`, which does not boot a JS VM, and debug/ASAN builds get a 3s window instead of 1s) and then waits for the abort event; on a released bun both time out after the preconditions pass.

### Verification

Rebased onto current main (the upgrade hand-off now sits next to #37477's `UpgradeState`); the rebased branch was rebuilt and the runs below repeated on it. `cargo check` / `clippy` / `fmt --check` clean for `bun_jsc` and `bun_runtime`, also for `x86_64-pc-windows-msvc`; debug (ASAN) build. Against it: `spawn-signal` (incl. the spawnSync `AbortSignal.timeout` case, which reads the hold through `abort_signal_ref()`), `spawn-maxbuf`, `websocket-upgrade-signal-gc` (the ctx to socket move), `websocket-server` close/upgrade cases, `bun-server.test.ts` (only the three `localhost` connection tests fail, identically with the released binary in this sandbox), `serve-pending-promise-abort-leak`, `serve-async-stream-client-abort`, `node-http2.test.js -t "abort|signal"`, `fetch-abort-queued`, `fetch-abort-stream-body` pass. `abortsignal-leak-fixture.ts` run directly (7,650 server requests creating and releasing a `PendingActivityRef` each, 5,100 of them aborted) ends with 1 / 2 / 1 live `AbortSignal`s after a full GC, so the counts balance. Its `bun test` wrapper and `fetch-abort-socket-close-race` only exceed their 5s ceilings here because this container is running at load average ~70; the latter passed at 4.1s earlier on a build whose fetch code was byte-identical.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 13 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/refcount-release-owner.test.ts test/js/bun/spawn/spawn-signal.test.ts
bun test v1.4.0 (ad5b7ecbc)

test/internal/source-lints/refcount-release-owner.test.ts:
(pass) scans a non-empty set of tracked Rust sources [7.16ms]
107 |   expect(scanned).toBeGreaterThan(0);
108 | });
109 | 
110 | for (const [shim, { owner }] of Object.entries(RELEASE_SHIMS)) {
111 |   test(`${shim} is declared once and called only from ${owner}`, () => {
112 |     expect(usage.get(shim)).toEqual({ declarations: 1, ownerCalls: 1, other: [] });
                                  ^
error: expect(received).toEqual(expected)

  {
    "declarations": 1,
-   "other": [],
+   "other": [
+     "src/jsc/AbortSignal.rs:167 (in fn unref): WebCore__AbortSignal__unref(self)",
+   ],
    "ownerCalls": 1,
  }

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/refcount-release-owner.test.ts:112:29)
(fail) WebCore__AbortSignal__unref is declared once and called only from ext_deref [7.73ms]
(pass) JSC__ArrayBu
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/refcount-release-owner.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.11ms]
107 |   expect(scanned).toBeGreaterThan(0);
108 | });
109 | 
110 | for (const [shim, { owner }] of Object.entries(RELEASE_SHIMS)) {
111 |   test(`${shim} is declared once and called only from ${owner}`, () => {
112 |     expect(usage.get(shim)).toEqual({ declarations: 1, ownerCalls: 1, other: [] });
                                  ^
error: expect(received).toEqual(expected)

  {
    "declarations": 1,
-   "other": [],
+   "other": [
+     "src/jsc/AbortSignal.rs:167 (in fn unref): WebCore__AbortSignal__unref(self)",
+   ],
    "ownerCalls": 1,
  }

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/refcount-release-owner.test.ts:112:29)
(fail) WebCore__AbortSignal__unref is declared once and called only from ext_deref [0.27ms]
(pass) JSC__ArrayBuffer__deref is declared once and called only from ext_deref
(pass) NapiEnv__deref is declared once and called only from ext_deref
(pass) CookieMap__deref is declared once and called only from drop

test/js/bun/spawn/spawn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/refcount-release-owner.test.ts test/js/bun/spawn/spawn-signal.test.ts
bun test v1.4.0 (ad5b7ecbc)

test/internal/source-lints/refcount-release-owner.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.51ms]
(pass) WebCore__AbortSignal__unref is declared once and called only from ext_deref [2.13ms]
(pass) JSC__ArrayBuffer__deref is declared once and called only from ext_deref [0.49ms]
(pass) NapiEnv__deref is declared once and called only from ext_deref [0.36ms]
(pass) CookieMap__deref is declared once and called only from drop [0.45ms]

test/js/bun/spawn/spawn-signal.test.ts:
(pass) spawn AbortSignal works after spawning [30.56ms]
(pass) spawn AbortSignal throws if already aborted [17.83ms]
(pass) spawn AbortSignal already aborted carries signal.reason as cause [9.03ms]
(pass) spawn AbortSignal already aborted throws before resolving the executable [7.66ms]
(pass) spawnSync AbortSignal throws if already aborted [6.76ms]
(pass) spawn AbortSignal args validation [5.20ms]
(pass) spawnSync AbortSigna
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1169ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/AbortSignal.rs                             |  87 +++++++++++++---
 src/runtime/api/bun/h2_frame_parser.rs             |  40 +++-----
 src/runtime/api/bun/js_bun_spawn_bindings.rs       |  67 ++++--------
 src/runtime/api/bun/subprocess.rs                  |  29 ++----
 src/runtime/server/RequestContext.rs               |  84 ++++-----------
 src/runtime/server/ServerWebSocket.rs              |  51 +++------
 src/runtime/server/mod.rs                          |  11 +-
 src/runtime/server/server_body.rs                  |  38 ++-----
 src/runtime/webcore/Response.rs                    |  25 ++---
 src/runtime/webcore/fetch.rs                       |  10 +-
 src/runtime/webcore/fetch/FetchTasklet.rs          |  14 +--
 .../source-lints/refcount-release-owner.test.ts    | 114 +++++++++++++++++++++
 test/js/bun/spawn/spawn-signal.test.ts             |  35 +++++++
 13 files changed, 331 insertions(+), 274 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/AbortSignal.rs                                        6     18      0
src/runtime/api/bun/h2_frame_parser.rs                        6     10      0
src/runtime/api/bun/js_bun_spawn_bindings.rs                  8     11      0
src/runtime/api/bun/subprocess.rs                             6     10      0
src/runtime/server/RequestContext.rs                         13     12      0
src/runtime/server/ServerWebSocket.rs                         9     16      0
src/runtime/server/mod.rs                                     2      2      0
src/runtime/server/server_body.rs                            10      9      0
src/runtime/webcore/Response.rs                               3      5      0
src/runtime/webcore/fetch.rs                                  1      2      0
src/runtime/webcore/fetch/FetchTasklet.rs                     2      3      0
…st/internal/source-lints/refcount-release-owner.test.ts      0      2      0
test/js/bun/spawn/spawn-signal.test.ts                        4      3      0
```

</details>

<!-- robobun:evidence:end -->
