### PR TITLE
WebSocket: throw on invalid proxy.headers instead of silently dropping them

### DIFF
--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -237,15 +237,18 @@ static ExceptionOr<std::optional<ProxyConfig>> setupProxy(const String& proxyUrl
         config.authorization = makeString("Basic "_s, encoded);
     }
 
-    // Store proxy headers
+    // Same validation and the same failure as the `headers` option: a name that
+    // is not a token or a value with CR/LF/NUL throws, instead of silently
+    // sending the CONNECT with every proxy header (Proxy-Authorization included)
+    // left out.
     if (proxyHeaders) {
         auto headersOrException = FetchHeaders::create(WTF::move(proxyHeaders));
-        if (!headersOrException.hasException()) {
-            auto hdrs = headersOrException.releaseReturnValue();
-            auto iterator = hdrs.get().createIterator(false);
-            while (auto value = iterator.next()) {
-                config.headers.append({ value->key, value->value });
-            }
+        if (headersOrException.hasException())
+            return headersOrException.releaseException();
+        auto hdrs = headersOrException.releaseReturnValue();
+        auto iterator = hdrs.get().createIterator(false);
+        while (auto value = iterator.next()) {
+            config.headers.append({ value->key, value->value });
         }
     }
 

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -189,6 +189,32 @@ describe("WebSocket proxy API", () => {
     }).toThrow(SyntaxError);
   });
 
+  // Until this threw, one bad entry made the constructor drop the whole
+  // proxy header set (Proxy-Authorization included) and send the CONNECT
+  // without it, while the same object passed as `headers` throws.
+  test.each([
+    ["a value containing CR LF", { "proxy-authorization": "Basic dXNlcjpwYXNz", "x-extra": "a\r\nx-injected: 1" }],
+    ["a value containing NUL", { "proxy-authorization": "Basic dXNlcjpwYXNz", "x-extra": "a\0b" }],
+    ["a name that is not a token", { "proxy-authorization": "Basic dXNlcjpwYXNz", "x extra": "1" }],
+  ])("rejects proxy headers with %s, with the same error as the headers option", (_, headers) => {
+    function errorFrom(options: object) {
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(`ws://127.0.0.1:${wsPort}`, options);
+      } catch (e: any) {
+        return { name: e.name, message: e.message };
+      }
+      ws.close();
+      return "constructed without throwing";
+    }
+    const viaHeadersOption = errorFrom({ headers });
+    expect(viaHeadersOption).toEqual({
+      name: "TypeError",
+      message: expect.stringMatching(/has invalid value|Invalid header name/),
+    });
+    expect(errorFrom({ proxy: { url: `http://127.0.0.1:${proxyPort}`, headers } })).toEqual(viaHeadersOption);
+  });
+
   test.each(["socks5", "socks4", "socks5h", "ftp", "ws", "gopher"])(
     "rejects unsupported proxy protocol %s://",
     scheme => {


### PR DESCRIPTION
### Problem
- `new WebSocket(url, { proxy: { url, headers } })` with one bad entry in `headers` (a value containing CR, LF or NUL, or a name that is not a token) constructs fine, and the proxy receives the CONNECT with none of the proxy headers, `Proxy-Authorization` included.
- The same object passed as the top-level `headers` option throws `TypeError: Header 'x-extra' has invalid value`.
- Cause: the proxy path validated the headers but discarded the failure along with the whole header set, so the only symptom was a later 407 pointing at nothing.
- No header injection was possible; the validation itself did run.

### Fix
- A bad `proxy.headers` entry now throws a synchronous `TypeError` from the constructor, with the same message the `headers` option gives, before any connection is attempted.
- Correct because both options already run the same validation; the change only stops discarding its result, so a proxy header set is either sent whole or rejected up front. Valid proxy headers are unaffected.
- This also covers `proxy.headers` given as a `Headers` instance: its pairs are copied in unchecked and reach this same validation, so invalid ones now throw too.
- Verification: three new tests (CR LF value, NUL value, non-token name) assert the `proxy.headers` error equals the `headers` error. They fail on the unpatched build and pass with the fix; the rest of the file still passes on the debug build.

### Background
- WebSocket proxying: with a `proxy` option, bun first sends the proxy an HTTP `CONNECT host:port` request. `proxy.headers` go on that CONNECT (usually `Proxy-Authorization`); the `headers` option goes on the WebSocket upgrade that follows.
- Header validation: both header sets are built through the same Fetch `Headers` constructor, which rejects non-token names and values containing CR, LF or NUL. On the C++ side it returns either the headers or an exception, and the caller decides whether to propagate the exception.
- 407 is the proxy's "Proxy Authentication Required" reply, which is what a CONNECT without `Proxy-Authorization` gets back.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-proxy.test.ts
bun test v1.4.0 (6255b16f2)

test/js/web/websocket/websocket-proxy.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) WebSocket proxy API > accepts proxy option as string (HTTP proxy) [12.82ms]
(pass) WebSocket proxy API > accepts proxy option as string (HTTPS proxy) [5.77ms]
(pass) WebSocket proxy API > accepts HTTPS proxy with wss:// target [3.60ms]
(pass) WebSocket proxy API > accepts proxy option as object with url [2.86ms]
(pass) WebSocket proxy API > accepts proxy option with headers [3.14ms]
(pass) WebSocket proxy API > accepts proxy option with Headers class instance [3.46ms]
(pass) WebSocket proxy API > accepts proxy URL with credentials [3.48ms]
(pass) WebSocket proxy API > can combine proxy with other options [3.46ms]
(pass) WebSocket proxy API > rejects invalid proxy URL [3.60ms]
210 |     const viaHeadersOption = errorFro
... (truncated)

release without fix: 5 failed, 4 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/js/web/websocket/websocket-proxy.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) WebSocket proxy API > accepts proxy option as string (HTTP proxy) [0.30ms]
(pass) WebSocket proxy API > accepts proxy option as string (HTTPS proxy) [0.17ms]
(pass) WebSocket proxy API > accepts HTTPS proxy with wss:// target [0.10ms]
(pass) WebSocket proxy API > accepts proxy option as object with url [0.08ms]
(pass) WebSocket proxy API > accepts proxy option with headers [0.09ms]
(pass) WebSocket proxy API > accepts proxy option with Headers class instance [0.09ms]
(pass) WebSocket proxy API > accepts proxy URL with credentials [0.07ms]
(pass) WebSocket proxy API > can combine proxy with other options [0.10ms]
(pass) WebSocket proxy API > rejects invalid proxy URL [0.09ms]
210 |     const viaHeadersOption = errorFrom({ headers });
211 |     expect(viaHeadersOption).toEqual({
212 |       name: "TypeError",
213 |       message: expect.stringMatching(/has invalid value|Invalid header na
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-proxy.test.ts
bun test v1.4.0 (6255b16f2)

test/js/web/websocket/websocket-proxy.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) WebSocket proxy API > accepts proxy option as string (HTTP proxy) [18.36ms]
(pass) WebSocket proxy API > accepts proxy option as string (HTTPS proxy) [6.25ms]
(pass) WebSocket proxy API > accepts HTTPS proxy with wss:// target [4.08ms]
(pass) WebSocket proxy API > accepts proxy option as object with url [3.32ms]
(pass) WebSocket proxy API > accepts proxy option with headers [4.13ms]
(pass) WebSocket proxy API > accepts proxy option with Headers class instance [5.01ms]
(pass) WebSocket proxy API > accepts proxy URL with credentials [4.11ms]
(pass) WebSocket proxy API > can combine proxy with other options [3.87ms]
(pass) WebSocket proxy API > rejects invalid proxy URL [4.23ms]
(pass) WebSocket proxy API > rejects proxy 
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1037ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (9459ms)
Bundle modules (59ms)
Postprocesss modules (460ms)
Bundle Functions (1209ms)
Generate Code (63ms)

[11.27s] Bundled "src/js" for production
  2610 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/21] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/WebSocket.cpp        | 17 ++++++++++-------
 test/js/web/websocket/websocket-proxy.test.ts | 26 ++++++++++++++++++++++++++
 2 files changed, 36 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/jsc/bindings/webcore/WebSocket.cpp             2      1      0
test/js/web/websocket/websocket-proxy.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`new WebSocket(url, { proxy: { url, headers } })` runs `headers` through `FetchHeaders::create` in `setupProxy` (`WebSocket.cpp`), but discards the result on failure instead of propagating it. One entry with a CR/LF/NUL in its value or a non-token name therefore made the constructor drop the entire proxy header set and send the CONNECT without it. The same object passed as the top-level `headers` option throws.

On the current release, with a fake proxy that prints what it receives:

```ts
const headers = { "proxy-authorization": "Basic abc", "x-extra": "a\r\nx-injected: 1" };
new WebSocket("ws://example.invalid/", { headers });                     // TypeError: Header 'x-extra' has invalid value
new WebSocket("ws://example.invalid/", { proxy: { url: proxyUrl, headers } }); // no error; proxy receives:
// CONNECT example.invalid:80 HTTP/1.1
// Host: example.invalid:80
// Proxy-Connection: Keep-Alive
//                                  <- no Proxy-Authorization, no x-extra
```

No header injection was possible (the validation did run), but the failure mode was a silent loss of `Proxy-Authorization`, surfacing later as a 407 with nothing pointing at the bad header. This also settles the question raised about the `JSFetchHeaders` fast path in `JSWebSocket.cpp`, which copies a `Headers` instance's pairs into the init without checking them: those pairs go through the same `FetchHeaders::create` here, so with this change anything invalid throws rather than being dropped.

### Fix

`setupProxy` returns the exception, so `proxy.headers` fails the same way `headers` does: a synchronous `TypeError` from the constructor, with the same message, before any connection is attempted. Valid proxy headers are unaffected.

### Tests

`test/js/web/websocket/websocket-proxy.test.ts`, "WebSocket proxy API": for a value containing CR LF, a value containing NUL, and a non-token name, the error thrown for `proxy.headers` must equal the error thrown for `headers` (`TypeError`, `has invalid value` / `Invalid header name`). All three fail on the unpatched build (`proxy.headers` constructs without throwing) and pass with the fix; the rest of the file (36 tests) still passes on the debug build.

</details>
