### PR TITLE
test/docker: make the squid and redis healthchecks prove the port is accepting

### DIFF
--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -152,19 +152,9 @@ test("copy data between databases", async () => {
 });
 ```
 
-### With Health Checks
+### Readiness
 
-```typescript
-test("wait for service to be healthy", async () => {
-  const redis = await dockerCompose.ensure("redis_unified");
-
-  // Optional: Wait for service to be ready
-  await dockerCompose.waitTcp(redis.host, redis.ports[6379], 30000);
-
-  // Now safe to connect
-  const client = new RedisClient(`redis://${redis.host}:${redis.ports[6379]}`);
-});
-```
+`ensure()` resolves once the service's `healthcheck` in `docker-compose.yml` passes (`compose up --wait`), so tests connect immediately after it. That is the only readiness signal there is: a TCP connect from the host to the published port succeeds even while the container is still starting (docker-proxy accepts, then closes the connection when the container refuses), so polling the port from the test proves nothing. Every service therefore needs a healthcheck that connects to its port from inside the container (`pg_isready`, `mysql -e 'SELECT 1'`, `redis-cli -e ping`, a socket connect for squid/autobahn), not one that looks for a process; `test/internal/docker-compose-services.test.ts` checks this.
 
 ## Architecture
 
@@ -300,7 +290,7 @@ A: This tells Docker to pick any available port, preventing conflicts.
 ## Best Practices
 
 1. **Always use dynamic ports**: Set `published: 0` for automatic port assignment
-2. **Use health checks**: Add healthcheck configurations for reliable startup
+2. **Health checks prove the port**: `ensure()` returns as soon as the healthcheck passes, so it must connect to the service (see Readiness above)
 3. **Clean up in tests**: Delete test data after each test (but keep containers running)
 4. **Prefer ensure()**: Always use `dockerCompose.ensure()` instead of assuming services are running
 5. **Handle failures gracefully**: Services might fail to start; handle errors appropriately
@@ -309,7 +299,7 @@ A: This tells Docker to pick any available port, preventing conflicts.
 
 | Problem | Solution |
 |---------|----------|
-| "Connection refused" | Service might still be starting. Add `waitTcp()` or increase timeout |
+| Connection refused or closed right after `ensure()` | The service's healthcheck passes before it listens. Fix the healthcheck in `docker-compose.yml` (see Readiness above) |
 | "Port already in use" | Another service using the port. Use dynamic ports (`published: 0`) |
 | "Container not found" | Run `docker-compose up -d SERVICE_NAME` manually |
 | Tests suddenly slow | Containers might have been stopped. Check with `docker-compose ps` |
@@ -321,7 +311,7 @@ To add a new service:
 
 1. Add service definition to `docker-compose.yml`
 2. Use dynamic ports unless specific port required
-3. Add health check if possible
+3. Add a healthcheck that connects to the service's port (required, see Readiness above)
 4. Document in this README
 5. Add example test
 6. Submit PR

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -162,6 +162,16 @@ services:
         protocol: tcp
     tmpfs:
       - /data
+    healthcheck:
+      # Without a healthcheck `up --wait` returns as soon as the container is
+      # running, i.e. before redis-server has bound its ports (same window as
+      # squid below, just shorter). ensure() callers connect immediately.
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+      start_interval: 1s
 
   redis_unified:
     build:
@@ -180,6 +190,15 @@ services:
     volumes:
       - redis-unix:/tmp/redis
       - redis-data:/data
+    healthcheck:
+      # redis-server binds 6379 and the 6380 TLS port in the same step, so a
+      # plain ping covers both listeners.
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+      start_interval: 1s
 
   # MinIO (S3) Service
   minio:
@@ -247,7 +266,12 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD-SHELL", "pgrep squid > /dev/null"]
+      # Prove 3128 is accepting, not merely that a squid process exists: the
+      # image's entrypoint runs `squid -Nz` (cache init) before the real server,
+      # which binds last, so `pgrep squid` went healthy before anything listened
+      # and ensure() callers hit docker-proxy's accept-then-close ("Connection
+      # ended"). The image has no nc/curl and /bin/sh is dash, hence bash /dev/tcp.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/3128"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       # Without a healthcheck `up --wait` returns as soon as the container is
       # running, i.e. before redis-server has bound its ports (same window as
       # squid below, just shorter). ensure() callers connect immediately.
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-e", "ping"]
       interval: 5s
       timeout: 5s
       retries: 30
@@ -192,8 +192,11 @@ services:
       - redis-data:/data
     healthcheck:
       # redis-server binds 6379 and the 6380 TLS port in the same step, so a
-      # plain ping covers both listeners.
-      test: ["CMD", "redis-cli", "ping"]
+      # plain ping covers both listeners. -e: /data is a volume with appendonly
+      # on and the ports are bound before the AOF is replayed; without -e
+      # redis-cli exits 0 on the -LOADING error reply and the replay window
+      # would count as healthy.
+      test: ["CMD", "redis-cli", "-e", "ping"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -278,28 +278,6 @@ class DockerComposeHelper {
     return process.env.BUN_DOCKER_TEST_HOST || "127.0.0.1";
   }
 
-  async waitForPort(port: number, timeout: number = 10000): Promise<void> {
-    const deadline = Date.now() + timeout;
-    while (Date.now() < deadline) {
-      try {
-        const socket = new net.Socket();
-        await new Promise<void>((resolve, reject) => {
-          socket.once("connect", () => {
-            socket.destroy();
-            resolve();
-          });
-          socket.once("error", reject);
-          socket.connect(port, this.testHost);
-        });
-        return;
-      } catch {
-        // Wait 100ms before retrying
-        await new Promise(resolve => setTimeout(resolve, 100));
-      }
-    }
-    throw new Error(`Port ${port} did not become ready within ${timeout}ms`);
-  }
-
   // Ask the shard's coordinator (test/docker/coordinator.ts, spawned by
   // scripts/runner.node.mjs) to start the service, and wait for its ready
   // message with the port mapping. The coordinator owns every `compose up`
@@ -475,25 +453,6 @@ class DockerComposeHelper {
     this.upPromises.clear();
   }
 
-  async waitTcp(host: string, port: number, timeout = 30000): Promise<void> {
-    const start = Date.now();
-
-    while (Date.now() - start < timeout) {
-      try {
-        const socket = await Bun.connect({
-          hostname: host,
-          port,
-        });
-        socket.end();
-        return;
-      } catch {
-        await Bun.sleep(500);
-      }
-    }
-
-    throw new Error(`TCP connection to ${host}:${port} timed out`);
-  }
-
   /**
    * Pull all Docker images explicitly - useful for CI
    */
@@ -558,10 +517,6 @@ export async function envFor(service: ServiceName): Promise<Record<string, strin
 
 export async function down(): Promise<void> {
   return getHelper().down();
-}
-
-export async function waitTcp(host: string, port: number, timeout?: number): Promise<void> {
-  return getHelper().waitTcp(host, port, timeout);
 }
 
 export async function pullImages(): Promise<void> {

--- a/test/internal/docker-compose-services.test.ts
+++ b/test/internal/docker-compose-services.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { prestartMap } from "../docker/prestart-map.mjs";
+
+// ensure() in test/docker/index.ts is `compose up --wait`, and tests connect as
+// soon as it returns. `--wait` only waits for a service's healthcheck; with none
+// it returns at "running", before the server has bound its port, and a
+// process-existence check (squid used `pgrep squid`; its image runs `squid -Nz`
+// before the real server) passes just as early. Either way the first connection
+// through the published port is accepted by docker-proxy and closed at once.
+
+interface Service {
+  ports?: unknown[];
+  healthcheck?: { test?: string | string[] };
+}
+
+const dockerDir = join(import.meta.dir, "..", "docker");
+const compose = Bun.YAML.parse(readFileSync(join(dockerDir, "docker-compose.yml"), "utf8")) as {
+  services: Record<string, Service>;
+};
+const services = Object.entries(compose.services);
+
+function healthcheckCommand({ healthcheck }: Service): string {
+  const command = healthcheck?.test;
+  return Array.isArray(command) ? command.join(" ") : (command ?? "");
+}
+
+test("docker-compose.yml parses and defines the test services", () => {
+  expect(services.length).toBeGreaterThan(5);
+});
+
+test("every service with published ports declares a healthcheck", () => {
+  const missing = services
+    .filter(([, service]) => service.ports?.length && healthcheckCommand(service).trim() === "")
+    .map(([name]) => name);
+  expect(missing).toEqual([]);
+});
+
+test("healthchecks connect to the service instead of checking for a process", () => {
+  const processChecks = services
+    .filter(([, service]) => /\b(pgrep|pidof|kill -0)\b/.test(healthcheckCommand(service)))
+    .map(([name]) => name);
+  expect(processChecks).toEqual([]);
+});
+
+test("prestart-map.mjs only names services that docker-compose.yml defines", () => {
+  const unknown = Object.entries(prestartMap).flatMap(([prefix, names]) =>
+    names.filter(name => !(name in compose.services)).map(name => `${prefix}: ${name}`),
+  );
+  expect(unknown).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- In [build 92450](https://buildkite.com/bun/bun/builds/92450) the two squid-backed tests in `websocket-proxy.test.ts` failed on two Linux lanes, each in under 3ms, with `WebSocket connection to 'ws://host.docker.internal:37575/' failed: Connection ended`, and passed on retry. The PR under test (#37610) does not touch that path.
- Cause: squid's compose healthcheck was `pgrep squid`. The image runs a `squid -Nz` init pass before the real server, and the server binds 3128 as its last init step, so the container reported healthy before anything listened and `ensure("squid")` returned into that window.
- `redis_plain` and `redis_unified` had no healthcheck at all, so `ensure()` returned once the container was running, before redis bound its ports. Same window, shorter, which is why it shows up less often.
- During the window a connection to the published port is accepted by docker-proxy and closed at once, which is exactly what the tests saw. A PR that edits a container-backed test file lands in the window reliably: the runner schedules that file first, while the service is still being prestarted.

### Fix
- squid's healthcheck now opens a TCP connection to 127.0.0.1:3128 from inside the container (bash `/dev/tcp`, because the image has no `nc` or `curl`). `redis_plain` and `redis_unified` get `redis-cli -e ping`; `-e` makes the `-LOADING` reply that `redis_unified` returns while replaying its AOF count as unhealthy.
- Correct because each check now fails until the port the tests connect to is being served: squid opens its listeners after all other init, and redis binds 6379 and the 6380 TLS port in one step, so one ping covers both. A host-side poll could not replace it, since docker-proxy accepts during the window.
- A new file-only test parses `docker-compose.yml` and fails on any service with published ports that has no healthcheck or uses a process check (`pgrep`, `pidof`, `kill -0`); on main it names exactly the three services above. The README advice to call `waitTcp()` after `ensure()` and the unused `waitTcp`/`waitForPort` helpers are removed.
- Verification: the race cannot be reproduced deterministically, so there is no test that fails without the fix. [Build 92500](https://buildkite.com/bun/bun/builds/92500) on this PR is green, the squid and valkey suites ran against the new checks, and squid startup time on the debian shards did not change (12.8 to 30.2s, against 11.6 to 28.3s with `pgrep`). The bash and redis-cli exit codes were checked by hand.

### Background
- `ensure(name)` is how a bun test asks for a shared service container. It is `docker compose up --wait`, which returns when the service's healthcheck passes, or as soon as the container is running if it has none. Tests connect the moment it returns, so the healthcheck is the only readiness signal.
- A compose healthcheck runs inside the container's own network namespace, so it is the one place a "port is accepting" probe can be made.
- docker-proxy is the host process behind a published port. It accepts the client before dialing the container, so while the container is not yet listening the client sees accept then close (`Connection ended`) rather than a refused connection, and polling the published port from the host looks healthy.
- `redis-cli -e` (redis 7 and later) exits non-zero on an error reply such as `-LOADING`; without it redis-cli exits 0 on any reply and only fails when it cannot connect.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/docker-compose-services.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/docker-compose-services.test.ts
bun test v1.4.0 (60eb4f58e)

test/internal/docker-compose-services.test.ts:
(pass) docker-compose.yml parses and defines the test services [3.79ms]
(pass) every service with published ports declares a healthcheck [8.72ms]
(pass) healthchecks connect to the service instead of checking for a process [7.60ms]
(pass) prestart-map.mjs only names services that docker-compose.yml defines [17.38ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [2.74s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/docker/README.md                         | 20 +++--------
 test/docker/docker-compose.yml                | 29 ++++++++++++++-
 test/docker/index.ts                          | 45 -----------------------
 test/internal/docker-compose-services.test.ts | 52 +++++++++++++++++++++++++++
 4 files changed, 85 insertions(+), 61 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/docker/README.md                              2      4      0
test/docker/docker-compose.yml                     3     10      0
test/docker/index.ts                               1      3      0
test/internal/docker-compose-services.test.ts      0      1      0
```

</details>

**root cause** · written by the author bot

The squid service's healthcheck in test/docker/docker-compose.yml was `pgrep squid`, which reported healthy as soon as the process existed but before it had bound port 3128, so `ensure("squid")` returned and the proxy tests connected while docker-proxy was still accepting and immediately closing connections to the published port, producing the "Connection ended" failures. The fix replaces that check with a bash /dev/tcp probe that only passes once port 3128 actually accepts connections, and the same process-based pattern on the redis_plain and redis_unified services is replaced with `redis-…

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Symptom

In [build 92450](https://buildkite.com/bun/bun/builds/92450) `test/js/web/websocket/websocket-proxy.test.ts` failed on two lanes (debian 13 x64-asan, alpine 3.23 x64) and passed on retry on both. Only the two container-backed tests failed, each in under 3ms, right after the file printed `Squid proxy ready at: 127.0.0.1:<port>`:

```
error: WebSocket connection to 'ws://host.docker.internal:37575/' failed: Connection ended
✗ WebSocket through Squid proxy (Docker) > ws:// through squid proxy to local server [2.66ms]
error: WebSocket connection to 'wss://host.docker.internal:37815/' failed: Connection ended
✗ WebSocket through Squid proxy (Docker) > wss:// through squid proxy to local server [1.26ms]
```

The TCP connection to the published squid port was accepted and closed immediately. The PR under test (#37610) only changes what happens after the CONNECT tunnel's 101 response, and the `ws://` case does not use that path at all, so this was not the code under test.

### Cause

`test/docker/docker-compose.yml` declared the squid healthcheck as `pgrep squid`. The `ubuntu/squid` image's entrypoint runs `squid -Nz` (cache directory init, exits) and only then starts the real server, which parses its config and binds `http_port 3128` as the last step of initialization (squid v5 `src/main.cc`: the PID file is written and `-z` is handled in `SquidMain()` before `mainInitialize()`, and inside `mainInitialize()` the ipcache, redirectors, external ACLs and the store are all set up before `serverConnectionsOpen()` opens the listeners, after which only `neighbors_init()` and event registration remain before the main loop). So there is a process named `squid`, and the container is reported healthy, well before anything listens on 3128. `ensure("squid")` in `test/docker/index.ts` is `compose up --wait`, which returns the moment health flips, and the tests connect right away.

During that window the host side of the published port is docker-proxy: it accepts the client's connection, fails to connect to the container, and closes. That is exactly the accept-then-immediate-close the two tests observed.

Both lanes hit it in the same build because #37610 modified `websocket-proxy.test.ts`, which the runner schedules first in its shard, at the same time the coordinator is prestarting squid for it. The file's `ensure()` therefore resolves at (or within a few hundred ms of) the health flip. Any PR that touches a container-backed test file lands in the same position.

`redis_plain` and `redis_unified` had no healthcheck at all, so for them `--wait` returned at "running", i.e. before `redis-server` bound its ports. Same window, just shorter (redis binds within milliseconds of exec rather than after a second process), which is why it has not shown up as often; `test/js/valkey/test-utils.ts` connects immediately after `ensure()` in the same way.

### Fix

- `squid`: the healthcheck connects to 127.0.0.1:3128 from inside the container (`bash -c 'exec 3<>/dev/tcp/127.0.0.1/3128'`). The image is a stock Ubuntu 22.04 with only the squid package installed (no `nc`, `curl` or `squidclient`), and `/bin/sh` is dash, so `CMD` with bash is used rather than `CMD-SHELL`. bash exits 1 with `connect: Connection refused` while nothing listens and 0 once the port accepts, and sends no bytes. Squid opens its listening sockets after everything else is initialized and then enters its event loop, so a connection that is accepted is served; a TCP-level probe is the same level of check the `autobahn` service already uses.
- `redis_plain`, `redis_unified`: `redis-cli -e ping`, with the same interval/timeout/start_period block as the other services. redis sets up all of its listeners (6379 and the 6380 TLS port) in `initListeners()` before it enters its event loop, so a reply on 6379 covers both. `-e` is needed because redis-cli exits 0 on an error reply without it (redis-cli.c only calls `exit(1)` for error replies when `set_errcode` is set; `-e` exists since 7.0, so it works for `redis:7-alpine` too): `redis_unified` keeps `/data` on a named volume with `appendonly yes`, and redis binds its ports before replaying the AOF, so a container recreated over an existing volume answers `-LOADING` for a while (each replayed `FLUSHALL` from the valkey suite does a synchronous RDB save), and a plain `ping` would have reported that window healthy. Checked locally with redis-cli 8.0.2: PONG exits 0, an error reply exits 1 with `-e` and 0 without, connection refused exits 1 either way.

The other services already prove they are accepting connections (`pg_isready`, `mysql ... -e 'SELECT 1'`, `mc ready`, a python socket connect for autobahn) and are unchanged.

This is the second time this file has had services in this state (autobahn got its healthcheck in #29568 after the same race; redis had none since #22740), so the invariant is now checked: `test/internal/docker-compose-services.test.ts` parses `docker-compose.yml` and asserts that every service with published ports declares a healthcheck, that no healthcheck is a process-existence check (`pgrep`/`pidof`/`kill -0`), and that `prestart-map.mjs` only names services the compose file defines. Against the compose file on main it reports exactly `redis_plain`, `redis_unified` (no healthcheck) and `squid` (pgrep); with this PR it passes. It only reads files, no docker, and lives next to `parallel-allowlist.test.ts`, the existing lint of the same kind.

`test/docker/README.md` recommended `waitTcp()` after `ensure()` as the readiness step, which is the host-side connect described above and proves nothing; the README now documents the healthcheck as the readiness signal, and the unused `waitTcp()`/`waitForPort()` helpers in `test/docker/index.ts` (no callers anywhere in the tree) are removed so nobody reaches for them.

Why the healthcheck and not a readiness poll in `index.ts`: a connect from the host to the published port succeeds during the window (docker-proxy accepts before it dials the container), so polling the published port cannot observe the problem. The check has to run in the container's network namespace, which is what a healthcheck is, and `--wait` already blocks on it. Only `docker-compose.yml` changes; no image or AMI needs rebuilding, and compose recreates an already-existing container when its config changes.

### Verification

This is test infrastructure, so the tests that exercise it are the existing container-backed suites on this PR's Linux lanes: the `Squid proxy (Docker)` block of `websocket-proxy.test.ts` and `test/js/valkey/*` (which now wait on the new redis healthchecks). The failing state is the build above; it cannot be reproduced deterministically from a test without racing a cold container start against the shared services of the shard, so no new test is added. `docker compose config` accepts the file, and the bash exit codes above were checked against a listening and a closed port on Debian's bash (Ubuntu ships the same build configuration).

[Build 92500](https://buildkite.com/bun/bun/builds/92500) on this PR is green. From the debian 13 x64 shard logs: the new squid healthcheck went healthy on all four shards that prestart squid, and `websocket-proxy.test.ts` ran against it with 36/36 passing; `redis_unified` went healthy and the valkey tests ran against it. Time from `coordinator: ensuring squid` to `squid ready` on those shards was 12.8s, 13.2s, 21.6s and 30.2s, against 11.6s, 13.5s, 17.9s and 28.3s with the `pgrep` check in build 92450, so the stricter probe does not add measurable startup time (the spread is the parallel `compose build`/`up` at shard start).

</details>
