### PR TITLE
install: hold TarballStream archive as Option<ReadArchive>

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -102,7 +102,7 @@ pub struct TarballStream {
     reading: Vec<u8>,
     read_pos: usize,
 
-    archive: Option<*mut lib::Archive>,
+    archive: Option<lib::ReadArchive>,
 
     /// Where we are in the per-entry state machine between drain
     /// invocations. libarchive preserves everything else (filter buffers,
@@ -528,9 +528,9 @@ impl TarballStream {
             }
 
             // `archive` points to a libarchive heap allocation disjoint from
-            // `*this`; holding `&mut lib::Archive` across the loop does not
+            // `*this`; holding `&lib::Archive` across the loop does not
             // alias any access to `*this`.
-            let archive = &mut *(*this).archive.unwrap();
+            let archive: &lib::Archive = (*this).archive.as_deref().unwrap();
 
             loop {
                 match (*this).phase {
@@ -551,9 +551,7 @@ impl TarballStream {
                                 (*this).begin_entry(&mut *entry)?;
                             }
                             lib::Result::Failed | lib::Result::Fatal => {
-                                // SAFETY: `(*this).archive` is the live `read_new()` handle
-                                // opened in `init` and held until `finish` frees it.
-                                let msg = (*(*this).archive.unwrap()).error_string();
+                                let msg = archive.error_string();
                                 bun_output::scoped_log!(
                                     TarballStream,
                                     "readNextHeader: {}",
@@ -579,9 +577,7 @@ impl TarballStream {
                                 }
                             }
                             _ => {
-                                // SAFETY: `(*this).archive` is the live `read_new()` handle
-                                // opened in `init` and held until `finish` frees it.
-                                let msg = (*(*this).archive.unwrap()).error_string();
+                                let msg = archive.error_string();
                                 bun_output::scoped_log!(
                                     TarballStream,
                                     "read_data_block: {}",
@@ -604,19 +600,12 @@ impl TarballStream {
     /// lifetime of the archive — see `step()` # Safety for the provenance
     /// requirement.
     unsafe fn open_archive(this: *mut Self) -> crate::Result<()> {
-        let archive = lib::Archive::read_new();
-        let guard = scopeguard::guard(archive, |a| {
-            // SAFETY: errdefer cleanup — archive is a valid handle from read_new().
-            unsafe {
-                let _ = (*a).read_close();
-                let _ = (*a).read_free();
-            }
-        });
+        let archive = lib::ReadArchive::new();
         // Bypass bidding entirely: the stream is always gzip → tar, and
         // bidding would try to read-ahead before any bytes have arrived.
         // ARCHIVE_FILTER_GZIP = 1, ARCHIVE_FORMAT_TAR = 0x30000.
         // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
-        if unsafe { lib::archive_read_append_filter(archive, 1) } != 0 {
+        if unsafe { lib::archive_read_append_filter(archive.as_mut_ptr(), 1) } != 0 {
             return Err(crate::Error::Fail);
         }
         // Register tar before read_set_options so the option has a format slot
@@ -627,22 +616,20 @@ impl TarballStream {
         // format away and archive_read_open1() falls back to bidding. Bidding
         // reads ahead 512 decompressed bytes and fails with "Unrecognized
         // archive format" when the first HTTP chunk is too small for that.
-        // SAFETY: archive is a valid handle.
-        let _ = unsafe { (*archive).read_support_format_tar() };
-        // SAFETY: archive is a valid handle.
-        let _ = unsafe { (*archive).read_set_options(c"read_concatenated_archives") };
+        let _ = archive.read_support_format_tar();
+        let _ = archive.read_set_options(c"read_concatenated_archives");
         // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
-        if unsafe { lib::archive_read_set_format(archive, 0x30000) } != 0 {
+        if unsafe { lib::archive_read_set_format(archive.as_mut_ptr(), 0x30000) } != 0 {
             return Err(crate::Error::Fail);
         }
 
         // SAFETY: archive is a valid handle; `this` outlives the archive
-        // (freed only in `Drop` after `read_free`). See fn-level # Safety
-        // for why client_data must be the Box-rooted `this` and not a
-        // `&mut self`-derived pointer.
+        // (dropped below on failure, otherwise as a field of `*this`). See
+        // fn-level # Safety for why client_data must be the Box-rooted
+        // `this` and not a `&mut self`-derived pointer.
         let rc_raw: c_int = unsafe {
             lib::archive_read_open(
-                archive,
+                archive.as_mut_ptr(),
                 this.cast::<c_void>(),
                 None,
                 Some(archive_read_callback),
@@ -666,21 +653,20 @@ impl TarballStream {
                 // open() runs the filter bidder which we bypassed, but the
                 // client open path may still probe; treat as transient.
                 // SAFETY: see fn-level # Safety — raw-ptr field write.
-                unsafe { (*this).archive = Some(scopeguard::ScopeGuard::into_inner(guard)) };
+                unsafe { (*this).archive = Some(archive) };
                 return Ok(());
             }
             _ => {
                 bun_output::scoped_log!(
                     TarballStream,
                     "archive_read_open: {}",
-                    // SAFETY: archive is a valid handle (guard not yet dropped).
-                    bstr::BStr::new(unsafe { (*archive).error_string() })
+                    bstr::BStr::new(archive.error_string())
                 );
                 return Err(crate::Error::Fail);
             }
         }
         // SAFETY: see fn-level # Safety — raw-ptr field write.
-        unsafe { (*this).archive = Some(scopeguard::ScopeGuard::into_inner(guard)) };
+        unsafe { (*this).archive = Some(archive) };
         Ok(())
     }
 
@@ -1230,13 +1216,6 @@ impl Drop for TarballStream {
         }
         if let Some(d) = self.dest {
             d.close();
-        }
-        if let Some(a) = self.archive {
-            // SAFETY: `a` is a live libarchive handle owned by this struct.
-            unsafe {
-                let _ = (*a).read_close();
-                let _ = (*a).read_free();
-            }
         }
     }
 }


### PR DESCRIPTION
## What

`TarballStream.archive` (the resumable libarchive handle behind streaming `bun install` extraction, `src/install/TarballStream.rs`) was an `Option<*mut lib::Archive>`. `open_archive` called `lib::Archive::read_new()`, armed a `scopeguard` whose closure ran `read_close` and `read_free` inside an `unsafe` block, called the setup methods through `(*archive).…` in further `unsafe` blocks, and disarmed the guard with `ScopeGuard::into_inner` at both success exits. `step()` re-read and dereferenced the unwrapped pointer in three places, and `impl Drop for TarballStream` had a hand-rolled arm that ran `read_close` and `read_free` again.

The field is now the RAII owner that `bun_libarchive` already provides and that `runtime/api/Archive.rs` already uses:

```rust
// before
archive: Option<*mut lib::Archive>,
// after
archive: Option<lib::ReadArchive>,   // NonNull<Archive>, archive_read_free on Drop
```

`open_archive` becomes `let archive = lib::ReadArchive::new();`, configures it with the safe `read_support_format_tar` / `read_set_options` methods through `Deref`, passes `archive.as_mut_ptr()` to the three raw setup calls (`archive_read_append_filter`, `archive_read_set_format`, `archive_read_open`), and moves it into the field at the two success exits; its three `return Err(..)` paths simply drop it. `step()` holds `let archive: &lib::Archive = (*this).archive.as_deref().unwrap();` and reuses it at the two `error_string()` sites. The `archive` arm of the `Drop` impl is deleted (the `out_fd` / `dest` closes stay). One file, 17 insertions and 38 deletions; removes 5 unsafe blocks (the scopeguard closure, two setup calls, one `error_string` call, and the `Drop` arm) and the two remaining raw dereferences of the field inside `step()`.

## Why

Ownership of the `struct archive *` is now stated by the type: the stream owns exactly one handle once `open_archive` succeeds, every early return in `open_archive` releases it without a guard to disarm, and the handle can no longer be leaked or double-freed by a future edit to `Drop`. It is zero-cost: `Option<lib::ReadArchive>` uses the `NonNull` niche, so the field shrinks from 16 to 8 bytes; the `Deref` and `as_mut_ptr()` calls are inlined pointer reinterpretations; and teardown performs one FFI call instead of two, because libarchive's `archive_read_free` itself closes the filters (`_archive_read_free` calls `archive_read_close` for an open archive, and `__archive_read_free_filters` runs `close_filters` in every state), with the stream's own read callback never invoked during either. The only added instruction is the drop-glue discriminant test of the always-`None` previous value when the field is assigned, once per archive open.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/cli/install/bun-install-streaming-extract.test.ts test/cli/install/symlink-path-traversal.test.ts`: 19 pass, 0 fail (19 tests across 2 files).
