### PR TITLE
install: pass caller buffers to Repository::try_ssh/try_https

### DIFF
--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -406,9 +406,10 @@ impl<'a> Task<'a> {
                     let name = req.name.slice();
                     let url = req.url.slice();
                     let mut attempt: u8 = 1;
+                    let mut url_buf = bun_paths::path_buffer_pool::get();
 
                     let dir = 'brk: {
-                        if let Some(https) = Repository::try_https(url) {
+                        if let Some(https) = Repository::try_https(url, &mut url_buf) {
                             match Repository::download(
                                 req.env,
                                 &mut this.log,
@@ -448,7 +449,7 @@ impl<'a> Task<'a> {
                     let dir = match dir {
                         Some(d) => d,
                         None => {
-                            if let Some(ssh) = Repository::try_ssh(url) {
+                            if let Some(ssh) = Repository::try_ssh(url, &mut url_buf) {
                                 match Repository::download(
                                     req.env,
                                     &mut this.log,

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -14,94 +14,6 @@ use crate::dependency as Dependency;
 use crate::hosted_git_info;
 use crate::install::{self as Install, ExtractData, PackageManager};
 
-// Thread-local scratch buffers. Callers return slices that outlive the access
-// (`try_ssh`/`try_https` hand a slice straight to `download`). `thread_local!`
-// closures cannot express that without unsafe, so this is a leaked per-thread
-// allocation with per-field projection accessors and a documented
-// single-use-per-field invariant (see `tl_bufs()` / the `TlBufs` accessor docs
-// below).
-struct TlBufs {
-    final_path_buf: PathBuffer,
-    ssh_path_buf: PathBuffer,
-    folder_name_buf: PathBuffer,
-    json_path_buf: PathBuffer,
-}
-
-thread_local! {
-    // bun.ThreadlocalBuffers: store only a pointer in TLS; lazily heap-allocate the
-    // 4×PathBuffer payload on first use so the static-TLS template stays small
-    // (see test/js/bun/binary/tls-segment-size).
-    static TL_BUFS: core::cell::Cell<*mut TlBufs> =
-        const { core::cell::Cell::new(core::ptr::null_mut()) };
-}
-
-fn tl_bufs() -> *mut TlBufs {
-    // SAFETY (audited):
-    // - `TL_BUFS` is thread-local `Cell<*mut TlBufs>`: no cross-thread sharing; the
-    //   pointer is `Copy` so `.get()/.set()` are zero-unsafe. The payload itself is a
-    //   leaked heap alloc (lazy-init below), so the `*mut` stays valid for thread life.
-    // - This function returns `*mut TlBufs` (a freely-aliasing raw ptr) and never
-    //   asserts uniqueness over sibling buffers: call sites project a SINGLE field via
-    //   raw-ptr place expr `unsafe { &mut (*tl_bufs()).<field> }` so only that one
-    //   field is retagged Unique under Stacked Borrows.
-    // - This is load-bearing: `try_https`/`try_ssh` return a slice into
-    //   `final_path_buf`/`ssh_path_buf` which is then passed straight into
-    //   `download(..., url, ...)`. `download` itself
-    //   borrows `folder_name_buf`. Materializing `&mut TlBufs` over the WHOLE struct
-    //   here would create a fresh Unique tag that invalidates the live `url` slice — UB.
-    //   The invariant is therefore disjoint-FIELD access, not whole-struct uniqueness.
-    // - The raw pointer is valid for the lifetime of the current thread (thread-local
-    //   outlives all in-thread borrows; `TlBufs` has no `Drop`). Callers reborrow into
-    //   a raw `*mut PathBuffer` per field as a deliberate escape hatch so
-    //   `try_ssh`/`try_https` can return slices into the buffer.
-    //   Callers must not retain a slice into a given field across a subsequent reborrow
-    //   of that SAME field.
-    TL_BUFS.with(|c| {
-        let mut p = c.get();
-        if p.is_null() {
-            p = bun_core::heap::into_raw(Box::new(TlBufs {
-                final_path_buf: PathBuffer::ZEROED,
-                ssh_path_buf: PathBuffer::ZEROED,
-                folder_name_buf: PathBuffer::ZEROED,
-                json_path_buf: PathBuffer::ZEROED,
-            }));
-            c.set(p);
-        }
-        p
-    })
-}
-
-impl TlBufs {
-    // Per-field projection accessors. Each returns `&'static mut` over a
-    // disjoint thread-local `PathBuffer`; see [`tl_bufs`] for the
-    // Stacked-Borrows rationale (forming `&mut TlBufs` over the whole struct
-    // would invalidate live slices into sibling fields). Callers must not hold
-    // a returned borrow across a re-entry into the *same* accessor — the same
-    // single-thread non-reentrant-scratch contract the prior inline raw-ptr
-    // field projections imposed, now centralised here.
-    #[inline]
-    fn ssh_path_buf() -> &'static mut PathBuffer {
-        // SAFETY: see `tl_bufs()` — thread-local leaked alloc; per-field
-        // projection retags only this field.
-        unsafe { &mut (*tl_bufs()).ssh_path_buf }
-    }
-    #[inline]
-    fn final_path_buf() -> &'static mut PathBuffer {
-        // SAFETY: see `tl_bufs()`.
-        unsafe { &mut (*tl_bufs()).final_path_buf }
-    }
-    #[inline]
-    fn folder_name_buf() -> &'static mut PathBuffer {
-        // SAFETY: see `tl_bufs()`.
-        unsafe { &mut (*tl_bufs()).folder_name_buf }
-    }
-    #[inline]
-    fn json_path_buf() -> &'static mut PathBuffer {
-        // SAFETY: see `tl_bufs()`.
-        unsafe { &mut (*tl_bufs()).json_path_buf }
-    }
-}
-
 #[derive(Clone, Copy, Default)]
 struct SloppyGlobalGitConfig {
     has_askpass: bool,
@@ -330,8 +242,11 @@ pub trait RepositoryExt: Sized {
     fn fmt_store_path<'a>(&'a self, label: &'a str, string_buf: &'a [u8])
     -> StorePathFormatter<'a>;
     fn fmt<'a>(&'a self, label: &'a str, buf: &'a [u8]) -> Formatter<'a>;
-    fn try_ssh(url: &[u8]) -> Option<&[u8]>;
-    fn try_https(url: &[u8]) -> Option<&[u8]>;
+    /// The result is either `url` itself or the rewritten URL formatted into
+    /// a prefix of `buf`.
+    fn try_ssh<'a>(url: &'a [u8], buf: &'a mut PathBuffer) -> Option<&'a [u8]>;
+    /// Like [`RepositoryExt::try_ssh`]: returns `url` or a prefix of `buf`.
+    fn try_https<'a>(url: &'a [u8], buf: &'a mut PathBuffer) -> Option<&'a [u8]>;
     fn download(
         env: &bun_dotenv::Map,
         log: &mut bun_ast::Log,
@@ -540,10 +455,7 @@ impl RepositoryExt for Repository {
         }
     }
 
-    fn try_ssh(url: &[u8]) -> Option<&[u8]> {
-        // May return a slice into the thread-local `ssh_path_buf` (see `tl_bufs()`);
-        // it is only valid until the next `try_ssh` call on this thread.
-        let ssh_path_buf = TlBufs::ssh_path_buf();
+    fn try_ssh<'a>(url: &'a [u8], buf: &'a mut PathBuffer) -> Option<&'a [u8]> {
         // Do not cast explicit http(s) URLs to SSH
         if url.starts_with(b"http") {
             return None;
@@ -553,14 +465,14 @@ impl RepositoryExt for Repository {
             return Some(url);
         }
 
-        if url.len() + b"ssh://git@".len() + b".org".len() > ssh_path_buf.len() {
+        if url.len() + b"ssh://git@".len() + b".org".len() > buf.len() {
             return None;
         }
 
         if url.starts_with(b"ssh://") {
             // TODO(markovejnovic): This is a stop-gap. One of the problems with the implementation
             // here is that we should integrate hosted_git_info more thoroughly into the codebase
-            // to avoid the allocation and copy here. For now, the thread-local buffer is a good
+            // to avoid the allocation and copy here. For now, the caller's buffer is a good
             // enough solution to avoid having to handle init/deinit.
 
             // Fix malformed ssh:// URLs with colons using hosted_git_info.correctUrl
@@ -576,23 +488,23 @@ impl RepositoryExt for Repository {
                 return Some(url); // If correction fails, return original
             };
 
-            // Copy corrected URL to thread-local buffer
+            // Copy corrected URL to the caller's buffer
             let corrected_str = corrected.url_slice();
-            if corrected_str.len() > ssh_path_buf.len() {
+            if corrected_str.len() > buf.len() {
                 return Some(url);
             }
-            let result = &mut ssh_path_buf[..corrected_str.len()];
+            let result = &mut buf[..corrected_str.len()];
             result.copy_from_slice(corrected_str);
-            return Some(&ssh_path_buf[..corrected_str.len()]);
+            return Some(&buf[..corrected_str.len()]);
         }
 
         if Dependency::is_scp_like_path(url) {
             const PREFIX: &[u8] = b"ssh://git@";
-            if PREFIX.len() + url.len() > ssh_path_buf.len() {
+            if PREFIX.len() + url.len() > buf.len() {
                 return None;
             }
-            ssh_path_buf[..PREFIX.len()].copy_from_slice(PREFIX);
-            let rest = &mut ssh_path_buf[PREFIX.len()..];
+            buf[..PREFIX.len()].copy_from_slice(PREFIX);
+            let rest = &mut buf[PREFIX.len()..];
 
             let colon_index = strings::index_of_char(url, b':');
 
@@ -607,7 +519,7 @@ impl RepositoryExt for Repository {
                     rest[colon + tld.len()] = b'/';
                     rest[colon + tld.len() + 1..colon + tld.len() + 1 + (url.len() - colon - 1)]
                         .copy_from_slice(&url[colon + 1..]);
-                    let out = &ssh_path_buf[..url.len() + PREFIX.len() + tld.len()];
+                    let out = &buf[..url.len() + PREFIX.len() + tld.len()];
                     return Some(out);
                 }
             }
@@ -616,44 +528,40 @@ impl RepositoryExt for Repository {
             if let Some(colon) = colon_index {
                 rest[colon as usize] = b'/';
             }
-            let final_ = &ssh_path_buf[..url.len() + b"ssh://".len()];
+            let final_ = &buf[..url.len() + b"ssh://".len()];
             return Some(final_);
         }
 
         None
     }
 
-    fn try_https(url: &[u8]) -> Option<&[u8]> {
-        // May return a slice into the thread-local `final_path_buf` (see `tl_bufs()`);
-        // it is only valid until the next use of `TlBufs::final_path_buf()` on this
-        // thread (another `try_https` call, or `checkout`'s `get_fd_path`).
-        let final_path_buf = TlBufs::final_path_buf();
+    fn try_https<'a>(url: &'a [u8], buf: &'a mut PathBuffer) -> Option<&'a [u8]> {
         if url.starts_with(b"http") {
             return Some(url);
         }
 
-        if url.len() + b"https://".len() + b".org".len() > final_path_buf.len() {
+        if url.len() + b"https://".len() + b".org".len() > buf.len() {
             return None;
         }
 
         if url.starts_with(b"ssh://") {
-            if url.len() - b"ssh".len() + b"https".len() > final_path_buf.len() {
+            if url.len() - b"ssh".len() + b"https".len() > buf.len() {
                 return None;
             }
-            final_path_buf[..b"https".len()].copy_from_slice(b"https");
+            buf[..b"https".len()].copy_from_slice(b"https");
             let tail = &url[b"ssh".len()..];
-            final_path_buf[b"https".len()..b"https".len() + tail.len()].copy_from_slice(tail);
-            let out = &final_path_buf[..url.len() - b"ssh".len() + b"https".len()];
+            buf[b"https".len()..b"https".len() + tail.len()].copy_from_slice(tail);
+            let out = &buf[..url.len() - b"ssh".len() + b"https".len()];
             return Some(out);
         }
 
         if Dependency::is_scp_like_path(url) {
             const PREFIX: &[u8] = b"https://";
-            if PREFIX.len() + url.len() > final_path_buf.len() {
+            if PREFIX.len() + url.len() > buf.len() {
                 return None;
             }
-            final_path_buf[..PREFIX.len()].copy_from_slice(PREFIX);
-            let rest = &mut final_path_buf[PREFIX.len()..];
+            buf[..PREFIX.len()].copy_from_slice(PREFIX);
+            let rest = &mut buf[PREFIX.len()..];
 
             let colon_index = strings::index_of_char(url, b':');
 
@@ -668,7 +576,7 @@ impl RepositoryExt for Repository {
                     rest[colon + tld.len()] = b'/';
                     rest[colon + tld.len() + 1..colon + tld.len() + 1 + (url.len() - colon - 1)]
                         .copy_from_slice(&url[colon + 1..]);
-                    let out = &final_path_buf[..url.len() + PREFIX.len() + tld.len()];
+                    let out = &buf[..url.len() + PREFIX.len() + tld.len()];
                     return Some(out);
                 }
             }
@@ -677,7 +585,7 @@ impl RepositoryExt for Repository {
             if let Some(colon) = colon_index {
                 rest[colon as usize] = b'/';
             }
-            return Some(&final_path_buf[..url.len() + PREFIX.len()]);
+            return Some(&buf[..url.len() + PREFIX.len()]);
         }
 
         None
@@ -696,11 +604,7 @@ impl RepositoryExt for Repository {
         // we never own/close it — only the freshly-opened repo `Dir` is owned.
         bun_analytics::features::git_dependencies
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        // Per-field accessor — retags only `folder_name_buf`, leaving any live
-        // shared borrow of `final_path_buf`/`ssh_path_buf` (the `url` argument
-        // handed over by `try_https`/`try_ssh` callers) valid under Stacked
-        // Borrows.
-        let folder_name_buf = TlBufs::folder_name_buf();
+        let mut folder_name_buf = [0u8; 32];
         let folder_name = {
             use std::io::Write;
             let total = folder_name_buf.len();
@@ -780,7 +684,7 @@ impl RepositoryExt for Repository {
         committish: &[u8],
         task_id: crate::package_manager_task::Id,
     ) -> Result<Vec<u8>, Error> {
-        let folder_name_buf = TlBufs::folder_name_buf();
+        let mut folder_name_buf = [0u8; 32];
         let folder_name = {
             use std::io::Write;
             let total = folder_name_buf.len();
@@ -866,7 +770,7 @@ impl RepositoryExt for Repository {
             return Err(crate::Error::InstallFailed);
         }
 
-        let folder_name_buf = TlBufs::folder_name_buf();
+        let mut folder_name_buf = Path::path_buffer_pool::get();
         let folder_name = crate::package_manager_real::cached_git_folder_name_print(
             &mut folder_name_buf[..],
             resolved,
@@ -889,12 +793,8 @@ impl RepositoryExt for Repository {
                     &[folder_name],
                 );
 
-                let repo_path = bun_sys::get_fd_path(
-                    repo_dir,
-                    // Per-field accessor — disjoint from `folder_name_buf`
-                    // borrow above. See `TlBufs` accessor doc.
-                    TlBufs::final_path_buf(),
-                )?;
+                let mut repo_path_buf = Path::path_buffer_pool::get();
+                let repo_path = bun_sys::get_fd_path(repo_dir, &mut repo_path_buf)?;
 
                 if let Err(err) = exec(
                     env,
@@ -990,7 +890,8 @@ impl RepositoryExt for Repository {
                 }
             };
 
-        let json_path = match json_file.get_path(TlBufs::json_path_buf()) {
+        let mut json_path_buf = Path::path_buffer_pool::get();
+        let json_path = match json_file.get_path(&mut json_path_buf) {
             Ok(p) => p,
             Err(err) => {
                 log.add_error_fmt(
@@ -1008,10 +909,9 @@ impl RepositoryExt for Repository {
             }
         };
 
-        // `json_path` lives in the thread-local
-        // `json_path_buf` (not in `json_file`), and `json_buf` is an owned alloc,
-        // so both fds are dead here — close before the fallible append so the
-        // `?`-propagation path doesn't leak them.
+        // `json_path` lives in `json_path_buf` (not in `json_file`), and
+        // `json_buf` is an owned alloc, so both fds are dead here: close before
+        // the fallible append so the `?`-propagation path doesn't leak them.
         let _ = json_file.close(); // close error is non-actionable
         package_dir.close();
 


### PR DESCRIPTION
## What

`src/install/repository.rs` kept four `PathBuffer`s in a lazily leaked per-thread `TlBufs` behind a `Cell<*mut TlBufs>`, exposed through four safe accessors returning `&'static mut PathBuffer` (one `unsafe` block each). `try_ssh` / `try_https` wrote the rewritten URL into two of those buffers but were typed as borrowing from `url`, so the rules that kept this sound (one field per accessor, never hold a result across the next call, `download` must not touch the buffer the result lives in) were documented in a comment block instead of being checked.

```rust
// before
fn try_https(url: &[u8]) -> Option<&[u8]>;                       // slice actually points into TlBufs
// after
fn try_https<'a>(url: &'a [u8], buf: &'a mut PathBuffer) -> Option<&'a [u8]>;  // url itself, or a prefix of buf
```

`try_ssh` changes the same way. The one external caller (the `GitClone` arm in `PackageManagerTask.rs`) takes a single `bun_paths::path_buffer_pool::get()` guard and passes it to both rewrites; the https result stays borrowed while `download` runs, and the borrow checker proves it is dead before `try_ssh` reuses the buffer. Inside `repository.rs`, `download` and `find_commit` format the `<16 hex task id>.git` folder name into a `[u8; 32]` stack array, and `checkout` takes pool guards for the cache folder name, `get_fd_path` and `File::get_path`. `TlBufs`, its `thread_local!`, `tl_bufs()` and the four accessors are deleted along with their SAFETY comments (about 90 lines, 4 `unsafe` blocks). `download` / `find_commit` / `checkout` keep their signatures, so their 5 call sites are unchanged.

## Why

Safe functions returning `&'static mut` to a shared thread-local are unsound by construction; after this change the owner of every scratch buffer is a local (a pool guard or a stack array) and the returned slice's lifetime names that owner, so the aliasing rules the comment block described are now enforced by the compiler. Each of these functions brackets a fork+exec of `git`; the per-call cost goes from a TLS load plus null check to a per-thread pool pop/push (the codebase's documented scratch-buffer idiom, already used at 22 call sites in `bun_install`) or a 32-byte stack array, `buf.len()` is still `MAX_PATH_BYTES` because the parameter type is still `PathBuffer`, and every byte handed to `git` is unchanged.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. test/cli/install/bun-add.test.ts: 54 pass, 0 fail. test/cli/install/bun-install.test.ts: 180 pass, 2 todo, 14 fail; the identical 14 fail on main (pre-existing, no outbound network: "should support --registry CLI flag", the bitbucket/gitlab git dependency cases, and "should treat non-GitHub http(s) URLs as tarballs"), so no new failures from this change.
