### PR TITLE
test(dns): accept DNS_ETIMEOUT for malformed names on the system and libc backends

### DIFF
--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -108,10 +108,25 @@ describe("dns", () => {
       });
     });
 
+    // These reject with whatever the resolver path reports for a name that
+    // cannot exist. On the system and libc backends that is an EAI code, and
+    // EAI_AGAIN (query unanswered, or SERVFAIL on glibc) used to come out of
+    // init_eai's catch-all as DNS_ENOTIMP, which is why ENOTIMP is in this set;
+    // since #36619 it is DNS_ETIMEOUT. It does happen: Google Public DNS
+    // (8.8.8.8) drops queries whose top-level label contains a space (" ",
+    // "this is not a hostname") instead of answering NXDOMAIN, and unless
+    // mDNSResponder fails over to the next resolver before its ~5s query
+    // timeout, the macOS system backend reports that timeout. c-ares stays
+    // strict: it rejects the ill-formed names itself (ARES_EBADNAME, nothing is
+    // sent) and "." gets a real rcode, so a timeout from it would be a bug.
+    const malformedHostnameCodes =
+      backend === "c-ares"
+        ? /^(?:DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP)$/
+        : /^(?:DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP|DNS_ETIMEOUT)$/;
     test.concurrent.each(malformedHostnames)("'%s'", async hostname => {
       // @ts-expect-error
       await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-        code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP$/),
+        code: expect.stringMatching(malformedHostnameCodes),
         name: "DNSException",
       });
     });


### PR DESCRIPTION
### Problem
- Since the macOS test fleet was reimaged, `test/js/bun/dns/resolve-dns.test.ts` failed on the darwin `previous` tier lanes (flaky in builds 92313 and 92335, red in 92351): the `system` backend cases for `' '` and `'this is not a hostname'` reject with `getaddrinfo ETIMEOUT` after about 5s, a code the test does not accept.
- Google Public DNS (8.8.8.8, the reimaged hosts' first resolver) drops queries whose top-level label contains a space instead of answering NXDOMAIN. Unless mDNSResponder fails over to the next resolver before its query timeout, the lookup times out, which is why the failing names vary and retries usually pass.
- An unanswered lookup on these backends is reported as `EAI_AGAIN`. Before #36619 that surfaced as `DNS_ENOTIMP`, which the test accepts; since #36619 it surfaces as `DNS_ETIMEOUT`, which it does not. The reimaged fleet was the first environment since then to produce it; a Buildkite-hosted macOS 26 agent did the same in build 92810.
- The fleet has since joined Tailscale, whose resolver answers NXDOMAIN for these names, and 0 of the 123 builds since have hit it. This corrects the accepted set; it is not an urgent CI fix.

### Fix
- On the `system` and `libc` backends the malformed-name cases also accept `DNS_ETIMEOUT`. The `c-ares` backend keeps the old set.
- This restores a tolerance rather than adding one: on those backends `DNS_ETIMEOUT` is the same `EAI_AGAIN` outcome the set already accepted under the name `DNS_ENOTIMP`. c-ares rejects the space and colon names locally without sending a query and gets a real rcode for `"."`, so a timeout from it would be a regression and still fails.
- The regex is now anchored as a whole; the old one anchored only its first and last alternatives. Inputs and code paths exercised are unchanged, and whether DNS works at all is still asserted strictly by the `adsfa.asdfasdf.asdf.com` case.
- Verification: the darwin failure is not reproducible on Linux. In a container whose resolver answers SERVFAIL, the `system` and `libc` `'.'` cases reject with `getaddrinfo ETIMEOUT` on main and pass with this change, via the same code path as on darwin. This PR's darwin lane passed, but the hosts are on Tailscale now, so that says nothing about the new branch.

### Background
- bun's `dns.lookup` has three backends and this file runs every case against each: `c-ares` (bun's bundled resolver, which builds and sends the queries itself), `system` (mDNSResponder on macOS) and `libc` (`getaddrinfo`).
- The `system` and `libc` backends report failures as `EAI_*` codes, which bun maps to `DNS_*` codes. `EAI_AGAIN` means the query went unanswered (or, on glibc, got SERVFAIL); it used to fall into the `DNS_ENOTIMP` catch-all and since #36619 maps to `DNS_ETIMEOUT`.
- macOS `getaddrinfo` folds a timeout into `EAI_NONAME`, so on macOS only the `system` backend fails. `libc` gets the same set because glibc reports `EAI_AGAIN` as itself.
- The malformed-name cases (`" "`, `"this is not a hostname"`, `"."`, and so on) assert only that the lookup rejects with a `DNSException` whose code is in an accepted set; which code a name produces depends on the resolver behind the backend.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## What

Since the macOS test fleet came back from being reimaged, `test/js/bun/dns/resolve-dns.test.ts` has had failing attempts on the `previous` tier lanes in every build that reached the fleet: flaky (failed, passed on retry) on darwin 14 x64 in build 92313 and on darwin 14 aarch64 (macOS 15 tart VMs) in 92335, and red after exhausting retries on darwin 14 aarch64 in 92351. No build in the ~2000 before the reimage hit it.

Update: the fleet no longer triggers it. The 14/15 hosts joined Tailscale a few hours after those builds ran, so their system resolver (and therefore the tart VMs') is now `100.100.100.100`, which answers NXDOMAIN for these names: on `darwin-arm64-challah` a system lookup of `this is not a hostname` now returns in 9ms, and 0 of the 123 builds whose `previous` tier jobs have finished since then (none of them with this change) have a `resolve-dns` annotation. The test is still wrong about the outcome, though: 8.8.8.8 still drops these queries, a host resolving through it directly (any macOS 14/15 machine configured that way, or the fleet hosts themselves if Tailscale is ever down, since 8.8.8.8 is now their only underlying resolver) still gets `DNS_ETIMEOUT`, and a Buildkite-hosted macOS 26 agent produced the same failure in build 92810. So this is a correction of the accepted set rather than an urgent CI fix.

```
✗ dns > lookup() [backend: system] > ' ' [5005.86ms]
✗ dns > lookup() [backend: system] > 'this is not a hostname' [5013.78ms]

- "code": StringMatching /^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP$/,
+ [Error: getaddrinfo ETIMEOUT]
```

## Cause

Only the malformed names whose single label contains a space fail, only through the `system` backend, and each failing attempt takes the resolver's query timeout (5.0s on the macOS 15 VMs, 7.1s on the 14.8.9 x64 box).

The reimaged 14/15 boxes resolve directly through the fleet's configured resolvers, `8.8.8.8` then `1.1.1.1` (`scutil --dns` on the fleet). Google Public DNS does not answer a query whose top-level label contains a space. From two fleet boxes, over UDP and TCP:

```
dig @8.8.8.8 'this\032is\032not\032a\032hostname' A   -> connection timed out (TCP: EOF)
dig @8.8.8.8 '\032' A                                 -> connection timed out
dig @8.8.8.8 'a\032b.com' A                           -> NXDOMAIN, 20 msec
dig @8.8.8.8 'localhost:80' A                         -> NXDOMAIN, 11 msec
dig @8.8.8.8 . A                                      -> NOERROR, 10 msec
dig @1.1.1.1 'this\032is\032not\032a\032hostname' A   -> NXDOMAIN, 2 msec
dig @9.9.9.9 'this\032is\032not\032a\032hostname' A   -> NXDOMAIN, 0 msec
```

mDNSResponder sends the A/AAAA queries for `" "` and `"this is not a hostname"` to 8.8.8.8 and gets nothing back. Whether it fails over to 1.1.1.1 before its `kDNSServiceFlagsTimeout` deadline decides the outcome per name, which is why the set of failing names varies between attempts and retries usually pass (once 8.8.8.8 has been marked unresponsive, the next attempt goes to 1.1.1.1 immediately). When it does not make it, it reports `kDNSServiceErr_Timeout` for each family, which `QueryState::empty_status` in `dns_sd.rs` maps to `EAI_AGAIN`, and `c_ares::Error::init_eai` reports as `DNS_ETIMEOUT`.

That last step is what changed recently. Until #36619 `init_eai` had no `EAI_AGAIN` arm, so on the `system` and `libc` backends an `EAI_AGAIN` came out of the `_ => ENOTIMP` catch-all as `DNS_ENOTIMP`, which this test has accepted for all five names since the set was written (81dec2657f, 2024). `DNS_ENOTIMP` is in the set because it was the `EAI_AGAIN` outcome; #36619 added `EAI::AGAIN => ETIMEOUT`, so the same outcome is now spelled `DNS_ETIMEOUT` and the test stopped accepting it. The fleet's new resolver config is just the first environment since then to produce it, and not the only one: build 92810, whose darwin lane still ran on a Buildkite-hosted macOS 26 agent, failed the same way with `getaddrinfo ETIMEOUT` for `' '` (5.0s), `' .'` (55s, the daemon's own give-up rather than the 5s flag timeout) and `'this is not a hostname'` (5.0s), so whatever resolver those agents use does not answer these names either. The fleet's macOS 26 boxes pass because they still run Tailscale, whose `100.100.100.100` resolver is the system resolver there and answers NXDOMAIN for these names; the pre-reimage fleet was on Tailscale as well. The `libc` backend keeps passing on the same boxes because macOS `getaddrinfo` folds a timeout into `EAI_NONAME` in Libinfo's `mdns_addrinfo` (which is also what the `system` backend used before #36619).

## Fix

On the `system` and `libc` backends, accept `DNS_ETIMEOUT` wherever `DNS_ENOTIMP` was accepted: it is the same `EAI_AGAIN` outcome under its current name (on glibc that bucket also covers a SERVFAIL, which the set already accepts from c-ares as `DNS_ESERVFAIL`). `c-ares` keeps the current set unchanged: it rejects the space and colon names itself with `ARES_EBADNAME` without sending anything (`errno: 8`, 0ms), and `"."` gets a real rcode, so a `DNS_ETIMEOUT` from it would be a real regression. The regex is also anchored as a whole; the old one anchored only its first and last alternatives.

The inputs, backends, and code paths exercised are unchanged. A lookup that resolves, rejects with something other than a `DNSException`, or hangs still fails, and whether DNS works at all is still asserted strictly by the `adsfa.asdfasdf.asdf.com` case.

An earlier revision of this PR additionally kept `"."` strict on `system`/`libc` as well. That would have been a new tightening rather than the restored tolerance: before #36619 an unanswered or SERVFAIL `"."` on those backends was accepted as `DNS_ENOTIMP`, and it would have rejected from `libc` the same SERVFAIL the set accepts from c-ares. Dropped.

Not changed: the `EAI_AGAIN` mapping itself. Reporting an unanswered query as `ENOTFOUND` would hide real resolver outages, and glibc (and Node on Linux, as `EAI_AGAIN`) distinguish the two as well.

Separately, every negative lookup on the 14/15 fleet boxes is now a failover race against 8.8.8.8's drop policy; listing 1.1.1.1 first would make those lanes faster, but the test should not depend on that either way.

## Verification

`bun bd test test/js/bun/dns/resolve-dns.test.ts -t "'"` runs the 15 malformed-name cases. This container's resolver answers SERVFAIL for everything, which glibc reports as `EAI_AGAIN`: on main the `system` and `libc` `'.'` cases reject with `getaddrinfo ETIMEOUT` and fail while the c-ares `'.'` case passes with `DNS_ESERVFAIL`; with this change all 15 pass. The space and colon names pass before and after on Linux because glibc and c-ares reject them locally, so the darwin failure itself is not reproducible here; the rest of the file (`example.com`, `adsfa.asdfasdf.asdf.com`) fails in this container with or without the change. This PR's CI (build 92955) ran the darwin `previous` tier lane and the file passed there, but since the hosts are on Tailscale now that pass says nothing about the new branch of the assertion; the Linux before/after above is the evidence that it accepts exactly the `getaddrinfo ETIMEOUT` rejection the darwin failures produced (same `init_eai` path). The build's two darwin 26 jobs expired waiting for an agent, as they did in most builds of the last few hours, and its one red job is an unrelated ASAN failure in `worker-transfer-terminate-stress.test.ts`.

</details>
