### PR TITLE
cron: own spawned process ref and temp path in RAII fields

### DIFF
--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -15,6 +15,7 @@ use super::cron_parser;
 use super::cron_parser::{CronExpression, CronTz};
 
 use core::ffi::c_char;
+use core::ptr::NonNull;
 use std::cell::Cell;
 
 #[cfg(not(windows))]
@@ -206,6 +207,62 @@ enum JobAction {
     Advance,
 }
 
+/// The ref on a spawned [`Process`] that `to_process` hands out. Releasing it
+/// also detaches the process, so it can no longer call back into the job.
+struct HeldProcess(NonNull<Process>);
+
+impl HeldProcess {
+    /// # Safety
+    /// `process` must have been returned by `to_process`; the returned value
+    /// takes over the ref it carries.
+    unsafe fn adopt(process: *mut Process) -> Self {
+        // SAFETY: caller contract: `to_process` never returns null.
+        Self(unsafe { NonNull::new_unchecked(process) })
+    }
+
+    fn as_ptr(&self) -> *mut Process {
+        self.0.as_ptr()
+    }
+}
+
+impl Drop for HeldProcess {
+    fn drop(&mut self) {
+        let process = self.as_ptr();
+        // SAFETY: `adopt` took over a ref, so `process` is live until this deref.
+        unsafe {
+            (*process).detach();
+            Process::deref(process);
+        }
+    }
+}
+
+/// A file removed when the job that wrote it goes away: the crontab/schtasks
+/// input, or on macOS the plist until `launchctl bootstrap` takes it over.
+struct UnlinkOnDrop(ZString);
+
+#[cfg(target_os = "macos")]
+impl UnlinkOnDrop {
+    /// Leaves the file in place and hands back its path.
+    fn keep(self) -> ZString {
+        let this = core::mem::ManuallyDrop::new(self);
+        // SAFETY: `this` is never dropped, so the path is moved out exactly once.
+        unsafe { core::ptr::read(&raw const this.0) }
+    }
+}
+
+impl core::ops::Deref for UnlinkOnDrop {
+    type Target = ZStr;
+    fn deref(&self) -> &ZStr {
+        self.0.as_zstr()
+    }
+}
+
+impl Drop for UnlinkOnDrop {
+    fn drop(&mut self) {
+        let _ = sys::unlink(&self.0);
+    }
+}
+
 // ============================================================================
 // CronRegisterJob
 // ============================================================================
@@ -225,8 +282,7 @@ struct CronRegisterJob {
     parsed_cron: CronExpression,
 
     state: RegisterState,
-    // LIFETIMES.tsv: SHARED — `Process` is intrusively refcounted (`*mut`).
-    process: Option<*mut Process>,
+    process: Option<HeldProcess>,
     stdout_reader: OutputReader,
     #[cfg(windows)]
     stderr_reader: OutputReader,
@@ -234,7 +290,7 @@ struct CronRegisterJob {
     has_called_process_exit: bool,
     exit_status: Option<Status>,
     err_msg: Option<Vec<u8>>,
-    tmp_path: Option<ZString>,
+    tmp_path: Option<UnlinkOnDrop>,
     /// Typed enum for the io-layer FilePoll vtable (`bun_io::EventLoopHandle`
     /// wraps `*const EventLoopHandle`).
     event_loop_handle: EventLoopHandle,
@@ -298,13 +354,7 @@ impl CronJobBase for CronRegisterJob {
         if !self.has_called_process_exit || self.remaining_fds != 0 {
             return JobAction::Pending;
         }
-        if let Some(proc) = self.process.take() {
-            // SAFETY: `proc` is the intrusive-RC pointer returned by `to_process`.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
+        self.process = None;
         if self.err_msg.is_some() {
             return JobAction::Finish;
         }
@@ -519,7 +569,7 @@ impl CronRegisterJob {
             }
         };
         let tmp_path_ptr = tmp_path.as_ptr();
-        self.tmp_path = Some(tmp_path);
+        self.tmp_path = Some(UnlinkOnDrop(tmp_path));
 
         let file = match File::openat(
             Fd::cwd(),
@@ -606,7 +656,7 @@ impl CronRegisterJob {
                 return Err(());
             }
         };
-        self.tmp_path = Some(plist_path);
+        self.tmp_path = Some(UnlinkOnDrop(plist_path));
 
         // XML-escape all dynamic values
         macro_rules! try_escape {
@@ -730,7 +780,7 @@ impl CronRegisterJob {
     #[cfg(target_os = "macos")]
     fn prepare_bootstrap(&mut self) -> Result<(ZString, ZString), ()> {
         self.state = RegisterState::Bootstrapping;
-        let Some(plist_path) = self.tmp_path.take() else {
+        let Some(plist_path) = self.tmp_path.take().map(UnlinkOnDrop::keep) else {
             self.set_err(format_args!("No plist path"));
             return Err(());
         };
@@ -999,7 +1049,7 @@ impl CronRegisterJob {
             }
         };
         let xml_path_ptr = xml_path.as_ptr();
-        self.tmp_path = Some(xml_path);
+        self.tmp_path = Some(UnlinkOnDrop(xml_path));
 
         let file = match File::openat(
             Fd::cwd(),
@@ -1024,23 +1074,6 @@ impl CronRegisterJob {
     }
 }
 
-impl Drop for CronRegisterJob {
-    fn drop(&mut self) {
-        // stdout_reader / stderr_reader drop via their own Drop.
-        if let Some(proc) = self.process.take() {
-            // SAFETY: intrusive-RC pointer; we hold a ref.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
-        if let Some(p) = self.tmp_path.take() {
-            let _ = sys::unlink(&p);
-        }
-        // err_msg, abs_path, schedule, title freed via field Drop.
-    }
-}
-
 #[cfg(windows)]
 const ASCII_WHITESPACE: [u8; 6] = *b" \t\n\r\x0b\x0c";
 
@@ -1056,8 +1089,7 @@ struct CronRemoveJob {
     title: ZString,
 
     state: RemoveState,
-    // LIFETIMES.tsv: SHARED — `Process` is intrusively refcounted (`*mut`).
-    process: Option<*mut Process>,
+    process: Option<HeldProcess>,
     stdout_reader: OutputReader,
     #[cfg(windows)]
     stderr_reader: OutputReader,
@@ -1065,7 +1097,8 @@ struct CronRemoveJob {
     has_called_process_exit: bool,
     exit_status: Option<Status>,
     err_msg: Option<Vec<u8>>,
-    tmp_path: Option<ZString>,
+    #[cfg(not(target_os = "macos"))]
+    tmp_path: Option<UnlinkOnDrop>,
     /// Typed enum for the io-layer FilePoll vtable (`bun_io::EventLoopHandle`
     /// wraps `*const EventLoopHandle`).
     event_loop_handle: EventLoopHandle,
@@ -1124,13 +1157,7 @@ impl CronJobBase for CronRemoveJob {
         if !self.has_called_process_exit || self.remaining_fds != 0 {
             return JobAction::Pending;
         }
-        if let Some(proc) = self.process.take() {
-            // SAFETY: intrusive-RC pointer; we hold a ref.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
+        self.process = None;
         if self.err_msg.is_some() {
             return JobAction::Finish;
         }
@@ -1321,7 +1348,7 @@ impl CronRemoveJob {
             }
         };
         let tmp_path_ptr = tmp_path.as_ptr();
-        self.tmp_path = Some(tmp_path);
+        self.tmp_path = Some(UnlinkOnDrop(tmp_path));
 
         let file = match File::openat(
             Fd::cwd(),
@@ -1405,6 +1432,7 @@ pub(crate) fn cron_remove(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
         has_called_process_exit: false,
         exit_status: None,
         err_msg: None,
+        #[cfg(not(target_os = "macos"))]
         tmp_path: None,
         // SAFETY: `vm_mut().event_loop()` returns the live per-thread `jsc::EventLoop`.
         event_loop_handle: EventLoopHandle::init(vm_mut().event_loop().cast::<()>()),
@@ -1461,21 +1489,6 @@ impl CronRemoveJob {
             bstr::BStr::new(self.title.as_bytes())
         ))
         .map_err(|_| self.set_err(format_args!("Out of memory")))
-    }
-}
-
-impl Drop for CronRemoveJob {
-    fn drop(&mut self) {
-        if let Some(proc) = self.process.take() {
-            // SAFETY: intrusive-RC pointer; we hold a ref.
-            unsafe {
-                (*proc).detach();
-                Process::deref(proc);
-            }
-        }
-        if let Some(p) = self.tmp_path.take() {
-            let _ = sys::unlink(&p);
-        }
     }
 }
 
@@ -2168,7 +2181,7 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
 /// Trait abstracting over CronRegisterJob/CronRemoveJob for `spawn_cmd_generic`.
 trait SpawnCmdTarget: CronJobBase + BufferedReaderParent {
     const EXIT_KIND: bun_spawn::ProcessExitKind;
-    fn process_slot(&mut self) -> &mut Option<*mut Process>;
+    fn process_slot(&mut self) -> &mut Option<HeldProcess>;
     #[cfg(unix)]
     fn stdout_reader(&mut self) -> &mut OutputReader;
     #[cfg(windows)]
@@ -2192,7 +2205,7 @@ bun_spawn::link_impl_ProcessExit! {
 
 impl SpawnCmdTarget for CronRegisterJob {
     const EXIT_KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRegister;
-    fn process_slot(&mut self) -> &mut Option<*mut Process> {
+    fn process_slot(&mut self) -> &mut Option<HeldProcess> {
         &mut self.process
     }
     #[cfg(unix)]
@@ -2209,7 +2222,7 @@ impl SpawnCmdTarget for CronRegisterJob {
 }
 impl SpawnCmdTarget for CronRemoveJob {
     const EXIT_KIND: bun_spawn::ProcessExitKind = bun_spawn::ProcessExitKind::CronRemove;
-    fn process_slot(&mut self) -> &mut Option<*mut Process> {
+    fn process_slot(&mut self) -> &mut Option<HeldProcess> {
         &mut self.process
     }
     #[cfg(unix)]
@@ -2472,8 +2485,10 @@ unsafe fn spawn_cmd_prepare<T: SpawnCmdTarget>(
 
     // SAFETY: `vm_mut().event_loop()` returns the live per-thread `jsc::EventLoop`.
     let ev_handle = EventLoopHandle::init(vm_mut().event_loop().cast::<()>());
-    let process = spawned.to_process(ev_handle);
-    *s!().process_slot() = Some(process);
+    // SAFETY: `to_process` returns a fresh `Process` carrying one ref, which `held` takes over.
+    let held = unsafe { HeldProcess::adopt(spawned.to_process(ev_handle)) };
+    let process = held.as_ptr();
+    *s!().process_slot() = Some(held);
     Ok(process)
 }
 


### PR DESCRIPTION
### Problem
- No user-visible change. Cleanup of the OS-level jobs behind `Bun.cron(path, schedule, title)` and `Bun.cron.remove(title)`.
- Each job holds one ref on the helper process it spawns and a temp file it must delete on the way out. Both were plain fields: a raw pointer and a path.
- Releasing them was written out four times (each job's `check_finished` plus a hand-written `Drop` per job), so nothing stopped a new stage from dropping the pointer without detaching, or skipping the unlink.

### Fix
- Two cron-private wrapper types own the obligations: one detaches and derefs the process on drop, the other unlinks the path on drop. The fields switch to them and both hand-written `Drop` impls go away.
- On macOS the plist is disarmed with `keep` where the old code took the path out, since `launchctl bootstrap` needs the file to stay.
- Property to check: the generated field drops run the same statements the deleted `Drop` bodies ran, in the same order, inside the same `enter()`/`exit()` bracket. The one new drop point, the slot assignment on spawn, always overwrites `None`.
- Verification: refactor only, no new test. `cargo check` and `cargo clippy` are clean; the existing cron tests pass (81 pass, 63 skip, 0 fail).

### Background
- `Bun.cron` has an in-process callback flavour (untouched) and OS-level jobs that spawn `crontab`, `launchctl` or `schtasks`. Only the latter change.
- `Process`, bun's spawned-child handle, is intrusively refcounted. `to_process` returns a raw pointer carrying one ref; the holder must `detach()` it (exit callbacks stop reaching the job) and `deref()` it when done.
- The helper reads its input from a temp file (crontab text, schtasks XML, or a plist on macOS), removed when the job ends. Exception: `launchctl bootstrap` takes over the plist, and the remove job writes no file on macOS.
- RAII here means the cleanup lives in a wrapper's `Drop`, so it runs wherever the value is dropped: in `check_finished`, on error paths, and when the job is freed.

<details>
<summary>Original description</summary>

## What

`CronRegisterJob` and `CronRemoveJob` (the `Bun.cron(path, schedule, title)` / `Bun.cron.remove(title)` OS-level jobs in `src/runtime/api/cron.rs`) each held the +1 ref returned by `to_process` as `process: Option<*mut Process>` and the file they have to remove when they go away as `tmp_path: Option<ZString>`. Releasing them was written out four times (`check_finished` on both jobs, plus a hand-written `impl Drop` on each job):

```rust
if let Some(proc) = self.process.take() {
    // SAFETY: intrusive-RC pointer; we hold a ref.
    unsafe {
        (*proc).detach();
        Process::deref(proc);
    }
}
if let Some(p) = self.tmp_path.take() {
    let _ = sys::unlink(&p);
}
```

Both obligations now live in two small cron-private types, and the fields become `process: Option<HeldProcess>` and `tmp_path: Option<UnlinkOnDrop>`:

```rust
struct HeldProcess(NonNull<Process>);   // Drop: detach() + Process::deref()
struct UnlinkOnDrop(ZString);           // Drop: sys::unlink(); Deref<Target = ZStr>
```

`HeldProcess::adopt` is the one place that takes over the ref from `to_process` (end of `spawn_cmd_prepare`, which still returns the raw pointer `spawn_cmd_generic` works with); `SpawnCmdTarget::process_slot` returns `&mut Option<HeldProcess>`; both `check_finished` sites become `self.process = None;`. The four sites that arm a file (`prepare_install_crontab`, `prepare_filtered_crontab`, `prepare_plist`, `prepare_schtasks_create`) wrap the path in `UnlinkOnDrop`, the `File::openat` calls are unchanged through `Deref`, and macOS `prepare_bootstrap` disarms with `UnlinkOnDrop::keep` at the point where it used to `take()` the path (the plist is handed to `launchctl bootstrap` and must stay). Both `impl Drop for Cron*Job` blocks are deleted; the two LIFETIMES comments describing the raw pointer go with them. `CronRemoveJob` never writes a file on macOS, so its `tmp_path` field is now `#[cfg(not(target_os = "macos"))]` (without the gate the field is never read there and `dead_code` rejects it).

The four copies of the detach/deref `unsafe` block are replaced by one in `HeldProcess::drop`, plus the `new_unchecked` in `adopt`, its call site, and the `ptr::read` in the macOS-only `keep`.

## Why

Who releases the process ref and who unlinks the file is now answered by the field types, a job can no longer drop the pointer without detaching (or unlink without having armed), and a new spawn stage cannot forget either cleanup. `Option<HeldProcess>` uses the `NonNull` niche (one word, down from two) and `Option<UnlinkOnDrop>` keeps `Option<ZString>`'s layout; the generated field drops execute exactly the statements the removed `Drop` bodies executed, in the same order (`process` is declared before `tmp_path`), still inside the `enter()`/`exit()` bracket in `finish()`. The only new drop glue is on the slot assignment in `spawn_cmd_prepare`, whose previous value is always `None` because `check_finished` clears it before any further spawn.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds; `bun bd test test/js/bun/cron/cron.test.ts test/js/bun/cron/in-process-cron.test.ts`: 81 pass, 63 skip, 0 fail (144 tests across 2 files).


</details>
