### PR TITLE
Discard infallible write results with `let _ =` instead of `.ok();`

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1040,14 +1040,13 @@ impl IntermediateOutput {
                     if ENABLE_SOURCE_MAP_SHIFTS && FeatureFlags::SOURCE_MAP_DEBUG_ID {
                         // This comment must go before the //# sourceMappingURL comment
                         let mut debug_id_fmt = Vec::new();
-                        write!(
+                        let _ = write!(
                             &mut debug_id_fmt,
                             "\n//# debugId={}\n",
                             source_map::DebugIDFormatter {
                                 id: chunk.isolated_hash
                             }
-                        )
-                        .ok();
+                        );
 
                         let _ = arena; // Note: StringJoiner::done* allocates from global mimalloc; arena token is plumbing-only.
                         break 'brk joiner.done_with_end(&debug_id_fmt)?;

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -340,14 +340,13 @@ impl Stringifier {
                     let mut key: Vec<u8> = Vec::new();
                     {
                         use std::io::Write;
-                        write!(
+                        let _ = write!(
                             &mut key,
                             "{}{}{}",
                             bstr::BStr::new(node.relative_path),
                             if node.depth == 0 { "" } else { "/" },
                             bstr::BStr::new(dep.name.slice(buf)),
-                        )
-                        .ok();
+                        );
                     }
                     pkg_map.put(&key, ());
                 }
@@ -475,22 +474,21 @@ impl Stringifier {
 
                     if lockfile.patched_dependencies.count() > 0 {
                         use std::io::Write;
-                        write!(&mut temp_buf, "{}@", bstr::BStr::new(pkg_name.slice(buf))).ok();
+                        let _ = write!(&mut temp_buf, "{}@", bstr::BStr::new(pkg_name.slice(buf)));
                         match res.tag {
                             ResolutionTag::Workspace => {
                                 if let Some(workspace_version) =
                                     lockfile.workspace_versions.get(&pkg_name_hash)
                                 {
-                                    write!(&mut temp_buf, "{}", workspace_version.fmt(buf)).ok();
+                                    let _ = write!(&mut temp_buf, "{}", workspace_version.fmt(buf));
                                 }
                             }
                             _ => {
-                                write!(
+                                let _ = write!(
                                     &mut temp_buf,
                                     "{}",
                                     res.fmt(buf, bun_core::fmt::PathSep::Posix)
-                                )
-                                .ok();
+                                );
                             }
                         }
 
@@ -981,7 +979,7 @@ impl Stringifier {
                             };
                             {
                                 use std::io::Write;
-                                write!(&mut temp_buf, "{}", repo.fmt(prefix, buf)).ok();
+                                let _ = write!(&mut temp_buf, "{}", repo.fmt(prefix, buf));
                             }
                             write!(
                                 writer,

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -768,60 +768,53 @@ impl AsyncModule {
         let mut msg: Vec<u8> = Vec::new();
         let e = result.err;
         if e == "PackageManifestHTTP400" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 400 while resolving package '{}' at '{}'",
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         } else if e == "PackageManifestHTTP401" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 401 while resolving package '{}' at '{}'",
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         } else if e == "PackageManifestHTTP402" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 402 while resolving package '{}' at '{}'",
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         } else if e == "PackageManifestHTTP403" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 403 while resolving package '{}' at '{}'",
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         } else if e == "PackageManifestHTTP404" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "Package '{}' was not found",
                 bstr::BStr::new(result.name)
-            )
-            .ok();
+            );
         } else if e == "PackageManifestHTTP4xx" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 4xx while resolving package '{}' at '{}'",
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         } else if e == "PackageManifestHTTP5xx" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 5xx while resolving package '{}' at '{}'",
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         } else if matches!(e, "DistTagNotFound" | "NoMatchingVersion") {
             // `Version::try_npm()` performs the tag guard and yields the
             // `NpmInfo` (whose `.version` is the semver query group).
@@ -835,23 +828,21 @@ impl AsyncModule {
                     b"No match found"
                 };
 
-            write!(
+            let _ = write!(
                 &mut msg,
                 "{} '{}' for package '{}' (but package exists)",
                 bstr::BStr::new(prefix),
                 bstr::BStr::new(vm.package_manager().lockfile.str(&result.version.literal)),
                 bstr::BStr::new(result.name)
-            )
-            .ok();
+            );
         } else {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "{} resolving package '{}' at '{}'",
                 e,
                 bstr::BStr::new(result.name),
                 bstr::BStr::new(result.url)
-            )
-            .ok();
+            );
         }
         // msg dropped at scope exit (defer bun.default_allocator.free(msg)).
 
@@ -986,71 +977,63 @@ impl AsyncModule {
         let mut msg: Vec<u8> = Vec::new();
         let e = result.err;
         if e == "TarballHTTP400" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 400 downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballHTTP401" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 401 downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballHTTP402" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 402 downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballHTTP403" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 403 downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballHTTP404" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 404 downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballHTTP4xx" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 4xx downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballHTTP5xx" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "HTTP 5xx downloading package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else if e == "TarballFailedToExtract" {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "Failed to extract tarball for package '{}@{}'",
                 bstr::BStr::new(result.name),
                 resolution_fmt
-            )
-            .ok();
+            );
         } else {
-            write!(
+            let _ = write!(
                 &mut msg,
                 "{} downloading package '{}@{}'",
                 e,
@@ -1063,8 +1046,7 @@ impl AsyncModule {
                         .as_slice(),
                     bun_core::fmt::PathSep::Any,
                 )
-            )
-            .ok();
+            );
         }
         // msg dropped at scope exit.
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -837,29 +837,27 @@ impl<'a> TablePrinter<'a> {
         row: &CollectedRow,
         cell_text: &[u8],
     ) {
-        writer.write_all("│".as_bytes()).ok();
+        let _ = writer.write_all("│".as_bytes());
         {
             let needed = columns[0].width.saturating_sub(row.key.width());
 
             // Right-align the number column
-            writer
-                .splat_byte_all(b' ', (needed + PADDING) as usize)
-                .ok();
+            let _ = writer.splat_byte_all(b' ', (needed + PADDING) as usize);
             match &row.key {
                 RowKey::Str { text, .. } => {
-                    writer.write_all(text.slice()).ok();
+                    let _ = writer.write_all(text.slice());
                 }
                 RowKey::Num(value) => {
-                    write!(writer, "{value}").ok();
+                    let _ = write!(writer, "{value}");
                 }
             }
-            writer.splat_byte_all(b' ', PADDING as usize).ok();
+            let _ = writer.splat_byte_all(b' ', PADDING as usize);
         }
 
         for col_idx in 1..columns.len() {
             let col = &columns[col_idx];
 
-            writer.write_all("│".as_bytes()).ok();
+            let _ = writer.write_all("│".as_bytes());
 
             let cell = if col_idx == self.values_col_idx {
                 row.values_cell
@@ -869,21 +867,17 @@ impl<'a> TablePrinter<'a> {
 
             match cell {
                 None => {
-                    writer
-                        .splat_byte_all(b' ', (col.width + PADDING * 2) as usize)
-                        .ok();
+                    let _ = writer.splat_byte_all(b' ', (col.width + PADDING * 2) as usize);
                 }
                 Some(cell) => {
                     let needed = col.width.saturating_sub(cell.width);
-                    writer.splat_byte_all(b' ', PADDING as usize).ok();
-                    writer.write_all(cell.text(cell_text)).ok();
-                    writer
-                        .splat_byte_all(b' ', (needed + PADDING) as usize)
-                        .ok();
+                    let _ = writer.splat_byte_all(b' ', PADDING as usize);
+                    let _ = writer.write_all(cell.text(cell_text));
+                    let _ = writer.splat_byte_all(b' ', (needed + PADDING) as usize);
                 }
             }
         }
-        writer.write_all("│\n".as_bytes()).ok();
+        let _ = writer.write_all("│\n".as_bytes());
     }
 
     pub fn print_table<const ENABLE_ANSI_COLORS: bool>(
@@ -1027,51 +1021,49 @@ impl<'a> TablePrinter<'a> {
                 );
             }
 
-            writer.write_all("┌".as_bytes()).ok();
+            let _ = writer.write_all("┌".as_bytes());
             for (i, col) in columns.iter().enumerate() {
                 if i > 0 {
-                    writer.write_all("┬".as_bytes()).ok();
+                    let _ = writer.write_all("┬".as_bytes());
                 }
-                Self::write_string_n_times(
+                let _ = Self::write_string_n_times(
                     writer,
                     "─".as_bytes(),
                     (col.width + PADDING * 2) as usize,
-                )
-                .ok();
+                );
             }
 
-            writer.write_all("┐\n│".as_bytes()).ok();
+            let _ = writer.write_all("┐\n│".as_bytes());
 
             for (i, col) in columns.iter().enumerate() {
                 if i > 0 {
-                    writer.write_all("│".as_bytes()).ok();
+                    let _ = writer.write_all("│".as_bytes());
                 }
                 let len = col.name.visible_width_exclude_ansi_colors(false);
                 let needed = (col.width as usize).saturating_sub(len);
-                writer.splat_byte_all(b' ', 1).ok();
+                let _ = writer.splat_byte_all(b' ', 1);
                 if ENABLE_ANSI_COLORS {
-                    writer.write_all(pfmt!("<r><b>", true).as_bytes()).ok();
+                    let _ = writer.write_all(pfmt!("<r><b>", true).as_bytes());
                 }
-                write!(writer, "{}", col.name).ok();
+                let _ = write!(writer, "{}", col.name);
                 if ENABLE_ANSI_COLORS {
-                    writer.write_all(pfmt!("<r>", true).as_bytes()).ok();
+                    let _ = writer.write_all(pfmt!("<r>", true).as_bytes());
                 }
-                writer.splat_byte_all(b' ', needed + PADDING as usize).ok();
+                let _ = writer.splat_byte_all(b' ', needed + PADDING as usize);
             }
 
-            writer.write_all("│\n├".as_bytes()).ok();
+            let _ = writer.write_all("│\n├".as_bytes());
             for (i, col) in columns.iter().enumerate() {
                 if i > 0 {
-                    writer.write_all("┼".as_bytes()).ok();
+                    let _ = writer.write_all("┼".as_bytes());
                 }
-                Self::write_string_n_times(
+                let _ = Self::write_string_n_times(
                     writer,
                     "─".as_bytes(),
                     (col.width + PADDING * 2) as usize,
-                )
-                .ok();
+                );
             }
-            writer.write_all("┤\n".as_bytes()).ok();
+            let _ = writer.write_all("┤\n".as_bytes());
         }
 
         // render pass: replay each row's pre-formatted cell bytes
@@ -1081,23 +1073,21 @@ impl<'a> TablePrinter<'a> {
 
         // print the table bottom border
         {
-            writer.write_all("└".as_bytes()).ok();
-            Self::write_string_n_times(
+            let _ = writer.write_all("└".as_bytes());
+            let _ = Self::write_string_n_times(
                 writer,
                 "─".as_bytes(),
                 (columns[0].width + PADDING * 2) as usize,
-            )
-            .ok();
+            );
             for column in columns[1..].iter() {
-                writer.write_all("┴".as_bytes()).ok();
-                Self::write_string_n_times(
+                let _ = writer.write_all("┴".as_bytes());
+                let _ = Self::write_string_n_times(
                     writer,
                     "─".as_bytes(),
                     (column.width + PADDING * 2) as usize,
-                )
-                .ok();
+                );
             }
-            writer.write_all("┘\n".as_bytes()).ok();
+            let _ = writer.write_all("┘\n".as_bytes());
         }
 
         Ok(())

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -170,12 +170,11 @@ impl ResolveMessage {
         let mut out = Vec::new();
         if import_kind != ImportKind::RequireResolve && specifier.starts_with(b"node:") {
             // This matches Node.js exactly.
-            write!(
+            let _ = write!(
                 &mut out,
                 "No such built-in module: {}",
                 BStr::new(specifier)
-            )
-            .ok();
+            );
             return out;
         }
         // The same logical error can arrive nested (e.g. via
@@ -184,71 +183,65 @@ impl ResolveMessage {
         match err.name() {
             "ModuleNotFound" => {
                 if referrer == b"bun:main" {
-                    write!(&mut out, "Module not found '{}'", BStr::new(specifier)).ok();
+                    let _ = write!(&mut out, "Module not found '{}'", BStr::new(specifier));
                     return out;
                 }
                 if bun_resolver::is_package_path(specifier)
                     && !strings::contains_char(specifier, b'/')
                 {
-                    write!(
+                    let _ = write!(
                         &mut out,
                         "Cannot find package '{}' from '{}'",
                         BStr::new(specifier),
                         BStr::new(referrer),
-                    )
-                    .ok();
+                    );
                 } else {
-                    write!(
+                    let _ = write!(
                         &mut out,
                         "Cannot find module '{}' from '{}'",
                         BStr::new(specifier),
                         BStr::new(referrer),
-                    )
-                    .ok();
+                    );
                 }
                 return out;
             }
             "InvalidDataURL" => {
-                write!(
+                let _ = write!(
                     &mut out,
                     "Cannot resolve invalid data URL '{}' from '{}'",
                     BStr::new(specifier),
                     BStr::new(referrer),
-                )
-                .ok();
+                );
                 return out;
             }
             "InvalidURL" => {
-                write!(
+                let _ = write!(
                     &mut out,
                     "Cannot resolve invalid URL '{}' from '{}'",
                     BStr::new(specifier),
                     BStr::new(referrer),
-                )
-                .ok();
+                );
                 return out;
             }
             _ => {}
         }
         // else
         if bun_resolver::is_package_path(specifier) {
-            write!(
+            let _ = write!(
                 &mut out,
                 "{} while resolving package '{}' from '{}'",
                 err.name(),
                 BStr::new(specifier),
                 BStr::new(referrer),
-            )
-            .ok();
+            );
         } else {
-            write!(
+            let _ = write!(
                 &mut out,
                 "{} while resolving '{}' from '{}'",
                 err.name(),
                 BStr::new(specifier),
                 BStr::new(referrer),
-            )
-            .ok();
+            );
         }
         out
     }
@@ -397,29 +390,27 @@ impl ResolveMessage {
         let mut out = Vec::new();
         match kind {
             ImportKind::Require | ImportKind::RequireResolve => {
-                write!(&mut out, "Cannot find module '{}'", BStr::new(specifier)).ok();
+                let _ = write!(&mut out, "Cannot find module '{}'", BStr::new(specifier));
                 if let Some(referrer) = referrer {
-                    write!(&mut out, "\nRequire stack:\n- {}", BStr::new(referrer)).ok();
+                    let _ = write!(&mut out, "\nRequire stack:\n- {}", BStr::new(referrer));
                 }
             }
             ImportKind::Stmt | ImportKind::Dynamic => {
                 let referrer = referrer?;
                 if is_bare_esm_specifier(specifier) {
-                    write!(
+                    let _ = write!(
                         &mut out,
                         "Cannot find package '{}' imported from {}",
                         BStr::new(esm_package_name(specifier)),
                         BStr::new(referrer),
-                    )
-                    .ok();
+                    );
                 } else {
-                    write!(
+                    let _ = write!(
                         &mut out,
                         "Cannot find module '{}' imported from {}",
                         BStr::new(specifier),
                         BStr::new(referrer),
-                    )
-                    .ok();
+                    );
                 }
             }
             _ => return None,

--- a/src/react_compiler/lowering/build_hir/helpers.rs
+++ b/src/react_compiler/lowering/build_hir/helpers.rs
@@ -1144,7 +1144,7 @@ pub(super) fn lower_object_property_key(
         }
         Data::ENumber(n) if !computed => {
             let mut buf: HirVec<u8> = AstAlloc::vec_with_capacity(24);
-            core::fmt::write(&mut WriteBytes(&mut buf), format_args!("{}", n.value())).ok();
+            let _ = core::fmt::write(&mut WriteBytes(&mut buf), format_args!("{}", n.value()));
             Ok(Some(ObjectPropertyKey::Identifier {
                 name: StoreStr::new(buf.leak()),
             }))

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6367,13 +6367,12 @@ impl<'a> Resolver<'a> {
                         if !symlink.is_empty() {
                             if let Some(logs) = self.debug_logs.as_mut() {
                                 let mut buf = Vec::new();
-                                write!(
+                                let _ = write!(
                                     &mut buf,
                                     "Resolved symlink \"{}\" to \"{}\"",
                                     bstr::BStr::new(path),
                                     bstr::BStr::new(symlink)
-                                )
-                                .ok();
+                                );
                                 logs.add_note(buf);
                             }
                             info.abs_real_path = symlink;
@@ -6393,13 +6392,12 @@ impl<'a> Resolver<'a> {
 
                             if let Some(logs) = self.debug_logs.as_mut() {
                                 let mut buf = Vec::new();
-                                write!(
+                                let _ = write!(
                                     &mut buf,
                                     "Resolved symlink \"{}\" to \"{}\"",
                                     bstr::BStr::new(path),
                                     bstr::BStr::new(symlink)
-                                )
-                                .ok();
+                                );
                                 logs.add_note(buf);
                             }
                             {

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -516,7 +516,7 @@ impl Config {
                             // `Vec` would silently grow instead, so check the
                             // bound explicitly to preserve the overflow throw.
                             let start = buf.len();
-                            write!(&mut buf, "{}", str).ok();
+                            let _ = write!(&mut buf, "{}", str);
                             if buf.len() > total_name_buf_len as usize {
                                 return Err(global.throw_invalid_arguments(format_args!(
                                     "Error reading exports.eliminate. TODO: utf-16",

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1929,11 +1929,11 @@ impl PublishCommand {
             headers.count(b"accept-encoding", b"gzip,deflate");
 
             if !registry.token.is_empty() {
-                write!(print_buf, "Bearer {}", bstr::BStr::new(&registry.token)).ok();
+                let _ = write!(print_buf, "Bearer {}", bstr::BStr::new(&registry.token));
                 headers.count(b"authorization", &**print_buf);
                 print_buf.clear();
             } else if !registry.auth.is_empty() {
-                write!(print_buf, "Basic {}", bstr::BStr::new(&registry.auth)).ok();
+                let _ = write!(print_buf, "Basic {}", bstr::BStr::new(&registry.auth));
                 headers.count(b"authorization", &**print_buf);
                 print_buf.clear();
             }
@@ -1949,7 +1949,7 @@ impl PublishCommand {
             }
             headers.count(b"npm-command", b"publish");
 
-            write!(
+            let _ = write!(
                 print_buf,
                 "{} {} {} workspaces/{}{}{}",
                 Global::user_agent,
@@ -1958,8 +1958,7 @@ impl PublishCommand {
                 uses_workspaces,
                 if ci_name.is_some() { " ci/" } else { "" },
                 bstr::BStr::new(ci_name.unwrap_or(b"")),
-            )
-            .ok();
+            );
             // headers.count("user-agent", "npm/10.8.3 node/v24.3.0 darwin arm64 workspaces/false");
             headers.count(b"user-agent", &**print_buf);
             print_buf.clear();
@@ -1968,7 +1967,7 @@ impl PublishCommand {
             headers.count(b"Host", registry.url.url().host);
 
             if let Some(json_len) = maybe_json_len {
-                write!(print_buf, "{}", json_len).ok();
+                let _ = write!(print_buf, "{}", json_len);
                 headers.count(b"Content-Length", &**print_buf);
                 print_buf.clear();
             }
@@ -1981,11 +1980,11 @@ impl PublishCommand {
             headers.append(b"accept-encoding", b"gzip,deflate");
 
             if !registry.token.is_empty() {
-                write!(print_buf, "Bearer {}", bstr::BStr::new(&registry.token)).ok();
+                let _ = write!(print_buf, "Bearer {}", bstr::BStr::new(&registry.token));
                 headers.append(b"authorization", &**print_buf);
                 print_buf.clear();
             } else if !registry.auth.is_empty() {
-                write!(print_buf, "Basic {}", bstr::BStr::new(&registry.auth)).ok();
+                let _ = write!(print_buf, "Basic {}", bstr::BStr::new(&registry.auth));
                 headers.append(b"authorization", &**print_buf);
                 print_buf.clear();
             }
@@ -2001,7 +2000,7 @@ impl PublishCommand {
             }
             headers.append(b"npm-command", b"publish");
 
-            write!(
+            let _ = write!(
                 print_buf,
                 "{} {} {} workspaces/{}{}{}",
                 Global::user_agent,
@@ -2010,8 +2009,7 @@ impl PublishCommand {
                 uses_workspaces,
                 if ci_name.is_some() { " ci/" } else { "" },
                 bstr::BStr::new(ci_name.unwrap_or(b"")),
-            )
-            .ok();
+            );
             // headers.append("user-agent", "npm/10.8.3 node/v24.3.0 darwin arm64 workspaces/false");
             headers.append(b"user-agent", &**print_buf);
             print_buf.clear();
@@ -2020,7 +2018,7 @@ impl PublishCommand {
             headers.append(b"Host", registry.url.url().host);
 
             if let Some(json_len) = maybe_json_len {
-                write!(print_buf, "{}", json_len).ok();
+                let _ = write!(print_buf, "{}", json_len);
                 headers.append(b"Content-Length", &**print_buf);
                 print_buf.clear();
             }
@@ -2050,42 +2048,39 @@ impl PublishCommand {
                 + encoded_tarball_len,
         );
 
-        write!(
+        let _ = write!(
             &mut buf,
             "{{\"_id\":\"{}\",\"name\":\"{}\"",
             bstr::BStr::new(&ctx.package_name),
             bstr::BStr::new(&ctx.package_name),
-        )
-        .ok();
+        );
 
-        write!(
+        let _ = write!(
             &mut buf,
             ",\"dist-tags\":{{{}:\"{}\"}}",
             bun_fmt::format_json_string_utf8(tag, Default::default()),
             bstr::BStr::new(version_without_build_tag),
-        )
-        .ok();
+        );
 
         // "versions"
         {
-            write!(
+            let _ = write!(
                 &mut buf,
                 ",\"versions\":{{\"{}\":{}}}",
                 bstr::BStr::new(version_without_build_tag),
                 bstr::BStr::new(&ctx.normalized_pkg_info),
-            )
-            .ok();
+            );
         }
 
         if let Some(access) = ctx.manager.options.publish_config.access {
-            write!(&mut buf, ",\"access\":\"{}\"", access.as_str()).ok();
+            let _ = write!(&mut buf, ",\"access\":\"{}\"", access.as_str());
         } else {
             buf.extend_from_slice(b",\"access\":null");
         }
 
         // "_attachments"
         {
-            write!(
+            let _ = write!(
                 &mut buf,
                 ",\"_attachments\":{{\"{}\":{{\"content_type\":\"application/octet-stream\",\"data\":\"",
                 pack::fmt_tarball_filename(
@@ -2093,8 +2088,7 @@ impl PublishCommand {
                     &ctx.package_version,
                     pack::TarballNameStyle::Raw
                 ),
-            )
-            .ok();
+            );
 
             // SAFETY: `encode_raw` writes exactly `encoded_tarball_len`
             // (= `base64::encode_len(tarball_bytes.len(), false)`) bytes into the
@@ -2108,7 +2102,7 @@ impl PublishCommand {
             };
             debug_assert!(count == encoded_tarball_len);
 
-            write!(&mut buf, "\",\"length\":{}}}}}}}", ctx.tarball_bytes.len(),).ok();
+            let _ = write!(&mut buf, "\",\"length\":{}}}}}}}", ctx.tarball_bytes.len());
         }
 
         Ok(buf.into_boxed_slice())

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1183,16 +1183,15 @@ impl FFI {
                     } else {
                         compile_c.source.first().as_bytes()
                     };
-                    writeln!(
+                    let _ = writeln!(
                         &mut combined,
                         "{} errors while compiling {}",
                         compile_c.deferred_errors.len(),
                         BStr::new(file_for_err)
-                    )
-                    .ok();
+                    );
 
                     for deferred_error in compile_c.deferred_errors.iter() {
-                        writeln!(&mut combined, "{}", BStr::new(deferred_error)).ok();
+                        let _ = writeln!(&mut combined, "{}", BStr::new(deferred_error));
                     }
 
                     return Err(global_this.throw(format_args!("{}", BStr::new(&combined))));
@@ -1525,13 +1524,12 @@ impl FFI {
                             let dlerror_msg = get_dl_error();
 
                             let mut msg = Vec::new();
-                            write!(
+                            let _ = write!(
                                 &mut msg,
                                 "Failed to open library \"{}\": {}",
                                 BStr::new(name),
                                 BStr::new(&dlerror_msg)
-                            )
-                            .ok();
+                            );
                             let system_error = SystemError {
                                 code: bun_core::String::clone_utf8(b"ERR_DLOPEN_FAILED").into(),
                                 message: bun_core::String::clone_utf8(&msg).into(),

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3281,7 +3281,7 @@ where
                     port: None,
                 };
                 let mut s = Vec::new();
-                write!(&mut s, "https://{}", fmt).ok();
+                let _ = write!(&mut s, "https://{}", fmt);
                 s
             });
             let path = ReqLike::url(req);
@@ -3641,7 +3641,7 @@ where
         //   }
         // }
         let mut json_string = Vec::new();
-        write!(
+        let _ = write!(
             &mut json_string,
             "{{ \"workspace\": {{ \"root\": {}, \"uuid\": \"{}\" }} }}",
             bun_fmt::format_json_string_utf8(
@@ -3649,8 +3649,7 @@ where
                 Default::default()
             ),
             uuid,
-        )
-        .ok();
+        );
 
         resp.write_status(b"200 OK");
         resp.write_header(b"Content-Type", b"application/json");


### PR DESCRIPTION
### What does this PR do?

Rewrites 89 statement-position `.ok();` calls to `let _ = ...;`. Every one of them is a `write!`/`write_all`/`splat_byte_all` into a `Vec<u8>` or a best-effort console writer, so nothing was being dropped that mattered, but `.ok();` reads like the error is being handled when it is being thrown away. `let _ =` is already the majority spelling in the tree (153 uses) and says what is happening.

No behavior change.

### How did you verify your code works?

`cargo check -p bun_jsc -p bun_runtime -p bun_install -p bun_md` and `cargo fmt --all` are clean. Nothing to observe at runtime.