### PR TITLE
sourcemap: Builder<'a> borrows its line-offset table

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1125,8 +1125,8 @@ pub struct Options<'a> {
     // us do binary search on to figure out what line a given AST node came from
     /// Borrowed from `LinkerGraph.files[i].line_offset_table`. The same
     /// source can print into multiple part-ranges/chunks, so the table must
-    /// not be consumed. `get_source_map_builder` shallow-copies it into the
-    /// builder (`ManuallyDrop`, never freed on the bundler path).
+    /// not be consumed. `get_source_map_builder` moves the borrow into the
+    /// builder as `LineOffsetTables::Borrowed`.
     pub line_offset_tables: Option<&'a SourceMap::line_offset_table::List<bun_alloc::AstAlloc>>,
 
     pub mangled_props: Option<&'a crate::MangledProps>,
@@ -1416,7 +1416,7 @@ pub(crate) mod __gated_printer {
 
         pub(crate) renamer: rename::Renamer<'a, 'a>,
         pub(crate) prev_stmt_tag: StmtTag,
-        pub(crate) source_map_builder: SourceMap::chunk::Builder,
+        pub(crate) source_map_builder: SourceMap::chunk::Builder<'a>,
 
         pub(crate) temporary_bindings: Vec<B::Property>,
 
@@ -6496,9 +6496,9 @@ pub(crate) mod __gated_printer {
             import_records: &'a [ImportRecord],
             opts: Options<'a>,
             renamer: rename::Renamer<'a, 'a>,
-            source_map_builder: SourceMap::chunk::Builder,
+            source_map_builder: SourceMap::chunk::Builder<'a>,
         ) -> Self {
-            let printer = Self {
+            Self {
                 bump,
                 import_records,
                 needs_semicolon: false,
@@ -6522,13 +6522,7 @@ pub(crate) mod __gated_printer {
                 stack_overflowed: false,
                 was_lazy_export: false,
                 module_info: None,
-            };
-            // The `Builder` field is `&'static [u32]` pending lifetime threading,
-            // so instead of caching a self-borrow here,
-            // `Builder::add_source_mapping` derives the slice on demand from `line_offset_tables`
-            // via `ListExt::items_byte_offset_to_start_of_line()` (see Chunk.rs).
-            let _ = GENERATE_SOURCE_MAP;
-            printer
+            }
         }
 
         pub(crate) fn print_dev_server_module(
@@ -7235,6 +7229,7 @@ impl GenerateSourceMap {
 // `Scope.parent` backref). `print_json` is live as well.
 // ───────────────────────────────────────────────────────────────────────────
 use self::__gated_printer::{Printer, slice_of};
+use SourceMap::chunk::LineOffsetTables;
 use js_ast::Ast;
 
 // `generate_source_map` is a runtime arg: `generic_const_exprs`
@@ -7242,17 +7237,16 @@ use js_ast::Ast;
 // viral `where` clauses, and the body only does runtime branches anyway. The
 // `IS_BUN_PLATFORM` axis stays const so `prepend_count` is still a compile-time
 // constant in the monomorphized callers.
-pub(crate) fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
+pub(crate) fn get_source_map_builder<'a, const IS_BUN_PLATFORM: bool>(
     generate_source_map: GenerateSourceMap,
-    opts: &mut Options,
-    source: &bun_ast::Source,
+    opts: &mut Options<'a>,
+    source: &'a bun_ast::Source,
     tree: &Ast,
-) -> SourceMap::chunk::Builder {
+) -> SourceMap::chunk::Builder<'a> {
     if generate_source_map == GenerateSourceMap::Disable {
         return SourceMap::chunk::Builder::default();
     }
 
-    let precomputed = opts.line_offset_tables.take();
     let mut builder = SourceMap::chunk::Builder {
         source_map: SourceMap::chunk::SourceMapFormat::init(
             // opts.source_map_allocator orelse opts.allocator — allocator dropped
@@ -7261,32 +7255,17 @@ pub(crate) fn get_source_map_builder<const IS_BUN_PLATFORM: bool>(
         cover_lines_without_mappings: true,
         approximate_input_line_count: tree.approximate_newline_count,
         prepend_count: IS_BUN_PLATFORM && generate_source_map == GenerateSourceMap::Lazy,
-        // `Options.line_offset_tables` is a borrow into shared linker
-        // state; copy it bitwise via `ptr::read` into a
-        // `ManuallyDrop` so dropping the `Builder` never frees borrowed
-        // storage. When no table is supplied (the runtime/transpiler path) we
-        // leave this `EMPTY` and let the builder build it lazily on the first
-        // mapping (see `set_deferred_line_offset_table` below).
-        line_offset_tables: core::mem::ManuallyDrop::new(match precomputed {
-            // SAFETY: `borrowed` points to a valid `List` owned by the caller
-            // (e.g. `LinkerGraph.files[i].line_offset_table`). The bitwise
-            // copy aliases that storage; it is wrapped in `ManuallyDrop` and
-            // never dropped, so ownership stays with the caller.
-            Some(borrowed) => unsafe { core::ptr::read(borrowed) },
-            None => SourceMap::line_offset_table::List::new_in(bun_alloc::AstAlloc),
-        }),
+        line_offset_tables: match opts.line_offset_tables.take() {
+            Some(table) => LineOffsetTables::Borrowed(table),
+            None if generate_source_map == GenerateSourceMap::Lazy => LineOffsetTables::Deferred {
+                contents: source.contents(),
+                approximate_line_count: i32::try_from(tree.approximate_newline_count)
+                    .expect("int cast"),
+            },
+            None => LineOffsetTables::None,
+        },
         ..Default::default()
     };
-    if precomputed.is_none() && generate_source_map == GenerateSourceMap::Lazy {
-        // Defer table construction to the first `add_source_mapping` call:
-        // modules that emit no mappings (asset/JSON shims, empty modules,
-        // fully-stripped files) never pay the full-source scan + allocation.
-        builder.set_deferred_line_offset_table(
-            // allocator dropped
-            &source.contents,
-            i32::try_from(tree.approximate_newline_count).expect("int cast"),
-        );
-    }
     // Pre-size the VLQ mappings buffer. With `--minify` we emit roughly one
     // mapping per token; growing from 0 by doubling means ~16 reallocs and
     // O(n) memmoves on a large module. The estimate is intentionally
@@ -7442,12 +7421,6 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         renamer,
         source_map_builder,
     );
-    // `defer { if (generate_source_map) printer.source_map_builder.line_offset_tables.deinit(opts.allocator); }`
-    // — no longer needed: `Builder.line_offset_tables` is `List<AstAlloc>` and on
-    // this path is always EMPTY (`get_source_map_builder` defers generation to
-    // the `Global`-backed `lazy_line_offset_tables`, freed by `Printer`'s drop
-    // via `OwnedLineOffsetTables::Drop`). No caller of `print_ast` supplies a
-    // precomputed table.
     printer.was_lazy_export = tree.has_lazy_export;
     // Borrowck: `opts` was moved into `Printer::init`; populate
     // `printer.module_info` by taking it back out of `printer.options`
@@ -7591,7 +7564,7 @@ pub fn print<'a, const GENERATE_SOURCE_MAPS: bool>(
     bump: &'a bun_alloc::Arena,
     target: bun_ast::Target,
     ast: &Ast,
-    source: &bun_ast::Source,
+    source: &'a bun_ast::Source,
     opts: Options<'a>,
     import_records: &'a [ImportRecord],
     parts: &[js_ast::Part],
@@ -7622,7 +7595,7 @@ pub fn print_with_writer<'a, W: WriterTrait, const GENERATE_SOURCE_MAPS: bool>(
     bump: &'a bun_alloc::Arena,
     target: bun_ast::Target,
     ast: &Ast,
-    source: &bun_ast::Source,
+    source: &'a bun_ast::Source,
     opts: Options<'a>,
     import_records: &'a [ImportRecord],
     parts: &[js_ast::Part],
@@ -7663,7 +7636,7 @@ pub(crate) fn print_with_writer_and_platform<
     mut writer: W,
     bump: &'a bun_alloc::Arena,
     ast: &Ast,
-    source: &bun_ast::Source,
+    source: &'a bun_ast::Source,
     opts: Options<'a>,
     import_records: &'a [ImportRecord],
     parts: &[js_ast::Part],

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -1,6 +1,7 @@
 use bun_ast::{Loc, Source};
 use bun_core::{MutableString, strings};
 use bun_paths::{PathBuffer, fs::FileSystem};
+use bun_ptr::RawSlice;
 
 use crate::{
     InternalSourceMap, LineOffsetTable, SourceMapState, append_mapping_to_buffer,
@@ -293,40 +294,71 @@ impl SourceMapFormatCtx for VLQSourceMap {
     }
 }
 
-pub struct NewBuilder<T: SourceMapFormatCtx> {
+/// The line-offset table `add_source_mapping` resolves source locations
+/// through, and who owns it.
+pub enum LineOffsetTables<'a> {
+    /// No table: every mapping is dropped (source maps disabled, or no table
+    /// was supplied for this source).
+    None,
+    /// `LinkerGraph.files[i].line_offset_table`. The linker keeps ownership
+    /// (one source prints into several chunks) and bulk-frees it with the
+    /// worker's AST heap.
+    Borrowed(&'a line_offset_table::List<bun_alloc::AstAlloc>),
+    /// Runtime/transpiler print path: the first `add_source_mapping` call
+    /// generates the table from `contents` (`Source.contents`) and replaces
+    /// this with `Owned`, so modules that emit no mappings (asset/JSON shims,
+    /// empty modules, fully-stripped files) never pay the full-source scan and
+    /// allocation.
+    Deferred {
+        contents: &'a [u8],
+        approximate_line_count: i32,
+    },
+    /// Generated from `Deferred`; freed with the builder.
+    Owned(OwnedLineOffsetTables),
+}
+
+impl LineOffsetTables<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        match self {
+            Self::Borrowed(list) => list.len(),
+            Self::Owned(table) => table.0.len(),
+            Self::None | Self::Deferred { .. } => 0,
+        }
+    }
+
+    /// The `byte_offset_to_start_of_line` and `byte_offset_to_first_non_ascii`
+    /// columns.
+    #[inline]
+    fn columns(&self) -> (&[u32], &[u32]) {
+        match self {
+            Self::Borrowed(list) => (
+                list.items_byte_offset_to_start_of_line(),
+                list.items_byte_offset_to_first_non_ascii(),
+            ),
+            Self::Owned(table) => (
+                table.0.items_byte_offset_to_start_of_line(),
+                table.0.items_byte_offset_to_first_non_ascii(),
+            ),
+            Self::None | Self::Deferred { .. } => (&[], &[]),
+        }
+    }
+
+    #[inline]
+    fn columns_for_non_ascii(&self, line: usize) -> &[i32] {
+        match self {
+            Self::Borrowed(list) => {
+                &list.items::<"columns_for_non_ascii", Box<[i32], bun_alloc::AstAlloc>>()[line]
+            }
+            Self::Owned(table) => &table.0.items::<"columns_for_non_ascii", Box<[i32]>>()[line],
+            Self::None | Self::Deferred { .. } => &[],
+        }
+    }
+}
+
+pub struct NewBuilder<'a, T: SourceMapFormatCtx> {
     pub source_map: SourceMapFormat<T>,
-    /// `ManuallyDrop` because in the bundler `printWithWriter` path this is a
-    /// shallow bitwise copy of `LinkerGraph.files[i].line_offset_table` and
-    /// must not be dropped here. The runtime/transpiler `printAst` path defers
-    /// table construction (see `lazy_line_offset_tables`), so this is left
-    /// `EMPTY` there.
-    pub line_offset_tables: core::mem::ManuallyDrop<line_offset_table::List<bun_alloc::AstAlloc>>,
-
-    /// Lazily-generated, *owned* line-offset table for the runtime/transpiler
-    /// print path. When no precomputed `line_offset_tables` is supplied and
-    /// `deferred_source` is set, this stays `None` until the first
-    /// `add_source_mapping` call, which fills it via `LineOffsetTable::generate`.
-    /// `AstAlloc`-typed because the only caller that supplies a precomputed
-    /// table is the bundler (`LinkerGraph.files[i].line_offset_table`), which
-    /// builds it with `generate_in::<AstAlloc>` so the slab and every per-row
-    /// `columns_for_non_ascii` payload bulk-free with the worker arena instead
-    /// of needing a per-file teardown loop. Runtime/transpiler callers leave
-    /// this `EMPTY` and use the `Global`-backed `lazy_line_offset_tables` below.
-    /// Building the table only on demand means
-    /// modules that emit no source mappings (asset/JSON shims, empty modules,
-    /// fully-stripped files) never pay the full-source scan + `MultiArrayList`
-    /// allocation. Unlike `line_offset_tables` (a `ManuallyDrop` bitwise alias
-    /// of borrowed linker storage) this table is uniquely owned;
-    /// [`OwnedLineOffsetTables`] drains its `columns_for_non_ascii` payloads on
-    /// drop (`MultiArrayList::Drop` is slab-only).
-    pub lazy_line_offset_tables: Option<OwnedLineOffsetTables>,
-
-    /// Source bytes + approximate line count for the lazy path. `&'static` is a
-    /// lifetime erasure of a borrow into `Source.contents` (same rationale as
-    /// `line_offset_table_byte_offset_list` below — a real lifetime would infect
-    /// every `Printer<'a, …>` instantiation). `None` ⇒ eager-table mode (a
-    /// precomputed table was supplied, or source maps are disabled).
-    pub deferred_source: Option<(&'static [u8], i32)>,
+    pub line_offset_tables: LineOffsetTables<'a>,
 
     pub prev_state: SourceMapState,
     pub last_generated_update: u32,
@@ -334,22 +366,14 @@ pub struct NewBuilder<T: SourceMapFormatCtx> {
     pub prev_loc: Loc,
     pub has_prev_state: bool,
 
-    /// Cached `byte_offset_to_start_of_line` column of whichever line-offset
-    /// table is in use (`line_offset_tables` or `lazy_line_offset_tables`).
-    ///
-    /// Borrows the heap storage owned by that table; both variants keep the
-    /// `MultiArrayList` header live and un-resized for the builder's lifetime
-    /// (`line_offset_tables` is a `ManuallyDrop` alias of linker storage;
-    /// `lazy_line_offset_tables` is built once and never mutated again), so the
-    /// pointer is stable across moves of `Self`. `&'static` is a lifetime
-    /// erasure of that self-borrow — threading a real `'a` would infect every
-    /// `Printer<'a, …>` instantiation for a field that's only ever read in
-    /// `add_source_mapping`. Populated lazily on the first mapping; reset to `&[]` when
-    /// the lazy table is generated so it re-derives against the new storage.
-    pub line_offset_table_byte_offset_list: &'static [u32],
-    /// Cached `byte_offset_to_first_non_ascii` column; same lifetime invariant
-    /// as `line_offset_table_byte_offset_list` above.
-    pub line_offset_table_first_non_ascii: &'static [u32],
+    /// `byte_offset_to_start_of_line` column of `line_offset_tables`, cached
+    /// by the first mapping. Points into the `Borrowed` linker table or into
+    /// this builder's own `Owned` table, neither of which is resized or
+    /// replaced once the cache is filled.
+    pub line_offset_table_byte_offset_list: RawSlice<u32>,
+    /// `byte_offset_to_first_non_ascii` column; same backing storage as
+    /// `line_offset_table_byte_offset_list`.
+    pub line_offset_table_first_non_ascii: RawSlice<u32>,
 
     // This is a workaround for a bug in the popular "source-map" library:
     // https://github.com/mozilla/source-map/issues/261. The library will
@@ -368,24 +392,20 @@ pub struct NewBuilder<T: SourceMapFormatCtx> {
     pub prepend_count: bool,
 }
 
-impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<T> {
+impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<'_, T> {
     /// `get_source_map_builder` returns this when source maps are disabled, so
     /// it only needs to be inert (never read) — but we zero everything for sanity.
     fn default() -> Self {
         Self {
             source_map: SourceMapFormat { ctx: T::default() },
-            line_offset_tables: core::mem::ManuallyDrop::new(line_offset_table::List::new_in(
-                bun_alloc::AstAlloc,
-            )),
-            lazy_line_offset_tables: None,
-            deferred_source: None,
+            line_offset_tables: LineOffsetTables::None,
             prev_state: SourceMapState::default(),
             last_generated_update: 0,
             generated_column: 0,
             prev_loc: Loc::EMPTY,
             has_prev_state: false,
-            line_offset_table_byte_offset_list: &[],
-            line_offset_table_first_non_ascii: &[],
+            line_offset_table_byte_offset_list: RawSlice::EMPTY,
+            line_offset_table_first_non_ascii: RawSlice::EMPTY,
             line_starts_with_mapping: false,
             cover_lines_without_mappings: false,
             approximate_input_line_count: 0,
@@ -399,12 +419,11 @@ impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<T> {
 ///
 /// `MultiArrayList::Drop` is **slab-only** — it frees the SoA buffer but never
 /// runs column destructors (a bitwise `clone` can alias two lists onto the same
-/// column heap pointers; see its docs). The bundler's eager
-/// `print_ast` path now uses `List<AstAlloc>` (bulk-freed
-/// with the per-worker AST heap) and leaves `Builder.line_offset_tables` empty,
-/// so they no longer need a guard. The lazily-built table here is `List<Global>`
-/// and still needs the per-row drain, so wrap it in a type that does it
-/// automatically. (A `Drop` impl on `NewBuilder` itself would forbid the
+/// column heap pointers; see its docs). The `LineOffsetTables::Borrowed` table
+/// is `List<AstAlloc>` and is never dropped here (it bulk-frees with the
+/// per-worker AST heap); the table generated for `LineOffsetTables::Deferred`
+/// is `List<Global>` and needs the per-row drain, so wrap it in a type that
+/// does it automatically. (A `Drop` impl on `NewBuilder` itself would forbid the
 /// `..Default::default()` struct-update used to build it in
 /// `get_source_map_builder`, hence the newtype.)
 pub struct OwnedLineOffsetTables(pub(crate) line_offset_table::List);
@@ -442,7 +461,7 @@ impl Drop for OwnedLineOffsetTables {
 // `update_generated_line_and_column_slow`, which is `#[inline(never)] #[cold]`
 // and lives once in this crate, adjacent to `flush_window`. The concrete
 // (non-generic) impl is what pins one copy per CGU.
-impl NewBuilder<VLQSourceMap> {
+impl NewBuilder<'_, VLQSourceMap> {
     #[inline(never)]
     pub fn generate_chunk(&mut self, output: &[u8]) -> Chunk {
         self.update_generated_line_and_column(output);
@@ -608,24 +627,6 @@ impl NewBuilder<VLQSourceMap> {
         self.has_prev_state = true;
     }
 
-    /// Defer line-offset-table construction to the first `add_source_mapping`
-    /// call. Use on the runtime/transpiler print path when no precomputed table
-    /// is supplied, so modules that emit no mappings skip the table's
-    /// full-source scan + allocation entirely. `contents` must point into the
-    /// live `Source.contents` and outlive the builder.
-    #[inline]
-    pub fn set_deferred_line_offset_table(&mut self, contents: &[u8], approximate_line_count: i32) {
-        debug_assert!(
-            self.line_offset_tables.len() == 0,
-            "deferred table requires no precomputed line_offset_tables",
-        );
-        // SAFETY: lifetime erased to `'static`; `contents` (`Source.contents`)
-        // outlives the builder. Same erasure as `line_offset_table_byte_offset_list`.
-        let contents: &'static [u8] =
-            unsafe { core::slice::from_raw_parts(contents.as_ptr(), contents.len()) };
-        self.deferred_source = Some((contents, approximate_line_count));
-    }
-
     #[inline(never)]
     pub fn add_source_mapping(&mut self, loc: Loc, output: &[u8]) {
         if
@@ -639,30 +640,22 @@ impl NewBuilder<VLQSourceMap> {
 
         self.prev_loc = loc;
 
-        // Lazily build the line-offset table on the first mapping. The
-        // runtime/transpiler path passes `deferred_source` instead of a
-        // precomputed table (see `set_deferred_line_offset_table`); modules that
-        // never reach this point skip the full-source scan + allocation.
-        if self.lazy_line_offset_tables.is_none() {
-            if let Some((contents, approx)) = self.deferred_source {
-                self.lazy_line_offset_tables = Some(OwnedLineOffsetTables(
-                    LineOffsetTable::generate(contents, approx).unwrap_or_default(),
-                ));
-                // The byte-offset cache below must re-derive against the new table.
-                self.line_offset_table_byte_offset_list = &[];
-            }
+        if let LineOffsetTables::Deferred {
+            contents,
+            approximate_line_count,
+        } = self.line_offset_tables
+        {
+            self.line_offset_tables = LineOffsetTables::Owned(OwnedLineOffsetTables(
+                LineOffsetTable::generate(contents, approximate_line_count).unwrap_or_default(),
+            ));
         }
 
-        // `line_offset_tables` (bundler-supplied, `AstAlloc`) and
-        // `lazy_line_offset_tables` (runtime-generated, `Global`) are different
-        // `List<A>` instantiations, so we can't unify them behind one `&List`.
-        // Instead, cache the two `u32` columns the hot path reads (both are
-        // `&[u32]` regardless of `A`) and re-dispatch only for the rare
+        // `Borrowed` (`AstAlloc`) and `Owned` (`Global`) are different `List<A>`
+        // instantiations, so we can't unify them behind one `&List`. Instead,
+        // cache the two `u32` columns the hot path reads (both are `&[u32]`
+        // regardless of `A`) and re-dispatch only for the rare
         // `columns_for_non_ascii` lookup below.
-        let list_len = match &self.lazy_line_offset_tables {
-            Some(t) => t.0.len(),
-            None => self.line_offset_tables.len(),
-        };
+        let list_len = self.line_offset_tables.len();
 
         // We have no sourcemappings.
         // This happens for example when importing an asset which does not support sourcemaps
@@ -674,35 +667,12 @@ impl NewBuilder<VLQSourceMap> {
             return;
         }
 
-        // PERF: cache the `byte_offset_to_start_of_line` / `…_first_non_ascii`
-        // columns once. The backing storage is heap-owned by whichever table is
-        // active — `line_offset_tables` (a `ManuallyDrop<MultiArrayList>`) or
-        // `lazy_line_offset_tables` (built once just above) — and both are kept
-        // live and un-resized for the builder's lifetime, so the slice stays
-        // valid across moves of `self`. We lazy-init here on the first mapping.
         if self.line_offset_table_byte_offset_list.len() != list_len {
-            let (start, first_na) = match &self.lazy_line_offset_tables {
-                Some(t) => (
-                    t.0.items_byte_offset_to_start_of_line(),
-                    t.0.items_byte_offset_to_first_non_ascii(),
-                ),
-                None => (
-                    self.line_offset_tables.items_byte_offset_to_start_of_line(),
-                    self.line_offset_tables
-                        .items_byte_offset_to_first_non_ascii(),
-                ),
-            };
-            // SAFETY: lifetime widened to `'static` per the invariant above —
-            // the backing table outlives every `add_source_mapping` call and is
-            // never reallocated.
-            self.line_offset_table_byte_offset_list =
-                unsafe { core::slice::from_raw_parts(start.as_ptr(), start.len()) };
-            // SAFETY: same invariant as above — backing table outlives every
-            // `add_source_mapping` call and is never reallocated.
-            self.line_offset_table_first_non_ascii =
-                unsafe { core::slice::from_raw_parts(first_na.as_ptr(), first_na.len()) };
+            let (start, first_na) = self.line_offset_tables.columns();
+            self.line_offset_table_byte_offset_list = RawSlice::new(start);
+            self.line_offset_table_first_non_ascii = RawSlice::new(first_na);
         }
-        let byte_offsets = self.line_offset_table_byte_offset_list;
+        let byte_offsets = self.line_offset_table_byte_offset_list.slice();
 
         // The printer emits mappings in (mostly) source order, so the previous
         // call's `original_line` is the right answer or one/two lines before
@@ -727,12 +697,7 @@ impl NewBuilder<VLQSourceMap> {
             // (the largest, ~16 B/line) is never touched on the hot ASCII path.
             let first_non_ascii = self.line_offset_table_first_non_ascii[idx];
             if original_column >= first_non_ascii as i32 {
-                let cols: &[i32] = match &self.lazy_line_offset_tables {
-                    Some(t) => &t.0.items::<"columns_for_non_ascii", Box<[i32]>>()[idx],
-                    None => &self
-                        .line_offset_tables
-                        .items::<"columns_for_non_ascii", Box<[i32], bun_alloc::AstAlloc>>()[idx],
-                };
+                let cols = self.line_offset_tables.columns_for_non_ascii(idx);
                 if !cols.is_empty() {
                     original_column = cols[(original_column as u32 - first_non_ascii) as usize];
                 }
@@ -770,4 +735,4 @@ impl NewBuilder<VLQSourceMap> {
     }
 }
 
-pub type Builder = NewBuilder<VLQSourceMap>;
+pub type Builder<'a> = NewBuilder<'a, VLQSourceMap>;


### PR DESCRIPTION
## What

`NewBuilder` in `src/sourcemap/Chunk.rs` (`chunk::Builder`, the per-file source map builder owned by the printer) tracked which line-offset table it maps through with four fields, each carrying its ownership rule in a comment: `line_offset_tables: ManuallyDrop<List<AstAlloc>>`, a bitwise copy of `LinkerGraph.files[i].line_offset_table` made by `unsafe { ptr::read(borrowed) }` in `get_source_map_builder` (`src/js_printer/lib.rs`) and never dropped; `lazy_line_offset_tables: Option<OwnedLineOffsetTables>` for the table the runtime path generates on the first mapping; `deferred_source: Option<(&'static [u8], i32)>`, a borrow of `Source.contents` widened to `'static` with `from_raw_parts` in `set_deferred_line_offset_table`; and the two column caches `line_offset_table_byte_offset_list` / `line_offset_table_first_non_ascii: &'static [u32]`, widened the same way inside `add_source_mapping`. The field docs justified the `'static`s with "a real lifetime would infect every `Printer<'a, ..>` instantiation", but `Printer` already has that `'a`, and the table arrives as `Options<'a>.line_offset_tables: Option<&'a List<AstAlloc>>`.

The builder is now `NewBuilder<'a, T>` (`pub type Builder<'a>`) with one field describing the table and its owner, plus the caches typed as what they are:

```rust
// before
pub line_offset_tables: ManuallyDrop<line_offset_table::List<AstAlloc>>,
pub lazy_line_offset_tables: Option<OwnedLineOffsetTables>,
pub deferred_source: Option<(&'static [u8], i32)>,
pub line_offset_table_byte_offset_list: &'static [u32],
pub line_offset_table_first_non_ascii: &'static [u32],

// after
pub enum LineOffsetTables<'a> {
    None,
    Borrowed(&'a line_offset_table::List<AstAlloc>),
    Deferred { contents: &'a [u8], approximate_line_count: i32 },
    Owned(OwnedLineOffsetTables),
}
pub line_offset_tables: LineOffsetTables<'a>,
pub line_offset_table_byte_offset_list: bun_ptr::RawSlice<u32>,
pub line_offset_table_first_non_ascii: bun_ptr::RawSlice<u32>,
```

`add_source_mapping` keeps its structure: the first mapping replaces `Deferred` with `Owned(generate(..))`, and its three dispatches between the two tables (`len`, the two `u32` columns filled into the caches, and the rare `columns_for_non_ascii` row) become three small private methods on the enum; the caches are filled with `RawSlice::new` and read with `slice()`. `get_source_map_builder<'a>` now takes `&mut Options<'a>` and `&'a Source` and writes the variant directly: `Borrowed` from `opts.line_offset_tables.take()`, `Deferred` for the runtime (`Lazy`) mode, `None` otherwise. `Printer.source_map_builder` and `Printer::init` take `Builder<'a>`; `print`, `print_with_writer` and `print_with_writer_and_platform` take `source: &'a Source` so the `Deferred` borrow is checked rather than asserted (their 5 callers in `bun_bundler` compile unchanged; `print_ast` already had it).

Deleted because the change makes them dead: `set_deferred_line_offset_table` (its only caller now builds the variant), the three replaced fields and their docs, the cache reset in the `Deferred` transition (the transition is the first thing the first mapping does, so the caches are necessarily still empty), and the `Printer::init` / `print_ast` comments describing the `'static` fields and the `ManuallyDrop` alias. Removes 4 `unsafe` blocks (the `ptr::read` and three `from_raw_parts`) and adds none. 2 files, 125 insertions, 187 deletions.

## Why

Who owns the table and which states exist are now answerable from the type: `Borrowed` is the linker's and is never freed here, `Owned` is freed with the builder through `OwnedLineOffsetTables::drop`, `Deferred` holds a borrow that the compiler checks against the same `'a` the printer already carries, and the impossible combinations the old fields allowed (a precomputed table plus a deferred source, or both tables populated) cannot be written. The `'a` is the existing `Options<'a>` lifetime, so no caller changes; `LineOffsetTables<'a>` is 32 bytes where the three fields it replaces were 72 (`Builder` goes from 1560 to 1520 bytes); `RawSlice<u32>` is `#[repr(transparent)]` over a fat pointer, so the cached columns are still one ptr+len read; per mapping, the enum tag check and match replace the `Option` checks on `lazy_line_offset_tables` and `deferred_source`, the caches are still filled once, and building the builder stores one pointer instead of copying a 24-byte list header.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/bundler/bun-build-api.test.ts test/js/bun/sourcemap/internal-sourcemap.test.ts test/bundler/bundler_bun.test.ts test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts: 90 pass, 1 skip, 1 todo, 0 fail (92 tests across 4 files).
