### PR TITLE
workspace: forbid unsafe_code in 16 crates that contain none

### DIFF
--- a/src/api/lib.rs
+++ b/src/api/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 //! Re-exports of the install config types (`BunInstall`, `NpmRegistry`, …)
 //! whose canonical definitions live in `bun_options_types::schema::api`, plus
 //! the registry-URL parser shared by the bunfig and npmrc loaders.

--- a/src/ast_jsc/lib.rs
+++ b/src/ast_jsc/lib.rs
@@ -1,6 +1,7 @@
 //! JSC bridge for `bun.logger`. Keeps `src/logger/` free of JSC types.
 
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 
 use std::borrow::Cow;
 

--- a/src/bun_output_tags/lib.rs
+++ b/src/bun_output_tags/lib.rs
@@ -4,6 +4,7 @@
 //! crates can import it without a cycle.
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 /// Named ANSI SGR escape sequences. One canonical literal per colour/attribute;
 /// every other crate aliases this module rather than re-declaring the bytes.

--- a/src/clap_macros/lib.rs
+++ b/src/clap_macros/lib.rs
@@ -8,6 +8,8 @@
 //! (`$crate`) injected by the `macro_rules!` wrappers in `bun_clap`. Use
 //! `bun_clap::parse_param!` / `bun_clap::param!` / `bun_clap::parse_params!` instead.
 
+#![forbid(unsafe_code)]
+
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;

--- a/src/csrf/lib.rs
+++ b/src/csrf/lib.rs
@@ -3,6 +3,7 @@
 //! by generating and validating tokens using HMAC signatures
 
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 use bun_boringssl_sys as boring;
 use bun_core::strings;
 use bun_sha_hmac::hmac;

--- a/src/css_derive/lib.rs
+++ b/src/css_derive/lib.rs
@@ -25,6 +25,8 @@
 //!   * Each type parameter `T` gets a `T: DeepClone<'bump>` where-bound so
 //!     generic containers like `CssRule<R>` constrain their payload.
 
+#![forbid(unsafe_code)]
+
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};

--- a/src/hash/lib.rs
+++ b/src/hash/lib.rs
@@ -21,6 +21,7 @@
 //! `wyhash` lives in `bun_wyhash`; `crc32` is provided by `bun_zlib`.
 
 #![allow(clippy::many_single_char_names)]
+#![forbid(unsafe_code)]
 pub mod adler32;
 pub mod cityhash;
 pub mod murmur;

--- a/src/install_jsc/lib.rs
+++ b/src/install_jsc/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 //! JSC bridge surface for `bun_install`. Keeps `src/install/` free of
 //! `JSValue`/`JSGlobalObject`/`CallFrame` references.
 //!

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -269,3 +269,11 @@ extern "C" fn NodeModuleModule__onRequireExtensionModifyNonFunction(
         bun_core::out_of_memory();
     }
 }
+
+/// Read by C++ (`createStreamIterEnabledFlag`, NodeModuleModule.cpp) so JS
+/// builtins can consult the write-once CLI bit instead of the user-mutable
+/// `process.execArgv`.
+#[unsafe(no_mangle)]
+extern "C" fn Bun__streamIterEnabled() -> bool {
+    bun_resolve_builtins::stream_iter_enabled()
+}

--- a/src/output/lib.rs
+++ b/src/output/lib.rs
@@ -11,6 +11,7 @@
 //! `$crate::pretty_fmt!`) continue to work unchanged.
 
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 // ── scoped logging (the requested symbol) ────────────────────────────────
 //
 //     bun_output::declare_scope!(X, visible);

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 
 pub mod error;
 pub use error::{Error, Result};

--- a/src/patch_jsc/lib.rs
+++ b/src/patch_jsc/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 
 pub mod testing;

--- a/src/resolve_builtins/HardcodedModule.rs
+++ b/src/resolve_builtins/HardcodedModule.rs
@@ -861,14 +861,6 @@ pub fn set_stream_iter_enabled(enabled: bool) {
     STREAM_ITER_ENABLED.store(enabled, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// Read by C++ (`createStreamIterEnabledFlag`, NodeModuleModule.cpp) so JS
-/// builtins can consult the write-once CLI bit instead of the user-mutable
-/// `process.execArgv`.
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Bun__streamIterEnabled() -> bool {
-    stream_iter_enabled()
-}
-
 /// True when `name` is a stream/iter specifier that must stay invisible
 /// because `--experimental-stream-iter` was not passed. Consulted by every
 /// reader of the alias tables (`Alias::get` and `ModuleLoader`'s raw-table

--- a/src/resolve_builtins/lib.rs
+++ b/src/resolve_builtins/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 #[path = "HardcodedModule.rs"]
 pub mod HardcodedModule;
 

--- a/src/safety/lib.rs
+++ b/src/safety/lib.rs
@@ -1,4 +1,5 @@
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 
 // `ThreadLock` and `thread_id` live in `bun_core` (tier-0) so `bun_ptr` /
 // `bun_threading` can use them without an upward dep. Re-exported here for

--- a/src/semver_jsc/lib.rs
+++ b/src/semver_jsc/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 //! JSC bridge for `bun_semver`. Keeps `src/semver/` free of JSC types.
 
 #[path = "SemverObject.rs"]

--- a/src/transpiler/lib.rs
+++ b/src/transpiler/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 // `Transpiler` is implemented in
 // `bun_bundler::transpiler` because it shares the bundler's
 // resolver/options/cache plumbing. This crate re-exports it under the

--- a/src/valkey/lib.rs
+++ b/src/valkey/lib.rs
@@ -1,3 +1,4 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
+#![forbid(unsafe_code)]
 pub mod valkey_protocol;


### PR DESCRIPTION
### Problem
- No user-facing bug. Only `bun_ini` (and one `bun_collections` module) declare `#![forbid(unsafe_code)]`, although 16 other crates contain no `unsafe` at all.
- For those crates "contains no unsafe" has to be re-established by grepping; nothing stops a later change from adding `unsafe` quietly.
- One of them, `bun_resolve_builtins`, holds a single item the lint rejects: the `#[unsafe(no_mangle)]` export `Bun__streamIterEnabled`, read by C++.

### Fix
- Add `#![forbid(unsafe_code)]` to the 16 crates, in the form `src/ini/lib.rs` already uses.
- Move the `Bun__streamIterEnabled` thunk, same symbol and signature, into the `bun_jsc` file that already holds the other exports read by the same C++ file. C++ and the crate's safe accessors are untouched.
- Why this is safe: `forbid` is a lint level and changes no codegen, and the thunk is the same function under the same symbol, so the binary is unchanged. No unsafe blocks are removed.
- Verification is build plus existing tests only: `cargo check` and `cargo clippy` clean on the touched crates, debug build, 75 existing tests pass in the patch, semver and hash suites. No new test.

### Background
- `#![forbid(unsafe_code)]` at the top of a crate makes any `unsafe` block, `unsafe fn/impl/trait`, or `no_mangle`-style export attribute written in that crate a compile error; unlike `deny`, an inner `#[allow]` cannot switch it off. Diagnostics only, no effect on generated code.
- rustc does not report lints for code produced by a macro from another crate, so the three crates using `#[bun_jsc::host_fn]`, whose expansion contains unsafe shims, compile under `forbid` without an `allow`.
- `#[unsafe(no_mangle)] extern "C" fn` exports a Rust function under a fixed symbol name for C++ to call. Which Rust file defines it is invisible to the caller as long as symbol and signature stay the same.
- The `*_jsc` crates are thin bridges holding the JSC-facing surface of a core crate so the core crate stays free of JSC types. `bun_resolve_builtins` is a table of built-in module names plus a couple of flags; `bun_jsc` already depends on it.

<details>
<summary>Original description</summary>

## What

Until now only `bun_ini` (and the `bun_collections::array_list` module) declared `#![forbid(unsafe_code)]`, even though a number of other crates contain no `unsafe` at all. This adds the same crate attribute to 16 crates whose sources have no `unsafe` blocks, `unsafe impl`/`unsafe trait`/`unsafe fn`, `unsafe extern` blocks or `no_mangle`/`export_name`/`link_section` attributes: `bun_api`, `bun_ast_jsc`, `bun_clap_macros`, `bun_csrf`, `bun_hash`, `bun_output`, `bun_output_tags`, `bun_patch`, `bun_patch_jsc`, `bun_safety`, `bun_semver_jsc`, `bun_transpiler`, `bun_valkey`, `bun_css_derive`, `bun_install_jsc` and `bun_resolve_builtins`. In each `lib.rs` the attribute sits next to the existing `#![warn(unused_must_use)]` / `#![no_std]` block, in the same form as `src/ini/lib.rs`.

`bun_resolve_builtins` had exactly one item the lint rejects, the `extern "C"` export read by `createStreamIterEnabledFlag` in `src/jsc/modules/NodeModuleModule.cpp`:

```rust
// src/resolve_builtins/HardcodedModule.rs (before)
#[unsafe(no_mangle)]
pub(crate) extern "C" fn Bun__streamIterEnabled() -> bool {
    stream_iter_enabled()
}
```

That thunk moves, with the same symbol name and signature, into `src/jsc/NodeModuleModule.rs`, the Rust side of that C++ file, which already holds the other `NodeModuleModule__*` exports it consumes; `bun_jsc` already depends on `bun_resolve_builtins`:

```rust
// src/jsc/NodeModuleModule.rs (after)
#[unsafe(no_mangle)]
extern "C" fn Bun__streamIterEnabled() -> bool {
    bun_resolve_builtins::stream_iter_enabled()
}
```

`NodeModuleModule.cpp` is untouched. The safe `stream_iter_enabled()` / `set_stream_iter_enabled()` / `stream_iter_alias_gated()` API of `bun_resolve_builtins` and its 4 existing call sites outside the crate (`cli/Arguments.rs`, `runtime/jsc_hooks.rs`, `jsc/ModuleLoader.rs`) are unchanged. No unsafe blocks are removed by this change; it is 16 lint attributes plus one relocated 3 line export.

The two crates that looked like they had `unsafe` do not: the single match in `bun_css_derive` is token text inside a `quote!` body that is emitted into the consuming crate, and the single match in `bun_install_jsc` is a comment. `bun_patch_jsc`, `bun_semver_jsc` and `bun_install_jsc` use `#[bun_jsc::host_fn]`, whose expansion contains unsafe shims; rustc does not report `unsafe_code` for code that originates in an external macro expansion, so these crates compile under `forbid` without any `allow` attribute, while an `unsafe` block written in the crate itself is still rejected.

## Why

For these 16 crates "contains no unsafe" is now a property the compiler enforces and a reader can see on line 1 of `lib.rs`, instead of something that has to be re-established by grepping; introducing `unsafe` into any of them (or the `_jsc` bridge crates that are meant to stay thin) now requires removing the `forbid` in a visible diff. `bun_resolve_builtins` in particular is a pure table crate, and its one FFI export now lives with the other exports of the C++ file that reads it. `forbid` is a lint level with no effect on code generation, and the moved thunk compiles to the same function under the same exported symbol, so the resulting binary is unchanged.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds; `bun bd test test/js/bun/patch/patch.test.ts test/cli/install/semver.test.ts test/js/bun/util/hash.test.js`: 75 pass, 0 fail (3 files).
test/js/node/test/parallel/test-stream-iter-readable-interop-disabled.js is not collected by `bun test` (no *.test.* suffix), so it contributed 0 tests to that run.

</details>
