### PR TITLE
toml: thread StoreRef through table navigation instead of raw pointers

### DIFF
--- a/src/parsers/toml.rs
+++ b/src/parsers/toml.rs
@@ -20,10 +20,12 @@
 //! - strings are UTF-8; non-ASCII content is re-encoded to UTF-16 EStrings
 //!   so both the JS conversion and the printer paths agree
 
+#![forbid(unsafe_code)]
+
 use bun_alloc::Arena as Bump;
 use bun_alloc::ArenaVec;
 use bun_alloc::ArenaVecExt as _;
-use bun_ast::{self, E, Expr, Loc, Log, Source};
+use bun_ast::{self, E, Expr, Loc, Log, Source, StoreRef};
 use bun_collections::HashMap;
 use bun_core::{self, StackCheck};
 
@@ -1441,19 +1443,23 @@ struct Parser<'a, 'log> {
     scanner: Scanner<'a, 'log>,
     bump: &'a Bump,
     stack_check: StackCheck,
-    /// Keyed by `E::Object::as_ptr()` / `E::Array::as_ptr()` addresses.
+    /// Keyed by `meta_key`: `E::Object` and `E::Array` nodes share one map.
     meta: HashMap<usize, Meta>,
     /// Current definition block: bumped per table header and per inline table.
     block: u32,
 }
 
+fn meta_key<T>(node: StoreRef<T>) -> usize {
+    node.as_ptr() as usize
+}
+
 impl<'a, 'log> Parser<'a, 'log> {
     /// Every table/array reachable during parsing was created by this parser
     /// and registered in `meta` at construction.
-    fn meta_of(&self, ptr: usize) -> Meta {
+    fn meta_of<T>(&self, node: StoreRef<T>) -> Meta {
         *self
             .meta
-            .get(&ptr)
+            .get(&meta_key(node))
             .expect("table/array was registered at creation")
     }
 
@@ -1463,13 +1469,9 @@ impl<'a, 'log> Parser<'a, 'log> {
         let start = self.scanner.init_document()?;
 
         let root = Expr::init(E::Object::default(), loc_of(start));
-        let root_ptr = root
-            .data
-            .e_object()
-            .expect("infallible: just constructed")
-            .as_ptr();
+        let root_ptr = root.data.e_object().expect("infallible: just constructed");
 
-        let mut current: *mut E::Object = root_ptr;
+        let mut current: StoreRef<E::Object> = root_ptr;
         loop {
             match self.scanner.scan_line_start()? {
                 LineStart::Eof => return Ok(root),
@@ -1489,10 +1491,10 @@ impl<'a, 'log> Parser<'a, 'log> {
     /// Returns the table that becomes current.
     fn parse_table_header(
         &mut self,
-        root: *mut E::Object,
+        root: StoreRef<E::Object>,
         aot: bool,
         header_pos: usize,
-    ) -> PResult<*mut E::Object> {
+    ) -> PResult<StoreRef<E::Object>> {
         let mut path: ArenaVec<'a, KeySeg<'a>> = ArenaVec::with_capacity_in(0, self.bump);
         path.push(self.scanner.scan_key_after_sep()?);
         loop {
@@ -1508,18 +1510,15 @@ impl<'a, 'log> Parser<'a, 'log> {
 
     fn navigate_header(
         &mut self,
-        root: *mut E::Object,
+        root: StoreRef<E::Object>,
         path: &[KeySeg<'a>],
         is_aot: bool,
         header_pos: usize,
-    ) -> PResult<*mut E::Object> {
-        let mut cur: *mut E::Object = root;
+    ) -> PResult<StoreRef<E::Object>> {
+        let mut cur: StoreRef<E::Object> = root;
         for (i, seg) in path.iter().enumerate() {
             let last = i + 1 == path.len();
-            // SAFETY: `cur` always points at an E::Object inside the AST store,
-            // created earlier in this parse; the store lives in `self.bump`.
-            let cur_obj: &mut E::Object = unsafe { &mut *cur };
-            let existing = cur_obj.as_property(seg.text).map(|q| q.expr);
+            let existing = cur.as_property(seg.text).map(|q| q.expr);
             match existing {
                 None => {
                     if last && is_aot {
@@ -1540,8 +1539,7 @@ impl<'a, 'log> Parser<'a, 'log> {
                 }
                 Some(found) => {
                     if let Some(obj) = found.data.e_object() {
-                        let ptr = obj.as_ptr();
-                        let meta = self.meta_of(ptr as usize);
+                        let meta = self.meta_of(obj);
                         if last {
                             if is_aot {
                                 return Err(self.scanner.err_keyed(
@@ -1554,13 +1552,13 @@ impl<'a, 'log> Parser<'a, 'log> {
                             match meta.kind {
                                 Kind::HeaderImplicit => {
                                     self.meta.insert(
-                                        ptr as usize,
+                                        meta_key(obj),
                                         Meta {
                                             kind: Kind::Header,
                                             block: self.block,
                                         },
                                     );
-                                    cur = ptr;
+                                    cur = obj;
                                 }
                                 Kind::Inline => {
                                     return Err(self.scanner.err_keyed(
@@ -1588,11 +1586,10 @@ impl<'a, 'log> Parser<'a, 'log> {
                                     "",
                                 ));
                             }
-                            cur = ptr;
+                            cur = obj;
                         }
                     } else if let Some(arr) = found.data.e_array() {
-                        let ptr = arr.as_ptr();
-                        let meta = self.meta_of(ptr as usize);
+                        let meta = self.meta_of(arr);
                         if meta.kind != Kind::AotArray {
                             return Err(self.scanner.err_keyed(
                                 header_pos,
@@ -1610,18 +1607,11 @@ impl<'a, 'log> Parser<'a, 'log> {
                                     " as a table",
                                 ));
                             }
-                            cur = self.append_aot_elem(ptr, seg.pos)?;
+                            cur = self.append_aot_elem(arr, seg.pos)?;
                         } else {
                             // Descend into the most recent element.
-                            // SAFETY: AoT arrays only ever contain E::Object
-                            // elements appended by `append_aot_elem`.
-                            let items = unsafe { (*ptr).items.as_slice() };
-                            let last_elem = items.last().expect("AoT arrays are never empty");
-                            cur = last_elem
-                                .data
-                                .e_object()
-                                .expect("AoT elements are tables")
-                                .as_ptr();
+                            let last_elem = arr.items.last().expect("AoT arrays are never empty");
+                            cur = last_elem.data.e_object().expect("AoT elements are tables");
                         }
                     } else {
                         return Err(self.scanner.err_keyed(
@@ -1643,7 +1633,7 @@ impl<'a, 'log> Parser<'a, 'log> {
 
     /// The rest of `key = value` (including dotted keys) after the first key
     /// segment, inserted into `table`.
-    fn parse_keyval(&mut self, table: *mut E::Object, first: KeySeg<'a>) -> PResult<()> {
+    fn parse_keyval(&mut self, table: StoreRef<E::Object>, first: KeySeg<'a>) -> PResult<()> {
         let mut path: ArenaVec<'a, KeySeg<'a>> = ArenaVec::with_capacity_in(0, self.bump);
         path.push(first);
         loop {
@@ -1661,15 +1651,13 @@ impl<'a, 'log> Parser<'a, 'log> {
     /// and inserts `value` at the final segment.
     fn assign_path(
         &mut self,
-        table: *mut E::Object,
+        table: StoreRef<E::Object>,
         path: &[KeySeg<'a>],
         value: Expr,
     ) -> PResult<()> {
         let mut cur = table;
         for seg in &path[..path.len() - 1] {
-            // SAFETY: `cur` points at a live E::Object in the AST store.
-            let cur_obj: &mut E::Object = unsafe { &mut *cur };
-            match cur_obj.as_property(seg.text).map(|q| q.expr) {
+            match cur.as_property(seg.text).map(|q| q.expr) {
                 None => {
                     let (expr, ptr) = self.new_table(seg.pos, Kind::Dotted);
                     self.insert_key(cur, *seg, expr)?;
@@ -1684,8 +1672,7 @@ impl<'a, 'log> Parser<'a, 'log> {
                             "",
                         ));
                     };
-                    let ptr = obj.as_ptr();
-                    let meta = self.meta_of(ptr as usize);
+                    let meta = self.meta_of(obj);
                     let extendable = meta.kind == Kind::Dotted && meta.block == self.block;
                     if !extendable {
                         return Err(self.scanner.err_keyed(
@@ -1695,7 +1682,7 @@ impl<'a, 'log> Parser<'a, 'log> {
                             " with a dotted key",
                         ));
                     }
-                    cur = ptr;
+                    cur = obj;
                 }
             }
         }
@@ -1730,7 +1717,7 @@ impl<'a, 'log> Parser<'a, 'log> {
 
     /// The rest of `[ ... ]` after the opening bracket.
     fn parse_array(&mut self, pos: usize) -> PResult<Expr> {
-        let (array, ptr) = self.new_array(pos, Kind::StaticArray);
+        let (array, mut ptr) = self.new_array(pos, Kind::StaticArray);
 
         loop {
             match self.scanner.scan_array_item()? {
@@ -1740,8 +1727,7 @@ impl<'a, 'log> Parser<'a, 'log> {
                 }
                 ArrayItem::Value(token) => {
                     let value = self.parse_value(token)?;
-                    // SAFETY: `ptr` points at the E::Array constructed above.
-                    unsafe { (*ptr).push(self.bump, value)? };
+                    ptr.push(self.bump, value)?;
                 }
             }
             match self
@@ -1789,7 +1775,7 @@ impl<'a, 'log> Parser<'a, 'log> {
 
         // Inline tables are closed: nothing may extend them later.
         self.meta.insert(
-            ptr as usize,
+            meta_key(ptr),
             Meta {
                 kind: Kind::Inline,
                 block: self.block,
@@ -1801,15 +1787,11 @@ impl<'a, 'log> Parser<'a, 'log> {
 
     // ── table bookkeeping ──────────────────────────────────────────────────
 
-    fn new_table(&mut self, pos: usize, kind: Kind) -> (Expr, *mut E::Object) {
+    fn new_table(&mut self, pos: usize, kind: Kind) -> (Expr, StoreRef<E::Object>) {
         let expr = Expr::init(E::Object::default(), loc_of(pos));
-        let ptr = expr
-            .data
-            .e_object()
-            .expect("infallible: just constructed")
-            .as_ptr();
+        let ptr = expr.data.e_object().expect("infallible: just constructed");
         self.meta.insert(
-            ptr as usize,
+            meta_key(ptr),
             Meta {
                 kind,
                 block: self.block,
@@ -1818,15 +1800,11 @@ impl<'a, 'log> Parser<'a, 'log> {
         (expr, ptr)
     }
 
-    fn new_array(&mut self, pos: usize, kind: Kind) -> (Expr, *mut E::Array) {
+    fn new_array(&mut self, pos: usize, kind: Kind) -> (Expr, StoreRef<E::Array>) {
         let expr = Expr::init(E::Array::default(), loc_of(pos));
-        let ptr = expr
-            .data
-            .e_array()
-            .expect("infallible: just constructed")
-            .as_ptr();
+        let ptr = expr.data.e_array().expect("infallible: just constructed");
         self.meta.insert(
-            ptr as usize,
+            meta_key(ptr),
             Meta {
                 kind,
                 block: self.block,
@@ -1835,16 +1813,22 @@ impl<'a, 'log> Parser<'a, 'log> {
         (expr, ptr)
     }
 
-    fn append_aot_elem(&mut self, array: *mut E::Array, pos: usize) -> PResult<*mut E::Object> {
+    fn append_aot_elem(
+        &mut self,
+        mut array: StoreRef<E::Array>,
+        pos: usize,
+    ) -> PResult<StoreRef<E::Object>> {
         let (elem, ptr) = self.new_table(pos, Kind::ArrayElem);
-        // SAFETY: `array` points at a live E::Array in the AST store.
-        unsafe { (*array).push(self.bump, elem)? };
+        array.push(self.bump, elem)?;
         Ok(ptr)
     }
 
-    fn insert_key(&mut self, obj: *mut E::Object, seg: KeySeg<'a>, value: Expr) -> PResult<()> {
-        // SAFETY: `obj` points at a live E::Object in the AST store.
-        let obj: &mut E::Object = unsafe { &mut *obj };
+    fn insert_key(
+        &mut self,
+        mut obj: StoreRef<E::Object>,
+        seg: KeySeg<'a>,
+        value: Expr,
+    ) -> PResult<()> {
         // The duplicate check must use the UTF-8 key bytes: `as_property`
         // compares correctly against both 8-bit and UTF-16 stored keys.
         if obj.as_property(seg.text).is_some() {


### PR DESCRIPTION
### Problem
- No user-visible change; one of a series of small type-system hardening PRs, each standing alone.
- The TOML parser walked tables and arrays through raw `*mut` pointers, stripped from handles it already held, and re-derived references in six `unsafe` blocks.
- Pointer validity rested on per-site SAFETY comments saying the store outlives the parse, not on anything the compiler checked.

### Fix
- Keep the `StoreRef` handle the AST already returns and read or mutate nodes through its `Deref` / `DerefMut`. The raw pointers and all six `unsafe` blocks are gone, so the module gains `#![forbid(unsafe_code)]`, as `src/ini/lib.rs` already has.
- The table bookkeeping map stays keyed by address, since object and array nodes share it; a one-line helper derives the key from the handle.
- Behaviour is unchanged: `StoreRef` is an 8-byte `NonNull` newtype whose inlined deref is the same dereference the removed blocks did, the map keys are the same addresses, and no check or branch is added. Diagnostics are untouched.
- Verification: refactor only, no new test. `cargo check` and `cargo clippy` are clean and the existing TOML and bunfig tests pass (821 pass, 0 fail).

### Background
- The TOML parser builds the shared `bun_ast` nodes (`E::Object`, `E::Array`) rather than its own tree: a table is an object, an array of tables is an array of objects.
- Nodes live in an arena store; an `Expr` hands out a `StoreRef<T>`, a handle that derefs to the node in that store, and `as_ptr()` exposes its address.
- TOML reaches one table from several syntaxes (`[a.b]`, `[[a]]`, dotted keys, inline tables) and only some may extend an existing table, so the parser records how each table or array was created in a `meta` map keyed by node address and consults it to reject illegal redefinitions.

<details>
<summary>Original description</summary>

## What

The TOML parser in `src/parsers/toml.rs` obtained every table and array it navigates as a `StoreRef<E::Object>` / `StoreRef<E::Array>` (the handle `Data::e_object()` / `e_array()` already return), immediately stripped it to a raw pointer with `.as_ptr()`, threaded that pointer through `parse_root`, `parse_table_header`, `navigate_header`, `parse_keyval`, `assign_path`, `parse_array`, `parse_inline_table`, `new_table`, `new_array`, `append_aot_elem` and `insert_key`, and re-derived references from it in six `unsafe` blocks. Those parameters, locals and return values now keep the `StoreRef`, and the nodes are read and mutated through its `Deref` / `DerefMut`:

```rust
// before
fn navigate_header(&mut self, root: *mut E::Object, ..) -> PResult<*mut E::Object>
fn new_table(&mut self, pos: usize, kind: Kind) -> (Expr, *mut E::Object)
fn append_aot_elem(&mut self, array: *mut E::Array, pos: usize) -> PResult<*mut E::Object>
// SAFETY: `cur` always points at an E::Object inside the AST store, ..
let cur_obj: &mut E::Object = unsafe { &mut *cur };
let existing = cur_obj.as_property(seg.text).map(|q| q.expr);

// after
fn navigate_header(&mut self, root: StoreRef<E::Object>, ..) -> PResult<StoreRef<E::Object>>
fn new_table(&mut self, pos: usize, kind: Kind) -> (Expr, StoreRef<E::Object>)
fn append_aot_elem(&mut self, mut array: StoreRef<E::Array>, pos: usize) -> PResult<StoreRef<E::Object>>
let existing = cur.as_property(seg.text).map(|q| q.expr);
```

The `meta` map (table / array kind bookkeeping) stays keyed by address because `E::Object` and `E::Array` nodes share it; a one-line `meta_key()` derives the key from the handle at the four insert sites, and `meta_of()` takes the handle directly at its three call sites instead of a pre-cast `usize`. Nine signatures change, the seven `.as_ptr()` strips are gone, all twelve `*mut E::Object` / `*mut E::Array` mentions are gone, and all six `unsafe` blocks in the module (with their SAFETY comments) are removed, so the module now carries `#![forbid(unsafe_code)]`, matching `src/ini/lib.rs`, which already builds its tables from `StoreRef<E::Object>` the same way. The `TOML::parse` entry point and every diagnostic are unchanged.

## Why

"Which arena node does this point at, and is it alive" is now answered by the `StoreRef` type that the rest of the AST uses for exactly this, instead of by per-site SAFETY comments restating that the store outlives the parse; the only remaining pointer arithmetic is the address used as a map key. It is zero-cost: `StoreRef<T>` is an 8-byte `NonNull<T>` newtype whose `#[inline]` `Deref` / `DerefMut` are the same raw dereference the removed `unsafe` blocks performed, the map keys are the same addresses, and no `Option`, check, or branch is introduced (the existing `expect`s on just-constructed nodes are untouched).

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/toml/toml.test.ts test/js/bun/toml/toml-test-suite.test.ts test/cli/install/bun-run-bunfig.test.ts`: 821 pass, 0 fail (3 files).

</details>
