### PR TITLE
strings: return Option from copy_latin1_into_utf8_stop_on_non_ascii

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1766,12 +1766,6 @@ pub(crate) mod strings_impl {
         }
     }
 
-    /// Port of `copyLatin1IntoUTF8` — encode Latin-1 into a fixed-size UTF-8 buffer.
-    #[inline]
-    pub fn copy_latin1_into_utf8(buf: &mut [u8], latin1: &[u8]) -> EncodeIntoResult {
-        copy_latin1_into_utf8_stop_on_non_ascii::<false>(buf, latin1)
-    }
-
     #[inline]
     fn copy_ascii_prefix(dst: &mut [u8], src: &[u8]) -> usize {
         debug_assert_eq!(dst.len(), src.len());
@@ -1806,11 +1800,9 @@ pub(crate) mod strings_impl {
         copied
     }
 
-    /// Port of `copyLatin1IntoUTF8StopOnNonASCII`.
-    pub fn copy_latin1_into_utf8_stop_on_non_ascii<const STOP: bool>(
-        buf_: &mut [u8],
-        latin1_: &[u8],
-    ) -> EncodeIntoResult {
+    /// Port of `copyLatin1IntoUTF8`: encode Latin-1 into a fixed-size UTF-8 buffer.
+    #[inline]
+    pub fn copy_latin1_into_utf8(buf_: &mut [u8], latin1_: &[u8]) -> EncodeIntoResult {
         let mut written = 0usize;
         let mut read = 0usize;
 
@@ -1825,12 +1817,6 @@ pub(crate) mod strings_impl {
             }
 
             debug_assert!(latin1_[read] >= 0x80);
-            if STOP {
-                return EncodeIntoResult {
-                    written: u32::MAX,
-                    read: u32::MAX,
-                };
-            }
             if buf_.len() - written < 2 {
                 break;
             }
@@ -1844,6 +1830,18 @@ pub(crate) mod strings_impl {
             written: written as u32,
             read: read as u32,
         }
+    }
+
+    /// Port of `copyLatin1IntoUTF8StopOnNonASCII`: copies up to the shorter of the
+    /// two lengths and returns the byte count, or `None` at the first non-ASCII
+    /// byte (the ASCII prefix before it has already been written to `buf`).
+    #[inline]
+    pub fn copy_latin1_into_utf8_stop_on_non_ascii(buf: &mut [u8], latin1: &[u8]) -> Option<usize> {
+        let n = buf.len().min(latin1.len());
+        if copy_ascii_prefix(&mut buf[..n], &latin1[..n]) < n {
+            return None;
+        }
+        Some(n)
     }
 
     /// Null-terminated variant of `to_utf8_from_latin1`. Returns `ZBox` so

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -173,15 +173,12 @@ impl<'a> RopeStringEncoder<'a> {
         let (it, this) = Self::resolve(it);
         // SAFETY: ptr[0..len] is provided by JSC rope iteration
         let src = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-        let result = strings::copy_latin1_into_utf8_stop_on_non_ascii::<true>(
-            &mut this.buf[this.tail..],
-            src,
-        );
-        if result.read == u32::MAX && result.written == u32::MAX {
-            it.stop = 1;
-            this.any_non_ascii = true;
-        } else {
-            this.tail += result.written as usize;
+        match strings::copy_latin1_into_utf8_stop_on_non_ascii(&mut this.buf[this.tail..], src) {
+            Some(written) => this.tail += written,
+            None => {
+                it.stop = 1;
+                this.any_non_ascii = true;
+            }
         }
     }
 
@@ -195,11 +192,9 @@ impl<'a> RopeStringEncoder<'a> {
         let (it, this) = Self::resolve(it);
         // SAFETY: ptr[0..len] is provided by JSC rope iteration
         let src = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
-        let result = strings::copy_latin1_into_utf8_stop_on_non_ascii::<true>(
-            &mut this.buf[offset as usize..],
-            src,
-        );
-        if result.read == u32::MAX && result.written == u32::MAX {
+        if strings::copy_latin1_into_utf8_stop_on_non_ascii(&mut this.buf[offset as usize..], src)
+            .is_none()
+        {
             it.stop = 1;
             this.any_non_ascii = true;
         }


### PR DESCRIPTION
### Problem
- No user-facing bug; hardening only. The Latin-1 to UTF-8 copy that stops at the first non-ASCII byte reported "stopped" in band, as an `EncodeIntoResult` with both counts set to `u32::MAX`.
- Its two callers had to recognise that magic value by comparing both fields, and any other consumer of the shared struct could be handed it as if it were a real count.
- The stopping and non-stopping copies were one function behind a `<const STOP: bool>` flag.

### Fix
- The plain copy becomes its own function (the old loop, minus the stop branch). The stopping copy becomes a separate function returning `Option<usize>`: bytes written, or `None` at the first non-ASCII byte.
- The two rope callbacks match on the `Option`. The plain copy's signature is unchanged, so its other callers are untouched.
- Correct because `EncodeIntoResult` now only ever holds real counts. Cost is unchanged: the generic already compiled to these two bodies, and both keep `#[inline]`.
- Verification: `cargo check` and `cargo clippy` clean, debug build succeeds, the existing TextEncoder and TextEncoderStream tests pass (66). No new test; the change is a refactor.

### Background
- Latin-1 strings: JSC stores a string whose chars all fit in 8 bits as one byte per char. Bytes below 0x80 are already UTF-8; 0x80 and above need two bytes each, so a straight copy is valid only up to the first non-ASCII byte.
- Rope strings: JSC keeps a concatenated string as a tree of pieces. TextEncoder walks them with a per-piece callback that may set a stop flag; on `None` the callback records that non-ASCII was seen and stops the walk.
- `EncodeIntoResult`: the read/written byte-count pair the encoding helpers return. The sentinel was smuggled through it.
- `<const STOP: bool>`: rustc emits one body per value and folds branches on it, so two hand-written functions produce the same code.

<details>
<summary>Original description</summary>

## What

`bun_core::strings::copy_latin1_into_utf8_stop_on_non_ascii` (`src/bun_core/lib.rs`) was a `<const STOP: bool>` generic returning `EncodeIntoResult`. The `STOP = true` instantiation signalled "hit a non-ASCII byte" in band, by returning `EncodeIntoResult { read: u32::MAX, written: u32::MAX }`, and its only two callers, the `append8` / `write8` rope callbacks in `src/runtime/webcore/TextEncoder.rs`, recognised that value by comparing both fields. The `STOP = false` instantiation had exactly one caller, the `copy_latin1_into_utf8` wrapper.

```rust
// before
pub fn copy_latin1_into_utf8(buf: &mut [u8], latin1: &[u8]) -> EncodeIntoResult {
    copy_latin1_into_utf8_stop_on_non_ascii::<false>(buf, latin1)
}
pub fn copy_latin1_into_utf8_stop_on_non_ascii<const STOP: bool>(..) -> EncodeIntoResult
    // STOP: returns EncodeIntoResult { written: u32::MAX, read: u32::MAX }

let result = strings::copy_latin1_into_utf8_stop_on_non_ascii::<true>(&mut this.buf[this.tail..], src);
if result.read == u32::MAX && result.written == u32::MAX { it.stop = 1; this.any_non_ascii = true; }
else { this.tail += result.written as usize; }

// after
pub fn copy_latin1_into_utf8(buf_: &mut [u8], latin1_: &[u8]) -> EncodeIntoResult   // the former loop body
pub fn copy_latin1_into_utf8_stop_on_non_ascii(buf: &mut [u8], latin1: &[u8]) -> Option<usize>

match strings::copy_latin1_into_utf8_stop_on_non_ascii(&mut this.buf[this.tail..], src) {
    Some(written) => this.tail += written,
    None => { it.stop = 1; this.any_non_ascii = true; }
}
```

The Latin-1 loop becomes `copy_latin1_into_utf8` itself (the wrapper and the `if STOP` block are deleted), and the stop-on-non-ASCII variant is a separate non-generic function: one `copy_ascii_prefix` call over `min(buf.len(), latin1.len())` bytes, returning `Some(count)` or `None` at the first non-ASCII byte. The 2 call sites in `TextEncoder.rs` match on the `Option` (`write8` only needs `is_none()`); the 8 callers of `copy_latin1_into_utf8` (`TextEncoder.rs`, `encoding.rs`, `TextEncoderStreamEncoder.rs`, `websocket_client.rs`, `fmt.rs`) and the two re-exports are unchanged since that signature did not change. Two files, +24/-31 lines.

## Why

`EncodeIntoResult` is now only ever a read/written count: the "stopped" outcome lives in the `Option` discriminant, where the caller cannot forget to check it or confuse it with a real count, instead of in a magic value that any consumer of the shared struct could have been handed. It is zero-cost: the generic was already monomorphised into exactly these two bodies, the `STOP = true` body reduced to a single `copy_ascii_prefix` call (every path through its loop body either broke out or returned), the removed branch was constant-folded in the `STOP = false` body, and both functions carry the `#[inline]` the wrapper had, so the callers get the same inlined code with one discriminant test in place of two `u32` compares.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/web/encoding/text-encoder.test.js test/js/web/encoding/text-encoder-stream.test.ts`: 66 pass, 0 fail (66 tests across 2 files).

</details>
