### PR TITLE
jsc: ExternColumnIdentifier ctors; create_structure takes a slice

### DIFF
--- a/src/jsc/JSObject.rs
+++ b/src/jsc/JSObject.rs
@@ -2,7 +2,7 @@ use core::ffi::{c_uint, c_void};
 use core::mem::ManuallyDrop;
 
 use crate::{JSCell, JSGlobalObject, JSValue, JsError, JsResult};
-use bun_core::{String as BunString, ZigString};
+use bun_core::{OwnedString, ZigString};
 
 unsafe extern "C" {
     // safe: read-only `const unsigned` exported by C++ (link-time constant).
@@ -18,7 +18,7 @@ unsafe extern "C" {
         global: *mut JSGlobalObject,
         owner: *mut JSCell,
         length: u32,
-        names: *mut ExternColumnIdentifier,
+        names: *const ExternColumnIdentifier,
     ) -> JSValue;
     // safe: `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle (`&` is
     // ABI-identical to non-null `*const`); `ctx` is an opaque round-trip pointer
@@ -128,16 +128,16 @@ impl JSObject {
         self.to_js().get(global, prop.as_ref())
     }
 
+    /// C++ copies the names it needs into the returned `Structure` and does
+    /// not retain `names`, so the slice may be dropped as soon as this returns.
+    ///
     /// # Safety
     /// `owner` must be a cell-tagged `JSValue` (its payload is a live
     /// `JSCell*`) that remains valid for the duration of the call.
-    /// `names` must point to `length` initialized `ExternColumnIdentifier`s
-    /// valid for the duration of the call; C++ does not retain the pointer.
     pub unsafe fn create_structure(
         global: &JSGlobalObject,
         owner: JSValue,
-        length: u32,
-        names: *mut ExternColumnIdentifier,
+        names: &[ExternColumnIdentifier],
     ) -> JSValue {
         crate::mark_binding!();
         debug_assert!(owner.is_cell());
@@ -145,11 +145,19 @@ impl JSObject {
         // payload IS the JSCell* (NotCellMask bits are zero), so the raw usize
         // is the pointer. SAFETY: caller guarantees `owner.is_cell()`.
         let owner_cell = owner.0 as *mut JSCell;
-        // SAFETY: thin FFI shim; `owner_cell` is non-null per caller contract.
+        // SAFETY: thin FFI shim; `owner_cell` is non-null per caller contract
+        // and `names` is a live slice that C++ only reads during the call.
         // `global.as_ptr()` yields the raw FFI handle — JSGlobalObject is an
         // opaque JSC cell with interior mutability on the C++ side; Rust holds
         // no `&`-derived view of any field C++ mutates.
-        unsafe { JSC__createStructure(global.as_ptr(), owner_cell, length, names) }
+        unsafe {
+            JSC__createStructure(
+                global.as_ptr(),
+                owner_cell,
+                names.len() as u32,
+                names.as_ptr(),
+            )
+        }
     }
 
     pub fn create_with_initializer<Ctx: ObjectInitializer>(
@@ -213,41 +221,55 @@ impl JSObject {
     }
 }
 
+/// Mirrors `ExternColumnIdentifier` in `SQLClient.cpp`, which only reads it.
+/// A named column owns one reference to its name, released on drop.
 #[repr(C)]
 pub struct ExternColumnIdentifier {
-    pub tag: u8,
-    pub value: ExternColumnIdentifierValue,
+    tag: ExternColumnIdentifierTag,
+    value: ExternColumnIdentifierValue,
+}
+
+/// The discriminants are what `isIndexedColumn()` / `isNamedColumn()` test for
+/// in `SQLClient.cpp`. C++ also knows a duplicate tag (0), but duplicates are
+/// filtered out before identifiers are built, so Rust never constructs one.
+#[repr(u8)]
+enum ExternColumnIdentifierTag {
+    Index = 1,
+    Name = 2,
 }
 
 #[repr(C)]
-pub union ExternColumnIdentifierValue {
-    pub index: u32,
-    pub name: ManuallyDrop<BunString>,
-}
-
-impl Default for ExternColumnIdentifier {
-    fn default() -> Self {
-        Self {
-            tag: 0,
-            value: ExternColumnIdentifierValue { index: 0 },
-        }
-    }
+union ExternColumnIdentifierValue {
+    index: u32,
+    name: ManuallyDrop<OwnedString>,
 }
 
 impl ExternColumnIdentifier {
-    pub(crate) fn string(&mut self) -> Option<&mut BunString> {
-        match self.tag {
-            // SAFETY: tag == 2 means `value.name` is the active union field.
-            2 => Some(unsafe { &mut *self.value.name }),
-            _ => None,
+    #[inline]
+    pub fn index(index: u32) -> Self {
+        Self {
+            tag: ExternColumnIdentifierTag::Index,
+            value: ExternColumnIdentifierValue { index },
+        }
+    }
+
+    #[inline]
+    pub fn name(name: OwnedString) -> Self {
+        Self {
+            tag: ExternColumnIdentifierTag::Name,
+            value: ExternColumnIdentifierValue {
+                name: ManuallyDrop::new(name),
+            },
         }
     }
 }
 
 impl Drop for ExternColumnIdentifier {
     fn drop(&mut self) {
-        if let Some(str) = self.string() {
-            str.deref();
+        if matches!(self.tag, ExternColumnIdentifierTag::Name) {
+            // SAFETY: `Self::name` is the only constructor that sets this tag and
+            // it initializes `value.name`; the field is not touched after this.
+            unsafe { ManuallyDrop::drop(&mut self.value.name) }
         }
     }
 }

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1202,7 +1202,7 @@ pub use self::js_global_object::BunPluginTarget;
 // ──────────────────────────────────────────────────────────────────────────
 #[path = "JSObject.rs"]
 pub mod js_object;
-pub use self::js_object::{ExternColumnIdentifier, ExternColumnIdentifierValue, JSObject};
+pub use self::js_object::{ExternColumnIdentifier, JSObject};
 
 // ──────────────────────────────────────────────────────────────────────────
 // CallFrame / ArgumentsSlice (real module in CallFrame.rs).

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -27,10 +27,10 @@ use core::ptr::NonNull;
 // ──────────────────────────────────────────────────────────────────────────
 
 pub use bun_jsc::{
-    ArrayBuffer, CallFrame, CoerceTo, ErrorBuilder, ErrorCode, ExternColumnIdentifier,
-    ExternColumnIdentifierValue, GlobalRef, JSArrayIterator, JSCell, JSGlobalObject, JSObject,
-    JSType, JSValue, JsCell, JsError, JsRef, JsResult, MarkedArgumentBuffer, StringJsc,
-    StrongOptional, ThrowFmtArgs, ZigStringJsc, bun_string_jsc, host_fn,
+    ArrayBuffer, CallFrame, CoerceTo, ErrorBuilder, ErrorCode, ExternColumnIdentifier, GlobalRef,
+    JSArrayIterator, JSCell, JSGlobalObject, JSObject, JSType, JSValue, JsCell, JsError, JsRef,
+    JsResult, MarkedArgumentBuffer, StringJsc, StrongOptional, ThrowFmtArgs, ZigStringJsc,
+    bun_string_jsc, host_fn,
 };
 
 /// Re-export — `bun_jsc` now defines `IntegerRange` at its crate root and the

--- a/src/sql_jsc/shared/CachedStructure.rs
+++ b/src/sql_jsc/shared/CachedStructure.rs
@@ -1,6 +1,6 @@
-use core::mem::{ManuallyDrop, MaybeUninit};
-
 use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSObject, JSValue, StrongOptional};
+use bun_collections::smallvec::SmallVec;
+use bun_core::OwnedString;
 use bun_sql::shared::ColumnIdentifier;
 
 #[derive(Default)]
@@ -51,83 +51,30 @@ impl CachedStructure {
     ) where
         I: Iterator<Item = &'a ColumnIdentifier> + Clone,
     {
-        // lets avoid most allocations
-        // SAFETY: `[MaybeUninit<T>; N]` is always sound to `assume_init` — every
-        // element is itself `MaybeUninit` and thus has no validity invariant.
-        let mut stack_ids: [MaybeUninit<ExternColumnIdentifier>; 70] =
-            unsafe { MaybeUninit::uninit().assume_init() };
         // lets de duplicate the fields early
         let non_duplicated_count = columns
             .clone()
             .filter(|c| !matches!(c, ColumnIdentifier::Duplicate))
             .count();
+        let ids = columns.filter_map(|name_or_index| match name_or_index {
+            ColumnIdentifier::Name(name) => Some(ExternColumnIdentifier::name(OwnedString::new(
+                bun_core::String::create_atom_if_possible(name.slice()),
+            ))),
+            ColumnIdentifier::Index(index) => Some(ExternColumnIdentifier::index(*index)),
+            ColumnIdentifier::Duplicate => None,
+        });
 
-        let max_inline = JSObject::max_inline_capacity() as usize;
-        // Initialized to empty so the `> max_inline` branch below can
-        // unconditionally `into_boxed_slice()` it; in the `<= max_inline`
-        // branch it stays empty and is never read.
-        let mut heap_ids: Vec<ExternColumnIdentifier> = Vec::new();
-        let ids: &mut [MaybeUninit<ExternColumnIdentifier>] = if non_duplicated_count <= max_inline
-        {
-            &mut stack_ids[..non_duplicated_count]
-        } else {
-            heap_ids = Vec::with_capacity(non_duplicated_count);
-            // Spare capacity is exactly the uninitialized `[MaybeUninit<T>]` view
-            // we need; fully initialized in the loop below before any read.
-            &mut heap_ids.spare_capacity_mut()[..non_duplicated_count]
-        };
-
-        let mut i: usize = 0;
-        for name_or_index in columns {
-            if matches!(name_or_index, ColumnIdentifier::Duplicate) {
-                continue;
-            }
-
-            let mut out = ExternColumnIdentifier::default();
-            match name_or_index {
-                ColumnIdentifier::Name(name) => {
-                    out.value.name =
-                        ManuallyDrop::new(bun_core::String::create_atom_if_possible(name.slice()));
-                }
-                ColumnIdentifier::Index(index) => {
-                    out.value.index = *index;
-                }
-                ColumnIdentifier::Duplicate => unreachable!(),
-            }
-            out.tag = match name_or_index {
-                ColumnIdentifier::Name(_) => 2,
-                ColumnIdentifier::Index(_) => 1,
-                ColumnIdentifier::Duplicate => 0,
-            };
-            ids[i].write(out);
-            i += 1;
-        }
-
-        if non_duplicated_count > max_inline {
-            // SAFETY: `heap_ids` has capacity `non_duplicated_count` and every
-            // slot in [0..non_duplicated_count] was initialized in the loop above.
-            unsafe { heap_ids.set_len(non_duplicated_count) };
-            // Ownership transfer of heap `ids` to CachedStructure, which
-            // becomes responsible for freeing the alloc'd slice.
+        if non_duplicated_count > JSObject::max_inline_capacity() as usize {
+            let mut heap_ids = Vec::with_capacity(non_duplicated_count);
+            heap_ids.extend(ids);
             self.set(global_object, None, Some(heap_ids.into_boxed_slice()));
         } else {
-            // Every element in `ids[..]` was `.write()`n above; C++ reads them as
-            // `ExternColumnIdentifier` by raw pointer, so pass the buffer through
-            // without materialising a typed slice (avoids an unsafe assume-init cast).
-            self.set(
-                global_object,
-                // SAFETY: every `ids[..len]` slot was initialized in the loop
-                // above; the stack buffer outlives the FFI call.
-                Some(unsafe {
-                    JSObject::create_structure(
-                        global_object,
-                        owner,
-                        ids.len() as u32,
-                        ids.as_mut_ptr().cast::<ExternColumnIdentifier>(),
-                    )
-                }),
-                None,
-            );
+            // lets avoid most allocations
+            let stack_ids: SmallVec<[ExternColumnIdentifier; 70]> = ids.collect();
+            // SAFETY: `owner` is the connection's JS object, passed through
+            // unchanged by `{Postgres,MySQL}SQLStatement::structure`.
+            let structure = unsafe { JSObject::create_structure(global_object, owner, &stack_ids) };
+            self.set(global_object, Some(structure), None);
         }
     }
 }


### PR DESCRIPTION
## What

`ExternColumnIdentifier` (`src/jsc/JSObject.rs`), the per-column record that `SQLClient.cpp` reads when it builds a row `Structure`, was a `#[repr(C)]` struct with a public `tag: u8` and a public union, and its only builder, `CachedStructure::build_from_columns` (`src/sql_jsc/shared/CachedStructure.rs`), filled the tag (`0` / `1` / `2`) and the active union field by hand. `JSObject::create_structure` took a `length` plus a `*mut ExternColumnIdentifier` that the builder obtained either from a `[MaybeUninit<_>; 70]` stack array or from the spare capacity of a `Vec` whose length it then set manually.

```rust
// before
pub struct ExternColumnIdentifier { pub tag: u8, pub value: ExternColumnIdentifierValue }
pub union ExternColumnIdentifierValue { pub index: u32, pub name: ManuallyDrop<BunString> }
pub unsafe fn create_structure(global: &JSGlobalObject, owner: JSValue, length: u32, names: *mut ExternColumnIdentifier) -> JSValue

// after
pub struct ExternColumnIdentifier { tag: ExternColumnIdentifierTag, value: ExternColumnIdentifierValue }
#[repr(u8)] enum ExternColumnIdentifierTag { Index = 1, Name = 2 }
union ExternColumnIdentifierValue { index: u32, name: ManuallyDrop<OwnedString> }
impl ExternColumnIdentifier { pub fn index(u32) -> Self; pub fn name(OwnedString) -> Self; }
pub unsafe fn create_structure(global: &JSGlobalObject, owner: JSValue, names: &[ExternColumnIdentifier]) -> JSValue
```

The fields and the union are private, so the two constructors are the only way to build a value; `Drop` releases the name through `ManuallyDrop::drop` on the `OwnedString`, replacing the `string()` accessor and the manual `deref()`. The unused `Default` impl (tag 0, "duplicate") is removed: duplicates are filtered out before identifiers are built, so Rust never produced that state; C++ keeps its `isDuplicateColumn()` check and is not touched. The `extern` declaration of `JSC__createStructure` takes `*const`, since the C++ side only reads the array.

`build_from_columns` now maps the columns through one `filter_map` into `ExternColumnIdentifier::name(..)` / `::index(..)` and collects it either into a `Vec` created with the exact non-duplicate count (the more-than-inline-capacity case, boxed and stored on `fields` exactly as before) or into a `SmallVec<[ExternColumnIdentifier; 70]>` on the stack that is passed to `create_structure` as a slice. One builder site and one `create_structure` call site updated; the `MaybeUninit::uninit().assume_init()` and `set_len` unsafe blocks are deleted, and the remaining unsafe block's contract shrinks to the `owner` clause. The `ExternColumnIdentifierValue` re-exports in `src/jsc/lib.rs` and `src/sql_jsc/jsc.rs` go away with the union's visibility.

## Why

The tag/union pairing is now established in one place and checked by the compiler rather than by convention at the build site, the ownership of a column name (one reference, released on drop) is stated by the `OwnedString` field and the `name(OwnedString)` signature, and the initialized-length-of-`names` contract moves out of a `# Safety` comment and into the slice type. Layout is unchanged (a `#[repr(u8)]` tag in the `#[repr(C)]` struct, `OwnedString` is `#[repr(transparent)]` over `String`, and the same pointer/length pair crosses FFI, as confirmed against the C++ struct), the heap case still makes exactly one allocation of exact size, the stack case still makes none, and the per-column bounds check becomes the equivalent length-against-capacity check of the pre-sized buffers.

One behavioural consequence worth flagging: the stack case previously never released the `+1` string references `create_atom_if_possible` produced for named columns (the `MaybeUninit` array was never dropped), so every named column of every prepared statement that fit inline leaked one reference. `create_structure` documents that C++ copies what it needs into the `Structure` and does not retain the array, so dropping the `SmallVec` after the call now releases those references; JS-visible behaviour is unchanged.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/sql/sql.test.ts (10 pass, server-gated cases not run locally), test/js/sql/postgres-multi-statement-fields.test.ts (5 pass), test/js/sql/postgres-datarow-overrun.test.ts (8 pass), test/js/sql/sql-mysql.auth.test.ts (3 pass): 26 pass, 0 fail.
