### PR TITLE
Read Request's abort signal and JSArrayIterator's fast path through accessors

### DIFF
--- a/src/jsc/JSArrayIterator.rs
+++ b/src/jsc/JSArrayIterator.rs
@@ -3,14 +3,20 @@ use bun_jsc::{JSGlobalObject, JSObject, JSValue, JsResult};
 pub struct JSArrayIterator<'a> {
     pub i: u32,
     pub len: u32,
-    pub array: JSValue,
+    array: JSValue,
     pub global: &'a JSGlobalObject,
     /// Direct pointer into the JSArray butterfly when the array has Int32 or
     /// Contiguous storage and a sane prototype chain. Holes are encoded as 0.
-    pub fast: Option<*const JSValue>,
+    fast: Option<*const JSValue>,
 }
 
 impl<'a> JSArrayIterator<'a> {
+    /// Iterating straight out of the butterfly (see `fast`), so `next()`
+    /// cannot run user JS.
+    pub fn is_fast(&self) -> bool {
+        self.fast.is_some()
+    }
+
     pub fn init(value: JSValue, global: &'a JSGlobalObject) -> JsResult<JSArrayIterator<'a>> {
         let mut length: u32 = 0;
         let elements = Bun__JSArray__getContiguousVector(value, &mut length);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3409,7 +3409,7 @@ impl BlobExt for Blob {
                     // instead of cloned, which would double peak memory for
                     // `new Blob(largeChunks)`. Non-fast arrays are conservatively
                     // treated as able to run user JS.
-                    let mut parts_can_run_js = iter.fast.is_none() || !stack.is_empty();
+                    let mut parts_can_run_js = !iter.is_fast() || !stack.is_empty();
                     if !parts_can_run_js {
                         let mut prescan = jsc::JSArrayIterator::init(current, global)?;
                         while let Some(item) = prescan.next()? {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -90,7 +90,7 @@ pub struct Request {
     // `Arc` of an opaque ZST is meaningless (its payload address is not the
     // C++ object). `AbortSignalRef` wraps `NonNull<AbortSignal>` and routes
     // Clone/Drop to the C++ ref/unref.
-    pub(crate) signal: JsCell<Option<AbortSignalRef>>,
+    signal: JsCell<Option<AbortSignalRef>>,
     /// Owning `+1` handle into the per-VM `Body::Value` hive pool. The
     /// `Request` and (when served by `Bun.serve`) the `RequestContext` each
     /// hold their own `+1` on the same slot. `ManuallyDrop` because
@@ -719,6 +719,12 @@ impl Request {
 
     pub(crate) fn get_integrity(_this: &Self, global_this: &JSGlobalObject) -> JSValue {
         ZigString::EMPTY.to_js(global_this)
+    }
+
+    /// The `AbortSignal` this request was constructed with or lazily created
+    /// for its `signal` getter, if any.
+    pub(crate) fn abort_signal(&self) -> Option<&AbortSignalRef> {
+        self.signal.get().as_ref()
     }
 
     pub(crate) fn get_signal(&self, global_this: &JSGlobalObject) -> JSValue {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1157,7 +1157,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
 
         if let Some(req) = request_mut!() {
-            if let Some(signal_) = req.signal.get() {
+            if let Some(signal_) = req.abort_signal() {
                 break 'extract_signal NonNull::new(signal_.ref_());
             }
             break 'extract_signal None;


### PR DESCRIPTION
### What does this PR do?

Two fields whose owner sets them up under a specific condition were writable from anywhere in the crate:

- `webcore::Request.signal` is only ever set from `construct_into` (after `AbortSignal::ref_from_js` type-checks it), `clone_into`, and the lazy `signal` getter. Its one outside reader, `fetch()` extracting the signal from a `Request` argument, now goes through `Request::abort_signal()`, and the field is private.
- `JSArrayIterator.fast`/`.array` are `Some`/set only when C++ reported a contiguous butterfly together with the `len` that `next()` bounds against; `Blob`'s parts loop read `fast` to decide whether iteration can run JS. That is now `iter.is_fast()`, and both fields are private (`i`/`len` stay public, they are read widely and `next()` bounds-checks `i`).

No behavior change.

### How did you verify your code works?

`cargo check -p bun_jsc -p bun_runtime`. With `bun-debug`: `fetch(new Request(url, { signal }))` still rejects with `AbortError` when the controller aborts mid-request, and `new Blob([...]).text()` is correct for both a plain array (fast path) and one containing an object with `toString` (slow path).