### PR TITLE
Bun.serve(http3): reject malformed request fields with 400

### DIFF
--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -35,6 +35,12 @@ struct Http3Context {
             rd->reset();
 
             Http3Request req(s);
+            /* Same layer at which HttpParser 400s a malformed HTTP/1 header
+             * block, so static and file routes are covered too. */
+            if (req.isMalformed()) {
+                res->writeStatus("400 Bad Request")->end();
+                return;
+            }
             if (req.getHeader("expect") == "100-continue") res->writeContinue();
             cd->router.getUserData() = {res, &req};
             if (!cd->router.route(req.getMethod(), req.getUrl())) {

--- a/packages/bun-uws/src/Http3Request.h
+++ b/packages/bun-uws/src/Http3Request.h
@@ -21,6 +21,7 @@ struct Http3Request {
             const us_quic_header_t *h = us_quic_stream_header(s, i);
             std::string_view name{h->name, h->name_len};
             std::string_view value{h->value, h->value_len};
+            if (isMalformedField(name, value)) malformed = true;
             if (name == ":method") {
                 method = value;
             } else if (name == ":path") {
@@ -42,6 +43,8 @@ struct Http3Request {
             }
         }
     }
+
+    bool isMalformed() { return malformed; }
 
     bool isAncient() { return false; }
     bool getYield() { return yield; }
@@ -103,6 +106,37 @@ struct Http3Request {
     }
 
 private:
+    /* RFC 9110 tchar minus uppercase; RFC 9114 §4.2 makes a message with an
+     * uppercase field name malformed. */
+    static bool isLowercaseTokenByte(unsigned char c) {
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') return true;
+        switch (c) {
+            case '!': case '#': case '$': case '%': case '&': case '\'': case '*':
+            case '+': case '.': case '^': case '_': case '`': case '|': case '~':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /* RFC 9114 §4.1.2 / §4.2, the same rules the HTTP/2 and HTTP/3 clients
+     * apply to response fields (is_malformed_response_field / _value). QPACK
+     * is length-prefixed, so nothing below this layer rejects a CR, LF or NUL
+     * the way HttpParser does for HTTP/1; whatever passes here is what
+     * Request.headers hands back to be re-serialized by fetch() et al. */
+    static bool isMalformedField(std::string_view name, std::string_view value) {
+        std::string_view token = name;
+        if (!token.empty() && token[0] == ':') token.remove_prefix(1);
+        if (token.empty()) return true;
+        for (unsigned char c : token) {
+            if (!isLowercaseTokenByte(c)) return true;
+        }
+        if (value.find_first_of(std::string_view{"\0\r\n", 3}) != std::string_view::npos) return true;
+        /* Connection-specific fields have no meaning outside HTTP/1 (§4.2). */
+        return name == "connection" || name == "keep-alive" || name == "proxy-connection"
+            || name == "transfer-encoding" || name == "upgrade";
+    }
+
     static bool equalsIgnoreCase(std::string_view a, std::string_view b) {
         if (a.size() != b.size()) return false;
         for (size_t i = 0; i < a.size(); i++) {
@@ -116,6 +150,7 @@ private:
     std::pair<int, std::string_view *> params{-1, nullptr};
     char methodLower[32];
     bool yield = false;
+    bool malformed = false;
 };
 
 }

--- a/packages/bun-uws/src/Http3Request.h
+++ b/packages/bun-uws/src/Http3Request.h
@@ -131,7 +131,9 @@ private:
         for (unsigned char c : token) {
             if (!isLowercaseTokenByte(c)) return true;
         }
-        if (value.find_first_of(std::string_view{"\0\r\n", 3}) != std::string_view::npos) return true;
+        for (unsigned char c : value) {
+            if (c == '\0' || c == '\r' || c == '\n') return true;
+        }
         /* Connection-specific fields have no meaning outside HTTP/1 (§4.2). */
         return name == "connection" || name == "keep-alive" || name == "proxy-connection"
             || name == "transfer-encoding" || name == "upgrade";

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3120,15 +3120,6 @@ where
         //
         // We first validate the self-reported request body length so that
         // we avoid needing to worry as much about what memory to free.
-        // RFC 9114 §4.2: an HTTP/3 message containing a transfer-encoding
-        // header field is malformed.
-        if Ctx::IS_H3 {
-            if ReqLike::header(req, b"transfer-encoding").is_some() {
-                RespLike::write_status(resp, b"400 Bad Request");
-                RespLike::end_without_body(resp, false);
-                return None;
-            }
-        }
 
         // Resolve once, reuse for both `has_request_body()` and the forward to
         // `Ctx::create`.

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash, randomBytes } from "crypto";
 import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
+import { connect } from "node:quic";
 import { join } from "path";
 
 // Native HTTP/3 fetch wrapper. Every request in this file forces
@@ -1269,10 +1270,11 @@ describe("Bun.serve HTTP/3 production", () => {
     });
   });
 
-  // RFC 9114 §4.2 forbids Transfer-Encoding; the server rejects it with 400
-  // (server.zig prepareJsRequestContextFor). Not testable via the native
-  // client either — `isConnectionSpecific()` strips the header before
-  // encoding — so the check is defense-in-depth against raw QUIC clients.
+  // Malformed request fields (RFC 9114 §4.1.2 / §4.2) get a 400 from
+  // Http3Context before routing; see "Bun.serve HTTP/3 malformed request
+  // fields" below. Only the CR/LF value rule is exercised there: neither
+  // in-tree client will put Transfer-Encoding, a non-token name or a NUL on
+  // the wire.
 
   // I: server.upgrade() returns false over H3 instead of crashing, and the
   // handler can still send a normal response.
@@ -1300,4 +1302,87 @@ describe("Bun.serve HTTP/3 production", () => {
   // Expect: 100-continue is handled at the uWS layer for both transports
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
+});
+
+// QPACK is length-prefixed, so a request field can carry bytes the HTTP/1
+// parser could never deliver. The native client refuses to send them, so
+// these drive the server with node:quic, the way a hostile peer would.
+describe("Bun.serve HTTP/3 malformed request fields", () => {
+  function serveRecordingHeaders(seen: Record<string, string>[]) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls,
+      http3: true,
+      routes: {
+        "/static": new Response("static"),
+      },
+      fetch(req) {
+        seen.push(Object.fromEntries(req.headers));
+        return new Response("handled");
+      },
+    });
+  }
+
+  async function rawH3(port: number, headers: Record<string, string>) {
+    const client = await connect(
+      { address: "127.0.0.1", port, family: "ipv4" },
+      { servername: "localhost", verifyPeer: "manual" },
+    );
+    try {
+      await client.opened;
+      const status = Promise.withResolvers<string | undefined>();
+      const stream = await client.createBidirectionalStream({
+        headers: { ":method": "GET", ":scheme": "https", ":path": "/", ":authority": "localhost", ...headers },
+        onheaders(received: Record<string, string>) {
+          status.resolve(received[":status"]);
+        },
+      });
+      const chunks: Uint8Array[] = [];
+      for await (const batch of stream) chunks.push(...batch);
+      // FIN arrived, so the response headers (if any) were delivered already.
+      stream.closed.then(
+        () => status.resolve(undefined),
+        () => status.resolve(undefined),
+      );
+      return { status: await status.promise, body: Buffer.concat(chunks).toString() };
+    } finally {
+      await client.close();
+    }
+  }
+
+  // RFC 9114 §4.1.2. Before this was enforced the value reached
+  // req.headers verbatim, and anything that re-serializes those headers over
+  // HTTP/1 (fetch(upstream, { headers: req.headers }) in a proxy, for one)
+  // would emit the injected line.
+  test.each([
+    ["x-forwarded-for", "1.2.3.4\r\nx-injected: 1"],
+    ["x-forwarded-for", "1.2.3.4\nx-injected: 1"],
+    ["x-forwarded-for", "1.2.3.4\r"],
+    // Surfaces as the synthesized `host` header.
+    [":authority", "localhost\r\nx-injected: 1"],
+  ])("a request whose %s field contains CR or LF is rejected with 400 before routing", async (name, value) => {
+    const seen: Record<string, string>[] = [];
+    using server = serveRecordingHeaders(seen);
+    const res = await rawH3(server.port, { [name]: value });
+    expect(res).toEqual({ status: "400", body: "" });
+    expect(seen).toEqual([]);
+  });
+
+  test("a malformed field is rejected before a declared route is matched", async () => {
+    const seen: Record<string, string>[] = [];
+    using server = serveRecordingHeaders(seen);
+    const res = await rawH3(server.port, { ":path": "/static", "x-forwarded-for": "1.2.3.4\r\nx-injected: 1" });
+    expect(res).toEqual({ status: "400", body: "" });
+  });
+
+  // Only NUL/CR/LF are out; the rest of the value is opaque, so an HTAB,
+  // embedded spaces and an empty value still reach the handler.
+  test("values without CR, LF or NUL are delivered unchanged", async () => {
+    const seen: Record<string, string>[] = [];
+    using server = serveRecordingHeaders(seen);
+    const res = await rawH3(server.port, { "x-tab": "a\tb c", "x-empty": "" });
+    expect(res).toEqual({ status: "200", body: "handled" });
+    expect(seen).toEqual([expect.objectContaining({ host: "localhost", "x-tab": "a\tb c", "x-empty": "" })]);
+  });
 });


### PR DESCRIPTION
### Problem
- `Bun.serve({ http3: true })` hands the handler a request header whose value contains CR, LF or NUL. On 1.4.0 a `node:quic` client sending `x-forwarded-for: 1.2.3.4\r\nx-injected: 1` gets `200` and the handler sees the raw value.
- Cause: the HTTP/3 server builds `Request.headers` straight from the decoded QPACK block, and nothing below that layer rejects such bytes; the HTTP/1 parser answers 400.
- Nothing re-validates a `Headers` object later, so a handler that proxies with `fetch(upstream, { headers: req.headers })` re-emits the injected line over HTTP/1.
- Bun's HTTP/3 client already rejects the same fields in responses; the server had no equivalent.

### Fix
- The pass that already walks the field block for pseudo-headers now flags the request malformed if a name is empty or not a lowercase token, a value contains NUL, CR or LF, or the field is an HTTP/1 connection header (`connection`, `keep-alive`, `proxy-connection`, `transfer-encoding`, `upgrade`). `:authority` is checked too since it becomes `host`.
- A flagged request gets `400` before routing, the point where HTTP/1 rejects its equivalents, so static and file routes are covered as well as `fetch()`. The older `transfer-encoding` check on the JS handler path is removed as subsumed.
- Well-formed traffic is unaffected: browsers, curl and Bun's own client never send these shapes over HTTP/3, and nghttp3-based servers reject them the same way.
- Verification: `node:quic` tests for CR or LF in a value, in `:authority`, and against a static route get `400` (five cases that return `200` without the fix), plus a control showing HTAB, spaces and an empty value still get through. `node:quic` cannot send a non-token name, a NUL or a connection header, so those rules are covered only by reading the predicate.

### Background
- HTTP/3 headers travel as a QPACK block of length-prefixed byte strings, so CR, LF, NUL or an uppercase name are representable on the wire; the HTTP/1 text parser can never deliver them.
- RFC 9114 sections 4.1.2 and 4.2 call a request malformed if a field name is not a lowercase token, a value contains NUL, CR or LF, or it carries an HTTP/1 connection-specific header.
- Bun's HTTP/3 server is the vendored uWebSockets in `packages/bun-uws`; it builds and routes the request before any Rust or JS code sees it, which is why the check lives there.
- Pseudo-headers (`:method`, `:path`, `:authority`) replace the HTTP/1 request line; the handler sees `:authority` as `host`.
- Bun's own HTTP/3 client refuses to send these fields, so the tests use Node's experimental `node:quic` API to put them on the wire.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.0 (69bfd40d6)

test/js/bun/http/serve-http3.test.ts:
(node:93154) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [1681.17ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1759.39ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1673.61ms]
(pass) Bun.serve HTTP/3 > query string is preserved [1711.32ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1735.81ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1683.01ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1653.24ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1803.19ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2524.92ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Co
... (truncated)

release without fix: 5 failed, 1 skipped
bun test v1.4.0-canary.1 (6255b16f2)

test/js/bun/http/serve-http3.test.ts:
(node:93873) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [142.48ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [161.11ms]
(pass) Bun.serve HTTP/3 > 204 with no body [161.48ms]
(pass) Bun.serve HTTP/3 > query string is preserved [144.14ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [147.41ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [144.10ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [157.63ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [143.18ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [1038.67ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without Content-Length [138.15ms]
(pass) Bun.serve HTTP/3 > unknown route returns 404 [139.92ms]
(pass) Bun.serve HTTP/3 > routes: handler with :params [140.06ms]
(pass) Bun.serve HTTP/3 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/serve-http3.test.ts"
bun test v1.4.0 (69bfd40d6)

test/js/bun/http/serve-http3.test.ts:
(node:103313) ExperimentalWarning: quic is an experimental feature and might change at any time
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) Bun.serve HTTP/3 > basic GET [1660.83ms]
(pass) Bun.serve HTTP/3 > POST echoes body, status, request headers [1826.53ms]
(pass) Bun.serve HTTP/3 > 204 with no body [1814.67ms]
(pass) Bun.serve HTTP/3 > query string is preserved [2014.20ms]
(pass) Bun.serve HTTP/3 > large response body crosses multiple QUIC packets [1657.56ms]
(pass) Bun.serve HTTP/3 > concurrent requests across separate connections [1592.71ms]
(pass) Bun.serve HTTP/3 > client abort mid-response does not crash the server [1618.70ms]
(pass) Bun.serve HTTP/3 > http1: false rejects HTTP/1.1 but accepts HTTP/3 [1577.51ms]
(pass) Bun.serve HTTP/3 > http1: false — url/address/stop see the QUIC listener [2621.34ms]
(pass) Bun.serve HTTP/3 > maxRequestBodySize is enforced for H3 bodies without C
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 937ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/38] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/38] gen cpp.rs (cppbind)
[4/38] gen JS modules (bundle-modules)
Preprocess modules (9440ms)
Bundle modules (94ms)
Postprocesss modules (555ms)
Bundle Functions (1380ms)
Generate Code (36ms)

[11.53s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/31] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/bor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/Http3Context.h  |  6 +++
 packages/bun-uws/src/Http3Request.h  | 37 ++++++++++++++
 src/runtime/server/server_body.rs    |  9 ----
 test/js/bun/http/serve-http3.test.ts | 93 ++++++++++++++++++++++++++++++++++--
 4 files changed, 132 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
packages/bun-uws/src/Http3Context.h       1      2      0
packages/bun-uws/src/Http3Request.h       3      9      0
src/runtime/server/server_body.rs         2      1      0
test/js/bun/http/serve-http3.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`Bun.serve({ http3: true })` builds `Request.headers` from the decoded QPACK block without looking at the bytes (`Http3Request::forEachHeader` into `WebCore__FetchHeaders__createFromH3`, which calls `HTTPHeaderMap::add` directly). QPACK is length-prefixed, so unlike the HTTP/1 path (uWS `HttpParser` answers 400) a field value can contain CR, LF or NUL, and a name can be anything. The value then sits in a `Headers` object that the JS API itself would never have accepted, and every consumer of that object trusts it: `fetch(upstream, { headers: req.headers })` and `fetch(..., { proxy: { headers } })` copy a `Headers` instance straight to the request (`from_fetch_headers` / `copyTo`), and `new Response(body, { headers: req.headers })` copies it into the response (`FetchHeaders::fill(const FetchHeaders&)`), none of them re-validating, so a proxying handler re-emits the injected line over HTTP/1.

Repro with a `node:quic` client against the current release (1.4.0):

```ts
const server = Bun.serve({ port: 0, tls, http3: true, fetch: req => new Response(req.headers.get("x-forwarded-for")) });
const client = await connect({ address: "127.0.0.1", port: server.port }, { servername: "localhost", verifyPeer: "manual" });
await client.createBidirectionalStream({
  headers: { ":method": "GET", ":path": "/", ":scheme": "https", ":authority": "localhost",
             "x-forwarded-for": "1.2.3.4\r\nx-injected: 1" },
  onheaders(h) { console.log(h[":status"]); },   // 200
});
// handler saw: "1.2.3.4\r\nx-injected: 1"
```

The HTTP/3 client side of `fetch()` already rejects the same thing in responses (`is_malformed_response_field` / `is_malformed_response_value`, wired into `h3_client/callbacks.rs`); this is the server side of that.

### Fix

- `packages/bun-uws/src/Http3Request.h`: the constructor already walks every field to pick out the pseudo-headers; it now also applies RFC 9114 4.1.2 / 4.2 to each one, using the same rules as the client helpers: the name (after the pseudo-header colon) must be a non-empty lowercase token, the value must not contain NUL, CR or LF, and `connection`, `keep-alive`, `proxy-connection`, `transfer-encoding` and `upgrade` are not allowed. Pseudo-header values are checked too, since `:authority` is surfaced as the `host` header.
- `packages/bun-uws/src/Http3Context.h`: a malformed request gets `400` before routing, the layer at which `HttpParser` rejects the HTTP/1 equivalents, so static and file routes are covered as well as `fetch()`.
- `src/runtime/server/server_body.rs`: the `transfer-encoding` check in `prepare_js_request_context_for` is subsumed (it only ran for the JS handler path, and treated an empty value as absent), so it is removed.

Behavior change for well-formed traffic: none. Uppercase field names and HTTP/1 connection headers are what RFC 9114 calls malformed; browsers, curl and Bun's own client never send them over HTTP/3, and nghttp3-based servers (Node's HTTP/3) reject them the same way.

#37600 adds a `:path` check to the same spot in `Http3Context.h` and appends a `node:quic`-driven `describe` to the same test file; the two are independent and whichever lands second needs a trivial rebase.

### Tests

`test/js/bun/http/serve-http3.test.ts`, new `describe("Bun.serve HTTP/3 malformed request fields")`, using a `node:quic` client because the native client refuses to send these fields:

- CR LF, bare LF and bare CR in a regular field value, and CR LF in `:authority`: `400`, empty body, handler not invoked
- the same value against a declared static route: `400` (rejected before routing)
- control: HTAB, embedded spaces and an empty value still reach the handler unchanged

The first five fail on the unpatched build (`200`, handler sees the raw value / static route served); all six pass with the fix. `node:quic` cannot put a non-token name, a NUL or a connection-specific header on the wire, so those rules are exercised only by reading the predicate. Also ran `serve-http3.test.ts` (54 pass), `serve-protocols.test.ts`, `fetch-http3-client.test.ts` and `fetch-http3-adversarial.test.ts` (100 pass) on the debug build.

</details>
