### PR TITLE
AsyncModule: update resolve_error comment after the .ok() rewrite

### DIFF
--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -750,9 +750,9 @@ impl AsyncModule {
         });
     }
 
-    // write! into Vec<u8>
-    // is infallible here; `.ok()` collapses the `fmt::Result`, so this never
-    // actually returns Err — the wide Result is kept for call-site uniformity.
+    // Never returns Err: the `write!`s below go into a `Vec<u8>` and their
+    // results are discarded with `let _ =`. The `Result` return type is kept
+    // for call-site uniformity with `download_error`.
     fn resolve_error(
         &mut self,
         vm: &mut VirtualMachine,


### PR DESCRIPTION
Follow-up to #37624, which was merged before the one review note on it was addressed.

The comment above `resolve_error` in `src/jsc/AsyncModule.rs` still said the `write!` results were collapsed with `.ok()`. That PR rewrote every one of those sites to `let _ =`, so the comment described code that no longer exists. This rewords it to match: the function never returns Err because the `write!`s go into a `Vec<u8>` and their results are discarded, and the `Result` return type stays for uniformity with `download_error` (both callers `.expect("unreachable")` it).

Comment-only change, no code or behavior change. `rustfmt --check` on the file is clean.