### PR TITLE
node/net: guard BlockList rules with Guarded<Vec<Rule>>

### DIFF
--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -32,8 +32,8 @@ use core::cmp::Ordering;
 use core::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 
 use bun_core::{String as BunString, ZStr};
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsCell, JsResult, StringJsc as _};
-use bun_threading::{Guarded, Mutex};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _};
+use bun_threading::Guarded;
 
 /// `(serialize_nonce, address)` of `BlockList` instances currently embedded in
 /// a live `SerializedScriptValue` (one entry per serialize; removed by
@@ -65,12 +65,9 @@ pub struct BlockList {
     // `ref()`/`deref()` (provided by the derive) bump it; hitting zero drops
     // the `Box` via the trait's default destructor.
     ref_count: bun_ptr::ThreadSafeRefCount<BlockList>,
-    // R-2: interior mutability so every host_fn takes `&self`. All access is
-    // serialized by `mutex` (held across every read and every `with_mut`), so
-    // the `JsCell` single-thread invariant is upheld even though `BlockList`
-    // can be touched from multiple JS realms via structured clone.
-    da_rules: JsCell<Vec<Rule>>,
-    mutex: Mutex,
+    /// Structured clone shares one `BlockList` between JS threads, hence a
+    /// lock rather than a `JsCell`.
+    rules: Guarded<Vec<Rule>>,
 
     /// We cannot lock/unlock a mutex
     estimated_size: AtomicU32,
@@ -103,8 +100,7 @@ impl BlockList {
     pub(crate) fn constructor(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<*mut Self> {
         let ptr = bun_core::heap::into_raw(Box::new(Self {
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
-            da_rules: JsCell::new(Vec::new()),
-            mutex: Mutex::default(),
+            rules: Guarded::new(Vec::new()),
             estimated_size: AtomicU32::new(0),
             serialize_nonce: {
                 let mut n = [0u8; 8];
@@ -152,8 +148,7 @@ impl BlockList {
             SocketAddress::init_from_addr_family(global, address_js, family_js)?._addr
         };
 
-        let _guard = this.mutex.lock_guard();
-        this.da_rules.with_mut(|r| r.insert(0, Rule::Addr(address)));
+        this.rules.lock().insert(0, Rule::Addr(address));
         this.estimated_size.fetch_add(
             u32::try_from(core::mem::size_of::<Rule>()).expect("int cast"),
             AtomicOrdering::Relaxed,
@@ -194,9 +189,7 @@ impl BlockList {
                 ));
             }
         }
-        let _guard = this.mutex.lock_guard();
-        this.da_rules
-            .with_mut(|r| r.insert(0, Rule::Range { start, end }));
+        this.rules.lock().insert(0, Rule::Range { start, end });
         this.estimated_size.fetch_add(
             u32::try_from(core::mem::size_of::<Rule>()).expect("int cast"),
             AtomicOrdering::Relaxed,
@@ -242,9 +235,9 @@ impl BlockList {
             )?)
             .unwrap();
         }
-        let _guard = this.mutex.lock_guard();
-        this.da_rules
-            .with_mut(|r| r.insert(0, Rule::Subnet { network, prefix }));
+        this.rules
+            .lock()
+            .insert(0, Rule::Subnet { network, prefix });
         this.estimated_size.fetch_add(
             u32::try_from(core::mem::size_of::<Rule>()).expect("int cast"),
             AtomicOrdering::Relaxed,
@@ -284,8 +277,7 @@ impl BlockList {
     }
 
     pub(crate) fn check_sockaddr(&self, address: &sockaddr) -> bool {
-        let _guard = self.mutex.lock_guard();
-        for item in self.da_rules.get().iter() {
+        for item in self.rules.lock().iter() {
             match item {
                 Rule::Addr(a) => {
                     let Some(order) = compare(address, a) else {
@@ -368,8 +360,7 @@ impl BlockList {
 
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn rules(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        let _guard = this.mutex.lock_guard();
-        let rules = this.da_rules.get();
+        let rules = this.rules.lock();
         // GC must be able to visit
         let array = JSValue::create_empty_array(global, rules.len())?;
 
@@ -416,7 +407,7 @@ impl BlockList {
         write_bytes: crate::generated_classes::WriteBytesFn,
     ) {
         use bun_io::Write as _;
-        let _guard = this.mutex.lock_guard();
+        let _guard = this.rules.lock();
         this.ref_();
         let addr = std::ptr::from_ref::<Self>(this) as usize;
         SERIALIZED_REFS.lock().push((this.serialize_nonce, addr));


### PR DESCRIPTION
### Problem
- `net.BlockList` kept its rules in a `JsCell<Vec<Rule>>` with a separate `Mutex` beside it; a comment asked every access site to take the mutex first.
- Nothing in the types stopped a call site from touching the rules without the lock, so the `JsCell` single-thread rule held only by convention.
- The lock matters because a structured-cloned `BlockList` is one instance shared between JS threads.

### Fix
- The two fields become one `Guarded<Vec<Rule>>`, so the rules are only reachable through a lock guard; the serialize hook takes the same lock as before.
- Property to check: every site still does one lock/unlock per call, `check_sockaddr` (used by QUIC) keeps its signature, no `unsafe` is added or removed.
- Layout is unchanged (`Guarded<T>` is `UnsafeCell<T>` plus the same `Mutex`, still 48 bytes), so `estimatedSize` reports the same number.
- Verification: `cargo check` and `clippy` clean; a debug build passes the one existing blocklist GC test. The Node blocklist tests named in the original did not run. No new test.

### Background
- `net.BlockList` is Node's address blocklist: rules are addresses, ranges, or subnets, and a check scans the list for a match. bun implements it in Rust.
- `JsCell<T>` is bun's interior-mutability cell for values only ever touched from one JS thread; a `Mutex` next to it cannot make the compiler enforce that.
- `Guarded<T>` (`bun_threading`) is a mutex that owns its value, like std's `Mutex<T>`: `.lock()` returns a guard borrowing the value, so no unlocked path exists.

<details>
<summary>Original description</summary>

## What

`BlockList` (`src/runtime/node/net/BlockList.rs`) kept its rules in a `JsCell<Vec<Rule>>` with a separate `mutex: Mutex` beside it, and a field comment asked every access site to take the mutex before touching the cell. The two fields are now a single `Guarded<Vec<Rule>>` (the same `bun_threading` type the file already uses for its `SERIALIZED_REFS` static), so the `Vec` is only reachable through the lock guard.

```rust
// before
da_rules: JsCell<Vec<Rule>>,
mutex: Mutex,

let _guard = this.mutex.lock_guard();
this.da_rules.with_mut(|r| r.insert(0, Rule::Addr(address)));

let _guard = self.mutex.lock_guard();
for item in self.da_rules.get().iter() { .. }

// after
rules: Guarded<Vec<Rule>>,

this.rules.lock().insert(0, Rule::Addr(address));

for item in self.rules.lock().iter() { .. }
```

The 6 lock-then-access pairs change accordingly: the three `add*` methods insert through the guard, `check_sockaddr` iterates under a guard that lives for the loop, the `rules` getter binds the guard for the duration of the array build exactly where it previously bound the `MutexGuard`, and `on_structured_clone_serialize` keeps taking the same lock it took before (`let _guard = this.rules.lock();`). The constructor initializes `Guarded::new(Vec::new())`, and the `JsCell` and `Mutex` imports plus the comment justifying the `JsCell` go away. `check_sockaddr`'s signature, used by the QUIC endpoint, is unchanged. No `unsafe` blocks are added or removed.

## Why

Reading the rules without holding the lock is no longer expressible: the `JsCell` single-thread invariant that a comment claimed was upheld by the adjacent mutex is now enforced by the field type, and the guard borrows the `Guarded` it unlocks, where `Mutex::lock_guard` only documented that the mutex must outlive the guard. This is zero-cost: `Guarded<T>` is `UnsafeCell<T>` plus the same `Mutex`, `BlockList` stays 48 bytes in release builds with both the 4-byte (Linux, macOS) and pointer-sized (Windows `SRWLOCK`) mutex, so `estimatedSize` reports the same value, and every site still performs exactly one lock/unlock pair per call.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds; bun bd test test/js/node/net/blocklist-gc.test.ts: 1 pass, 0 fail.
Note: test/js/node/test/parallel/test-blocklist.js, test-blocklist-clone.js and test-quic-blocklist.mjs were given on the same command line but were not matched by the test runner's file filter (no .test. suffix), so only 1 test across 1 file actually executed.

</details>
