### PR TITLE
Blob: wrap blobs for JS through JsClass::to_js only

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -190,6 +190,16 @@ const _: () = {
         safe fn __bun_blob_from_build_artifact(value: JSValue) -> Option<*mut Blob>;
     }
 
+    // `JSS3File` (src/jsc/bindings/JSS3File.cpp) is the `JSBlob` subclass whose
+    // prototype carries `presign` / `stat` / `bucket`. Like `Blob__create` it
+    // adopts `blob` as `m_ctx`; the `JSBlob` finalizer releases it.
+    crate::jsc_abi_extern! {
+        fn BUN__createJSS3FileUnsafely(
+            global: &JSGlobalObject,
+            blob: *mut core::ffi::c_void,
+        ) -> JSValue;
+    }
+
     impl JsClass for Blob {
         fn from_js(value: JSValue) -> Option<*mut Self> {
             JSBlob::from_js(value).or_else(|| __bun_blob_from_build_artifact(value))
@@ -197,12 +207,19 @@ const _: () = {
         fn from_js_direct(value: JSValue) -> Option<*mut Self> {
             JSBlob::from_js_direct(value)
         }
+        /// The Rust-side way to wrap a `Blob` (the JS constructors and the
+        /// `Blob__dupe` / `Blob__fromBytes*` exports instead return the
+        /// [`Blob::new`] pointer for C++ to wrap): heap-promotes `self` and gives
+        /// the allocation to the wrapper, which owns it from then on
+        /// ([`Blob::finalize`]). S3-backed blobs get the `JSS3File` subclass.
         fn to_js(self, global: &JSGlobalObject) -> JSValue {
-            // Heap-promote and hand
-            // ownership to the codegen wrapper. The S3File fast-path (different
-            // JS wrapper) is layered on by `bun_runtime`'s `BlobExt::to_js` for
-            // S3-backed blobs; lower-tier callers never construct S3 blobs.
+            let is_s3 = self.is_s3();
             let ptr = Blob::new(self);
+            if is_s3 {
+                // SAFETY: `ptr` is the allocation `Blob::new` just returned and
+                // nothing else holds it; the wrapper becomes its sole owner.
+                return unsafe { BUN__createJSS3FileUnsafely(global, ptr.cast()) };
+            }
             JSBlob::to_js(ptr, global)
         }
         fn get_constructor(global: &JSGlobalObject) -> JSValue {
@@ -212,10 +229,15 @@ const _: () = {
 };
 
 impl Blob {
-    /// Heap-promote and mark as
-    /// heap-allocated so `deinit` knows to free the heap box.
+    /// Heap-promote and mark as heap-allocated so `deinit` knows to free the
+    /// heap box. Every JS wrapper, whether created from Rust ([`JsClass::to_js`])
+    /// or from C++ (the constructors, `Blob__dupe`, `Blob__fromBytes*`), adopts
+    /// a pointer minted here and reports `reported_estimated_size` to the GC
+    /// from then on, so this is where the size is computed: only the store,
+    /// content type and name set before this call are counted.
     #[inline]
     pub fn new(mut blob: Blob) -> *mut Blob {
+        blob.calculate_estimated_byte_size();
         blob.ref_count = bun_ptr::RawRefCount::init(1);
         bun_core::heap::into_raw(Box::new(blob))
     }
@@ -449,6 +471,47 @@ impl Blob {
             // Use `s3.path()` (URL-normalized), NOT `s3.pathlike.slice()`.
             store::Data::S3(s3) => Some(s3.path()),
         }
+    }
+
+    /// Compute `reported_estimated_size`: the in-memory footprint (not the size
+    /// on disk) that [`Self::estimated_size`] reports. [`Blob::new`] calls this
+    /// for every heap blob; a type that embeds a `Blob` by value and reports it
+    /// as part of its own size calls it directly. The GC reads the result from
+    /// its marking threads once the blob is reachable, which is why it is a
+    /// value cached up front rather than a walk of the store at report time.
+    pub fn calculate_estimated_byte_size(&self) {
+        let mut size = core::mem::size_of::<Blob>();
+
+        if let Some(store) = self.store() {
+            size += core::mem::size_of::<Store>();
+            match &store.data {
+                store::Data::Bytes(bytes) => {
+                    size += bytes.stored_name.len();
+                    size += if self.size.get() != MAX_SIZE {
+                        self.size.get() as usize
+                    } else {
+                        bytes.len() as usize
+                    };
+                }
+                store::Data::File(file) => size += file.pathlike.estimated_size(),
+                store::Data::S3(s3) => size += s3.estimated_size(),
+            }
+        }
+
+        let content_type = self.content_type.get();
+        if content_type.is_owned() {
+            size += content_type.as_slice().len();
+        }
+        self.reported_estimated_size
+            .set(size + self.name.get().byte_slice().len());
+    }
+
+    /// Body of the generated `Blob__estimatedSize` thunk (`estimatedSize: true`
+    /// in response.classes.ts): what `Blob__create` reports when it allocates
+    /// the wrapper and what `JSBlob::visitChildren` re-reports on every GC.
+    #[inline]
+    pub fn estimated_size(&self) -> usize {
+        self.reported_estimated_size.get()
     }
 
     /// Tear down owned resources; if

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -11,7 +11,7 @@ use bun_glob as glob;
 use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSMap, JSPromise, JSPromiseStrong, JSValue, JsResult,
 };
-use bun_jsc::{StringJsc as _, SysErrorJsc as _};
+use bun_jsc::{JsClass as _, StringJsc as _, SysErrorJsc as _};
 use bun_libarchive as libarchive;
 use bun_sys::{self, Fd, FdDirExt as _, FdExt as _, Mode};
 
@@ -865,10 +865,7 @@ impl TaskContext for BlobContext {
                 // self.result already replaced with Uncompressed above — ownership transferred
                 Ok(PromiseResult::Resolve(match self.output_type {
                     BlobOutputType::Blob => {
-                        let blob_ptr =
-                            Blob::new(Blob::create_with_bytes_and_allocator(data, global, false));
-                        // SAFETY: blob_ptr is the heap allocation just produced by Blob::new.
-                        unsafe { (*blob_ptr).to_js(global) }
+                        Blob::create_with_bytes_and_allocator(data, global, false).to_js(global)
                     }
                     BlobOutputType::Bytes => {
                         // Ownership transfers to JSC's `MarkedArrayBuffer_deallocator`.
@@ -881,9 +878,7 @@ impl TaskContext for BlobContext {
                     // The clone bumps the refcount; ownership of
                     // the new ref transfers into the Blob via init_with_store.
                     let store = self.store.clone();
-                    let blob_ptr = Blob::new(Blob::init_with_store(store, global));
-                    // SAFETY: blob_ptr is the heap allocation just produced by Blob::new.
-                    PromiseResult::Resolve(unsafe { (*blob_ptr).to_js(global) })
+                    PromiseResult::Resolve(Blob::init_with_store(store, global).to_js(global))
                 }
                 BlobOutputType::Bytes => {
                     // On allocation failure, reject the promise instead of aborting.
@@ -1173,10 +1168,7 @@ impl TaskContext for FilesContext {
 
                 for entry in entries.iter_mut() {
                     let data = core::mem::take(&mut entry.data); // Ownership transferred
-                    let blob_ptr =
-                        Blob::new(Blob::create_with_bytes_and_allocator(data, global, false));
-                    // SAFETY: blob_ptr is the heap allocation just produced by Blob::new.
-                    let blob = unsafe { &mut *blob_ptr };
+                    let blob = Blob::create_with_bytes_and_allocator(data, global, false);
                     blob.is_jsdom_file.set(true);
                     blob.name.set(bun_core::String::clone_utf8(&entry.path));
                     blob.last_modified.set((entry.mtime * 1000) as f64);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1971,7 +1971,8 @@ fn get_is_standalone_executable(global_this: &JSGlobalObject, _: &JSObject) -> J
 }
 
 fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {
-    use crate::webcore::blob::{Blob, BlobExt as _};
+    use crate::webcore::blob::Blob;
+    use bun_jsc::JsClass as _;
     use bun_standalone_graph::{File as GraphFile, Graph as StandaloneModuleGraph};
     // SAFETY: bun_vm() returns the live thread-local VM for a Bun-owned global.
     let vm = global_this.bun_vm();
@@ -2022,11 +2023,9 @@ fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JS
         // as the blob name, preserving any subdirectory from the asset template.
         let input_blob: &mut Blob = file.file_blob(global_this);
         // We call .dupe() on this to ensure that we don't return a blob that might get freed later.
-        let blob = Blob::new(input_blob.dupe_with_content_type(true));
-        // SAFETY: `Blob::new` returned a fresh heap allocation.
-        unsafe { (*blob).name.set(input_blob.name.get().dupe_ref()) };
-        // SAFETY: `blob` is heap-allocated and lives until JS owns it via to_js.
-        array.put_index(global_this, i as u32, unsafe { (*blob).to_js(global_this) })?;
+        let blob = input_blob.dupe_with_content_type(true);
+        blob.name.set(input_blob.name.get().dupe_ref());
+        array.put_index(global_this, i as u32, blob.to_js(global_this))?;
     }
 
     Ok(array)
@@ -2990,7 +2989,8 @@ mod stdio_stores {
     use super::*;
     use crate::node::types::PathOrFileDescriptor;
     use crate::webcore::blob::store::{Data, File as FileStore};
-    use crate::webcore::blob::{Blob, BlobExt as _, Store, StoreRef};
+    use crate::webcore::blob::{Blob, Store, StoreRef};
+    use bun_jsc::JsClass as _;
 
     thread_local! {
         static STDIN: core::cell::RefCell<Option<StoreRef>> = const { core::cell::RefCell::new(None) };
@@ -3036,9 +3036,7 @@ mod stdio_stores {
             // store.ref() — extra +1 for the new Blob.
             s.as_ref().unwrap().clone()
         });
-        let blob = Blob::new(Blob::init_with_store(store, global_this));
-        // SAFETY: `Blob::new` heap-allocates; the JS wrapper takes ownership.
-        unsafe { (&*blob).to_js(global_this) }
+        Blob::init_with_store(store, global_this).to_js(global_this)
     }
 
     pub(super) fn stdin(global_this: &JSGlobalObject) -> JSValue {

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1854,11 +1854,7 @@ impl PipelineTask {
                                 format.mime().as_bytes(),
                             ));
                         blob.content_type_was_set.set(true);
-                        // UFCS to pick the consuming `JsClass::to_js(self, _)`
-                        // (heap-promotes via `Blob::new`) over the inherent
-                        // `Blob::to_js(&mut self, _)` that expects an
-                        // already-heap-allocated receiver.
-                        promise.resolve(global, <Blob as bun_jsc::JsClass>::to_js(blob, global))?;
+                        promise.resolve(global, blob.to_js(global))?;
                     }
                     tag @ (Deliver::Base64 | Deliver::DataUrl) => {
                         // This arm copies the bytes out — re-arm `Encoded::drop` so

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -128,8 +128,6 @@ pub use bun_jsc::webcore_types::{Blob, BlobContentType, ClosingState, MAX_SIZE, 
 ///    keeps its window's end across structuredClone/postMessage
 const SERIALIZATION_VERSION: u8 = 4;
 
-pub use bun_jsc::generated::JSBlob as js;
-
 // ──────────────────────────────────────────────────────────────────────────
 
 // is_s3: defined once above (near is_bun_file); duplicate removed to fix E0034.
@@ -388,9 +386,6 @@ pub trait BlobExt {
     ) -> JsResult<Blob>
     where
         Self: Sized;
-    fn calculate_estimated_byte_size(&self);
-    fn estimated_size(&self) -> usize;
-    fn to_js(&self, global_object: &JSGlobalObject) -> JSValue;
     fn find_or_create_file_from_path(
         path_or_fd: &mut PathOrFileDescriptor,
         global_this: &JSGlobalObject,
@@ -1961,12 +1956,7 @@ impl BlobExt for Blob {
         blob.content_type_was_set
             .set(self.content_type_was_set.get() || content_type_was_allocated);
 
-        let ptr = Blob::new(blob);
-        // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Explicit
-        // `&mut *` forces the inherent `Blob::to_js(&mut self)` (which calls
-        // `calculate_estimated_byte_size` and routes S3 blobs to
-        // `S3File.toJSUnchecked`) over the by-value `JsClass::to_js`.
-        unsafe { BlobExt::to_js(&*ptr, global_this) }
+        blob.to_js(global_this)
     }
 
     /// https://w3c.github.io/FileAPI/#slice-method-algo
@@ -1976,10 +1966,7 @@ impl BlobExt for Blob {
         let args = &mut arguments_[..];
 
         if self.size.get() == 0 {
-            let ptr = Blob::new(Blob::init_empty(global_this));
-            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`; force
-            // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js`.
-            return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
+            return Ok(Blob::init_empty(global_this).to_js(global_this));
         }
 
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.
@@ -2395,7 +2382,6 @@ impl BlobExt for Blob {
             }
         }
 
-        blob.calculate_estimated_byte_size();
         Ok(Blob::new(blob))
     }
 
@@ -3537,54 +3523,6 @@ impl BlobExt for Blob {
 
     // is_detached: defined once above; duplicate removed to fix E0034.
 
-    fn calculate_estimated_byte_size(&self) {
-        // in-memory size. not the size on disk.
-        let mut size: usize = core::mem::size_of::<Blob>();
-
-        if let Some(store) = self.store.get() {
-            size += core::mem::size_of::<Store>();
-            match &store.data {
-                store::Data::Bytes(bytes) => {
-                    size += bytes.stored_name.len();
-                    size += if self.size.get() != MAX_SIZE {
-                        self.size.get() as usize
-                    } else {
-                        bytes.len() as usize
-                    };
-                }
-                store::Data::File(file) => size += file.pathlike.estimated_size(),
-                store::Data::S3(s3) => size += s3.estimated_size(),
-            }
-        }
-
-        let ct = self.content_type.get();
-        self.reported_estimated_size.set(
-            size + (ct.as_slice().len() * (ct.is_owned() as usize))
-                + self.name.get().byte_slice().len(),
-        );
-    }
-
-    fn estimated_size(&self) -> usize {
-        self.reported_estimated_size.get()
-    }
-
-    fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
-        // if cfg!(debug_assertions) { debug_assert!(self.is_heap_allocated()); }
-        self.calculate_estimated_byte_size();
-
-        // R-2: `&self` receiver, but the FFI shims take `*mut Blob` (the
-        // heap-allocated `m_ctx` pointer). `self` *is* that allocation (caller
-        // contract), so the const→mut cast is the original `Blob::new` provenance.
-        let this = std::ptr::from_ref::<Blob>(self).cast_mut();
-        if self.is_s3() {
-            // SAFETY: `self` is a heap-allocated *mut Blob (see `Blob::new`); the
-            // C++ side wraps it in a JSS3File without taking a second ref.
-            return crate::webcore::s3_file::to_js_unchecked(global_object, this);
-        }
-
-        js::to_js_unchecked(global_object, this)
-    }
-
     /// `Bun.file(pathOrFd)` core: wrap a path-or-fd in a `Store::File` and
     /// return a Blob viewing it. Runtime `check_s3` matches the call shape used
     /// by `server_body.rs` / `fetch.rs` (collapsed from a const generic since
@@ -4075,16 +4013,15 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     // Bun.file() keeps its window's end. MAX_SIZE means unknown.
     let mut file_size: Option<u64> = None;
 
-    let blob: *mut Blob = match store_tag {
-        store::SerializeTag::Bytes => 'bytes: {
+    // `blob` stays a by-value local until the final `to_js`, so an early `?` on
+    // a truncated record drops it (and releases its store) like any other
+    // local.
+    let blob: Blob = match store_tag {
+        store::SerializeTag::Bytes => {
             let bytes_len = reader.read_int_le::<u32>()?;
             let bytes = read_slice(reader, bytes_len as usize)?;
 
             let blob = Blob::init(bytes, global_this);
-            // `blob` now owns `bytes` (via its Store when non-empty). If any
-            // of the remaining reads fail before we heap-promote it, Drop on
-            // `blob` releases the store so the payload bytes don't leak.
-            let guard = scopeguard::guard(blob, |mut b| b.deinit());
 
             'versions: {
                 if version == 1 {
@@ -4094,8 +4031,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 let name_len = reader.read_int_le::<u32>()?;
                 let name = read_slice(reader, name_len as usize)?;
 
-                // ScopeGuard derefs to its inner Blob.
-                if let Some(store) = (*guard).store() {
+                if let Some(store) = blob.store() {
                     if let store::Data::Bytes(bytes_store) = &mut store.data_mut() {
                         // Transfer ownership of the local `name: Vec<u8>` into
                         // `stored_name` (a `Box<[u8]>`); freed by `Bytes::Drop`.
@@ -4109,10 +4045,9 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 }
             }
 
-            let blob = scopeguard::ScopeGuard::into_inner(guard);
-            break 'bytes Blob::new(blob);
+            blob
         }
-        store::SerializeTag::File => 'file: {
+        store::SerializeTag::File => {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
             if version >= 4 {
                 file_size = Some(reader.read_int_le::<u64>()?);
@@ -4132,11 +4067,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                         return Err(crate::Error::InvalidValue);
                     }
                     let mut path_or_fd = PathOrFileDescriptor::Fd(fd);
-                    break 'file Blob::new(Blob::find_or_create_file_from_path(
-                        &mut path_or_fd,
-                        global_this,
-                        true,
-                    ));
+                    Blob::find_or_create_file_from_path(&mut path_or_fd, global_this, true)
                 }
                 PathOrFileDescriptorSerializeTag::Path => {
                     let path_len = reader.read_int_le::<u32>()?;
@@ -4154,25 +4085,12 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                     let mut dest = PathOrFileDescriptor::Path(node::PathLike::String(
                         bun_ptr::cow_slice::CowSlice::init_owned(path.into_boxed_slice()),
                     ));
-                    break 'file Blob::new(Blob::find_or_create_file_from_path(
-                        &mut dest,
-                        global_this,
-                        true,
-                    ));
+                    Blob::find_or_create_file_from_path(&mut dest, global_this, true)
                 }
             }
         }
-        store::SerializeTag::Empty => Blob::new(Blob::init_empty(global_this)),
+        store::SerializeTag::Empty => Blob::init_empty(global_this),
     };
-    // `blob` is heap-allocated past this point; on any remaining error
-    // (truncated trailer fields) tear down both the heap object and its
-    // store. `content_type` is handled by its own Drop above since it
-    // hasn't been attached to `blob` yet.
-    // SAFETY: blob is a freshly-allocated heap pointer from Blob::new.
-    let blob_guard = scopeguard::guard(blob, |b| unsafe { (*b).deinit() });
-    // SAFETY: `blob_guard` holds the sole pointer to the fresh heap allocation.
-    // Shared access only — Blob state is Cell/JsCell-based.
-    let blob = unsafe { &**blob_guard };
 
     'versions: {
         if version == 1 {
@@ -4197,11 +4115,6 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
             break 'versions;
         }
     }
-
-    debug_assert!(
-        blob.is_heap_allocated(),
-        "expected blob to be heap-allocated"
-    );
 
     // `offset` comes from untrusted bytes. Clamp it so a crafted payload cannot
     // make shared_view() slice past the end of the backing store (OOB heap read).
@@ -4229,10 +4142,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         blob.content_type_was_set.set(content_type_was_set);
     }
 
-    let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
-    // SAFETY: blob_ptr is valid; toJS is infallible. Explicit `&mut *` forces
-    // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
-    Ok(unsafe { BlobExt::to_js(&*blob_ptr, global_this) })
+    Ok(blob.to_js(global_this))
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -4737,13 +4647,10 @@ pub(crate) fn write_file_with_source_destination(
         // If this is bytes <> bytes, we can just duplicate it
         // this is an edgecase
         // it will happen if someone did Bun.write(new Blob([123]), new Blob([456]))
-        let cloned = Blob::new(source_blob.dupe());
-        // SAFETY: ptr was just produced by heap::alloc in Blob::new; the
-        // inherent `to_js(&mut self)` (not the by-value `JsClass` one) hands
-        // ownership to the C++ wrapper.
-        return Ok(JSPromise::resolved_promise_value(ctx, unsafe {
-            BlobExt::to_js(&*cloned, ctx)
-        }));
+        return Ok(JSPromise::resolved_promise_value(
+            ctx,
+            source_blob.dupe().to_js(ctx),
+        ));
     } else if destination_type == store::DataTag::Bytes
         && (source_type == store::DataTag::File || source_type == store::DataTag::S3)
     {
@@ -5646,11 +5553,8 @@ pub(crate) fn jsdom_file_construct(
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// estimatedSize / constructBunFile / findOrCreateFileFromPath
+// constructBunFile / findOrCreateFileFromPath
 // ──────────────────────────────────────────────────────────────────────────
-
-// `calculate_estimated_byte_size` / `estimated_size`: canonical impls live
-// later in this file (near `dupe`/`to_js`). Duplicates removed here.
 
 pub(crate) fn construct_bun_file(
     global_object: &JSGlobalObject,
@@ -5712,10 +5616,7 @@ pub(crate) fn construct_bun_file(
         }
     }
 
-    let ptr = Blob::new(blob);
-    // SAFETY: ptr was just produced by heap::alloc in Blob::new. Explicit
-    // `&mut *` forces inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
-    Ok(unsafe { BlobExt::to_js(&*ptr, global_object) })
+    Ok(blob.to_js(global_object))
 }
 
 // `find_or_create_file_from_path`: canonical impl lives later in this file
@@ -6445,13 +6346,9 @@ impl Any {
                 self.to_uint8_array_transfer(global_this)
             }
             streams::BufferActionTag::Blob => {
-                let result = Blob::new(self.to_blob(global_this));
-                // SAFETY: `Blob::new` returns a fresh heap allocation we own;
-                // `BlobExt::to_js` (the `&mut self` overload) consumes the
-                // pointer into a JS wrapper which takes ownership.
-                unsafe { (*result).global_this.set(global_this) };
-                // SAFETY: same fresh `result` allocation; ownership transfers to the JS wrapper.
-                Ok(BlobExt::to_js(unsafe { &*result }, global_this))
+                let blob = self.to_blob(global_this);
+                blob.global_this.set(global_this);
+                Ok(blob.to_js(global_this))
             }
             streams::BufferActionTag::ArrayBuffer => {
                 if matches!(self, Any::Blob(_)) {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -20,7 +20,7 @@ use crate::webcore::form_data::AsyncFormDataExt as _;
 use bun_core::{String as BunString, ZigString};
 use bun_core::{WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::ZigStringJsc as _;
-use bun_jsc::{JsCell, StringJsc as _};
+use bun_jsc::{JsCell, JsClass as _, StringJsc as _};
 
 /// Deref the `Value::WTFStringImpl` / `AnyBlob::WTFStringImpl` payload.
 /// Centralises the per-site `(**s)` raw deref at the dozen `match` arms below
@@ -1181,9 +1181,7 @@ impl Value {
                         result?;
                     }
                     Action::None | Action::GetBlob => {
-                        let blob_ptr = Blob::new(new.use_());
-                        // SAFETY: `Blob::new` returns a freshly heap-allocated *mut Blob.
-                        let blob = unsafe { &mut *blob_ptr };
+                        let blob = new.use_();
                         if let Some(fetch_headers) = headers {
                             // `headers` is a live C++ FetchHeaders handle;
                             // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
@@ -1194,12 +1192,12 @@ impl Value {
                             {
                                 let content_slice = content_type.to_slice();
                                 let mime_type = MimeType::init(content_slice.slice(), true, None);
-                                set_blob_content_type(blob, mime_type);
+                                set_blob_content_type(&blob, mime_type);
                                 // content_slice dropped (replaces defer content_slice.deinit())
                             }
                         }
                         if !blob.content_type_was_set.get() && blob.store.get().is_some() {
-                            set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
+                            set_blob_content_type(&blob, bun_http_types::MimeType::TEXT);
                         }
                         promise.resolve(global, blob.to_js(global))?;
                     }
@@ -2205,9 +2203,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
 
         let value = self.get_body_value();
-        let blob_ptr = Blob::new(value.use_());
-        // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.
-        let blob = unsafe { &mut *blob_ptr };
+        let blob = value.use_();
         if blob.content_type().is_empty() {
             if let Some(fetch_headers) = BodyMixin::get_fetch_headers(self) {
                 // `fetch_headers` is a live C++ FetchHeaders handle;
@@ -2216,12 +2212,12 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 if let Some(content_type) = fetch_headers.fast_get(HTTPHeaderName::ContentType) {
                     let content_slice = content_type.to_slice();
                     let mime_type = MimeType::init(content_slice.slice(), true, None);
-                    set_blob_content_type(blob, mime_type);
+                    set_blob_content_type(&blob, mime_type);
                     // content_slice dropped (replaces defer content_slice.deinit())
                 }
             }
             if !blob.content_type_was_set.get() && blob.store.get().is_some() {
-                set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
+                set_blob_content_type(&blob, bun_http_types::MimeType::TEXT);
             }
         }
         Ok(JSPromise::resolved_promise_value(

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -3,11 +3,10 @@ use std::sync::OnceLock;
 use bun_collections::HashMap;
 use bun_core::strings;
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, UUID};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass as _, JsResult, StringJsc as _, UUID};
 use bun_threading::Guarded;
 
 use crate::webcore::Blob;
-use crate::webcore::BlobExt as _;
 
 // The map is wrapped in a `Guarded` (mutex + value).
 //
@@ -78,9 +77,7 @@ impl ObjectURLRegistry {
         pathname: &[u8],
         global_object: &JSGlobalObject,
     ) -> Option<JSValue> {
-        let blob = Blob::new(self.resolve_and_dupe(pathname)?);
-        // SAFETY: `Blob::new` returns a freshly-boxed heap pointer.
-        Some(unsafe { (*blob).to_js(global_object) })
+        Some(self.resolve_and_dupe(pathname)?.to_js(global_object))
     }
 
     pub(crate) fn revoke(&self, pathname: &[u8]) {

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -2,11 +2,12 @@ use bstr::BStr;
 
 use crate::node::PathLike;
 use crate::node::types::PathLikeExt as _;
-use crate::webcore::blob::BlobExt as _;
 use crate::webcore::blob::store::S3Ext as _;
 use crate::webcore::s3::MultiPartUploadOptions;
 use crate::webcore::s3::client::{ACL, S3Credentials, StorageClass};
-use bun_jsc::{CallFrame, ConsoleFormatter, ErrorCode, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{
+    CallFrame, ConsoleFormatter, ErrorCode, JSGlobalObject, JSValue, JsClass as _, JsResult,
+};
 
 use super::s3_file as S3File;
 
@@ -420,16 +421,7 @@ impl S3Client {
             }
         };
         let options = args.next_eat();
-        // `Blob::new` heap-promotes and marks `ref_count = 1` so
-        // the JSS3File wrapper's `finalize` knows to free the blob.
-        let blob = crate::webcore::blob::Blob::new(ptr.construct_blob(global, path, options)?);
-        // `to_js` runs `calculateEstimatedByteSize()`
-        // before wrapping the heap Blob in a JSS3File so JSC sees the correct
-        // GC pressure. Route through `BlobExt::to_js` (the `&mut self` method
-        // that owns the heap pointer), same as `S3File::construct_internal_js`.
-        // SAFETY: `blob` is a freshly leaked `*mut Blob` from `Blob::new`;
-        // `to_js` hands ownership of that pointer to the C++ wrapper.
-        Ok(unsafe { &mut *blob }.to_js(global))
+        Ok(ptr.construct_blob(global, path, options)?.to_js(global))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -344,16 +344,6 @@ fn finish_s3_blob(
     Ok(blob)
 }
 
-fn construct_s3_file_internal(
-    global: &JSGlobalObject,
-    path: PathLike,
-    options: Option<JSValue>,
-) -> JsResult<*mut Blob> {
-    Ok(Blob::new(construct_s3_file_internal_store(
-        global, path, options,
-    )?))
-}
-
 pub(crate) struct S3BlobStatTask {
     promise: bun_jsc::JSPromiseStrong,
     // LIFETIMES.tsv: JSC_BORROW (&JSGlobalObject). `BackRef` so the heap task
@@ -706,18 +696,7 @@ pub(crate) fn construct_internal_js(
     path: PathLike,
     options: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    let blob = construct_s3_file_internal(global, path, options)?;
-    // SAFETY: `blob` is a freshly heap-allocated `*mut Blob` from `Blob::new`.
-    // Call the `BlobExt::to_js` `&mut self` method (not the by-value
-    // `JsClass::to_js`), which hands the existing heap pointer to the C++
-    // wrapper.
-    Ok(BlobExt::to_js(unsafe { &mut *blob }, global))
-}
-
-pub(crate) fn to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSValue {
-    // C++ adopts `this` opaquely (stored as `void* m_ctx` in the JS wrapper);
-    // ownership-transfer contract lives on `to_js_unchecked`'s callers.
-    BUN__createJSS3FileUnsafely(global, this.cast::<core::ffi::c_void>())
+    Ok(construct_s3_file_internal_store(global, path, options)?.to_js(global))
 }
 
 // Symbols exported with C linkage and JSC calling convention.
@@ -762,16 +741,4 @@ pub(crate) mod exports {
         let (this, global, callframe) = unsafe { (&mut *this, &*global, &*callframe) };
         bun_jsc::to_js_host_call(global, || super::get_stat(this, global, callframe))
     }
-}
-
-// C++ side defines `SYSV_ABI EncodedJSValue` (JSS3File.cpp).
-bun_jsc::jsc_abi_extern! {
-    // `&JSGlobalObject` discharges the only deref'd-param precondition; `blob`
-    // is stored opaquely as `void* m_ctx` (module-private — sole caller is
-    // `to_js_unchecked`, whose own signature carries the ownership-transfer
-    // contract). Matches the `*__createObject` precedent.
-    safe fn BUN__createJSS3FileUnsafely(
-        global: &JSGlobalObject,
-        blob: *mut core::ffi::c_void,
-    ) -> JSValue;
 }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,6 +1,7 @@
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
-import type { BlobOptions } from "node:buffer";
+import { resolveObjectURL, type BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
 import path from "node:path";
 
@@ -733,5 +734,138 @@ describe("Blob from ArrayBuffer-like values", () => {
       new DataView(new Uint8Array([0x67, 0x68]).buffer),
     ]);
     expect(await blob.text()).toBe("abcdefgh");
+  });
+});
+
+// Every Blob wrapper, whichever native producer made it, reports the blob's
+// in-memory footprint to the GC (`estimateShallowMemoryUsageOf` reports that
+// same number), and S3-backed blobs get the S3File wrapper. A producer that
+// skips the bookkeeping shows up here as a wrapper whose estimate is just the
+// JS cell (a few dozen bytes), which is what `Bun.Image#blob()`, `new File()`,
+// parsed `formData()` entries and WebSocket blob messages used to report.
+describe("blobs handed to JS report their bytes to the GC", () => {
+  // Incompressible payload so gzip and PNG outputs stay far above the fixed
+  // per-blob overhead, which keeps `estimate >= size` a meaningful bound.
+  const noise = new Uint8Array(64 * 1024);
+  for (let i = 0, seed = 0x2545f491; i < noise.length; i++) {
+    seed = (Math.imul(seed, 1103515245) + 12345) >>> 0;
+    noise[i] = seed >>> 24;
+  }
+
+  // 64x64 24-bit BMP (54-byte BITMAPINFOHEADER file, uncompressed) whose pixel
+  // rows are the noise above; the row stride (192 bytes) is already 4-aligned.
+  function noiseBmp(): Uint8Array {
+    const pixelBytes = 64 * 64 * 3;
+    const bmp = new Uint8Array(54 + pixelBytes);
+    const header = new DataView(bmp.buffer);
+    bmp.set([0x42, 0x4d]); // "BM"
+    header.setUint32(2, bmp.length, true);
+    header.setUint32(10, 54, true); // pixel array offset
+    header.setUint32(14, 40, true); // BITMAPINFOHEADER size
+    header.setInt32(18, 64, true); // width
+    header.setInt32(22, 64, true); // height
+    header.setUint16(26, 1, true); // planes
+    header.setUint16(28, 24, true); // bits per pixel
+    header.setUint32(34, pixelBytes, true);
+    bmp.set(noise.subarray(0, pixelBytes), 54);
+    return bmp;
+  }
+
+  const producers: Record<string, () => Blob | Promise<Blob>> = {
+    "new Blob()": () => new Blob([noise]),
+    "new File()": () => new File([noise], "noise.bin"),
+    "Blob#slice()": () => new Blob([noise]).slice(0, 48 * 1024),
+    "structuredClone(blob)": () => structuredClone(new Blob([noise])),
+    "resolveObjectURL()": () => {
+      const url = URL.createObjectURL(new Blob([noise]));
+      try {
+        return resolveObjectURL(url)!;
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    },
+    "ReadableStream#blob() on Blob#stream()": () => new Blob([noise]).stream().blob(),
+    "Response#blob() with a buffered body": () => new Response(noise).blob(),
+    "Response#blob() with a streamed body": () => new Response(new Blob([noise]).stream()).blob(),
+    "Request#blob()": () => new Request("http://localhost/", { method: "POST", body: noise }).blob(),
+    "Response#formData() file entry": async () => {
+      const form = new FormData();
+      form.append("f", new Blob([noise]), "noise.bin");
+      return (await new Response(form).formData()).get("f") as Blob;
+    },
+    'WebSocket message with binaryType = "blob"': async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch: (request, server) => (server.upgrade(request) ? undefined : new Response(null, { status: 400 })),
+        websocket: {
+          open(ws) {
+            ws.send(noise);
+          },
+          message() {},
+        },
+      });
+      const ws = new WebSocket(server.url);
+      ws.binaryType = "blob";
+      const message = Promise.withResolvers<Blob>();
+      ws.onmessage = event => message.resolve(event.data);
+      ws.onerror = () => message.reject(new Error("WebSocket connection failed"));
+      ws.onclose = event => message.reject(new Error(`WebSocket closed (${event.code}) before delivering the message`));
+      const blob = await message.promise;
+      const closed = Promise.withResolvers<void>();
+      ws.onclose = () => closed.resolve();
+      ws.close();
+      await closed.promise;
+      return blob;
+    },
+    "Bun.Archive#blob()": () => new Bun.Archive({ "noise.bin": noise }).blob(),
+    "Bun.Archive#blob() with gzip": () => new Bun.Archive({ "noise.bin": noise }, { compress: "gzip" }).blob(),
+    "Bun.Archive#files()": async () => {
+      const tar = await new Bun.Archive({ "noise.bin": noise }).bytes();
+      return (await new Bun.Archive(tar).files()).get("noise.bin")!;
+    },
+    "Bun.Image#blob()": () => new Bun.Image(noiseBmp()).png().blob(),
+  };
+
+  for (const [name, produce] of Object.entries(producers)) {
+    test(name, async () => {
+      const blob = await produce();
+      expect(blob).toBeInstanceOf(Blob);
+      // Sanity check on the producer itself: the payload has to dwarf the
+      // per-blob overhead for the bound below to say anything.
+      expect(blob.size).toBeGreaterThan(8 * 1024);
+      expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThanOrEqual(blob.size);
+    });
+  }
+
+  const credentials = { accessKeyId: "key", secretAccessKey: "secret", bucket: "bucket" };
+  const s3Producers = {
+    "Bun.s3.file()": () => Bun.s3.file("object.bin", credentials),
+    "new Bun.S3Client().file()": () => new Bun.S3Client(credentials).file("object.bin"),
+    "Bun.S3Client.file()": () => Bun.S3Client.file("object.bin", credentials),
+  };
+
+  // File- and S3-backed blobs keep no bytes in memory, so what is observable is
+  // the bookkeeping itself: the wrapper accounts for its store (and for S3, its
+  // credentials) on top of what an empty in-memory blob reports.
+  const storeBackedProducers: Record<string, () => Blob> = {
+    "Bun.file()": () => Bun.file(import.meta.path),
+    "Bun.stdin": () => Bun.stdin,
+    ...s3Producers,
+  };
+
+  for (const [name, produce] of Object.entries(storeBackedProducers)) {
+    test(name, () => {
+      const blob = produce();
+      expect(blob).toBeInstanceOf(Blob);
+      expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThan(estimateShallowMemoryUsageOf(new Blob([])));
+    });
+  }
+
+  test("only S3-backed blobs get the S3File wrapper", () => {
+    for (const produce of Object.values(s3Producers)) {
+      expect(typeof produce().presign).toBe("function");
+    }
+    expect("presign" in Bun.file(import.meta.path)).toBe(false);
+    expect("presign" in new Blob([noise])).toBe(false);
   });
 });


### PR DESCRIPTION
### Problem
- Several native Blob producers hand JS a wrapper that reports almost nothing to the GC: `estimateShallowMemoryUsageOf` returns 48 for a `new File()`, a parsed `formData()` file entry, a WebSocket `binaryType = "blob"` message and a `Bun.Image#blob()` result, against 65856 for the same 64 KiB in `new Blob()`. A parsed `FormData`, whose `memoryCost` reads the same field, is undercounted with them.
- Cause: the size was computed on only one of several wrapping routes (`BlobExt::to_js` and the `Blob` constructor). A blob wrapped through the by-value `JsClass::to_js` (`Bun.Image`) or wrapped directly by C++ (`File`, `Blob__dupe`, `Blob__fromBytes*`) never gets the field filled in, and the GC re-reads that same field for the blob's whole life.
- Separately, `BlobExt::to_js(&self)` handed C++ a mutable pointer cast from a shared reference (C++ refcounts through it and frees it), and it was a safe fn that was only correct when `self` was exactly the `Blob::new` allocation. Nothing in the signature enforced that; the pattern was repeated at 16 call sites. Harmless in practice today.

### Fix
- `JsClass::to_js(self)` becomes the only Rust-side way to wrap a Blob: it heap-promotes and passes the `Blob::new` pointer straight to the plain wrapper, or to the S3File wrapper when the store is S3. `BlobExt::to_js` and the S3-specific helpers are deleted and every former caller passes the Blob by value; structured clone deserialization also drops its two scope guards, since the blob is now an ordinary local until the final `to_js`.
- The size is computed inside `Blob::new`. Property to check: every wrapper, whether Rust or C++ creates it, adopts a pointer minted by `Blob::new`, so no wrapping route can skip the bookkeeping, and taking the Blob by value removes the heap-receiver precondition instead of documenting it.
- Overlaps with #37667, #37697 and #31987 are spelled out in the original; this branch leaves their lines alone, and their Blob-side size calls become redundant once this lands.
- Verification: new tests run a table of in-memory producers plus `Bun.file()`, `Bun.stdin` and the three S3 constructors through `estimateShallowMemoryUsageOf`, and check that only S3 blobs get the S3File wrapper. Without the fix the `new File()`, `formData()`, WebSocket and `Bun.Image#blob()` cases fail (each reports 48); with it the file and the neighbouring suites listed in the original pass on a debug build.

### Background
- A JS `Blob` is a Rust `Blob` struct behind a C++ wrapper. The wrapper adopts a raw heap pointer, bumps and drops the refcount through it, and frees it from its finalizer, so wrapping a blob gives the allocation away. S3-backed blobs get a wrapper subclass whose prototype adds `presign`, `stat` and `bucket`.
- `Blob::new` is heap promotion: it boxes a by-value `Blob`, sets the refcount to 1 and returns the pointer a wrapper adopts. Before that a `Blob` is an ordinary value. Some producers (the JS constructors, `Blob__dupe` for FormData entries and MessageEvent, `Blob__fromBytes*` for WebSocket messages) return that pointer for C++ to wrap and never go through a Rust `to_js`.
- `reported_estimated_size` is a cached in-memory footprint (held bytes plus store, content type and name; not size on disk). JSC reads it when the wrapper is allocated and again from `visitChildren` on every GC; it is cached because GC marking threads read it. `estimateShallowMemoryUsageOf` from `bun:jsc` returns the same number, which is how the tests observe it.
- `JsClass` is the `bun_jsc` trait that gives a Rust type its `from_js` / `to_js`; `Request` already wraps itself this way. `BlobExt` is an extension trait in the runtime crate that layered more Blob methods, including the second `to_js`, on top of it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Symptom

Several native Blob producers hand JS a wrapper that reports no memory to the GC:

```ts
import { estimateShallowMemoryUsageOf } from "bun:jsc";
const bytes = new Uint8Array(64 * 1024);
estimateShallowMemoryUsageOf(new Blob([bytes]));                                      // 65856
estimateShallowMemoryUsageOf(await new Bun.Image(someBmp).png().blob());              // 48 (for a 14585 byte blob)
estimateShallowMemoryUsageOf(new File([bytes], "a.bin"));                             // 48
estimateShallowMemoryUsageOf((await new Response(formWithFile).formData()).get("f")); // 48
// a WebSocket binaryType = "blob" message: 48 as well
```

`JSBlob` reports `Blob__estimatedSize(ptr)` (the cached `reported_estimated_size` field) to JSC when the wrapper is created and again from `visitChildren` on every GC. If nothing computed the field before the blob was wrapped, those blobs, and containers such as a parsed `FormData` whose `memoryCost` reads the same number, stay invisible to the collector's memory accounting for their whole life.

### Cause

`Blob` had two Rust-side ways of becoming a JS object, and the size bookkeeping was attached to one of them:

* `BlobExt::to_js(&self)` (src/runtime/webcore/Blob.rs) computed the estimated size and picked the `JSS3File` wrapper for S3 stores, but built the pointer the wrapper adopts with `ptr::from_ref(self).cast_mut()`. That pointer is derived from a shared reborrow, yet it is what C++ later writes the refcount through (`Blob__ref`/`Blob__deref`; `ref_count` is a plain `u32`) and what the finalizer frees; under the aliasing model those are writes and a deallocation through a read-only pointer. It was also a safe fn whose correctness depended on `self` being exactly the `Blob::new` allocation, which nothing in the signature enforced (the shape #31987 found crashing for a stack `Response`). Harmless in practice today, but a contract the compiler could not see, repeated at 16 call sites as `Blob::new(x)` + `unsafe { to_js(&*ptr) }`, and the comment claiming the cast kept the `Blob::new` provenance was wrong.
* `JsClass::to_js(self)` (src/jsc/webcore_types.rs) took the Blob by value and heap-promoted it, but skipped the bookkeeping and the S3 routing. Image.rs used it precisely to avoid the heap-receiver precondition of the other one, which is the `Bun.Image` symptom.
* The C++-wrapped producers went through neither: the `File` constructor, `Blob__dupe` (how `FormData` entries and `MessageEvent` blobs are wrapped) and `Blob__fromBytes*` (WebSocket messages, webview screenshots) return a `Blob::new` pointer that C++ wraps directly, and the only explicit size computations were in `BlobExt::to_js` and the `Blob` constructor.

### Fix

1. `JsClass::to_js` becomes the only Rust-side wrapping path, the arrangement `Request` already uses for its `JsClass` impl: it heap-promotes and passes the `Blob::new` pointer straight to `Blob__create` or `BUN__createJSS3FileUnsafely` (whose extern moves next to its only caller). `BlobExt::to_js`, `s3_file::to_js_unchecked` and `construct_s3_file_internal` are deleted; every former caller (Blob.rs, Body.rs, Archive.rs, BunObject.rs, ObjectURLRegistry.rs, S3Client.rs, S3File.rs, Image.rs) passes the `Blob` by value, which removes the `Blob::new` + raw reborrow pair at each site. Structured clone deserialization no longer needs its two scope guards: the blob is a local until the final `to_js`, so an early `?` drops it like any other value (`Blob` has no `Drop` impl; its store, content type and name release through their field drops, which is what `deinit()` did for a non-heap blob).
2. The size is computed in `Blob::new` itself (`calculate_estimated_byte_size` / `estimated_size` move to webcore_types.rs as inherent methods). Every wrapper, Rust- or C++-created, adopts a pointer minted there, so this covers the C++-wrapped producers as well, and the explicit calls in `to_js` and in the `Blob` constructor go away. Two open PRs change the neighbouring lines and are complementary to this one rather than conflicting with it, so this branch leaves those lines alone: #37667 makes `JSDOMFile.cpp` / `JSS3File.cpp` report the size when the wrapper is allocated (today the S3 wrapper only re-reports from `visitChildren`, so it never feeds the allocation budget), and #37697 reorders the `Blob__fromBytes*` exports so the content type is set before promotion. Once this lands, the explicit `calculate_estimated_byte_size()` calls those PRs add become redundant and can be removed (the constructor line, which #37697 also edits, is the one place the diffs touch the same lines); the method stays `pub` for them and for types that embed a `Blob` by value (#37708).

Why this shape rather than marking the old function `unsafe` and adding the missing calls producer by producer: the precondition only existed because the function took a reference to an allocation it was about to give away, and the gaps only existed because the bookkeeping was attached to one of several wrapping routes. Taking the value removes the precondition instead of documenting it, and computing at heap promotion leaves no route around the bookkeeping, which is also why the producer-by-producer fixes in #37667 and #37697 reduce to their create-time reporting, field ordering and tests once this is in. #31987 (open) marks the old `&self` method `unsafe`; its Blob hunks are superseded by this change, the rest of that PR is unaffected.

### Verification

New tests at the end of test/js/web/fetch/blob.test.ts: a table of in-memory Blob producers (`new Blob`, `new File`, `slice()`, `structuredClone`, `resolveObjectURL`, `ReadableStream#blob()` on a blob stream, buffered and streamed `Response#blob()`, `Request#blob()`, a natively parsed `formData()` entry, a WebSocket `binaryType = "blob"` message, the three `Bun.Archive` outputs, `Bun.Image#blob()`) asserting `estimateShallowMemoryUsageOf(blob) >= blob.size` on a 64 KiB incompressible payload; a table of store-backed producers (`Bun.file()`, `Bun.stdin`, the three S3 constructors) asserting the wrapper reports more than an empty in-memory blob does; and a check that exactly the S3 producers get the S3File wrapper. Without the fix the `new File()`, `formData()`, WebSocket and `Bun.Image#blob()` cases fail (each receives 48); the rest cover the call sites the change converts (every JS-reachable one: the bytes-to-bytes `Bun.write` branch is rejected earlier by argument validation, `Bun.embeddedFiles` is exercised by test/regression/issue/31575.test.ts, and the webview screenshot exports have no test here). Whole file: 96 pass on the fixed debug build (rebased on main, which added its own tests to the file in the meantime). Cross-check against the neighbouring PRs, run by applying only their test hunks to this branch: the four tests #37697 adds (parsed multipart files, a parsed file re-appended to another FormData, a WebSocket blob message, including the `FormData` and `MessageEvent` memory costs) pass against this branch as is, and #37667's `File` estimate test passes too, while its two allocation-time tests fail here exactly as they do on main, since reporting at allocation for the two wrappers C++ creates directly is that PR's own change.

Also run on the fixed debug build: test/js/web/fetch/{blob,body,body-clone,blob-file-name-ownership}.test.ts, test/js/web/html/FormData*.test.ts, test/js/web/structured-clone-blob-file.test.ts, test/js/node/buffer-resolveObjectURL.test.ts, test/js/web/websocket/websocket-client-short-read.test.ts, test/js/bun/archive.test.ts, test/js/bun/util/bun-stdin-slice.test.ts, test/js/web/workers/worker_blob.test.ts, test/regression/issue/31575.test.ts, the FormData/Request/Response/WebSocket cases of test/js/bun/util/heap-snapshot.test.ts, the local parts of test/js/bun/s3/s3.test.ts and the image `.blob()` test. `cargo check` for bun_bin on linux-x64 plus bun_runtime on x86_64-pc-windows-msvc (the `jsc_abi_extern!` sysv64 branch) and aarch64-apple-darwin, `cargo clippy` and `cargo fmt --check` on bun_jsc and bun_runtime, and test/internal/source-lints are clean.

</details>

