### PR TITLE
bundler: do not record tree-shaken imports in the bytecode ESM module record

### DIFF
--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -280,13 +280,9 @@ pub(crate) fn post_process_js_chunk(
             let source_parts = all_parts[part_range.source_index.get() as usize].as_slice();
             let source_import_records =
                 all_import_records[part_range.source_index.get() as usize].as_slice();
-            // A wrapped file's range covers every part of the file, including
-            // tree-shaken ones (find_imported_parts_in_js_order), which are
-            // skipped when printing. The symbols of a dead import were never
-            // renamed, so recording it would add an import binding under its
-            // original source name; if a live binding of the chunk ended up with
-            // that name, `ModuleInfo::finalize` would turn its export into a
-            // re-export from the external module.
+            // A wrapped file's range spans all of its parts, tree-shaken ones
+            // included (find_imported_parts_in_js_order); the printer skips
+            // those, so the record has to as well.
             let parts_live = &c.graph.parts_live[part_range.source_index.get() as usize];
             let mut part_i = part_range.part_index_begin;
             while part_i < part_range.part_index_end {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -280,8 +280,20 @@ pub(crate) fn post_process_js_chunk(
             let source_parts = all_parts[part_range.source_index.get() as usize].as_slice();
             let source_import_records =
                 all_import_records[part_range.source_index.get() as usize].as_slice();
+            // A wrapped file's range covers every part of the file, including
+            // tree-shaken ones (find_imported_parts_in_js_order), which are
+            // skipped when printing. The symbols of a dead import were never
+            // renamed, so recording it would add an import binding under its
+            // original source name; if a live binding of the chunk ended up with
+            // that name, `ModuleInfo::finalize` would turn its export into a
+            // re-export from the external module.
+            let parts_live = &c.graph.parts_live[part_range.source_index.get() as usize];
             let mut part_i = part_range.part_index_begin;
             while part_i < part_range.part_index_end {
+                if !parts_live.is_set(part_i as usize) {
+                    part_i += 1;
+                    continue;
+                }
                 // `Part.stmts: StoreSlice<Stmt>` — arena-backed, safe `Deref`.
                 for stmt in source_parts[part_i as usize].stmts.iter() {
                     match &stmt.data {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -280,9 +280,7 @@ pub(crate) fn post_process_js_chunk(
             let source_parts = all_parts[part_range.source_index.get() as usize].as_slice();
             let source_import_records =
                 all_import_records[part_range.source_index.get() as usize].as_slice();
-            // A wrapped file's range spans all of its parts, tree-shaken ones
-            // included (find_imported_parts_in_js_order); the printer skips
-            // those, so the record has to as well.
+            // A wrapped file's range spans all of its parts, including the tree-shaken ones.
             let parts_live = &c.graph.parts_live[part_range.source_index.get() as usize];
             let mut part_i = part_range.part_index_begin;
             while part_i < part_range.part_index_end {

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -61,5 +61,55 @@ describe("bundler", () => {
         },
       });
     }
+
+    // The shared chunk contains a require()d (so __esm-wrapped) module with an
+    // unused import of a node builtin. Builtins are side-effect free, so that
+    // import is tree-shaken out of the printed chunk, but the module record
+    // built for --bytecode still listed it, under the import's original local
+    // name because the dead symbol was never renamed. When a live export of the
+    // chunk had the same name, its export entry turned into a re-export of the
+    // builtin, and the other chunk got fs/promises.rm instead of the local rm().
+    //
+    // The unused import binds every single-character name as well, so the
+    // collision also happens with whatever name the minifier gives `rm`.
+    const deadImportNames = [
+      "rm",
+      ...Array.from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$", c => `rm as ${c}`),
+    ];
+    for (const minify of [false, true]) {
+      itBundled(`compile/splitting/BytecodeDeadExternalImportInWrappedModule${minify ? "+minify" : ""}`, {
+        compile: true,
+        splitting: true,
+        bytecode: true,
+        format: "esm",
+        ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
+        files: {
+          "/entry.js": /* js */ `
+            import { rm } from "./shared.js";
+            console.log("entry:", rm());
+            await import("./page.js");
+          `,
+          "/page.js": /* js */ `
+            import { rm } from "./shared.js";
+            console.log("page:", rm());
+          `,
+          "/shared.js": /* js */ `
+            const { value } = require("./wrapped.js");
+            export function rm() {
+              return "local rm " + value;
+            }
+          `,
+          // A .js file on purpose: in TypeScript an unused import is dropped by
+          // the parser and never reaches the linker.
+          "/wrapped.js": /* js */ `
+            import { ${deadImportNames.join(", ")} } from "fs/promises";
+            export const value = 42;
+          `,
+        },
+        run: {
+          stdout: "entry: local rm 42\npage: local rm 42",
+        },
+      });
+    }
   });
 });

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -72,44 +72,53 @@ describe("bundler", () => {
     //
     // The unused import binds every single-character name as well, so the
     // collision also happens with whatever name the minifier gives `rm`.
+    //
+    // Only the bytecode builds have a record to get wrong, and only the
+    // splitting builds export `rm` across chunks; the other combinations pin
+    // the configurations that already worked.
     const deadImportNames = [
       "rm",
       ...Array.from("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$", c => `rm as ${c}`),
     ];
-    for (const minify of [false, true]) {
-      itBundled(`compile/splitting/BytecodeDeadExternalImportInWrappedModule${minify ? "+minify" : ""}`, {
-        compile: true,
-        splitting: true,
-        bytecode: true,
-        format: "esm",
-        ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
-        files: {
-          "/entry.js": /* js */ `
-            import { rm } from "./shared.js";
-            console.log("entry:", rm());
-            await import("./page.js");
-          `,
-          "/page.js": /* js */ `
-            import { rm } from "./shared.js";
-            console.log("page:", rm());
-          `,
-          "/shared.js": /* js */ `
-            const { value } = require("./wrapped.js");
-            export function rm() {
-              return "local rm " + value;
-            }
-          `,
-          // A .js file on purpose: in TypeScript an unused import is dropped by
-          // the parser and never reaches the linker.
-          "/wrapped.js": /* js */ `
-            import { ${deadImportNames.join(", ")} } from "fs/promises";
-            export const value = 42;
-          `,
-        },
-        run: {
-          stdout: "entry: local rm 42\npage: local rm 42",
-        },
-      });
+    for (const splitting of [false, true]) {
+      for (const bytecode of [false, true]) {
+        for (const minify of [false, true]) {
+          const suffix = (splitting ? "+splitting" : "") + (bytecode ? "+bytecode" : "") + (minify ? "+minify" : "");
+          itBundled(`compile/DeadExternalImportInWrappedModule${suffix}`, {
+            compile: true,
+            splitting,
+            bytecode,
+            format: "esm",
+            ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
+            files: {
+              "/entry.js": /* js */ `
+                import { rm } from "./shared.js";
+                console.log("entry:", rm());
+                await import("./page.js");
+              `,
+              "/page.js": /* js */ `
+                import { rm } from "./shared.js";
+                console.log("page:", rm());
+              `,
+              "/shared.js": /* js */ `
+                const { value } = require("./wrapped.js");
+                export function rm() {
+                  return "local rm " + value;
+                }
+              `,
+              // A .js file on purpose: in TypeScript an unused import is dropped by
+              // the parser and never reaches the linker.
+              "/wrapped.js": /* js */ `
+                import { ${deadImportNames.join(", ")} } from "fs/promises";
+                export const value = 42;
+              `,
+            },
+            run: {
+              stdout: "entry: local rm 42\npage: local rm 42",
+            },
+          });
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## Repro

`bun build --compile --bytecode --format=esm --splitting` of these five files (released 1.4.0):

```js
// entry.js
import { rm } from "./shared.js";
console.log("entry:", rm());
await import("./page.js");

// page.js
import { rm } from "./shared.js";
console.log("page:", rm());

// shared.js
const { value } = require("./wrapped.js");   // require() makes wrapped.js an __esm-wrapped module
export function rm() { return "local rm " + value; }

// wrapped.js (a .js file: in TypeScript the parser drops the unused import)
import { rm } from "fs/promises";            // unused, tree-shaken out of the chunk
export const value = 42;
```

```
TypeError: path must be a string or TypedArray
 code: "ERR_INVALID_ARG_TYPE"
entry: Promise { <rejected> }
```

The cross-chunk `rm` import is bound to `fs/promises.rm` instead of the local function. Without `--bytecode`, or with `bun run` on the emitted chunks, it prints `entry: local rm 42` / `page: local rm 42`. On a debug build the compiled binary fails at startup instead with `Imports different between parseFromSourceCode and fallbackParse`, since `BunAnalyzeTranspiledModule.cpp` cross-checks the record against JSC's analyzer.

This is the report of a minified split build where an importing chunk's init thunk import resolved to `fs/promises.rm`. There, minification is what made the names collide: the exporting chunk had a live init thunk whose minified name was `rm`, and some file in it had a tree-shaken `import { rm } from "fs/promises"`.

## Cause

For `--compile --bytecode --format=esm` the linker builds each chunk's module record itself (`post_process_js_chunk`). External imports are collected by walking the statements of every part in `parts_in_chunk_in_order`. For non-wrapped files those ranges only contain live parts, but `find_imported_parts_in_js_order` gives a wrapped file a single range covering all of its parts, and `generate_code_for_file_in_chunk_js` then skips the dead ones when printing. The record walk did not, so the dead import was recorded even though it is not in the chunk. Builtins are external-without-side-effects, so an unused builtin import is a dead part.

Because the dead import's symbols were never given a name by the renamer, `name_for_symbol` returns the original source name, so the record gained an import entry `fs/promises.rm` with local name `rm`. `ModuleInfo::finalize` then saw the chunk's `export { rm }` (a local export whose local name matches an import entry) and, per the usual local-to-indirect conversion, rewrote it into an indirect export of `fs/promises.rm`. Any importing chunk resolving that export got the builtin's function.

## Fix

Skip parts that `parts_live` says were tree-shaken when collecting the external imports, the same check the printer applies.

A related gap in the same loop (imports that `convert_stmts_for_chunk` synthesizes from `export * as ns from "node:fs"` are printed but never recorded, so under bytecode `ns` is left in TDZ) is a separate bug and is not changed here.

## Verification

`test/bundler/bundler_compile_splitting.test.ts` gains `compile/splitting/BytecodeDeadExternalImportInWrappedModule` and its `+minify` variant. The unused import also binds every single-character identifier, so the minified variant collides with whatever name the minifier gives `rm` and reproduces the reported minified shape (`import{a as r,b as o}` bound to `fs/promises.rm`). Both fail on the released binary with the `ERR_INVALID_ARG_TYPE` error above and on a debug build of `main` with the record cross-check error; both pass with this change. `bundler_compile.test.ts` (ESM bytecode matrix) and `bundler_bun.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_compile_splitting.test.ts
bun test v1.4.0 (c41e11cd8)

test/bundler/bundler_compile_splitting.test.ts:
(pass) bundler > compile with splitting > compile/splitting/RelativePathsAcrossChunks [3471.28ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk [2840.81ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk+minify [3209.16ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule [2964.99ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+minify [3595.82ms]
1815 |           }
1816 |         } else if (!success) {
1817 |           if (run.exitCode) {
1818 |             expect([exitCode, signalCode]).toEqual([run.exitCode, undefined]);
1819 |           } else {
1820 |             throw new Error(prefix + "Runtime failed\n" + stdout!.toUnixString() + "\n" + stderr!.toUnixString());
                             ^
error: Runtime failed







[95mBEGIN analyzeTranspiledModule(B[m
  --
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/bundler/bundler_compile_splitting.test.ts:
(pass) bundler > compile with splitting > compile/splitting/RelativePathsAcrossChunks [258.33ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk [130.07ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk+minify [126.04ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule [130.64ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+minify [127.47ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode [132.27ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode+minify [134.99ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting [126.54ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+minify [139.96ms]
1815 |           }
1816 |         } else if (!success) {
1817 |           if (run.exitCode) {
1818 |             expect([exitCode, signalCode]).toEqual([run.exitCode, undefined]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_compile_splitting.test.ts
bun test v1.4.0 (c41e11cd8)

test/bundler/bundler_compile_splitting.test.ts:
(pass) bundler > compile with splitting > compile/splitting/RelativePathsAcrossChunks [4756.62ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk [3800.33ms]
(pass) bundler > compile with splitting > compile/splitting/ImportMetaInSplitChunk+minify [4564.40ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule [3790.46ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+minify [4133.71ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode [3839.16ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+bytecode+minify [4335.57ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting [3817.69ms]
(pass) bundler > compile with splitting > compile/DeadExternalImportInWrappedModule+splitting+minify [4362.33m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1236ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/30] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/30] gen JS modules (bundle-modules)
Preprocess modules (15369ms)
Bundle modules (46ms)
Postprocesss modules (45ms)
Bundle Functions (926ms)
Generate Code (36ms)

[16.44s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/21] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_sour
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/linker_context/postProcessJSChunk.rs |  6 +++
 test/bundler/bundler_compile_splitting.test.ts   | 59 ++++++++++++++++++++++++
 2 files changed, 65 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/bundler/linker_context/postProcessJSChunk.rs      5      6      0
test/bundler/bundler_compile_splitting.test.ts        3      5      0
```

</details>

<!-- robobun:evidence:end -->