### PR TITLE
mysql: make DateTime's fields private to the module that range-checks them

### DIFF
--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -420,13 +420,13 @@ impl Value {
 
 #[derive(Default, Clone, Copy)]
 pub struct DateTime {
-    pub(crate) year: u16,
-    pub(crate) month: u8,
-    pub(crate) day: u8,
-    pub(crate) hour: u8,
-    pub(crate) minute: u8,
-    pub(crate) second: u8,
-    pub(crate) microsecond: u32,
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+    microsecond: u32,
 }
 
 impl DateTime {


### PR DESCRIPTION
### What does this PR do?

`DateTime::from_text` and `to_js_timestamp` in `MySQLValue.rs` both enforce `month` in 1..=12, `day` within the month, `hour <= 23`, `minute`/`second <= 59`, and `days_in_month` indexes `DAYS[month - 1]` on the strength of that. The seven fields were `pub(crate)`, so anything in `bun_sql_jsc` could have written a `month = 13` and reached that index. Nothing does today (there is no reader or writer of these fields outside `MySQLValue.rs`), so this just drops the visibility to keep it that way.

### How did you verify your code works?

`cargo check -p bun_sql_jsc` is clean with the fields private, which is the proof that nothing outside the module touched them.