### PR TITLE
crypto: make CryptoHasherBun (was CryptoHasherZig) an enum of boxed hash states

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -1,4 +1,3 @@
-use core::any::Any;
 use core::cell::Cell;
 use core::ffi::c_char;
 
@@ -128,7 +127,7 @@ impl CryptoHasher {
     ) -> Option<Box<CryptoHasher>> {
         match other_handle {
             CryptoHasher::Zig(other) => {
-                let hasher = CryptoHasher::new(CryptoHasher::Zig(JsCell::new(other.get().copy())));
+                let hasher = CryptoHasher::new(CryptoHasher::Zig(JsCell::new(other.get().clone())));
                 Some(hasher)
             }
             CryptoHasher::Evp(other) => {
@@ -190,7 +189,7 @@ impl CryptoHasher {
     #[bun_uws::uws_callback(export = "Bun__CryptoHasherExtern__getDigestSize", no_catch)]
     pub fn extern_digest_size(&self) -> u32 {
         match self {
-            CryptoHasher::Zig(inner) => inner.get().digest_length as u32,
+            CryptoHasher::Zig(inner) => inner.get().digest_length() as u32,
             CryptoHasher::Evp(inner) => inner.get().size() as u32,
             _ => 0,
         }
@@ -200,8 +199,8 @@ impl CryptoHasher {
     pub fn extern_is_xof(&self) -> bool {
         match self {
             CryptoHasher::Zig(inner) => matches!(
-                inner.get().algorithm,
-                evp::Algorithm::Shake128 | evp::Algorithm::Shake256
+                inner.get(),
+                CryptoHasherZig::Shake128(_) | CryptoHasherZig::Shake256(_)
             ),
             _ => false,
         }
@@ -315,7 +314,7 @@ impl CryptoHasher {
                 Some(hmac) => hmac.size() as f64,
                 None => return Err(Self::throw_hmac_consumed(global)),
             },
-            CryptoHasher::Zig(inner) => inner.get().digest_length as f64,
+            CryptoHasher::Zig(inner) => inner.get().digest_length() as f64,
         }))
     }
 
@@ -323,7 +322,7 @@ impl CryptoHasher {
     pub(crate) fn get_algorithm(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         let tag: &'static [u8] = match this {
             CryptoHasher::Evp(inner) => inner.get().algorithm.tag_cstr().to_bytes(),
-            CryptoHasher::Zig(inner) => inner.get().algorithm.tag_cstr().to_bytes(),
+            CryptoHasher::Zig(inner) => inner.get().algorithm().tag_cstr().to_bytes(),
             CryptoHasher::Hmac(inner) => match inner.get() {
                 Some(hmac) => hmac.algorithm.tag_cstr().to_bytes(),
                 None => return Err(Self::throw_hmac_consumed(global)),
@@ -678,7 +677,7 @@ impl CryptoHasher {
                     }
                 })));
             }
-            CryptoHasher::Zig(inner) => CryptoHasher::Zig(JsCell::new(inner.get().copy())),
+            CryptoHasher::Zig(inner) => CryptoHasher::Zig(JsCell::new(inner.get().clone())),
         };
         Ok(copied.to_js(global))
     }
@@ -805,15 +804,22 @@ impl CryptoHasher {
 // CryptoHasherZig
 // ───────────────────────────────────────────────────────────────────────────
 
-pub struct CryptoHasherZig {
-    pub(crate) algorithm: evp::Algorithm,
-    pub(crate) state: Box<dyn Any>,
-    pub(crate) digest_length: u8,
+/// The variant is the algorithm. Each state is boxed (Keccak states are a few
+/// hundred bytes), like the `Evp` arm of `CryptoHasher`.
+#[derive(Clone)]
+pub enum CryptoHasherZig {
+    Sha3_224(Box<Sha3_224>),
+    Sha3_256(Box<Sha3_256>),
+    Sha3_384(Box<Sha3_384>),
+    Sha3_512(Box<Sha3_512>),
+    Shake128(Box<Shake128>),
+    Shake256(Box<Shake256>),
+    Blake2s256(Box<Blake2s256>),
 }
 
 /// Trait for the non-BoringSSL hash algorithms used by `CryptoHasherZig`.
 /// Implemented for each algo in `zig_crypto_algos` below.
-trait ZigHashAlgo: Default + Clone + 'static {
+trait ZigHashAlgo: Default + Clone {
     const ALGORITHM: evp::Algorithm;
     /// Shake128→16, Shake256→32, else the algorithm's digest length.
     const DIGEST_LENGTH: u8;
@@ -898,6 +904,43 @@ macro_rules! for_each_zig_algo {
         $mac!(Shake128   $(, $($args)*)?);
         $mac!(Shake256   $(, $($args)*)?);
         $mac!(Blake2s256 $(, $($args)*)?);
+    };
+}
+
+/// Exhaustive `match` over a `CryptoHasherZig`; every arm binds the boxed
+/// state to `$state` and names its `ZigHashAlgo` type `$algo`.
+macro_rules! match_zig_algo {
+    ($hasher:expr, |$state:tt: $algo:ident| $body:expr) => {
+        match $hasher {
+            CryptoHasherZig::Sha3_224($state) => {
+                type $algo = Sha3_224;
+                $body
+            }
+            CryptoHasherZig::Sha3_256($state) => {
+                type $algo = Sha3_256;
+                $body
+            }
+            CryptoHasherZig::Sha3_384($state) => {
+                type $algo = Sha3_384;
+                $body
+            }
+            CryptoHasherZig::Sha3_512($state) => {
+                type $algo = Sha3_512;
+                $body
+            }
+            CryptoHasherZig::Shake128($state) => {
+                type $algo = Shake128;
+                $body
+            }
+            CryptoHasherZig::Shake256($state) => {
+                type $algo = Shake256;
+                $body
+            }
+            CryptoHasherZig::Blake2s256($state) => {
+                type $algo = Blake2s256;
+                $body
+            }
+        }
     };
 }
 
@@ -1033,14 +1076,9 @@ impl CryptoHasherZig {
     pub(crate) fn init(name: &[u8]) -> Option<CryptoHasherZig> {
         let algorithm = evp::lookup_ignore_case(name)?;
         macro_rules! arm {
-            ($ty:ty, $alg:expr) => {
-                if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
-                    let handle = CryptoHasherZig {
-                        algorithm: <$ty as ZigHashAlgo>::ALGORITHM,
-                        state: Box::new(<$ty as ZigHashAlgo>::init()),
-                        digest_length: <$ty as ZigHashAlgo>::DIGEST_LENGTH,
-                    };
-                    return Some(handle);
+            ($algo:ident, $alg:expr) => {
+                if $alg == <$algo as ZigHashAlgo>::ALGORITHM {
+                    return Some(Self::$algo(Box::new(<$algo as ZigHashAlgo>::init())));
                 }
             };
         }
@@ -1048,35 +1086,16 @@ impl CryptoHasherZig {
         None
     }
 
-    fn update(&mut self, bytes: &[u8]) {
-        macro_rules! arm {
-            ($ty:ty, $self:expr, $bytes:expr) => {
-                if $self.algorithm == <$ty as ZigHashAlgo>::ALGORITHM {
-                    // SAFETY: tag matches type stored in `state` (set in init/constructor).
-                    let state = $self.state.downcast_mut::<$ty>().expect("unreachable");
-                    return <$ty as ZigHashAlgo>::update(state, $bytes);
-                }
-            };
-        }
-        for_each_zig_algo!(arm, self, bytes);
-        unreachable!();
+    fn algorithm(&self) -> evp::Algorithm {
+        match_zig_algo!(self, |_: A| A::ALGORITHM)
     }
 
-    fn copy(&self) -> CryptoHasherZig {
-        macro_rules! arm {
-            ($ty:ty, $self:expr) => {
-                if $self.algorithm == <$ty as ZigHashAlgo>::ALGORITHM {
-                    let state = $self.state.downcast_ref::<$ty>().expect("unreachable");
-                    return CryptoHasherZig {
-                        algorithm: $self.algorithm,
-                        state: Box::new(state.clone()),
-                        digest_length: $self.digest_length,
-                    };
-                }
-            };
-        }
-        for_each_zig_algo!(arm, self);
-        unreachable!();
+    fn digest_length(&self) -> u8 {
+        match_zig_algo!(self, |_: A| A::DIGEST_LENGTH)
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        match_zig_algo!(self, |state: A| A::update(state, bytes))
     }
 
     fn final_with_len<'a>(
@@ -1084,22 +1103,15 @@ impl CryptoHasherZig {
         output_digest_slice: &'a mut [u8],
         res_len: usize,
     ) -> &'a mut [u8] {
-        macro_rules! arm {
-            ($ty:ty, $self:expr, $out:expr, $len:expr) => {
-                if $self.algorithm == <$ty as ZigHashAlgo>::ALGORITHM {
-                    let state = $self.state.downcast_mut::<$ty>().expect("unreachable");
-                    <$ty as ZigHashAlgo>::final_(state, $out);
-                    *state = <$ty as ZigHashAlgo>::init();
-                    return &mut $out[0..$len];
-                }
-            };
-        }
-        for_each_zig_algo!(arm, self, output_digest_slice, res_len);
-        unreachable!();
+        match_zig_algo!(self, |state: A| {
+            A::final_(state, output_digest_slice);
+            **state = A::init();
+        });
+        &mut output_digest_slice[0..res_len]
     }
 
     fn final_<'a>(&mut self, output_digest_slice: &'a mut [u8]) -> &'a mut [u8] {
-        let len = self.digest_length as usize;
+        let len = self.digest_length() as usize;
         self.final_with_len(output_digest_slice, len)
     }
 }

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -16,8 +16,8 @@ use bun_sha_hmac::sha as hashers;
 
 // sha3/blake2 algorithms with no BoringSSL streaming context:
 // RustCrypto's `sha3`/`blake2` crates are wired into the
-// `ZigHashAlgo` trait below.
-use zig_crypto_algos::{Blake2s256, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256};
+// `BunHashAlgo` trait below.
+use bun_crypto_algos::{Blake2s256, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256};
 
 // `[u8; EVP_MAX_MD_SIZE]`
 type Digest = evp::Digest;
@@ -67,7 +67,7 @@ pub enum CryptoHasher {
     Hmac(JsCell<Option<Box<HMAC>>>),
     // EVP_CTX is ~280 bytes; box it so the enum stays small.
     Evp(Box<JsCell<EVP>>),
-    Zig(JsCell<CryptoHasherZig>),
+    Bun(JsCell<CryptoHasherBun>),
 }
 
 impl CryptoHasher {
@@ -77,7 +77,7 @@ impl CryptoHasher {
         Box::new(init)
     }
 
-    // ── Extern: For using only CryptoHasherZig in c++ ──────────────────────
+    // ── Extern: For using only CryptoHasherBun in c++ ──────────────────────
 
     #[unsafe(no_mangle)]
     pub(crate) extern "C" fn Bun__CryptoHasherExtern__getByName(
@@ -88,8 +88,8 @@ impl CryptoHasher {
         // SAFETY: caller passes a valid (ptr,len) byte slice
         let name = unsafe { bun_core::ffi::slice(name_bytes.cast::<u8>(), name_len) };
 
-        if let Some(inner) = CryptoHasherZig::init(name) {
-            return Some(CryptoHasher::new(CryptoHasher::Zig(JsCell::new(inner))));
+        if let Some(inner) = CryptoHasherBun::init(name) {
+            return Some(CryptoHasher::new(CryptoHasher::Bun(JsCell::new(inner))));
         }
 
         let algorithm = evp::lookup_ignore_case(name)?;
@@ -126,8 +126,8 @@ impl CryptoHasher {
         other_handle: &CryptoHasher,
     ) -> Option<Box<CryptoHasher>> {
         match other_handle {
-            CryptoHasher::Zig(other) => {
-                let hasher = CryptoHasher::new(CryptoHasher::Zig(JsCell::new(other.get().clone())));
+            CryptoHasher::Bun(other) => {
+                let hasher = CryptoHasher::new(CryptoHasher::Bun(JsCell::new(other.get().clone())));
                 Some(hasher)
             }
             CryptoHasher::Evp(other) => {
@@ -157,8 +157,8 @@ impl CryptoHasher {
     #[bun_uws::uws_callback(export = "Bun__CryptoHasherExtern__update")]
     pub fn extern_update(&self, input: &[u8]) -> bool {
         match self {
-            CryptoHasher::Zig(zig) => {
-                zig.with_mut(|z| z.update(input));
+            CryptoHasher::Bun(inner) => {
+                inner.with_mut(|h| h.update(input));
                 true
             }
             CryptoHasher::Evp(evp) => {
@@ -173,8 +173,8 @@ impl CryptoHasher {
     pub fn extern_digest(&self, global: &JSGlobalObject, digest_buf: &mut [u8]) -> u32 {
         let buf_len = digest_buf.len();
         match self {
-            CryptoHasher::Zig(zig) => {
-                let res = zig.with_mut(move |z| z.final_with_len(digest_buf, buf_len));
+            CryptoHasher::Bun(inner) => {
+                let res = inner.with_mut(move |h| h.final_with_len(digest_buf, buf_len));
                 u32::try_from(res.len()).expect("int cast")
             }
             CryptoHasher::Evp(evp) => {
@@ -189,7 +189,7 @@ impl CryptoHasher {
     #[bun_uws::uws_callback(export = "Bun__CryptoHasherExtern__getDigestSize", no_catch)]
     pub fn extern_digest_size(&self) -> u32 {
         match self {
-            CryptoHasher::Zig(inner) => inner.get().digest_length() as u32,
+            CryptoHasher::Bun(inner) => inner.get().digest_length() as u32,
             CryptoHasher::Evp(inner) => inner.get().size() as u32,
             _ => 0,
         }
@@ -198,9 +198,9 @@ impl CryptoHasher {
     #[bun_uws::uws_callback(export = "Bun__CryptoHasherExtern__isXof", no_catch)]
     pub fn extern_is_xof(&self) -> bool {
         match self {
-            CryptoHasher::Zig(inner) => matches!(
+            CryptoHasher::Bun(inner) => matches!(
                 inner.get(),
-                CryptoHasherZig::Shake128(_) | CryptoHasherZig::Shake256(_)
+                CryptoHasherBun::Shake128(_) | CryptoHasherBun::Shake256(_)
             ),
             _ => false,
         }
@@ -314,7 +314,7 @@ impl CryptoHasher {
                 Some(hmac) => hmac.size() as f64,
                 None => return Err(Self::throw_hmac_consumed(global)),
             },
-            CryptoHasher::Zig(inner) => inner.get().digest_length() as f64,
+            CryptoHasher::Bun(inner) => inner.get().digest_length() as f64,
         }))
     }
 
@@ -322,7 +322,7 @@ impl CryptoHasher {
     pub(crate) fn get_algorithm(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         let tag: &'static [u8] = match this {
             CryptoHasher::Evp(inner) => inner.get().algorithm.tag_cstr().to_bytes(),
-            CryptoHasher::Zig(inner) => inner.get().algorithm().tag_cstr().to_bytes(),
+            CryptoHasher::Bun(inner) => inner.get().algorithm().tag_cstr().to_bytes(),
             CryptoHasher::Hmac(inner) => match inner.get() {
                 Some(hmac) => hmac.algorithm.tag_cstr().to_bytes(),
                 None => return Err(Self::throw_hmac_consumed(global)),
@@ -426,7 +426,7 @@ impl CryptoHasher {
     ) -> JsResult<JSValue> {
         let mut evp = match EVP::by_name(&algorithm, global) {
             Some(e) => e,
-            None => match CryptoHasherZig::hash_by_name(global, &algorithm, input, output)? {
+            None => match CryptoHasherBun::hash_by_name(global, &algorithm, input, output)? {
                 Some(v) => return Ok(v),
                 None => {
                     return Err(global.throw_invalid_arguments(format_args!(
@@ -544,7 +544,7 @@ impl CryptoHasher {
             break 'brk CryptoHasher::Evp(Box::new(JsCell::new(
                 match EVP::by_name(&algorithm, global) {
                     Some(e) => e,
-                    None => match CryptoHasherZig::constructor(&algorithm) {
+                    None => match CryptoHasherBun::constructor(&algorithm) {
                         Some(h) => return Ok(h),
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -640,8 +640,8 @@ impl CryptoHasher {
                     return Err(global.throw_value(instance));
                 }
             }
-            CryptoHasher::Zig(inner) => {
-                inner.with_mut(|z| z.update(buffer.slice()));
+            CryptoHasher::Bun(inner) => {
+                inner.with_mut(|h| h.update(buffer.slice()));
                 return Ok(this_value);
             }
         }
@@ -677,7 +677,7 @@ impl CryptoHasher {
                     }
                 })));
             }
-            CryptoHasher::Zig(inner) => CryptoHasher::Zig(JsCell::new(inner.get().clone())),
+            CryptoHasher::Bun(inner) => CryptoHasher::Bun(JsCell::new(inner.get().clone())),
         };
         Ok(copied.to_js(global))
     }
@@ -790,7 +790,7 @@ impl CryptoHasher {
                 let engine = boring_engine(global);
                 Ok(inner.with_mut(move |e| e.r#final(engine, output_digest_slice)))
             }
-            CryptoHasher::Zig(inner) => Ok(inner.with_mut(move |z| z.final_(output_digest_slice))),
+            CryptoHasher::Bun(inner) => Ok(inner.with_mut(move |h| h.final_(output_digest_slice))),
         }
     }
 
@@ -801,13 +801,13 @@ impl CryptoHasher {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// CryptoHasherZig
+// CryptoHasherBun
 // ───────────────────────────────────────────────────────────────────────────
 
 /// The variant is the algorithm. Each state is boxed (Keccak states are a few
 /// hundred bytes), like the `Evp` arm of `CryptoHasher`.
 #[derive(Clone)]
-pub enum CryptoHasherZig {
+pub enum CryptoHasherBun {
     Sha3_224(Box<Sha3_224>),
     Sha3_256(Box<Sha3_256>),
     Sha3_384(Box<Sha3_384>),
@@ -817,9 +817,9 @@ pub enum CryptoHasherZig {
     Blake2s256(Box<Blake2s256>),
 }
 
-/// Trait for the non-BoringSSL hash algorithms used by `CryptoHasherZig`.
-/// Implemented for each algo in `zig_crypto_algos` below.
-trait ZigHashAlgo: Default + Clone {
+/// Trait for the non-BoringSSL hash algorithms used by `CryptoHasherBun`.
+/// Implemented for each algo in `bun_crypto_algos` below.
+trait BunHashAlgo: Default + Clone {
     const ALGORITHM: evp::Algorithm;
     /// Shake128→16, Shake256→32, else the algorithm's digest length.
     const DIGEST_LENGTH: u8;
@@ -833,8 +833,8 @@ trait ZigHashAlgo: Default + Clone {
 /// Hash-state types for the algorithms that BoringSSL does not expose as a
 /// streaming context. Backed by RustCrypto's `sha3`/`blake2` crates
 /// (Keccak-p[1600,24] permutation and BLAKE2s).
-mod zig_crypto_algos {
-    use super::{ZigHashAlgo, evp};
+mod bun_crypto_algos {
+    use super::{BunHashAlgo, evp};
     use sha3::digest::{ExtendableOutputReset, FixedOutputReset, Output, Update};
 
     pub(super) type Sha3_224 = sha3::Sha3_224;
@@ -849,7 +849,7 @@ mod zig_crypto_algos {
     /// bytes via `FixedOutputReset`.
     macro_rules! impl_fixed {
         ($ty:ty, $variant:ident, $len:expr) => {
-            impl ZigHashAlgo for $ty {
+            impl BunHashAlgo for $ty {
                 const ALGORITHM: evp::Algorithm = evp::Algorithm::$variant;
                 const DIGEST_LENGTH: u8 = $len;
                 fn update(&mut self, bytes: &[u8]) {
@@ -870,7 +870,7 @@ mod zig_crypto_algos {
     /// `final_` squeezes exactly `out.len` bytes.
     macro_rules! impl_xof {
         ($ty:ty, $variant:ident, $len:expr) => {
-            impl ZigHashAlgo for $ty {
+            impl BunHashAlgo for $ty {
                 const ALGORITHM: evp::Algorithm = evp::Algorithm::$variant;
                 const DIGEST_LENGTH: u8 = $len;
                 fn update(&mut self, bytes: &[u8]) {
@@ -894,8 +894,8 @@ mod zig_crypto_algos {
     impl_fixed!(Blake2s256, Blake2s256, 32);
 }
 
-/// Expands the macro once per supported `ZigHashAlgo` type.
-macro_rules! for_each_zig_algo {
+/// Expands the macro once per supported `BunHashAlgo` type.
+macro_rules! for_each_bun_algo {
     ($mac:ident $(, $($args:tt)*)?) => {
         $mac!(Sha3_224   $(, $($args)*)?);
         $mac!(Sha3_256   $(, $($args)*)?);
@@ -907,36 +907,36 @@ macro_rules! for_each_zig_algo {
     };
 }
 
-/// Exhaustive `match` over a `CryptoHasherZig`; every arm binds the boxed
-/// state to `$state` and names its `ZigHashAlgo` type `$algo`.
-macro_rules! match_zig_algo {
+/// Exhaustive `match` over a `CryptoHasherBun`; every arm binds the boxed
+/// state to `$state` and names its `BunHashAlgo` type `$algo`.
+macro_rules! match_bun_algo {
     ($hasher:expr, |$state:tt: $algo:ident| $body:expr) => {
         match $hasher {
-            CryptoHasherZig::Sha3_224($state) => {
+            CryptoHasherBun::Sha3_224($state) => {
                 type $algo = Sha3_224;
                 $body
             }
-            CryptoHasherZig::Sha3_256($state) => {
+            CryptoHasherBun::Sha3_256($state) => {
                 type $algo = Sha3_256;
                 $body
             }
-            CryptoHasherZig::Sha3_384($state) => {
+            CryptoHasherBun::Sha3_384($state) => {
                 type $algo = Sha3_384;
                 $body
             }
-            CryptoHasherZig::Sha3_512($state) => {
+            CryptoHasherBun::Sha3_512($state) => {
                 type $algo = Sha3_512;
                 $body
             }
-            CryptoHasherZig::Shake128($state) => {
+            CryptoHasherBun::Shake128($state) => {
                 type $algo = Shake128;
                 $body
             }
-            CryptoHasherZig::Shake256($state) => {
+            CryptoHasherBun::Shake256($state) => {
                 type $algo = Shake256;
                 $body
             }
-            CryptoHasherZig::Blake2s256($state) => {
+            CryptoHasherBun::Blake2s256($state) => {
                 type $algo = Blake2s256;
                 $body
             }
@@ -944,7 +944,7 @@ macro_rules! match_zig_algo {
     };
 }
 
-impl CryptoHasherZig {
+impl CryptoHasherBun {
     pub(crate) fn hash_by_name(
         global: &JSGlobalObject,
         algorithm: &ZigString,
@@ -957,16 +957,16 @@ impl CryptoHasherZig {
         };
         macro_rules! arm {
             ($ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr) => {
-                if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
+                if $alg == <$ty as BunHashAlgo>::ALGORITHM {
                     return Ok(Some(Self::hash_by_name_inner::<$ty>($g, $in, $out)?));
                 }
             };
         }
-        for_each_zig_algo!(arm, global, algo, input, output);
+        for_each_bun_algo!(arm, global, algo, input, output);
         Ok(None)
     }
 
-    fn hash_by_name_inner<A: ZigHashAlgo>(
+    fn hash_by_name_inner<A: BunHashAlgo>(
         global: &JSGlobalObject,
         input: &BlobOrStringOrBuffer,
         output: Option<StringOrBuffer>,
@@ -997,7 +997,7 @@ impl CryptoHasherZig {
         Self::hash_by_name_inner_to_bytes::<A>(global, input, None)
     }
 
-    fn hash_by_name_inner_to_string<A: ZigHashAlgo>(
+    fn hash_by_name_inner_to_string<A: BunHashAlgo>(
         global: &JSGlobalObject,
         input: &BlobOrStringOrBuffer,
         encoding: Encoding,
@@ -1023,7 +1023,7 @@ impl CryptoHasherZig {
         encoding.encode_with_max_size(global, EVP_MAX_MD_SIZE_USIZE, &out[..len])
     }
 
-    fn hash_by_name_inner_to_bytes<A: ZigHashAlgo>(
+    fn hash_by_name_inner_to_bytes<A: BunHashAlgo>(
         global: &JSGlobalObject,
         input: &BlobOrStringOrBuffer,
         output: Option<ArrayBuffer>,
@@ -1070,32 +1070,32 @@ impl CryptoHasherZig {
     fn constructor(algorithm: &ZigString) -> Option<Box<CryptoHasher>> {
         let name = algorithm.to_slice();
         Self::init(name.slice())
-            .map(|inner| CryptoHasher::new(CryptoHasher::Zig(JsCell::new(inner))))
+            .map(|inner| CryptoHasher::new(CryptoHasher::Bun(JsCell::new(inner))))
     }
 
-    pub(crate) fn init(name: &[u8]) -> Option<CryptoHasherZig> {
+    pub(crate) fn init(name: &[u8]) -> Option<CryptoHasherBun> {
         let algorithm = evp::lookup_ignore_case(name)?;
         macro_rules! arm {
             ($algo:ident, $alg:expr) => {
-                if $alg == <$algo as ZigHashAlgo>::ALGORITHM {
-                    return Some(Self::$algo(Box::new(<$algo as ZigHashAlgo>::init())));
+                if $alg == <$algo as BunHashAlgo>::ALGORITHM {
+                    return Some(Self::$algo(Box::new(<$algo as BunHashAlgo>::init())));
                 }
             };
         }
-        for_each_zig_algo!(arm, algorithm);
+        for_each_bun_algo!(arm, algorithm);
         None
     }
 
     fn algorithm(&self) -> evp::Algorithm {
-        match_zig_algo!(self, |_: A| A::ALGORITHM)
+        match_bun_algo!(self, |_: A| A::ALGORITHM)
     }
 
     fn digest_length(&self) -> u8 {
-        match_zig_algo!(self, |_: A| A::DIGEST_LENGTH)
+        match_bun_algo!(self, |_: A| A::DIGEST_LENGTH)
     }
 
     fn update(&mut self, bytes: &[u8]) {
-        match_zig_algo!(self, |state: A| A::update(state, bytes))
+        match_bun_algo!(self, |state: A| A::update(state, bytes))
     }
 
     fn final_with_len<'a>(
@@ -1103,7 +1103,7 @@ impl CryptoHasherZig {
         output_digest_slice: &'a mut [u8],
         res_len: usize,
     ) -> &'a mut [u8] {
-        match_zig_algo!(self, |state: A| {
+        match_bun_algo!(self, |state: A| {
             A::final_(state, output_digest_slice);
             **state = A::init();
         });


### PR DESCRIPTION
## What

`CryptoHasherZig`, now renamed `CryptoHasherBun` (the `Bun.CryptoHasher` / `node:crypto` backend for sha3-224/256/384/512, shake128/256 and blake2s256, which BoringSSL has no streaming context for) was a hand-rolled tagged union: an `evp::Algorithm` tag, a `Box<dyn Any>` holding one of seven RustCrypto states, and a `digest_length` byte copied out of the state type's constant. `update`, `copy` and `final_with_len` each expanded `for_each_zig_algo!` into a seven-way `if self.algorithm == <T>::ALGORITHM { self.state.downcast_mut::<T>().expect("unreachable") ... }` chain terminated by `unreachable!()`.

```rust
// before
pub struct CryptoHasherZig {
    pub(crate) algorithm: evp::Algorithm,
    pub(crate) state: Box<dyn Any>,
    pub(crate) digest_length: u8,
}

// after
#[derive(Clone)]
pub enum CryptoHasherBun {
    Sha3_224(Box<Sha3_224>),
    Sha3_256(Box<Sha3_256>),
    Sha3_384(Box<Sha3_384>),
    Sha3_512(Box<Sha3_512>),
    Shake128(Box<Shake128>),
    Shake256(Box<Shake256>),
    Blake2s256(Box<Blake2s256>),
}
```

A file-local `match_bun_algo!` expands to one exhaustive `match` that binds the state and names its `BunHashAlgo` type in each arm; `update` and `final_with_len` are one such match each, `copy` is replaced by `derive(Clone)`, and the two removed fields become `algorithm()` and `digest_length()`, which return the per-variant `ALGORITHM` / `DIGEST_LENGTH` constants the fields used to mirror. `init` builds the matching variant from the same `for_each_bun_algo!` lookup as before; `hash_by_name` and the `BunHashAlgo` impls are unchanged (the trait only loses the `'static` bound that existed for `dyn Any`). In `impl CryptoHasher`, 6 sites change: the two `copy()` calls become `clone()`, three field reads become the accessor calls, and `extern_is_xof` matches the `Shake128` / `Shake256` variants directly. Deletes the three comparison chains, three `expect("unreachable")`, three `unreachable!()` and the `core::any::Any` import. No `unsafe` is involved on either side.

The second commit renames the type and its helpers from "Zig" to "Bun" as requested in review: `CryptoHasherZig` is now `CryptoHasherBun`, the `CryptoHasher::Zig` variant is `CryptoHasher::Bun`, and `ZigHashAlgo` / `zig_crypto_algos` / `for_each_zig_algo!` / `match_zig_algo!` follow suit. Everything is file-local; the `Bun__CryptoHasherExtern__*` exports that C++ links against are unchanged. (`ZigString` is an unrelated type and is left alone.)

## Why

The tag, the dynamic type behind the `Box<dyn Any>` and the digest length were three copies of one fact that the old code re-checked at runtime on every call; the variant is now that fact, so a mismatch is unrepresentable and there is nothing left to check. It is zero-cost: each variant boxes exactly the state the `Box<dyn Any>` used to point at, so heap allocations are unchanged; the inline value shrinks from 24 to 16 bytes (the fat pointer's vtable half and the mirrored byte go away), which takes the `#[repr(C)]` `CryptoHasher` payload from 32 to 24 bytes; and each `update` / `digest` dispatch is a single jump on the discriminant instead of a comparison chain, a virtual `type_id` call, a `TypeId` compare and two panic paths, while `algorithm()` / `digest_length()` are constant-per-variant lookups. C++ only ever holds `CryptoHasher` as an opaque pointer, so no bindings change.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/js/bun/util/bun-cryptohasher.test.ts (400 pass), test/js/node/crypto/crypto.test.ts (369 pass), test/js/node/crypto/crypto-oneshot.test.ts (35 pass): 804 pass, 0 fail on the debug build. test/js/node/test/parallel/test-crypto-hash.js was not executed because its filename does not match the test-file pattern, so it was not counted.

