### PR TITLE
serve: don't crash on a bracketed hostname longer than 1024 bytes

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2986,7 +2986,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // on the next access. So: hoist every config read into a local via a
         // short-lived `&*this` BEFORE the call, drop the borrow, call listen,
         // then re-derive fresh for each post-listen field access.
-        let mut host_buff: Vec<u8> = Vec::new();
+
+        // Owns the bracket-stripped copy of an IPv6 literal hostname; `host`
+        // points into it, so it has to outlive the listen calls below.
+        let mut stripped_hostname: Option<bun_core::ZBox> = None;
         // Extract (discriminant, raw payload) and drop the `&*this` borrow at `;`.
         // The raw pointers reference `config.address`'s backing storage,
         // which the trampolines never touch (they only write `listener`/
@@ -3004,11 +3007,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         let bytes = existing.as_bytes();
                         if bytes.len() > 2 && bytes[0] == b'[' {
                             // strip "[" and "]" from IPv6 literal
-                            let inner = &bytes[1..bytes.len() - 1];
-                            host_buff.reserve_exact(inner.len() + 1);
-                            host_buff.extend_from_slice(inner);
-                            host_buff.push(0);
-                            host = host_buff.as_ptr().cast::<c_char>();
+                            host = stripped_hostname
+                                .insert(bun_core::ZBox::from_bytes(&bytes[1..bytes.len() - 1]))
+                                .as_ptr();
                         } else {
                             host = existing.as_ptr();
                         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2986,7 +2986,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // on the next access. So: hoist every config read into a local via a
         // short-lived `&*this` BEFORE the call, drop the borrow, call listen,
         // then re-derive fresh for each post-listen field access.
-        let mut host_buff = [0u8; 1025];
+        let mut host_buff: Vec<u8> = Vec::new();
         // Extract (discriminant, raw payload) and drop the `&*this` borrow at `;`.
         // The raw pointers reference `config.address`'s backing storage,
         // which the trampolines never touch (they only write `listener`/
@@ -3005,8 +3005,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         if bytes.len() > 2 && bytes[0] == b'[' {
                             // strip "[" and "]" from IPv6 literal
                             let inner = &bytes[1..bytes.len() - 1];
-                            host_buff[..inner.len()].copy_from_slice(inner);
-                            host_buff[inner.len()] = 0;
+                            host_buff.reserve_exact(inner.len() + 1);
+                            host_buff.extend_from_slice(inner);
+                            host_buff.push(0);
                             host = host_buff.as_ptr().cast::<c_char>();
                         } else {
                             host = existing.as_ptr();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2330,28 +2330,6 @@ it("#5859 arrayBuffer", async () => {
   expect(async () => await Bun.file(tmp).json()).toThrow();
 });
 
-it("a bracketed hostname longer than 1024 bytes throws instead of crashing", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `try {
-        const server = Bun.serve({ hostname: "[" + "a".repeat(1100) + "]", port: 0, fetch: () => new Response("x") });
-        server.stop(true);
-        console.log("listening");
-      } catch (e) {
-        console.log("threw");
-      }`,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout.trim()).toBe("threw");
-  expect(exitCode).toBe(0);
-});
-
 describe("server.requestIP", () => {
   it.if(isIPv4())("v4", async () => {
     using server = Bun.serve({
@@ -3181,6 +3159,40 @@ it("Bun.serve hostname with interior NUL byte does not crash the process", async
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
     stdout: expect.stringMatching(/^(listening:\d+|caught:\w+)$/),
     stderr: expect.any(String),
+    exitCode: 0,
+  });
+});
+
+// A "[...]" hostname has its brackets stripped before it is handed to the socket layer.
+// That copy used to live in a fixed 1024-byte buffer, so a longer bracketed hostname
+// aborted the process instead of failing to listen like any other bogus hostname.
+it("Bun.serve with a bracketed hostname longer than 1024 bytes throws instead of crashing", async () => {
+  const script = `
+    const hostname = "[" + Buffer.alloc(1100, "a").toString() + "]";
+    let server;
+    try {
+      server = Bun.serve({ port: 0, hostname, fetch() { return new Response("ok"); } });
+    } catch (e) {
+      console.log("caught:" + (e instanceof Error));
+    }
+    if (server) {
+      console.log("listening:" + server.port);
+      server.stop(true);
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "caught:true",
+    stderr: "",
     exitCode: 0,
   });
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2330,6 +2330,28 @@ it("#5859 arrayBuffer", async () => {
   expect(async () => await Bun.file(tmp).json()).toThrow();
 });
 
+it("a bracketed hostname longer than 1024 bytes throws instead of crashing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `try {
+        const server = Bun.serve({ hostname: "[" + "a".repeat(1100) + "]", port: 0, fetch: () => new Response("x") });
+        server.stop(true);
+        console.log("listening");
+      } catch (e) {
+        console.log("threw");
+      }`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("threw");
+  expect(exitCode).toBe(0);
+});
+
 describe("server.requestIP", () => {
   it.if(isIPv4())("v4", async () => {
     using server = Bun.serve({


### PR DESCRIPTION
### What does this PR do?

`NewServer::listen` strips the `[`/`]` off an IPv6-literal `hostname` by copying the inner bytes into a `[0u8; 1025]` stack buffer, and `Bun.serve`'s option parsing puts no length bound on `hostname`. So

```js
Bun.serve({ hostname: "[" + "a".repeat(1100) + "]", port: 0, fetch() {} })
```

indexed past the buffer and took the process down with `panic: range end index 1100 out of range for slice of length 1025` instead of throwing. The stripped copy is now a heap-allocated `ZBox` (the same type the config stores the hostname in) held in a local that lives to the end of `listen`, same as the array did, so an over-long name just fails to resolve and `Bun.serve` throws like any other unbindable address.

### How did you verify your code works?

New test in `test/js/bun/http/serve.test.ts` (next to the existing interior-NUL hostname test) spawns the snippet above and asserts stdout, stderr and exit code together: the child must catch an `Error` and exit 0. Against the current release the child aborts and the assertion diff shows the panic above; it passes with this change via `bun bd test test/js/bun/http/serve.test.ts -t "bracketed hostname"`. The existing `allows listen on IPV6` test in `bun-server.test.ts` (`hostname: "[::1]"`) covers the bracket-stripping path still binding.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->