### PR TITLE
Make constructor-checked fields private where nothing outside their module touches them

### DIFF
--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -847,8 +847,8 @@ impl DynamicBitSetUnmanaged {
 pub struct DynamicBitSetList {
     buf: ptr::NonNull<usize>,
     buf_len: usize,
-    pub(crate) n: usize,
-    pub(crate) bit_length: usize,
+    n: usize,
+    bit_length: usize,
 }
 
 impl DynamicBitSetList {

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2011,8 +2011,8 @@ pub mod waker {
 
     #[cfg(target_os = "macos")]
     pub struct KEventWaker {
-        pub(crate) kq: i32,
-        pub(crate) machport: bun_core::mach_port,
+        kq: i32,
+        machport: bun_core::mach_port,
         pub machport_buf: Box<[u8]>,
     }
 

--- a/src/runtime/crypto/EVP.rs
+++ b/src/runtime/crypto/EVP.rs
@@ -9,7 +9,7 @@ use crate::jsc::JSGlobalObject;
 pub struct EVP {
     pub ctx: boringssl::EVP_MD_CTX,
     // FFI: BoringSSL EVP_MD singletons are static for the process lifetime.
-    pub(crate) md: *const boringssl::EVP_MD,
+    md: *const boringssl::EVP_MD,
     pub(crate) algorithm: Algorithm,
 }
 

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -15,7 +15,7 @@ pub(crate) struct PBKDF2 {
     pub salt: StringOrBuffer,
     pub iteration_count: u32,
     pub length: i32,
-    pub algorithm: Algorithm,
+    algorithm: Algorithm,
 }
 
 impl PBKDF2 {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1575,7 +1575,7 @@ impl PathOrFdExt for PathOrFileDescriptor {
 /// Non-exhaustive set of flag values; newtype over c_int.
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct FileSystemFlags(pub c_int);
+pub struct FileSystemFlags(c_int);
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum FileSystemFlagsKind {

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -313,19 +313,19 @@ extern "C" fn on_data(
 }
 
 pub struct ConnectConfig {
-    pub(crate) port: u16,
-    pub(crate) address: BunString,
+    port: u16,
+    address: BunString,
 }
 
 pub struct UDPSocketConfig {
     pub(crate) hostname: BunString,
-    pub(crate) connect: Option<ConnectConfig>,
+    connect: Option<ConnectConfig>,
     pub(crate) port: u16,
     pub(crate) flags: i32,
     /// Adopt this already-created (and usually bound) socket descriptor
     /// instead of creating a new one. Used by node:dgram for
     /// `socket.bind({ fd })` and cluster-shared sockets.
-    pub(crate) fd: Option<i32>,
+    fd: Option<i32>,
     pub(crate) binary_type: BinaryType,
 }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -103,7 +103,7 @@ pub struct Request {
     pub(crate) request_context: AnyRequestContext,
     pub(crate) weak_ptr_data: WeakPtrData,
     // We must report a consistent value for this
-    pub(crate) reported_estimated_size: Cell<usize>,
+    reported_estimated_size: Cell<usize>,
     pub(crate) internal_event_callback: JsCell<InternalJSEventCallback>,
 }
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -216,12 +216,12 @@ pub struct Response {
     redirected: Cell<bool>,
     /// We increment this count in fetch so if JS Response is discarted we can resolve the Body
     /// In the server we use a flag response_protected to protect/unprotect the response
-    pub(crate) ref_count: Cell<u32>,
+    ref_count: Cell<u32>,
     /// Bun.serve's RequestContext holds a weak reference so `onAbort` /
     /// `handleResolveStream` / `handleRejectStream` can safely observe that the
     /// Response was GC'd (null) instead of dereferencing a freed pointer when
     /// backpressure lets GC run between `render()` and the async callback.
-    pub(crate) weak_ptr_data: WeakPtrData,
+    weak_ptr_data: WeakPtrData,
     js_ref: JsCell<JsRef>,
 
     // We must report a consistent value for this

--- a/src/sys/tmp.rs
+++ b/src/sys/tmp.rs
@@ -8,9 +8,9 @@ const ALLOW_TMPFILE: bool = false;
 // To be used with files
 // not folders!
 pub struct Tmpfile<'a> {
-    pub(crate) destination_dir: Fd,
+    destination_dir: Fd,
     // Caller-supplied tmp name, valid for the lifetime of the Tmpfile.
-    pub(crate) tmpfilename: &'a ZStr,
+    tmpfilename: &'a ZStr,
     pub fd: Fd,
     pub using_tmpfile: bool,
 }


### PR DESCRIPTION
### What does this PR do?

Each of these fields has a constructor in its own module that establishes something about it, and each was `pub`/`pub(crate)` even though no code outside that module reads or writes it. Dropping the visibility costs nothing today and means a future write from elsewhere has to go through the module that knows the rule:

- `Tmpfile.{destination_dir, tmpfilename}`: `finish()` renames exactly the pair `create` opened.
- `KEventWaker.{kq, machport}` (macOS): `init` rejects `machport == 0`; `wake`/`wait` are the only readers.
- `DynamicBitSetList.{n, bit_length}`: they size the raw buffer that `at()` does pointer arithmetic on.
- `webcore::Response.{ref_count, weak_ptr_data}`, `Request.reported_estimated_size`: maintained only by their own `ref_`/`unref`/`estimated_size` methods.
- `EVP.md`: `init` rejects a null digest.
- `PBKDF2.algorithm`: `from_js` rejects digests without an `md()`, and `run()` unwraps it.
- `UDPSocketConfig.{connect, fd}` and `ConnectConfig`'s fields: `from_js` range-checks the port and rejects a negative fd before they reach usockets.
- `FileSystemFlags.0`: every construction already goes through `from_js`/the named constants.

No behavior change; visibility only.

### How did you verify your code works?

`cargo check -p bun_sys -p bun_io -p bun_collections -p bun_runtime` is clean, which is the whole claim: nothing outside these modules used the fields.