### PR TITLE
spawn: open Bun.file() stdio paths in the parent so a blocking open cannot freeze the runtime

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1259,8 +1259,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 {
                     return Err(global_this.throw_value(c.target.blame(&err).to_js(global_this)));
                 }
-                // A stdio `Bun.file(path)` that failed to open already names
-                // its own path; the argv[0] attribution below is for exec.
+                // Stdio path open errors name their own path; the rewrite below is for exec.
                 if err.syscall == sys::Tag::open {
                     return Err(global_this.throw_value(err.to_js(global_this)));
                 }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1259,6 +1259,11 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 {
                     return Err(global_this.throw_value(c.target.blame(&err).to_js(global_this)));
                 }
+                // A stdio `Bun.file(path)` that failed to open already names
+                // its own path; the argv[0] attribution below is for exec.
+                if err.syscall == sys::Tag::open {
+                    return Err(global_this.throw_value(err.to_js(global_this)));
+                }
                 match err.get_errno() {
                     errno @ (sys::Errno::EACCES
                     | sys::Errno::ENOENT

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1925,9 +1925,16 @@ mod spawn_process_body {
                             cleanup_uv_files(&uv_files_to_close, loop_);
                             return Ok(Err(err.with_path(path)));
                         }
-                        stdio.flags = uv::UV_INHERIT_FD;
                         let fd = rc.int();
                         uv_files_to_close.push(fd);
+                        if let Err(err) = bun_spawn_sys::spawn_process::reject_directory_stdio(
+                            Fd::from_uv(fd),
+                            path,
+                        ) {
+                            cleanup_uv_files(&uv_files_to_close, loop_);
+                            return Ok(Err(err));
+                        }
+                        stdio.flags = uv::UV_INHERIT_FD;
                         stdio.data.fd = fd;
                     }
                     WindowsStdio::Buffer(my_pipe) => {

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1873,7 +1873,7 @@ mod spawn_process_body {
             let flag: c_int = if fd_i == 0 {
                 uv::O::RDONLY
             } else {
-                uv::O::WRONLY
+                uv::O::WRONLY | uv::O::CREAT
             };
 
             let mut treat_as_dup: bool = false;
@@ -1918,19 +1918,12 @@ mod spawn_process_body {
                         // loop, `path_z` is NUL-terminated and outlives the call
                         // (sync — no callback).
                         let rc = unsafe {
-                            uv::uv_fs_open(
-                                loop_,
-                                &mut req,
-                                path_z.as_ptr(),
-                                flag | uv::O::CREAT,
-                                0o644,
-                                None,
-                            )
+                            uv::uv_fs_open(loop_, &mut req, path_z.as_ptr(), flag, 0o644, None)
                         };
                         req.deinit();
                         if let Some(err) = rc.to_error(bun_sys::Tag::open) {
                             cleanup_uv_files(&uv_files_to_close, loop_);
-                            return Ok(Err(err));
+                            return Ok(Err(err.with_path(path)));
                         }
                         stdio.flags = uv::UV_INHERIT_FD;
                         let fd = rc.int();
@@ -2013,7 +2006,7 @@ mod spawn_process_body {
                     req.deinit();
                     if let Some(err) = rc.to_error(bun_sys::Tag::open) {
                         cleanup_uv_files(&uv_files_to_close, loop_);
-                        return Ok(Err(err));
+                        return Ok(Err(err.with_path(path)));
                     }
                     stdio.flags = uv::UV_INHERIT_FD;
                     let fd = rc.int();

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -45,22 +45,18 @@ mod darwin_spawn_np {
 // MOVE_DOWN stub from `bun_errno`). Shim the remainder locally so this file
 // is self-contained; delete in favour of `bun_sys::posix::*` once that module
 // widens.
+#[cfg(unix)]
+use self::posix_compat::fd_t;
 use self::posix_compat::pid_t;
 #[cfg(unix)]
 use self::posix_compat::{Errno, errno};
 #[cfg(target_os = "macos")]
 use self::posix_compat::{errno_from_posix_spawn, mode_t};
-#[cfg(unix)]
-use self::posix_compat::{fd_t, to_posix_path};
 
 #[allow(non_camel_case_types)]
 mod posix_compat {
     #[cfg(unix)]
-    use crate::Error;
-    #[cfg(unix)]
     use core::ffi::c_int;
-    #[cfg(unix)]
-    use std::ffi::CString;
 
     /// Native fd backing int.
     // posix_spawn file actions use libc `int` fds on the C side
@@ -111,12 +107,6 @@ mod posix_compat {
     pub(super) fn errno_from_posix_spawn(rc: c_int) -> Errno {
         Errno(rc)
     }
-
-    /// Copy a path into a NUL-terminated buffer.
-    #[cfg(unix)]
-    pub(super) fn to_posix_path(path: &[u8]) -> Result<CString, Error> {
-        CString::new(path).map_err(|_| crate::Error::Unexpected)
-    }
 }
 
 // MOVE_DOWN: this file was `src/runtime/api/bun/spawn.rs`; the `stdio`
@@ -163,17 +153,6 @@ pub mod bun_spawn {
 
         // deinit: freed chdir_buf, each action.path, and the actions list — all owned
         // types now, so Drop is automatic.
-
-        pub(crate) fn open(
-            &mut self,
-            fd: Fd,
-            path: &[u8],
-            flags: u32,
-            mode: i32,
-        ) -> Result<(), Error> {
-            let posix_path = to_posix_path(path)?;
-            self.open_z(fd, &posix_path, flags, mode)
-        }
 
         pub(crate) fn open_z(
             &mut self,

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -624,13 +624,8 @@ impl Drop for PosixSpawnFdGuard {
     }
 }
 
-/// Opens a `PosixStdio::Path` in the parent and has the child dup2 it onto
-/// `fileno`. As a child-side open action it would run under vfork (Linux) or
-/// inside the posix_spawn syscall (macOS), so an open(2) that blocks (a FIFO
-/// with no peer, a hung mount) would park this thread with it, and a failure
-/// would be reported as a posix_spawn error against argv[0]. O_NONBLOCK only
-/// covers the open itself; it is cleared before the child inherits the
-/// description.
+/// Not an open file action: that runs in the vfork child (inside posix_spawn on
+/// Darwin), so an open(2) that blocks, e.g. a FIFO with no peer, blocks the spawn.
 #[cfg(unix)]
 fn open_stdio_path(
     actions: &mut PosixSpawnActions,
@@ -662,9 +657,7 @@ fn open_stdio_path(
     Ok(Ok(()))
 }
 
-/// Opening a directory read-only succeeds (only writing is refused), and a
-/// child handed one as stdin would just get EISDIR from every read(). Fail
-/// the spawn with that error instead.
+/// A read-only open of a directory succeeds; the child could only ever get EISDIR from it.
 pub fn reject_directory_stdio(fd: Fd, path: &[u8]) -> bun_sys::Result<()> {
     let stat = bun_sys::fstat(fd).map_err(|err| err.with_path(path))?;
     if bun_sys::S::ISDIR(stat.st_mode as _) {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -624,8 +624,7 @@ impl Drop for PosixSpawnFdGuard {
     }
 }
 
-/// Not an open file action: that runs in the vfork child (inside posix_spawn on
-/// Darwin), so an open(2) that blocks, e.g. a FIFO with no peer, blocks the spawn.
+/// Not an open file action, which would block the spawn itself on e.g. a FIFO with no peer.
 #[cfg(unix)]
 fn open_stdio_path(
     actions: &mut PosixSpawnActions,

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -13,6 +13,8 @@ use core::sync::atomic::Ordering;
 #[cfg(target_os = "macos")]
 use bun_core::Output;
 #[cfg(unix)]
+use bun_core::ZStr;
+#[cfg(unix)]
 use bun_sys::FdExt as _;
 use bun_sys::{self, Fd};
 
@@ -622,6 +624,51 @@ impl Drop for PosixSpawnFdGuard {
     }
 }
 
+/// Opens a `PosixStdio::Path` in the parent and has the child dup2 it onto
+/// `fileno`. As a child-side open action it would run under vfork (Linux) or
+/// inside the posix_spawn syscall (macOS), so an open(2) that blocks (a FIFO
+/// with no peer, a hung mount) would park this thread with it, and a failure
+/// would be reported as a posix_spawn error against argv[0]. O_NONBLOCK only
+/// covers the open itself; it is cleared before the child inherits the
+/// description.
+#[cfg(unix)]
+fn open_stdio_path(
+    actions: &mut PosixSpawnActions,
+    cleanup: &mut PosixSpawnFdGuard,
+    fileno: Fd,
+    path: &[u8],
+    flags: i32,
+) -> crate::Result<bun_sys::Result<()>> {
+    let path_z = bun_sys::to_posix_path(path).map_err(|_| crate::Error::Unexpected)?;
+    let fd = match bun_sys::open(
+        ZStr::from_cstr(&path_z),
+        flags | bun_sys::O::CLOEXEC | bun_sys::O::NOCTTY | bun_sys::O::NONBLOCK,
+        0o664,
+    ) {
+        Ok(fd) => fd,
+        Err(err) => return Ok(Err(err)),
+    };
+    cleanup.to_close_at_end.push(fd);
+    // The kernel only refuses directories for writing; a read-only stdin
+    // would otherwise hand the child an fd whose every read() fails.
+    match bun_sys::fstat(fd) {
+        Ok(stat) if bun_sys::S::ISDIR(stat.st_mode as _) => {
+            let err = bun_sys::Error::from_code(bun_sys::E::EISDIR, bun_sys::Tag::open);
+            return Ok(Err(err.with_path(path)));
+        }
+        Ok(_) => {}
+        Err(err) => return Ok(Err(err.with_path(path))),
+    }
+    if let Err(err) = bun_sys::update_nonblocking(fd, false) {
+        return Ok(Err(err.with_path(path)));
+    }
+    actions.dup2(fd, fileno)?;
+    if fd != fileno {
+        actions.close(fd)?;
+    }
+    Ok(Ok(()))
+}
+
 /// # Safety
 /// `argv` must point to a null-terminated array of NUL-terminated C strings
 /// with at least one non-null element (`argv[0]`); `envp` must point to a
@@ -777,7 +824,15 @@ pub unsafe fn spawn_process_posix(
                 actions.open_z(fileno, c"/dev/null", flag | bun_sys::O::CREAT as u32, 0o664)?;
             }
             PosixStdio::Path(path) => {
-                actions.open(fileno, path, flag | bun_sys::O::CREAT as u32, 0o664)?;
+                let flags = if i == 0 {
+                    bun_sys::O::RDONLY
+                } else {
+                    bun_sys::O::WRONLY | bun_sys::O::CREAT
+                };
+                if let Err(err) = open_stdio_path(&mut actions, &mut cleanup, fileno, path, flags)?
+                {
+                    return Ok(Err(err));
+                }
             }
             PosixStdio::Buffer => {
                 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -921,12 +976,15 @@ pub unsafe fn spawn_process_posix(
                 extra_fds.push(ExtraPipe::Unavailable);
             }
             PosixStdio::Path(path) => {
-                actions.open(
+                if let Err(err) = open_stdio_path(
+                    &mut actions,
+                    &mut cleanup,
                     fileno,
                     path,
-                    (bun_sys::O::RDWR | bun_sys::O::CREAT) as u32,
-                    0o664,
-                )?;
+                    bun_sys::O::RDWR | bun_sys::O::CREAT,
+                )? {
+                    return Ok(Err(err));
+                }
                 extra_fds.push(ExtraPipe::Unavailable);
             }
             PosixStdio::Ipc | PosixStdio::Buffer | PosixStdio::SocketFd => {

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -649,15 +649,8 @@ fn open_stdio_path(
         Err(err) => return Ok(Err(err)),
     };
     cleanup.to_close_at_end.push(fd);
-    // The kernel only refuses directories for writing; a read-only stdin
-    // would otherwise hand the child an fd whose every read() fails.
-    match bun_sys::fstat(fd) {
-        Ok(stat) if bun_sys::S::ISDIR(stat.st_mode as _) => {
-            let err = bun_sys::Error::from_code(bun_sys::E::EISDIR, bun_sys::Tag::open);
-            return Ok(Err(err.with_path(path)));
-        }
-        Ok(_) => {}
-        Err(err) => return Ok(Err(err.with_path(path))),
+    if let Err(err) = reject_directory_stdio(fd, path) {
+        return Ok(Err(err));
     }
     if let Err(err) = bun_sys::update_nonblocking(fd, false) {
         return Ok(Err(err.with_path(path)));
@@ -667,6 +660,18 @@ fn open_stdio_path(
         actions.close(fd)?;
     }
     Ok(Ok(()))
+}
+
+/// Opening a directory read-only succeeds (only writing is refused), and a
+/// child handed one as stdin would just get EISDIR from every read(). Fail
+/// the spawn with that error instead.
+pub fn reject_directory_stdio(fd: Fd, path: &[u8]) -> bun_sys::Result<()> {
+    let stat = bun_sys::fstat(fd).map_err(|err| err.with_path(path))?;
+    if bun_sys::S::ISDIR(stat.st_mode as _) {
+        let err = bun_sys::Error::from_code(bun_sys::E::EISDIR, bun_sys::Tag::open);
+        return Err(err.with_path(path));
+    }
+    Ok(())
 }
 
 /// # Safety

--- a/test/js/bun/spawn/spawn-stdio-bunfile.test.ts
+++ b/test/js/bun/spawn/spawn-stdio-bunfile.test.ts
@@ -7,11 +7,9 @@ import { join } from "node:path";
 const versionCmd = JSON.stringify([bunExe(), "--version"]);
 
 describe.skipIf(isWindows)("Bun.file() as stdio is opened without blocking the parent", () => {
-  // A bun that opens the path in its pre-exec child sits in Bun.spawn() until
-  // the fifo's other end is opened, so those calls run in a child bun and a
-  // regression is a timed-out test rather than a frozen runner. Killing that
-  // bun afterwards and opening each fifo's peer end once releases the pre-exec
-  // grandchild it left parked in open(2).
+  // On a regressed bun these spawns block, so they run in a child bun (a timed-out test, not a
+  // frozen runner). Afterwards it is killed and each fifo's peer end is opened once to release
+  // the pre-exec grandchild it leaves parked in open(2).
   const childBuns: Bun.Subprocess[] = [];
   const fifos: string[] = [];
   afterAll(() => {

--- a/test/js/bun/spawn/spawn-stdio-bunfile.test.ts
+++ b/test/js/bun/spawn/spawn-stdio-bunfile.test.ts
@@ -1,0 +1,216 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, isWindows, libcPathForDlopen, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
+import { closeSync, constants, existsSync, openSync } from "node:fs";
+import { join } from "node:path";
+
+const versionCmd = JSON.stringify([bunExe(), "--version"]);
+
+describe.skipIf(isWindows)("Bun.file() as stdio is opened without blocking the parent", () => {
+  // A bun that opens the path in its pre-exec child sits in Bun.spawn() until
+  // the fifo's other end is opened, so those calls run in a child bun and a
+  // regression is a timed-out test rather than a frozen runner. Killing that
+  // bun afterwards and opening each fifo's peer end once releases the pre-exec
+  // grandchild it left parked in open(2).
+  const childBuns: Bun.Subprocess[] = [];
+  const fifos: string[] = [];
+  afterAll(() => {
+    for (const proc of childBuns) proc.kill("SIGKILL");
+    for (const fifo of fifos) {
+      for (const flags of [constants.O_WRONLY, constants.O_RDONLY]) {
+        try {
+          closeSync(openSync(fifo, flags | constants.O_NONBLOCK));
+        } catch {}
+      }
+    }
+  });
+
+  async function runInChildBun(script: string) {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    childBuns.push(proc);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  function makeFifo(dir: string) {
+    const fifo = join(dir, "stdio.fifo");
+    mkfifo(fifo);
+    fifos.push(fifo);
+    return fifo;
+  }
+
+  // Nothing ever opens these fifos for writing, so the child reads EOF.
+  test.concurrent("Bun.spawn with a stdin fifo nobody writes to returns", async () => {
+    using dir = tempDir("spawn-fifo-stdin", {});
+    const fifo = makeFifo(String(dir));
+
+    const result = await runInChildBun(`
+      const proc = Bun.spawn(["cat"], { stdin: Bun.file(${JSON.stringify(fifo)}), stdout: "pipe", stderr: "inherit" });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      console.log(JSON.stringify({ stdout, exitCode }));
+    `);
+
+    expect(result).toEqual({
+      stdout: JSON.stringify({ stdout: "", exitCode: 0 }),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("Bun.spawnSync with a stdin fifo nobody writes to returns", async () => {
+    using dir = tempDir("spawn-fifo-stdin-sync", {});
+    const fifo = makeFifo(String(dir));
+
+    const result = await runInChildBun(`
+      const { exitCode, stdout } = Bun.spawnSync(["cat"], { stdin: Bun.file(${JSON.stringify(fifo)}), stderr: "inherit" });
+      console.log(JSON.stringify({ stdout: stdout.toString(), exitCode }));
+    `);
+
+    expect(result).toEqual({
+      stdout: JSON.stringify({ stdout: "", exitCode: 0 }),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("Bun.spawn throws ENXIO for a stdout fifo with no reader instead of waiting for one", async () => {
+    using dir = tempDir("spawn-fifo-stdout", {});
+    const fifo = makeFifo(String(dir));
+
+    const result = await runInChildBun(`
+      try {
+        const proc = Bun.spawn(${versionCmd}, { stdout: Bun.file(${JSON.stringify(fifo)}) });
+        proc.kill();
+        console.log(JSON.stringify({ spawned: true }));
+      } catch (err) {
+        console.log(JSON.stringify({ code: err.code, syscall: err.syscall, path: err.path }));
+      }
+    `);
+
+    expect(result).toEqual({
+      stdout: JSON.stringify({ code: "ENXIO", syscall: "open", path: fifo }),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("the child does not inherit the O_NONBLOCK used to open the path", async () => {
+    using dir = tempDir("spawn-stdio-blocking", { "input.txt": "" });
+
+    // Same value on Linux, macOS and FreeBSD.
+    const F_GETFL = 3;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { dlopen } = require("bun:ffi");
+          const { O_NONBLOCK } = require("node:fs").constants;
+          const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, { fcntl: { args: ["i32", "i32"], returns: "i32" } });
+          const flags = libc.symbols.fcntl(0, ${F_GETFL});
+          console.log(JSON.stringify({ fcntlFailed: flags < 0, nonblocking: (flags & O_NONBLOCK) !== 0 }));
+        `,
+      ],
+      env: bunEnv,
+      stdin: Bun.file(join(String(dir), "input.txt")),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ fcntlFailed: false, nonblocking: false }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
+describe("Bun.file(path) as stdio errors", () => {
+  function thrownBy(fn: () => unknown): unknown {
+    try {
+      fn();
+    } catch (err) {
+      return err;
+    }
+    throw new Error("expected the spawn to throw");
+  }
+
+  const errorFields = (err: any) => ({ code: err.code, syscall: err.syscall, path: err.path });
+
+  describe.each(["spawn", "spawnSync"] as const)("%s", kind => {
+    const spawnWith = (options: object) =>
+      kind === "spawn"
+        ? thrownBy(() => Bun.spawn([bunExe(), "--version"], options).kill())
+        : thrownBy(() => Bun.spawnSync([bunExe(), "--version"], options));
+
+    test.concurrent("stdin: Bun.file(missing) throws ENOENT and does not create the file", () => {
+      using dir = tempDir("spawn-stdin-missing", {});
+      const missing = join(String(dir), "does-not-exist.txt");
+
+      const err = spawnWith({ stdin: Bun.file(missing), stdout: "ignore", stderr: "ignore" });
+
+      expect({ ...errorFields(err), created: existsSync(missing) }).toEqual({
+        code: "ENOENT",
+        syscall: "open",
+        path: missing,
+        created: false,
+      });
+    });
+
+    test.concurrent("stdin: Bun.file(directory) throws EISDIR", () => {
+      using dir = tempDir("spawn-stdin-dir", {});
+
+      const err = spawnWith({ stdin: Bun.file(String(dir)), stdout: "ignore", stderr: "ignore" });
+
+      expect(errorFields(err)).toEqual({ code: "EISDIR", syscall: "open", path: String(dir) });
+    });
+
+    test.concurrent.each([
+      ["stdout", (file: Bun.BunFile) => ({ stdout: file, stderr: "ignore" })],
+      ["stderr", (file: Bun.BunFile) => ({ stdout: "ignore", stderr: file })],
+      ["stdio[3]", (file: Bun.BunFile) => ({ stdio: ["ignore", "ignore", "ignore", file] })],
+    ])("%s: Bun.file() in a missing directory reports the file's path, not the command", (_, options) => {
+      using dir = tempDir("spawn-stdio-missing-dir", {});
+      const out = join(String(dir), "no-such-dir", "out.txt");
+
+      const err = spawnWith(options(Bun.file(out)));
+
+      expect(errorFields(err)).toEqual({ code: "ENOENT", syscall: "open", path: out });
+    });
+  });
+});
+
+test("a relative Bun.file() stdio path resolves against the parent's cwd, not the cwd option", async () => {
+  using dir = tempDir("spawn-stdio-relative", { "parent/.keep": "", "child/.keep": "" });
+  const parentCwd = join(String(dir), "parent");
+  const childCwd = join(String(dir), "child");
+
+  const result = await bunRun([
+    "-e",
+    `
+      process.chdir(${JSON.stringify(parentCwd)});
+      const { exitCode } = Bun.spawnSync(${versionCmd}, { cwd: ${JSON.stringify(childCwd)}, stdout: Bun.file("out.txt") });
+      console.log(JSON.stringify({ exitCode }));
+    `,
+  ]);
+
+  expect({
+    result,
+    inParentCwd: existsSync(join(parentCwd, "out.txt")),
+    inChildCwd: existsSync(join(childCwd, "out.txt")),
+  }).toEqual({
+    result: { stdout: JSON.stringify({ exitCode: 0 }), stderr: "", exitCode: 0, signalCode: null },
+    inParentCwd: true,
+    inChildCwd: false,
+  });
+});


### PR DESCRIPTION
### Problem
- `Bun.spawn` / `Bun.spawnSync` with a `Bun.file(path)` stdio whose `open(2)` blocks (FIFO with no peer, hung mount, device waiting for carrier) freezes the whole runtime inside the spawn call. `timeout` and `signal` never run, and SIGTERM is blocked around the spawn.
- Cause: the path was opened as a spawn file action, so the open ran in the child before exec, and the parent thread is suspended until file actions finish (vfork on Linux, inside the `posix_spawn` syscall on macOS).
- A failed open took the exec-failure error route, so it blamed the command: `ENOENT: no such file or directory, posix_spawn 'true'` for a stdout file in a missing directory.
- stdin was opened with `O_RDONLY|O_CREAT`, so `stdin: Bun.file(missing)` silently created an empty file and the child read EOF.

### Fix
- The parent opens the path itself with `O_NONBLOCK|O_CLOEXEC|O_NOCTTY`, clears `O_NONBLOCK`, and registers a `dup2` onto the target fd. Nothing that can block runs inside the spawn any more, so the call always returns; Windows already worked this way.
- stdin is opened read-only, a directory is rejected with `EISDIR`, and open failures are thrown as `open` errors carrying the stdio path, on POSIX and Windows.
- Behavior changes: a stdout/stderr FIFO with no reader fails at spawn with `ENXIO` instead of waiting, and a relative `Bun.file("out.txt")` resolves against the parent's cwd, not the `cwd` option (as on Windows already).
- Verification: one new test file. 14 of 15 cases fail on an unfixed build and all pass with the fix; the FIFO cases run in a child bun so a regression is a timed-out test, not a frozen runner. A Windows debug build passes it too; the shipped canary fails 10 of its 11 cases.

### Background
- Spawn file actions are the open/dup2/close list applied between fork and exec. With vfork (Linux) or inside `posix_spawn` (macOS) the parent thread waits for all of them, so a blocking open blocks bun's event loop.
- Opening a FIFO waits for a peer. With `O_NONBLOCK` a read open returns at once (EOF until a writer arrives) and a write open with no reader fails with `ENXIO`. The flag lives on the open file, so it must be cleared again or the child inherits a non-blocking stdin.
- Spawn errors carry a syscall tag. The JS binding rewrites exec-shaped errors (`ENOENT`, `EACCES`, ...) to name argv[0], so an open failure needs its own tag and path to escape that rewrite.
- `open(2)` on a directory succeeds read-only; only an `fstat` of the fd tells a directory stdin from a file, hence the separate directory check.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-stdio-bunfile.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## What does this PR do?

`Bun.spawn` / `Bun.spawnSync` with a `Bun.file(path)` stdio whose `open(2)` blocks freezes the whole runtime inside the `Bun.spawn(...)` call. `timeout` / `signal` cannot help because the call never returns, and SIGTERM does not get through either since signals are blocked around the spawn.

```sh
mkfifo /tmp/ff
bun -e '
setTimeout(() => console.log("timer fired"), 200);
console.log("spawning");
const p = Bun.spawn(["true"], { stdin: Bun.file("/tmp/ff"), timeout: 300 });
console.log("returned", p.pid);'
# before: prints "spawning" and hangs until something opens /tmp/ff for writing
```

Same with `stdout: Bun.file(fifo)`, with `spawnSync`, and with any other path whose open blocks (hung mount, device node waiting for carrier).

### Cause

A path stdio was registered as an open file action (`spawn_process.rs` -> `actions.open`), so the `open()` ran in the child before exec. On Linux that child is a vfork child (`bun-spawn.cpp`), so the parent thread is suspended until the open returns; on macOS the file actions are executed inside the `posix_spawn` syscall, with the same effect. A failing open was reported by the same route as an exec failure, so the error blamed the executable:

```
ENOENT: no such file or directory, posix_spawn 'true'     # stdout: Bun.file("/nonexistent-dir/out.txt")
```

and stdin was opened with `O_RDONLY|O_CREAT`, so `stdin: Bun.file(missing)` silently created an empty file and the child read EOF.

### Fix

`spawn_process_posix` now opens the path itself (`open_stdio_path`) with `O_NONBLOCK|O_CLOEXEC|O_NOCTTY`, clears `O_NONBLOCK` again, and registers a `dup2` onto the target fd; the parent's copy is closed after the spawn through the existing fd guard. This is what `spawn_process_windows` already did with `uv_fs_open`. The child-side `Actions::open` (and its `to_posix_path`) had no other callers and is removed; the `/dev/null` open for `"ignore"` stays an action since it cannot block.

* stdin is opened with `O_RDONLY` only. Since a directory opens fine read-only, the parent `fstat`s and rejects it with `EISDIR` (`reject_directory_stdio`, shared with the Windows path). On POSIX that is what the `O_CREAT` open used to produce; on Windows a directory stdin used to spawn successfully even before this change, so it is a fix there too.
* Open failures are returned as `open` errors carrying the stdio path, and the JS bindings no longer rewrite those to argv[0] (same shape as the existing `cgroup` guard). Windows attaches the path to its `uv_fs_open` error too, stops passing `O_CREAT` for stdin, and runs the same directory check.

```
ENOENT: no such file or directory, open '/nonexistent-dir/out.txt'
ENOENT: no such file or directory, open '/tmp/missing-input'        # was: spawned, file created, exit 0
EISDIR: illegal operation on a directory, open '/etc'
```

### Behavior notes

* A FIFO no longer blocks the spawn. With no writer yet, the child reads EOF; a FIFO with no reader given as stdout/stderr fails with `ENXIO` at spawn time. Anyone who wants the blocking open can still do it explicitly and pass the fd (`stdin: openSync(fifo, "r")`).
* A relative `Bun.file("out.txt")` now resolves against the parent's cwd like every other use of that `Bun.file`, instead of against the `cwd` option. Windows already behaved this way.
* `O_NOCTTY` keeps a tty path given as stdio from becoming bun's controlling terminal when bun is a session leader.
* #35352 (add `O_TRUNC` for stdout/stderr paths) touches the same flags; either order rebases trivially.

## How did you verify your code works?

New `test/js/bun/spawn/spawn-stdio-bunfile.test.ts`. The FIFO cases run inside a child bun so that on an unfixed build they show up as timed-out tests rather than a frozen runner (the hook afterwards kills that bun and unblocks the grandchild it left in `open()`).

* stdin FIFO with no writer: `spawn` and `spawnSync` return, child exits 0 (before: both hang)
* stdout FIFO with no reader: `ENXIO` with `syscall: "open"` and the fifo path (before: hangs)
* the child's stdin does not have `O_NONBLOCK` set (`fcntl(0, F_GETFL)` via `bun:ffi`)
* `stdin: Bun.file(missing)` throws `ENOENT` and the file is not created; `stdin: Bun.file(dir)` throws `EISDIR`; stdout / stderr / `stdio[3]` in a missing directory report the file's path. All for both `spawn` and `spawnSync` (before: path is argv[0], and the missing-stdin case spawns)
* relative path resolves against the parent's cwd

Unfixed build: 14 fail / 1 pass (the `O_NONBLOCK` guard also passes there). With the fix: 15 pass, and `spawn.test.ts`, `spawnSync.test.ts`, `null-byte-injection.test.ts`, `spawn-renamed-cwd.test.ts`, `exit-code.test.ts` still pass. On a Windows debug build the file passes as well (11 pass, the FIFO cases are POSIX-only); with the shipped canary it fails 10 of those 11, including the directory case. `cargo check -p bun_spawn_sys -p bun_spawn` passes for the `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc` and `x86_64-apple-darwin` targets.

</details>
