### PR TITLE
ast: make cargo test -p bun_ast link natively

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -2848,6 +2848,8 @@ pub mod use_directive;
 pub mod lexer_log;
 pub use lexer_log::LexerLog;
 pub mod lexer_tables;
+#[cfg(test)]
+mod native_test_shims;
 pub mod nodes;
 pub mod runtime;
 

--- a/src/ast/native_test_shims.rs
+++ b/src/ast/native_test_shims.rs
@@ -1,16 +1,8 @@
-//! mimalloc entry points this crate's `cargo test` binary references; mimalloc
-//! itself is only linked into the full bun binary. Never compiled into the real
-//! build.
-//!
-//! The JSON tape tests only build `TapeAlloc::Global` tapes, but the
-//! `TapeAlloc::Arena` arm of the same `Allocator` impl keeps
-//! `<&MimallocArena as Allocator>::{allocate, deallocate}` live, so the link
-//! needs everything those two reach: `mi_free_checked` in `bun_alloc::basic`
-//! frees through `mi_free_size*` under `debug_assertions` and `mi_free`
-//! otherwise, hence both sets (test/internal/rust-ast-cargo-test.test.ts
-//! links both profiles). Nothing in the binary references `mi_heap_new` or
-//! `mi_heap_main`, so no test can hold an arena and none of these is ever
-//! called; they abort instead of pretending to allocate.
+//! mimalloc symbols this crate's `cargo test` binary references through the
+//! `TapeAlloc::Arena` arm (in either profile); mimalloc itself is only linked
+//! into bun. The tests use `TapeAlloc::Global`, and nothing in the binary can
+//! create a heap (`mi_heap_new` is not even referenced), so these are never
+//! called. Never compiled into the real build.
 
 use core::ffi::c_void;
 

--- a/src/ast/native_test_shims.rs
+++ b/src/ast/native_test_shims.rs
@@ -1,0 +1,60 @@
+//! mimalloc entry points this crate's `cargo test` binary references; mimalloc
+//! itself is only linked into the full bun binary. Never compiled into the real
+//! build.
+//!
+//! The JSON tape tests only build `TapeAlloc::Global` tapes, but the
+//! `TapeAlloc::Arena` arm of the same `Allocator` impl keeps
+//! `<&MimallocArena as Allocator>::{allocate, deallocate}` live, so the link
+//! needs everything those two reach: `mi_free_checked` in `bun_alloc::basic`
+//! frees through `mi_free_size*` under `debug_assertions` and `mi_free`
+//! otherwise, hence both sets (test/internal/rust-windows-sys-link.test.ts
+//! links both profiles). Nothing in the binary references `mi_heap_new` or
+//! `mi_heap_main`, so no test can hold an arena and none of these is ever
+//! called; they abort instead of pretending to allocate.
+
+use core::ffi::c_void;
+
+use bun_alloc::mimalloc::Heap;
+
+fn no_mimalloc_in_test_binary(symbol: &str) -> ! {
+    unreachable!("{symbol} called, but bun_ast's test binary does not link mimalloc")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_heap_malloc(_heap: *mut Heap, _size: usize) -> *mut c_void {
+    no_mimalloc_in_test_binary("mi_heap_malloc")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_heap_malloc_aligned(
+    _heap: *mut Heap,
+    _size: usize,
+    _alignment: usize,
+) -> *mut c_void {
+    no_mimalloc_in_test_binary("mi_heap_malloc_aligned")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_malloc_usable_size(_p: *const c_void) -> usize {
+    no_mimalloc_in_test_binary("mi_malloc_usable_size")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_is_in_heap_region(_p: *const c_void) -> bool {
+    no_mimalloc_in_test_binary("mi_is_in_heap_region")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_free(_p: *mut c_void) {
+    no_mimalloc_in_test_binary("mi_free")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_free_size(_p: *mut c_void, _size: usize) {
+    no_mimalloc_in_test_binary("mi_free_size")
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn mi_free_size_aligned(_p: *mut c_void, _size: usize, _alignment: usize) {
+    no_mimalloc_in_test_binary("mi_free_size_aligned")
+}

--- a/src/ast/native_test_shims.rs
+++ b/src/ast/native_test_shims.rs
@@ -1,13 +1,12 @@
-//! mimalloc symbols this crate's `cargo test` binary references through the
-//! `TapeAlloc::Arena` arm (in either profile); mimalloc itself is only linked
-//! into bun. The tests use `TapeAlloc::Global`, and nothing in the binary can
-//! create a heap (`mi_heap_new` is not even referenced), so these are never
-//! called. Never compiled into the real build.
+//! mimalloc symbols the `TapeAlloc::Arena` arm makes this crate's `cargo test`
+//! binary reference; mimalloc is only linked into bun. Never compiled into the
+//! real build.
 
 use core::ffi::c_void;
 
 use bun_alloc::mimalloc::Heap;
 
+/// Unreachable: the test binary does not reference `mi_heap_new`, so no test can hold an arena.
 fn no_mimalloc_in_test_binary(symbol: &str) -> ! {
     unreachable!("{symbol} called, but bun_ast's test binary does not link mimalloc")
 }

--- a/src/ast/native_test_shims.rs
+++ b/src/ast/native_test_shims.rs
@@ -6,8 +6,7 @@ use core::ffi::c_void;
 
 use bun_alloc::mimalloc::Heap;
 
-/// Unreachable: the test binary references neither `mi_heap_new` nor `mi_heap_main`, so no
-/// test can hold an arena.
+/// Nothing here references `mi_heap_new` or `mi_heap_main`, so no arena exists to get here.
 fn no_mimalloc_in_test_binary(symbol: &str) -> ! {
     unreachable!("{symbol} called, but bun_ast's test binary does not link mimalloc")
 }

--- a/src/ast/native_test_shims.rs
+++ b/src/ast/native_test_shims.rs
@@ -7,7 +7,7 @@
 //! `<&MimallocArena as Allocator>::{allocate, deallocate}` live, so the link
 //! needs everything those two reach: `mi_free_checked` in `bun_alloc::basic`
 //! frees through `mi_free_size*` under `debug_assertions` and `mi_free`
-//! otherwise, hence both sets (test/internal/rust-windows-sys-link.test.ts
+//! otherwise, hence both sets (test/internal/rust-ast-cargo-test.test.ts
 //! links both profiles). Nothing in the binary references `mi_heap_new` or
 //! `mi_heap_main`, so no test can hold an arena and none of these is ever
 //! called; they abort instead of pretending to allocate.

--- a/src/ast/native_test_shims.rs
+++ b/src/ast/native_test_shims.rs
@@ -6,7 +6,8 @@ use core::ffi::c_void;
 
 use bun_alloc::mimalloc::Heap;
 
-/// Unreachable: the test binary does not reference `mi_heap_new`, so no test can hold an arena.
+/// Unreachable: the test binary references neither `mi_heap_new` nor `mi_heap_main`, so no
+/// test can hold an arena.
 fn no_mimalloc_in_test_binary(symbol: &str) -> ! {
     unreachable!("{symbol} called, but bun_ast's test binary does not link mimalloc")
 }

--- a/test/internal/rust-ast-cargo-test.test.ts
+++ b/test/internal/rust-ast-cargo-test.test.ts
@@ -1,0 +1,58 @@
+// bun_ast is one of the crates scripts/rust-miri.ts runs under Miri, and Miri
+// never links, so it stays green while the crate's test binary references
+// symbols only the full bun binary defines. A host `cargo test -p bun_ast` is
+// what notices: the tape tests build JsonTapes on TapeAlloc::Global, but the
+// Arena arm of the same Allocator impl keeps <&MimallocArena as Allocator>
+// live, and mimalloc is not part of the test binary. src/ast/native_test_shims.rs
+// defines the mi_* entry points that code reaches; without it lld fails with
+//   ld.lld: error: undefined symbol: mi_heap_malloc
+// Which entry points are live depends on the profile (bun_alloc's
+// mi_free_checked frees through mi_free_size* under debug_assertions and
+// mi_free otherwise), so both profiles are built. The tests are run rather
+// than stopped at --no-run: the shims abort if anything reaches them.
+//
+// Unix only: the check relies on the linker reporting only references from
+// live code (lld with --gc-sections). link.exe also resolves references from
+// dead code, so there a test binary depending on bun_core either fails on
+// ~100 unrelated externs or is linked with unresolved symbols forced through,
+// and neither outcome says anything about these shims. Same remaining
+// prerequisites as rust-windows-sys-link.test.ts: cargo on PATH and a
+// configured checkout (cargo needs vendor/lolhtml to resolve the workspace,
+// bun_core/build.rs needs build_options.rs); test-only CI lanes have neither
+// and skip.
+import { which } from "bun";
+import { expect, test } from "bun:test";
+import { isWindows } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const cargo = which("cargo");
+const repoRoot = join(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+
+test.skipIf(isWindows || !cargo || !workspaceResolvable).each([
+  ["dev", []],
+  ["release", ["--release"]],
+] as const)(
+  "cargo test -p bun_ast links and passes without the rest of bun (%s profile)",
+  async (_profile, profileArgs) => {
+    await using proc = Bun.spawn({
+      cmd: [cargo!, "test", "--locked", "-p", "bun_ast", "--lib", ...profileArgs],
+      cwd: repoRoot,
+      env: { ...process.env, CARGO_TERM_COLOR: "never" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("undefined symbol");
+    // The test whose tape allocations keep the arena arm live must have run here, natively.
+    expect(stdout).toContain("test e::json_tape_tests::tape_rooted_at_a_mutable_borrow_still_accepts_writes ... ok");
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+  },
+  // Cold target dir: compiles bun_core and ~30 other crates first, and the
+  // release row ends in a fat-LTO link.
+  180_000,
+);

--- a/test/internal/rust-ast-cargo-test.test.ts
+++ b/test/internal/rust-ast-cargo-test.test.ts
@@ -1,25 +1,19 @@
-// bun_ast is one of the crates scripts/rust-miri.ts runs under Miri, and Miri
-// never links, so it stays green while the crate's test binary references
-// symbols only the full bun binary defines. A host `cargo test -p bun_ast` is
-// what notices: the tape tests build JsonTapes on TapeAlloc::Global, but the
-// Arena arm of the same Allocator impl keeps <&MimallocArena as Allocator>
-// live, and mimalloc is not part of the test binary. src/ast/native_test_shims.rs
-// defines the mi_* entry points that code reaches; without it lld fails with
+// The Miri lane (scripts/rust-miri.ts) runs bun_ast's tests without linking,
+// so only a host `cargo test -p bun_ast` notices when the test binary
+// references symbols that exist only in the full bun link. The tape tests keep
+// the TapeAlloc::Arena arm live, and src/ast/native_test_shims.rs defines the
+// mimalloc symbols it reaches; without it:
 //   ld.lld: error: undefined symbol: mi_heap_malloc
-// Which entry points are live depends on the profile (bun_alloc's
-// mi_free_checked frees through mi_free_size* under debug_assertions and
-// mi_free otherwise), so both profiles are built. The tests are run rather
-// than stopped at --no-run: the shims abort if anything reaches them.
+// The set differs per profile (bun_alloc's mi_free_checked uses mi_free_size*
+// under debug_assertions and mi_free otherwise), hence both rows; the tests
+// are run, not just linked, because the shims abort if anything reaches them.
 //
-// Unix only: the check relies on the linker reporting only references from
-// live code (lld with --gc-sections). link.exe also resolves references from
-// dead code, so there a test binary depending on bun_core either fails on
-// ~100 unrelated externs or is linked with unresolved symbols forced through,
-// and neither outcome says anything about these shims. Same remaining
-// prerequisites as rust-windows-sys-link.test.ts: cargo on PATH and a
-// configured checkout (cargo needs vendor/lolhtml to resolve the workspace,
-// bun_core/build.rs needs build_options.rs); test-only CI lanes have neither
-// and skip.
+// Unix only: this relies on the linker reporting only references from live
+// code (lld --gc-sections). link.exe reports dead ones too, so a bun_core
+// dependent's test binary there either fails on ~100 unrelated externs or has
+// them forced through; neither says anything about these shims. Remaining
+// prerequisites as in rust-windows-sys-link.test.ts: cargo, and a configured
+// checkout (vendor/lolhtml, build_options.rs), which test-only CI lanes lack.
 import { which } from "bun";
 import { expect, test } from "bun:test";
 import { isWindows } from "harness";

--- a/test/internal/rust-ast-cargo-test.test.ts
+++ b/test/internal/rust-ast-cargo-test.test.ts
@@ -42,8 +42,9 @@ test.skipIf(isWindows || !cargo || !workspaceResolvable).each([
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("undefined symbol");
-    // The test whose tape allocations keep the arena arm live must have run here, natively.
-    expect(stdout).toContain("test e::json_tape_tests::tape_rooted_at_a_mutable_borrow_still_accepts_writes ... ok");
+    // The tape tests are what make the arena arm live; they must have run here, natively.
+    expect(stdout).toMatch(/^test e::json_tape_tests::\w+ \.\.\. ok$/m);
+    expect(stdout).toContain("test result: ok.");
     expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
   },
   // Cold target dir: compiles bun_core and ~30 other crates first, and the


### PR DESCRIPTION
### Repro

On a configured checkout (`bun run build --configure-only`), on main (97e21e5405):

```
$ cargo test --locked -p bun_ast
ld.lld: error: undefined symbol: mi_heap_malloc
>>> referenced by MimallocArena.rs:563 (bun_alloc::mimalloc_arena::heap_alloc_maybe_aligned)
ld.lld: error: undefined symbol: mi_heap_malloc_aligned
ld.lld: error: undefined symbol: mi_malloc_usable_size
ld.lld: error: undefined symbol: mi_is_in_heap_region
>>> referenced by basic.rs:15 (<&MimallocArena as core::alloc::Allocator>::deallocate)
ld.lld: error: undefined symbol: mi_free_size
ld.lld: error: undefined symbol: mi_free_size_aligned
error: could not compile `bun_ast` (lib test)

$ cargo test --locked --release -p bun_ast
ld.lld: error: undefined symbol: mi_free
ld.lld: error: undefined symbol: mi_heap_malloc
```

`bun run rust:miri -p bun_ast` passes (20 tests), so the crate's entry in `MIRI_CRATES` did not catch this: Miri never links. Of the other crates in that list, all link natively except `bun_ptr` (#37592) and `bun_clap` (#37599), which reach highway kernels instead; `bun_ast` is the only one whose missing symbols are mimalloc's.

### Cause

A standalone test binary links the crate's Rust dependencies and nothing else; mimalloc (and the `#[global_allocator]`, which lives in `bun_bin`) exist only in the full bun link. lld only reports undefined symbols referenced from sections that survive `--gc-sections`, and `--why-live` roots both chains in `e::json_tape_tests` (added in #33311): `JsonTape` stores `Vec<_, TapeAlloc>`, the tests append to and drop such tapes, and `<TapeAlloc as Allocator>::{allocate, deallocate}` contain the `TapeAlloc::Arena` arm next to the `Global` arm the tests take. That arm is `<&MimallocArena as Allocator>`, which reaches `mi_heap_malloc[_aligned]` (plus `mi_malloc_usable_size` under `debug_assertions`) and `bun_alloc::basic::mi_free_checked`, whose debug half is `mi_is_in_heap_region` + `mi_free_size[_aligned]` and whose release half is `mi_free`. Hence the two different sets per profile, seven symbols in total. `TapeAlloc` forwards only those two methods, so nothing else of the arena is live.

This is not what #37575 addresses: that is link.exe failing on references from dead code, and it leaves Linux unchanged. These references are live.

### Fix

`src/ast/native_test_shims.rs`, mounted `#[cfg(test)]` from lib.rs, defines the seven symbols. This is the workspace's existing answer for test binaries that reference externs only the full binary provides (`src/parsers/native_test_shims.rs`, the simdutf stubs in `src/paths/string_paths.rs`, #37592, #37599): the crate whose tests make the references live defines them, and any new reference stays a link error naming the symbol. Nothing here is compiled into bun itself, and `TapeAlloc` is unchanged: the `Arena` arm is how `bun_parsers` uses the tape, not something to restructure around the test link, and the tape tests exist precisely to exercise `JsonTape`.

The shims abort rather than allocating. Nothing in the test binary references `mi_heap_new` or `mi_heap_main` (neither appears in the linker's list, and they are the only two ways to construct a `MimallocArena`), so no test can obtain an arena and none of the seven can be called; the link just needs them resolved. A test that does create an `Arena` in future fails at link time on `mi_heap_new`, before any stub could run, which is the point to decide whether the crate wants a real allocator behind these. System-backed stubs would have been platform-specific code (`malloc_usable_size` vs `malloc_size` vs `_msize`, aligned frees that `mi_free` cannot tell apart on Windows) that nothing executes.

Not done in `bun_alloc`: dependencies are never built with the downstream crate's `cfg(test)`, so the only way to do it there is a cargo feature turned on from `bun_ast`'s dev-dependencies. The shipped build (`cargo build -p bun_bin --lib`, resolver 2) could not pick that up, but multi-package test invocations can, and some of those link the real mimalloc (`scripts/bench-json-rust.sh` runs `cargo test -p bun_parsers` against a mimalloc archive; `bun_parsers` and `bun_react_compiler` test binaries genuinely need `mi_heap_new` and friends), so a unified feature would produce duplicate definitions exactly where the real allocator is wanted. `bun_ast` is also the only crate that needs stubs for these symbols; the other crates that reference `mi_*` from tests need the real thing, so there is nothing to share.

### Verification

* `cargo test --locked -p bun_ast`: links, 20 passed; same with `--release`. The crate has no doctests, benches or integration tests, so `--lib` is the whole surface.
* `bun run rust:miri -p bun_ast`: 20 passed, as before.
* `cargo fmt --check`, `cargo clippy -p bun_ast --tests`, `cargo check -p bun_ast`, `test/internal/source-lints`: clean.
* Rebased onto 8c5296ac45 and re-checked there: the unmounted build still fails on exactly the six (dev) and two (release) symbols above, both profiles pass when mounted, and the other `MIRI_CRATES` entries (now including `bun_threading`) still all link natively apart from `bun_ptr` and `bun_clap`.
* `test/internal/rust-ast-cargo-test.test.ts` runs `cargo test -p bun_ast --lib` in both profiles and asserts that a `json_tape_tests` case and libtest's overall `ok` line were printed. With the module unmounted both rows fail with the errors above (dev: the six symbols, release: `mi_free` + `mi_heap_malloc`); mounted, both pass (`bun bd test test/internal/rust-ast-cargo-test.test.ts`). Removing any one of the seven shims fails a row: six of them the dev row, `mi_free` only the release row, which is why the release row exists; it costs about 10s warm here (fat LTO link of the test binary) against about 2s for the dev row, and the file skips on the test-only CI lanes like `rust-windows-sys-link.test.ts` does (no cargo or no configured checkout). The explicit timeout is for a cold target dir. It also skips on Windows: link.exe reports references from dead code too, so there a `bun_core` dependent's test binary either fails on ~100 unrelated externs or (#37575) links with unresolved symbols forced through, and neither outcome says anything about these shims.

### Merge order

No CI lane on main runs native `cargo test` for workspace crates today (only Miri), so `test/internal/rust-ast-cargo-test.test.ts` is a local guard. #37592 and #37599 each add such a lane (`scripts/rust-test.ts`) that runs the Miri crate set natively and carries a `NATIVE_LINK_PENDING` list containing `bun_ast` with a ratchet that fails once a listed crate links. If either of them lands before this, this PR needs `bun_ast` dropped from that list in the same change (the script says so when it trips); if this lands first, they drop it when they rebase. Once a lane like that is on main, the dev row of the test here is covered by it and only the release row (the `mi_free` half) adds anything.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/internal/rust-ast-cargo-test.test.ts

<!-- robobun:evidence:end -->

