### PR TITLE
shell: make SubprocExec child/resume backrefs Option types

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -12,10 +12,11 @@ use crate::shell::shell_body::subproc::{Readable, ShellSubprocess, StdioKind};
 use crate::shell::states::assigns::{AssignCtx, Assigns};
 use crate::shell::states::base::Base;
 use crate::shell::states::expansion::Expansion;
-use crate::shell::subproc::{ShellIO, SpawnArgs};
+use crate::shell::subproc::{CmdHandle, ShellIO, SpawnArgs};
 use crate::shell::util::{OutKind, Stdio};
 use crate::shell::yield_::Yield;
 use bun_collections::VecExt;
+use core::ptr::NonNull;
 
 pub struct Cmd {
     pub(crate) base: Base,
@@ -66,16 +67,17 @@ impl Cmd {
 }
 
 pub struct SubprocExec {
-    pub(crate) child: *mut ShellSubprocess,
+    /// The `heap::alloc`'d subprocess owned by this `Cmd` and reclaimed in
+    /// [`Cmd::deinit`]. `None` from staging in `transition_to_exec` until
+    /// `spawn_async` writes it through its out pointer.
+    pub(crate) child: Option<NonNull<ShellSubprocess>>,
     pub(crate) buffered_closed: BufferedIoClosed,
-    /// NodeId-arena backrefs so the legacy `&mut self` subprocess callbacks
-    /// (`buffered_output_close` / `on_exit`) can hand a [`Yield`] back to the
-    /// trampoline. The `Cmd` lives inside `interp.nodes`, so we stash the
-    /// indices and
-    /// return `Yield::Next(this_id)` for the caller (`PipeReader::run_yield`)
-    /// to drive.
-    pub(crate) interp: *mut Interpreter,
-    pub(crate) this_id: NodeId,
+    /// How the `&mut self` subprocess callbacks (`buffered_output_close` /
+    /// `on_exit`) resume this `Cmd`, which lives inside `interp.nodes` and so
+    /// cannot reach the trampoline from `self`. `None` until the spawn call
+    /// has returned: a callback that fires synchronously inside the spawn only
+    /// records its result, and `transition_to_exec` resumes instead.
+    pub(crate) resume: Option<CmdHandle>,
 }
 
 /// Tracks which subprocess stdio pipes are still open. Each `Option` is `None`
@@ -550,22 +552,21 @@ impl Cmd {
         // Stage the exec slot *before* spawning so PipeReader / process-exit
         // callbacks (which deref `cmd_parent.exec`) see a populated `Subproc`
         // with the correct `child` once `spawn_async` writes through
-        // `out_subproc`. `interp` is left null until `spawn_async` and the
+        // `out_subproc`. `resume` is left `None` until `spawn_async` and the
         // `did_exit_immediately` handling have returned: a synchronous
         // `Cmd::on_exit` (process exit handler) or `Cmd::buffered_output_close`
         // (an eager `read_all` on a pipe erroring inside the spawn) would
         // otherwise drive the trampoline (`Yield::run(&*interp)`) while this
         // frame still holds `&Interpreter`, tearing the Cmd down (and freeing
-        // `child`) underneath the live `subproc` borrow. With `interp` null,
+        // `child`) underneath the live `subproc` borrow. With `resume` unset,
         // both record `exit_code`/`state = Done` and return; we resume via
         // the Yield we hand back below.
         let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
-            child: core::ptr::null_mut(),
+            child: None,
             buffered_closed,
-            interp: core::ptr::null_mut(),
-            this_id: this,
+            resume: None,
         }));
 
         // Derive the raw backrefs `spawn_async` needs from a single
@@ -579,7 +580,7 @@ impl Cmd {
         // `cmd_parent` is `(interp, NodeId)` rather than the spec's `*ShellCmd`
         // — the Cmd lives inline in `interp.nodes: Vec<Node>`, and a raw
         // `*mut Cmd` would dangle on the next `alloc_node` reallocation.
-        let child_out: *mut *mut ShellSubprocess = {
+        let child_out: *mut Option<NonNull<ShellSubprocess>> = {
             let cmd = interp.as_cmd_mut(this);
             spawn_args.argv.reserve_exact(cmd.args.len() + 1);
             for arg in &cmd.args {
@@ -592,7 +593,7 @@ impl Cmd {
                 _ => unreachable!(),
             }
         };
-        let cmd_parent = crate::shell::subproc::CmdHandle {
+        let cmd_parent = CmdHandle {
             // SAFETY: `interp_ptr` is the live owning Interpreter (from
             // `&mut Interpreter` above); single-threaded, write provenance.
             interp: unsafe { bun_ptr::ParentRef::from_raw_mut(interp_ptr) },
@@ -617,21 +618,23 @@ impl Cmd {
 
         if let Err(e) = spawn_result {
             drop(arena);
-            // Revert exec so `deinit` doesn't free a null `child`.
+            // Revert exec: a failed `spawn_async` owns the teardown of its
+            // subprocess, so `deinit` must not act on anything it wrote into
+            // `child`.
             interp.as_cmd_mut(this).exec = Exec::None;
             return Builtin::cmd_write_failing_error(interp, this, format_args!("{}\n", e));
         }
 
         // Read the subprocess back via the arena instead of holding `child_out`
         // across the call.
-        let child: *mut ShellSubprocess = match &interp.as_cmd(this).exec {
+        let child = match &interp.as_cmd(this).exec {
             Exec::Subproc(sub) => sub.child,
             _ => unreachable!(),
         };
         // SAFETY: `spawn_async` Ok ⇒ wrote a live `heap::alloc` subprocess
         // pointer into `*child_out` (== `sub.child`); valid until `Cmd::deinit`
         // reclaims the box. Single-threaded.
-        let subproc = unsafe { &mut *child };
+        let subproc = unsafe { child.unwrap_unchecked().as_mut() };
         subproc.r#ref();
         drop(arena);
 
@@ -646,14 +649,14 @@ impl Cmd {
             }
         }
 
-        // Publish the interpreter backref now that all synchronous spawn-time
+        // Publish the resume handle now that all synchronous spawn-time
         // callbacks have returned, so subsequent async pipe-close /
         // process-exit notifications can drive the trampoline themselves. If a
         // synchronous callback already finished the command (`state = Done`),
-        // resume here instead — the callback couldn't, with `interp` null.
+        // resume here instead: the callback couldn't, with `resume` unset.
         let me = interp.as_cmd_mut(this);
         if let Exec::Subproc(exec) = &mut me.exec {
-            exec.interp = interp_ptr;
+            exec.resume = Some(cmd_parent);
         }
         if matches!(me.state, CmdState::Done) {
             return Yield::Next(this);
@@ -859,12 +862,14 @@ impl Cmd {
             let me = interp.as_cmd_mut(this);
             match &mut me.exec {
                 Exec::Builtin(b) => b.defuse_array_buf_pins(),
-                Exec::Subproc(sub) if !sub.child.is_null() => {
-                    // SAFETY: `child` is the live heap::alloc'd subprocess;
-                    // the call only writes its own fields.
-                    unsafe { ShellSubprocess::defuse_array_buffer_unpins(sub.child) };
+                Exec::Subproc(sub) => {
+                    if let Some(child) = sub.child {
+                        // SAFETY: `child` is the live heap::alloc'd subprocess;
+                        // the call only writes its own fields.
+                        unsafe { ShellSubprocess::defuse_array_buffer_unpins(child.as_ptr()) };
+                    }
                 }
-                _ => {}
+                Exec::None => {}
             }
         }
         Self::deinit(interp, this);
@@ -888,29 +893,30 @@ impl Cmd {
         match exec {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
-            Exec::Subproc(sub) if !sub.child.is_null() => {
-                // SAFETY: `child` was set by `initSubproc` from a
-                // `heap::alloc(ShellSubprocess)` and stays valid until this
-                // drop. Single-threaded. Reclaiming the box runs
-                // `ShellSubprocess::drop` → `finalize_sync` (closes stdio).
-                unsafe {
-                    let child = sub.child;
-                    if !(*child).has_exited() {
-                        let _ = (*child).try_kill(9);
+            // `child` is still `None` if the spawn failed before the
+            // subprocess box was returned: nothing to tear down.
+            Exec::Subproc(sub) => {
+                if let Some(child) = sub.child {
+                    let child = child.as_ptr();
+                    // SAFETY: `child` was set by `initSubproc` from a
+                    // `heap::alloc(ShellSubprocess)` and stays valid until this
+                    // drop. Single-threaded. Reclaiming the box runs
+                    // `ShellSubprocess::drop` → `finalize_sync` (closes stdio).
+                    unsafe {
+                        if !(*child).has_exited() {
+                            let _ = (*child).try_kill(9);
+                        }
+                        (*child).unref::<true>();
+                        // Stop any still-active stdio before the drop (only the
+                        // VM-shutdown path reaches here in flight).
+                        #[cfg(not(windows))]
+                        ShellSubprocess::deinit_in_flight_io(child);
+                        drop(bun_core::heap::take(child));
                     }
-                    (*child).unref::<true>();
-                    // Stop any still-active stdio before the drop (only the
-                    // VM-shutdown path reaches here in flight).
-                    #[cfg(not(windows))]
-                    ShellSubprocess::deinit_in_flight_io(child);
-                    drop(bun_core::heap::take(child));
                 }
                 // `sub.buffered_closed` drops here, freeing any captured
                 // `Vec<u8>`s (spec `buffered_closed.deinit()`).
             }
-            // `Exec::Subproc` with null `child`: spawn failed before the
-            // subprocess box was returned. Nothing to tear down.
-            Exec::Subproc(_) => {}
         }
         // Argv/env are heap-owned `Vec`s; there is no spawn arena to free.
         // `base.shell` is borrowed (or, when parent is Pipeline, freed by
@@ -920,9 +926,9 @@ impl Cmd {
 
     // ── Subprocess callbacks (legacy `*Cmd` backref shape) ────────────────
     // `ShellSubprocess` / `PipeReader` hold a `*mut Cmd` backref and call
-    // these via `&mut self`. The NodeId-arena port stashes `(interp, this_id)`
-    // on `SubprocExec` so the resulting `Yield` can be driven by the caller's
-    // `PipeReader::run_yield` without aliasing `&Interpreter` against
+    // these via `&mut self`. The NodeId-arena port stashes a `CmdHandle`
+    // (`SubprocExec::resume`) so the resulting `Yield` can be driven by the
+    // caller's `PipeReader::run_yield` without aliasing `&Interpreter` against
     // `&mut self`.
 
     /// True once the command has both an exit code and (for subprocesses)
@@ -964,19 +970,19 @@ impl Cmd {
             // `*mut Interpreter` it already holds, landing in `Cmd::next` →
             // `CmdState::Done` → `interp.child_done(...)`.
             self.state = CmdState::Done;
-            let (interp, this_id) = match &self.exec {
-                Exec::Subproc(sub) => (sub.interp, sub.this_id),
+            let resume = match &self.exec {
+                Exec::Subproc(sub) => sub.resume,
                 // Only the subprocess path calls this; builtin output goes
                 // through `Builtin::done` → `on_exec_done`.
                 _ => return Yield::suspended(),
             };
-            // Same gate as `on_exit`: `exec.interp` stays null until the spawn
+            // Same gate as `on_exit`: `resume` stays `None` until the spawn
             // returns, so a Yield run here would reach `Cmd::deinit` and free the
             // `ShellSubprocess` still on the spawn frame. `transition_to_exec` resumes.
-            if interp.is_null() {
-                return Yield::suspended();
-            }
-            return Yield::Next(this_id);
+            return match resume {
+                Some(handle) => Yield::Next(handle.id),
+                None => Yield::suspended(),
+            };
         }
         Yield::suspended()
     }
@@ -992,8 +998,10 @@ impl Cmd {
             return;
         };
         // Raw deref keeps the borrow disjoint from `sub.buffered_closed` below.
-        // SAFETY: `child` is the live subprocess owned by this Cmd.
-        let child = unsafe { &mut *sub.child };
+        // SAFETY: pipe readers exist only once `spawn_async` has stored the
+        // subprocess in `child`, which stays live (owned by this Cmd) until
+        // `deinit`.
+        let child = unsafe { sub.child.unwrap_unchecked().as_mut() };
         // Tee into the JS-side captured buffer if stdout is an fd with a
         // `captured` slot and the redirect didn't send stdout elsewhere.
         if let IoOutKind::Fd(fd) = &self.io.stdout {
@@ -1028,8 +1036,8 @@ impl Cmd {
             return;
         };
         // Raw deref keeps the borrow disjoint from `sub.buffered_closed` below.
-        // SAFETY: `child` is the live subprocess owned by this Cmd.
-        let child = unsafe { &mut *sub.child };
+        // SAFETY: as in `buffered_output_close_stdout`.
+        let child = unsafe { sub.child.unwrap_unchecked().as_mut() };
         if let IoOutKind::Fd(fd) = &self.io.stderr {
             // SAFETY: single-threaded; the captured `Vec<u8>` lives in the
             // owning `ShellExecEnv` and no other borrow of it is live here.
@@ -1059,20 +1067,19 @@ impl Cmd {
         if has_finished {
             self.state = CmdState::Done;
             // `self` lives inside `interp.nodes`, so resume via the stashed
-            // backrefs.
-            let (interp, this_id) = match &self.exec {
-                Exec::Subproc(sub) => (sub.interp, sub.this_id),
+            // handle.
+            let resume = match &self.exec {
+                Exec::Subproc(sub) => sub.resume,
                 _ => return,
             };
-            if interp.is_null() {
+            let Some(handle) = resume else {
                 return;
-            }
-            // SAFETY: `interp` outlives every spawned subprocess (it owns the
-            // arena slot containing `self`). `&mut self` is dead by NLL after
-            // this point so the `&Interpreter` borrow does not alias it.
-            // The caller (`ShellSubprocess::on_process_exit`) does not touch
+            };
+            // `&mut self` is dead by NLL after this point so the `&Interpreter`
+            // borrow (it owns the arena slot containing `self`) does not alias
+            // it. The caller (`ShellSubprocess::on_process_exit`) does not touch
             // its `*mut Cmd` again after this returns.
-            Yield::Next(this_id).run(unsafe { &*interp });
+            Yield::Next(handle.id).run(&handle.interp);
         }
     }
 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -604,7 +604,7 @@ impl ShellSubprocess {
         // to initialize the object. Raw (not `&mut`) so the caller can pass an
         // address inside the `Cmd` arena slot without holding a `&mut` borrow
         // across this re-entrant call.
-        out: *mut *mut Self,
+        out: *mut Option<core::ptr::NonNull<Self>>,
         notify_caller_process_already_exited: &mut bool,
     ) -> sh::Result<()> {
         let mut spawn_args = spawn_args_;
@@ -633,7 +633,7 @@ impl ShellSubprocess {
         // We have to use an out pointer because this function may invoke callbacks that expect a
         // fully initialized parent object. Writing to this out pointer may be the last step needed
         // to initialize the object.
-        out_subproc: *mut *mut Self,
+        out_subproc: *mut Option<core::ptr::NonNull<Self>>,
         notify_caller_process_already_exited: &mut bool,
     ) -> sh::Result<()> {
         // Owns the `K=V\0` storage when inheriting the parent env. The struct
@@ -794,14 +794,15 @@ impl ShellSubprocess {
         // `*mut Subprocess` is available to `Writable::init` / `Readable::init`
         // (they store it on StaticPipeWriter / PipeReader as a backref).
         let mut slot = Box::<Subprocess>::new_uninit();
-        let subprocess: *mut Subprocess = slot.as_mut_ptr();
+        let child = core::ptr::NonNull::from(&mut *slot).cast::<Subprocess>();
+        let subprocess: *mut Subprocess = child.as_ptr();
         // SAFETY: `out_subproc` points at the `SubprocExec.child` slot inside
         // the heap-stable `Box<SubprocExec>` staged by the caller before this
         // call; no `&` to that slot is live (the caller's `&mut Cmd` borrow
         // ended before the call). Written *before* any callback below
         // (`watch`/`start`/`read_all`) so re-entrant `Cmd` callbacks see a
         // populated `exec.subproc.child`.
-        unsafe { *out_subproc = subprocess };
+        unsafe { *out_subproc = Some(child) };
 
         let stdin = match Writable::init(stdio0, event_loop, subprocess, spawn_stdin) {
             Ok(w) => w,


### PR DESCRIPTION
### Problem
- No user-visible bug. `SubprocExec`, the state a shell `Cmd` keeps while an external process runs, held two raw pointers that each used null to mean a state.
- `child` is null from staging until the spawn writes the subprocess back. The two deinit paths null-checked it; the pipe-close paths dereferenced it blindly.
- `interp` (paired with `this_id`) is deliberately null until the spawn call has returned, so a callback firing inside the spawn records its result instead of resuming the command. Both callbacks tested it for null.
- That pair is a hand-rolled copy of the `CmdHandle` the same function already builds and passes to the spawn.

### Fix
- `child` becomes `Option<NonNull<ShellSubprocess>>`; `interp` and `this_id` become `resume: Option<CmdHandle>`, set at the same points the pointers were. Null checks become `Some`/`None` matches; the spawn's out pointer changes type to match.
- Nothing changes at runtime: both `Option`s use the null niche, so the struct stays 80 bytes and each `None` test is the null compare it replaces. The three derefs that were unchecked stay unchecked. One `unsafe` block removed, none added.
- Verification: no new test. `cargo check` and `clippy` are clean, a debug build succeeds, and the shell test files were run (498 pass). The 9 failures are reported as pre-existing on main, caused by `/dev/null` being a regular file on the test machine.

### Background
- The shell runs a script as a state machine. Every node, including each `Cmd`, lives by index (`NodeId`) in a `Vec` owned by the `Interpreter`, which can reallocate, so nodes hold indices rather than pointers to each other. A step returns a `Yield` that a trampoline drives onward.
- A `Cmd` running an external process owns a heap-allocated subprocess. Process exit and pipe close arrive as callbacks holding only `&mut Cmd`, so the `Cmd` must stash how to reach the interpreter to resume itself.
- Those callbacks can fire synchronously inside the spawn call. Resuming from there would tear the `Cmd` down under the spawn's own borrow, so the resume handle is published only after the spawn returns; an earlier callback records its result and the spawn path resumes.
- `CmdHandle` is `(ParentRef<Interpreter>, NodeId)`, the handle the subprocess itself holds. `ParentRef` wraps a non-null pointer, so `Option<CmdHandle>`, like `Option<NonNull<T>>`, is pointer-sized.

<details>
<summary>Original description</summary>

## What

`SubprocExec` (`src/runtime/shell/states/Cmd.rs`), the `Exec::Subproc` payload of a shell `Cmd`, stored two raw pointers that each used null as a state. `child: *mut ShellSubprocess` is null from the moment the slot is staged until `ShellSubprocess::spawn_async` writes the freshly allocated subprocess through its out pointer, and was null-checked in `deinit` / `deinit_from_finalizer` but dereferenced blindly on the pipe-close paths. `interp: *mut Interpreter` (paired with `this_id: NodeId`) is deliberately left null until the spawn call has returned, so that a `Cmd::on_exit` or `Cmd::buffered_output_close` firing synchronously inside the spawn records its result instead of driving the trampoline while the spawn frame still borrows the subprocess; both callbacks tested it for null before yielding. The `(interp, this_id)` pair is exactly the `subproc::CmdHandle { interp: ParentRef<Interpreter, Mut>, id: NodeId }` that `transition_to_exec` already builds a few lines later and hands to `spawn_async`.

```rust
// before
pub struct SubprocExec {
    pub(crate) child: *mut ShellSubprocess,
    pub(crate) buffered_closed: BufferedIoClosed,
    pub(crate) interp: *mut Interpreter,
    pub(crate) this_id: NodeId,
}
exec.interp = interp_ptr;                               // publish after spawn
let (interp, this_id) = (sub.interp, sub.this_id);      // on_exit
if interp.is_null() { return; }
Yield::Next(this_id).run(unsafe { &*interp });

// after
pub struct SubprocExec {
    pub(crate) child: Option<NonNull<ShellSubprocess>>,
    pub(crate) buffered_closed: BufferedIoClosed,
    pub(crate) resume: Option<CmdHandle>,
}
exec.resume = Some(cmd_parent);                         // publish after spawn
let Some(handle) = sub.resume else { return };          // on_exit
Yield::Next(handle.id).run(&handle.interp);
```

In `Cmd.rs` the staging literal writes `None` for both fields, `child_out` becomes `*mut Option<NonNull<ShellSubprocess>>`, the post-spawn read-back derefs with `unwrap_unchecked().as_mut()` inside its existing `unsafe` block (whose SAFETY comment already stated that `Ok` implies the pointer was written), `deinit` and `deinit_from_finalizer` replace their `!is_null()` match guards with `if let Some(child)`, `buffered_output_close` matches on `resume`, the two `buffered_output_close_{stdout,stderr}` derefs stay inside their existing `unsafe` blocks, and `on_exit` runs the `Yield` through the handle's `ParentRef` `Deref`, which removes its `unsafe { &*interp }` block. In `subproc.rs`, `spawn_async` and `spawn_maybe_sync_impl` take `*mut Option<NonNull<Self>>`, and the write site derives the `NonNull` from the same `&mut *slot` reborrow the raw `subprocess` pointer was already derived from, so the provenance chain is unchanged. 10 sites in `Cmd.rs`, 3 in `subproc.rs`; removes 1 `unsafe` block and adds none; 2 files, +82/-74. `IOWriter` and `IOReader` already keep their interpreter backref as `Option<ParentRef<Interpreter>>`, so this brings the third shell backref into the same shape.

## Why

"Not yet spawned" and "spawn has not returned yet" are now `None` values a reader can see in the field types, rather than two null conventions documented in comments, and the resume path reuses the handle type the subprocess itself holds instead of a second hand-rolled copy of it. It is zero-cost: `Option<NonNull<T>>` is pointer-sized via the null niche and `Option<CmdHandle>` takes the niche of its `ParentRef` (`repr(transparent)` over `NonNull`), so `SubprocExec` stays 80 bytes with the same field sizes; each remaining `Some`/`None` test compiles to the null compare it replaces, the three blind derefs remain unchecked, and no allocation, copy or branch is added on any path.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `test/js/bun/shell/{shell-pipe-read-fault,exec,pipeline_stack,bunshell}.test.ts`: 498 pass, 2 skip, 83 todo, 9 fail (592 tests); the three smaller files pass fully.
The 9 failures are all in `bunshell.test.ts` (condexprs "-c", "-f character device", and the "stdin redirect from a zero-length buffer" cases) and are pre-existing: they fail identically on main because /dev/null on this machine is a regular file rather than a character device (an earlier "> /dev/null" test writes "Bunception!" into it, which the empty-stdin children then read back); unrelated to the `Cmd.rs`/`subproc.rs` `Option<NonNull>` refactor.


</details>
