### PR TITLE
websocket: enter tunnel forwarding mode before dispatching open

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1615,6 +1615,20 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     // SAFETY: short-lived `&mut` for the field take.
                     let ws = unsafe { (*this).outgoing_websocket.take().unwrap() };
 
+                    // Switch to forwarding before entering C++. did_connect_with_tunnel
+                    // dispatches `open`, and an open handler that spins the event loop
+                    // (expect().resolves, a debugger pause) delivers socket data to
+                    // handle_data while this frame is on the stack; with the state
+                    // still `Reading` and `outgoing_websocket` taken, handle_data
+                    // would fail the client and close the socket. In `Done` it hands
+                    // the bytes to the tunnel, whose SSL engine is still inside the
+                    // pass that decrypted the 101 and so queues them until that pass
+                    // resumes, by which point C++ has attached the connected WebSocket.
+                    // Same order as the non-tunnel arm below, which detaches the socket
+                    // before did_connect.
+                    // SAFETY: short-lived write.
+                    unsafe { (*this).state = State::Done };
+
                     // Create the WebSocket client with the tunnel
                     // SAFETY: live C++ back-reference.
                     unsafe {
@@ -1630,9 +1644,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         )
                     };
 
-                    // Switch state to connected - handle_data will forward to tunnel
-                    // SAFETY: short-lived write.
-                    unsafe { (*this).state = State::Done };
                     // SAFETY: drops the outgoing_websocket ref; no `&mut Self` is live.
                     unsafe { Self::deref(this) };
                 } else if tcp.is_closed() {

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -622,6 +622,86 @@ describe("WebSocket wss:// through HTTP proxy (TLS tunnel)", () => {
       }
     });
   });
+
+  // The upgrade client keeps owning the proxy socket after the 101 and forwards
+  // whatever arrives on it into the tunnel. It used to flip into that forwarding
+  // mode only after the open event had been dispatched, so bytes read off the
+  // proxy socket while an open handler spins the event loop (expect().resolves
+  // here; a debugger pause does the same) were taken for a response to an
+  // upgrade that no longer had a WebSocket attached: the upgrade client failed
+  // itself and closed the proxy connection, and the WebSocket that had just
+  // fired open stayed OPEN forever without ever receiving a message or a close.
+  test("frames read off the proxy socket while the open handler spins the event loop are delivered", async () => {
+    const serverClosed = Promise.withResolvers<number>();
+    using server = Bun.serve({
+      port: 0,
+      tls: { key: tlsCerts.key, cert: tlsCerts.cert },
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("Expected WebSocket", { status: 400 });
+      },
+      websocket: {
+        message(ws, message) {
+          if (message === "go") ws.send("hello");
+        },
+        close(_ws, code) {
+          serverClosed.resolve(code);
+        },
+      },
+    });
+
+    // Once the client is inside its open handler, everything the server still
+    // sends is the reply to "go". setImmediate runs at the start of the next
+    // loop iteration and the expect().resolves spin below only re-checks its
+    // promise after that iteration has also polled I/O, so by the time the spin
+    // ends the client has read the forwarded reply off the proxy socket.
+    let inOpenHandler = false;
+    const replyReadByClient = Promise.withResolvers<void>();
+    const spinProxy = createConnectProxy({
+      onTargetData(chunk, forward) {
+        forward(chunk);
+        if (inOpenHandler) setImmediate(replyReadByClient.resolve);
+      },
+    });
+    const spinProxyPort = await startProxy(spinProxy);
+
+    const received: string[] = [];
+    const openReturned = Promise.withResolvers<void>();
+    const clientClosed = Promise.withResolvers<number>();
+    const ws = new WebSocket(`wss://127.0.0.1:${server.port}`, {
+      proxy: `http://127.0.0.1:${spinProxyPort}`,
+      tls: { rejectUnauthorized: false },
+    });
+    try {
+      ws.onopen = () => {
+        inOpenHandler = true;
+        ws.send("go");
+        expect(replyReadByClient.promise).resolves.toBeUndefined();
+        inOpenHandler = false;
+        openReturned.resolve();
+      };
+      ws.onmessage = event => {
+        received.push(String(event.data));
+        ws.close(1000);
+      };
+      ws.onclose = event => clientClosed.resolve(event.code);
+
+      await openReturned.promise;
+      // A client that dropped the proxy connection never closes the WebSocket,
+      // so only wait for its close event once the server saw a clean close.
+      const serverCloseCode = await serverClosed.promise;
+      const clientCloseCode =
+        serverCloseCode === 1000 ? await clientClosed.promise : "client never closed (server saw the connection drop)";
+      expect({ received, serverCloseCode, clientCloseCode }).toEqual({
+        received: ["hello"],
+        serverCloseCode: 1000,
+        clientCloseCode: 1000,
+      });
+    } finally {
+      ws.terminate();
+      spinProxy.close();
+    }
+  });
 });
 
 describe("WebSocket through HTTPS proxy (TLS proxy)", () => {


### PR DESCRIPTION
### What

For `wss://` through an HTTP CONNECT proxy (tunnel mode), the upgrade client keeps owning the proxy socket after the 101 and forwards everything it reads into the TLS tunnel. It only switched into that forwarding state (`State::Done`) after `did_connect_with_tunnel` returned. That call dispatches the `open` event, so an open handler that spins the event loop (`expect(...).resolves` in `bun:test`, a debugger pause, `Bun.build()` with an async plugin `setup`) can deliver bytes from the proxy socket to `handle_data` while the call is still on the stack. At that point the state is still `Reading` and `outgoing_websocket` has already been taken, so `handle_data` marked the client failed, dropped the proxy state (shutting the tunnel down while nothing is attached to it to hear about it) and closed the proxy connection. After `open` returned, C++ attached the new WebSocket client to the dead tunnel:

```ts
// bun test, wss:// server behind a CONNECT proxy; the server answers "go" with "hello"
ws.onopen = () => {
  ws.send("go");
  expect(replyForwardedByProxy).resolves.toBeUndefined(); // spins the loop inside open
};
ws.onmessage = e => console.log(e.data); // never fires
ws.onclose = e => console.log(e.code);   // never fires either; the server sees 1006
```

The WebSocket stays `OPEN` forever with no `message` and no `close`, and the server sees the connection drop.

### Fix

`src/http_jsc/websocket_client/WebSocketUpgradeClient.rs`: set `State::Done` before calling `did_connect_with_tunnel`, the same order the non-tunnel arm already uses (it detaches the socket before `did_connect`).

Why this is enough on its own: in `Done`, `handle_data` hands the bytes to the tunnel. The 101 that got us here was decrypted by the tunnel's `SslWrapper`, whose traffic pass is still on the stack and is not re-entrant, so bytes received during the call are only queued in the read BIO and get decrypted when that pass resumes. By then `did_connect_with_tunnel` has returned and `didConnectWithTunnel` has pointed the tunnel at the connected WebSocket client, whose C++ side is already `OPEN`, so the frames come out as ordinary `message` events and the connection carries on. The C++ ordering (`didConnect()` before `setConnectedWebSocket`) does not need to change.

### Test

`test/js/web/websocket/websocket-proxy.test.ts`: the open handler sends `"go"` and spins with `expect().resolves` until the in-process proxy has forwarded the reply and one more loop iteration has polled I/O (the spin only re-checks its promise after an `auto_tick`, which always polls, so the client has read the reply off the proxy socket by the time the spin ends). Without the fix it fails deterministically (30/30 release, 10/10 debug):

```
-   "clientCloseCode": 1000,
-   "received": ["hello"],
-   "serverCloseCode": 1000,
+   "clientCloseCode": "client never closed (server saw the connection drop)",
+   "received": [],
+   "serverCloseCode": 1006,
```

With the fix it passes (15/15 on the debug/ASAN build), along with the rest of `websocket-proxy.test.ts`, the other `websocket-proxy-*` files, `test-ws-bidir-proxy.test.ts` and `test/js/first_party/ws/ws-proxy.test.ts`.

### Notes

- Also looked at the `if state == State::Failed` branches in `connect()` that were flagged alongside this: they are unreachable. `connect_group` / `connect_unix_group` write the client into the socket's ext slot only after uSockets' connect returns, so no callback can reach the client while `connect()` is running, and nothing else sets `Failed` before it returns. Left untouched here since #37594 is rewriting that function.
- Surfaced by review of #37594, which preserves the old order; whichever of the two lands second needs a trivial rebase of this block.
