### PR TITLE
run: stack-local Run<'a> replaces the RUN static

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -4,7 +4,7 @@
 //! bun-shell / system shell. PATH stitching, `node_modules/.bin` lookup,
 //! markdown rendering, and the Windows bunx fast-path are all handled here.
 
-use ::core::ffi::{c_char, c_void};
+use ::core::ffi::c_char;
 use ::core::sync::atomic::{AtomicBool, Ordering};
 use std::io::Write as _;
 
@@ -959,15 +959,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // it to `bun_dns::Order`; the enum is `#[repr(u8)]` so `as u8` is exact.
         vm.dns_result_order =
             bun_dns::Order::from_string_or_die(&ctx.runtime_options.dns_result_order) as u8;
-        // `vm.main` is a BACKREF into these bytes; convert the `Box` to a raw
-        // heap pointer now so the address
-        // is stable for both `set_main` and the `RUN` write below. The runner
-        // never returns, so the allocation is process-lifetime by construction.
-        // `mut` because the cron-execution branch below may swap in a synthetic
-        // `cwd/[eval]` path.
-        let mut entry_ptr: *const [u8] = bun_core::heap::into_raw(entry_path);
-        // SAFETY: freshly-allocated heap bytes, never freed (see above).
-        let entry: &[u8] = unsafe { &*entry_ptr };
+        // `vm.main` is a BACKREF into these bytes and the runner never returns,
+        // so the allocation is process-lifetime by construction.
+        let entry: &'static [u8] = Box::leak(entry_path);
+        // What `Run::start` passes to `vm.load_entry_point`; `mut` because the
+        // cron-execution branch below may swap in a synthetic `cwd/[eval]` path
+        // while `entry` stays the user's path for the loader check further down.
+        let mut run_entry = entry;
         vm.set_main(entry);
 
         if !ctx.runtime_options.eval.script.is_empty() {
@@ -1026,7 +1024,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             )));
             // Override what
             // `Run::start` will pass to `vm.load_entry_point`.
-            entry_ptr = std::ptr::from_ref::<[u8]>(heap_entry);
+            run_entry = heap_entry;
             vm.set_main(heap_entry);
         }
 
@@ -1079,40 +1077,17 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             .unwrap_or_else(|| vm.transpiler.options.loader(paths::extension(entry)))
             == Loader::Html;
 
-        // ── enter `Run::start` under the JSC API lock ──────────────────────
-        // SAFETY: `RUN` is the process-global singleton;
-        // written exactly once here on the main thread before the API-lock
-        // trampoline reads it, never freed (`global_exit` ends the process).
-        unsafe {
-            RUN.get().write(Run {
-                ctx: std::ptr::from_mut::<ContextData>(ctx),
-                vm: vm_ptr,
-                entry_path: entry_ptr,
-            });
-        }
         // `ctx.debug.hot_reload` → `vm.hot_reload` (a `u8` until the
         // b2-cycle widens it to `cli::HotReload`); `Run::start` re-reads it
         // from `self.ctx` to drive the hot-reloader enable.
         vm.hot_reload = ctx.debug.hot_reload as u8;
 
-        extern "C" fn trampoline(ctx: *mut c_void) {
-            // SAFETY: `ctx` is `&mut RUN` passed through `holdAPILock`'s
-            // opaque slot; the API lock is held for the full call so no
-            // other thread touches the VM.
-            let this = unsafe { &mut *ctx.cast::<Run>() };
-            this.start();
+        Run {
+            ctx,
+            vm,
+            entry_path: run_entry,
         }
-        // SAFETY: `vm.global` set in `init`; `vm()` borrows the JSC VM for
-        // the API-lock FFI call. `&raw mut RUN` yields a stable raw pointer
-        // to the static.
-        #[allow(deprecated)]
-        vm.global()
-            .vm()
-            .hold_api_lock(RUN.get().cast::<c_void>(), trampoline);
-
-        // `Run::start` never returns (ends in `global_exit`); this is dead
-        // code kept so the type unifies with the `?`-early-return above.
-        Ok(())
+        .start()
     }
 
     /// Entry point for
@@ -1175,13 +1150,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         vm.argv = std::mem::take(&mut ctx.passthrough);
 
         // `vm.main` is a BACKREF (`*const [u8]`) into `entry_path`'s heap
-        // buffer; convert the `Box` to a raw heap pointer now
-        // so the address is stable for both
-        // `set_main` and the `RUN` write below. The runner never returns, so
-        // the allocation is process-lifetime by construction.
-        let entry_ptr: *const [u8] = bun_core::heap::into_raw(entry_path);
-        // SAFETY: freshly-allocated heap bytes, never freed (see above).
-        vm.set_main(unsafe { &*entry_ptr });
+        // buffer and the runner never returns, so the allocation is
+        // process-lifetime by construction.
+        let entry: &'static [u8] = Box::leak(entry_path);
+        vm.set_main(entry);
 
         // reshaped for borrowck — `b` borrows `vm.transpiler`
         // exclusively; `fail_with_build_error(vm)` needs the whole `vm`, so
@@ -1221,32 +1193,12 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         );
         Self::do_preconnect(&ctx.runtime_options.preconnect);
 
-        // SAFETY: `RUN` is the process-global singleton;
-        // written exactly once here on the main thread before the API-lock
-        // trampoline reads it, never freed (`global_exit` ends the process).
-        unsafe {
-            RUN.get().write(Run {
-                ctx: std::ptr::from_mut::<ContextData>(ctx),
-                vm: vm_ptr,
-                entry_path: entry_ptr,
-            });
+        Run {
+            ctx,
+            vm,
+            entry_path: entry,
         }
-
-        extern "C" fn trampoline(ctx: *mut c_void) {
-            // SAFETY: `ctx` is `&mut RUN` passed through `holdAPILock`'s
-            // opaque slot; the API lock is held for the full call.
-            let this = unsafe { &mut *ctx.cast::<Run>() };
-            this.start();
-        }
-        // SAFETY: `vm.global` set in `init`; `vm()` borrows the JSC VM for
-        // the API-lock FFI call.
-        #[allow(deprecated)]
-        vm.global()
-            .vm()
-            .hold_api_lock(RUN.get().cast::<c_void>(), trampoline);
-
-        // `Run::start` never returns; dead code for `?`-early-return type unify.
-        Ok(())
+        .start()
     }
 }
 
@@ -1256,40 +1208,22 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 // without a crate-cycle; `crate::run_main` re-exports it.
 // ──────────────────────────────────────────────────────────────────────────
 
-pub struct Run {
-    /// The CLI's
-    /// `ContextData` is parse-once / process-lifetime; `boot()` writes the raw
-    /// pointer here so [`Run::start`] can read profiler / preconnect /
-    /// hot-reload flags under the API lock without re-threading every field.
-    ctx: *mut ContextData,
-    vm: *mut VirtualMachine,
-    /// Heap bytes (from `boot`'s `heap::alloc`) or a borrow into the standalone graph's
-    /// `entryPoint().name` (from `boot_standalone`). Either way the bytes live
-    /// for the process — `Run::start` never returns — so a raw `*const [u8]`
-    /// works without forcing a `'static`
-    /// borrow or a `MaybeUninit` static for `Box<[u8]>`.
-    entry_path: *const [u8],
+/// Everything [`Run::start`] needs; built on the stack at the end of
+/// `RunCommand::boot` / `boot_standalone`.
+pub struct Run<'a> {
+    ctx: &'a ContextData,
+    vm: &'a mut VirtualMachine,
+    /// `vm.main` already points into these bytes; `'static` because the hot
+    /// reloader stores them too (`boot` leaks the `Box<[u8]>`, cron mode uses
+    /// the runner arena).
+    entry_path: &'static [u8],
 }
 
-// Process-global, written once in `boot`.
-// PORTING.md §Global mutable state: `Run` is `!Sync` (raw ptrs); RacyCell so
-// `boot`/`boot_standalone` can `ptr::write` it on the single CLI thread and
-// the `holdAPILock` trampoline can re-derive `&mut Run` from the static.
-static RUN: bun_core::RacyCell<Run> = bun_core::RacyCell::new(Run {
-    ctx: ::core::ptr::null_mut(),
-    vm: ::core::ptr::null_mut(),
-    entry_path: ::core::ptr::slice_from_raw_parts(::core::ptr::null(), 0),
-});
-
-// The unhandled-rejection callback fires
-// while `Run::start` holds `&mut self` (via the
-// `holdAPILock` trampoline). Storing the flag on `Run` and writing through a
-// fresh `&raw mut RUN` would alias that exclusive borrow (PORTING.md
-// §Forbidden — Stacked Borrows UB). Keep it as a sibling static instead so the
-// callback's write and `start()`'s reads never overlap a `&mut`.
+// `on_unhandled_rejection_before_close` is a plain fn pointer stored on the
+// VM, so it has no way to reach the stack-local `Run`; the flag lives here.
 static ANY_UNHANDLED: AtomicBool = AtomicBool::new(false);
 
-impl Run {
+impl Run<'_> {
     /// `onUnhandledRejectionBeforeClose` — record that *something* rejected so
     /// `start()` sets a non-zero exit code, then route through the VM's
     /// default error printer.
@@ -1308,16 +1242,12 @@ impl Run {
 
     /// Wire `--eval`/`--print`
     /// node-module globals and `--expose-gc` into the JSC global object.
-    fn add_conditional_globals(&mut self) {
+    fn add_conditional_globals(vm: &VirtualMachine, ctx: &ContextData) {
         unsafe extern "C" {
             fn Bun__ExposeNodeModuleGlobals(global: *const JSGlobalObject);
             fn JSC__JSGlobalObject__addGc(global: *const JSGlobalObject);
         }
-        // SAFETY: `self.vm`/`self.ctx` are process-lifetime; written by
-        // `boot()` before the API-lock trampoline runs.
-        let vm = unsafe { &*self.vm };
-        // SAFETY: `self.ctx` is process-lifetime; see comment on `vm` above.
-        let ro = unsafe { &(*self.ctx).runtime_options };
+        let ro = &ctx.runtime_options;
         if !ro.eval.script.is_empty() {
             // SAFETY: FFI; `vm.global` is live for the VM lifetime.
             unsafe { Bun__ExposeNodeModuleGlobals(vm.global) };
@@ -1328,22 +1258,16 @@ impl Run {
         }
     }
 
-    /// `Run.start` — load the entry point, run the event loop until idle,
-    /// fire `beforeExit`/`exit`, then `globalExit`. Called under the JSC API
-    /// lock via `hold_api_lock`.
-    fn start(&mut self) -> ! {
-        // deref the raw VM/ctx pointers once so the rest of this
-        // body can borrow `vm` and `ctx` alongside `self.entry_path`.
-        // SAFETY: `self.vm` is the boxed-and-leaked main-thread VM; `self.ctx`
-        // is the CLI's process-lifetime `ContextData`. Both are written by
-        // `boot()`/`boot_standalone()` before the API-lock trampoline runs.
-        let vm = unsafe { &mut *self.vm };
-        // SAFETY: `self.ctx` is process-lifetime; see comment on `vm` above.
-        let ctx = unsafe { &*self.ctx };
-        // SAFETY: `entry_path` is process-lifetime (heap from `heap::alloc`
-        // or a borrow into the standalone graph); deref to a `'static` slice
-        // so `enable_hot_module_reloading` can store it without re-erasing.
-        let mut entry: &'static [u8] = unsafe { &*self.entry_path };
+    /// `Run.start`: take the JSC API lock, load the entry point, run the event
+    /// loop until idle, fire `beforeExit`/`exit`, then `globalExit`. The lock
+    /// guard is never dropped because this never returns.
+    fn start(self) -> ! {
+        let Run {
+            ctx,
+            vm,
+            entry_path: mut entry,
+        } = self;
+        let _api_lock = vm.global().vm().get_api_lock();
 
         vm.hot_reload = ctx.debug.hot_reload as u8;
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
@@ -1384,7 +1308,7 @@ impl Run {
             bun_analytics::features::heap_snapshot.fetch_add(1, Ordering::Relaxed);
         }
 
-        self.add_conditional_globals();
+        Self::add_conditional_globals(vm, ctx);
 
         // ── redis preconnect (must run under the API lock) ─────────────────
         'do_redis_preconnect: {
@@ -1458,21 +1382,21 @@ impl Run {
         // ── hot-reloader enable ─────────────────────────────────────────────
         match ctx.debug.hot_reload {
             cli::command::HotReload::Hot => {
-                // SAFETY: `self.vm` is the boxed-and-leaked main-thread VM
+                // SAFETY: `vm` is the boxed-and-leaked main-thread VM
                 // (process-lifetime); it outlives the leaked reloader.
                 unsafe {
                     bun_jsc::hot_reloader::HotReloader::enable_hot_module_reloading(
-                        self.vm,
+                        std::ptr::from_mut::<VirtualMachine>(vm),
                         Some(entry),
                     )
                 }
             }
             cli::command::HotReload::Watch => {
-                // SAFETY: `self.vm` is the boxed-and-leaked main-thread VM
+                // SAFETY: `vm` is the boxed-and-leaked main-thread VM
                 // (process-lifetime); it outlives the leaked reloader.
                 unsafe {
                     bun_jsc::hot_reloader::WatchReloader::enable_hot_module_reloading(
-                        self.vm,
+                        std::ptr::from_mut::<VirtualMachine>(vm),
                         Some(entry),
                     )
                 }


### PR DESCRIPTION
## What

`src/runtime/cli/run_command.rs` drove the VM through a process-global:

```rust
pub struct Run { ctx: *mut ContextData, vm: *mut VirtualMachine, entry_path: *const [u8] }
static RUN: RacyCell<Run> = RacyCell::new(Run { ctx: null_mut(), vm: null_mut(), entry_path: .. });
```

`RunCommand::boot` and `RunCommand::boot_standalone` each turned the entry path `Box<[u8]>` into a raw pointer with `heap::into_raw` and dereferenced it again for `set_main`, wrote the three pointers into `RUN` with `ptr::write`, defined an identical `extern "C" fn trampoline` that re-derived `&mut Run` from the `c_void`, called the `#[deprecated]` `hold_api_lock` under `#[allow(deprecated)]`, and ended in an unreachable `Ok(())`. `Run::start` and `Run::add_conditional_globals` then dereferenced all three fields once more, each with its own SAFETY comment, and a six line comment explained why `ANY_UNHANDLED` could not be a field of `Run`.

`Run` is now a stack local built as the tail expression of both boot functions:

```rust
pub struct Run<'a> {
    ctx: &'a ContextData,
    vm: &'a mut VirtualMachine,
    entry_path: &'static [u8],
}

fn start(self) -> ! {
    let Run { ctx, vm, entry_path: mut entry } = self;
    let _api_lock = vm.global().vm().get_api_lock();
    ...
}
```

Both boot sites bind `let entry: &'static [u8] = Box::leak(entry_path);` once and set `vm.main` from it. `boot` keeps the same two values it had before: `entry` is still the user's path and still feeds the `main_is_html_entrypoint` loader check after the cron branch, while the former `entry_ptr` (the path `Run::start` hands to `load_entry_point`, swapped for the synthetic `cwd/[eval]` path in cron mode) is now `let mut run_entry = entry;` and ends up in `Run { ctx, vm, entry_path: run_entry }.start()`; `boot_standalone` has a single path and passes `entry` directly. `start` diverging makes the `Ok(())` tails dead, so they are deleted. `start` takes the lock through the non-deprecated `VM::get_api_lock` guard (`vm.global()` returns `&'static JSGlobalObject`, so the guard does not borrow the Rust `VirtualMachine`), and the rest of its body is unchanged apart from the two `enable_hot_module_reloading` calls, which pass `ptr::from_mut(vm)` exactly as `test_command.rs` already does, and the call to `add_conditional_globals`, which is now `fn add_conditional_globals(vm: &VirtualMachine, ctx: &ContextData)`. Deleted: the `RUN` static, both trampolines, both `#[allow(deprecated)]`, both `Ok(())` tails, the `c_void` import and 11 unsafe blocks (2 `into_raw` derefs, 2 `RUN` writes, 2 trampoline derefs, 5 field derefs in `start`/`add_conditional_globals`); no unsafe is added. One file, 52 insertions, 128 deletions.

Left as is on purpose: the four cpu/heap profiler `&'static [u8]` launders in `start` (they need `boot` to take `&'static mut ContextData`, which ripples through `Command::start`), and the remaining `hold_api_lock` users in `repl_command.rs` and `jsc/Debugger.rs`, which have their own context structs.

## Why

The types now state what the comments used to: `start` has a shared borrow of the CLI context and the exclusive borrow of the VM that `boot` already held, the entry path is `'static` because `vm.main` and the hot reloader keep pointing at it, and `Run` cannot exist before `boot` has finished initialising the VM or be observed half written, because there is no longer a static to observe. `JSC__VM__getAPILock` runs the same `JSLock::lock()` that the `JSLockHolder` inside `JSC__VM__holdAPILock` ran, and neither shape ever unlocks (the callback never returned before; the guard is never dropped now, and the workspace builds with `panic = "abort"`); `Box::leak` is `Box::into_raw` plus a reborrow; the three words move from a BSS static into the caller's frame and one indirect call through the trampoline disappears. The only difference in the machine state is that the lock is taken from `start`'s frame instead of from inside the two removed shim frames, which shifts the stack position JSC records at lock acquisition by a few dozen bytes, the same kind of variation any edit to these functions' locals produces.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/cli/run/run-eval.test.ts test/js/bun/resolve/bun-main-entry-point.test.ts test/cli/hot/watch.test.ts test/bundler/compile-process-execargv.test.ts: 44 pass, 0 fail (44 tests across 4 files).
