### PR TITLE
install: make parse_append_dependencies take a DepsOwner enum

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2091,15 +2091,15 @@ pub(crate) fn parse_into_binary_lockfile(
             None
         };
 
-        let (off, len) = parse_append_dependencies::<false, true>(
+        let (off, len) = parse_append_dependencies(
             lockfile,
             &root_pkg_exr,
             &mut *log,
             source,
             &mut optional_peers_buf,
-            None,
-            None,
-            Some(&workspaces_obj),
+            DepsOwner::Root {
+                workspaces_obj: &workspaces_obj,
+            },
         )?;
 
         let mut root_pkg = Package::default();
@@ -2159,15 +2159,13 @@ pub(crate) fn parse_into_binary_lockfile(
                 pkg.name = sbuf!(lockfile).append_with_hash(name, name_hash)?;
                 pkg.name_hash = name_hash;
 
-                let (off, len) = parse_append_dependencies::<false, false>(
+                let (off, len) = parse_append_dependencies(
                     lockfile,
                     &value,
                     &mut *log,
                     source,
                     &mut optional_peers_buf,
-                    None,
-                    None,
-                    None,
+                    DepsOwner::Workspace,
                 )?;
 
                 pkg.dependencies = DependencySlice::new(off, len);
@@ -2512,15 +2510,16 @@ pub(crate) fn parse_into_binary_lockfile(
                         };
                         let deps_expr = Expr::from_json_value(&pkg_info[deps_idx], key_loc);
 
-                        let (off, len) = parse_append_dependencies::<true, false>(
+                        let (off, len) = parse_append_dependencies(
                             lockfile,
                             &deps_expr,
                             &mut *log,
                             source,
                             &mut optional_peers_buf,
-                            Some(pkg_path),
-                            Some(&bundled_pkgs),
-                            None,
+                            DepsOwner::Package {
+                                pkg_path,
+                                bundled_pkgs: &bundled_pkgs,
+                            },
                         )?;
 
                         pkg.dependencies = DependencySlice::new(off, len);
@@ -3198,21 +3197,34 @@ fn dependency_resolution_failure(
     Ok(())
 }
 
+/// Which package's dependency groups `parse_append_dependencies` is reading.
+/// `Root` also appends one workspace dependency per entry of `workspaces_obj`;
+/// `Package` also marks dependencies whose `<pkg_path>/<name>` is in
+/// `bundled_pkgs` as `Behavior::BUNDLED`.
+#[derive(Clone, Copy)]
+enum DepsOwner<'a> {
+    Root {
+        workspaces_obj: &'a Expr,
+    },
+    Workspace,
+    Package {
+        pkg_path: &'a [u8],
+        bundled_pkgs: &'a PkgPathSet,
+    },
+}
+
 // A separate `string_buf` parameter would borrow the same
 // `lockfile.buffers.string_bytes` / `string_pool` fields and alias `lockfile`.
 // Instead each append constructs a fresh `sbuf!(lockfile)` so the borrow
 // checker can see the disjoint field accesses against `buffers.dependencies`
 // and `workspace_paths`.
-fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>(
+fn parse_append_dependencies(
     lockfile: &mut BinaryLockfile,
     obj: &Expr,
     log: &mut bun_ast::Log,
     source: &bun_ast::Source,
     optional_peers_buf: &mut HashMap<u64, ()>,
-    // Only meaningful when `CHECK_FOR_BUNDLED`; carried as Option.
-    pkg_path: Option<&[u8]>,
-    bundled_pkgs: Option<&PkgPathSet>,
-    workspaces_obj: Option<&Expr>,
+    owner: DepsOwner<'_>,
 ) -> Result<(u32, u32), ParseError> {
     // Clearing on entry is equivalent to clearing on every exit path for all
     // callers (none read the buf between calls) and also covers early-error exits.
@@ -3242,10 +3254,12 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
         }
     }
 
-    let mut path_buf = if CHECK_FOR_BUNDLED {
-        Some(PathBuffer::uninit())
-    } else {
-        None
+    let mut bundled = match owner {
+        DepsOwner::Package {
+            pkg_path,
+            bundled_pkgs,
+        } => Some((pkg_path, bundled_pkgs, PathBuffer::uninit())),
+        DepsOwner::Root { .. } | DepsOwner::Workspace => None,
     };
 
     let off = lockfile.buffers.dependencies.len();
@@ -3309,11 +3323,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     ..Default::default()
                 };
 
-                if CHECK_FOR_BUNDLED {
-                    let pkg_path = pkg_path.expect("pkg_path required when CHECK_FOR_BUNDLED");
-                    let bundled_pkgs =
-                        bundled_pkgs.expect("bundled_pkgs required when CHECK_FOR_BUNDLED");
-                    let path_buf = &mut path_buf.as_mut().unwrap()[..];
+                if let Some((pkg_path, bundled_pkgs, path_buf)) = &mut bundled {
                     let bundled_location_len = pkg_path
                         .len()
                         .saturating_add(1)
@@ -3342,8 +3352,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
         }
     }
 
-    if IS_ROOT {
-        let workspaces_obj = workspaces_obj.expect("workspaces_obj required when IS_ROOT");
+    if let DepsOwner::Root { workspaces_obj } = owner {
         'workspaces: for workspace_path in lockfile.workspace_paths.values() {
             for row in object_rows(workspaces_obj) {
                 let path = row.key.slice();


### PR DESCRIPTION
### Problem
- No user-visible bug. This is a refactor of the bun.lock parser helper that reads one package's dependency groups into the binary lockfile.
- The helper was generic over two const bools and also took three `Option` arguments that had to agree with the bools. Callers use exactly three of the combinations the signature allows.
- That agreement lived in a comment and was re-checked at runtime with three `expect` calls and an `unwrap`, inside the per-dependency loop.

### Fix
- The bools and `Option`s become one `DepsOwner` argument with three variants: root (carries the workspaces object), workspace (carries nothing), and `packages` entry (carries the package path and the bundled set).
- Correct because each variant carries exactly the data its branch reads, so the bundled check or the root handling can no longer be requested without its inputs. Error messages and the appended rows are unchanged.
- No extra cost: the enum holds only references and is `Copy`, and one plain function replaces three monomorphized copies of the body.
- Verification: `cargo check` and `cargo clippy` clean, debug build passes, existing lockfile and workspace install tests pass (90 tests). No new test, since behavior is unchanged.

### Background
- `bun install` parses the text `bun.lock` into a binary lockfile with one flat dependencies buffer. Each package points at a slice of it, and this helper appends one package's rows and returns that slice as (offset, length).
- The root package additionally gets one dependency row per entry in the lockfile's `workspaces` object.
- In a `packages` entry, a dependency whose `<pkg_path>/<name>` is in the bundled set is flagged `BUNDLED`: it ships inside the parent package instead of being installed separately.
- Const generic bools compile a separate copy of the function per combination used; an enum argument compiles one copy with a `match`.

<details>
<summary>Original description</summary>

## What

`parse_append_dependencies` in `src/install/lockfile/bun.lock.rs` (the bun.lock parser helper that appends one package's `dependencies` / `devDependencies` / `optionalDependencies` / `peerDependencies` rows to `lockfile.buffers.dependencies`) was generic over two const bools and took three `Option` parameters whose presence had to agree with those bools:

```rust
// before
fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>(
    lockfile: &mut BinaryLockfile, obj: &Expr, log: &mut bun_ast::Log, source: &bun_ast::Source,
    optional_peers_buf: &mut HashMap<u64, ()>,
    // Only meaningful when `CHECK_FOR_BUNDLED`; carried as Option.
    pkg_path: Option<&[u8]>,
    bundled_pkgs: Option<&PkgPathSet>,
    workspaces_obj: Option<&Expr>,
) -> Result<(u32, u32), ParseError>
```

Of the states that signature can express, exactly three are used, one per caller: the root package (`<false, true>` with `Some(&workspaces_obj)`), a workspace package (`<false, false>` with three `None`s) and a `packages` entry (`<true, false>` with `Some(pkg_path)` and `Some(&bundled_pkgs)`). The body re-checked the agreement at runtime with `pkg_path.expect(..)`, `bundled_pkgs.expect(..)` and `path_buf.as_mut().unwrap()` inside the per-dependency loop, and `workspaces_obj.expect(..)` at the tail.

The function is now non-generic and takes one value describing whose dependencies are being read:

```rust
// after
#[derive(Clone, Copy)]
enum DepsOwner<'a> {
    Root { workspaces_obj: &'a Expr },
    Workspace,
    Package { pkg_path: &'a [u8], bundled_pkgs: &'a PkgPathSet },
}

fn parse_append_dependencies(.., owner: DepsOwner<'_>) -> Result<(u32, u32), ParseError>
```

Before the row loop the `Package` variant is matched once into `Option<(pkg_path, bundled_pkgs, PathBuffer)>`; the bundled check in the loop becomes `if let Some((pkg_path, bundled_pkgs, path_buf)) = &mut bundled` around the unchanged body, and the tail becomes `if let DepsOwner::Root { workspaces_obj } = owner`. The 3 call sites pass `DepsOwner::Root { workspaces_obj: &workspaces_obj }`, `DepsOwner::Workspace` and `DepsOwner::Package { pkg_path, bundled_pkgs: &bundled_pkgs }`. This removes the three `expect` calls, the `unwrap`, and the comment that documented which parameters went with which bool. Error messages, error variants and the appended dependencies are unchanged. Removes 0 unsafe blocks.

## Why

A caller can no longer ask for the bundled check without supplying the package path and bundled set, or ask for root handling without the workspaces object: each variant carries exactly the data its branch reads, so the invariant that used to live in a comment and four runtime checks is now the parameter type. It is zero-cost: `DepsOwner` holds only shared references, so it is `Copy` and needs no destructor; the per-row work in the package case goes from three loop-invariant `Option` checks to one; the root and workspace cases run once per lockfile and once per workspace respectively; the scratch `PathBuffer` is still created uninitialized and only in the package case; and collapsing the generic into a plain function replaces three monomorphized copies of the roughly 200-line body with one.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/cli/install/bun-lock.test.ts test/cli/install/lockfile-version-2.test.ts test/cli/install/bun-workspaces.test.ts`: 90 pass, 0 fail (90 tests across 3 files).

</details>
