### PR TITLE
node:http2: add Http2SecureServer#closeIdleConnections()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6780,7 +6780,7 @@ class Http2SecureServer extends tls.Server {
     }
     super(options, connectionListener);
     this[kSessions] = new SafeSet();
-    this[kOptions] = { settings: settings || {}, allowHTTP1: options.allowHTTP1 === true };
+    this[kOptions] = { settings: settings || {} };
     this.setMaxListeners(0);
     this.on("newListener", setupCompat);
     if (options.allowHTTP1 === true) {
@@ -6832,11 +6832,11 @@ class Http2SecureServer extends tls.Server {
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L3475-L3487
   close(callback?: Function) {
     super.close(callback);
-    if (this[kOptions].allowHTTP1) this.closeIdleConnections();
+    if (this[bunSocketServerOptions]?.allowHTTP1 === true) this.closeIdleConnections();
     closeAllSessions(this);
   }
   closeIdleConnections() {
-    if (this[kOptions].allowHTTP1) closeIdleHttp1Connections(this);
+    if (this[bunSocketServerOptions]?.allowHTTP1 === true) closeIdleHttp1Connections(this);
   }
 }
 function createServer(options, onRequestHandler) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6780,7 +6780,7 @@ class Http2SecureServer extends tls.Server {
     }
     super(options, connectionListener);
     this[kSessions] = new SafeSet();
-    this[kOptions] = { settings: settings || {} };
+    this[kOptions] = { settings: settings || {}, allowHTTP1: options.allowHTTP1 === true };
     this.setMaxListeners(0);
     this.on("newListener", setupCompat);
     if (options.allowHTTP1 === true) {
@@ -6829,10 +6829,14 @@ class Http2SecureServer extends tls.Server {
     }
     this[kOptions].settings = { ...this[kOptions].settings, ...settings };
   }
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L3475-L3487
   close(callback?: Function) {
     super.close(callback);
-    closeIdleHttp1Connections(this);
+    if (this[kOptions].allowHTTP1) this.closeIdleConnections();
     closeAllSessions(this);
+  }
+  closeIdleConnections() {
+    if (this[kOptions].allowHTTP1) closeIdleHttp1Connections(this);
   }
 }
 function createServer(options, onRequestHandler) {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -13,7 +13,7 @@ import tls from "node:tls";
 import { Duplex, duplexPair } from "stream";
 import http2utils from "./helpers";
 import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
-const { describe, expect, it, beforeAll, afterAll, createCallCheckCtx } = createTest(import.meta.path);
+const { describe, expect, it, beforeAll, afterAll, createCallCheckCtx, mock } = createTest(import.meta.path);
 // bun-debug ships with ASAN but isn't named bun-asan, so isASAN is false
 // there; the 10k-request maxSessionMemory stress test takes ~105s under
 // debug+ASAN vs ~2s release, so scale for either.
@@ -3963,6 +3963,183 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   } finally {
     server.close();
   }
+});
+
+function connectOverHttp1(port) {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const socket = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] }, () =>
+    resolve(socket),
+  );
+  socket.on("error", reject);
+  return promise;
+}
+
+// Reads one Content-Length framed response off a raw HTTP/1 connection. Rejects if the
+// connection goes away first, so a wrongly destroyed connection fails instead of hanging.
+function readHttp1Response(socket) {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  let raw = "";
+  function onData(chunk) {
+    raw += chunk.toString("latin1");
+    const headersEnd = raw.indexOf("\r\n\r\n");
+    if (headersEnd === -1) return;
+    const head = raw.slice(0, headersEnd);
+    const contentLength = /\r\ncontent-length: (\d+)/i.exec(head);
+    if (!contentLength) {
+      done();
+      reject(new Error(`expected a Content-Length framed response, got:\n${head}`));
+      return;
+    }
+    const body = raw.slice(headersEnd + 4);
+    if (body.length < Number(contentLength[1])) return;
+    done();
+    resolve({ statusLine: head.slice(0, head.indexOf("\r\n")), body });
+  }
+  function onClose() {
+    done();
+    reject(new Error("connection closed before the response completed"));
+  }
+  function done() {
+    socket.off("data", onData);
+    socket.off("close", onClose);
+  }
+  socket.on("data", onData);
+  socket.on("close", onClose);
+  return promise;
+}
+
+function requestOverSession(session, path) {
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const req = session.request({ ":path": path });
+  let body = "";
+  req.setEncoding("utf8");
+  req.on("data", chunk => (body += chunk));
+  req.on("end", () => resolve(body));
+  req.on("error", reject);
+  req.end();
+  return promise;
+}
+
+it("Http2SecureServer has closeIdleConnections() on its prototype like node, Http2Server does not", () => {
+  const secure = http2.createSecureServer(TLS_CERT);
+  const plain = http2.createServer();
+  expect({
+    secure: typeof secure.closeIdleConnections,
+    ownPrototypeMethod: Object.hasOwn(Object.getPrototypeOf(secure), "closeIdleConnections"),
+    length: secure.closeIdleConnections.length,
+    closeAllConnections: typeof secure.closeAllConnections,
+    plain: typeof plain.closeIdleConnections,
+  }).toEqual({
+    secure: "function",
+    ownPrototypeMethod: true,
+    length: 0,
+    closeAllConnections: "undefined",
+    plain: "undefined",
+  });
+});
+
+it("Http2SecureServer#closeIdleConnections() destroys idle allowHTTP1 connections only", async () => {
+  const holdRequestReceived = Promise.withResolvers();
+  const releaseHeldResponse = Promise.withResolvers();
+  const serverSockets = {};
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    serverSockets[req.url] = req.socket;
+    if (req.url === "/hold") {
+      holdRequestReceived.resolve();
+      releaseHeldResponse.promise.then(() => res.end("held"));
+      return;
+    }
+    res.end("ok");
+  });
+  const serverSessionPromise = new Promise(resolve => server.once("session", resolve));
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+  const idle = await connectOverHttp1(port);
+  const busy = await connectOverHttp1(port);
+  const h2 = http2.connect(`https://localhost:${port}`, TLS_OPTIONS);
+  try {
+    // `idle` completes one keep-alive exchange and then sits there.
+    const idleResponse = readHttp1Response(idle);
+    idle.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    expect(await idleResponse).toEqual({ statusLine: "HTTP/1.1 200 OK", body: "ok" });
+    // `busy` has a request in flight whose response the handler is holding back.
+    busy.write("GET /hold HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    await holdRequestReceived.promise;
+    const serverSession = await serverSessionPromise;
+
+    const idleClosed = new Promise(resolve => idle.once("close", resolve));
+    expect(server.closeIdleConnections()).toBeUndefined();
+    expect({
+      idleDestroyed: serverSockets["/"].destroyed,
+      busyDestroyed: serverSockets["/hold"].destroyed,
+      sessionClosed: serverSession.closed,
+      sessionDestroyed: serverSession.destroyed,
+      listening: server.listening,
+    }).toEqual({
+      idleDestroyed: true,
+      busyDestroyed: false,
+      sessionClosed: false,
+      sessionDestroyed: false,
+      listening: true,
+    });
+    await idleClosed;
+
+    // The held request still completes on its connection and the h2 session is still usable.
+    const heldResponse = readHttp1Response(busy);
+    releaseHeldResponse.resolve();
+    expect(await heldResponse).toEqual({ statusLine: "HTTP/1.1 200 OK", body: "held" });
+    expect(await requestOverSession(h2, "/over-h2")).toBe("ok");
+
+    // With its response finished, the formerly busy connection is idle and goes on the next call.
+    const busyClosed = new Promise(resolve => busy.once("close", resolve));
+    server.closeIdleConnections();
+    expect(serverSockets["/hold"].destroyed).toBe(true);
+    await busyClosed;
+    expect({ sessionClosed: serverSession.closed, sessionDestroyed: serverSession.destroyed }).toEqual({
+      sessionClosed: false,
+      sessionDestroyed: false,
+    });
+  } finally {
+    releaseHeldResponse.resolve();
+    h2.close();
+    idle.destroy();
+    busy.destroy();
+    server.close();
+  }
+});
+
+it("Http2SecureServer#closeIdleConnections() without allowHTTP1 is a no-op that leaves sessions alone", async () => {
+  const server = http2.createSecureServer(TLS_CERT, (req, res) => res.end("ok"));
+  const serverSessionPromise = new Promise(resolve => server.once("session", resolve));
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = http2.connect(`https://localhost:${server.address().port}`, TLS_OPTIONS);
+  try {
+    const serverSession = await serverSessionPromise;
+    expect(server.closeIdleConnections()).toBeUndefined();
+    expect({ closed: serverSession.closed, destroyed: serverSession.destroyed, listening: server.listening }).toEqual({
+      closed: false,
+      destroyed: false,
+      listening: true,
+    });
+    expect(await requestOverSession(client, "/")).toBe("ok");
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
+// Node's Http2SecureServer#close() runs httpServerPreClose, which calls the server's own
+// closeIdleConnections(), and only does so for an allowHTTP1 server.
+it("Http2SecureServer#close() calls closeIdleConnections() exactly when allowHTTP1 is enabled", async () => {
+  const calls = {};
+  for (const allowHTTP1 of [true, false]) {
+    const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1 });
+    await new Promise(resolve => server.listen(0, resolve));
+    server.closeIdleConnections = mock(() => {});
+    await new Promise(resolve => server.close(resolve));
+    calls[`allowHTTP1: ${allowHTTP1}`] = server.closeIdleConnections.mock.calls;
+  }
+  expect(calls).toEqual({ "allowHTTP1: true": [[]], "allowHTTP1: false": [] });
 });
 
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy


### PR DESCRIPTION
### Repro

```js
const http2 = require("node:http2");
console.log(typeof http2.createSecureServer({}).closeIdleConnections);
// node v26.3.0: function
// bun 1.4.0:    undefined  (so server.closeIdleConnections() throws a TypeError)
```

In practice this surfaces through code that feature-detects the method. With the fastify vendored in `test/node_modules`:

```js
fastify({ http2: true, https: { key, cert, allowHTTP1: true }, forceCloseConnections: "idle" });
// bun:  FST_ERR_FORCE_CLOSE_CONNECTIONS_IDLE_NOT_AVAILABLE: Cannot set forceCloseConnections to 'idle'
//       as your HTTP server does not support closeIdleConnections method
// node: works
```

### Cause

Node's `Http2SecureServer` defines `closeIdleConnections()` on its prototype ([core.js L3475-L3487](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L3475-L3487)). With `allowHTTP1: true` it applies `http.Server.prototype.closeIdleConnections`, i.e. it destroys the HTTP/1.1 fallback connections that have no request in flight and leaves HTTP/2 sessions alone; without `allowHTTP1` it is a no-op. `close()` calls it through `httpServerPreClose()`, again only for an `allowHTTP1` server. Plain `Http2Server` has no such method in node either.

Bun's `Http2SecureServer` (`src/js/node/http2.ts`) had the building block (`close()` already called `closeIdleHttp1Connections` from `internal/http1_server_fallback`) but never exposed the method.

### Fix

- `Http2SecureServer#closeIdleConnections()` calls `closeIdleHttp1Connections(this)` when the server was created with `allowHTTP1: true`, otherwise does nothing. The fallback already tracks per-connection in-flight requests, so a connection whose response is still being held is left alone, and HTTP/2 sessions are not touched.
- `close()` now calls `this.closeIdleConnections()` under the same `allowHTTP1` gate instead of calling the helper unconditionally, matching node's `httpServerPreClose()` (observable: an instance override is invoked by `close()` on an `allowHTTP1` server and not otherwise).
- Both gates read `allowHTTP1` from the server options bag that `connectionListener` already uses to decide whether a connection gets the HTTP/1 fallback (this file's stand-in for node's `this[kOptions]`; bun's `kOptions` only holds `settings`), so the accept side and the teardown side cannot disagree.

Why this is the right shape: it matches node. The same flow as the new tests, run as a plain script under node v26.3.0 and under this build, prints identical results for both:

```
closeIdleConnections() returned: undefined
idle keep-alive HTTP/1 connection destroyed: true
HTTP/1 connection with a held response destroyed: false   (its response still arrives afterwards)
HTTP/2 session closed/destroyed: false/false              (still serves a request afterwards)
server.listening: true
second call after the held response finished destroys that connection: true
close() calls closeIdleConnections(): {"allowHTTP1: true":[[]],"allowHTTP1: false":[]}
```

### Tests

Four tests added next to the existing `allowHTTP1` fallback tests in `test/js/node/http2/node-http2.test.js`:

- the method exists on `Http2SecureServer.prototype` (length 0), `closeAllConnections` does not, and `Http2Server` has neither, as in node
- `allowHTTP1: true`: an idle keep-alive HTTP/1 connection is destroyed synchronously, a connection with a held response and an h2 session are not and both still complete work afterwards, the server keeps listening, and a second call after the held response finished destroys that connection too
- without `allowHTTP1`: returns undefined and the h2 session stays usable
- `close()` invokes `closeIdleConnections()` exactly once with no arguments when `allowHTTP1` is set and not at all otherwise

All four fail on the released bun (`TypeError: server.closeIdleConnections is not a function`, and `close()` not reaching the method) and pass with this change. The rest of `node-http2.test.js` (351 tests), `fetch-http2-client.test.ts`, and the ported upstream `test-http2-allow-http1.js`, `test-http2-https-fallback*.js`, `test-http2-server-close-idle-connection.js`, `test-http2-server-unknown-protocol.js` and `test-http2-server-http1-client.js` still pass. No upstream http2 test exercises this method directly, so there is no additional upstream test to enable.
