### PR TITLE
crypto: store PBKDF2's key length as usize

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -322,7 +322,7 @@ impl CryptoHasher {
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_algorithm(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
         let tag: &'static [u8] = match this {
-            CryptoHasher::Evp(inner) => inner.get().algorithm.tag_cstr().to_bytes(),
+            CryptoHasher::Evp(inner) => inner.get().algorithm().tag_cstr().to_bytes(),
             CryptoHasher::Zig(inner) => inner.get().algorithm.tag_cstr().to_bytes(),
             CryptoHasher::Hmac(inner) => match inner.get() {
                 Some(hmac) => hmac.algorithm.tag_cstr().to_bytes(),

--- a/src/runtime/crypto/EVP.rs
+++ b/src/runtime/crypto/EVP.rs
@@ -10,7 +10,7 @@ pub struct EVP {
     pub ctx: boringssl::EVP_MD_CTX,
     // FFI: BoringSSL EVP_MD singletons are static for the process lifetime.
     md: *const boringssl::EVP_MD,
-    pub(crate) algorithm: Algorithm,
+    algorithm: Algorithm,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -162,6 +162,10 @@ pub(crate) fn lookup_ignore_case(bytes: &[u8]) -> Option<Algorithm> {
 }
 
 impl EVP {
+    pub fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
     /// # Safety
     /// `md` must be a valid `EVP_MD` pointer (BoringSSL static singleton) and
     /// `engine` must be either null or a valid `ENGINE` pointer.

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -14,7 +14,7 @@ pub(crate) struct PBKDF2 {
     pub password: StringOrBuffer,
     pub salt: StringOrBuffer,
     pub iteration_count: u32,
-    pub length: i32,
+    pub length: usize,
     algorithm: Algorithm,
 }
 
@@ -27,7 +27,7 @@ impl PBKDF2 {
         let length = self.length;
 
         output.fill(0);
-        debug_assert!(self.length <= i32::try_from(output.len()).expect("int cast"));
+        debug_assert!(self.length <= output.len());
         // Node.js (OpenSSL) rejects a zero-length derivation; BoringSSL accepts it.
         if length == 0 {
             return false;
@@ -47,7 +47,7 @@ impl PBKDF2 {
                 salt.len(),
                 iteration_count as c_uint,
                 algorithm.md().unwrap(),
-                usize::try_from(length).expect("int cast"),
+                length,
                 output.as_mut_ptr(),
             )
         };
@@ -101,7 +101,8 @@ impl PBKDF2 {
             ));
         }
 
-        let keylen: i32 = keylen_num as i32;
+        // 0..=i32::MAX was checked above.
+        let keylen = keylen_num as usize;
 
         if !arg2.is_number() {
             return Err(global_this.throw_invalid_argument_type_value(
@@ -271,7 +272,7 @@ impl JobContext for Pbkdf2Job {
     type Js = JSPromiseStrong;
 
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
-        let len = usize::try_from(this.pbkdf2.length).expect("int cast");
+        let len = this.pbkdf2.length;
         // `Vec` allocation aborts on OOM; use try_reserve to surface an error instead.
         let mut buf = Vec::new();
         if buf.try_reserve_exact(len).is_err() {
@@ -299,7 +300,7 @@ impl JobContext for Pbkdf2Job {
         }
 
         let output_slice = core::mem::take(&mut this.output);
-        debug_assert!(output_slice.len() == usize::try_from(this.pbkdf2.length).expect("int cast"));
+        debug_assert!(output_slice.len() == this.pbkdf2.length);
         // Ownership transfers to JSC (freed via MarkedArrayBuffer_deallocator → mimalloc free).
         let buffer_value = JSValue::create_buffer(global_this, output_slice.leak());
         promise.settle(global_this, buffer_value)?;

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -1124,8 +1124,7 @@ mod _impl {
         // with `JSBufferSubclassStructure` (a Node.js `Buffer`, not a plain Uint8Array/ArrayBuffer).
         // `pbkdf2Sync()` MUST return a Buffer — `Buffer.isBuffer(result)` and Buffer-only methods
         // (`.toString('hex')`, `.readUInt32BE`, …) depend on it.
-        let out_arraybuffer =
-            JSValue::create_buffer_from_length(global_this, data.length as usize)?;
+        let out_arraybuffer = JSValue::create_buffer_from_length(global_this, data.length)?;
         let Some(mut output) = out_arraybuffer.as_array_buffer(global_this) else {
             return Err(global_this.throw_out_of_memory());
         };

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -69,6 +69,34 @@ testPBKDF2("password", "salt", 32, 32, "64c486c55d30d4c5a079b8823b7d7cb37ff0556f
 
 testPBKDF2("", "", 1, 32, "f7ce0b653d2d72a4108cf5abe912ffdd777616dbbb27a70e8204f3ae2d0f6fad", "hex");
 
+describe("keylen is the length of the derived key", () => {
+  // RFC 7914 section 11: PBKDF2-HMAC-SHA-256, P="passwd", S="salt", c=1, dkLen=64.
+  // 64 bytes is two sha256 blocks, and PBKDF2 output is prefix consistent, so a
+  // shorter keylen must return exactly the first keylen bytes of this key.
+  const rfc7914 = Buffer.from(
+    "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc" +
+      "49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783",
+    "hex",
+  );
+
+  test.each([1, 31, 32, 33, 63, 64])("keylen=%d", async keylen => {
+    const expected = rfc7914.subarray(0, keylen);
+
+    const sync = crypto.pbkdf2Sync("passwd", "salt", 1, keylen, "sha256");
+    expect(Buffer.isBuffer(sync)).toBe(true);
+    expect(sync.length).toBe(keylen);
+    expect(sync).toStrictEqual(expected);
+
+    const { promise, resolve } = Promise.withResolvers();
+    crypto.pbkdf2("passwd", "salt", 1, keylen, "sha256", (err, key) => resolve({ err, key }));
+    const { err, key } = await promise;
+    expect(err).toBeNull();
+    expect(Buffer.isBuffer(key)).toBe(true);
+    expect(key.length).toBe(keylen);
+    expect(key).toStrictEqual(expected);
+  });
+});
+
 describe("invalid inputs", () => {
   for (let input of ["test", [], true, undefined, null]) {
     test(`${input} is invalid`, () => {


### PR DESCRIPTION
`crypto.pbkdf2`'s `keylen` is validated to `0..=i32::MAX` and was then stored as an `i32`, so each of the four places that used it (buffer allocation, the BoringSSL call, the sync path, a length assert) converted it back to `usize` with an `expect`. It is now stored as `usize`, converted once directly under the range check. A negative length was never reachable; the type just no longer pretends it is. Also: `EVP.algorithm` becomes private with a getter, since only `EVP::init` should set it.

No behavior change. Same bytes as Node for fixed inputs; `-1` and `2**31` still throw ERR_OUT_OF_RANGE; `0` still throws as in Node 22. Added a test that sync and async both return exactly `keylen` bytes of the RFC 7914 SHA-256 vector for lengths either side of the block size (1, 31, 32, 33, 63, 64). It passes on main too, by construction; it pins the field this retypes rather than proving a bug.