### PR TITLE
picohttp: carry Response.bytes_read as usize

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3717,8 +3717,7 @@ impl<'a> HTTPClient<'a> {
                 }
             };
 
-            let bytes_read =
-                (usize::try_from(parsed.bytes_read).expect("int cast")).min(to_read.len());
+            let bytes_read = parsed.bytes_read.min(to_read.len());
             to_read = &to_read[bytes_read..];
 
             if parsed.status_code == 101 {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -875,7 +875,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         match picohttp::Response::parse(body, &mut self.headers_buf) {
             Ok(response) => HeadParse::Done {
                 status_code: response.status_code,
-                head_len: usize::try_from(response.bytes_read).expect("int cast"),
+                head_len: response.bytes_read,
                 full: body.to_vec(),
             },
             Err(picohttp::ParseResponseError::MalformedHttpResponse) => HeadParse::Invalid,
@@ -998,7 +998,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
             // SAFETY: forwards to the existing teardown path.
             return unsafe { Self::terminate(this.as_ptr(), ErrorCode::InvalidResponse) };
         };
-        let head_len = usize::try_from(response.bytes_read).expect("int cast");
+        let head_len = response.bytes_read;
         let is_101 = response.status_code == 101;
 
         // 101: one scope across 'upgrade'+'open' so microtasks drain after open.

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -435,7 +435,7 @@ pub struct Response<'a> {
     pub status_code: u32,
     pub status: &'a [u8],
     pub headers: HeaderList<'a>,
-    pub bytes_read: c_int,
+    pub bytes_read: usize,
 }
 
 impl<'a> Default for Response<'a> {
@@ -539,7 +539,9 @@ impl<'a> Response<'a> {
                     headers: HeaderList {
                         list: &src[0..num_headers.min(src.len())],
                     },
-                    bytes_read: rc,
+                    // > 0 here: -1/-2 were handled above and 0 is not a
+                    // return value of phr_parse_response.
+                    bytes_read: rc as usize,
                 })
             }
         }


### PR DESCRIPTION
### What does this PR do?

`picohttp::Response.bytes_read` was the raw `c_int` from `phr_parse_response`. `Response::parse_parts` already turns the two negative returns (`-1` malformed, `-2` short read) into errors before constructing a `Response`, so every stored value is a positive header length, but the field type did not say so and each consumer re-proved it with `usize::try_from(..).expect("int cast")` (`http/lib.rs`, twice in `WebSocketUpgradeClient.rs`). The field is now `usize`, converted once where the sign is known, and the three `expect`s are gone. The struct literals that build a synthetic response (`bytes_read: 0`) are unchanged.

### How did you verify your code works?

`cargo check -p bun_picohttp -p bun_http -p bun_http_jsc -p bun_runtime`. With `bun-debug`: a `fetch()` against a real HTTPS origin (response head parse) and a WebSocket client round trip against `Bun.serve` (upgrade response parse) both work.