### PR TITLE
node:tls: make client-side new TLSSocket(socket) upgrade the socket it wraps

### DIFF
--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -4,8 +4,6 @@ export default {
   // 'secureConnect' (node parity), so internal deferrals park on this instead.
   kSecureConnectDone: Symbol("kSecureConnectDone"),
   kVerifyError: Symbol("kVerifyError"),
-  // net.Socket.prototype method driving the client-side upgrade behind
-  // `new tls.TLSSocket(socket)`; lives in net.ts next to the connect() path it
-  // shares with tls.connect({ socket }).
+  // net.Socket.prototype method behind the client-side `new tls.TLSSocket(socket)`.
   kUpgradeClientTLS: Symbol("kUpgradeClientTLS"),
 };

--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -4,4 +4,8 @@ export default {
   // 'secureConnect' (node parity), so internal deferrals park on this instead.
   kSecureConnectDone: Symbol("kSecureConnectDone"),
   kVerifyError: Symbol("kVerifyError"),
+  // net.Socket.prototype method driving the client-side upgrade behind
+  // `new tls.TLSSocket(socket)`; lives in net.ts next to the connect() path it
+  // shares with tls.connect({ socket }).
+  kUpgradeClientTLS: Symbol("kUpgradeClientTLS"),
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -42,7 +42,7 @@ import type { TLSSocket } from "node:tls";
 const { kTimeout, getTimerDuration } = require("internal/timers");
 const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
 const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
-const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError, kUpgradeClientTLS } = require("internal/net/symbols");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -144,6 +144,9 @@ const kConnectOptions = Symbol("connect-options");
 const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kupgraded = Symbol("kupgraded");
+// Set on a TLSSocket constructed over an existing socket (`new tls.TLSSocket(socket)`
+// rather than tls.connect()); see onClientHandshakeComplete.
+const kStandaloneWrap = Symbol("kStandaloneWrap");
 const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
 const ksocket = Symbol("ksocket");
 const khandlers = Symbol("khandlers");
@@ -299,6 +302,14 @@ function onClientHandshakeComplete(self, socket, verifyError) {
   self._secureEstablished = true;
   self[kVerifyError] = verifyError ?? null;
   self.alpnProtocol = socket.alpnProtocol;
+  // Node installs onConnectSecure from tls.connect() only: a TLSSocket
+  // constructed over an existing socket gets _finishInit alone, so it neither
+  // checks the certificate against a connect() host it does not have nor emits
+  // 'secureConnect'. It still applies the chain verdict (authorized /
+  // rejectUnauthorized), like the standalone server wrap in ServerHandlers.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1081-L1108
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1810
+  const connectSecure = !self[kStandaloneWrap];
   // Node has no try/catch around these emits; a listener throw reaches
   // InternalCallbackScope as uncaughtException. reportError mirrors that
   // without changing Bun.connect's handshake-throw-to-error-handler contract.
@@ -306,7 +317,7 @@ function onClientHandshakeComplete(self, socket, verifyError) {
   try {
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1662-L1673
     const { checkServerIdentity } = self[bunTLSConnectOptions];
-    if (!verifyError && !self.isSessionReused() && typeof checkServerIdentity === "function") {
+    if (connectSecure && !verifyError && !self.isSessionReused() && typeof checkServerIdentity === "function") {
       const hostname = self.servername || self._host || "localhost";
       const cert = self.getPeerCertificate(true);
       if (cert) {
@@ -321,7 +332,10 @@ function onClientHandshakeComplete(self, socket, verifyError) {
         if (rejectUnauthorized ?? self._rejectUnauthorized) {
           self.destroy(verifyError);
           // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1686-L1688
-          self.emit("secure", self);
+          // A wrap reports the rejection once, through the destroy: its
+          // 'secure' listeners read ssl.verifyError(), which is gone after
+          // destroy (the mysql driver's STARTTLS does exactly this).
+          if (connectSecure) self.emit("secure", self);
           return;
         }
       } else {
@@ -333,7 +347,7 @@ function onClientHandshakeComplete(self, socket, verifyError) {
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1697-L1698
     self.secureConnecting = false;
     self.emit(kSecureConnectDone);
-    self.emit("secureConnect", verifyError);
+    if (connectSecure) self.emit("secureConnect", verifyError);
     const pendingSession = self[kpendingSession];
     if (pendingSession) {
       self[kpendingSession] = null;
@@ -1940,10 +1954,6 @@ Socket.prototype.connect = function connect(...args) {
         }
         tls.checkServerIdentity = checkServerIdentity || tls.checkServerIdentity;
         this[bunTLSConnectOptions] = tls;
-        let tlsSocket;
-        if (!connection && (tlsSocket = tls.socket)) {
-          connection = tlsSocket;
-        }
       }
       if (connection) {
         if (
@@ -1994,10 +2004,7 @@ Socket.prototype.connect = function connect(...args) {
             tls,
             socket: this[khandlers],
           });
-          connection.on("data", events[0]);
-          connection.on("end", events[1]);
-          connection.on("drain", events[2]);
-          connection.on("close", events[3]);
+          listenToUpgradedDuplex(this, connection, events);
           this._handle = result;
         } else {
           // upgradeTLS requires an established socket; a socket that is still
@@ -2024,8 +2031,15 @@ Socket.prototype.connect = function connect(...args) {
               throw new Error("Invalid socket");
             }
           } else {
+            // Until the upgrade takes the connection over, destroying this
+            // socket destroys it too, as closing Node's wrap does; afterwards the
+            // upgrade's own teardown (kCloseRawConnection / the shared fd) owns it.
+            // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L242-L253
+            const destroyConnection = () => connection.destroy();
+            this.once("close", destroyConnection);
             // wait to be connected
             connection.once("connect", () => {
+              this.removeListener("close", destroyConnection);
               // The TLS socket may have been destroyed before the underlying
               // socket connected (e.g. tls.connect({ socket }).destroy()); don't
               // start a handshake on a dead socket.
@@ -2045,10 +2059,7 @@ Socket.prototype.connect = function connect(...args) {
                   tls,
                   socket: this[khandlers],
                 });
-                connection.on("data", events[0]);
-                connection.on("end", events[1]);
-                connection.on("drain", events[2]);
-                connection.on("close", events[3]);
+                listenToUpgradedDuplex(this, connection, events);
                 this._handle = result;
               } else {
                 this[kupgraded] = connection;
@@ -2278,6 +2289,27 @@ function hasUnflushedWrites(connection) {
   return connection.writableLength > 0 || connection[kwriteCallback] != null;
 }
 
+// Wires the stream-level TLS engine to the stream it runs over. The engine only
+// listens for traffic; the stream's 'error' is ours to take, as Node routes it
+// to the TLS socket (JSStreamSocket re-emits it, _init forwards it) and tears
+// the wrap down on the stream's close. Left unhandled it would be thrown out of
+// the stream's destroy, and the 'close' that tears the TLS socket down would
+// never be emitted.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L65
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L740
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
+function listenToUpgradedDuplex(self, connection, events) {
+  connection.on("data", events[0]);
+  connection.on("end", events[1]);
+  connection.on("drain", events[2]);
+  connection.on("close", events[3]);
+  connection.on("error", onUpgradedDuplexError.bind(self));
+}
+
+function onUpgradedDuplexError(err) {
+  if (!this.destroyed) this.destroy(err);
+}
+
 function drainOnreadTail(self, fromRead?) {
   if (self[kOnreadTail] === undefined) return false;
   if (fromRead) self[kOnreadReadRequested] = true;
@@ -2360,10 +2392,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
       socket: serverHandlersFor(this),
       isServer: true,
     });
-    connection.on("data", events[0]);
-    connection.on("end", events[1]);
-    connection.on("drain", events[2]);
-    connection.on("close", events[3]);
+    listenToUpgradedDuplex(this, connection, events);
     this[kupgraded] = connection;
     this._handle = result;
     return;
@@ -2389,10 +2418,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
         socket: serverHandlersFor(this),
         isServer: true,
       });
-      connection.on("data", events[0]);
-      connection.on("end", events[1]);
-      connection.on("drain", events[2]);
-      connection.on("close", events[3]);
+      listenToUpgradedDuplex(this, connection, events);
       this._handle = result;
       this.emit(kUpgradeAttached);
       return;
@@ -2421,6 +2447,18 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     this._handle = tlsHandle;
     this.emit(kUpgradeAttached);
   });
+};
+
+// Client-side counterpart, for `new tls.TLSSocket(socket)` (a STARTTLS client
+// wrapping the connection it already holds): the same upgrade as
+// tls.connect({ socket }), so the handshake starts here and _handle is the TLS
+// handle that _write/_read/_destroy expect. Node likewise wraps the handle in
+// the constructor; only the onConnectSecure half of tls.connect() is left out
+// (see onClientHandshakeComplete).
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L608
+Socket.prototype[kUpgradeClientTLS] = function (connection) {
+  this[kStandaloneWrap] = true;
+  Socket.prototype.connect.$call(this, { socket: connection });
 };
 
 Socket.prototype.read = function read(size) {
@@ -3073,11 +3111,6 @@ function internalConnect(self, options, address, port, addressType, localAddress
   }
 
   //TLS
-  let connection = self[ksocket];
-  const optionsSocket = options.socket;
-  if (optionsSocket) {
-    connection = optionsSocket;
-  }
   let tls = undefined;
   const bunTLS = self[bunTlsSymbol];
   if (typeof bunTLS === "function") {
@@ -3091,10 +3124,6 @@ function internalConnect(self, options, address, port, addressType, localAddress
       self.servername = tls.servername;
       tls.checkServerIdentity = checkServerIdentity || tls.checkServerIdentity;
       self[bunTLSConnectOptions] = tls;
-      let tlsSocket;
-      if (!connection && (tlsSocket = tls.socket)) {
-        connection = tlsSocket;
-      }
     }
     self.authorized = false;
     self.secureConnecting = true;
@@ -3221,11 +3250,6 @@ function internalConnectMultiple(context, canceled?) {
   }
 
   //TLS
-  let connection = self[ksocket];
-  const contextOptionsSocket = context.options.socket;
-  if (contextOptionsSocket) {
-    connection = contextOptionsSocket;
-  }
   let tls = undefined;
   const bunTLS = self[bunTlsSymbol];
   if (typeof bunTLS === "function") {
@@ -3239,10 +3263,6 @@ function internalConnectMultiple(context, canceled?) {
       self.servername = tls.servername;
       tls.checkServerIdentity = checkServerIdentity || tls.checkServerIdentity;
       self[bunTLSConnectOptions] = tls;
-      let tlsSocket;
-      if (!connection && (tlsSocket = tls.socket)) {
-        connection = tlsSocket;
-      }
     }
     self.authorized = false;
     self.secureConnecting = true;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -144,8 +144,6 @@ const kConnectOptions = Symbol("connect-options");
 const kAttach = Symbol("kAttach");
 const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kupgraded = Symbol("kupgraded");
-// Set on a TLSSocket constructed over an existing socket (`new tls.TLSSocket(socket)`
-// rather than tls.connect()); see onClientHandshakeComplete.
 const kStandaloneWrap = Symbol("kStandaloneWrap");
 const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
 const ksocket = Symbol("ksocket");
@@ -302,12 +300,7 @@ function onClientHandshakeComplete(self, socket, verifyError) {
   self._secureEstablished = true;
   self[kVerifyError] = verifyError ?? null;
   self.alpnProtocol = socket.alpnProtocol;
-  // Node installs onConnectSecure from tls.connect() only: a TLSSocket
-  // constructed over an existing socket gets _finishInit alone, so it neither
-  // checks the certificate against a connect() host it does not have nor emits
-  // 'secureConnect'. It still applies the chain verdict (authorized /
-  // rejectUnauthorized), like the standalone server wrap in ServerHandlers.
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1081-L1108
+  // Only tls.connect() installs the onConnectSecure half; a constructor wrap gets _finishInit alone.
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1810
   const connectSecure = !self[kStandaloneWrap];
   // Node has no try/catch around these emits; a listener throw reaches
@@ -332,9 +325,7 @@ function onClientHandshakeComplete(self, socket, verifyError) {
         if (rejectUnauthorized ?? self._rejectUnauthorized) {
           self.destroy(verifyError);
           // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1686-L1688
-          // A wrap reports the rejection once, through the destroy: its
-          // 'secure' listeners read ssl.verifyError(), which is gone after
-          // destroy (the mysql driver's STARTTLS does exactly this).
+          // A wrap's 'secure' listeners read ssl.verifyError(), which is null once destroyed.
           if (connectSecure) self.emit("secure", self);
           return;
         }
@@ -2031,9 +2022,7 @@ Socket.prototype.connect = function connect(...args) {
               throw new Error("Invalid socket");
             }
           } else {
-            // Until the upgrade takes the connection over, destroying this
-            // socket destroys it too, as closing Node's wrap does; afterwards the
-            // upgrade's own teardown (kCloseRawConnection / the shared fd) owns it.
+            // Destroying a not-yet-upgraded wrap destroys the stream under it, like Node's JSStreamSocket.doClose.
             // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L242-L253
             const destroyConnection = () => connection.destroy();
             this.once("close", destroyConnection);
@@ -2289,14 +2278,7 @@ function hasUnflushedWrites(connection) {
   return connection.writableLength > 0 || connection[kwriteCallback] != null;
 }
 
-// Wires the stream-level TLS engine to the stream it runs over. The engine only
-// listens for traffic; the stream's 'error' is ours to take, as Node routes it
-// to the TLS socket (JSStreamSocket re-emits it, _init forwards it) and tears
-// the wrap down on the stream's close. Left unhandled it would be thrown out of
-// the stream's destroy, and the 'close' that tears the TLS socket down would
-// never be emitted.
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L65
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L740
+// The stream's 'error' becomes the TLS socket's (as in Node); unhandled, it would also swallow the 'close' below.
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
 function listenToUpgradedDuplex(self, connection, events) {
   connection.on("data", events[0]);
@@ -2449,13 +2431,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
   });
 };
 
-// Client-side counterpart, for `new tls.TLSSocket(socket)` (a STARTTLS client
-// wrapping the connection it already holds): the same upgrade as
-// tls.connect({ socket }), so the handshake starts here and _handle is the TLS
-// handle that _write/_read/_destroy expect. Node likewise wraps the handle in
-// the constructor; only the onConnectSecure half of tls.connect() is left out
-// (see onClientHandshakeComplete).
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L608
+// Client-side counterpart for `new tls.TLSSocket(socket)`: the tls.connect({ socket }) upgrade minus onConnectSecure.
 Socket.prototype[kUpgradeClientTLS] = function (connection) {
   this[kStandaloneWrap] = true;
   Socket.prototype.connect.$call(this, { socket: connection });

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -22,7 +22,7 @@ const {
 } = require("internal/validators");
 
 const { Server: NetServer, Socket: NetSocket } = net;
-const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError, kUpgradeClientTLS } = require("internal/net/symbols");
 
 const getBundledRootCertificates = $newCppFunction("NodeTLS.cpp", "getBundledRootCertificates", 1);
 const getExtraCACertificates = $newCppFunction("NodeTLS.cpp", "getExtraCACertificates", 1);
@@ -783,15 +783,6 @@ function TLSSocket(socket?, options?) {
     if (ALPNProtocols) {
       convertALPNProtocols(ALPNProtocols, this);
     }
-
-    if (isNetSocketOrDuplex && !this.isServer) {
-      this._handle = socket;
-      // keep compatibility with http2-wrapper or other places that try to grab JSStreamSocket in node.js, with here is just the TLSSocket
-      this._handle._parentWrap = this;
-    }
-    // For the server wrap, _handle is assigned the upgraded TLS handle by the
-    // server-upgrade method below; leaving it unset until then means a synchronous
-    // teardown during upgradeTLS won't call close() on the bare net.Socket.
   }
   // Internal path: keep the per-digest cache (the user-facing constructors,
   // createSecureContext() and new tls.SecureContext(), own theirs exclusively).
@@ -807,12 +798,22 @@ function TLSSocket(socket?, options?) {
   this[kcheckServerIdentity] = checkServerIdentityOption || checkServerIdentity;
   this[ksession] = options.session || null;
 
-  // `new tls.TLSSocket(socket, { isServer: true })`: drive the server-side TLS
-  // handshake over the provided socket via net.ts's native upgrade path (reaches
-  // the module-private kupgraded + the shared ServerHandlers). Client-side wraps
-  // go through the connect path elsewhere.
-  if (isNetSocketOrDuplex && this.isServer) {
-    this[Symbol.for("::bunUpgradeServerTLS::")](socket, this[buntls](null, null));
+  // `new tls.TLSSocket(socket, ...)`: drive the handshake over the provided
+  // socket via net.ts's native upgrade paths (they reach the module-private
+  // kupgraded state and handler tables). Both leave _handle unset until the
+  // upgrade hands back the TLS handle, so nothing ever treats the wrapped
+  // net.Socket itself as a handle.
+  if (isNetSocketOrDuplex) {
+    if (isServer) {
+      this[Symbol.for("::bunUpgradeServerTLS::")](socket, this[buntls](null, null));
+    } else {
+      this[kUpgradeClientTLS](socket);
+      // http2-wrapper derives its JSStreamSocket from
+      // `new TLSSocket(new PassThrough())._handle._parentWrap.constructor`;
+      // here that is the TLSSocket itself.
+      const handle = this._handle;
+      if (handle) handle._parentWrap = this;
+    }
   }
 }
 $toClass(TLSSocket, "TLSSocket", NetSocket);
@@ -871,8 +872,11 @@ TLSSocket.prototype._destroySSL = function _destroySSL() {
 };
 
 TLSSocket.prototype._start = function _start() {
-  // some frameworks uses this _start internal implementation is suposed to start TLS handshake/connect
-  this.connect();
+  // In Node this sends the ClientHello of a socket wrapped by the constructor
+  // (the mysql driver's STARTTLS calls it right after `new TLSSocket(socket)`).
+  // Here the constructor's upgrade and connect() both start the handshake
+  // natively, so there is nothing left to kick off.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1110-L1129
 };
 
 TLSSocket.prototype._final = function _final(callback) {
@@ -1117,7 +1121,6 @@ TLSSocket.prototype[buntls] = function (port, host) {
     servername = host && !net.isIP(host) ? host : "";
   }
   return {
-    socket: this._handle,
     ALPNProtocols: this.ALPNProtocols,
     checkServerIdentity: this[kcheckServerIdentity],
     session: this[ksession],

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -798,19 +798,13 @@ function TLSSocket(socket?, options?) {
   this[kcheckServerIdentity] = checkServerIdentityOption || checkServerIdentity;
   this[ksession] = options.session || null;
 
-  // `new tls.TLSSocket(socket, ...)`: drive the handshake over the provided
-  // socket via net.ts's native upgrade paths (they reach the module-private
-  // kupgraded state and handler tables). Both leave _handle unset until the
-  // upgrade hands back the TLS handle, so nothing ever treats the wrapped
-  // net.Socket itself as a handle.
+  // Both upgrades live in net.ts (module-private state); _handle stays unset until one hands back the TLS handle.
   if (isNetSocketOrDuplex) {
     if (isServer) {
       this[Symbol.for("::bunUpgradeServerTLS::")](socket, this[buntls](null, null));
     } else {
       this[kUpgradeClientTLS](socket);
-      // http2-wrapper derives its JSStreamSocket from
-      // `new TLSSocket(new PassThrough())._handle._parentWrap.constructor`;
-      // here that is the TLSSocket itself.
+      // http2-wrapper reads `new TLSSocket(new PassThrough())._handle._parentWrap.constructor` as its JSStreamSocket.
       const handle = this._handle;
       if (handle) handle._parentWrap = this;
     }
@@ -872,10 +866,7 @@ TLSSocket.prototype._destroySSL = function _destroySSL() {
 };
 
 TLSSocket.prototype._start = function _start() {
-  // In Node this sends the ClientHello of a socket wrapped by the constructor
-  // (the mysql driver's STARTTLS calls it right after `new TLSSocket(socket)`).
-  // Here the constructor's upgrade and connect() both start the handshake
-  // natively, so there is nothing left to kick off.
+  // Node sends a constructor wrap's ClientHello here (the mysql driver calls it); ours went out in the constructor.
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1110-L1129
 };
 

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -241,8 +241,6 @@ impl UpgradedDuplex {
             _ => return,
         };
 
-        // `on_error` hands the value to the JS error handler, so it must be the
-        // thrown value (`take_error`), not the `JSC::Exception` cell wrapping it.
         if let Some(data) = data {
             let buffer = match bun_jsc::array_buffer::BinaryType::Buffer.to_js(data, &global) {
                 Ok(b) => b,

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -241,22 +241,24 @@ impl UpgradedDuplex {
             _ => return,
         };
 
+        // `on_error` hands the value to the JS error handler, so it must be the
+        // thrown value (`take_error`), not the `JSC::Exception` cell wrapping it.
         if let Some(data) = data {
             let buffer = match bun_jsc::array_buffer::BinaryType::Buffer.to_js(data, &global) {
                 Ok(b) => b,
                 Err(err) => {
-                    (self.handlers.on_error)(self.handlers.ctx, global.take_exception(err));
+                    (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
                     return;
                 }
             };
             buffer.ensure_still_alive();
 
             if let Err(err) = write_or_end.call(&global, duplex, &[buffer]) {
-                (self.handlers.on_error)(self.handlers.ctx, global.take_exception(err));
+                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
             }
         } else {
             if let Err(err) = write_or_end.call(&global, duplex, &[JSValue::NULL]) {
-                (self.handlers.on_error)(self.handlers.ctx, global.take_exception(err));
+                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
             }
         }
     }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { once } from "events";
+import { readFileSync } from "fs";
 import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN } from "harness";
 import https from "https";
 import net from "net";
@@ -1424,5 +1425,260 @@ describe("throwing 'secureConnect' listener", () => {
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(JSON.parse(stdout.trim())).toEqual({ uncaught: "boom-secureConnect", socketError: null });
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("new tls.TLSSocket(socket) on the client side", () => {
+  // The STARTTLS client shape: the caller holds a connected socket and wraps
+  // it itself instead of going through tls.connect({ socket }). Node wraps the
+  // handle in the constructor; the handshake result arrives as 'secure' and
+  // the verification verdict through ssl.verifyError(). 'secureConnect' and
+  // the hostname check belong to tls.connect()'s onConnectSecure, which a
+  // constructor wrap never gets. Verified against node v26.3.0.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1081-L1108
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1810
+  const fixturesDir = join(import.meta.dir, "fixtures");
+  // events.once() would reject on the 'error' these sockets are expected to
+  // emit on their way to 'close'.
+  const closed = (socket: net.Socket) => new Promise<void>(resolve => socket.once("close", () => resolve()));
+
+  async function echoServer(options: tls.TlsOptions) {
+    const server = tls.createServer(options, socket => {
+      socket.on("data", data => socket.write(`echo:${data}`));
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    return server;
+  }
+
+  async function connectedRawSocket(server: tls.Server) {
+    const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+    await once(raw, "connect");
+    return raw;
+  }
+
+  it("a write right after the wrap goes out over TLS", async () => {
+    const server = await echoServer(COMMON_CERT_);
+    try {
+      const raw = await connectedRawSocket(server);
+      const socket = new TLSSocket(raw, { isServer: false, rejectUnauthorized: false });
+      const events: string[] = [];
+      socket.on("secure", () => events.push("secure"));
+      socket.on("secureConnect", () => events.push("secureConnect"));
+      const writeReturned = socket.write("ping");
+      const [reply] = await once(socket, "data");
+      expect({
+        writeReturned,
+        reply: String(reply),
+        events,
+        protocol: socket.getProtocol(),
+        authorized: socket.authorized,
+        verifyError: (socket as any).ssl.verifyError().code,
+        wrapsTheRawSocket: (socket as any)._handle !== raw,
+      }).toEqual({
+        writeReturned: true,
+        reply: "echo:ping",
+        events: ["secure"],
+        protocol: "TLSv1.3",
+        authorized: false,
+        verifyError: "DEPTH_ZERO_SELF_SIGNED_CERT",
+        wrapsTheRawSocket: true,
+      });
+      socket.destroy();
+      await closed(socket);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("_start() is accepted after the wrap (how the mysql driver starts TLS)", async () => {
+    const server = await echoServer(COMMON_CERT_);
+    try {
+      const raw = await connectedRawSocket(server);
+      const socket = new TLSSocket(raw, { rejectUnauthorized: false });
+      (socket as any)._start();
+      await once(socket, "secure");
+      socket.write("ping");
+      const [reply] = await once(socket, "data");
+      expect(String(reply)).toBe("echo:ping");
+      socket.destroy();
+      await closed(socket);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("rejectUnauthorized refuses an untrusted server once, without a 'secure' event", async () => {
+    const server = await echoServer(COMMON_CERT_);
+    try {
+      const raw = await connectedRawSocket(server);
+      const socket = new TLSSocket(raw, { rejectUnauthorized: true });
+      const events: string[] = [];
+      socket.on("secure", () => events.push("secure"));
+      // Installed by the constructor ahead of any user listener, so a wrap
+      // whose owner listens to nothing is not an uncaught exception.
+      socket.on("_tlsError", (err: NodeJS.ErrnoException) => events.push(`_tlsError ${err.code}`));
+      socket.on("error", (err: NodeJS.ErrnoException) => events.push(`error ${err.code}`));
+      await closed(socket);
+      expect({ events, authorizationError: socket.authorizationError }).toEqual({
+        events: ["_tlsError DEPTH_ZERO_SELF_SIGNED_CERT", "error DEPTH_ZERO_SELF_SIGNED_CERT"],
+        authorizationError: "DEPTH_ZERO_SELF_SIGNED_CERT",
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("verifies the chain but, unlike tls.connect({ socket }), not the hostname", async () => {
+    // agent1's certificate names no host at all, so only tls.connect()'s
+    // onConnectSecure has something to object to.
+    const ca = readFileSync(join(fixturesDir, "ca1-cert.pem"));
+    const server = await echoServer({
+      key: readFileSync(join(fixturesDir, "agent1-key.pem")),
+      cert: readFileSync(join(fixturesDir, "agent1-cert.pem")),
+    });
+    try {
+      const wrapped = new TLSSocket(await connectedRawSocket(server), { ca, rejectUnauthorized: true });
+      await once(wrapped, "secure");
+      wrapped.write("ping");
+      const [reply] = await once(wrapped, "data");
+
+      const connected = tls.connect({ socket: await connectedRawSocket(server), ca, rejectUnauthorized: true });
+      const connectedClosed = closed(connected);
+      const [connectError] = (await once(connected, "error")) as [NodeJS.ErrnoException];
+      await connectedClosed;
+
+      expect({
+        reply: String(reply),
+        authorized: wrapped.authorized,
+        verifyError: (wrapped as any).ssl.verifyError(),
+        connectError: connectError.code,
+      }).toEqual({
+        reply: "echo:ping",
+        authorized: true,
+        verifyError: null,
+        connectError: "ERR_TLS_CERT_ALTNAME_INVALID",
+      });
+      wrapped.destroy();
+      await closed(wrapped);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("wraps a generic Duplex, talking to a server-side wrap over an in-memory pair", async () => {
+    const makeSide = (peer: () => Duplex) =>
+      new Duplex({
+        read() {},
+        write(chunk, _encoding, callback) {
+          peer().push(chunk);
+          callback();
+        },
+        final(callback) {
+          peer().push(null);
+          callback();
+        },
+      });
+    const clientSide: Duplex = makeSide(() => serverSide);
+    const serverSide: Duplex = makeSide(() => clientSide);
+
+    const secure: string[] = [];
+    const server = new TLSSocket(serverSide, { isServer: true, ...COMMON_CERT_ });
+    server.on("secure", () => secure.push("server"));
+    server.on("data", data => server.write(`pong ${data}`));
+    server.on("end", () => server.end());
+
+    const client = new TLSSocket(clientSide, { rejectUnauthorized: false });
+    client.on("secure", () => {
+      secure.push("client");
+      // Unlike the fd-adopting wrap above, this only exercises the stream
+      // engine once the handshake is done; its pre-handshake buffering is a
+      // separate matter shared with tls.connect({ socket: duplex }).
+      client.write("one");
+    });
+    const exchange: string[] = [];
+    client.on("data", data => {
+      exchange.push(String(data));
+      if (exchange.length === 1) client.write("two");
+      else client.end();
+    });
+    await once(client, "close");
+    expect({ secure: secure.sort(), exchange }).toEqual({
+      secure: ["client", "server"],
+      exchange: ["pong one", "pong two"],
+    });
+  });
+
+  it("the http2-wrapper JSStreamSocket probe still resolves and exits quietly", async () => {
+    // http2-wrapper (and so got) runs this at import time; the wrap it leaves
+    // behind handshakes against its own PassThrough and must fail quietly.
+    const script = `
+      const { TLSSocket } = require("node:tls");
+      const { PassThrough } = require("node:stream");
+      const JSStreamSocket = new TLSSocket(new PassThrough())._handle._parentWrap.constructor;
+      process.on("exit", () => console.log(typeof JSStreamSocket));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "function\n", stderr: "", exitCode: 0 });
+  });
+
+  it.each([
+    ["an unconnected net.Socket", () => new net.Socket()],
+    ["a Duplex", () => new Duplex()],
+  ])("destroy() straight after wrapping %s destroys both and emits 'close'", async (_name, makeStream) => {
+    // Closing Node's wrap destroys the stream underneath it (JSStreamSocket.doClose).
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L242-L253
+    const stream = makeStream();
+    const socket = new TLSSocket(stream);
+    socket.destroy();
+    await closed(socket);
+    expect({ socketDestroyed: socket.destroyed, streamDestroyed: stream.destroyed }).toEqual({
+      socketDestroyed: true,
+      streamDestroyed: true,
+    });
+  });
+
+  describe("an error of the wrapped stream is the TLS socket's error", () => {
+    // Node routes the stream's 'error' to the TLS socket (JSStreamSocket
+    // re-emits it, _init forwards it) and tears the wrap down on its close.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L65
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L977
+    // A Duplex without _read() errors itself as soon as the engine starts
+    // reading it; one with _read() but no _write() throws from inside the
+    // engine's own write of the ClientHello instead, so that exception has to
+    // come back out as a plain error value.
+    const unreadable = () => new Duplex();
+    const unwritable = () => new Duplex({ read() {} });
+    const cases: [name: string, makeStream: () => Duplex, wrap: (stream: Duplex) => TLSSocket][] = [
+      ["client wrap of a stream that errors", unreadable, stream => new TLSSocket(stream)],
+      [
+        "server wrap of a stream that errors",
+        unreadable,
+        stream => new TLSSocket(stream, { isServer: true, ...COMMON_CERT_ }),
+      ],
+      [
+        "tls.connect({ socket }) over a stream that errors",
+        unreadable,
+        stream => tls.connect({ socket: stream, rejectUnauthorized: false }),
+      ],
+      ["client wrap of a stream whose write() throws", unwritable, stream => new TLSSocket(stream)],
+      [
+        "tls.connect({ socket }) over a stream whose write() throws",
+        unwritable,
+        stream => tls.connect({ socket: stream, rejectUnauthorized: false }),
+      ],
+    ];
+    it.each(cases)("%s", async (_name, makeStream, wrap) => {
+      const stream = makeStream();
+      const socket = wrap(stream);
+      const errors: string[] = [];
+      socket.on("error", (err: NodeJS.ErrnoException) => errors.push(err.code!));
+      await closed(socket);
+      expect({ errors, streamDestroyed: stream.destroyed }).toEqual({
+        errors: ["ERR_METHOD_NOT_IMPLEMENTED"],
+        streamDestroyed: true,
+      });
+    });
   });
 });


### PR DESCRIPTION
### Problem
- Client-side STARTTLS, wrapping an already connected socket with `new tls.TLSSocket(raw)`, is inert on Bun 1.4.0 and main: the first write throws `TypeError: socket.@write is not a function`, later writes return `true` and are dropped, and no handshake starts. Node handshakes and passes data.
- On the same wrap, `_start()` (what the `mysql` driver calls) throws `ERR_MISSING_ARGS` and `destroy()` fails with `handle.close is not a function`.
- Cause: the client branch of the constructor kept the wrapped JS socket as the TLS socket's native handle and nothing ever replaced it. Only the server wrap and `tls.connect({ socket })` had an upgrade path.
- Two more gaps when the wrapped thing is a generic Duplex (also via `tls.connect({ socket: duplex })`): its `'error'` had no listener, so it became an uncaught exception and `'close'` never fired; and a throwing `write()` reached the error handler as an exception cell, not the thrown value (`ASSERTION FAILED: isSymbol()` on debug, `TypeError: Cannot convert a symbol to a string` on release).

### Fix
- The client wrap now runs the same upgrade as `tls.connect({ socket })`, so the handshake starts in the constructor and `_start()` is a no-op. Check: after construction `_handle` is never the stream passed in, and `_handle._parentWrap` (read by http2-wrapper, so by `got`, at import) is still set.
- The wrap gets only Node's `_finishInit` half of completion: `'secure'` fires and the verdict lands in `authorized` / `ssl.verifyError()`; no hostname check, no `'secureConnect'`. Deliberate differences from Node: `rejectUnauthorized: true` is still enforced, and the ClientHello goes out at construction, so `servername` / `session` must be constructor options.
- Every upgrade path now turns the stream's `'error'` into a destroy of the TLS socket, the native engine passes the thrown value (same hunk as #36909, byte-identical), and destroying a wrap before its socket connects destroys that socket too. Pre-handshake writes over a generic Duplex are still lost; pre-existing, tracked separately.
- Verification: 13 new tests. All but the http2-wrapper probe fail without the change (the throwing `write()` case aborts a debug build); all pass with it. Vendored Node tls / https / net / http-upgrade tests pass; two `test/js/node/tls/` tests fail identically on main in this environment.

### Background
- STARTTLS: a connection starts in plaintext and switches to TLS in place. In Node the client does this with `new tls.TLSSocket(existingSocket)`, optionally followed by `_start()`; `tls.connect()` is the other entry point and adds client checks on top.
- Upgrade: in Bun's `node:net` a socket's `_handle` must be a native handle, since `_write` and `_destroy` call into it. Making an existing socket speak TLS means the native side takes the connection over (adopting the fd, or driving a generic Duplex through `UpgradedDuplex`) and hands back a TLS handle to install as `_handle`.
- Node splits client handshake completion in two: `_finishInit` (emit `'secure'`, record the verdict), which every TLSSocket gets, and `onConnectSecure` (hostname check, `rejectUnauthorized`, `'secureConnect'`), which only `tls.connect()` installs.
- `take_exception` vs `take_error` in the JSC bindings: the first yields the engine's exception wrapper cell, the second the value JS threw. The JS error handlers expect the latter.
- http2-wrapper evaluates `new TLSSocket(new PassThrough())._handle._parentWrap.constructor` at import time, so a client wrap must expose `_handle._parentWrap` synchronously and then fail quietly.

<details>
<summary>Original description</summary>

### Reproduction

The STARTTLS client shape: wrap a connected socket yourself instead of calling `tls.connect({ socket })`.

```js
import net from "node:net"; import tls from "node:tls";
const srv = tls.createServer({ key, cert }, s => s.on("data", d => s.write("echo:" + d))).listen(0, "127.0.0.1", () => {
  const raw = net.connect(srv.address().port, "127.0.0.1", () => {
    const t = new tls.TLSSocket(raw, { isServer: false, rejectUnauthorized: false });
    t.on("secure", () => console.log("secure", t.getProtocol()));
    t.on("data", d => console.log("data", String(d)));
    setInterval(() => console.log("write ->", t.write("tick")), 100);
  });
});
```

Node v26.3.0: `write -> true`, `secure TLSv1.3`, `data echo:tick` per tick.

Bun 1.4.0 (and main): the first write throws

```
TypeError: socket.@write is not a function. (In 'socket.@write(chunk, encoding)', 'socket.@write' is undefined)
```

every later write returns `true` and is dropped, no handshake ever starts (`raw.bytesWritten` stays 0, no `secure`/`error`/`close`), `t._start()` (what the `mysql` driver calls after constructing the wrap) throws `ERR_MISSING_ARGS`, and `t.destroy()` fails with `handle.close is not a function`.

### Cause

The client branch of the `TLSSocket` constructor stored the wrapped `net.Socket` itself as `this._handle` and nothing ever upgraded it, so `net.Socket`'s `_write`/`_destroy` called native handle methods on a JS socket. Only the server wrap (`isServer: true`) and `tls.connect({ socket })` have upgrade paths. `_start()` called `connect()` with no arguments, which throws.

### Fix

- `tls.ts`: the client branch now drives the same upgrade `tls.connect({ socket })` uses, through a new `net.Socket.prototype[kUpgradeClientTLS]` (the counterpart of the existing server-wrap method), so the handshake starts in the constructor and `_handle` is a TLS handle. The `_handle._parentWrap` that http2-wrapper (and therefore `got`) reads at import time is kept. `_start()` is a no-op: the handshake is already running. The `socket: this._handle` field of `[buntls]` and the `tls.socket` fallbacks in the three connect paths existed only for the old `_start()` and are removed.
- `net.ts` `onClientHandshakeComplete`: a constructor wrap gets Node's `_finishInit` semantics, since Node installs `onConnectSecure` from `tls.connect()` only: `'secure'` is emitted, the chain verdict lands in `authorized`/`authorizationError`/`ssl.verifyError()`, there is no hostname check against a `connect()` host the wrap does not have, and no `'secureConnect'`. `rejectUnauthorized: true` still refuses an unverifiable peer, reported once through the destroy (the standalone server wrap already behaves this way). Node itself verifies nothing on a constructor wrap; the `mysql` driver's STARTTLS, the main user of this API, reads `ssl.verifyError()` from its `'secure'` listener and works with either.
- Wrapping a generic stream reached two gaps in the shared duplex path (also reachable through `tls.connect({ socket: duplex })` before this change):
  - the stream's own `'error'` had no listener, so it surfaced as an uncaught exception and the stream's `'close'` was never emitted. Both upgrade paths now attach the four engine listeners plus an error forwarder (`listenToUpgradedDuplex`), destroying the TLS socket with the stream's error, which is where Node routes it too.
  - `UpgradedDuplex::call_write_or_end` passed `take_exception()`, the `JSC::Exception` cell, to the error handler; JS then read properties off it (`ASSERTION FAILED: isSymbol()` in `JSValue::synthesizePrototype` in debug builds, `TypeError: Cannot convert a symbol to a string` in release). It now passes the thrown value with `take_error()`, like the other handler sites. This is the same three-line hunk as #36909 (kept byte-identical so either lands first without conflict); it is carried here because the client wrap makes the vendored `test-tls-socket-allow-half-open-option` reach it. #36909 additionally fixes the `on_data` conversion site and has its own test.
- Destroying a wrap whose socket has not connected yet destroys that socket as well, as closing Node's `JSStreamSocket` does; the hook is removed once the upgrade takes over.

Deliberate differences from Node, for review: the ClientHello is sent at construction rather than on `_start()`/first write, so `setServername()`/`setSession()` between construction and `_start()` are too late (pass `servername`/`session` in the constructor options instead); and `rejectUnauthorized: true` is enforced on the wrap. Writes before the handshake are delivered on the normal (fd adopting) path; over a generic Duplex they are lost, which is pre-existing behaviour of `tls.connect({ socket: duplex })` and tracked separately, so the duplex test here writes after `'secure'`.

Overlaps: #32824 makes `_start()` perform the upgrade lazily (this change starts it in the constructor instead, so `_start()` and a write without `_start()` both work); #36909 carries the identical `UpgradedDuplex` hunk (above); #35842 adds a `closeSocketHandle` fallback for the same root cause (with this change `_handle` is never a plain stream, and its two scenarios are covered by the destroy tests here).

### Verification

13 new tests in `test/js/node/tls/node-tls-connect.test.ts` (write after wrap over TCP, `_start()`, `rejectUnauthorized` rejection, chain-but-not-hostname versus `tls.connect({ socket })`, wrap over an in-memory Duplex pair, the http2-wrapper probe exiting quietly, destroy before connect for `net.Socket` and `Duplex`, and stream errors / throwing `write()` for the client wrap, the server wrap and `tls.connect({ socket })`). Without the change every one of them except the probe test (which guards existing behaviour) fails, and the throwing `write()` case aborts a debug build on the assertion above; all pass with the change.

`test/js/node/tls/` passes apart from two tests that fail identically on main in this environment (`SNICallback ... bind hostname`, which needs `localhost` to resolve consistently, and the root-certificate Worker race hitting its 5s timeout on a debug build). The vendored `test-tls-*`, `test-https-*`, `test-net-*` and `test-http-upgrade*` parallel tests pass, including `test-tls-socket-allow-half-open-option` (which wraps a write-less Duplex on the client side and previously only passed because the wrap was inert), `test-http-upgrade-reconsume-stream` and `test-tls-transport-destroy-after-own-gc`.


</details>
