### PR TITLE
Bun.serve: percent-decode literal route segments before matching

### DIFF
--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -52,6 +52,63 @@ private:
     std::string_view urlSegmentVector[MAX_URL_SEGMENTS] = {};
     int urlSegmentTop = -1;
 
+    /* Percent-decoded form of each URL segment, filled when the segment is parsed.
+     * Literal route matching compares decoded bytes (RFC 3986 6.2.2.2: "%74" and "t"
+     * are the same), consistent with how :param captures are decoded before reaching
+     * JS. Decoding per segment keeps "%2F" as data rather than a path separator.
+     * Only set when the raw segment actually contains a valid %XX escape. */
+    std::string urlSegmentDecodedStorage[MAX_URL_SEGMENTS] = {};
+    bool urlSegmentIsDecoded[MAX_URL_SEGMENTS] = {};
+
+    static int hexValue(char c) {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    }
+
+    /* Decode valid %XX escapes into output; invalid escapes stay literal (same
+     * policy as decodeURIComponentSIMD for :params). Returns false when nothing
+     * was decoded, in which case output is untouched and the raw view is usable. */
+    static bool percentDecodeSegment(std::string_view input, std::string &output) {
+        size_t firstPercent = input.find('%');
+        if (firstPercent == std::string_view::npos) {
+            return false;
+        }
+        output.clear();
+        output.reserve(input.length());
+        output.append(input.substr(0, firstPercent));
+        for (size_t i = firstPercent; i < input.length();) {
+            if (input[i] == '%' && i + 2 < input.length()) {
+                int hi = hexValue(input[i + 1]);
+                int lo = hexValue(input[i + 2]);
+                if (hi >= 0 && lo >= 0) {
+                    output.push_back((char) ((hi << 4) | lo));
+                    i += 3;
+                    continue;
+                }
+            }
+            output.push_back(input[i]);
+            i++;
+        }
+        /* Decoding strictly shrinks; equal length means every escape was invalid */
+        return output.length() != input.length();
+    }
+
+    /* The segment to use when matching or registering a literal (non-':', non-'*')
+     * pattern segment: the percent-decoded form, unless decoding would turn the
+     * segment into a parameter or wildcard marker. */
+    std::string_view literalSegment(int urlSegment, std::string_view raw) {
+        if (!urlSegmentIsDecoded[urlSegment]) {
+            return raw;
+        }
+        const std::string &decoded = urlSegmentDecodedStorage[urlSegment];
+        if (!decoded.empty() && (decoded[0] == ':' || decoded[0] == '*')) {
+            return raw;
+        }
+        return decoded;
+    }
+
     /* The matching tree */
     struct Node {
         std::string name = {};
@@ -157,6 +214,8 @@ private:
                 /* Update currentUrl */
                 currentUrl = currentUrl.substr(segmentLength);
             }
+
+            urlSegmentIsDecoded[urlSegment] = percentDecodeSegment(urlSegmentVector[urlSegment], urlSegmentDecodedStorage[urlSegment]);
         }
         /* In any case we return it */
         return {urlSegmentVector[urlSegment], false};
@@ -179,6 +238,9 @@ private:
             return false;
         }
 
+        /* Literal children are matched against the percent-decoded segment */
+        std::string_view decodedSegment = literalSegment(urlSegment, segment);
+
         for (auto &p : parent->children) {
             if (p->name.starts_with('*')) {
                 /* Wildcard match (can be seen as a shortcut) */
@@ -188,13 +250,13 @@ private:
                     }
                 }
             } else if (p->name.starts_with(':') && !segment.empty()) {
-                /* Parameter match */
+                /* Parameter match (raw bytes: params are percent-decoded later, in JS land) */
                 routeParameters.push(segment);
                 if (executeHandlers(p.get(), urlSegment + 1, userData)) {
                     return true;
                 }
                 routeParameters.pop();
-            } else if (p->name == segment) {
+            } else if (p->name == decodedSegment) {
                 /* Static match */
                 if (executeHandlers(p.get(), urlSegment + 1, userData)) {
                     return true;
@@ -211,8 +273,8 @@ private:
                 setUrl(pattern);
                 Node *n = node.get();
                 for (int i = 0; !getUrlSegment(i).second; i++) {
-                    /* Go to next segment or quit */
-                    std::string segment(getUrlSegment(i).first);
+                    /* Go to next segment or quit (same decoded form as add()) */
+                    std::string segment(literalSegment(i, getUrlSegment(i).first));
                     Node *next = nullptr;
                     for (const std::unique_ptr<Node> &child : n->children) {
                         if (((segment.starts_with(':') && child->name.starts_with(':')) || child->name == segment) && child->isHighPriority == (priority == HIGH_PRIORITY)) {
@@ -287,7 +349,9 @@ public:
             /* Iterate over all segments */
             setUrl(pattern);
             for (int i = 0; !getUrlSegment(i).second; i++) {
-                std::string strippedSegment(getUrlSegment(i).first);
+                /* Literal pattern segments are stored percent-decoded so every
+                 * encoded spelling of a path reaches the same node */
+                std::string strippedSegment(literalSegment(i, getUrlSegment(i).first));
                 if (strippedSegment.length() > 1 && strippedSegment[0] == ':') {
                     /* Parameter routes must be named only : */
                     strippedSegment.resize(1);

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1044,3 +1044,66 @@ describe.concurrent("false route with no fetch handler", () => {
     await proc.exited;
   });
 });
+
+// https://github.com/oven-sh/bun/issues/37603
+describe("percent-encoded literal segments", () => {
+  test("literal route segments match percent-decoded, like :params", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/robots.txt": new Response("static-hit"),
+        "/fn-literal.txt": () => new Response("fn-hit"),
+        "/user/:id": req => Response.json({ id: req.params.id }),
+        "/one/two": () => new Response("two-seg"),
+        "/100%": () => new Response("invalid-escape-hit"),
+        "/a%20b": () => new Response("encoded-key-hit"),
+      },
+      fetch: () => new Response("fell-through", { status: 404 }),
+    });
+    const get = async (path: string) => {
+      const res = await fetch(`http://localhost:${server.port}${path}`);
+      return `${res.status} ${await res.text()}`;
+    };
+
+    // RFC 3986 6.2.2.2: "%74" is a non-canonical spelling of "t"
+    expect(await get("/robots.txt")).toBe("200 static-hit");
+    expect(await get("/robots.tx%74")).toBe("200 static-hit");
+    expect(await get("/fn-literal.txt")).toBe("200 fn-hit");
+    expect(await get("/fn%2Dliteral.txt")).toBe("200 fn-hit");
+    expect(await get("/fn%2dliteral.txt")).toBe("200 fn-hit"); // lowercase hex
+
+    // route keys registered encoded match either spelling
+    expect(await get("/a%20b")).toBe("200 encoded-key-hit");
+    expect(await get("/a b")).toBe("200 encoded-key-hit"); // fetch re-encodes to %20
+
+    // :params still decode exactly once
+    expect(await get("/user/a%20b")).toBe('200 {"id":"a b"}');
+    expect(await get("/user/a%2520b")).toBe('200 {"id":"a%20b"}');
+
+    // %2F is data, not a path separator
+    expect(await get("/one%2Ftwo")).toBe("404 fell-through");
+    expect(await get("/one/two")).toBe("200 two-seg");
+
+    // invalid escapes stay literal
+    expect(await get("/100%")).toBe("200 invalid-escape-hit");
+    expect(await get("/100%25")).toBe("200 invalid-escape-hit");
+  });
+
+  test("decoded literal match keeps precedence over :param", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/p/secret": () => new Response("literal"),
+        "/p/:v": req => new Response(`param:${req.params.v}`),
+      },
+      fetch: () => new Response("fell-through", { status: 404 }),
+    });
+    const get = async (path: string) => {
+      const res = await fetch(`http://localhost:${server.port}${path}`);
+      return await res.text();
+    };
+    expect(await get("/p/secret")).toBe("literal");
+    expect(await get("/p/%73ecret")).toBe("literal");
+    expect(await get("/p/other")).toBe("param:other");
+  });
+});


### PR DESCRIPTION
### What

Literal segments in `Bun.serve` routes were compared against the raw request-target bytes, while `:param` segments already percent-decode before reaching `req.params`. Any non-canonical spelling of a static route therefore 404'd:

```js
Bun.serve({
  port: 0,
  routes: {
    "/robots.txt": new Response("static-hit"),
    "/user/:id": req => Response.json({ id: req.params.id }),
  },
  fetch: () => new Response("fell-through", { status: 404 }),
});
```
```
/robots.txt   -> 200 static-hit
/robots.tx%74 -> 404 fell-through     (RFC 3986 6.2.2.2: same URI)
/user/a%20b   -> 200 {"id":"a b"}    (params already decode)
```

SvelteKit registers every static path twice to work around this (sveltejs/kit#16695).

### Cause

`HttpRouter::executeHandlers` (`packages/bun-uws/src/HttpRouter.h`) matched static children with a raw `std::string_view` compare, and `add()` stored pattern segments raw, so the encoded and decoded spellings of the same segment landed on different tree nodes.

### Fix

Percent-decode each URL segment once when it is parsed (only when it contains a valid `%XX` escape; the common no-`%` path stays a plain view compare with no copy), and use the decoded form both when registering literal pattern segments and when matching them. This keeps both sides in one canonical space, so `/robots.tx%74`, mixed-case hex, and encoded route keys like `/a%20b` all reach the same node.

Deliberate semantics:

- Decoding is per segment, so `%2F` stays data rather than becoming a path separator: `/one%2Ftwo` still does not match a `/one/two` route, and `:id` still captures `a%2Fb` as `a/b`.
- Invalid escapes (`%`, `%zz`) stay literal, the same policy `decodeURIComponentSIMD` applies to params.
- Params still capture the raw segment and decode exactly once in JS, so `/user/a%2520b` still yields `a%20b`.
- A decoded segment is never allowed to become a `:` or `*` marker: a literal route key spelled `/%3Afoo` keeps its raw spelling instead of turning into a parameter node.
- Literal-over-`:param` precedence now applies in decoded space: `/p/%73ecret` hits a `/p/secret` route rather than `/p/:v`, matching what `/p/secret` does.

HTTP/1, HTTP/3, static `Response` routes, and negative (`false`) routes all route through this tree, so they behave consistently. #33096 (dot-segment normalization) and #35249 (canonical encoding of route keys) both touch this file and explicitly deferred percent-decoding equivalence; whichever lands second needs a small rebase.

### Verification

New `percent-encoded literal segments` block in `test/js/bun/http/bun-serve-routes.test.ts`: 15 assertions covering the issue's repro, lowercase/mixed hex, encoded route keys, single-decode of params, `%2F` non-separation, invalid escapes, and literal-vs-param precedence. Both tests fail on the released build and pass with this change; the other 55 tests in the file are unchanged. `serve.test.ts`, `bun-server.test.ts`, `bun-serve-static.test.ts`, and `bun-serve-html.test.ts` show no new failures (the handful of failures there reproduce on main without this diff).