### PR TITLE
bun_jsc: hold a non-optional Strong in JsRef::Strong

### DIFF
--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -1,9 +1,6 @@
 use core::marker::PhantomData;
 
-// The methods used below (`get() -> Option`, `has()`, `try_swap()`) live on
-// the Optional wrapper, so import it under the local name `Strong`.
-use crate::strong::Optional as Strong;
-use crate::{JSGlobalObject, JSValue};
+use crate::{JSGlobalObject, JSValue, Strong};
 
 /// Holds a reference to a JSValue with lifecycle management.
 ///
@@ -65,8 +62,9 @@ use crate::{JSGlobalObject, JSValue};
 ///   The JSValue may become invalid if the object is collected.
 ///   Use `try_get()` to safely check if the value is still alive.
 ///
-/// - **Strong**: Holds a Strong reference that prevents garbage collection.
-///   The JavaScript object will stay alive as long as this reference exists.
+/// - **Strong**: Holds a [`Strong`] reference that prevents garbage collection.
+///   The JavaScript object will stay alive as long as this reference exists, and a
+///   `Strong` always holds a value, so this state is never empty (`try_get()` is `Some`).
 ///   Released by dropping/overwriting the `JsRef`, or by `finalize()`.
 ///
 /// - **Finalized**: The reference has been finalized (object was GC'd or explicitly cleaned up).
@@ -133,7 +131,7 @@ impl JsRef {
                     Some(*weak)
                 }
             }
-            JsRef::Strong(strong) => strong.get(),
+            JsRef::Strong(strong) => Some(strong.get()),
             JsRef::Finalized => None,
         }
     }
@@ -188,7 +186,7 @@ impl JsRef {
         match self {
             JsRef::Weak(_) => {}
             JsRef::Strong(strong) => {
-                let value = strong.try_swap().unwrap_or(JSValue::UNDEFINED);
+                let value = strong.get();
                 value.ensure_still_alive();
                 // The old `Strong` is dropped by the assignment below; the
                 // `strong` borrow ends at its last use above, permitting
@@ -202,7 +200,7 @@ impl JsRef {
     pub fn is_empty(&self) -> bool {
         match self {
             JsRef::Weak(weak) => weak.is_empty_or_undefined_or_null(),
-            JsRef::Strong(strong) => !strong.has(),
+            JsRef::Strong(_) => false,
             JsRef::Finalized => true,
         }
     }
@@ -210,7 +208,7 @@ impl JsRef {
     pub fn is_not_empty(&self) -> bool {
         match self {
             JsRef::Weak(weak) => !weak.is_empty_or_undefined_or_null(),
-            JsRef::Strong(strong) => strong.has(),
+            JsRef::Strong(_) => true,
             JsRef::Finalized => false,
         }
     }
@@ -234,7 +232,7 @@ impl JsRef {
                 *weak = value;
             }
             JsRef::Strong(strong) => {
-                if strong.get() != Some(value) {
+                if strong.get() != value {
                     strong.set(global, value);
                 }
             }


### PR DESCRIPTION
## What

`JsRef::Strong` in `src/jsc/JSRef.rs` held a `strong::Optional` (imported under the local name `Strong`): a handle that may be null, or non-null with an empty slot. Every constructor (`init_strong`, `set_strong`, `upgrade`) built it from a value, and nothing cleared it in place (the only clear was the `try_swap()` in `downgrade`, immediately followed by overwriting `*self`), so the empty states were never reachable but every reader still had to handle them. The payload is now `crate::Strong`, which always holds a value.

```rust
// before
use crate::strong::Optional as Strong;
JsRef::Strong(strong) => strong.get(),                      // try_get: Option from a nullable handle
JsRef::Strong(strong) => !strong.has(),                     // is_empty
let value = strong.try_swap().unwrap_or(JSValue::UNDEFINED); // downgrade
if strong.get() != Some(value) { strong.set(global, value) } // update

// after
use crate::{JSGlobalObject, JSValue, Strong};
JsRef::Strong(strong) => Some(strong.get()),
JsRef::Strong(_) => false,
let value = strong.get();
if strong.get() != value { strong.set(global, value) }
```

`init_strong`, `set_strong` and `upgrade` are textually unchanged and now resolve to `Strong::create` / `Strong::set`. `downgrade` reads the value and lets the old `Strong`'s `Drop` release the slot; `Bun__StrongRef__delete` clears the slot itself, so the separate in-place clear was redundant. No code outside this file names the `Strong` or `Weak` payloads (all 38 files using `JsRef` go through its methods), so no call sites change. Single file, 9 insertions, 11 deletions.

## Why

A `JsRef` in the `Strong` state can no longer represent "strong but holding nothing"; the three states a reader has to consider are exactly the three enum variants, and `try_get()` on the `Strong` arm is `Some` by type rather than by convention. It is zero-cost: `NonNull<Impl>` and `Option<NonNull<Impl>>` are both one pointer wide, so `JsRef` keeps its layout; the change removes a null check and an empty-slot check from `try_get` / `is_empty` / `is_not_empty` / `update` and one redundant slot store from `downgrade`, and the same two FFI calls (`Bun__StrongRef__new`, `Bun__StrongRef__delete`) happen at the same points as before.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/net/socket-retention.test.ts test/js/bun/spawn/spawn-unread-stdout-gc.test.ts test/js/bun/spawn/spawn-ipc-gc.test.ts test/js/bun/udp/udp_socket.test.ts`: 214 pass, 0 fail across 4 files.
