### PR TITLE
url: own the WTF::URL with whatwg::Handle; getters return OwnedString

### DIFF
--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -50,13 +50,12 @@
 //! tags like `github:` which are handled as "shortcuts" by this library.
 
 use core::ops::Range;
-use core::ptr::NonNull;
 
 use bun_alloc::AllocError;
 use bun_core::StringBuilder;
-use bun_core::{OwnedString, strings};
+use bun_core::strings;
 use bun_url::PercentEncoding;
-use bun_url::whatwg::URL as JscUrl;
+use bun_url::whatwg::{self, URL as JscUrl};
 use enum_map::{Enum, EnumMap};
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -255,7 +254,6 @@ impl HostedGitInfo {
         let Ok(parsed) = parse_url(git_url_mut) else {
             return Ok(None);
         };
-        // `parsed.url` is `OwnedJscUrl`; Drop handles `defer parsed.url.deinit()`.
 
         let host_provider = match parsed.proto {
             UrlProtocol::WellFormed(p) => p
@@ -333,28 +331,8 @@ impl HostedGitInfo {
 // parse_url
 // ──────────────────────────────────────────────────────────────────────────
 
-/// RAII handle over a heap-allocated `WTF::URL` (C++). The allocation comes from
-/// `URL__fromString` (C++ `new`), so it MUST be freed via `URL__deinit` — wrapping
-/// the pointer in `Box` is allocator-mismatch UB and never runs the C++ destructor.
-pub struct OwnedJscUrl(NonNull<JscUrl>);
-impl core::ops::Deref for OwnedJscUrl {
-    type Target = JscUrl;
-    fn deref(&self) -> &JscUrl {
-        // SAFETY: `from_string`/`from_utf8` returned a live heap WTF::URL we own.
-        unsafe { self.0.as_ref() }
-    }
-}
-impl Drop for OwnedJscUrl {
-    fn drop(&mut self) {
-        // SAFETY: pointer is the unique owner of a `new WTF::URL` from C++; `deinit`
-        // calls `URL__deinit` which `delete`s it.
-        unsafe { self.0.as_mut() }.deinit();
-    }
-}
-
-// `url` is owned: `jsc.URL.fromString` creates it and the holder deinits.
 pub struct ParsedUrl<'a> {
-    pub url: OwnedJscUrl,
+    pub url: whatwg::Handle,
     pub(crate) proto: UrlProtocol<'a>,
 }
 
@@ -670,7 +648,7 @@ impl<'a> UrlProtocolPair<'a> {
     }
 
     /// Given a protocol pair, create a jsc.URL if possible. May allocate, but owns its memory.
-    fn to_url(&self) -> Option<OwnedJscUrl> {
+    fn to_url(&self) -> Option<whatwg::Handle> {
         let mut protocol_buf: StringWithColonBuffer =
             [0u8; WellDefinedProtocol::MAX_PROTOCOL_LENGTH + 1];
 
@@ -692,12 +670,12 @@ impl<'a> UrlProtocolPair<'a> {
         }
     }
 
-    fn concat_parts_to_url(parts: &[&[u8]]) -> Option<OwnedJscUrl> {
+    fn concat_parts_to_url(parts: &[&[u8]]) -> Option<whatwg::Handle> {
         // TODO(markovejnovic): There is a sad unnecessary allocation here that I don't know how to
         // get rid of -- in theory, the URL layer could allocate once.
         let new_str = strings::concat(parts);
         // Drop handles `defer allocator.free(new_str)`.
-        JscUrl::from_utf8(&new_str).map(OwnedJscUrl)
+        JscUrl::from_utf8(&new_str)
     }
 }
 
@@ -971,7 +949,7 @@ impl HostProvider {
 
     /// Parse a URL and return the appropriate host provider, if any.
     fn from_url(url: &JscUrl) -> Option<HostProvider> {
-        let proto_str = OwnedString::new(url.protocol());
+        let proto_str = url.protocol();
 
         // Try shortcut first (github:, gitlab:, etc.)
         if let Some(provider) = HostProvider::from_shortcut(proto_str.byte_slice(), false) {
@@ -983,7 +961,7 @@ impl HostProvider {
 
     /// Given a URL, use the domain in the URL to find the appropriate host provider.
     fn from_url_domain(url: &JscUrl) -> Option<HostProvider> {
-        let hostname_str = OwnedString::new(url.hostname());
+        let hostname_str = url.hostname();
 
         let hostname_utf8 = hostname_str.to_utf8();
         let hostname = strings::without_prefix(hostname_utf8.slice(), b"www.");
@@ -1072,7 +1050,7 @@ pub(crate) mod formatters {
             // valid until it's copied into the StringBuilder.
             let fragment_utf8;
             let committish: Option<&[u8]> = if type_part.is_none() {
-                let fragment_str = OwnedString::new(url.fragment_identifier());
+                let fragment_str = url.fragment_identifier();
                 fragment_utf8 = fragment_str.to_utf8();
                 let fragment = fragment_utf8.slice();
                 if !fragment.is_empty() {
@@ -1133,7 +1111,7 @@ pub(crate) mod formatters {
                 return Ok(None);
             }
 
-            let fragment_str = OwnedString::new(url.fragment_identifier());
+            let fragment_str = url.fragment_identifier();
             let fragment_utf8 = fragment_str.to_utf8();
             let fragment = fragment_utf8.slice();
             let committish: Option<&[u8]> = if !fragment.is_empty() {
@@ -1188,7 +1166,7 @@ pub(crate) mod formatters {
                 return Ok(None);
             }
 
-            let fragment_str = OwnedString::new(url.fragment_identifier());
+            let fragment_str = url.fragment_identifier();
             let fragment_utf8 = fragment_str.to_utf8();
             let committish = fragment_utf8.slice();
 
@@ -1253,7 +1231,7 @@ pub(crate) mod formatters {
                 return Ok(None);
             }
 
-            let fragment_str = OwnedString::new(url.fragment_identifier());
+            let fragment_str = url.fragment_identifier();
             let fragment_utf8 = fragment_str.to_utf8();
             let fragment = fragment_utf8.slice();
             let committish: Option<&[u8]> = if !fragment.is_empty() {
@@ -1330,7 +1308,7 @@ pub(crate) mod formatters {
                 return Ok(None);
             }
 
-            let fragment_str = OwnedString::new(url.fragment_identifier());
+            let fragment_str = url.fragment_identifier();
             let fragment_utf8 = fragment_str.to_utf8();
             let fragment = fragment_utf8.slice();
             let committish: Option<&[u8]> = if !fragment.is_empty() {

--- a/src/install_jsc/hosted_git_info_jsc.rs
+++ b/src/install_jsc/hosted_git_info_jsc.rs
@@ -87,8 +87,6 @@ pub fn js_parse_url(go: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
         }
     };
 
-    // `parsed.url` is `Box<WhatwgUrl>` (C++-owned WTF::URL); `href()` yields a
-    // `bun_core::String`. `defer parsed.url.deinit()` deleted — Box Drop frees.
     parsed.url.href().to_js(go)
 }
 

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -42,11 +42,12 @@ use route_param::List as ParamsList;
 // stay in tier-6 `bun_jsc` as extension methods — they need JSValue/JSGlobalObject.
 // Everything else is a thin extern-"C" wrapper around WTF::URL and is JSC-agnostic.
 pub mod whatwg {
+    use bun_core::OwnedString;
+
     use super::BunString as String;
     use super::strings;
 
-    /// Opaque handle to a heap-allocated WTF::URL (C++). Always behind `*mut URL`.
-    /// Construct via `from_string`/`from_utf8`; free via `deinit`.
+    /// Opaque heap-allocated WTF::URL (C++); only ever reached through a [`Handle`].
     #[repr(C)]
     pub struct URL {
         _opaque: [u8; 0],
@@ -57,7 +58,7 @@ pub mod whatwg {
     // `*mut` to match the C ABI; callers pass a mutable local copy (see below).
     // SAFETY (safe fn): `URL` is an opaque ZST handle (never null when behind `&`);
     // `String` is a `#[repr(C)]` Copy POD that C++ reads (`BunString::toWTFString() const`).
-    // Getters take `&URL` (C++ never mutates on read); `deinit` takes `&mut URL` (consumes).
+    // Getters take `&URL` (C++ never mutates on read); `URL__deinit` frees, so stays `unsafe fn`.
     // `URL__originLength` keeps a raw `(*const u8, usize)` slice pair → stays `unsafe fn`.
     unsafe extern "C" {
         // `URL__fromJS` / `URL__getHrefFromJS` intentionally omitted — tier-6 (bun_jsc).
@@ -65,13 +66,35 @@ pub mod whatwg {
         safe fn URL__protocol(url: &URL) -> String;
         safe fn URL__href(url: &URL) -> String;
         safe fn URL__hostname(url: &URL) -> String;
-        safe fn URL__deinit(url: &mut URL);
+        fn URL__deinit(url: *mut URL);
         safe fn URL__pathname(url: &URL) -> String;
         safe fn URL__getHref(input: &mut String) -> String;
         safe fn URL__getFileURLString(input: &mut String) -> String;
         safe fn URL__getHrefJoin(base: &mut String, relative: &mut String) -> String;
         safe fn URL__fragmentIdentifier(url: &URL) -> String;
         fn URL__originLength(latin1_slice: *const u8, len: usize) -> u32;
+    }
+
+    /// Owns the `new WTF::URL` handed back by `URL__fromString` and deletes it on drop.
+    #[repr(transparent)]
+    pub struct Handle(core::ptr::NonNull<URL>);
+
+    impl core::ops::Deref for Handle {
+        type Target = URL;
+
+        #[inline]
+        fn deref(&self) -> &URL {
+            // SAFETY: `self.0` is the live heap `WTF::URL` this handle owns until `drop`.
+            unsafe { self.0.as_ref() }
+        }
+    }
+
+    impl Drop for Handle {
+        #[inline]
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is a C++ `new WTF::URL` and this handle is its only owner.
+            unsafe { URL__deinit(self.0.as_ptr()) }
+        }
     }
 
     // The C ABI wants a mutable address. We take `&String` (matching existing call sites
@@ -114,22 +137,22 @@ pub mod whatwg {
     }
 
     impl URL {
-        pub(crate) fn from_string(str: &String) -> Option<core::ptr::NonNull<URL>> {
-            let mut input = *str;
-            URL__fromString(&mut input)
+        pub fn from_utf8(input: &[u8]) -> Option<Handle> {
+            let mut input = String::borrow_utf8(input);
+            URL__fromString(&mut input).map(Handle)
         }
-        pub fn from_utf8(input: &[u8]) -> Option<core::ptr::NonNull<URL>> {
-            Self::from_string(&String::borrow_utf8(input))
-        }
+        // `protocol`, `pathname` and `fragment_identifier` alias the WTF::URL's own buffer
+        // (BunString.cpp uses `toStringWithoutCopying`): consume them while the `Handle` is alive.
+
         /// The URL fragment (the part after `#`), excluding the leading '#'.
-        pub fn fragment_identifier(&self) -> String {
-            URL__fragmentIdentifier(self)
+        pub fn fragment_identifier(&self) -> OwnedString {
+            OwnedString::new(URL__fragmentIdentifier(self))
         }
-        pub fn protocol(&self) -> String {
-            URL__protocol(self)
+        pub fn protocol(&self) -> OwnedString {
+            OwnedString::new(URL__protocol(self))
         }
-        pub fn href(&self) -> String {
-            URL__href(self)
+        pub fn href(&self) -> OwnedString {
+            OwnedString::new(URL__href(self))
         }
         /// Returns the host WITH the port.
         ///
@@ -139,14 +162,11 @@ pub mod whatwg {
         /// ```text
         /// URL("http://example.com:8080").hostname() => "example.com:8080"
         /// ```
-        pub fn hostname(&self) -> String {
-            URL__hostname(self)
+        pub fn hostname(&self) -> OwnedString {
+            OwnedString::new(URL__hostname(self))
         }
-        pub fn pathname(&self) -> String {
-            URL__pathname(self)
-        }
-        pub fn deinit(&mut self) {
-            URL__deinit(self)
+        pub fn pathname(&self) -> OwnedString {
+            OwnedString::new(URL__pathname(self))
         }
     }
 }


### PR DESCRIPTION
### Problem
- No user-facing bug is claimed; this is one of a series of small type-system hardening changes.
- Safe Rust could free a parsed URL twice, or use it after freeing: the only way to free the C++ `WTF::URL` was a safe `deinit(&mut self)` that deletes the object behind a reference the caller still holds.
- The URL getters returned a `Copy` string carrying a reference each caller had to release by hand. 7 call sites did, 8 did not, so `bun install` git dependency parsing leaked one reference per call at those sites.
- The type that did free the URL correctly lived in the consumer crate, not the crate that declares the FFI.

### Fix
- `whatwg::Handle` owns the `WTF::URL` and deletes it on drop. `URL__deinit` becomes an unsafe fn called only from that drop; the safe `deinit` and the consumer's own owner type are removed.
- The getters return `OwnedString`, so the reference is released when the result goes out of scope on every path; the 8 leaking sites compile unchanged and now release.
- Property to check: `Handle` is `#[repr(transparent)]` over the same pointer and drops at the same scope exits as before, so the only new work is the release the leaking sites were missing.
- Verification: `cargo check` and `cargo clippy` clean, debug build ok, the three existing hosted-git-info test files pass (655 pass, 32 skip). No test is added for the leak or the double free.

### Background
- `WTF::URL` is WebKit's URL object. `bun_url::whatwg` reaches it over `extern "C"`: C++ allocates it with `new`, so only the C++ `URL__deinit` may free it, never a Rust `Box`.
- `bun_core::String` (BunString) is a `Copy`, `#[repr(C)]` value that may hold one reference on a WTF string; the receiver must release it exactly once. `OwnedString` is a transparent wrapper whose `Drop` does that.
- In an `unsafe extern "C"` block, a `safe fn` item is callable without `unsafe`; dropping the marker forces callers into an `unsafe` block, which here confines the free to `Handle::drop`.
- `hosted_git_info` is the part of `bun install` that parses git dependency specifiers and is the only user of this wrapper.

<details>
<summary>Original description</summary>

## What

`bun_url::whatwg::URL::from_utf8` returned `Option<NonNull<URL>>` pointing at a C++ `new WTF::URL`, and the only way to free it was `pub fn deinit(&mut self)`, a safe method (backed by a `safe fn URL__deinit(&mut URL)` declaration) that `delete`s the object behind a reference safe code can keep using or call again. The single consumer, `bun_install::hosted_git_info`, rebuilt the owner itself as `OwnedJscUrl(NonNull<JscUrl>)` with its own `Deref` and `Drop`. The getters (`protocol`, `href`, `hostname`, `pathname`, `fragment_identifier`) returned a `Copy` `bun_core::String` carrying the +1 ref that `Bun::toStringRef` takes in BunString.cpp; 7 call sites released it by wrapping the result in `OwnedString::new(..)`, while 7 `.to_owned_slice()` sites in `hosted_git_info.rs` and the `.href().to_js(go)` site in `hosted_git_info_jsc.rs` dropped the ref on the floor.

`whatwg` now owns the handle and the refs:

```rust
// before
pub fn from_utf8(input: &[u8]) -> Option<NonNull<URL>>
pub fn deinit(&mut self)
pub fn pathname(&self) -> String

// after
#[repr(transparent)]
pub struct Handle(NonNull<URL>);            // Deref<Target = URL>; Drop calls URL__deinit
pub fn from_utf8(input: &[u8]) -> Option<Handle>
pub fn pathname(&self) -> OwnedString        // same for protocol/href/hostname/fragment_identifier
```

`URL__deinit` is declared as `unsafe fn(*mut URL)` and is called only from `Handle::drop`; `deinit`, the `pub(crate) from_string` helper that only `from_utf8` used, and `OwnedJscUrl` are deleted. `ParsedUrl.url` becomes a `whatwg::Handle`, `to_url` / `concat_parts_to_url` return `JscUrl::from_utf8(..)` directly, the 7 `OwnedString::new(url.x())` wrappers become `url.x()`, and the other 8 getter call sites compile unchanged through `Deref` and now release the ref at the end of the statement. The two `unsafe` blocks move from `bun_install` to the crate that declares the FFI (`Handle`'s `Deref` and `Drop`), so `hosted_git_info.rs` has none left. The free helpers (`href_from_string`, `join`, `file_url_from_string`), which have their own callers in other crates, are intentionally unchanged.

## Why

Who deletes the `WTF::URL`, and that it happens exactly once, is now stated by `Handle`: safe code can no longer free a URL it is still holding, and every getter result is released on every return path instead of at whichever call sites remembered to. It is zero-cost: `Handle` is `#[repr(transparent)]` over the same `NonNull<URL>` that `OwnedJscUrl` held (so `Option<Handle>` is still one nullable pointer) and its `Drop` issues the same `URL__deinit` call at the same scope exits; `OwnedString` is `#[repr(transparent)]` over `String`, and the only added work is the refcount decrement the 8 leaking sites were missing, on the `bun install` git-dependency parsing path.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/cli/install/hosted-git-info/from-url.test.ts test/cli/install/hosted-git-info/parse-url.test.ts test/cli/install/hosted-git-info/boundary-conditions.test.ts`: 655 pass, 32 skip, 0 fail (687 tests across 3 files).


</details>
