### PR TITLE
io: take &self in KEventWaker::wake and stop forming &mut over IoRequestLoop from other threads

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -174,10 +174,10 @@ impl<C: CompletionStruct> BundleThread<C> {
         // SAFETY: field projections via raw ptr — `thread_main` on the bundle thread
         // accesses the same struct concurrently, so we never materialize `&mut Self`.
         // `UnboundedQueue::push` takes `&self` (lock-free MPSC). `Waker::wake` takes
-        // `&self` on all platforms (LinuxWaker/Windows/KEventWaker — the latter uses
-        // `AtomicBool` for `has_pending_wake`), so this autorefs to `&Waker` and is
-        // safe to call concurrently with `wait(&self)` in `thread_main` and with
-        // other `enqueue` callers.
+        // `&self` on all platforms and only hands a Copy fd / mach port to the
+        // kernel (eventfd write, mach_msg send, uv_async_send), so this autorefs to
+        // `&Waker` and is safe to call concurrently with `wait(&self)` in
+        // `thread_main` and with other `enqueue` callers.
         unsafe {
             (*instance).queue.push(completion);
             (*instance).waker.wake();

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -174,10 +174,10 @@ impl<C: CompletionStruct> BundleThread<C> {
         // SAFETY: field projections via raw ptr — `thread_main` on the bundle thread
         // accesses the same struct concurrently, so we never materialize `&mut Self`.
         // `UnboundedQueue::push` takes `&self` (lock-free MPSC). `Waker::wake` takes
-        // `&self` on all platforms and only hands a Copy fd / mach port to the
-        // kernel (eventfd write, mach_msg send, uv_async_send), so this autorefs to
-        // `&Waker` and is safe to call concurrently with `wait(&self)` in
-        // `thread_main` and with other `enqueue` callers.
+        // `&self` on all platforms and only reads a Copy field (eventfd, mach port,
+        // `WindowsLoop` pointer) to pass to a wake call that is safe from any thread
+        // (eventfd write, mach_msg send, uv_async_send), so the `&Waker` autoref is
+        // sound alongside `wait(&self)` in `thread_main` and other `enqueue` callers.
         unsafe {
             (*instance).queue.push(completion);
             (*instance).waker.wake();

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -921,14 +921,14 @@ impl IoRequestLoop {
         let request = core::ptr::NonNull::from(request);
         // SAFETY: `ONCE` above established happens-before for `load()`'s
         // init of `pending`/`waker`. We use `get_unchecked` (no owner assert)
-        // and stay in raw-ptr land via `addr_of_mut!` so we never materialize
+        // and stay in raw-ptr land via `addr_of!` so we never materialize
         // a `&mut IoRequestLoop` that would alias the IO thread's `tick()`
-        // borrow. `pending.push` takes `&self` (lock-free MPSC); `waker.wake`
-        // is async-signal-safe by design.
+        // borrow. `pending.push` and `waker.wake` both take `&self` (lock-free
+        // MPSC push; eventfd write / mach_msg send / uv_async_send).
         unsafe {
             let loop_p = (*LOOP.get_unchecked()).as_mut_ptr();
             (*core::ptr::addr_of!((*loop_p).pending)).push(request);
-            (*core::ptr::addr_of_mut!((*loop_p).waker)).wake();
+            (*core::ptr::addr_of!((*loop_p).waker)).wake();
         }
     }
 
@@ -2043,7 +2043,7 @@ pub mod waker {
             }
         }
 
-        pub fn wake(&mut self) {
+        pub fn wake(&self) {
             let _ = io_darwin_schedule_wakeup(self.machport);
         }
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -920,13 +920,14 @@ impl IoRequestLoop {
         request.scheduled = true;
         let request = core::ptr::NonNull::from(request);
         // SAFETY: `ONCE` above established happens-before for `load()`'s
-        // init of `pending`/`waker`. We use `get_unchecked` (no owner assert)
-        // and stay in raw-ptr land via `addr_of!` so we never materialize
-        // a `&mut IoRequestLoop` that would alias the IO thread's `tick()`
-        // borrow. `pending.push` and `waker.wake` both take `&self` (lock-free
-        // MPSC push; eventfd write / mach_msg send / uv_async_send).
+        // init of `pending`/`waker`. `get_unchecked` (no owner assert) and a
+        // pointer cast of the `repr(transparent)` `MaybeUninit` (not
+        // `as_mut_ptr(&mut self)`) keep this in raw-ptr land: the only
+        // references formed are the `&pending` / `&waker` autorefs, which may
+        // coexist with the IO thread's `&IoRequestLoop` held across `tick()`.
+        // `pending.push` (lock-free MPSC) and `waker.wake` both take `&self`.
         unsafe {
-            let loop_p = (*LOOP.get_unchecked()).as_mut_ptr();
+            let loop_p = LOOP.get_unchecked().cast::<IoRequestLoop>();
             (*core::ptr::addr_of!((*loop_p).pending)).push(request);
             (*core::ptr::addr_of!((*loop_p).waker)).wake();
         }


### PR DESCRIPTION
Adopts #37626 by @alii (rebased onto current main, with the two review threads from that PR addressed).

### What does this PR do?

`bun_io::waker` has one waker type per platform. `LinuxWaker::wake` and `WindowsWaker::wake` take `&self`, but `KEventWaker::wake` (macOS) took `&mut self`. Both cross-thread callers, `BundleThread::enqueue` and `IoRequestLoop::schedule`, call `wake()` through a raw pointer while the owning thread is parked in `wait(&self)` on the same waker, so on macOS the autoref materialised a `&mut KEventWaker` aliasing a live `&KEventWaker` on another thread. Nothing miscompiles today (`wake` only reads the `Copy` `machport` and hands it to `mach_msg`), but it is aliasing UB under Stacked Borrows and a trap for the next person who adds state to `wake` and trusts the `&mut`.

Changes:

- `KEventWaker::wake` takes `&self`; the body is unchanged.
- `IoRequestLoop::schedule` no longer forms any reference to the loop struct. It used `(*LOOP.get_unchecked()).as_mut_ptr()`, and `MaybeUninit::as_mut_ptr` takes `&mut self`, so that line autoref'd a `&mut MaybeUninit<IoRequestLoop>` on the scheduling thread while the IO thread holds `&IoRequestLoop` across `tick()` for the life of the process. This is the same aliasing as the waker one, on every platform, and it sat directly under a SAFETY comment claiming it did not happen. The raw pointer is now cast (`MaybeUninit<T>` is `repr(transparent)`), the same shape `bundler/ThreadPool.rs` and `io/source.rs` already use for their `MaybeUninit` statics, and the waker projection uses `addr_of!`.
- The SAFETY comments at both call sites now describe what is there. The old `BundleThread::enqueue` comment cited a `has_pending_wake` AtomicBool that no longer exists; the new text also describes the Windows waker correctly (it passes the `WindowsLoop` pointer to `uv_async_send`, not a Copy fd).

Not changed here: `HTTPThread::schedule` and `shutdown_for_exit` use the same `as_mut_ptr()` autoref on `HTTP_THREAD`, but the HTTP thread itself holds a `&'static mut HttpThread` across `process_events`, so swapping the cast there would not make that path sound on its own. That needs its own change.

### How did you verify your code works?

There is no observable behavior change to test: the generated code is the same, only the reference types formed on the scheduling side differ.

- `cargo check -p bun_io -p bun_bundler` for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc` and `x86_64-unknown-freebsd`; `cargo clippy` and `cargo fmt --check` on both crates are clean.
- Debug build on Linux: `test/bundler/bun-build-api.test.ts` (52 pass) plus 50 concurrent and 20 sequential `Bun.build` calls, which race `enqueue`/`wake` against the bundle thread's `wait`.
- `IoRequestLoop::schedule` path: piping 4 MB into `Bun.stdin.text()` with `BUN_DEBUG_WriteFile=1` shows `ReadFile.waitForReadable` (which calls `schedule`) firing ~300 times and the full length coming back; `test/js/bun/io/bun-write.test.js`, `test/js/bun/util/bun-stdin-slice.test.ts` and the stdin regression tests (07500, 27849, 29787) pass.
- The macOS-only receiver change was built and exercised on macOS in #37626 (`bun-debug` with concurrent `Bun.build` calls and the `bun build` CLI); its CI run there built green on both darwin lanes.
