### PR TITLE
socket: own Listener.secure_ctx through OwnedSslCtx

### DIFF
--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -82,10 +82,10 @@ pub struct Listener {
     /// listener. `group.ext` = `*Listener`, so the dispatch handler recovers us
     /// from the socket without a context-ext lookup.
     pub(crate) group: JsCell<uws::SocketGroup>,
-    /// `SSL_CTX*` for accepted sockets. One owned ref; `SSL_CTX_free` on close.
-    /// `SSL_new()` per-accept takes its own ref, so accepted sockets outlive a
-    /// stopped listener safely.
-    pub(crate) secure_ctx: Cell<Option<NonNull<boring_sys::SSL_CTX>>>,
+    /// `SSL_CTX` for accepted sockets; released in `do_stop`, or with the
+    /// `Listener` if it is torn down without one. `SSL_new()` per-accept takes
+    /// its own ref, so accepted sockets outlive a stopped listener safely.
+    pub(crate) secure_ctx: JsCell<Option<boring_sys::OwnedSslCtx>>,
     pub(crate) ssl: bool,
     pub(crate) protos: Option<Box<[u8]>>,
     pub(crate) reject_unauthorized: bool,
@@ -231,7 +231,7 @@ impl Listener {
                     ),
                     poll_ref: JsCell::new(KeepAlive::init()),
                     group: JsCell::new(uws::SocketGroup::default()),
-                    secure_ctx: Cell::new(None),
+                    secure_ctx: JsCell::new(None),
                     strong_data: JsCell::new(Strong::empty()),
                     this_value: JsCell::new(JsRef::empty()),
                 }));
@@ -344,6 +344,20 @@ impl Listener {
             .into_boxed_slice();
         let fd_opt = socket_config.fd;
         let ssl_cfg_taken = socket_config.ssl.take();
+        let secure_ctx: Option<boring_sys::OwnedSslCtx> = match ssl_cfg_taken.as_ref() {
+            Some(ssl_cfg) => {
+                let mut create_err = uws::create_bun_socket_error_t::none;
+                let Some(ctx) = ssl_cfg.as_usockets().create_ssl_context(&mut create_err) else {
+                    return Err(global.throw_value(
+                        crate::socket::uws_jsc::create_bun_socket_error_to_js(create_err, global),
+                    ));
+                };
+                // SAFETY: `create_ssl_context` returns a +1 ref that is ours to release.
+                unsafe { boring_sys::OwnedSslCtx::from_raw(ctx) }
+            }
+            None => None,
+        };
+        let secure_ctx_ptr: Option<*mut uws::SslCtx> = secure_ctx.as_ref().map(|c| c.as_ptr());
 
         let this: *mut Listener = bun_core::heap::into_raw(Box::new(Listener {
             handlers,
@@ -360,7 +374,7 @@ impl Listener {
             listener: Cell::new(ListenerType::None),
             poll_ref: JsCell::new(KeepAlive::init()),
             group: JsCell::new(uws::SocketGroup::default()),
-            secure_ctx: Cell::new(None),
+            secure_ctx: JsCell::new(secure_ctx),
             strong_data: JsCell::new(Strong::empty()),
             this_value: JsCell::new(JsRef::empty()),
         }));
@@ -386,11 +400,7 @@ impl Listener {
             // SAFETY: this is still the sole owner on the error path; the
             // fields below are `Cell`/`JsCell`, so a shared borrow suffices.
             let this_ref = unsafe { &*this };
-            if let Some(c) = this_ref.secure_ctx.take() {
-                // SAFETY: FFI — secure_ctx holds one owned SSL_CTX ref from create_ssl_context
-                unsafe { boring_sys::SSL_CTX_free(c.as_ptr()) };
-            }
-            // protos: Box drops automatically when Listener is dropped below
+            // protos / secure_ctx: drop with the Listener below
             bun_core::asan::unregister_root_region(
                 this_ref.group.as_ptr().cast::<c_void>(),
                 size_of::<uws::SocketGroup>(),
@@ -401,19 +411,6 @@ impl Listener {
             drop(unsafe { bun_core::heap::take(this) });
         });
 
-        if let Some(ssl_cfg) = ssl_cfg_taken.as_ref() {
-            let mut create_err = uws::create_bun_socket_error_t::none;
-            match ssl_cfg.as_usockets().create_ssl_context(&mut create_err) {
-                Some(ctx) => this_ref
-                    .secure_ctx
-                    .set(NonNull::new(ctx.cast::<boring_sys::SSL_CTX>())),
-                None => {
-                    return Err(global.throw_value(
-                        crate::socket::uws_jsc::create_bun_socket_error_to_js(create_err, global),
-                    ));
-                }
-            }
-        }
         let kind: uws::SocketKind = if ssl_enabled {
             uws::SocketKind::BunListenerTls
         } else {
@@ -432,11 +429,6 @@ impl Listener {
         } else {
             UnixOrHost::Unix(hostname_owned)
         };
-
-        let secure_ctx_ptr: Option<*mut uws::SslCtx> = this_ref
-            .secure_ctx
-            .get()
-            .map(|p| p.as_ptr().cast::<uws::SslCtx>());
 
         let mut errno: c_int = 0;
         let listen_socket: *mut uws_sys::ListenSocket = match &mut connection {
@@ -543,9 +535,7 @@ impl Listener {
                 .set(Strong::create(default_data, global));
         }
 
-        if let Some(ssl_config) = ssl_cfg_taken.as_ref() {
-            // `ssl_enabled` ⇒ `createSSLContext` succeeded above ⇒ `secure_ctx` set.
-            let secure = this_ref.secure_ctx.get().expect("unreachable");
+        if let (Some(ssl_config), Some(secure)) = (ssl_cfg_taken.as_ref(), secure_ctx_ptr) {
             if let Some(server_name) = ssl_config.server_name_cstr() {
                 if !server_name.to_bytes().is_empty() {
                     // Registering the default cert under its own server_name is a
@@ -554,7 +544,7 @@ impl Listener {
                     // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
                     let _ = bun_opaque::opaque_deref_mut(listen_socket).add_server_name(
                         server_name,
-                        secure.as_ptr().cast(),
+                        secure,
                         core::ptr::null_mut(),
                     );
                 }
@@ -882,10 +872,7 @@ impl Listener {
             ListenerType::None => {}
         }
 
-        if let Some(ctx) = this.secure_ctx.take() {
-            // SAFETY: FFI — releases the one ref `listen()` took from the cache.
-            unsafe { boring_sys::SSL_CTX_free(ctx.as_ptr()) };
-        }
+        this.secure_ctx.set(None);
     }
 
     pub fn finalize(self: Box<Self>) {
@@ -960,13 +947,8 @@ impl Listener {
         );
         // SAFETY: group was init'd in listen(); not concurrently walked.
         unsafe { uws::SocketGroup::destroy(this_ref.group.as_ptr()) };
-        if let Some(ctx) = this_ref.secure_ctx.take() {
-            // SAFETY: FFI — a Listener torn down without do_stop() still owns
-            // its ref; do_stop() already took it when it ran.
-            unsafe { boring_sys::SSL_CTX_free(ctx.as_ptr()) };
-        }
 
-        // connection / protos / the handlers `Rc`: dropped by heap::take below
+        // connection / protos / secure_ctx / the handlers `Rc`: dropped by heap::take below
         // SAFETY: reclaim the Box allocated in listen()
         drop(unsafe { bun_core::heap::take(this) });
     }


### PR DESCRIPTION
### Problem
- Nothing is broken for users today. This hardens how the listener behind `Bun.listen()` (and so `tls.Server`) holds its `SSL_CTX`.
- The field was a raw pointer whose ownership lived in a doc comment, released by three hand-written `SSL_CTX_free` calls (listen failure, `stop()`, finalize). A new teardown path could skip the free or run it twice and nothing would catch it.
- `listen()` created the context after allocating the listener, so it read the field back twice, once through `.expect("unreachable")`.

### Fix
- The field becomes `Option<OwnedSslCtx>`, a wrapper `bun_boringssl_sys` already has that frees the context in `Drop`. `listen()` builds it before allocating the listener; `stop()` sets the field to `None`; the other two paths free it by dropping the listener, which they already did.
- Correct because the wrapper's `Drop` is the only release left, so the free runs exactly once on the same three paths as before. Three `SSL_CTX_free` blocks go away; one `unsafe` `from_raw` appears where the +1 reference arrives.
- Layout is unchanged: `Option<OwnedSslCtx>` is the same nullable pointer as `Option<NonNull<SSL_CTX>>`, and `JsCell` is `repr(transparent)`.
- Verification: no new test, since behaviour is meant to be identical. `cargo check` and `clippy` are clean; the existing tls and tcp-server tests match main (same 5 localhost ECONNREFUSED failures on both).

### Background
- `SSL_CTX` is reference counted. `create_ssl_context` returns a +1 reference to free exactly once; each accepted socket takes its own reference at `SSL_new`, so freeing the listener's does not affect live connections.
- `OwnedSslCtx` is a `NonNull<SSL_CTX>` newtype: `from_raw` adopts a +1 pointer, `as_ptr` lends it out, `Drop` frees it.
- `JsCell<T>` is bun's `Cell` for fields of JS-heap-owned structs, minus the `T: Copy` bound. Needed here because `OwnedSslCtx` is not `Copy`; `set(None)` drops the old value.
- A `Listener` is torn down three ways: `listen()` failing partway (a scope guard frees the box), `stop()`, or GC finalize with no prior `stop()`.

<details>
<summary>Original description</summary>

## What

`Listener` (the object behind `Bun.listen()` and, through it, `tls.Server`) holds one reference to the `SSL_CTX` its accepted sockets are created from. The field was a raw pointer whose ownership lived in a doc comment, and the reference was released by three hand-written `SSL_CTX_free` calls:

```rust
/// `SSL_CTX*` for accepted sockets. One owned ref; `SSL_CTX_free` on close.
pub(crate) secure_ctx: Cell<Option<NonNull<boring_sys::SSL_CTX>>>,
```

`listen()` allocated the `Listener` with `secure_ctx: None`, created the context afterwards and stored it into the cell, so the error-unwind `scopeguard` had to `take()` and free it by hand; it then read the cell back twice, once as a raw pointer for `group.listen` / `listen_unix` and once through `.get().expect("unreachable")` for the `add_server_name` hint. `do_stop` freed the reference eagerly, and `deinit` freed it again for listeners torn down without a `stop()`. The field is now

```rust
pub(crate) secure_ctx: JsCell<Option<boring_sys::OwnedSslCtx>>,
```

using the `OwnedSslCtx` wrapper that `bun_boringssl_sys` already provides (`SSL_CTX_free` in `Drop`). `listen()` builds the context before the `Listener` is allocated (`create_ssl_context` followed by one `OwnedSslCtx::from_raw`), takes `secure_ctx_ptr` from it for the two uWS listen calls, and moves it into the struct literal; the `add_server_name` block pairs the config and the pointer in one `if let (Some(..), Some(..))` instead of the `expect`. `do_stop` keeps releasing the reference early via `this.secure_ctx.set(None)`; the error guard and `deinit` no longer mention the field because dropping the `Box<Listener>` they already perform releases it. The Windows named-pipe construction site changes only its constructor. All 11 uses of the field are in `src/runtime/socket/Listener.rs`; the change removes three `unsafe { SSL_CTX_free(..) }` blocks and the `expect`, and adds one `unsafe` call (`from_raw`) at the point where the +1 reference is received. One file, +25/-43 lines.

## Why

Who owns the listener's `SSL_CTX` reference and when it is released (at `stop()`, otherwise when the `Listener` is freed) is now stated by the field type, and a teardown path cannot forget the release or perform it twice, since the only release is the wrapper's `Drop`. It is zero-cost: `Option<OwnedSslCtx>` is the same single nullable pointer as `Option<NonNull<SSL_CTX>>` (`NonNull` niche) and `JsCell` is `repr(transparent)`, so the struct layout is unchanged; the `from_raw` null check is the `NonNull::new` the old code already performed; `SSL_CTX_free` runs exactly once on the same three paths as before (stop, finalize, or listen failure); and the only removed runtime work is the `expect` and, on the context-creation failure path, an allocation that was immediately freed.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/js/node/tls/ssl-ctx-cache.test.ts test/js/node/tls/node-tls-context.test.ts test/js/node/tls/node-tls-server.test.ts test/js/bun/net/tcp-server.test.ts: 101 pass, 5 fail (ssl-ctx-cache 14/0, node-tls-context 17/0, node-tls-server 66/1, tcp-server 4/4).
The 5 failures ("echo server 1 on 1", "tcp socket binaryType > arraybuffer/uint8array/buffer", "SNICallback runs even when the requested servername matches the bind hostname") are localhost ECONNREFUSED failures in tests that listen on hostname "localhost"; they fail identically on main (70 pass, same 5 fail) and are pre-existing/environmental, unrelated to the Listener.rs secure_ctx change.


</details>
