### PR TITLE
usockets: follow the whole adopted-socket chain when re-deriving the live socket

### DIFF
--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -44,11 +44,7 @@ int us_internal_libuv_peer_reset_probe(LIBUS_SOCKET_DESCRIPTOR fd) {
 }
 
 static struct us_socket_t *us_internal_poll_cb_adopted_socket(struct us_poll_t *wp) {
-  struct us_socket_t *s = (struct us_socket_t *)wp;
-  if (s->flags.adopted && s->prev) {
-    s = s->prev;
-  }
-  return s;
+  return us_internal_socket_follow_adopted((struct us_socket_t *)wp);
 }
 
 static int us_internal_poll_cb_socket_is_probeable(struct us_poll_t *wp) {

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -343,6 +343,21 @@ struct us_socket_t {
 _Static_assert(sizeof(struct us_socket_flags) == 1, "us_socket_flags grew");
 #endif
 
+/* us_socket_adopt relocates a socket whose ext grows and retires the old block
+ * (is_closed + adopted, prev -> replacement; freed by the outermost tick's
+ * us_internal_free_closed_sockets, so it is still readable mid-dispatch). A
+ * callback may adopt more than once before returning, retiring each block in
+ * turn, so walk the whole chain rather than one link: one link can land on a
+ * block that is itself retired. The walk ends on the live block, which never
+ * has adopted set (the copy is taken before the source is flagged). Tolerates
+ * NULL, which callbacks may return. */
+static inline struct us_socket_t *us_internal_socket_follow_adopted(struct us_socket_t *s) {
+    while (s && s->flags.adopted && s->prev) {
+        s = s->prev;
+    }
+    return s;
+}
+
 struct us_connecting_socket_t {
     alignas(LIBUS_EXT_ALIGNMENT) struct addrinfo_request *addrinfo_req;
     struct us_socket_group_t *group;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -555,9 +555,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                             us_dispatch_open(s, 0, bsd_addr_get_ip(&addr), bsd_addr_get_ip_length(&addr));
                         }
                         /* After socket adoption, track the new socket; the old one becomes invalid */
-                        if(s && s->flags.adopted && s->prev) {
-                            s = s->prev;
-                        }
+                        s = us_internal_socket_follow_adopted(s);
 
                         /* When the kernel deferred the accept until data arrived (TCP_DEFER_ACCEPT
                          * on Linux, SO_ACCEPTFILTER on FreeBSD), the request/ClientHello is already
@@ -583,9 +581,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             /* We should only use s, no p after this point */
             struct us_socket_t *s = (struct us_socket_t *) p;
             /* After socket adoption, track the new socket; the old one becomes invalid */
-            if(s && s->flags.adopted && s->prev) {
-                s = s->prev;
-            }
+            s = us_internal_socket_follow_adopted(s);
             /* The group can change after calling a callback but the loop is always the same */
             struct us_loop_t* loop = s->group->loop;
             if (events & LIBUS_SOCKET_WRITABLE && !error) {
@@ -601,9 +597,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
 
                 s = s->ssl ? us_internal_ssl_on_writable(s) : us_dispatch_writable(s);
                 /* After socket adoption, track the new socket; the old one becomes invalid */
-                if(s && s->flags.adopted && s->prev) {
-                    s = s->prev;
-                }
+                s = us_internal_socket_follow_adopted(s);
 
                 if (!s || us_socket_is_closed(s)) {
                     return;
@@ -724,9 +718,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         s = s->ssl ? us_internal_ssl_on_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length)
                                    : us_dispatch_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length);
                         /* After socket adoption, track the new socket; the old one becomes invalid */
-                        if(s && s->flags.adopted && s->prev) {
-                            s = s->prev;
-                        }
+                        s = us_internal_socket_follow_adopted(s);
                         read_any = 1;
                         // loop->num_ready_polls isn't accessible on Windows.
                         #ifndef WIN32


### PR DESCRIPTION
### What does this PR do?

When `us_socket_adopt` has to grow a socket's ext it goes through `us_poll_resize`, which allocates a new `us_socket_t`, copies the old one over, and retires the old block: `is_closed = 1`, `flags.adopted = 1`, `prev = <replacement>`, pushed onto `loop->data.closed_head` (context.c, `us_socket_adopt`). The dispatcher in `loop.c` is usually holding the old pointer while this happens (the adoption runs inside `on_open`, `on_writable` or `on_data`), so after each of those callbacks it re-derives the live socket from that bookkeeping. Until now every one of those sites followed exactly one link:

```c
if (s && s->flags.adopted && s->prev) {
    s = s->prev;
}
```

That is only right if the socket was relocated once per callback. Every relocation retires its source block the same way, so a callback that adopts twice before returning (`old -> mid -> new`, with `mid` also flagged and pointing at `new`) leaves one hop parked on `mid`, which is itself retired. The `is_closed` checks that follow then give up on the rest of the event for a socket that is still live: the readable half of a combined readable+writable event, the rest of the recv drain loop and the eof/error handling behind it (loop.c), the deferred-accept readable dispatch after `on_open`, and on Windows the paused-socket probe and `fin_deferred` bookkeeping in `poll_cb` (libuv.c). The kernel re-reports these level-triggered conditions on the next tick, so the result is a dropped event tail rather than a crash, but the bookkeeping is only correct because there happens to be a single link.

The fix replaces the five copies of the one-hop `if` with one helper in `internal/internal.h`, `us_internal_socket_follow_adopted`, which walks to the end of the chain. `loop.c` uses it at the four dispatch sites, and the libuv.c `us_internal_poll_cb_adopted_socket` helper that `poll_cb` already funnels through now calls it too. Nothing else reads `flags.adopted`, so these are all the readers.

Why walking the chain is sound:

- Every block on the chain is still allocated while a dispatch holds it. Retired blocks sit on `closed_head` and are only freed by `us_internal_free_closed_sockets`, which runs in the outermost tick's `us_internal_loop_post`, never from inside a dispatch (see the `tick_depth` check in loop.c). For the same reason a retired block's memory cannot be handed out as a new socket within the tick.
- The walk terminates on the live block. `us_poll_resize` copies the source before `us_socket_adopt` flags it, so the copy, and therefore the live tail, always has `adopted` clear. `adopted` is set in exactly one place and always together with `prev`, so every link the walk follows is a forwarding link.

When `adopted` is clear, which is every socket today, the `while` evaluates its condition once, which is the same work the `if` did. The NULL tolerance of the old checks is kept because `on_writable` and `on_data` may return NULL.

### Reachability and testing

This PR has no test because the code it changes cannot currently execute. No in-tree adopter grows its ext: `upgradeTLS`, the Postgres and MySQL TLS upgrades (`adopt_tls`) and the WebSocket client (`adopt_group`) pass equal pointer-sized old/new ext sizes, and the uWS server WebSocket upgrade shrinks (checked against this tree's headers: `sizeof(WebSocketData) + sizeof(void *)` is 168 vs `sizeof(HttpResponseData<SSL>)` at 232), so `us_poll_resize` always takes its early return and `flags.adopted` is never set. The redirection itself dates from #25361; #37098 (open, same grow path) reaches the same conclusion and adds a fault-injection hook so that a single relocation can be exercised. A two-link chain additionally needs two adoptions inside one callback, which nothing JS-reachable does even with that hook. There is therefore no input on which the old and new code behave differently, and any test added here would pass with or without the change, so none is included. The change adds no state and touches no data structures.

It also does not touch `context.c` or `epoll_kqueue.c`, so it is independent of #37098; if that lands first, its tests run the helper's one-link case for real.

### How did you verify your code works?

- The debug (ASAN) build compiles, including the C++ translation units that include `internal.h` (`AsyncSocket.h`, `libuwsockets.cpp`, `bindings.cpp`). libuv.c is Windows-only and its change is a one-line body replacement behind the same signature; the Windows CI lanes compile it.
- `bun bd test test/js/bun/net/socket.test.ts` and `test/js/bun/websocket/websocket-server.test.ts` cover the in-tree adopters (`upgradeTLS`, server WebSocket upgrade). The only failures are the ones this sandbox also produces with the released binary: `localhost` resolving to `::1` makes a handful of `Bun.connect` tests fail with ECONNREFUSED, one test needs public DNS, and the 300k-message `(benchmark)` case exceeds its 30s budget under ASAN. Everything else passes.
