### PR TITLE
AbortSignal.timeout: keep the timer armed when the signal loses its observers

### DIFF
--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -71,9 +71,7 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     // The JS wrapper is the sole owner; isReachableFromOpaqueRoots keeps it
     // alive while an abort listener or an AbortSignal.any() dependent observes
     // the timeout. With no observer, collecting the wrapper destroys the
-    // signal and ~AbortSignal() cancels and frees the timer. Nothing else may
-    // cancel it: whoever still holds the signal (JS, or a Request that hands it
-    // back out) must see it abort at its deadline, listeners or not.
+    // signal and ~AbortSignal() cancels and frees the timer.
     signal->m_timeout = AbortSignal__Timeout__create(bunVM(context.vm()), signal.ptr(), milliseconds);
     ASSERT(signal->m_timeout);
     return signal;

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -71,12 +71,9 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     // The JS wrapper is the sole owner; isReachableFromOpaqueRoots keeps it
     // alive while an abort listener or an AbortSignal.any() dependent observes
     // the timeout. With no observer, collecting the wrapper destroys the
-    // signal and ~AbortSignal() cancels and frees the timer.
-    //
-    // Those are the only two things that stop the timer (see markAborted() and
-    // ~AbortSignal()). Losing every observer must not: a signal JS still holds
-    // has to read as aborted once its deadline passes, whether or not anything
-    // was listening when it did.
+    // signal and ~AbortSignal() cancels and frees the timer. Nothing else may
+    // cancel it: whoever still holds the signal (JS, or a Request that hands it
+    // back out) must see it abort at its deadline, listeners or not.
     signal->m_timeout = AbortSignal__Timeout__create(bunVM(context.vm()), signal.ptr(), milliseconds);
     ASSERT(signal->m_timeout);
     return signal;

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -72,6 +72,11 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     // alive while an abort listener or an AbortSignal.any() dependent observes
     // the timeout. With no observer, collecting the wrapper destroys the
     // signal and ~AbortSignal() cancels and frees the timer.
+    //
+    // Those are the only two things that stop the timer (see markAborted() and
+    // ~AbortSignal()). Losing every observer must not: a signal JS still holds
+    // has to read as aborted once its deadline passes, whether or not anything
+    // was listening when it did.
     signal->m_timeout = AbortSignal__Timeout__create(bunVM(context.vm()), signal.ptr(), milliseconds);
     ASSERT(signal->m_timeout);
     return signal;
@@ -297,14 +302,6 @@ void AbortSignal::eventListenersDidChange()
         else
             m_timeoutObserverCount.fetch_sub(1, std::memory_order_relaxed);
     }
-
-    // When a timeout signal loses all observers there is nothing left to
-    // notify when the timer fires, so cancel it eagerly.
-    // JSAbortSignalOwner::isReachableFromOpaqueRoots then no longer keeps the
-    // wrapper alive and ~AbortSignal() runs on collection; this just frees the
-    // native timer sooner.
-    if (m_timeout && !aborted() && !hasTimeoutObserver())
-        cancelTimer();
 }
 
 uint32_t AbortSignal::addAbortAlgorithmToSignal(AbortSignal& signal, Ref<AbortAlgorithm>&& algorithm)

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { writeFileSync } from "fs";
+import { watch, writeFileSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -233,6 +233,14 @@ describe.concurrent("AbortSignal.timeout() still fires after its observers go aw
         signal.addEventListener("unrelated", () => {});
       },
     ],
+    [
+      // Native consumers observe the signal through a native callback rather
+      // than a JS listener; fs.watch() drops its callback synchronously in close().
+      "the fs.watch() it was passed to was closed",
+      signal => {
+        watch(import.meta.dir, { signal }).close();
+      },
+    ],
   ];
 
   test.each(churn)("after %s", async (_, apply) => {
@@ -267,8 +275,8 @@ describe.concurrent("AbortSignal.timeout() still fires after its observers go aw
     expect(thrown).toBe(signal.reason);
   });
 
-  // Native consumers observe the signal through a native callback instead of a
-  // JS listener; Bun.spawn() registers one and releases it when the child exits.
+  // Same native-callback release as fs.watch() above, but asynchronous: the
+  // subprocess lets go of the signal when the child exits.
   test("after the Bun.spawn() child it was passed to has exited", async () => {
     // The child has to be gone before the deadline. A shell exits in ~1ms
     // (a debug build of bun takes 100ms+ just to start), so 500ms leaves

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -290,4 +290,45 @@ describe.concurrent("AbortSignal.timeout() still fires after its observers go aw
     await deadline;
     expect(summarize(signal)).toEqual({ aborted: true, reason: "TimeoutError" });
   });
+
+  // A Request keeps its signal as a native ref and wraps it again on demand, so
+  // the signal's JS wrapper can be collected while the timeout is still
+  // observable through request.signal. The timer has to survive the wrapper as
+  // well; only the signal itself going away (or aborting) may stop it.
+  // Subprocess so heapStats() only sees this scenario's signals.
+  test("after its wrapper was collected while a Request still held the signal", async () => {
+    const src = `
+      const { heapStats } = require("bun:jsc");
+      const wrappers = () => heapStats().objectTypeCounts.AbortSignal ?? 0;
+      const N = 32;
+      // A full GC of the debug heap takes ~100ms under ASAN; the deadline only
+      // has to come after it.
+      const deadline = 1000;
+      const started = performance.now();
+      const requests = [];
+      for (let i = 0; i < N; i++) {
+        requests.push(new Request("http://localhost/", { signal: AbortSignal.timeout(deadline) }));
+      }
+      const fence = AbortSignal.timeout(deadline + 100);
+      const withWrappers = wrappers();
+      // Fresh stack first, so nothing conservatively scanned still points at a wrapper.
+      await new Promise(resolve => setImmediate(resolve));
+      Bun.gc(true);
+      const collected = withWrappers - wrappers();
+      const collectedBeforeDeadline = performance.now() - started < deadline;
+      await new Promise(resolve => fence.addEventListener("abort", resolve, { once: true }));
+      // request.signal wraps the native signal again.
+      const timedOut = requests.filter(r => r.signal.aborted && r.signal.reason.name === "TimeoutError").length;
+      console.log(JSON.stringify({ N, collected, collectedBeforeDeadline, timedOut }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { N, collected, collectedBeforeDeadline, timedOut } = JSON.parse(stdout);
+    // The wrappers have to be gone before the timers fire for the run to mean
+    // anything; allow a straggler or two in case something still pins one.
+    expect(collected).toBeGreaterThanOrEqual(N - 4);
+    expect({ collectedBeforeDeadline, timedOut }).toEqual({ collectedBeforeDeadline: true, timedOut: N });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { writeFileSync } from "fs";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -178,5 +178,116 @@ describe("AbortSignal", () => {
     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(JSON.parse(stdout.trim())).toEqual([0, 1, 2, 3, 4, 5, "t"]);
     expect(exitCode).toBe(0);
+  });
+});
+
+// https://dom.spec.whatwg.org/#dom-abortsignal-timeout: a timeout signal aborts
+// once its deadline passes for as long as the signal exists. Whether anything
+// was listening in the meantime only matters for GC, never for whether it fires.
+// The native timer used to be cancelled as soon as the signal's listener count
+// dropped to zero, leaving a signal the program still held stuck at
+// aborted === false. Node and the browsers abort it in every case below.
+describe.concurrent("AbortSignal.timeout() still fires after its observers go away", () => {
+  // Resolves after the deadline of a signal armed before this call with a
+  // shorter delay: the fence sits behind it in the timer heap, so by the time
+  // the fence fires that signal's own timer has had its turn. Waiting on a
+  // fence rather than on the signal under test keeps the latter unobserved.
+  function fence(ms: number): Promise<void> {
+    const signal = AbortSignal.timeout(ms);
+    return new Promise(resolve => signal.addEventListener("abort", () => resolve(), { once: true }));
+  }
+
+  function summarize(signal: AbortSignal) {
+    return { aborted: signal.aborted, reason: signal.reason?.name };
+  }
+
+  const churn: [string, (signal: AbortSignal) => void][] = [
+    [
+      "an abort listener was added and removed",
+      signal => {
+        const listener = () => {};
+        signal.addEventListener("abort", listener);
+        signal.removeEventListener("abort", listener);
+      },
+    ],
+    [
+      "onabort was set and cleared",
+      signal => {
+        signal.onabort = () => {};
+        signal.onabort = null;
+      },
+    ],
+    [
+      "its abort listener was removed through the listener's { signal } option",
+      signal => {
+        const controller = new AbortController();
+        signal.addEventListener("abort", () => {}, { signal: controller.signal });
+        controller.abort();
+      },
+    ],
+    [
+      // Not even a removal: adding a listener for any other event type updates
+      // the listener bookkeeping while the abort listener count is still zero.
+      "a listener for an unrelated event type was added",
+      signal => {
+        signal.addEventListener("unrelated", () => {});
+      },
+    ],
+  ];
+
+  test.each(churn)("after %s", async (_, apply) => {
+    const signal = AbortSignal.timeout(1);
+    apply(signal);
+    await fence(20);
+    expect(summarize(signal)).toEqual({ aborted: true, reason: "TimeoutError" });
+  });
+
+  test("consumers attached after the listener churn still see the abort", async () => {
+    const signal = AbortSignal.timeout(1);
+    const listener = () => {};
+    signal.addEventListener("abort", listener);
+    signal.removeEventListener("abort", listener);
+
+    const events: string[] = [];
+    signal.addEventListener("abort", event => events.push(event.type));
+    const dependent = AbortSignal.any([signal]);
+    await fence(20);
+
+    let thrown: DOMException | undefined;
+    try {
+      signal.throwIfAborted();
+    } catch (error) {
+      thrown = error as DOMException;
+    }
+    expect({ events, dependent: summarize(dependent), thrown: thrown?.name }).toEqual({
+      events: ["abort"],
+      dependent: { aborted: true, reason: "TimeoutError" },
+      thrown: "TimeoutError",
+    });
+    expect(thrown).toBe(signal.reason);
+  });
+
+  // Native consumers observe the signal through a native callback instead of a
+  // JS listener; Bun.spawn() registers one and releases it when the child exits.
+  test("after the Bun.spawn() child it was passed to has exited", async () => {
+    // The child has to be gone before the deadline. A shell exits in ~1ms
+    // (a debug build of bun takes 100ms+ just to start), so 500ms leaves
+    // plenty of room for a loaded CI machine.
+    const signal = AbortSignal.timeout(500);
+    const deadline = fence(600);
+    await using proc = Bun.spawn({
+      cmd: isWindows ? [process.env.comspec || "cmd.exe", "/c", "exit", "0"] : ["/bin/sh", "-c", "exit 0"],
+      signal,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    expect({ exitCode: await proc.exited, ...summarize(signal) }).toEqual({
+      exitCode: 0,
+      aborted: false,
+      reason: undefined,
+    });
+
+    await deadline;
+    expect(summarize(signal)).toEqual({ aborted: true, reason: "TimeoutError" });
   });
 });


### PR DESCRIPTION
### Problem
- `AbortSignal.timeout()` never fires if the signal loses its observers before the deadline: add then remove an abort listener, set then clear `onabort`, close the `fs.watch()` it was passed to, let a `Bun.spawn()` child exit, or even add a listener for an unrelated event. Repro in the original below.
- Once stuck, `aborted` stays `false`, `reason` stays `undefined`, `throwIfAborted()` never throws, and listeners or `AbortSignal.any([s])` dependents added later never fire. Node and the browsers report `aborted: true` with a `TimeoutError` in every case.
- Cause: the native timer was cancelled as a side effect of listener bookkeeping whenever the observer count read zero. No observers does not mean unreachable; the program still holds the signal, and the DOM spec says a timeout signal aborts for as long as it exists.
- The cancel dates from #28761, when the timer held a ref on the signal and this was the only way to reclaim an unobserved signal (#28756). #35849 removed that ref, so since then the branch only freed the timer slightly before the next GC would.

### Fix
- Delete the eager cancel. The timer is now stopped in exactly two places: when the signal aborts and when the signal is destroyed. The observer count itself is unchanged and still drives GC.
- Why it is correct: a churned signal now ends up in the same state as one nobody ever touched (timer armed, zero observers, wrapper the only owner), which already worked. The timer never held the event loop open, so leaving it armed cannot keep a process alive.
- The #28756 memory case still holds: removing the last listener leaves the wrapper collectible and GC frees the signal and timer together. That regression test still passes; measured growth was 36.0 MB before and 36.7 MB after.
- Verification: new tests for the listener churn variants, `fs.watch()`, `Bun.spawn()`, re-observation after churn, and a Request whose signal wrapper was collected before the deadline. Seven fail on the unfixed build and on bun 1.4.0 and pass with the change; CI is green on every lane. `node:http2` was affected too and was checked by hand only.

### Background
- `AbortSignal.timeout(ms)` must abort with a `TimeoutError` once `ms` passes, whether or not anything is listening. Bun backs it with a native timer that does not keep the event loop alive, like Node's unref'd timer.
- Timeout observer count: the C++ signal counts abort listeners plus native consumers (spawn, fs.watch, http2, fetch) currently holding it. Its job is GC only: while it is nonzero, the signal's JS wrapper is kept alive so the timeout still has someone to notify.
- Ownership: since #35849 the JS wrapper is the sole owner of the C++ signal, and collecting the wrapper runs the C++ destructor, which frees the timer. GC, not listener removal, is what reclaims an unobserved timeout signal.
- Native consumers register an observer while they hold the signal and release it when done, so a subprocess exiting or a watcher closing dropped the count to zero through the same path as removing a JS listener. fetch and `node:fs` escaped only because of the order they release things in.
- `Request` is the exception: it holds a native ref and re-wraps the signal each time `request.signal` is read, so the wrapper can be collected while the timeout is still observable. That is why the timer has to outlive the wrapper and only stop when the signal itself dies.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/abort/abort.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

`AbortSignal.timeout()` stops working as soon as the signal's observer count touches zero while the program still holds the signal:

```js
const s = AbortSignal.timeout(50);
const f = () => {};
s.addEventListener("abort", f);
s.removeEventListener("abort", f);
await Bun.sleep(150);
console.log(s.aborted); // bun 1.4.0: false    node 26.3.0: true
```

The same happens after `s.onabort = fn; s.onabort = null`, after a listener registered with `{ signal: controller.signal }` is removed by `controller.abort()`, after `await Bun.spawn({ cmd, signal: s }).exited` (the subprocess releases its native callback when the child exits), and even after `s.addEventListener("unrelated", fn)` with nothing removed at all. Once it has happened, `s.reason` stays `undefined`, `s.throwIfAborted()` never throws, and abort listeners or `AbortSignal.any([s])` dependents attached afterwards never fire. Node prints `true` with a `TimeoutError` reason for every one of these, and so do the browsers.

## Cause

`AbortSignal::eventListenersDidChange()` in `src/jsc/bindings/webcore/AbortSignal.cpp` ended with

```cpp
if (m_timeout && !aborted() && !hasTimeoutObserver())
    cancelTimer();
```

It runs on every listener add or remove, and `m_timeoutObserverCount` is zero for any timeout signal nobody is listening to, so the native timer was freed as a side effect of ordinary listener bookkeeping. "No observers" is not "unreachable": the program can still read `aborted`/`reason`, call `throwIfAborted()`, or hand the signal to something later, and https://dom.spec.whatwg.org/#dom-abortsignal-timeout requires the signal to abort after the timeout for as long as it exists. Listener presence only matters for GC (that is the "strong reference while it has abort listeners" clause), which `JSAbortSignalOwner::isReachableFromOpaqueRoots` already implements separately.

## Fix

Delete that branch. The timer is now stopped in exactly two places: `markAborted()` (the signal aborted, by the timer or otherwise) and `~AbortSignal()` (nothing references the signal any more). A signal that went through listener churn therefore behaves exactly like one that was never touched, which already worked.

Cancelling later instead, once the JS wrapper has been finalized, is not safe with the current holders either. `new Request(url, { signal })` keeps only a native ref (`Request.rs:1343`), nothing pins the signal's wrapper until `request.signal` is first read, and the getter re-wraps the C++ signal (`Request.rs:727`), so the wrapper is routinely collected while the timeout is still observable through `request.signal`; that works today and is now covered by a test. Every other native holder (FetchTasklet, Response's BodyAbortListener, Subprocess, the http2 SignalRef, node_fs ReadFile/WriteFile, fs.watch) registers an observer for as long as it holds the signal, which keeps the wrapper alive, and releases the observer and the ref in the same call, so for those the wrapper is only finalized when it holds the last ref and `~AbortSignal()` frees the timer at that moment anyway.

Why this is the right fix rather than a narrower one: the cancel dates from #28761, when the timer held a ref on the signal and cancelling on the last listener removal was the only way to free an unobserved `AbortSignal.timeout()` before its deadline (#28756). #35849 removed that self-ref: the JS wrapper is the sole owner, `isReachableFromOpaqueRoots` keeps it alive only while `hasTimeoutObserver()`, and collecting the wrapper runs `~AbortSignal()` which frees the timer. With that in place the branch could only free the timer slightly earlier than the next GC would, and it is observably wrong. The observer counter itself is unchanged; it still drives GC reachability. The timer does not hold the event loop open (it never did; `AbortSignal__Timeout__create` inserts it without a ref, the same as Node's unref'd timer), so keeping it armed cannot keep a process alive. The resulting lifetime is the same as Node's: its timer is cleared when the signal aborts or when the signal is collected, and never because listeners were removed.

The state this leaves a churned signal in (timer armed, observer count zero, wrapper the only owner) is already reachable on main: `releaseSourceObserverCounts()` (an `AbortSignal.any()` dependent aborting) and `decrementPendingActivityCount()` (fetch finishing) drop the count without going through `eventListenersDidChange()`, and the existing `timer-gc-roots.test.ts` case "AbortSignal.any([timeout, controller.signal]).abort releases the timeout" checks that GC alone reclaims the signals and their 600 s timers from that state. This change only routes the listener and native-callback paths into the same state.

The #28756 scenario still reclaims memory: removing the last listener makes the wrapper collectible, and the next GC frees the signal and its timer together. Running that test's script under the debug build gives 36.0 MB growth without this change and 36.7 MB with it (the number is dominated by ASAN quarantine; 202 signals remain live in both cases, which are the test's 200 warm-up signals that keep a listener), and `test/regression/issue/28756.test.ts` passes.

## Verification

New tests in `test/js/web/abort/abort.test.ts` (`AbortSignal.timeout() still fires after its observers go away`): the four listener-churn variants above plus `fs.watch(dir, { signal }).close()` (a native consumer releasing its callback synchronously), re-observation after churn (a listener added afterwards fires, `AbortSignal.any([signal])` aborts, `throwIfAborted()` throws `signal.reason`), and the asynchronous `Bun.spawn()` release when the child exits. A further test constructs Requests around timeout signals, checks with `heapStats()` that the signal wrappers were collected before the deadline, and then reads `request.signal.aborted`; it passes on 1.4.0 as well and pins the Request case described above. Each waits on a second timeout signal armed afterwards with a longer delay, which sits behind the signal under test in the timer heap, so the signal under test stays unobserved and the tests do not depend on wall-clock timing (the spawn case needs the child to exit before a 500 ms deadline; a shell exits in about 1 ms). The seven churn/fs.watch/spawn tests fail on the unfixed debug build (`aborted: false`, `reason: undefined`) and on bun 1.4.0, and pass with the change (repeated runs locally with `--rerun-each`; CI is green on every lane, including Windows and ASAN).

Also passing with the change: `test/regression/issue/28756.test.ts`, `test/js/web/timers/timer-gc-roots.test.ts`, `test/js/web/abort/*`, `test/js/web/streams/pipeTo-signal-leak.test.ts`, `pipeTo-shutdown-gc.test.ts`, `test/js/web/fetch/fetch-tls-abortsignal-timeout.test.ts`, the abort-signal tests in `fetch-leak.test.ts`, `test/js/bun/spawn/spawn-signal.test.ts`, `test/js/node/util/test-aborted.test.ts`, the `--isolate` leaked-timeout test in `test/cli/test/isolation.test.ts`, and Node's `test-abortsignal-any.mjs`.

Native consumers affected on the unfixed build, from going through each `add_listener`/`listen` site and its release order: `Bun.spawn`/`spawnSync` (`Subprocess::clear_abort_signal` drops pending activity first, then the callback), `fs.watch` (`detach()` removes the callback; closing the watcher left the signal stuck), and `node:http2` `session.request(headers, { signal })` (the stream's `SignalRef` drop; a signal reused after a stream closed never fired). spawn and fs.watch are tested; http2 was verified by hand (stuck on 1.4.0, `TimeoutError` with the fix, same as Node) and goes through the same `cleanNativeBindings()` entry point, but an http2 round trip takes over a second on a debug build, so it did not get a test of its own. A side effect of the same bug was that `spawnSync({ signal })` ignored the deadline of a signal that had lost its observers, since it reads the armed timer's deadline (`js_bun_spawn_bindings.rs`); that now works too. `fetch()`, `Response` and `node:fs` `readFile`/`writeFile` were not affected: they drop their callback before their pending-activity count (or hold only pending activity), so the counter never reached zero inside `eventListenersDidChange()`. With this change the release order of native consumers no longer matters.

</details>
