### PR TITLE
webcore: replace NewSource close fn-ptr/ctx pair with a one-shot bool

### DIFF
--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -823,13 +823,11 @@ pub trait SourceContext: Sized {
 pub struct NewSource<C: SourceContext> {
     pub context: C,
     pub cancelled: bool,
+    /// Armed by the `onClose` setter ([`Self::set_on_close_from_js`]);
+    /// [`Self::on_close`] disarms it and runs [`Self::on_js_close`] once.
+    pub js_on_close_armed: bool,
     pub ref_count: u32,
     pub pending_err: Option<syscall::Error>,
-    pub close_handler: Option<fn(Option<*mut c_void>)>,
-    /// Borrowed opaque context for native `close_handler`s (never
-    /// owned/freed here). The JS path stores
-    /// `on_js_close` and leaves this `None` — see [`Self::on_close`].
-    pub close_ctx: Option<NonNull<c_void>>,
     /// Upstream producer to notify on cancel/drain/consumer-attach. Replaces
     /// the per-signal fn-ptr + ctx-ptr pairs with one typed handle.
     pub producer: Cell<streams::SourceHandle>,
@@ -856,10 +854,9 @@ impl<C: SourceContext + Default> Default for NewSource<C> {
         Self {
             context: C::default(),
             cancelled: false,
+            js_on_close_armed: false,
             ref_count: 1,
             pending_err: None,
-            close_handler: None,
-            close_ctx: None,
             producer: Cell::new(streams::SourceHandle::None),
             global_this: None,
             this_jsvalue: jsc::JsRef::empty(),
@@ -1080,32 +1077,22 @@ impl<C: SourceContext> NewSource<C> {
         if self.cancelled {
             return;
         }
-        if let Some(close) = self.close_handler.take() {
-            // Identity check against the *exact* fn pointer stored by `set_on_close_from_js`, so the
-            // JS path receives `self` (not `close_ctx`, which is unset on that path).
-            if close as usize == Self::on_js_close as fn(Option<*mut c_void>) as usize {
-                Self::on_js_close(Some(std::ptr::from_mut(self).cast::<c_void>()));
-            } else {
-                close(self.close_ctx.map(|p| p.as_ptr()));
-            }
+        if core::mem::take(&mut self.js_on_close_armed) {
+            self.on_js_close();
         }
     }
 
-    /// `JSReadableStreamSource.onClose` — invoked via `close_handler` when the
-    /// JS side registered an `onclose` callback. Stored *directly* in
-    /// `close_handler` by [`Self::set_on_close_from_js`] so the fn-pointer
-    /// identity check above matches.
-    fn on_js_close(ptr: Option<*mut c_void>) {
-        // SAFETY: ptr was set to `self as *mut NewSource<C>` in on_close()/set_on_close_from_js.
-        let this = unsafe { &mut *(ptr.unwrap().cast::<NewSource<C>>()) };
+    /// `JSReadableStreamSource.onClose`: queues the JS `onclose` callback, if
+    /// any, then clears it.
+    fn on_js_close(&self) {
         // Reached from `FileReader::on_reader_done` off the event loop. While
         // the across-read ref is held (`increment_count` upgraded to Strong),
         // the wrapper is rooted and `try_get()` is `Some`. If the wrapper was
         // already finalized, `try_get()` is `None` and there is no callback.
-        let Some(this_jsvalue) = this.this_jsvalue.try_get() else {
+        let Some(this_jsvalue) = self.this_jsvalue.try_get() else {
             return;
         };
-        let global_this = this.global_this();
+        let global_this = self.global_this();
         if let Some(cb) = <Self as NewSourceCodegen>::on_close_callback_get_cached(this_jsvalue) {
             if !cb.is_undefined() {
                 global_this.queue_microtask(cb, &[]);
@@ -1322,10 +1309,7 @@ impl<C: SourceContext> NewSource<C> {
         global_object: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<()> {
-        // Store the handler by *identity* — `NewSource::on_close` compares the
-        // stored fn pointer against `on_js_close` to decide whether to pass
-        // `self` (JS path) or `close_ctx` (native path).
-        self.close_handler = Some(Self::on_js_close);
+        self.js_on_close_armed = true;
         self.global_this = Some(bun_ptr::BackRef::new(global_object));
 
         if value.is_undefined() {


### PR DESCRIPTION
### Problem
- No user-visible bug. `NewSource` stored its close notification as a fn pointer plus a context pointer, but the only handler ever stored is the JS one and the context is only ever `None`.
- To recognise the JS handler, `on_close` compared the stored fn pointer against `on_js_close` by address, which Rust does not guarantee is stable across codegen units.
- The JS handler then rebuilt `&mut NewSource` from an erased pointer via `unwrap()` and an unsafe deref; the native-handler branch had no reachable caller.

### Fix
- The two fields become one `bool`, set when JS registers `onclose`; `on_close` takes it and, if set, calls `on_js_close`, now a safe `&self` method with the same body.
- Correct because the bool is the only state the old pair could reach; construction sites (all via `Default`) and the one caller of `on_close` are unchanged.
- The struct stays `repr(C)` with `context` at offset 0, which is all the C++ wrappers rely on; each instantiation shrinks by 16 bytes.
- Verification: refactor only, no new test. `cargo check` and `clippy` clean, debug build ok, 172 existing stream, file, and spawn tests pass.

### Background
- `NewSource<C>` is the Rust side of a native `ReadableStream` source (file reader, byte stream, blob loader). A C++ wrapper holds a pointer to it, so it is `repr(C)` and its first field must stay put.
- JS can set `onclose` on such a source; when the reader finishes, `on_close` queues that callback as a microtask, once.
- Rust fn pointers to one function can differ in address between codegen units, so address comparison is not a reliable identity check.

<details>
<summary>Original description</summary>

## What

`NewSource<C>` in `src/runtime/webcore/ReadableStream.rs` carried the close notification as a fn pointer plus an opaque context:

```rust
pub close_handler: Option<fn(Option<*mut c_void>)>,
pub close_ctx: Option<NonNull<c_void>>,
```

Across `src/` these two fields have exactly three writers: `Default` sets both to `None`, `set_on_close_from_js` stores `Some(Self::on_js_close)`, and `on_close` takes the handler. `close_ctx` is never written to anything but `None`. `on_close` therefore compared the stored fn pointer against `Self::on_js_close` by address to decide whether to pass `self` or `close_ctx`, and `on_js_close(ptr: Option<*mut c_void>)` rebuilt `&mut NewSource<C>` from the erased pointer through `unwrap()` and an unsafe deref. Its `else` branch, calling a foreign handler with `close_ctx`, had no reachable caller.

The pair is now one field:

```rust
pub js_on_close_armed: bool,
```

`set_on_close_from_js` sets it, `on_close` becomes `if core::mem::take(&mut self.js_on_close_armed) { self.on_js_close() }`, and `on_js_close` is a safe `fn on_js_close(&self)` with the same body. The 6 construction sites of `NewSource` (`Body.rs`, `s3/client.rs`, `ReadableStream.rs`) all go through `..Default::default()` and are unchanged, as is the single caller of `on_close` in `FileReader::on_reader_done`. Removes 1 unsafe block, the fn pointer identity comparison, the `unwrap()`, and the dead native-handler branch.

## Why

The "native close handler with a context pointer" state was representable but unreachable, and the reachable state was only recoverable by comparing fn pointers by address, which Rust does not guarantee to be stable across codegen units; a bool makes the only real state the only representable one and the `&self` signature replaces the pointer round trip with an ordinary borrow. It is zero-cost: the bool lands in the existing padding between `cancelled` and `ref_count` (offsets 336 and 340 in `NewSource<FileReader>`, the flag is at 337) and the two pointer-sized fields are gone, so each of the three instantiations shrinks by 16 bytes (`NewSource<FileReader>` 448 to 432, `NewSource<ByteStream>` 304 to 288, `NewSource<ByteBlobLoader>` 176 to 160); `on_close` does a byte load and store instead of a pointer load, compare, and call. The struct stays `repr(C)` with `context` at offset 0, which is the only part of the layout the C++ wrappers rely on (they only ever hand the `wrapped()` pointer back to Rust).

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/web/streams/native-source-onclose-leak.test.ts test/js/web/streams/streams.test.js test/js/bun/util/bun-file.test.ts test/js/bun/spawn/spawn-streaming-stdout.test.ts`: 172 pass, 0 fail across 4 files.

</details>
